### PR TITLE
Ignore updates for now, minor script changes

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -103,7 +103,10 @@ func (c *Controller) Start() error {
 		}
 
 		switch functionChange.Kind {
-		case functioncr.ChangeKindUpdated, functioncr.ChangeKindAdded:
+		case functioncr.ChangeKindUpdated:
+			c.logger.Debug("Ignoring update, currently unsupported")
+			err = nil
+		case functioncr.ChangeKindAdded:
 			err = c.handleFunctionCRAddOrUpdate(functionChange.Function)
 		case functioncr.ChangeKindDeleted:
 			err = c.handleFunctionCRDelete(functionChange.Function)

--- a/hack/k8s/README.md
+++ b/hack/k8s/README.md
@@ -39,7 +39,7 @@ The above command can be run whenever you want a fresh cluster. However, for the
 $GOPATH/src/github.com/nuclio/nuclio/hack/k8s/scripts/install_cni_plugins
 ```
 
-We're done running commands on the master, now we move on to a local machine with kubectl installed. 
+We're done running commands on the master, now we move on to a local machine with kubectl installed.
 
 Copy `~/kube/config` from the master node to `~/kube/config`, change the IP address under `server` to the external IP address (leave port as is) and test kubectl:
 
@@ -49,7 +49,7 @@ kubectl get pods --all-namespaces
 
 Finally, create a docker registry, a docker registry proxy and grant the default namespace complete access to everything via RBAC:
 ```
-cd $GOPATH/src/github.com/nuclio/nuclio/hack/k8s/resources && kubectl create -f full-access-role.yaml,registry.yaml && cd -
+cd $GOPATH/src/github.com/nuclio/nuclio/hack/k8s/resources && kubectl create -f default-cluster-admin.yaml,registry.yaml && cd -
 ```
 
 ### Build / deploy a controller

--- a/hack/k8s/resources/default-cluster-admin.yaml
+++ b/hack/k8s/resources/default-cluster-admin.yaml
@@ -1,21 +1,12 @@
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-    name: full-access
-rules:
-  - apiGroups: ["*"]
-    resources: ["*"]
-    verbs: ["*"]
----
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: default-service-account
+  name: default-cluster-admin
 subjects:
   - kind: ServiceAccount
     namespace: default
     name: default
 roleRef:
   kind: ClusterRole
-  name: full-access
+  name: cluster-admin
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
1. Don't handle function updates until this is properly tested. This broke functions whose HTTP port was not set
2. Remove superfluous "full-access-admin" cluster role, use built-in cluster-admin role