### PR TITLE
Support default configuration for builds

### DIFF
--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -223,15 +223,9 @@ func (p *Processor) getRuntimeConfiguration() (*viper.Viper, error) {
 		// initialize with a new viper
 		runtimeConfiguration = viper.New()
 
-		// try to read env var
-		functionName := os.Getenv("NUCLIO_FUNCTION_NAME")
-
-		// env not set
-		if functionName == "" {
-			return nil, errors.New("If configuration not passed, NUCLIO_FUNCTION_NAME must be set")
-		}
-
-		runtimeConfiguration.SetDefault("name", functionName)
+		// try to read env var. if env doesn't exist, the function selection logic will
+		// just choose the first registered function
+		runtimeConfiguration.SetDefault("name", os.Getenv("NUCLIO_FUNCTION_NAME"))
 	}
 
 	// by default use golang

--- a/hack/processor/build/Dockerfile.alpine
+++ b/hack/processor/build/Dockerfile.alpine
@@ -1,6 +1,6 @@
 FROM alpine
 
 COPY bin/processor /usr/local/bin
-COPY function.yml /etc/nuclio/function.yml
+COPY processor.yaml /etc/nuclio/processor.yaml
 
-CMD [ "processor" ]
+CMD [ "processor", "--config", "/etc/nuclio/processor.yaml" ]

--- a/hack/processor/build/Dockerfile.jessie
+++ b/hack/processor/build/Dockerfile.jessie
@@ -10,6 +10,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY bin/processor /usr/local/bin
-COPY function.yml /etc/nuclio/function.yml
+COPY processor.yaml /etc/nuclio/processor.yaml
 
-CMD [ "processor", "--config", "/etc/nuclio/function.yml" ]
+CMD [ "processor", "--config", "/etc/nuclio/processor.yaml" ]

--- a/hack/processor/build/onbuild/nuclio-builder.sh
+++ b/hack/processor/build/onbuild/nuclio-builder.sh
@@ -8,5 +8,4 @@ if [[ -e .deps ]]; then
     rm -rf /var/lib/apt/lists/*
 fi
 
-go get -v github.com/nuclio/nuclio/cmd/processor
-go install -v github.com/nuclio/nuclio/cmd/processor
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go get -a -installsuffix cgo github.com/nuclio/nuclio/cmd/processor

--- a/pkg/nuclio-build/build/docker.go
+++ b/pkg/nuclio-build/build/docker.go
@@ -34,7 +34,7 @@ type dockerHelper struct {
 func newDockerHelper(parentLogger logger.Logger, env *env) (*dockerHelper, error) {
 	b := &dockerHelper{
 		logger: parentLogger.GetChild("docker").(logger.Logger),
-		env: env,
+		env:    env,
 	}
 
 	if err := b.init(); err != nil {
@@ -198,7 +198,7 @@ func (d *dockerHelper) createProcessorImage() error {
 
 	buildContextPaths := []string{
 		d.env.getNuclioDir(),
-		d.env.options.FunctionPath,
+		filepath.Join(d.env.userFunctionPath, d.env.config.Name), // function path in temp
 	}
 
 	buildContext, err := d.prepareBuildContext("nuclio-output", buildContextPaths)

--- a/pkg/processor/runtime/golang/event_handler/demo.go
+++ b/pkg/processor/runtime/golang/event_handler/demo.go
@@ -3,37 +3,13 @@ package golangruntimeeventhandler
 import (
 	"github.com/nuclio/nuclio-sdk/event"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
-
-	"github.com/pkg/errors"
 )
 
 func demo(context *runtime.Context, event event.Event) (interface{}, error) {
-
-	// get the full data of the object
-	itemContents, err := context.V3ioClient.Get(event.GetPath())
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get item contents")
-	}
-
-	context.Logger.DebugWith("Processing event in demo",
-		"url", event.GetURL(),
-		"size", event.GetSize(),
-		"timestamp", event.GetTimestamp(),
-		"contents", string(itemContents))
-
 	return nil, nil
-
-	//return http.Response{
-	//	StatusCode:  201,
-	//	ContentType: "application/text",
-	//	Header: map[string]string{
-	//		"x-v3io-something": "30",
-	//		// "x-v3io-request-id": string(*event.GetID()),
-	//	},
-	//	Body: []byte("Response from golang"),
-	//}, nil
 }
 
-func init() {
-	EventHandlers.Add("demo", demo)
-}
+// uncomment to register demo
+// func init() {
+// 	EventHandlers.Add("demo", demo)
+// }

--- a/pkg/processor/runtime/golang/runtime.go
+++ b/pkg/processor/runtime/golang/runtime.go
@@ -18,6 +18,15 @@ type golang struct {
 func NewRuntime(parentLogger logger.Logger, configuration *Configuration) (runtime.Runtime, error) {
 	handlerName := configuration.EventHandlerName
 
+	runtimeLogger := parentLogger.GetChild("golang").(logger.Logger)
+
+	// if the handler name is not specified, just get the first one
+	if handlerName == "" {
+		handlerName = golangruntimeeventhandler.EventHandlers.GetKinds()[0]
+
+		runtimeLogger.InfoWith("Handler name unspecified, using first", "handler", handlerName)
+	}
+
 	eventHandler, err := golangruntimeeventhandler.EventHandlers.Get(handlerName)
 	if err != nil {
 		return nil, err
@@ -25,7 +34,7 @@ func NewRuntime(parentLogger logger.Logger, configuration *Configuration) (runti
 
 	// create the command string
 	newGoRuntime := &golang{
-		AbstractRuntime: *runtime.NewAbstractRuntime(parentLogger.GetChild("golang").(logger.Logger), &configuration.Configuration),
+		AbstractRuntime: *runtime.NewAbstractRuntime(runtimeLogger, &configuration.Configuration),
 		configuration:   configuration,
 		eventHandler:    eventHandler.(golangruntimeeventhandler.EventHandler),
 	}

--- a/pkg/util/registry/registry.go
+++ b/pkg/util/registry/registry.go
@@ -47,3 +47,16 @@ func (r *Registry) Get(kind string) (interface{}, error) {
 
 	return registree, nil
 }
+
+func (r *Registry) GetKinds() []string {
+	r.Lock.Lock()
+	defer r.Lock.Unlock()
+
+	keys := make([]string, 0, len(r.Registered))
+
+	for key := range r.Registered {
+		keys = append(keys, key)
+	}
+
+	return keys
+}


### PR DESCRIPTION
General:
1. `function.yml` and `build.yml` renamed to `processor.yaml` and `build.yaml` respectively (processor renamed because we want to allow the user to work with kubernetes directly and he'll most likely have a `function.yaml` for the custom resource)

Processor:
1. if `--config` is not passed or is passed and file is empty, the processor will not fail - rather assume `golang` runtime and try to use `NUCLIO_FUNCTION_NAME` env var for the function name. If that isn't set, uses the first registered handler

Build:
1. Alpine support fixed
2. If user doesn't supply `processor.yaml` in the directory, the package name must be `handler` and function must be `Handler`. Adding an issue to support parsing the code and alleviating this limitation
3. Fixed support for user not supplying `build.yaml`
4. Build faster, since both `go get` and `go install` were needlessly called
 