### PR TITLE
Processor has a separate log stream for functions + HTTP event source can retrieve invocation logs

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -153,7 +153,7 @@ func (c *Controller) getClientConfig(configurationPath string) (*rest.Config, er
 func (c *Controller) createLogger() (nuclio.Logger, error) {
 
 	// TODO: configuration stuff
-	return nucliozap.NewNuclioZap("controller", nucliozap.DebugLevel)
+	return nucliozap.NewNuclioZapCmd("controller", nucliozap.DebugLevel)
 }
 
 func (c *Controller) handleFunctionCRAdd(function *functioncr.Function) error {

--- a/cmd/controller/app/controller_test.go
+++ b/cmd/controller/app/controller_test.go
@@ -138,7 +138,7 @@ type ControllerTestSuite struct {
 }
 
 func (suite *ControllerTestSuite) SetupTest() {
-	suite.logger, _ = nucliozap.NewNuclioZap("test", nucliozap.DebugLevel)
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
 
 	suite.mockFunctioncrClient = &MockFunctioncrClient{}
 	suite.mockFunctiondepClient = &MockFunctiondepClient{}

--- a/pkg/functiondep/client_test.go
+++ b/pkg/functiondep/client_test.go
@@ -36,7 +36,7 @@ type FunctiondepTestSuite struct {
 func (suite *FunctiondepTestSuite) SetupTest() {
 	var err error
 
-	suite.logger, _ = nucliozap.NewNuclioZap("test", nucliozap.DebugLevel)
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
 
 	suite.client, err = NewClient(suite.logger, nil)
 	suite.Require().NoError(err)

--- a/pkg/nubuild/build/build_test.go
+++ b/pkg/nubuild/build/build_test.go
@@ -44,14 +44,7 @@ type BuildSuite struct {
 }
 
 func (bs *BuildSuite) SetupSuite() {
-	var loggerLevel nucliozap.Level
-	if testing.Verbose() {
-		loggerLevel = nucliozap.DebugLevel
-	} else {
-		loggerLevel = nucliozap.InfoLevel
-	}
-
-	zap, err := nucliozap.NewNuclioZap("test-build", loggerLevel)
+	zap, err := nucliozap.NewNuclioZapTest("test-build")
 	bs.Require().NoError(err, "Can't create logger")
 	bs.logger = zap
 }

--- a/pkg/nubuild/build/env.go
+++ b/pkg/nubuild/build/env.go
@@ -193,7 +193,7 @@ func (e *env) isGoRuntime() bool {
 	processorConfigFilePath := filepath.Join(e.options.FunctionPath, processorConfigFileName)
 	processorConfig, err := processorconfig.ReadProcessorConfiguration(processorConfigFilePath)
 	if err != nil {
-		e.logger.WarnWith("Can't read processor configuration file", "error", err)
+		e.logger.DebugWith("Can't read processor configuration file", "error", err)
 		return true
 	}
 

--- a/pkg/nubuild/cmd.go
+++ b/pkg/nubuild/cmd.go
@@ -61,7 +61,7 @@ func NewNuclioBuildCommand() *cobra.Command {
 				loggerLevel = nucliozap.InfoLevel
 			}
 
-			zap, err := nucliozap.NewNuclioZap("cmd", loggerLevel)
+			zap, err := nucliozap.NewNuclioZapCmd("cmd", loggerLevel)
 			if err != nil {
 				return errors.Wrap(err, "Failed to create logger")
 			}

--- a/pkg/nubuild/eventhandlerparser/parse_test.go
+++ b/pkg/nubuild/eventhandlerparser/parse_test.go
@@ -80,15 +80,7 @@ type ParseSuite struct {
 }
 
 func (suite *ParseSuite) SetupSuite() {
-	var level nucliozap.Level
-
-	if testing.Verbose() {
-		level = nucliozap.DebugLevel
-	} else {
-		level = nucliozap.InfoLevel
-	}
-
-	zap, err := nucliozap.NewNuclioZap("parsereventhandler-test", level)
+	zap, err := nucliozap.NewNuclioZapTest("parsereventhandler-test")
 	suite.Require().NoError(err, "Can't craete logger")
 	suite.parser = NewEventHandlerParser(zap)
 }

--- a/pkg/nuctl/command/execute.go
+++ b/pkg/nuctl/command/execute.go
@@ -45,6 +45,14 @@ func newExecuteCommandeer(rootCommandeer *RootCommandeer) *executeCommandeer {
 				return errors.New("Function exec requires name")
 			}
 
+			// verify correctness of logger level
+			switch commandeer.executeOptions.LogLevelName {
+			case "debug", "info", "warn", "error":
+				break
+			default:
+				return errors.New("Invalid logger level name. Must be one of debug / info / warn / error")
+			}
+
 			// set common
 			commandeer.executeOptions.Common = &rootCommandeer.commonOptions
 			commandeer.executeOptions.Common.Identifier = args[0]
@@ -71,6 +79,7 @@ func newExecuteCommandeer(rootCommandeer *RootCommandeer) *executeCommandeer {
 	cmd.Flags().StringVarP(&commandeer.executeOptions.Method, "method", "m", "GET", "HTTP Method")
 	cmd.Flags().StringVarP(&commandeer.executeOptions.Body, "body", "b", "", "Message body")
 	cmd.Flags().StringVarP(&commandeer.executeOptions.Headers, "headers", "d", "", "HTTP headers (name=val1, ..)")
+	cmd.Flags().StringVarP(&commandeer.executeOptions.LogLevelName, "log-level", "l", "debug", "One of debug / info / warn / error")
 
 	commandeer.cmd = cmd
 

--- a/pkg/nuctl/command/execute.go
+++ b/pkg/nuctl/command/execute.go
@@ -47,7 +47,7 @@ func newExecuteCommandeer(rootCommandeer *RootCommandeer) *executeCommandeer {
 
 			// verify correctness of logger level
 			switch commandeer.executeOptions.LogLevelName {
-			case "debug", "info", "warn", "error":
+			case "none", "debug", "info", "warn", "error":
 				break
 			default:
 				return errors.New("Invalid logger level name. Must be one of debug / info / warn / error")
@@ -79,7 +79,7 @@ func newExecuteCommandeer(rootCommandeer *RootCommandeer) *executeCommandeer {
 	cmd.Flags().StringVarP(&commandeer.executeOptions.Method, "method", "m", "GET", "HTTP Method")
 	cmd.Flags().StringVarP(&commandeer.executeOptions.Body, "body", "b", "", "Message body")
 	cmd.Flags().StringVarP(&commandeer.executeOptions.Headers, "headers", "d", "", "HTTP headers (name=val1, ..)")
-	cmd.Flags().StringVarP(&commandeer.executeOptions.LogLevelName, "log-level", "l", "debug", "One of debug / info / warn / error")
+	cmd.Flags().StringVarP(&commandeer.executeOptions.LogLevelName, "log-level", "l", "info", "One of none / debug / info / warn / error")
 
 	commandeer.cmd = cmd
 

--- a/pkg/nuctl/command/execute.go
+++ b/pkg/nuctl/command/execute.go
@@ -50,7 +50,7 @@ func newExecuteCommandeer(rootCommandeer *RootCommandeer) *executeCommandeer {
 			case "none", "debug", "info", "warn", "error":
 				break
 			default:
-				return errors.New("Invalid logger level name. Must be one of debug / info / warn / error")
+				return errors.New("Invalid logger level name. Must be one of none / debug / info / warn / error")
 			}
 
 			// set common

--- a/pkg/nuctl/command/nuctl.go
+++ b/pkg/nuctl/command/nuctl.go
@@ -87,7 +87,15 @@ func (rc *RootCommandeer) getDefaultKubeconfigPath() (string, error) {
 }
 
 func (rc *RootCommandeer) createLogger() (nuclio.Logger, error) {
-	logger, err := nucliozap.NewNuclioZapTest("nuctl")
+	var loggerLevel nucliozap.Level
+
+	if rc.commonOptions.Verbose {
+		loggerLevel = nucliozap.DebugLevel
+	} else {
+		loggerLevel = nucliozap.InfoLevel
+	}
+
+	logger, err := nucliozap.NewNuclioZapCmd("nuctl", loggerLevel)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create logger")
 	}

--- a/pkg/nuctl/command/nuctl.go
+++ b/pkg/nuctl/command/nuctl.go
@@ -87,15 +87,7 @@ func (rc *RootCommandeer) getDefaultKubeconfigPath() (string, error) {
 }
 
 func (rc *RootCommandeer) createLogger() (nuclio.Logger, error) {
-	var loggerLevel nucliozap.Level
-
-	if rc.commonOptions.Verbose {
-		loggerLevel = nucliozap.DebugLevel
-	} else {
-		loggerLevel = nucliozap.InfoLevel
-	}
-
-	logger, err := nucliozap.NewNuclioZap("nuctl", loggerLevel)
+	logger, err := nucliozap.NewNuclioZapTest("nuctl")
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create logger")
 	}

--- a/pkg/nuctl/executor/function.go
+++ b/pkg/nuctl/executor/function.go
@@ -18,6 +18,8 @@ package executor
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -28,6 +30,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/nuctl"
 	"github.com/nuclio/nuclio/pkg/util/common"
 
+	"github.com/mgutz/ansi"
 	"github.com/nuclio/nuclio-sdk"
 	"github.com/pkg/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -110,6 +113,7 @@ func (fe *FunctionExecutor) Execute() error {
 	}
 
 	req.Header.Set("Content-Type", fe.options.ContentType)
+	req.Header.Set("X-nuclio-logs", "true")
 	headers := common.StringToStringMap(fe.options.Headers)
 	for k, v := range headers {
 		req.Header.Set(k, v)
@@ -122,15 +126,110 @@ func (fe *FunctionExecutor) Execute() error {
 
 	defer response.Body.Close()
 
+	fe.logger.InfoWith("Got response", "status", response.Status)
+
+	// try to output the logs (ignore errors
+	fe.outputFunctionLogs(response)
+
+	// output the headers
+	fe.outputResponseHeaders(response)
+
+	// output the boy
+	fe.outputResponseBody(response)
+
+	return nil
+}
+
+func (fe *FunctionExecutor) outputFunctionLogs(response *http.Response) error {
+
+	// the function logs should return as JSON
+	functionLogs := []map[string]interface{}{}
+
+	// wrap the contents in [] so that it appears as a JSON array
+	encodedFunctionLogs := "[" + response.Header.Get("X-nuclio-logs") + "]"
+
+	// parse the JSON into function logs
+	err := json.Unmarshal([]byte(encodedFunctionLogs), &functionLogs)
+	if err != nil {
+		return errors.Wrap(err, "Failed to parse logs")
+	}
+
+	if len(functionLogs) != 0 {
+		fe.logger.Info(">>> Start of function logs")
+	}
+
+	// iterate through all the logs
+	for _, functionLog := range functionLogs {
+		message := functionLog["message"].(string)
+		levelName := functionLog["level"].(string)
+		delete(functionLog, "message")
+		delete(functionLog, "level")
+
+		// convert args map to a slice of interfaces
+		args := fe.stringInterfaceMapToInterfaceSlice(functionLog)
+
+		// output to log by level
+		fe.getOutputByLevelName(levelName)(message, args...)
+	}
+
+	if len(functionLogs) != 0 {
+		fe.logger.Info("<<< End of function logs")
+	}
+
+	return nil
+}
+
+func (fe *FunctionExecutor) stringInterfaceMapToInterfaceSlice(input map[string]interface{}) []interface{} {
+	output := []interface{}{}
+
+	// convert the map to a flat slice of interfaces
+	for argName, argValue := range input {
+		output = append(output, argName)
+		output = append(output, argValue)
+	}
+
+	return output
+}
+
+func (fe *FunctionExecutor) getOutputByLevelName(levelName string) func(interface{}, ...interface{}) {
+	switch levelName {
+	case "info":
+		return fe.logger.InfoWith
+	case "warn":
+		return fe.logger.WarnWith
+	case "error":
+		return fe.logger.ErrorWith
+	default:
+		return fe.logger.DebugWith
+	}
+}
+
+func (fe *FunctionExecutor) outputResponseHeaders(response *http.Response) error {
+	fmt.Printf("\n%s\n", ansi.Color("> Response headers:", "blue+h"))
+
+	for headerName, headerValue := range response.Header {
+
+		// skip the log headers
+		if strings.ToLower(headerName) == strings.ToLower("X-Nuclio-Logs") {
+			continue
+		}
+
+		fmt.Printf("%s = %s\n", headerName, headerValue[0])
+	}
+
+	return nil
+}
+
+func (fe *FunctionExecutor) outputResponseBody(response *http.Response) error {
+
 	htmlData, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return err
 	}
 
-	fe.logger.InfoWith("Got response",
-		"status", response.Status,
-		"body", string(htmlData),
-	)
+	// Print raw body
+	fmt.Printf("\n%s\n", ansi.Color("> Response body:", "blue+h"))
+	fmt.Println(string(htmlData))
 
 	return nil
 }

--- a/pkg/nuctl/executor/function.go
+++ b/pkg/nuctl/executor/function.go
@@ -114,7 +114,12 @@ func (fe *FunctionExecutor) Execute() error {
 	}
 
 	req.Header.Set("Content-Type", fe.options.ContentType)
-	req.Header.Set("X-nuclio-log-level", fe.options.LogLevelName)
+
+	// request logs from a given verbosity unless we're specified no logs should be returned
+	if fe.options.LogLevelName != "none" {
+		req.Header.Set("X-nuclio-log-level", fe.options.LogLevelName)
+	}
+
 	headers := common.StringToStringMap(fe.options.Headers)
 	for k, v := range headers {
 		req.Header.Set(k, v)
@@ -129,8 +134,10 @@ func (fe *FunctionExecutor) Execute() error {
 
 	fe.logger.InfoWith("Got response", "status", response.Status)
 
-	// try to output the logs (ignore errors
-	fe.outputFunctionLogs(response)
+	// try to output the logs (ignore errors)
+	if fe.options.LogLevelName != "none" {
+		fe.outputFunctionLogs(response)
+	}
 
 	// output the headers
 	fe.outputResponseHeaders(response)

--- a/pkg/nuctl/executor/types.go
+++ b/pkg/nuctl/executor/types.go
@@ -19,11 +19,12 @@ package executor
 import "github.com/nuclio/nuclio/pkg/nuctl"
 
 type Options struct {
-	Common      *nucliocli.CommonOptions
-	ClusterIP   string
-	ContentType string
-	Url         string
-	Method      string
-	Body        string
-	Headers     string
+	Common       *nucliocli.CommonOptions
+	ClusterIP    string
+	ContentType  string
+	Url          string
+	Method       string
+	Body         string
+	Headers      string
+	LogLevelName string
 }

--- a/pkg/processor/eventsource/eventsource.go
+++ b/pkg/processor/eventsource/eventsource.go
@@ -59,6 +59,7 @@ func (aes *AbstractEventSource) GetKind() string {
 }
 
 func (aes *AbstractEventSource) SubmitEventToWorker(event nuclio.Event,
+	functionLogger nuclio.Logger,
 	timeout time.Duration) (response interface{}, submitError error, processError error) {
 
 	var workerInstance *worker.Worker
@@ -86,7 +87,7 @@ func (aes *AbstractEventSource) SubmitEventToWorker(event nuclio.Event,
 		return nil, errors.Wrap(err, "Failed to allocate worker"), nil
 	}
 
-	response, err = workerInstance.ProcessEvent(event)
+	response, err = workerInstance.ProcessEvent(event, functionLogger)
 	if err != nil {
 		processError = errors.Wrap(err, "Failed to process event")
 	}
@@ -98,6 +99,7 @@ func (aes *AbstractEventSource) SubmitEventToWorker(event nuclio.Event,
 }
 
 func (aes *AbstractEventSource) SubmitEventsToWorker(events []nuclio.Event,
+	functionLogger nuclio.Logger,
 	timeout time.Duration) (responses []interface{}, submitError error, processErrors []error) {
 
 	var workerInstance *worker.Worker
@@ -134,7 +136,7 @@ func (aes *AbstractEventSource) SubmitEventsToWorker(events []nuclio.Event,
 	// iterate over events and process them at the worker
 	for _, event := range events {
 
-		response, err := workerInstance.ProcessEvent(event)
+		response, err := workerInstance.ProcessEvent(event, functionLogger)
 
 		// add response and error
 		eventResponses = append(eventResponses, response)

--- a/pkg/processor/eventsource/generator/eventsource.go
+++ b/pkg/processor/eventsource/generator/eventsource.go
@@ -79,7 +79,7 @@ func (g *generator) generateEvents() error {
 
 	// for ever (for now)
 	for {
-		g.SubmitEventToWorker(&event, 10*time.Second)
+		g.SubmitEventToWorker(&event, nil, 10*time.Second)
 
 		var sleepMs int
 

--- a/pkg/processor/eventsource/http/eventsource.go
+++ b/pkg/processor/eventsource/http/eventsource.go
@@ -32,29 +32,23 @@ import (
 
 type http struct {
 	eventsource.AbstractEventSource
-	configuration *Configuration
-	event         Event
-	bufferLogger  *nucliozap.NuclioZap
-	bufferWriter  *bytes.Buffer
+	configuration    *Configuration
+	event            Event
+	bufferLoggerChan chan *bufferLogger
+}
+
+type bufferLogger struct {
+	logger *nucliozap.NuclioZap
+	writer *bytes.Buffer
 }
 
 func newEventSource(logger nuclio.Logger,
 	workerAllocator worker.WorkerAllocator,
 	configuration *Configuration) (eventsource.EventSource, error) {
 
-	bufferWriter := &bytes.Buffer{}
-
-	// create a logger that is able to capture the output into a buffer. if a request arrives
-	// and the user wishes to capture the log, this will be used as the logger instead of the default
-	// logger
-	bufferLogger, err := nucliozap.NewNuclioZap("function",
-		"json",
-		bufferWriter,
-		bufferWriter,
-		nucliozap.DebugLevel)
-
+	bufferLoggerChan, err := createBufferLoggerChan(configuration)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create buffer logger")
+		return nil, errors.Wrap(err, "Failed to create buffer loggers")
 	}
 
 	// we need a shareable allocator to support multiple go-routines. check that we were provided
@@ -70,10 +64,9 @@ func newEventSource(logger nuclio.Logger,
 			Class:           "sync",
 			Kind:            "http",
 		},
-		configuration: configuration,
-		event:         Event{},
-		bufferLogger:  bufferLogger,
-		bufferWriter:  bufferWriter,
+		configuration:    configuration,
+		event:            Event{},
+		bufferLoggerChan: bufferLoggerChan,
 	}
 
 	return &newEventSource, nil
@@ -96,7 +89,7 @@ func (h *http) Stop(force bool) (eventsource.Checkpoint, error) {
 
 func (h *http) requestHandler(ctx *fasthttp.RequestCtx) {
 	var functionLogger nuclio.Logger
-	var prevLevel nucliozap.Level
+	var bufferLogger *bufferLogger
 
 	// attach the context to the event
 	h.event.ctx = ctx
@@ -110,26 +103,26 @@ func (h *http) requestHandler(ctx *fasthttp.RequestCtx) {
 		// set the function logger to the runtime's logger capable of writing to a buffer
 		// TODO: we should have a logger wrapper that can write to multiple loggers. this way function logs
 		// get written both to the original function logger _and_ the HTTP stream
-		functionLogger = h.bufferLogger
-
-		// store previous level so we can restore it afterwards
-		prevLevel = h.bufferLogger.GetLevel()
+		bufferLogger = <-h.bufferLoggerChan
 
 		// set the logger level
-		h.bufferLogger.SetLevel(nucliozap.GetLevelByName(string(responseLogLevel)))
+		bufferLogger.logger.SetLevel(nucliozap.GetLevelByName(string(responseLogLevel)))
 
 		// reset the buffer writer
-		h.bufferWriter.Reset()
+		bufferLogger.writer.Reset()
+
+		// set the function logger to that of the chosen buffer logger
+		functionLogger = bufferLogger.logger
 	}
 
 	response, submitError, processError := h.SubmitEventToWorker(&h.event, functionLogger, 10*time.Second)
 
 	if responseLogLevel != nil {
-		logContents := h.bufferWriter.Bytes()
+		logContents := bufferLogger.writer.Bytes()
 		ctx.Response.Header.SetBytesV("X-nuclio-logs", logContents[:len(logContents)-1])
 
-		// restore the function logger level
-		h.bufferLogger.SetLevel(prevLevel)
+		// return the buffer logger to the pool
+		h.bufferLoggerChan <- bufferLogger
 	}
 
 	// if we failed to submit the event to a worker
@@ -183,4 +176,36 @@ func (h *http) requestHandler(ctx *fasthttp.RequestCtx) {
 	case string:
 		ctx.WriteString(typedResponse)
 	}
+}
+
+func createBufferLoggerChan(configuration *Configuration) (chan *bufferLogger, error) {
+
+	// will limit max number of concurrent HTTP invocations specifying logs returned
+	// TODO: possibly from configuration
+	numBufferLoggers := 4
+
+	// create a channel for the buffer loggers
+	bufferLoggersChan := make(chan *bufferLogger, numBufferLoggers)
+
+	for bufferLoggerIdx := 0; bufferLoggerIdx < numBufferLoggers; bufferLoggerIdx++ {
+		writer := &bytes.Buffer{}
+
+		// create a logger that is able to capture the output into a buffer. if a request arrives
+		// and the user wishes to capture the log, this will be used as the logger instead of the default
+		// logger
+		logger, err := nucliozap.NewNuclioZap("function",
+			"json",
+			writer,
+			writer,
+			nucliozap.DebugLevel)
+
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to create buffer logger")
+		}
+
+		// shove to channel
+		bufferLoggersChan <- &bufferLogger{logger, writer}
+	}
+
+	return bufferLoggersChan, nil
 }

--- a/pkg/processor/eventsource/poller/eventsource.go
+++ b/pkg/processor/eventsource/poller/eventsource.go
@@ -101,7 +101,7 @@ func (ap *AbstractPoller) getEventsSingleCycle() {
 
 			// send the batch to the worker
 			// eventResponses, submitError, eventErrors := ap.SubmitEventsToWorker(eventBatch, 10 * time.Second)
-			eventResponses, submitError, eventErrors := ap.SubmitEventsToWorker(eventBatch, 10*time.Second)
+			eventResponses, submitError, eventErrors := ap.SubmitEventsToWorker(eventBatch, nil, 10*time.Second)
 
 			if submitError != nil {
 				errors.Wrap(err, "Failed to submit events to worker")

--- a/pkg/processor/eventsource/rabbitmq/eventsource.go
+++ b/pkg/processor/eventsource/rabbitmq/eventsource.go
@@ -142,7 +142,7 @@ func (rmq *rabbitMq) handleBrokerMessages() {
 			rmq.event.message = &message
 
 			// submit to worker
-			_, submitError, processError := rmq.SubmitEventToWorker(&rmq.event, 10*time.Second)
+			_, submitError, processError := rmq.SubmitEventToWorker(&rmq.event, nil, 10*time.Second)
 
 			// TODO: do something with response and process error?
 			rmq.Logger.DebugWith("Processed message", "processError", processError)

--- a/pkg/processor/runtime/golang/event_handler/demo.go
+++ b/pkg/processor/runtime/golang/event_handler/demo.go
@@ -26,5 +26,5 @@ func demo(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
 
 // uncomment to register demo
 //func init() {
-// 	EventHandlers.Add("demo", demo)
+//	EventHandlers.Add("demo", demo)
 //}

--- a/pkg/processor/runtime/golang/event_handler/demo.go
+++ b/pkg/processor/runtime/golang/event_handler/demo.go
@@ -20,7 +20,10 @@ import (
 	"github.com/nuclio/nuclio-sdk"
 )
 
-func demo(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
+func Demo(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
+	context.Logger.DebugWith("Message1", "v", 1, "m", "01")
+	context.Logger.DebugWith("Message2", "v", 2, "m", "02")
+
 	return nil, nil
 }
 

--- a/pkg/processor/runtime/golang/event_handler/demo.go
+++ b/pkg/processor/runtime/golang/event_handler/demo.go
@@ -20,14 +20,11 @@ import (
 	"github.com/nuclio/nuclio-sdk"
 )
 
-func Demo(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
-	context.Logger.DebugWith("Message1", "v", 1, "m", "01")
-	context.Logger.DebugWith("Message2", "v", 2, "m", "02")
-
+func demo(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
 	return nil, nil
 }
 
 // uncomment to register demo
 //func init() {
-//	EventHandlers.Add("demo", demo)
+// 	EventHandlers.Add("demo", demo)
 //}

--- a/pkg/processor/runtime/python/encode_test.go
+++ b/pkg/processor/runtime/python/encode_test.go
@@ -122,7 +122,7 @@ type EventJSONEncoderSuite struct {
 }
 
 func (suite *EventJSONEncoderSuite) TestEncode() {
-	logger, err := nucliozap.NewNuclioZap("test", nucliozap.DebugLevel)
+	logger, err := nucliozap.NewNuclioZapTest("test")
 	suite.Require().NoError(err, "Can't create logger")
 
 	var buf bytes.Buffer

--- a/pkg/processor/runtime/python/runtime.go
+++ b/pkg/processor/runtime/python/runtime.go
@@ -206,7 +206,7 @@ func (py *python) pythonLog(log map[string]interface{}) {
 	}
 }
 
-func (py *python) ProcessEvent(event nuclio.Event) (interface{}, error) {
+func (py *python) ProcessEvent(event nuclio.Event, functionLogger nuclio.Logger) (interface{}, error) {
 	py.Logger.DebugWith("Executing python",
 		"name", py.configuration.Name,
 		"version", py.configuration.Version,

--- a/pkg/processor/runtime/runtime.go
+++ b/pkg/processor/runtime/runtime.go
@@ -21,22 +21,26 @@ import (
 )
 
 type Runtime interface {
-	ProcessEvent(event nuclio.Event) (interface{}, error)
+	ProcessEvent(event nuclio.Event, functionLogger nuclio.Logger) (interface{}, error)
 }
 
 type AbstractRuntime struct {
-	Logger  nuclio.Logger
-	Context *nuclio.Context
+	Logger         nuclio.Logger
+	FunctionLogger nuclio.Logger
+	Context        *nuclio.Context
 }
 
-func NewAbstractRuntime(logger nuclio.Logger, configuration *Configuration) (*AbstractRuntime, error) {
-	context, err := newContext(logger, configuration)
+func NewAbstractRuntime(logger nuclio.Logger,
+	configuration *Configuration) (*AbstractRuntime, error) {
+
+	context, err := newContext(configuration.FunctionLogger, configuration)
 	if err != nil {
 		return nil, err
 	}
 
 	return &AbstractRuntime{
-		Logger:  logger,
-		Context: context,
+		Logger:         logger,
+		FunctionLogger: configuration.FunctionLogger,
+		Context:        context,
 	}, nil
 }

--- a/pkg/processor/runtime/shell/runtime.go
+++ b/pkg/processor/runtime/shell/runtime.go
@@ -61,7 +61,7 @@ func NewRuntime(parentLogger nuclio.Logger, configuration *Configuration) (runti
 	return newShellRuntime, nil
 }
 
-func (s *shell) ProcessEvent(event nuclio.Event) (interface{}, error) {
+func (s *shell) ProcessEvent(event nuclio.Event, functionLogger nuclio.Logger) (interface{}, error) {
 	s.Logger.DebugWith("Executing shell",
 		"name", s.configuration.Name,
 		"version", s.configuration.Version,

--- a/pkg/processor/runtime/types.go
+++ b/pkg/processor/runtime/types.go
@@ -17,28 +17,32 @@ limitations under the License.
 package runtime
 
 import (
-	"github.com/nuclio/nuclio/pkg/functioncr"
-
-	"github.com/pkg/errors"
-	"github.com/spf13/viper"
 	"os"
 	"strings"
+
+	"github.com/nuclio/nuclio/pkg/functioncr"
+
+	"github.com/nuclio/nuclio-sdk"
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 )
 
 type Configuration struct {
-	Name         string
-	Version      string
-	Description  string
-	DataBindings map[string]*functioncr.DataBinding
+	Name           string
+	Version        string
+	Description    string
+	DataBindings   map[string]*functioncr.DataBinding
+	FunctionLogger nuclio.Logger
 }
 
 func NewConfiguration(configuration *viper.Viper) (*Configuration, error) {
 
 	newConfiguration := &Configuration{
-		Name:         configuration.GetString("name"),
-		Description:  configuration.GetString("description"),
-		Version:      configuration.GetString("version"),
-		DataBindings: map[string]*functioncr.DataBinding{},
+		Name:           configuration.GetString("name"),
+		Description:    configuration.GetString("description"),
+		Version:        configuration.GetString("version"),
+		DataBindings:   map[string]*functioncr.DataBinding{},
+		FunctionLogger: configuration.Get("function_logger").(nuclio.Logger),
 	}
 
 	// get databindings by environment variables

--- a/pkg/processor/worker/allocator_test.go
+++ b/pkg/processor/worker/allocator_test.go
@@ -32,7 +32,7 @@ type AllocatorTestSuite struct {
 }
 
 func (suite *AllocatorTestSuite) SetupSuite() {
-	suite.logger, _ = nucliozap.NewNuclioZap("test", nucliozap.DebugLevel)
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
 }
 
 func (suite *AllocatorTestSuite) TestSingletonAllocator() {

--- a/pkg/processor/worker/factory.go
+++ b/pkg/processor/worker/factory.go
@@ -84,7 +84,7 @@ func (waf *WorkerFactory) createWorker(parentLogger nuclio.Logger,
 		return nil, errors.Wrap(err, "Failed to create runtime")
 	}
 
-	return NewWorker(workerLogger, workerIndex, runtimeInstance), nil
+	return NewWorker(workerLogger, workerIndex, runtimeInstance)
 }
 
 func (waf *WorkerFactory) createWorkers(logger nuclio.Logger,

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -30,7 +30,7 @@ type Worker struct {
 
 func NewWorker(parentLogger nuclio.Logger,
 	index int,
-	runtime runtime.Runtime) *Worker {
+	runtime runtime.Runtime) (*Worker, error) {
 
 	newWorker := Worker{
 		logger:  parentLogger,
@@ -42,15 +42,15 @@ func NewWorker(parentLogger nuclio.Logger,
 	}
 
 	// return an instance of the default worker
-	return &newWorker
+	return &newWorker, nil
 }
 
 // called by event sources
-func (w *Worker) ProcessEvent(evt nuclio.Event) (interface{}, error) {
-	evt.SetID(nuclio.NewID())
+func (w *Worker) ProcessEvent(event nuclio.Event, functionLogger nuclio.Logger) (interface{}, error) {
+	event.SetID(nuclio.NewID())
 
 	// process the event at the runtime
-	response, err := w.runtime.ProcessEvent(evt)
+	response, err := w.runtime.ProcessEvent(event, functionLogger)
 
 	return response, err
 }

--- a/pkg/processor/worker/worker_test.go
+++ b/pkg/processor/worker/worker_test.go
@@ -30,8 +30,8 @@ type MockRuntime struct {
 	mock.Mock
 }
 
-func (mr *MockRuntime) ProcessEvent(event nuclio.Event) (interface{}, error) {
-	args := mr.Called(event)
+func (mr *MockRuntime) ProcessEvent(event nuclio.Event, functionLogger nuclio.Logger) (interface{}, error) {
+	args := mr.Called(event, functionLogger)
 	return args.Get(0), args.Error(1)
 }
 
@@ -46,14 +46,14 @@ func (suite *WorkerTestSuite) SetupSuite() {
 
 func (suite *WorkerTestSuite) TestProcessEvent() {
 	mockRuntime := MockRuntime{}
-	worker := NewWorker(suite.logger, 100, &mockRuntime)
+	worker, _ := NewWorker(suite.logger, 100, &mockRuntime)
 	event := &nuclio.AbstractEvent{}
 
 	// expect the mock process event to be called with the event
-	mockRuntime.On("ProcessEvent", event).Return(nil, nil).Once()
+	mockRuntime.On("ProcessEvent", event, suite.logger).Return(nil, nil).Once()
 
 	// process the event
-	worker.ProcessEvent(event)
+	worker.ProcessEvent(event, suite.logger)
 
 	// make sure all expectations are met
 	mockRuntime.AssertExpectations(suite.T())

--- a/pkg/processor/worker/worker_test.go
+++ b/pkg/processor/worker/worker_test.go
@@ -41,7 +41,7 @@ type WorkerTestSuite struct {
 }
 
 func (suite *WorkerTestSuite) SetupSuite() {
-	suite.logger, _ = nucliozap.NewNuclioZap("test", nucliozap.DebugLevel)
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
 }
 
 func (suite *WorkerTestSuite) TestProcessEvent() {

--- a/pkg/util/cmdrunner/cmdrunner_test.go
+++ b/pkg/util/cmdrunner/cmdrunner_test.go
@@ -37,7 +37,7 @@ type CmdRunnerTestSuite struct {
 func (suite *CmdRunnerTestSuite) SetupTest() {
 	var err error
 
-	suite.logger, _ = nucliozap.NewNuclioZap("test", nucliozap.ErrorLevel)
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
 	suite.commandRunner, err = NewCmdRunner(suite.logger)
 	if err != nil {
 		panic("Failed to create command runner")

--- a/pkg/zap/logger_test.go
+++ b/pkg/zap/logger_test.go
@@ -25,7 +25,7 @@ import (
 func TestSimpleLogging(t *testing.T) {
 	var baseLogger nuclio.Logger
 
-	baseLogger, err := NewNuclioZap("test", DebugLevel)
+	baseLogger, err := NewNuclioZapTest("test")
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/e2e/python/python_test.go
+++ b/test/e2e/python/python_test.go
@@ -32,14 +32,7 @@ func (suite *PythonHandlerSuite) gitRoot() string {
 }
 
 func (suite *PythonHandlerSuite) SetupSuite() {
-	var loggerLevel nucliozap.Level
-
-	if testing.Verbose() {
-		loggerLevel = nucliozap.DebugLevel
-	} else {
-		loggerLevel = nucliozap.InfoLevel
-	}
-	zap, err := nucliozap.NewNuclioZap("end2end", loggerLevel)
+	zap, err := nucliozap.NewNuclioZapTest("end2end")
 	suite.Require().NoError(err, "Can't create logger")
 	suite.logger = zap
 	cmd, err := cmdrunner.NewCmdRunner(suite.logger)

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -216,14 +216,7 @@ func (suite *End2EndTestSuite) nodePort() int {
 }
 
 func (suite *End2EndTestSuite) SetupSuite() {
-	var loggerLevel nucliozap.Level
-
-	if testing.Verbose() {
-		loggerLevel = nucliozap.DebugLevel
-	} else {
-		loggerLevel = nucliozap.InfoLevel
-	}
-	zap, err := nucliozap.NewNuclioZap("end2end", loggerLevel)
+	zap, err := nucliozap.NewNuclioZapTest("end2end")
 	suite.failOnError(err, "Can't create logger")
 	suite.logger = zap
 	cmd, err := cmdrunner.NewCmdRunner(suite.logger)

--- a/test/suite/suite.go
+++ b/test/suite/suite.go
@@ -25,14 +25,7 @@ func (suite *NuclioTestSuite) gitRoot() string {
 }
 
 func (suite *NuclioTestSuite) SetupSuite() {
-	var loggerLevel nucliozap.Level
-
-	if testing.Verbose() {
-		loggerLevel = nucliozap.DebugLevel
-	} else {
-		loggerLevel = nucliozap.InfoLevel
-	}
-	zap, err := nucliozap.NewNuclioZap("nuclio-test", loggerLevel)
+	zap, err := nucliozap.NewNuclioZapTest("nuclio-test")
 	suite.Require().NoError(err, "Can't create logger")
 	suite.Logger = zap
 	cmd, err := cmdrunner.NewCmdRunner(suite.Logger)

--- a/vendor/github.com/iguazio/v3io-go-http/context_test.go
+++ b/vendor/github.com/iguazio/v3io-go-http/context_test.go
@@ -23,7 +23,7 @@ type ContextTestSuite struct {
 func (suite *ContextTestSuite) SetupTest() {
 	var err error
 
-	suite.logger, err = nucliozap.NewNuclioZap("test", nucliozap.DebugLevel)
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
 
 	suite.context, err = NewContext(suite.logger, "192.168.51.240:8081", 8)
 	suite.Require().NoError(err, "Failed to create context")

--- a/vendor/github.com/iguazio/v3io-go-http/synccontext_test.go
+++ b/vendor/github.com/iguazio/v3io-go-http/synccontext_test.go
@@ -24,7 +24,7 @@ type SyncContextTestSuite struct {
 func (suite *SyncContextTestSuite) SetupTest() {
 	var err error
 
-	suite.logger, err = nucliozap.NewNuclioZap("test", nucliozap.DebugLevel)
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
 
 	suite.context, err = NewContext(suite.logger, "192.168.51.240:8081", 1)
 	suite.Require().NoError(err, "Failed to create context")


### PR DESCRIPTION
1. NuclioZap now has two helper functions to create common logger configurations for tests and commands. The test configuration respects the test verbosity setting
2. A processor now has two loggers - one for internal processor logging and one for function invocations (passed in context). As of now, they both point to the same underlying logger instance
3. Function invocations through a worker (and a runtime) accept an optional function logger override 
4. HTTP event sources have a pool of logger instances which are set up to output to a buffer and encode logs as JSON. The event source looks for a `X-nuclio-log-level` header in the request. If it exists, it will pull a buffer logger from the pool, set its severity and specify it as the function logger override to the worker. Once the invocation is complete, it will encode the comma separated JSON result (held in the buffer logger) to `X-nuclio-logs` in the response. Through this, it is possible to specify log levels per HTTP invocation and receive the logs in the response
5. nuctl exec receives `--log-level` argument that specifies which log level the execution should request back

Fixes #153.