### PR TITLE
Support data bindings in playground

### DIFF
--- a/pkg/nuctl/command/delete.go
+++ b/pkg/nuctl/command/delete.go
@@ -18,8 +18,8 @@ package command
 
 import (
 	"github.com/nuclio/nuclio/pkg/errors"
-	"github.com/nuclio/nuclio/pkg/nuctl/deleter"
 	"github.com/nuclio/nuclio/pkg/nuctl"
+	"github.com/nuclio/nuclio/pkg/nuctl/deleter"
 
 	"github.com/spf13/cobra"
 )

--- a/pkg/nuctl/command/run.go
+++ b/pkg/nuctl/command/run.go
@@ -208,6 +208,6 @@ func addRunFlags(cmd *cobra.Command, options *runner.Options, encodedDataBinding
 	cmd.Flags().Int32Var(&options.MinReplicas, "min-replica", 0, "Minimum number of function replicas")
 	cmd.Flags().Int32Var(&options.MaxReplicas, "max-replica", 0, "Maximum number of function replicas")
 	cmd.Flags().BoolVar(&options.Publish, "publish", false, "Publish the function")
-	cmd.Flags().StringVar(encodedDataBindings, "data-bindings", "", "JSON encoded data bindings for the function")
+	cmd.Flags().StringVar(encodedDataBindings, "data-bindings", "{}", "JSON encoded data bindings for the function")
 	cmd.Flags().StringVar(&options.RunRegistry, "run-registry", os.Getenv("NUCTL_RUN_REGISTRY"), "The registry URL to pull the image from, if differs from -r (env: NUCTL_RUN_REGISTRY)")
 }

--- a/pkg/nuctl/command/update.go
+++ b/pkg/nuctl/command/update.go
@@ -52,6 +52,7 @@ func newUpdateCommandeer(rootCommandeer *RootCommandeer) *updateCommandeer {
 
 type updateFunctionCommandeer struct {
 	*updateCommandeer
+	encodedDataBindings string
 }
 
 func newUpdateFunctionCommandeer(updateCommandeer *updateCommandeer) *updateFunctionCommandeer {
@@ -98,7 +99,7 @@ func newUpdateFunctionCommandeer(updateCommandeer *updateCommandeer) *updateFunc
 	}
 
 	// add run flags
-	addRunFlags(cmd, &commandeer.updateOptions.Run)
+	addRunFlags(cmd, &commandeer.updateOptions.Run, &commandeer.encodedDataBindings)
 
 	commandeer.cmd = cmd
 

--- a/pkg/nuctl/command/update.go
+++ b/pkg/nuctl/command/update.go
@@ -18,9 +18,9 @@ package command
 
 import (
 	"github.com/nuclio/nuclio/pkg/errors"
-	"github.com/nuclio/nuclio/pkg/nuctl/updater"
 	"github.com/nuclio/nuclio/pkg/nuctl"
-	
+	"github.com/nuclio/nuclio/pkg/nuctl/updater"
+
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/nuctl/runner/function.go
+++ b/pkg/nuctl/runner/function.go
@@ -184,9 +184,7 @@ func UpdateFunctioncrWithOptions(options *Options, functioncrInstance *functionc
 	}
 
 	// update data bindings
-	if err := updateDataBindings(options.DataBindings, functioncrInstance); err != nil {
-		return errors.Wrap(err, "Failed to decode data bindings")
-	}
+	functioncrInstance.Spec.DataBindings = options.DataBindings
 
 	return nil
 }

--- a/pkg/nuctl/runner/types.go
+++ b/pkg/nuctl/runner/types.go
@@ -44,9 +44,9 @@ type Options struct {
 	Scale        string
 	MinReplicas  int32
 	MaxReplicas  int32
-	DataBindings string
 	RunRegistry  string
 	Spec         functioncr.Function
+	DataBindings map[string]functioncr.DataBinding
 }
 
 func (o *Options) InitDefaults() {

--- a/pkg/playground/resource/function.go
+++ b/pkg/playground/resource/function.go
@@ -35,6 +35,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/zap"
 
 	"github.com/nuclio/nuclio-sdk"
+	"github.com/nuclio/nuclio/pkg/functioncr"
 )
 
 //
@@ -42,14 +43,14 @@ import (
 //
 
 type functionAttributes struct {
-	Name         string                   `json:"name"`
-	State        string                   `json:"state"`
-	SourceURL    string                   `json:"source_url"`
-	DataBindings string                   `json:"data_bindings"`
-	Registry     string                   `json:"registry"`
-	RunRegistry  string                   `json:"run_registry"`
-	Logs         []map[string]interface{} `json:"logs"`
-	NodePort     int                      `json:"node_port"`
+	Name         string                            `json:"name"`
+	State        string                            `json:"state"`
+	SourceURL    string                            `json:"source_url"`
+	DataBindings map[string]functioncr.DataBinding `json:"data_bindings"`
+	Registry     string                            `json:"registry"`
+	RunRegistry  string                            `json:"run_registry"`
+	Logs         []map[string]interface{}          `json:"logs"`
+	NodePort     int                               `json:"node_port"`
 }
 
 type function struct {

--- a/pkg/playground/resource/tunnel.go
+++ b/pkg/playground/resource/tunnel.go
@@ -17,14 +17,14 @@ limitations under the License.
 package resource
 
 import (
-	"net/http"
-	"strings"
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"strings"
 
+	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/playground"
 	"github.com/nuclio/nuclio/pkg/restful"
-	"github.com/nuclio/nuclio/pkg/errors"
 )
 
 type tunnelResource struct {
@@ -92,7 +92,7 @@ func (tr *tunnelResource) handleRequest(responseWriter http.ResponseWriter, requ
 	}
 
 	// set headers
-	for headerName, headerValue := range tunneledHttpResponse.Header{
+	for headerName, headerValue := range tunneledHttpResponse.Header {
 		responseWriter.Header()[headerName] = headerValue
 	}
 
@@ -109,7 +109,7 @@ func (tr *tunnelResource) getTunneledHostAndPath(fullPath string) (host string, 
 	}
 
 	// remove /tunnel portion and /
-	fullPath = fullPath[len(pathPrefix) + 1:]
+	fullPath = fullPath[len(pathPrefix)+1:]
 
 	// split host portion
 	hostAndPath := strings.SplitN(fullPath, "/", 2)

--- a/pkg/util/common/url.go
+++ b/pkg/util/common/url.go
@@ -25,9 +25,9 @@ func DownloadFile(URL, destFile string) error {
 	if err := out.Close(); err != nil {
 		return err
 	}
-	if written != response.ContentLength {
+	if response.ContentLength != -1 && written != response.ContentLength {
 		return fmt.Errorf(
-			"Downloaded file length (%d) is different then URL content length (%d)",
+			"Downloaded file length (%d) is different than URL content length (%d)",
 			written,
 			response.ContentLength)
 	}


### PR DESCRIPTION
Playground accepts a request in the form of:
```
{
	"name": "<name>",
	"source_url": "<source>",
	"registry": "<registry>",
	"run_registry": "localhost:5000",
	"data_bindings": {
		"db0": {
			"class": "v3io",
			"url": "<url>"
		}
	}
}
```

And creates the proper data binding