### PR TITLE
nuctl run can auto-delete existing functions and more

### DIFF
--- a/pkg/nubuild/build/env.go
+++ b/pkg/nubuild/build/env.go
@@ -126,10 +126,10 @@ func (e *env) getNuclioSource() error {
 
 		if ref != nil {
 			workingDir := e.nuclioDestDir
-			_, err := e.cmdRunner.Run(&cmdrunner.RunOptions{WorkingDir: &workingDir}, "git checkout %s", ref)
+			_, err := e.cmdRunner.Run(&cmdrunner.RunOptions{WorkingDir: &workingDir}, "git checkout %s", *ref)
 
 			if err != nil {
-				return errors.Wrap(err, "Unable to checkout nuclio ref")
+				return errors.Wrapf(err, "Unable to checkout nuclio ref %s", *ref)
 			}
 		}
 	} else {

--- a/pkg/nuctl/command/run.go
+++ b/pkg/nuctl/command/run.go
@@ -61,7 +61,8 @@ func newRunCommandeer(rootCommandeer *RootCommandeer) *runCommandeer {
 				return errors.Wrap(err, "Failed to create function runner")
 			}
 
-			return functionRunner.Execute()
+			_, err = functionRunner.Execute()
+			return err
 		},
 	}
 

--- a/pkg/nuctl/kubeconsumer.go
+++ b/pkg/nuctl/kubeconsumer.go
@@ -18,6 +18,7 @@ package nuctl
 
 import (
 	"github.com/nuclio/nuclio/pkg/functioncr"
+	"github.com/nuclio/nuclio/pkg/functiondep"
 	"github.com/pkg/errors"
 
 	"github.com/nuclio/nuclio-sdk"
@@ -26,8 +27,9 @@ import (
 )
 
 type KubeConsumer struct {
-	Clientset        *kubernetes.Clientset
-	FunctioncrClient *functioncr.Client
+	Clientset         *kubernetes.Clientset
+	FunctioncrClient  *functioncr.Client
+	FunctiondepClient *functiondep.Client
 }
 
 func (kc *KubeConsumer) GetClients(logger nuclio.Logger, kubeconfigPath string) (kubeHost string, clientsErr error) {
@@ -54,6 +56,13 @@ func (kc *KubeConsumer) GetClients(logger nuclio.Logger, kubeconfigPath string) 
 	kc.FunctioncrClient, err = functioncr.NewClient(logger, restConfig, kc.Clientset)
 	if err != nil {
 		clientsErr = errors.Wrap(err, "Failed to create function custom resource client")
+		return
+	}
+
+	// create a client for function deployments
+	kc.FunctiondepClient, err = functiondep.NewClient(logger, kc.Clientset)
+	if err != nil {
+		clientsErr = errors.Wrap(err, "Failed to create function deployment client")
 		return
 	}
 

--- a/pkg/nuctl/runner/function.go
+++ b/pkg/nuctl/runner/function.go
@@ -30,12 +30,18 @@ import (
 	"github.com/nuclio/nuclio-sdk"
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type FunctionRunner struct {
 	nuctl.KubeConsumer
 	logger  nuclio.Logger
 	options *Options
+}
+
+type RunResult struct {
+	NodePort int
 }
 
 func NewFunctionRunner(parentLogger nuclio.Logger, options *Options) (*FunctionRunner, error) {
@@ -55,7 +61,9 @@ func NewFunctionRunner(parentLogger nuclio.Logger, options *Options) (*FunctionR
 	return newFunctionRunner, nil
 }
 
-func (fr *FunctionRunner) Execute() error {
+func (fr *FunctionRunner) Execute() (*RunResult, error) {
+	var runResult *RunResult
+
 	fr.logger.InfoWith("Running function", "name", fr.options.Common.Identifier)
 
 	// create a function, set default values and try to update from file
@@ -66,36 +74,73 @@ func (fr *FunctionRunner) Execute() error {
 	if fr.options.SpecPath != "" {
 		err := functioncr.FromSpecFile(fr.options.SpecPath, &functioncrInstance)
 		if err != nil {
-			return errors.Wrap(err, "Failed to read function spec file")
+			return nil, errors.Wrap(err, "Failed to read function spec file")
 		}
 	}
 
 	// override with options
 	if err := UpdateFunctioncrWithOptions(fr.options, &functioncrInstance); err != nil {
-		return errors.Wrap(err, "Failed to update function with options")
+		return nil, errors.Wrap(err, "Failed to update function with options")
 	}
 
 	// create a builder
 	builder, err := builder.NewFunctionBuilder(fr.logger, &fr.options.Build)
 	if err != nil {
-		return errors.Wrap(err, "Failed to create builder")
+		return nil, errors.Wrap(err, "Failed to create builder")
 	}
 
 	// execute the build
 	err = builder.Execute()
 	if err != nil {
-		return err
+		return nil, err
+	}
+
+	// before we do anything, delete the current version of the function if it exists
+	existingFunctioncrInstance, err := fr.FunctioncrClient.Get(fr.options.Common.Namespace,
+		fr.options.Common.Identifier)
+
+	if err != nil {
+
+		// don't fail, maybe we'll succeed in deploying
+		fr.logger.WarnWith("Failed to get function while checking if it already exists", "err", err)
+	}
+
+	// if the function exists, delete it
+	if existingFunctioncrInstance != nil {
+		fr.logger.InfoWith("Function already exists, deleting")
+
+		err = fr.FunctioncrClient.Delete(fr.options.Common.Namespace,
+			fr.options.Common.Identifier,
+			&meta_v1.DeleteOptions{})
+
+		if err != nil {
+
+			// don't fail
+			fr.logger.WarnWith("Failed to delete existing function", "err", err)
+		} else {
+
+			// wait a bit to work around a controller bug
+			time.Sleep(2 * time.Second)
+		}
 	}
 
 	// deploy the function
 	err = fr.deployFunction(&functioncrInstance)
 	if err != nil {
-		return errors.Wrap(err, "Failed to deploy function")
+		return nil, errors.Wrap(err, "Failed to deploy function")
 	}
 
-	fr.logger.Info("Function run complete")
+	// get the function (might take a few seconds til it's created)
+	service, err := fr.getFunctionService(fr.options.Common.Namespace, fr.options.Common.Identifier)
+	if err == nil {
+		runResult = &RunResult{
+			NodePort: int(service.Spec.Ports[0].NodePort),
+		}
+	}
 
-	return nil
+	fr.logger.InfoWith("Function run complete", "node_port", runResult.NodePort)
+
+	return runResult, nil
 }
 
 func UpdateFunctioncrWithOptions(options *Options, functioncrInstance *functioncr.Function) error {
@@ -202,4 +247,34 @@ func (fr *FunctionRunner) deployFunction(functioncrToCreate *functioncr.Function
 		functioncr.WaitConditionProcessed,
 		10*time.Second,
 	)
+}
+
+func (fr *FunctionRunner) getFunctionService(namespace string, name string) (service *v1.Service, err error) {
+	deadline := time.Now().Add(10 * time.Second)
+
+	for {
+
+		// after a few seconds, give up
+		if time.Now().After(deadline) {
+			break
+		}
+
+		service, err = fr.Clientset.CoreV1().Services(namespace).Get(name, meta_v1.GetOptions{})
+
+		// if there was an error other than the fact that the service wasn't found,
+		// return now
+		if !apierrors.IsNotFound(err) {
+			return
+		}
+
+		// if we got a service, check that it has a node port
+		if service != nil && service.Spec.Ports[0].NodePort != 0 {
+			return
+		}
+
+		// wait a bit
+		time.Sleep(1 * time.Second)
+	}
+
+	return
 }

--- a/pkg/processor/webadmin/resource/eventsources.go
+++ b/pkg/processor/webadmin/resource/eventsources.go
@@ -67,7 +67,7 @@ func (esr *eventSourcesResource) GetCustomRoutes() map[string]restful.CustomRout
 	// just for demonstration. when stats are supported, this will be wired
 	return map[string]restful.CustomRoute{
 		"/{id}/stats": {
-			Method: http.MethodGet,
+			Method:    http.MethodGet,
 			RouteFunc: esr.getStatistics,
 		},
 	}


### PR DESCRIPTION
- fixed --nuclio-src-url with a reference (e.g. `--nuclio-src-url https://github.com/nuclio/nuclio.git#development`)
- can run function when it exists (nuctl and playground) - it'll be deleted
- node port is returned as part of function run response
- function state is returned properly when run from playground
