### PR TITLE
Build supports receiving a specific handler file, rather than directory

### DIFF
--- a/pkg/nubuild/build/build.go
+++ b/pkg/nubuild/build/build.go
@@ -59,6 +59,7 @@ type Builder struct {
 
 const (
 	defaultBuilderImage     = "golang:1.8"
+	defaultProcessorImage   = "alpine"
 	processorConfigFileName = "processor.yaml"
 	buildConfigFileName     = "build.yaml"
 	nuclioDockerDir         = "/opt/nuclio"
@@ -244,7 +245,7 @@ func (b *Builder) createConfig(functionPath string) (*config, error) {
 
 	// initialize config and populate with defaults.
 	config := config{}
-	config.Build.Image = defaultBuilderImage
+	config.Build.Image = defaultProcessorImage
 	config.Build.Commands = []string{}
 	config.Build.Script = ""
 

--- a/pkg/nubuild/build/docker.go
+++ b/pkg/nubuild/build/docker.go
@@ -181,16 +181,18 @@ func isDir(path string) bool {
 func (d *dockerHelper) createProcessorDockerfile() (string, error) {
 	baseTemplateName := "Dockerfile.tmpl"
 	templateFile := filepath.Join("hack", "processor", "build", baseTemplateName)
-	d.logger.InfoWith("Creating Dockerfile from template", "path", templateFile)
+	d.logger.DebugWith("Creating Dockerfile from template", "path", templateFile)
 
 	funcMap := template.FuncMap{
 		"basename": path.Base,
 		"isDir":    isDir,
 	}
+
 	dockerfileTemplate, err := template.New("dockerfile").Funcs(funcMap).ParseFiles(templateFile)
 	if err != nil {
 		return "", errors.Wrapf(err, "Can't parse template at %q", templateFile)
 	}
+
 	dockerfilePath := filepath.Join(d.env.getNuclioDir(), "Dockerfile.processor")
 	dockerfile, err := os.Create(dockerfilePath)
 	if err != nil {
@@ -230,6 +232,7 @@ func (d *dockerHelper) createProcessorImage() error {
 		Tag:        d.env.outputName,
 		Dockerfile: dockerfile,
 	}
+
 	if err := d.doBuild(d.env.outputName, buildContext, &options); err != nil {
 		return errors.Wrap(err, "Failed to build image")
 	}

--- a/pkg/nubuild/build/docker.go
+++ b/pkg/nubuild/build/docker.go
@@ -180,7 +180,7 @@ func isDir(path string) bool {
 
 func (d *dockerHelper) createProcessorDockerfile() (string, error) {
 	baseTemplateName := "Dockerfile.tmpl"
-	templateFile := filepath.Join("hack", "processor", "build", baseTemplateName)
+	templateFile := filepath.Join(d.env.getNuclioDir(), "hack", "processor", "build", baseTemplateName)
 	d.logger.DebugWith("Creating Dockerfile from template", "path", templateFile)
 
 	funcMap := template.FuncMap{

--- a/pkg/nubuild/build/env.go
+++ b/pkg/nubuild/build/env.go
@@ -181,10 +181,12 @@ func (e *env) createUserFunctionPath() error {
 		return errors.Wrapf(err, "error creating %s.", e.userFunctionPath)
 	}
 
+	copyFrom := e.options.getFunctionDir()
+
 	functionCompletePath := filepath.Join(e.userFunctionPath, e.config.Name)
-	e.logger.DebugWith("Copying user data", "from", e.options.FunctionPath, "to", functionCompletePath)
-	if err := util.CopyDir(e.options.FunctionPath, functionCompletePath); err != nil {
-		return errors.Wrapf(err, "error when copying from %s to %s.", e.options.FunctionPath, functionCompletePath)
+	e.logger.DebugWith("Copying user data", "from", copyFrom, "to", functionCompletePath)
+	if err := util.CopyDir(copyFrom, functionCompletePath); err != nil {
+		return errors.Wrapf(err, "Error copying from %s to %s.", copyFrom, functionCompletePath)
 	}
 
 	// check if processor.yaml not provided. if it isn't, create it because docker COPYs this in

--- a/pkg/nubuild/eventhandlerparser/parse_test.go
+++ b/pkg/nubuild/eventhandlerparser/parse_test.go
@@ -166,5 +166,3 @@ func (suite *ParseSuite) TestFindHandlersInFile() {
 func TestParse(t *testing.T) {
 	suite.Run(t, new(ParseSuite))
 }
-
-

--- a/pkg/nubuild/eventhandlerparser/parse_test.go
+++ b/pkg/nubuild/eventhandlerparser/parse_test.go
@@ -89,83 +89,82 @@ func (suite *ParseSuite) SetupSuite() {
 	}
 
 	zap, err := nucliozap.NewNuclioZap("parsereventhandler-test", level)
-	suite.failOnError(err, "Can't craete logger")
+	suite.Require().NoError(err, "Can't craete logger")
 	suite.parser = NewEventHandlerParser(zap)
-}
-
-func (suite *ParseSuite) failOnError(err error, fmt string, args ...interface{}) {
-	if err != nil {
-		suite.FailNowf(err.Error(), fmt, args...)
-	}
 }
 
 func (suite *ParseSuite) parseCode(code string) ([]string, []string, error) {
 	tmp, err := ioutil.TempDir("", "test-parse")
-	suite.failOnError(err, "Can't create temp directory file")
+	suite.Require().NoError(err, "Can't create temp directory file")
 	defer os.RemoveAll(tmp)
 
 	fileName := filepath.Join(tmp, "handler.go")
 
 	file, err := os.Create(fileName)
-	suite.failOnError(err, "Can't create %s", fileName)
+	suite.Require().NoError(err, "Can't create %s", fileName)
 	fmt.Fprint(file, code)
 	err = file.Close()
-	suite.failOnError(err, "Can't sync")
+	suite.Require().NoError(err, "Can't sync")
 	return suite.parser.ParseEventHandlers(tmp)
+}
+
+func (suite *ParseSuite) createHandler(handlerDir string, index int) string {
+	handlerPath := fmt.Sprintf("%s/hdlr%d.go", handlerDir, index)
+
+	file, err := os.Create(handlerPath)
+	suite.Require().NoError(err, "Can't create %s", handlerPath)
+	err = codeTemplate.Execute(file, index)
+	suite.Require().NoError(err, "Can't write to %s", handlerPath)
+	file.Close()
+
+	return handlerPath
 }
 
 func (suite *ParseSuite) TestHandlerNames() {
 	pkgs, handlers, err := suite.parseCode(code)
-	if err != nil {
-		suite.FailNow("Can't find handlers", "error: %s", err)
-	}
-	if !suite.Len(pkgs, 1, "Bad length") {
-		suite.FailNow("")
-	}
-	if !suite.Len(handlers, 2, "Bad length") {
-		suite.FailNow("")
-	}
+	suite.Require().NoErrorf(err, "Can't find handlers", "error: %s", err)
+	suite.Require().Len(pkgs, 1)
+	suite.Require().Len(handlers, 2)
+
 	sort.Strings(handlers)
-	fmt.Println(handlers)
-	if !suite.Equal(handlers[0], "AlsoHandler", "First handler") {
-		suite.FailNow("")
-	}
-	if !suite.Equal(handlers[1], "Handler1", "Second handler") {
-		suite.FailNow("")
-	}
+	suite.Require().Equal("AlsoHandler", handlers[0])
+	suite.Require().Equal("Handler1", handlers[1])
 }
 
 func (suite *ParseSuite) TestBadCode() {
 	_, _, err := suite.parseCode(badCode)
-	if err == nil {
-		suite.FailNow("No error on bad code")
-	}
+	suite.Require().Error(err, "No error on bad code")
 }
 
-func (suite *ParseSuite) TestFindHandlers() {
-	path, err := ioutil.TempDir("", "parse-test")
-	suite.failOnError(err, "Can't create temp directory")
+func (suite *ParseSuite) TestFindHandlersInDirectory() {
+	handlerDir, err := ioutil.TempDir("", "parse-test")
+	suite.Require().NoError(err, "Can't create temp directory")
 	n := 3
 
 	for i := 0; i < n; i++ {
-		goFile := fmt.Sprintf("%s/hdlr%d.go", path, i)
-		file, err := os.Create(goFile)
-		suite.failOnError(err, "Can't create %s", goFile)
-		err = codeTemplate.Execute(file, i)
-		suite.failOnError(err, "Can't write to %s", goFile)
-		file.Close()
+		suite.createHandler(handlerDir, i)
 	}
 
-	pkgs, handlers, err := suite.parser.ParseEventHandlers(path)
-	suite.failOnError(err, "Can't find handlers in %s", path)
-	if !suite.Equal(len(handlers), n) {
-		suite.FailNow("Bad number of handlers")
-	}
-	if !suite.Equal(len(pkgs), 1) {
-		suite.FailNow("Bad number of packages")
-	}
+	pkgs, handlers, err := suite.parser.ParseEventHandlers(handlerDir)
+	suite.Require().NoError(err, "Can't find handlers in %s", handlerDir)
+	suite.Require().Equal(n, len(handlers))
+	suite.Require().Equal(1, len(pkgs))
+}
+
+func (suite *ParseSuite) TestFindHandlersInFile() {
+	handlerDir, err := ioutil.TempDir("", "parse-test")
+	suite.Require().NoError(err, "Can't create temp directory")
+
+	handlerPath := suite.createHandler(handlerDir, 0)
+
+	pkgs, handlers, err := suite.parser.ParseEventHandlers(handlerPath)
+	suite.Require().NoError(err, "Can't find handlers in %s", handlerPath)
+	suite.Require().Equal(1, len(handlers))
+	suite.Require().Equal(1, len(pkgs))
 }
 
 func TestParse(t *testing.T) {
 	suite.Run(t, new(ParseSuite))
 }
+
+

--- a/pkg/processor/eventsource/http/eventsource.go
+++ b/pkg/processor/eventsource/http/eventsource.go
@@ -24,8 +24,8 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/eventsource"
 	"github.com/nuclio/nuclio/pkg/processor/worker"
 
-	"github.com/valyala/fasthttp"
 	"github.com/pkg/errors"
+	"github.com/valyala/fasthttp"
 )
 
 type http struct {

--- a/pkg/processor/eventsource/poller/v3ioitempoller/eventsource.go
+++ b/pkg/processor/eventsource/poller/v3ioitempoller/eventsource.go
@@ -31,11 +31,11 @@ import (
 
 type v3ioItemPoller struct {
 	poller.AbstractPoller
-	configuration  *Configuration
-	query          string
-	attributes     string
-	firstPoll      bool
-	v3ioContainer  *v3io.Container
+	configuration *Configuration
+	query         string
+	attributes    string
+	firstPoll     bool
+	v3ioContainer *v3io.Container
 }
 
 func newEventSource(logger nuclio.Logger,
@@ -119,7 +119,7 @@ func (vip *v3ioItemPoller) PostProcessEvents(events []nuclio.Event, responses []
 
 			// update the attributes
 			err := vip.v3ioContainer.UpdateItem(&v3io.UpdateItemInput{
-				Path: event.(*Event).GetPath(),
+				Path:       event.(*Event).GetPath(),
 				Attributes: updatedAttributes,
 			})
 

--- a/pkg/processor/runtime/golang/event_handler/demo.go
+++ b/pkg/processor/runtime/golang/event_handler/demo.go
@@ -25,6 +25,6 @@ func demo(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
 }
 
 // uncomment to register demo
-func init() {
- 	EventHandlers.Add("demo", demo)
-}
+//func init() {
+// 	EventHandlers.Add("demo", demo)
+//}


### PR DESCRIPTION
1. Users can now run build on a specific handler file. This allows keeping multiple functions in a single 
2. Fixed function images deriving from golang:1.8 rather than alpine