### PR TITLE
More metrics

### DIFF
--- a/pkg/processor/eventsource/eventsource.go
+++ b/pkg/processor/eventsource/eventsource.go
@@ -37,6 +37,9 @@ type EventSource interface {
 	// stop creating events. returns the current checkpoint
 	Stop(force bool) (Checkpoint, error)
 
+	// get the user given ID for this event source
+	GetID() string
+
 	// get the class of source (sync, async, etc)
 	GetClass() string
 
@@ -46,16 +49,21 @@ type EventSource interface {
 	// get the configuration
 	GetConfig() map[string]interface{}
 
+	// get statistics
+	GetStatistics() *Statistics
+
 	// get direct access to workers for things like housekeeping / management
 	// TODO: locks and such when relevant
 	GetWorkers() []*worker.Worker
 }
 
 type AbstractEventSource struct {
+	ID              string
 	Logger          nuclio.Logger
 	WorkerAllocator worker.WorkerAllocator
 	Class           string
 	Kind            string
+	Statistics      Statistics
 }
 
 func (aes *AbstractEventSource) GetClass() string {
@@ -72,26 +80,7 @@ func (aes *AbstractEventSource) SubmitEventToWorker(event nuclio.Event,
 
 	var workerInstance *worker.Worker
 
-	defer func() {
-		if err := recover(); err != nil {
-			callStack := debug.Stack()
-
-			functionLogger.ErrorWith("Panic caught during submit event",
-				"err",
-				err,
-				"stack",
-				string(callStack))
-
-			submitError = fmt.Errorf("Caught panic: %s", err)
-
-			response = nil
-			processError = nil
-
-			if workerInstance != nil {
-				aes.WorkerAllocator.Release(workerInstance)
-			}
-		}
-	}()
+	defer aes.handleSubmitPanic(&workerInstance, &submitError)
 
 	// set event source info provider (ourselves)
 	event.SetSourceProvider(aes)
@@ -99,6 +88,8 @@ func (aes *AbstractEventSource) SubmitEventToWorker(event nuclio.Event,
 	// allocate a worker
 	workerInstance, err := aes.WorkerAllocator.Allocate(timeout)
 	if err != nil {
+		aes.updateStatistics(false)
+
 		return nil, errors.Wrap(err, "Failed to allocate worker"), nil
 	}
 
@@ -106,6 +97,9 @@ func (aes *AbstractEventSource) SubmitEventToWorker(event nuclio.Event,
 
 	// release worker when we're done
 	aes.WorkerAllocator.Release(workerInstance)
+
+	// increment statistics based on results. if process error is nil, we successfully handled
+	aes.updateStatistics(processError == nil)
 
 	return
 }
@@ -115,27 +109,9 @@ func (aes *AbstractEventSource) SubmitEventsToWorker(events []nuclio.Event,
 	timeout time.Duration) (responses []interface{}, submitError error, processErrors []error) {
 
 	var workerInstance *worker.Worker
+	processErrorsExist := false
 
-	defer func() {
-		if err := recover(); err != nil {
-			callStack := debug.Stack()
-
-			functionLogger.ErrorWith("Panic caught during submit events",
-				"err",
-				err,
-				"stack",
-				string(callStack))
-
-			submitError = fmt.Errorf("Caught panic: %s", err)
-
-			responses = nil
-			processErrors = nil
-
-			if workerInstance != nil {
-				aes.WorkerAllocator.Release(workerInstance)
-			}
-		}
-	}()
+	defer aes.handleSubmitPanic(&workerInstance, &submitError)
 
 	// create responses / errors slice
 	eventResponses := make([]interface{}, 0, len(events))
@@ -149,6 +125,8 @@ func (aes *AbstractEventSource) SubmitEventsToWorker(events []nuclio.Event,
 	// allocate a worker
 	workerInstance, err := aes.WorkerAllocator.Allocate(timeout)
 	if err != nil {
+		aes.updateStatistics(false)
+
 		return nil, errors.Wrap(err, "Failed to allocate worker"), nil
 	}
 
@@ -156,6 +134,9 @@ func (aes *AbstractEventSource) SubmitEventsToWorker(events []nuclio.Event,
 	for _, event := range events {
 
 		response, err := workerInstance.ProcessEvent(event, functionLogger)
+
+		// sticky boolean to hold whether process errors exist
+		processErrorsExist = processErrorsExist || (response != nil)
 
 		// add response and error
 		eventResponses = append(eventResponses, response)
@@ -165,9 +146,52 @@ func (aes *AbstractEventSource) SubmitEventsToWorker(events []nuclio.Event,
 	// release worker
 	aes.WorkerAllocator.Release(workerInstance)
 
+	// increment statistics based on results. if all process error iare nil, we successfully handled
+	aes.updateStatistics(false)
+
 	return eventResponses, nil, eventErrors
 }
 
 func (aes *AbstractEventSource) GetWorkers() []*worker.Worker {
 	return aes.WorkerAllocator.GetWorkers()
+}
+
+// get statistics
+func (aes *AbstractEventSource) GetStatistics() *Statistics {
+	return &aes.Statistics
+}
+
+// get user given ID for this event source
+func (aes *AbstractEventSource) GetID() string {
+	return aes.ID
+}
+
+func (aes *AbstractEventSource) handleSubmitPanic(workerInstance **worker.Worker,
+	submitError *error) {
+
+	if err := recover(); err != nil {
+		callStack := debug.Stack()
+
+		aes.Logger.ErrorWith("Panic caught during submit events",
+			"err",
+			err,
+			"stack",
+			string(callStack))
+
+		*submitError = fmt.Errorf("Caught panic: %s", err)
+
+		if workerInstance != nil {
+			aes.WorkerAllocator.Release(*workerInstance)
+		}
+
+		aes.updateStatistics(false)
+	}
+}
+
+func (aes *AbstractEventSource) updateStatistics(success bool) {
+	if success {
+		aes.Statistics.EventsHandleSuccess++
+	} else {
+		aes.Statistics.EventsHandleFailure++
+	}
 }

--- a/pkg/processor/eventsource/eventsource.go
+++ b/pkg/processor/eventsource/eventsource.go
@@ -190,8 +190,8 @@ func (aes *AbstractEventSource) handleSubmitPanic(workerInstance **worker.Worker
 
 func (aes *AbstractEventSource) updateStatistics(success bool) {
 	if success {
-		aes.Statistics.EventsHandleSuccess++
+		aes.Statistics.EventsHandleSuccessTotal++
 	} else {
-		aes.Statistics.EventsHandleFailure++
+		aes.Statistics.EventsHandleFailureTotal++
 	}
 }

--- a/pkg/processor/eventsource/generator/eventsource.go
+++ b/pkg/processor/eventsource/generator/eventsource.go
@@ -44,6 +44,7 @@ func newEventSource(logger nuclio.Logger,
 
 	newEventSource := generator{
 		AbstractEventSource: eventsource.AbstractEventSource{
+			ID:              configuration.ID,
 			Logger:          logger,
 			WorkerAllocator: workerAllocator,
 			Class:           "sync",

--- a/pkg/processor/eventsource/http/eventsource.go
+++ b/pkg/processor/eventsource/http/eventsource.go
@@ -43,7 +43,7 @@ func newEventSource(logger nuclio.Logger,
 	configuration *Configuration) (eventsource.EventSource, error) {
 
 	bufferLoggerPool, err := nucliozap.NewBufferLoggerPool(8,
-		"http",
+		configuration.ID,
 		"json",
 		nucliozap.DebugLevel)
 	if err != nil {
@@ -58,6 +58,7 @@ func newEventSource(logger nuclio.Logger,
 
 	newEventSource := http{
 		AbstractEventSource: eventsource.AbstractEventSource{
+			ID:              configuration.ID,
 			Logger:          logger,
 			WorkerAllocator: workerAllocator,
 			Class:           "sync",

--- a/pkg/processor/eventsource/rabbitmq/eventsource.go
+++ b/pkg/processor/eventsource/rabbitmq/eventsource.go
@@ -45,7 +45,8 @@ func newEventSource(parentLogger nuclio.Logger,
 
 	newEventSource := rabbitMq{
 		AbstractEventSource: eventsource.AbstractEventSource{
-			Logger:          parentLogger.GetChild("rabbitMq").(nuclio.Logger),
+			ID:              configuration.ID,
+			Logger:          parentLogger.GetChild(configuration.ID).(nuclio.Logger),
 			WorkerAllocator: workerAllocator,
 			Class:           "async",
 			Kind:            "rabbitMq",

--- a/pkg/processor/eventsource/types.go
+++ b/pkg/processor/eventsource/types.go
@@ -27,3 +27,8 @@ func NewConfiguration(configuration *viper.Viper) *Configuration {
 		ID: configuration.GetString("ID"),
 	}
 }
+
+type Statistics struct {
+	EventsHandleSuccess uint64
+	EventsHandleFailure uint64
+}

--- a/pkg/processor/eventsource/types.go
+++ b/pkg/processor/eventsource/types.go
@@ -29,6 +29,13 @@ func NewConfiguration(configuration *viper.Viper) *Configuration {
 }
 
 type Statistics struct {
-	EventsHandleSuccess uint64
-	EventsHandleFailure uint64
+	EventsHandleSuccessTotal uint64
+	EventsHandleFailureTotal uint64
+}
+
+func (s *Statistics) DiffFrom(prev *Statistics) Statistics {
+	return Statistics{
+		EventsHandleSuccessTotal: s.EventsHandleSuccessTotal - prev.EventsHandleSuccessTotal,
+		EventsHandleFailureTotal: s.EventsHandleFailureTotal - prev.EventsHandleFailureTotal,
+	}
 }

--- a/pkg/processor/runtime/golang/event_handler/demo.go
+++ b/pkg/processor/runtime/golang/event_handler/demo.go
@@ -25,6 +25,6 @@ func Demo(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
 }
 
 // uncomment to register demo
-func init() {
-	EventHandlers.Add("demo", Demo)
-}
+//func init() {
+//	EventHandlers.Add("demo", Demo)
+//}

--- a/pkg/processor/runtime/golang/event_handler/demo.go
+++ b/pkg/processor/runtime/golang/event_handler/demo.go
@@ -25,6 +25,6 @@ func Demo(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
 }
 
 // uncomment to register demo
-//func init() {
-//	EventHandlers.Add("demo", Demo)
-//}
+func init() {
+	EventHandlers.Add("demo", Demo)
+}

--- a/pkg/processor/runtime/golang/runtime.go
+++ b/pkg/processor/runtime/golang/runtime.go
@@ -19,6 +19,7 @@ package golang
 import (
 	"fmt"
 	"runtime/debug"
+	"time"
 
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
@@ -110,5 +111,17 @@ func (g *golang) callEventHandler(event nuclio.Event, functionLogger nuclio.Logg
 		}
 	}()
 
-	return g.eventHandler(g.Context, event)
+	// before we call, save timestamp
+	startTime := time.Now()
+
+	response, responseErr = g.eventHandler(g.Context, event)
+
+	// calculate how long it took to invoke the function
+	callDuration := time.Since(startTime)
+
+	// add duration to sum
+	g.Statistics.DurationMilliSecondsSum += uint64(callDuration.Nanoseconds() / 1000000)
+	g.Statistics.DurationMilliSecondsCount++
+
+	return
 }

--- a/pkg/processor/runtime/runtime.go
+++ b/pkg/processor/runtime/runtime.go
@@ -24,12 +24,15 @@ type Runtime interface {
 	ProcessEvent(event nuclio.Event, functionLogger nuclio.Logger) (interface{}, error)
 
 	GetFunctionLogger() nuclio.Logger
+
+	GetStatistics() *Statistics
 }
 
 type AbstractRuntime struct {
 	Logger         nuclio.Logger
 	FunctionLogger nuclio.Logger
 	Context        *nuclio.Context
+	Statistics     Statistics
 }
 
 func NewAbstractRuntime(logger nuclio.Logger,
@@ -49,4 +52,8 @@ func NewAbstractRuntime(logger nuclio.Logger,
 
 func (ar *AbstractRuntime) GetFunctionLogger() nuclio.Logger {
 	return ar.FunctionLogger
+}
+
+func (ar *AbstractRuntime) GetStatistics() *Statistics {
+	return &ar.Statistics
 }

--- a/pkg/processor/runtime/types.go
+++ b/pkg/processor/runtime/types.go
@@ -26,6 +26,18 @@ import (
 	"github.com/spf13/viper"
 )
 
+type Statistics struct {
+	DurationMilliSecondsSum   uint64
+	DurationMilliSecondsCount uint64
+}
+
+func (s *Statistics) DiffFrom(prev *Statistics) Statistics {
+	return Statistics{
+		DurationMilliSecondsSum:   s.DurationMilliSecondsSum - prev.DurationMilliSecondsSum,
+		DurationMilliSecondsCount: s.DurationMilliSecondsCount - prev.DurationMilliSecondsCount,
+	}
+}
+
 // Copied from functioncr to prevent dependencies on functioncr
 type DataBinding struct {
 	Name    string            `json:"name"`

--- a/pkg/processor/statistics/eventsource.go
+++ b/pkg/processor/statistics/eventsource.go
@@ -1,0 +1,58 @@
+package statistics
+
+import (
+	"github.com/nuclio/nuclio/pkg/errors"
+
+	"github.com/nuclio/nuclio/pkg/processor/eventsource"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type eventSourceGatherer struct {
+	eventSource   eventsource.EventSource
+	handledEvents *prometheus.GaugeVec
+}
+
+func newEventSourceGatherer(instanceName string,
+	eventSource eventsource.EventSource,
+	metricRegistry *prometheus.Registry) (*eventSourceGatherer, error) {
+
+	newEventSourceGatherer := &eventSourceGatherer{
+		eventSource: eventSource,
+	}
+
+	// base labels for handle events
+	labels := prometheus.Labels{
+		"instance":           instanceName,
+		"event_source_class": eventSource.GetClass(),
+		"event_source_kind":  eventSource.GetKind(),
+		"event_source_id":    eventSource.GetID(),
+	}
+
+	newEventSourceGatherer.handledEvents = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name:        "nuclio_processor_handled_events",
+		Help:        "Number of handled events",
+		ConstLabels: labels,
+	}, []string{"result"})
+
+	if err := metricRegistry.Register(newEventSourceGatherer.handledEvents); err != nil {
+		return nil, errors.Wrap(err, "Failed to register handled events metric")
+	}
+
+	return newEventSourceGatherer, nil
+}
+
+func (esg *eventSourceGatherer) Gather() error {
+
+	// read stats (copy)
+	statistics := *esg.eventSource.GetStatistics()
+
+	esg.handledEvents.With(prometheus.Labels{
+		"result": "success",
+	}).Set(float64(statistics.EventsHandleSuccess))
+
+	esg.handledEvents.With(prometheus.Labels{
+		"result": "failure",
+	}).Set(float64(statistics.EventsHandleFailure))
+
+	return nil
+}

--- a/pkg/processor/statistics/eventsource.go
+++ b/pkg/processor/statistics/eventsource.go
@@ -1,9 +1,25 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package statistics
 
 import (
 	"github.com/nuclio/nuclio/pkg/errors"
-
 	"github.com/nuclio/nuclio/pkg/processor/eventsource"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/pkg/processor/statistics/gatherer.go
+++ b/pkg/processor/statistics/gatherer.go
@@ -1,0 +1,8 @@
+package statistics
+
+// a reflection of an object in the processor (e.g. event source, runtime, worker) that holds promethues
+// metrics. when Gather() is called, the resource is queried for its primitive statistics. this way we decouple
+// prometheus metrics from the fast path
+type Gatherer interface {
+	Gather() error
+}

--- a/pkg/processor/statistics/gatherer.go
+++ b/pkg/processor/statistics/gatherer.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package statistics
 
 // a reflection of an object in the processor (e.g. event source, runtime, worker) that holds promethues

--- a/pkg/processor/statistics/metricpusher.go
+++ b/pkg/processor/statistics/metricpusher.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package statistics
 
 import (

--- a/pkg/processor/statistics/metricpusher.go
+++ b/pkg/processor/statistics/metricpusher.go
@@ -1,17 +1,16 @@
 package statistics
 
 import (
-	"strconv"
+	"os"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/processor/eventsource"
 
 	"github.com/nuclio/nuclio-sdk"
-	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/spf13/viper"
-	"os"
 )
 
 type eventSourceProvider interface {
@@ -19,14 +18,13 @@ type eventSourceProvider interface {
 }
 
 type MetricPusher struct {
-	logger             nuclio.Logger
-	eventSources       []eventsource.EventSource
-	handledEventsGauge *prometheus.GaugeVec
-	metricRegistry     *prometheus.Registry
-	jobName            string
-	instanceName       string
-	pushGatewayURL     string
-	pushInterval       int
+	logger              nuclio.Logger
+	metricRegistry      *prometheus.Registry
+	jobName             string
+	instanceName        string
+	pushGatewayURL      string
+	pushIntervalSeconds int
+	gatherers           []Gatherer
 }
 
 func NewMetricPusher(parentLogger nuclio.Logger,
@@ -35,7 +33,6 @@ func NewMetricPusher(parentLogger nuclio.Logger,
 
 	newMetricPusher := &MetricPusher{
 		logger:         parentLogger.GetChild("metrics").(nuclio.Logger),
-		eventSources:   eventSourceProvider.GetEventSources(),
 		metricRegistry: prometheus.NewRegistry(),
 	}
 
@@ -45,7 +42,7 @@ func NewMetricPusher(parentLogger nuclio.Logger,
 	}
 
 	// create a bunch of prometheus metrics which we will populate periodically
-	if err := newMetricPusher.registerMetrics(); err != nil {
+	if err := newMetricPusher.createGatherers(eventSourceProvider); err != nil {
 		return nil, errors.Wrap(err, "Failed to register metrics")
 	}
 
@@ -53,7 +50,7 @@ func NewMetricPusher(parentLogger nuclio.Logger,
 		"jobName", newMetricPusher.jobName,
 		"instanceName", newMetricPusher.instanceName,
 		"pushGatewayURL", newMetricPusher.pushGatewayURL,
-		"pushInterval", newMetricPusher.pushInterval)
+		"pushInterval", newMetricPusher.pushIntervalSeconds)
 
 	return newMetricPusher, nil
 }
@@ -67,7 +64,7 @@ func (mp *MetricPusher) Start() error {
 func (mp *MetricPusher) readConfiguration(configuration *viper.Viper) error {
 	pushGatewayURLDefault := os.Getenv("NUCLIO_PROM_PUSH_GATEWAY_URL")
 	if pushGatewayURLDefault == "" {
-		pushGatewayURLDefault = "http://nuclio-prometheus-pushgateway:9091"
+		pushGatewayURLDefault = "http://prometheus-prometheus-pushgateway:9091"
 	}
 
 	pushInterval := os.Getenv("NUCLIO_PROM_PUSH_INTERVAL")
@@ -83,22 +80,22 @@ func (mp *MetricPusher) readConfiguration(configuration *viper.Viper) error {
 	mp.pushGatewayURL = configuration.GetString("push_gateway_url")
 	mp.jobName = configuration.GetString("job_name")
 	mp.instanceName = configuration.GetString("instance")
-	mp.pushInterval = configuration.GetInt("push_interval")
+	mp.pushIntervalSeconds = configuration.GetInt("push_interval")
 
 	return nil
 }
 
-func (mp *MetricPusher) registerMetrics() error {
-	mp.handledEventsGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "nuclio_processor_handled_events",
-		Help: "Number of handled events",
-	}, []string{"instance", "event_source_class", "event_source_kind", "worker_index", "result"})
+func (mp *MetricPusher) createGatherers(eventSourceProvider eventSourceProvider) error {
 
-	// register all the metrics
-	for _, collector := range []prometheus.Collector{mp.handledEventsGauge} {
-		if err := mp.metricRegistry.Register(collector); err != nil {
-			return errors.Wrap(err, "Failed to register metric")
+	for _, eventSource := range eventSourceProvider.GetEventSources() {
+
+		// create a gatherer for the event source
+		eventSourceGatherer, err := newEventSourceGatherer(mp.instanceName, eventSource, mp.metricRegistry)
+		if err != nil {
+			return errors.Wrap(err, "Failed to create event source gatherer")
 		}
+
+		mp.gatherers = append(mp.gatherers, eventSourceGatherer)
 	}
 
 	return nil
@@ -108,12 +105,12 @@ func (mp *MetricPusher) periodicallyPushMetrics() {
 
 	for {
 
-		// every 10 seconds
-		time.Sleep(10 * time.Second)
+		// every mp.pushInterval seconds
+		time.Sleep(time.Duration(mp.pushIntervalSeconds) * time.Second)
 
 		// gather the metrics from the event sources - this will update the metrics
 		// from counters internally held by event sources and their child objects
-		mp.gatherEventSourceMetrics()
+		mp.gather()
 
 		// AddFromGatherer is used here rather than FromGatherer to not delete a
 		// previously pushed success timestamp in case of a failure of this
@@ -124,40 +121,13 @@ func (mp *MetricPusher) periodicallyPushMetrics() {
 	}
 }
 
-func (mp *MetricPusher) gatherEventSourceMetrics() {
-	for _, eventSource := range mp.eventSources {
-		for _, worker := range eventSource.GetWorkers() {
+func (mp *MetricPusher) gather() error {
 
-			// copy the current state of worker statistics
-			workerStatistics := worker.GetStatistics()
-
-			//
-			// TODO: proper label management
-			//
-
-			// generate worker labels
-			workerLabels0 := prometheus.Labels{
-				"instance":           mp.instanceName,
-				"event_source_class": eventSource.GetClass(),
-				"event_source_kind":  eventSource.GetKind(),
-				"worker_index":       strconv.Itoa(worker.GetIndex()),
-				"result":             "success",
-			}
-
-			// increment the appropriate counters
-			mp.handledEventsGauge.With(workerLabels0).Set(float64(workerStatistics.EventsHandleSuccess))
-
-			// generate worker labels
-			workerLabels1 := prometheus.Labels{
-				"instance":           mp.instanceName,
-				"event_source_class": eventSource.GetClass(),
-				"event_source_kind":  eventSource.GetKind(),
-				"worker_index":       strconv.Itoa(worker.GetIndex()),
-				"result":             "failure",
-			}
-
-			// increment the appropriate counters
-			mp.handledEventsGauge.With(workerLabels1).Set(float64(workerStatistics.EventsHandleError))
+	for _, gatherer := range mp.gatherers {
+		if err := gatherer.Gather(); err != nil {
+			return err
 		}
 	}
+
+	return nil
 }

--- a/pkg/processor/statistics/metricpusher.go
+++ b/pkg/processor/statistics/metricpusher.go
@@ -96,6 +96,16 @@ func (mp *MetricPusher) createGatherers(eventSourceProvider eventSourceProvider)
 		}
 
 		mp.gatherers = append(mp.gatherers, eventSourceGatherer)
+
+		// now add workers
+		for _, worker := range eventSource.GetWorkers() {
+			workerGatherer, err := newWorkerGatherer(mp.instanceName, eventSource, worker, mp.metricRegistry)
+			if err != nil {
+				return errors.Wrap(err, "Failed to create worker gatherer")
+			}
+
+			mp.gatherers = append(mp.gatherers, workerGatherer)
+		}
 	}
 
 	return nil

--- a/pkg/processor/statistics/worker.go
+++ b/pkg/processor/statistics/worker.go
@@ -1,13 +1,29 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package statistics
 
 import (
 	"strconv"
 
 	"github.com/nuclio/nuclio/pkg/errors"
-
 	"github.com/nuclio/nuclio/pkg/processor/eventsource"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/worker"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/pkg/processor/statistics/worker.go
+++ b/pkg/processor/statistics/worker.go
@@ -1,0 +1,77 @@
+package statistics
+
+import (
+	"strconv"
+
+	"github.com/nuclio/nuclio/pkg/errors"
+
+	"github.com/nuclio/nuclio/pkg/processor/eventsource"
+	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/worker"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type workerGatherer struct {
+	worker                                 *worker.Worker
+	prevRuntimeStatistics                  runtime.Statistics
+	handledEventsDurationMillisecondsSum   prometheus.Counter
+	handledEventsDurationMillisecondsCount prometheus.Counter
+}
+
+func newWorkerGatherer(instanceName string,
+	eventSource eventsource.EventSource,
+	worker *worker.Worker,
+	metricRegistry *prometheus.Registry) (*workerGatherer, error) {
+
+	newWorkerGatherer := &workerGatherer{
+		worker: worker,
+	}
+
+	// base labels for handle events
+	labels := prometheus.Labels{
+		"instance":           instanceName,
+		"event_source_class": eventSource.GetClass(),
+		"event_source_kind":  eventSource.GetKind(),
+		"event_source_id":    eventSource.GetID(),
+		"worker_index":       strconv.Itoa(worker.GetIndex()),
+	}
+
+	newWorkerGatherer.handledEventsDurationMillisecondsSum = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "nuclio_processor_handled_events_duration_milliseconds_sum",
+		Help:        "Total sum of milliseconds it took to handle events",
+		ConstLabels: labels,
+	})
+
+	if err := metricRegistry.Register(newWorkerGatherer.handledEventsDurationMillisecondsSum); err != nil {
+		return nil, errors.Wrap(err, "Failed to register handledEventsDurationSum")
+	}
+
+	newWorkerGatherer.handledEventsDurationMillisecondsCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "nuclio_processor_handled_events_duration_milliseconds_count",
+		Help:        "Number of measurements taken for nuclio_processor_handled_events_duration_sum",
+		ConstLabels: labels,
+	})
+
+	if err := metricRegistry.Register(newWorkerGatherer.handledEventsDurationMillisecondsCount); err != nil {
+		return nil, errors.Wrap(err, "Failed to register handledEventsDurationCount")
+	}
+
+	return newWorkerGatherer, nil
+}
+
+func (wg *workerGatherer) Gather() error {
+
+	// read current stats
+	currentRuntimeStatistics := *wg.worker.GetRuntime().GetStatistics()
+
+	// diff from previous to get this period
+	diffRuntimeStatistics := currentRuntimeStatistics.DiffFrom(&wg.prevRuntimeStatistics)
+
+	wg.handledEventsDurationMillisecondsSum.Add(float64(diffRuntimeStatistics.DurationMilliSecondsSum))
+	wg.handledEventsDurationMillisecondsCount.Add(float64(diffRuntimeStatistics.DurationMilliSecondsCount))
+
+	// save previous
+	wg.prevRuntimeStatistics = currentRuntimeStatistics
+
+	return nil
+}

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -72,10 +72,14 @@ func (w *Worker) ProcessEvent(event nuclio.Event, functionLogger nuclio.Logger) 
 	return response, err
 }
 
-func (w *Worker) GetStatistics() Statistics {
-	return w.statistics
+func (w *Worker) GetStatistics() *Statistics {
+	return &w.statistics
 }
 
 func (w *Worker) GetIndex() int {
 	return w.index
+}
+
+func (w *Worker) GetRuntime() runtime.Runtime {
+	return w.runtime
 }

--- a/pkg/processor/worker/worker_test.go
+++ b/pkg/processor/worker/worker_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/zap"
+	"github.com/nuclio/nuclio/pkg/processor/runtime"
 
 	"github.com/nuclio/nuclio-sdk"
 	"github.com/stretchr/testify/mock"
@@ -36,6 +37,10 @@ func (mr *MockRuntime) ProcessEvent(event nuclio.Event, functionLogger nuclio.Lo
 }
 
 func (mr *MockRuntime) GetFunctionLogger() nuclio.Logger {
+	return nil
+}
+
+func (mr *MockRuntime) GetStatistics() *runtime.Statistics {
 	return nil
 }
 


### PR DESCRIPTION
1. Metrics gathering refactored such that metric specifics are held in "gatherers" of which there are currently two: one for event source and one for worker
2. Added support for function duration statistics - currently only golang
3. The # of events metric is now a counter, gathered at the event source level. Should catch any and all invocations and failures
4. Default prometheus URL is now `http://prometheus-prometheus-pushgateway:9091` (*shakes fist at helm*)
