### PR TITLE
nuctl run overhaul

### DIFF
--- a/pkg/nubuild/build/build.go
+++ b/pkg/nubuild/build/build.go
@@ -135,8 +135,6 @@ func (b *Builder) buildDockerSteps(env *env, outputToImage bool) error {
 		return errors.Wrap(err, "Error building docker helper")
 	}
 
-	defer docker.close()
-
 	buildSteps := []buildStep{
 		{Message: "Preparing docker base images", Func: docker.createOnBuildImage},
 		{Message: "Building processor (in docker)", Func: docker.createProcessorBinary},

--- a/pkg/nubuild/build/docker.go
+++ b/pkg/nubuild/build/docker.go
@@ -17,7 +17,6 @@ limitations under the License.
 package build
 
 import (
-	"bufio"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -34,8 +33,8 @@ import (
 )
 
 const (
-	onBuildImageName       = "nuclio/nuclio:onbuild"
-	builderOutputImageName = "nuclio/builder-output"
+	onBuildImageName           = "nuclio/nuclio:onbuild"
+	binaryBuilderImageName     = "nuclio/builder-output"
 )
 
 type dockerHelper struct {
@@ -99,10 +98,10 @@ func (d *dockerHelper) createOnBuildImage() error {
 func (d *dockerHelper) buildBinaryBuilder() error {
 	buildContext := d.env.getNuclioDir()
 	options := buildOptions{
-		Tag:        builderOutputImageName,
+		Tag:        binaryBuilderImageName,
 		Dockerfile: filepath.Join("hack", "processor", "build", "builder", "Dockerfile"),
 	}
-	return d.doBuild(builderOutputImageName, buildContext, &options)
+	return d.doBuild(binaryBuilderImageName, buildContext, &options)
 }
 
 func (d *dockerHelper) createProcessorBinary() error {
@@ -114,11 +113,17 @@ func (d *dockerHelper) createProcessorBinary() error {
 		return err
 	}
 
+	// whatever happens, clear the builder image
+	defer d.removeBinaryBuilderImage()
+
 	// create a stopped container from the image so that we may extract processor binary
 	binaryBuilderContainerID, err := d.createBinaryBuilderContainer()
 	if err != nil {
 		return err
 	}
+
+	// whatever happens, clear the builder image
+	defer d.removeBinaryBuilderContainer(binaryBuilderContainerID)
 
 	destDir := d.env.getWorkDir()
 
@@ -150,14 +155,25 @@ func (d *dockerHelper) createProcessorBinary() error {
 }
 
 func (d *dockerHelper) createBinaryBuilderContainer() (string, error) {
-	d.logger.DebugWith("Creating container for image", "name", builderOutputImageName)
+	d.logger.DebugWith("Creating container for image", "name", binaryBuilderImageName)
 
-	out, err := d.cmdRunner.Run(nil, "docker create %s", builderOutputImageName)
+	out, err := d.cmdRunner.Run(nil, "docker create %s", binaryBuilderImageName)
+
 	if err != nil {
 		return "", errors.Wrap(err, "Unable to create builder container.")
 	}
 
 	return strings.TrimSpace(out), nil
+}
+
+func (d *dockerHelper) removeBinaryBuilderImage() error {
+	_, err := d.cmdRunner.Run(nil, "docker rmi -f %s", binaryBuilderImageName)
+	return err
+}
+
+func (d *dockerHelper) removeBinaryBuilderContainer(containerID string) error {
+	_, err := d.cmdRunner.Run(nil, "docker rm -f %s", containerID)
+	return err
 }
 
 func (d *dockerHelper) copyFileFromContainer(containerID string, containerPath string, destPath string) error {
@@ -293,31 +309,7 @@ func (d *dockerHelper) createProcessorImage() error {
 	return nil
 }
 
-func (d *dockerHelper) cleanupBuilder() {
-	out, err := d.cmdRunner.Run(nil, "docker ps -a --filter ancestor=%s --format {{.ID}}", builderOutputImageName)
-	if err != nil {
-		d.logger.WarnWith("Can't list containers", "image", builderOutputImageName, "error", err)
-		return
-	}
-	scanner := bufio.NewScanner(strings.NewReader(out))
-	for scanner.Scan() {
-		containerID := strings.TrimSpace(scanner.Text())
-		if len(containerID) == 0 {
-			continue
-		}
-		d.logger.DebugWith("Deleting container", "id", containerID)
-		if _, err := d.cmdRunner.Run(nil, "docker rm %s", containerID); err != nil {
-			d.logger.WarnWith("Can't delete container", "id", containerID, "error", err)
-		}
-	}
-
-	if err = scanner.Err(); err != nil {
-		d.logger.WarnWith("Can't scan docker output", "error", err)
-	}
-}
-
 func (d *dockerHelper) close() {
-	d.cleanupBuilder()
 }
 
 func (d *dockerHelper) pushImage(imageName, registryURL string) error {

--- a/pkg/nuctl/builder/function.go
+++ b/pkg/nuctl/builder/function.go
@@ -48,7 +48,7 @@ func (fb *FunctionBuilder) Execute() error {
 		Version:         fb.options.ImageVersion,
 		NuclioSourceDir: fb.options.NuclioSourceDir,
 		NuclioSourceURL: fb.options.NuclioSourceURL,
-		PushRegistry:    fb.options.PushRegistry,
+		PushRegistry:    fb.options.Registry,
 	}
 
 	// if output name isn't set, use identifier

--- a/pkg/nuctl/builder/function.go
+++ b/pkg/nuctl/builder/function.go
@@ -44,11 +44,16 @@ func (fb *FunctionBuilder) Execute() error {
 		Verbose:         fb.options.Common.Verbose,
 		FunctionPath:    fb.options.Path,
 		OutputType:      fb.options.OutputType,
-		OutputName:      fb.options.Common.Identifier,
-		Version:         "latest",
+		OutputName:      fb.options.ImageName,
+		Version:         fb.options.ImageVersion,
 		NuclioSourceDir: fb.options.NuclioSourceDir,
 		NuclioSourceURL: fb.options.NuclioSourceURL,
 		PushRegistry:    fb.options.PushRegistry,
+	}
+
+	// if output name isn't set, use identifier
+	if buildOptions.OutputName == "" {
+		buildOptions.OutputName = fb.options.Common.Identifier
 	}
 
 	// execute a build

--- a/pkg/nuctl/builder/types.go
+++ b/pkg/nuctl/builder/types.go
@@ -28,4 +28,5 @@ type Options struct {
 	NuclioSourceURL string
 	PushRegistry    string
 	ImageName       string
+	ImageVersion    string
 }

--- a/pkg/nuctl/builder/types.go
+++ b/pkg/nuctl/builder/types.go
@@ -26,7 +26,7 @@ type Options struct {
 	OutputType      string
 	NuclioSourceDir string
 	NuclioSourceURL string
-	PushRegistry    string
+	Registry        string
 	ImageName       string
 	ImageVersion    string
 }

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -76,7 +76,8 @@ func newBuildCommandeer(rootCommandeer *RootCommandeer) *buildCommandeer {
 
 func addBuildFlags(cmd *cobra.Command, options *builder.Options) {
 	cmd.Flags().StringVarP(&options.Path, "path", "p", "", "Function source code path")
-	cmd.Flags().StringVarP(&options.ImageName, "image", "i", "", "Container image to use, will use function name if not specified")
+	cmd.Flags().StringVarP(&options.ImageName, "image", "i", "", "Docker image name, will use function name if not specified")
+	cmd.Flags().StringVar(&options.ImageVersion, "version", "latest", "Docker image version")
 	cmd.Flags().StringVarP(&options.OutputType, "output", "o", "docker", "Build output type - docker|binary")
 	cmd.Flags().StringVarP(&options.PushRegistry, "registry", "r", os.Getenv("PUSH_REGISTRY"), "URL of container registry (for push)")
 	cmd.Flags().StringVar(&options.NuclioSourceDir, "nuclio-src-dir", "", "Local directory with nuclio sources (avoid cloning)")

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -79,7 +79,7 @@ func addBuildFlags(cmd *cobra.Command, options *builder.Options) {
 	cmd.Flags().StringVarP(&options.ImageName, "image", "i", "", "Docker image name, will use function name if not specified")
 	cmd.Flags().StringVar(&options.ImageVersion, "version", "latest", "Docker image version")
 	cmd.Flags().StringVarP(&options.OutputType, "output", "o", "docker", "Build output type - docker|binary")
-	cmd.Flags().StringVarP(&options.PushRegistry, "registry", "r", os.Getenv("PUSH_REGISTRY"), "URL of container registry (for push)")
+	cmd.Flags().StringVarP(&options.Registry, "registry", "r", os.Getenv("NUCTL_REGISTRY"), "URL of container registry (env: NUCTL_REGISTRY)")
 	cmd.Flags().StringVar(&options.NuclioSourceDir, "nuclio-src-dir", "", "Local directory with nuclio sources (avoid cloning)")
 	cmd.Flags().StringVar(&options.NuclioSourceURL, "nuclio-src-url", "https://github.com/nuclio/nuclio.git", "nuclio sources url for git clone")
 }

--- a/pkg/nuctl/command/run.go
+++ b/pkg/nuctl/command/run.go
@@ -17,11 +17,13 @@ limitations under the License.
 package command
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
 	"github.com/nuclio/nuclio/pkg/functioncr"
 	"github.com/nuclio/nuclio/pkg/nuctl/runner"
+	"github.com/nuclio/nuclio/pkg/nuctl"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -42,82 +44,10 @@ func newRunCommandeer(rootCommandeer *RootCommandeer) *runCommandeer {
 		Use:   "run function-name",
 		Short: "Build, deploy and run a function",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			functionName := ""
-			var specRegistryURL, specImageName, specImageVersion string
-			var err error
-
-			// if the spec path was set, load the spec
-			if commandeer.runOptions.SpecPath != "" {
-				err := functioncr.FromSpecFile(commandeer.runOptions.SpecPath, &commandeer.runOptions.Spec)
-				if err != nil {
-					return errors.Wrap(err, "Failed to read spec file")
-				}
+			err := prepareRunnerOptions(args, &rootCommandeer.commonOptions, &commandeer.runOptions)
+			if err != nil {
+				return err
 			}
-
-			// name can either be a positional argument or passed in the spec
-			if len(args) != 1 {
-				if commandeer.runOptions.Spec.ObjectMeta.Name == "" {
-					return errors.New("Function run requires name")
-				}
-
-				// use name from spec
-				functionName = commandeer.runOptions.Spec.ObjectMeta.Name
-
-			} else {
-				functionName = args[0]
-			}
-
-			// function can either be in the path or received inline
-			if commandeer.runOptions.Build.Path == "" && commandeer.runOptions.Spec.Spec.Code.Inline == "" {
-				return errors.New("Function code must be provided either in path or inline in a spec file")
-			}
-
-			// the image in the specfile can hold both the image name and the push/run registry. check that if it's
-			// empty, we have what we need from command line arguments
-			if commandeer.runOptions.Spec.Spec.Image == "" {
-
-				if commandeer.runOptions.Build.Registry == "" {
-					return errors.New("Registry is required (can also be specified in spec.image or a NUCTL_REGISTRY env var")
-				}
-
-				if commandeer.runOptions.Build.ImageName == "" {
-
-					// use the function name if image name not provided in specfile
-					commandeer.runOptions.Build.ImageName = functionName
-				}
-			} else {
-
-				// parse the image passed in the spec - we might need it
-				specRegistryURL, specImageName, specImageVersion, err = parseImageURL(commandeer.runOptions.Spec.Spec.Image)
-				if err != nil {
-					return errors.Wrap(err, "Failed to parse image URL")
-				}
-			}
-
-			// if the image name was not provided in command line / env, take it from the spec image
-			if commandeer.runOptions.Build.ImageName == "" {
-				commandeer.runOptions.Build.ImageName = specImageName
-			}
-
-			// same for version
-			if commandeer.runOptions.Build.ImageVersion == "latest" && specImageVersion != "" {
-				commandeer.runOptions.Build.ImageVersion = specImageVersion
-			}
-
-			// same for push registry
-			if commandeer.runOptions.Build.Registry == "" {
-				commandeer.runOptions.Build.Registry = specRegistryURL
-			}
-
-			// if the run registry wasn't specified, take the build registry
-			if commandeer.runOptions.RunRegistry == "" {
-				commandeer.runOptions.RunRegistry = commandeer.runOptions.Build.Registry
-			}
-
-			// set common
-			commandeer.runOptions.Build.Common = &rootCommandeer.commonOptions
-			commandeer.runOptions.Common = &rootCommandeer.commonOptions
-			commandeer.runOptions.Common.Identifier = functionName
 
 			// create logger
 			logger, err := rootCommandeer.createLogger()
@@ -140,6 +70,90 @@ func newRunCommandeer(rootCommandeer *RootCommandeer) *runCommandeer {
 	commandeer.cmd = cmd
 
 	return commandeer
+}
+
+func prepareRunnerOptions(args []string,
+	commonOptions *nucliocli.CommonOptions,
+	runOptions *runner.Options) error {
+
+	functionName := ""
+	var specRegistryURL, specImageName, specImageVersion string
+	var err error
+
+	// if the spec path was set, load the spec
+	if runOptions.SpecPath != "" {
+		err := functioncr.FromSpecFile(runOptions.SpecPath, &runOptions.Spec)
+		if err != nil {
+			return errors.Wrap(err, "Failed to read spec file")
+		}
+	}
+
+	// name can either be a positional argument or passed in the spec
+	if len(args) != 1 {
+		if runOptions.Spec.ObjectMeta.Name == "" {
+			return errors.New("Function run requires name")
+		}
+
+		// use name from spec
+		functionName = runOptions.Spec.ObjectMeta.Name
+
+	} else {
+		functionName = args[0]
+	}
+
+	// function can either be in the path or received inline
+	if runOptions.Build.Path == "" && runOptions.Spec.Spec.Code.Inline == "" {
+		return errors.New("Function code must be provided either in path or inline in a spec file")
+	}
+
+	// the image in the specfile can hold both the image name and the push/run registry. check that if it's
+	// empty, we have what we need from command line arguments
+	if runOptions.Spec.Spec.Image == "" {
+
+		if runOptions.Build.Registry == "" {
+			return errors.New("Registry is required (can also be specified in spec.image or a NUCTL_REGISTRY env var")
+		}
+
+		if runOptions.Build.ImageName == "" {
+
+			// use the function name if image name not provided in specfile
+			runOptions.Build.ImageName = functionName
+		}
+	} else {
+
+		// parse the image passed in the spec - we might need it
+		specRegistryURL, specImageName, specImageVersion, err = parseImageURL(runOptions.Spec.Spec.Image)
+		if err != nil {
+			return fmt.Errorf("Failed to parse image URL: %s", err.Error())
+		}
+	}
+
+	// if the image name was not provided in command line / env, take it from the spec image
+	if runOptions.Build.ImageName == "" {
+		runOptions.Build.ImageName = specImageName
+	}
+
+	// same for version
+	if runOptions.Build.ImageVersion == "latest" && specImageVersion != "" {
+		runOptions.Build.ImageVersion = specImageVersion
+	}
+
+	// same for push registry
+	if runOptions.Build.Registry == "" {
+		runOptions.Build.Registry = specRegistryURL
+	}
+
+	// if the run registry wasn't specified, take the build registry
+	if runOptions.RunRegistry == "" {
+		runOptions.RunRegistry = runOptions.Build.Registry
+	}
+
+	// set common
+	runOptions.Build.Common = commonOptions
+	runOptions.Common = commonOptions
+	runOptions.Common.Identifier = functionName
+
+	return nil
 }
 
 func parseImageURL(imageURL string) (url string, imageName string, imageVersion string, err error) {

--- a/pkg/nuctl/command/run_test.go
+++ b/pkg/nuctl/command/run_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"testing"
+	"os"
+	"io/ioutil"
+
+	"github.com/nuclio/nuclio-sdk"
+	"github.com/nuclio/nuclio/pkg/zap"
+	"github.com/nuclio/nuclio/pkg/nuctl"
+	"github.com/nuclio/nuclio/pkg/nuctl/runner"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type RunTestSuite struct {
+	suite.Suite
+	logger nuclio.Logger
+	commonOptions nucliocli.CommonOptions
+	runOptions runner.Options
+}
+
+func (suite *RunTestSuite) SetupTest() {
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
+
+	suite.commonOptions = nucliocli.CommonOptions{}
+	suite.runOptions = runner.Options{}
+
+	// by default image version is latest, as set by cobra
+	suite.runOptions.Build.ImageVersion = "latest"
+}
+
+func (suite *RunTestSuite) TestRunFromSpecFile() {
+	specFilePath := suite.createSpecFile(`
+apiVersion: nuclio.io/v1
+kind: Function
+metadata:
+  name: function-name
+spec:
+  image: 5.5.5.5:2000/image-name:image-version`)
+
+	defer os.Remove(specFilePath)
+
+	// only set spec file path and code path
+	suite.runOptions.SpecPath = specFilePath
+	suite.runOptions.Build.Path = "f.go"
+
+	err := prepareRunnerOptions([]string{}, &suite.commonOptions, &suite.runOptions)
+	suite.Require().NoError(err)
+
+	suite.Require().Equal("function-name", suite.runOptions.Common.Identifier)
+	suite.Require().Equal("5.5.5.5:2000", suite.runOptions.Build.Registry)
+	suite.Require().Equal("image-name", suite.runOptions.Build.ImageName)
+	suite.Require().Equal("image-version", suite.runOptions.Build.ImageVersion)
+	suite.Require().Equal("5.5.5.5:2000", suite.runOptions.RunRegistry)
+}
+
+func (suite *RunTestSuite) TestRunFromSpecFileWithRunRegistry() {
+	specFilePath := suite.createSpecFile(`
+apiVersion: nuclio.io/v1
+kind: Function
+metadata:
+  name: function-name
+spec:
+  image: 5.5.5.5:2000/image-name:image-version`)
+
+	defer os.Remove(specFilePath)
+
+	suite.runOptions.SpecPath = specFilePath
+	suite.runOptions.Build.Path = "f.go"
+	suite.runOptions.RunRegistry = "1.1.1.1:9000"
+
+	err := prepareRunnerOptions([]string{}, &suite.commonOptions, &suite.runOptions)
+	suite.Require().NoError(err)
+
+	suite.Require().Equal("function-name", suite.runOptions.Common.Identifier)
+	suite.Require().Equal("5.5.5.5:2000", suite.runOptions.Build.Registry)
+	suite.Require().Equal("image-name", suite.runOptions.Build.ImageName)
+	suite.Require().Equal("image-version", suite.runOptions.Build.ImageVersion)
+	suite.Require().Equal("1.1.1.1:9000", suite.runOptions.RunRegistry)
+}
+
+func (suite *RunTestSuite) TestRunPushRegistryAndFuncName() {
+	suite.runOptions.Build.Path = "f.go"
+	suite.runOptions.Build.Registry = "5.5.5.5:2000"
+
+	err := prepareRunnerOptions([]string{"function-name"}, &suite.commonOptions, &suite.runOptions)
+	suite.Require().NoError(err)
+
+	suite.Require().Equal("function-name", suite.runOptions.Common.Identifier)
+	suite.Require().Equal("5.5.5.5:2000", suite.runOptions.Build.Registry)
+	suite.Require().Equal("function-name", suite.runOptions.Build.ImageName)
+	suite.Require().Equal("latest", suite.runOptions.Build.ImageVersion)
+	suite.Require().Equal("5.5.5.5:2000", suite.runOptions.RunRegistry)
+}
+
+func (suite *RunTestSuite) TestRunPushRegistryRunRegistryAndFuncName() {
+	suite.runOptions.Build.Path = "f.go"
+	suite.runOptions.Build.Registry = "5.5.5.5:2000"
+	suite.runOptions.RunRegistry = "1.1.1.1:9000"
+
+	err := prepareRunnerOptions([]string{"function-name"}, &suite.commonOptions, &suite.runOptions)
+	suite.Require().NoError(err)
+
+	suite.Require().Equal("function-name", suite.runOptions.Common.Identifier)
+	suite.Require().Equal("5.5.5.5:2000", suite.runOptions.Build.Registry)
+	suite.Require().Equal("function-name", suite.runOptions.Build.ImageName)
+	suite.Require().Equal("latest", suite.runOptions.Build.ImageVersion)
+	suite.Require().Equal("1.1.1.1:9000", suite.runOptions.RunRegistry)
+}
+
+func (suite *RunTestSuite) TestRunPushRegistryRunRegistryImageVersionAndFuncName() {
+	suite.runOptions.Build.Path = "f.go"
+	suite.runOptions.Build.Registry = "5.5.5.5:2000"
+	suite.runOptions.Build.ImageName = "image-name"
+	suite.runOptions.Build.ImageVersion = "image-version"
+	suite.runOptions.RunRegistry = "1.1.1.1:9000"
+
+	err := prepareRunnerOptions([]string{"function-name"}, &suite.commonOptions, &suite.runOptions)
+	suite.Require().NoError(err)
+
+	suite.Require().Equal("function-name", suite.runOptions.Common.Identifier)
+	suite.Require().Equal("5.5.5.5:2000", suite.runOptions.Build.Registry)
+	suite.Require().Equal("image-name", suite.runOptions.Build.ImageName)
+	suite.Require().Equal("image-version", suite.runOptions.Build.ImageVersion)
+	suite.Require().Equal("1.1.1.1:9000", suite.runOptions.RunRegistry)
+}
+
+func (suite *RunTestSuite) TestErrInvalidSpecFile() {
+	specFilePath := suite.createSpecFile(`
+	invalid
+	---contents`)
+
+	defer os.Remove(specFilePath)
+
+	suite.runOptions.SpecPath = specFilePath
+	suite.runOptions.Build.Path = "f.go"
+
+	err := prepareRunnerOptions([]string{}, &suite.commonOptions, &suite.runOptions)
+	suite.Require().Error(err)
+}
+
+func (suite *RunTestSuite) TestErrNoSpecFileNoArguments() {
+	suite.runOptions.Build.Path = "f.go"
+
+	err := prepareRunnerOptions([]string{}, &suite.commonOptions, &suite.runOptions)
+	suite.Require().Equal("Function run requires name", err.Error())
+}
+
+func (suite *RunTestSuite) TestErrNoSpecImageNoBuildRegistry() {
+	specFilePath := suite.createSpecFile(`
+apiVersion: nuclio.io/v1
+kind: Function
+metadata:
+  name: function-name
+`)
+
+	defer os.Remove(specFilePath)
+
+	suite.runOptions.SpecPath = specFilePath
+	suite.runOptions.Build.Path = "f.go"
+
+	err := prepareRunnerOptions([]string{}, &suite.commonOptions, &suite.runOptions)
+	suite.Require().Equal("Registry is required (can also be specified in spec.image or a NUCTL_REGISTRY env var", err.Error())
+}
+
+func (suite *RunTestSuite) TestErrNoPathAndNoInline() {
+	specFilePath := suite.createSpecFile(`
+apiVersion: nuclio.io/v1
+kind: Function
+metadata:
+  name: function-name
+spec:
+  image: 5.5.5.5:2000/image-name:image-version`)
+
+	defer os.Remove(specFilePath)
+
+	suite.runOptions.SpecPath = specFilePath
+
+	err := prepareRunnerOptions([]string{}, &suite.commonOptions, &suite.runOptions)
+	suite.Require().Equal("Function code must be provided either in path or inline in a spec file", err.Error())
+}
+
+func (suite *RunTestSuite) TestErrInvalidSpecImage() {
+	specFilePath := suite.createSpecFile(`
+apiVersion: nuclio.io/v1
+kind: Function
+metadata:
+  name: function-name
+spec:
+  image: notavalidimage`)
+
+	defer os.Remove(specFilePath)
+
+	suite.runOptions.SpecPath = specFilePath
+	suite.runOptions.Build.Path = "f.go"
+
+	err := prepareRunnerOptions([]string{}, &suite.commonOptions, &suite.runOptions)
+	suite.Require().Equal("Failed to parse image URL: Failed looking for image splitter: /", err.Error())
+}
+
+func (suite *RunTestSuite) createSpecFile(contents string) string {
+	file, err := ioutil.TempFile("", "specfile")
+	suite.Require().NoError(err)
+
+	defer file.Close()
+
+	bytesWritten, err := file.WriteString(contents)
+	suite.Require().NoError(err)
+	suite.Require().Equal(len(contents), bytesWritten)
+
+	return file.Name()
+}
+
+func TestRunTestSuite(t *testing.T) {
+	suite.Run(t, new(RunTestSuite))
+}

--- a/pkg/nuctl/runner/function.go
+++ b/pkg/nuctl/runner/function.go
@@ -165,10 +165,17 @@ func UpdateFunctioncrWithOptions(options *Options, functioncrInstance *functionc
 		functioncrInstance.Spec.Disabled = options.Disabled // TODO: use string to detect if noop/true/false
 	}
 
-	if options.Image == "" {
+	// if the user passed image in command line arguments
+	if options.Build.ImageName != "" {
+
+		// use that no matter what
+		functioncrInstance.Spec.Image = options.Build.ImageName
+
+	// if the user *didn't* pass image in command line arguments and image wasn't specified in
+	// the spec file, use a default for now (assuming registry proxy)
+	} else if functioncrInstance.Spec.Image == "" {
+
 		functioncrInstance.Spec.Image = fmt.Sprintf("localhost:5000/%s:%s", options.Common.Identifier, "latest")
-	} else {
-		functioncrInstance.Spec.Image = options.Image
 	}
 
 	// update data bindings

--- a/pkg/nuctl/runner/function.go
+++ b/pkg/nuctl/runner/function.go
@@ -165,17 +165,11 @@ func UpdateFunctioncrWithOptions(options *Options, functioncrInstance *functionc
 		functioncrInstance.Spec.Disabled = options.Disabled // TODO: use string to detect if noop/true/false
 	}
 
-	// if the user passed image in command line arguments
-	if options.Build.ImageName != "" {
-
-		// use that no matter what
-		functioncrInstance.Spec.Image = options.Build.ImageName
-
-	// if the user *didn't* pass image in command line arguments and image wasn't specified in
-	// the spec file, use a default for now (assuming registry proxy)
-	} else if functioncrInstance.Spec.Image == "" {
-
-		functioncrInstance.Spec.Image = fmt.Sprintf("localhost:5000/%s:%s", options.Common.Identifier, "latest")
+	if functioncrInstance.Spec.Image == "" {
+		functioncrInstance.Spec.Image = fmt.Sprintf("%s/%s:%s",
+			options.RunRegistry,
+			options.Build.ImageName,
+			options.Build.ImageVersion)
 	}
 
 	// update data bindings

--- a/pkg/nuctl/runner/types.go
+++ b/pkg/nuctl/runner/types.go
@@ -45,5 +45,6 @@ type Options struct {
 	MinReplicas  int32
 	MaxReplicas  int32
 	DataBindings string
+	RunRegistry  string
 	Spec         functioncr.Function
 }

--- a/pkg/nuctl/runner/types.go
+++ b/pkg/nuctl/runner/types.go
@@ -29,7 +29,6 @@ type Options struct {
 	Build        builder.Options
 	SpecPath     string
 	Description  string
-	Image        string
 	Env          string
 	Labels       string
 	CPU          string


### PR DESCRIPTION
The first thing this PR does is perform proper cleanup during build. Nothing intermediate should be left behind.

But mostly, this solves three issues with regards to `nuctl run`:
1. Custom image names / versions are not respected (bug)
2. We magically default to running the image from `localhost:5000` under some conditions - super sneaky
3. The command can be much friendlier when the push registry is also the registry the function pulls from. This is not the case right now, but I think this will be the majority

Things user needs to pass:
1. Registry to push to
2. Optionally, image name if different than function name
3. Optionally, version name if not latest
4. Optionally registry to run the function from if different from push registry

Examples, from simple to complex:

`nuctl run -p ./f.go -f function.yaml`
- pushed to url from spec.image
- image name/version from spec.image
- run from spec.image
- function name from spec.name

`nuctl run -p ./f.go -f function.yaml -r 10.0.0.1:8080`
- pushed to 10.0.0.1:8080
- image name/version from spec.image
- run from spec.image
- function name from spec.name

`nuctl run fname -p ./f.go -r 10.0.0.1:8080`
- pushed to 10.0.0.1:8080
- image name = fname
- image version = latest
- run from 10.0.0.1:8080/fname:latest

`nuctl run fname -p ./f.go -r 10.0.0.1:8080 --run-registry 5.5.5.5:9090`
- pushed to 10.0.0.1:8080
- image name = fname
- image version = latest
- run from 5.5.5.5:9090/fname:latest

`nuctl run fname -p ./f.go -r 10.0.0.1:8080 --image foo --version unstable --run-registry 5.5.5.5:9090`
- pushed to 10.0.0.1:8080
- image name = foo
- image version = unstable
- run from 5.5.5.5:9090/foo:unstable

Note that `--registry` can be passed as `NUCTL_REGISTRY` env var and `--run-registry` can be passed as `NUCTL_RUN_REGISTRY`