### PR TITLE
Fix build, broken by adding_tools

### DIFF
--- a/pkg/nuclio-build/build/build.go
+++ b/pkg/nuclio-build/build/build.go
@@ -109,7 +109,7 @@ func (b *Builder) buildDockerSteps(env *env, outputToImage bool) error {
 	}
 
 	for _, step := range buildSteps {
-		b.logger.Info("Running build step", "message", step.Message)
+		b.logger.InfoWith("Running build step", "message", step.Message)
 		if err := step.Func(); err != nil {
 			return errors.Wrap(err, "Error while "+step.Message)
 		}

--- a/pkg/nuclio-build/build/env.go
+++ b/pkg/nuclio-build/build/env.go
@@ -90,7 +90,7 @@ func (e *env) getOutputName() string {
 func (e *env) getNuclioSource() error {
 
 	if e.options.NuclioSourceDir == "" {
-		url, ref := e.parseGitUrl(e.options.NuclioSourceDir)
+		url, ref := e.parseGitUrl(e.options.NuclioSourceURL)
 
 		err := cmdutil.RunCommand(e.logger, nil, "git clone %s %s", url, e.nuclioDestDir)
 		if err != nil {

--- a/vendor/github.com/jhoonb/archivex/archivex.go
+++ b/vendor/github.com/jhoonb/archivex/archivex.go
@@ -420,6 +420,11 @@ func addAll(dir string, rootDir string, includeCurrentFolder bool, writerFunc Ar
 	// Loop through all entries
 	for _, info := range fileInfos {
 
+		// HACK: skip symlinks
+		if (info.Mode() & os.ModeSymlink) != 0 {
+			continue
+		}
+
 		full := filepath.Join(dir, info.Name())
 
 		// If the entry is a file, get an io.Reader for it


### PR DESCRIPTION
1. Tar'ing would not work on vendors w/symlinks (e.g. docker). Temporary workaround introduced
2. Build without passing local nuclio source fixed