### PR TITLE
More options in integration test helpers

### DIFF
--- a/pkg/processor/build/runtime/golang/test/golang_test.go
+++ b/pkg/processor/build/runtime/golang/test/golang_test.go
@@ -25,8 +25,10 @@ import (
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/processor/build"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime/test/suite"
-
+	"github.com/nuclio/nuclio/pkg/processor/test/suite"
+	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/processor/eventsource/http/test/suite"
+
 	"github.com/stretchr/testify/suite"
 )
 
@@ -37,10 +39,13 @@ type TestSuite struct {
 func (suite *TestSuite) TestBuildFile() {
 	// suite.T().Skip()
 
-	suite.FunctionBuildRunAndRequest("incrementor",
-		path.Join(suite.getGolangDir(), "incrementor", "incrementor.go"),
-		"",
-		map[int]int{8080: 8080},
+	buildOptions := build.Options{
+		FunctionName: "incrementor",
+		FunctionPath: path.Join(suite.getGolangDir(), "incrementor", "incrementor.go"),
+	}
+
+	suite.FunctionBuildRunAndRequest(&buildOptions,
+		nil,
 		&httpsuite.Request{
 			RequestPort:          8080,
 			RequestPath:          "/",
@@ -53,10 +58,13 @@ func (suite *TestSuite) TestBuildFile() {
 func (suite *TestSuite) TestBuildDir() {
 	// suite.T().Skip()
 
-	suite.FunctionBuildRunAndRequest("incrementor",
-		path.Join(suite.getGolangDir(), "incrementor"),
-		"",
-		map[int]int{8080: 8080},
+	buildOptions := build.Options{
+		FunctionName: "incrementor",
+		FunctionPath: path.Join(suite.getGolangDir(), "incrementor"),
+	}
+
+	suite.FunctionBuildRunAndRequest(&buildOptions,
+		nil,
 		&httpsuite.Request{
 			RequestPort:          8080,
 			RequestPath:          "/",
@@ -69,10 +77,19 @@ func (suite *TestSuite) TestBuildDir() {
 func (suite *TestSuite) TestBuildDirWithProcessorYAML() {
 	// suite.T().Skip()
 
-	suite.FunctionBuildRunAndRequest("incrementor",
-		path.Join(suite.getGolangDir(), "incrementor-with-processor"),
-		"",
-		map[int]int{9999: 9999},
+	buildOptions := build.Options{
+		FunctionName: "incrementor",
+		FunctionPath: path.Join(suite.getGolangDir(), "incrementor-with-processor"),
+	}
+
+	runOptions := processorsuite.RunOptions{
+		RunOptions: dockerclient.RunOptions{
+			Ports: map[int]int{9999: 9999},
+		},
+	}
+
+	suite.FunctionBuildRunAndRequest(&buildOptions,
+		&runOptions,
 		&httpsuite.Request{
 			RequestPort:          9999,
 			RequestPath:          "/",
@@ -124,10 +141,13 @@ func (suite *TestSuite) TestBuildURL() {
 
 	defer httpServer.Shutdown(nil)
 
-	suite.FunctionBuildRunAndRequest("incrementor",
-		"http://localhost:6666/some/path/incrementor.go",
-		"",
-		map[int]int{8080: 8080},
+	buildOptions := build.Options{
+		FunctionName: "incrementor",
+		FunctionPath: "http://localhost:6666/some/path/incrementor.go",
+	}
+
+	suite.FunctionBuildRunAndRequest(&buildOptions,
+		nil,
 		&httpsuite.Request{
 			RequestPort:          8080,
 			RequestPath:          "/",

--- a/pkg/processor/build/runtime/golang/test/golang_test.go
+++ b/pkg/processor/build/runtime/golang/test/golang_test.go
@@ -47,9 +47,6 @@ func (suite *TestSuite) TestBuildFile() {
 	suite.FunctionBuildRunAndRequest(&buildOptions,
 		nil,
 		&httpsuite.Request{
-			RequestPort:          8080,
-			RequestPath:          "/",
-			RequestMethod:        "POST",
 			RequestBody:          "abcdef",
 			ExpectedResponseBody: "bcdefg",
 		})
@@ -66,9 +63,6 @@ func (suite *TestSuite) TestBuildDir() {
 	suite.FunctionBuildRunAndRequest(&buildOptions,
 		nil,
 		&httpsuite.Request{
-			RequestPort:          8080,
-			RequestPath:          "/",
-			RequestMethod:        "POST",
 			RequestBody:          "abcdef",
 			ExpectedResponseBody: "bcdefg",
 		})
@@ -92,8 +86,6 @@ func (suite *TestSuite) TestBuildDirWithProcessorYAML() {
 		&runOptions,
 		&httpsuite.Request{
 			RequestPort:          9999,
-			RequestPath:          "/",
-			RequestMethod:        "POST",
 			RequestBody:          "abcdef",
 			ExpectedResponseBody: "bcdefg",
 		})
@@ -149,8 +141,6 @@ func (suite *TestSuite) TestBuildURL() {
 	suite.FunctionBuildRunAndRequest(&buildOptions,
 		nil,
 		&httpsuite.Request{
-			RequestPort:          8080,
-			RequestPath:          "/",
 			RequestMethod:        "POST",
 			RequestBody:          "abcdef",
 			ExpectedResponseBody: "bcdefg",

--- a/pkg/processor/build/runtime/golang/test/golang_test.go
+++ b/pkg/processor/build/runtime/golang/test/golang_test.go
@@ -22,12 +22,12 @@ import (
 	"path"
 	"testing"
 
+	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/processor/build"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime/test/suite"
-	"github.com/nuclio/nuclio/pkg/processor/test/suite"
-	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/processor/eventsource/http/test/suite"
+	"github.com/nuclio/nuclio/pkg/processor/test/suite"
 
 	"github.com/stretchr/testify/suite"
 )

--- a/pkg/processor/build/runtime/python/test/python_test.go
+++ b/pkg/processor/build/runtime/python/test/python_test.go
@@ -20,13 +20,13 @@ import (
 	"path"
 	"testing"
 
-	"github.com/nuclio/nuclio/pkg/processor/build/runtime/test/suite"
-
-	"github.com/nuclio/nuclio/pkg/processor/eventsource/http/test/suite"
-	"github.com/stretchr/testify/suite"
-	"github.com/nuclio/nuclio/pkg/processor/build"
-	"github.com/nuclio/nuclio/pkg/processor/test/suite"
 	"github.com/nuclio/nuclio/pkg/dockerclient"
+	"github.com/nuclio/nuclio/pkg/processor/build"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtime/test/suite"
+	"github.com/nuclio/nuclio/pkg/processor/eventsource/http/test/suite"
+	"github.com/nuclio/nuclio/pkg/processor/test/suite"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type TestSuite struct {
@@ -56,7 +56,7 @@ func (suite *TestSuite) TestBuildDir() {
 	buildOptions := build.Options{
 		FunctionName: "reverser",
 		FunctionPath: path.Join(suite.getPythonDir(), "reverser"),
-		Runtime: "python",
+		Runtime:      "python",
 	}
 
 	suite.FunctionBuildRunAndRequest(&buildOptions,
@@ -74,7 +74,7 @@ func (suite *TestSuite) TestBuildDirWithProcessorYAML() {
 	buildOptions := build.Options{
 		FunctionName: "reverser",
 		FunctionPath: path.Join(suite.getPythonDir(), "reverser-with-processor"),
-		Runtime: "python",
+		Runtime:      "python",
 	}
 
 	runOptions := processorsuite.RunOptions{
@@ -124,7 +124,7 @@ func (suite *TestSuite) TestBuildDirWithBuildYAML() {
 	buildOptions := build.Options{
 		FunctionName: "parser",
 		FunctionPath: path.Join(suite.getPythonDir(), "json-parser-with-build"),
-		Runtime: "python",
+		Runtime:      "python",
 	}
 
 	suite.FunctionBuildRunAndRequest(&buildOptions,

--- a/pkg/processor/build/runtime/python/test/python_test.go
+++ b/pkg/processor/build/runtime/python/test/python_test.go
@@ -24,6 +24,9 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/processor/eventsource/http/test/suite"
 	"github.com/stretchr/testify/suite"
+	"github.com/nuclio/nuclio/pkg/processor/build"
+	"github.com/nuclio/nuclio/pkg/processor/test/suite"
+	"github.com/nuclio/nuclio/pkg/dockerclient"
 )
 
 type TestSuite struct {
@@ -33,10 +36,13 @@ type TestSuite struct {
 func (suite *TestSuite) TestBuildFile() {
 	// suite.T().Skip()
 
-	suite.FunctionBuildRunAndRequest("reverser",
-		path.Join(suite.getPythonDir(), "reverser", "reverser.py"),
-		"",
-		map[int]int{8080: 8080},
+	buildOptions := build.Options{
+		FunctionName: "reverser",
+		FunctionPath: path.Join(suite.getPythonDir(), "reverser", "reverser.py"),
+	}
+
+	suite.FunctionBuildRunAndRequest(&buildOptions,
+		nil,
 		&httpsuite.Request{
 			RequestPort:          8080,
 			RequestPath:          "/",
@@ -49,10 +55,14 @@ func (suite *TestSuite) TestBuildFile() {
 func (suite *TestSuite) TestBuildDir() {
 	// suite.T().Skip()
 
-	suite.FunctionBuildRunAndRequest("reverser",
-		path.Join(suite.getPythonDir(), "reverser"),
-		"python",
-		map[int]int{8080: 8080},
+	buildOptions := build.Options{
+		FunctionName: "reverser",
+		FunctionPath: path.Join(suite.getPythonDir(), "reverser"),
+		Runtime: "python",
+	}
+
+	suite.FunctionBuildRunAndRequest(&buildOptions,
+		nil,
 		&httpsuite.Request{
 			RequestPort:          8080,
 			RequestPath:          "/",
@@ -65,10 +75,20 @@ func (suite *TestSuite) TestBuildDir() {
 func (suite *TestSuite) TestBuildDirWithProcessorYAML() {
 	// suite.T().Skip()
 
-	suite.FunctionBuildRunAndRequest("reverser",
-		path.Join(suite.getPythonDir(), "reverser-with-processor"),
-		"python",
-		map[int]int{8888: 8888},
+	buildOptions := build.Options{
+		FunctionName: "reverser",
+		FunctionPath: path.Join(suite.getPythonDir(), "reverser-with-processor"),
+		Runtime: "python",
+	}
+
+	runOptions := processorsuite.RunOptions{
+		RunOptions: dockerclient.RunOptions{
+			Ports: map[int]int{8888: 8888},
+		},
+	}
+
+	suite.FunctionBuildRunAndRequest(&buildOptions,
+		&runOptions,
 		&httpsuite.Request{
 			RequestPort:          8888,
 			RequestPath:          "/",
@@ -90,10 +110,13 @@ func (suite *TestSuite) TestBuildURL() {
 
 	defer httpServer.Shutdown(nil)
 
-	suite.FunctionBuildRunAndRequest("reverser",
-		"http://localhost:7777/some/path/reverser.py",
-		"",
-		map[int]int{8080: 8080},
+	buildOptions := build.Options{
+		FunctionName: "reverser",
+		FunctionPath: "http://localhost:7777/some/path/reverser.py",
+	}
+
+	suite.FunctionBuildRunAndRequest(&buildOptions,
+		nil,
 		&httpsuite.Request{
 			RequestPort:          8080,
 			RequestPath:          "/",
@@ -106,10 +129,14 @@ func (suite *TestSuite) TestBuildURL() {
 func (suite *TestSuite) TestBuildDirWithBuildYAML() {
 	// suite.T().Skip()
 
-	suite.FunctionBuildRunAndRequest("parser",
-		path.Join(suite.getPythonDir(), "json-parser-with-build"),
-		"python",
-		map[int]int{8080: 8080},
+	buildOptions := build.Options{
+		FunctionName: "parser",
+		FunctionPath: path.Join(suite.getPythonDir(), "json-parser-with-build"),
+		Runtime: "python",
+	}
+
+	suite.FunctionBuildRunAndRequest(&buildOptions,
+		nil,
 		&httpsuite.Request{
 			RequestPort:          8080,
 			RequestPath:          "/",
@@ -131,10 +158,19 @@ func (suite *TestSuite) TestBuildURLWithInlineBlock() {
 
 	defer httpServer.Shutdown(nil)
 
-	suite.FunctionBuildRunAndRequest("parser",
-		"http://localhost:7777/some/path/parser.py",
-		"",
-		map[int]int{7979: 7979},
+	buildOptions := build.Options{
+		FunctionName: "parser",
+		FunctionPath: "http://localhost:7777/some/path/parser.py",
+	}
+
+	runOptions := processorsuite.RunOptions{
+		RunOptions: dockerclient.RunOptions{
+			Ports: map[int]int{7979: 7979},
+		},
+	}
+
+	suite.FunctionBuildRunAndRequest(&buildOptions,
+		&runOptions,
 		&httpsuite.Request{
 			RequestPort:          7979,
 			RequestPath:          "/",

--- a/pkg/processor/build/runtime/python/test/python_test.go
+++ b/pkg/processor/build/runtime/python/test/python_test.go
@@ -44,8 +44,6 @@ func (suite *TestSuite) TestBuildFile() {
 	suite.FunctionBuildRunAndRequest(&buildOptions,
 		nil,
 		&httpsuite.Request{
-			RequestPort:          8080,
-			RequestPath:          "/",
 			RequestMethod:        "POST",
 			RequestBody:          "abcdef",
 			ExpectedResponseBody: "fedcba",
@@ -64,8 +62,6 @@ func (suite *TestSuite) TestBuildDir() {
 	suite.FunctionBuildRunAndRequest(&buildOptions,
 		nil,
 		&httpsuite.Request{
-			RequestPort:          8080,
-			RequestPath:          "/",
 			RequestMethod:        "POST",
 			RequestBody:          "abcdef",
 			ExpectedResponseBody: "fedcba",
@@ -91,8 +87,6 @@ func (suite *TestSuite) TestBuildDirWithProcessorYAML() {
 		&runOptions,
 		&httpsuite.Request{
 			RequestPort:          8888,
-			RequestPath:          "/",
-			RequestMethod:        "POST",
 			RequestBody:          "abcdef",
 			ExpectedResponseBody: "fedcba",
 		})
@@ -118,8 +112,6 @@ func (suite *TestSuite) TestBuildURL() {
 	suite.FunctionBuildRunAndRequest(&buildOptions,
 		nil,
 		&httpsuite.Request{
-			RequestPort:          8080,
-			RequestPath:          "/",
 			RequestMethod:        "POST",
 			RequestBody:          "abcdef",
 			ExpectedResponseBody: "fedcba",
@@ -138,9 +130,6 @@ func (suite *TestSuite) TestBuildDirWithBuildYAML() {
 	suite.FunctionBuildRunAndRequest(&buildOptions,
 		nil,
 		&httpsuite.Request{
-			RequestPort:          8080,
-			RequestPath:          "/",
-			RequestMethod:        "POST",
 			RequestBody:          `{"a": 100, "return_this": "returned value"}`,
 			ExpectedResponseBody: "returned value",
 		})
@@ -173,8 +162,6 @@ func (suite *TestSuite) TestBuildURLWithInlineBlock() {
 		&runOptions,
 		&httpsuite.Request{
 			RequestPort:          7979,
-			RequestPath:          "/",
-			RequestMethod:        "POST",
 			RequestBody:          `{"a": 100, "return_this": "returned value"}`,
 			ExpectedResponseBody: "returned value",
 		})

--- a/pkg/processor/eventsource/http/test/suite/suite.go
+++ b/pkg/processor/eventsource/http/test/suite/suite.go
@@ -65,6 +65,19 @@ func (suite *TestSuite) FunctionBuildRunAndRequest(buildOptions *build.Options,
 		request.ExpectedResponseStatusCode = &defaultStatusCode
 	}
 
+	// by default BuildAndRunFunction will map 8080
+	if request.RequestPort == 0 {
+		request.RequestPort = 8080
+	}
+
+	if request.RequestPath == "" {
+		request.RequestPath = "/"
+	}
+
+	if request.RequestMethod == "" {
+		request.RequestMethod = "POST"
+	}
+
 	suite.BuildAndRunFunction(buildOptions, runOptions, func() bool {
 		return suite.SendRequestVerifyResponse(request)
 	})

--- a/pkg/processor/eventsource/http/test/suite/suite.go
+++ b/pkg/processor/eventsource/http/test/suite/suite.go
@@ -24,7 +24,9 @@ import (
 	"strings"
 	"time"
 
+
 	"github.com/nuclio/nuclio/pkg/processor/test/suite"
+	"github.com/nuclio/nuclio/pkg/processor/build"
 	"github.com/nuclio/nuclio/test/compare"
 )
 
@@ -54,10 +56,8 @@ func (suite *TestSuite) SetupTest() {
 	}
 }
 
-func (suite *TestSuite) FunctionBuildRunAndRequest(functionName string,
-	functionPath string,
-	runtime string,
-	ports map[int]int,
+func (suite *TestSuite) FunctionBuildRunAndRequest(buildOptions *build.Options,
+	runOptions *processorsuite.RunOptions,
 	request *Request) {
 
 	defaultStatusCode := http.StatusOK
@@ -65,7 +65,7 @@ func (suite *TestSuite) FunctionBuildRunAndRequest(functionName string,
 		request.ExpectedResponseStatusCode = &defaultStatusCode
 	}
 
-	suite.BuildAndRunFunction(functionName, functionPath, runtime, ports, func() bool {
+	suite.BuildAndRunFunction(buildOptions, runOptions, func() bool {
 		return suite.SendRequestVerifyResponse(request)
 	})
 }

--- a/pkg/processor/eventsource/http/test/suite/suite.go
+++ b/pkg/processor/eventsource/http/test/suite/suite.go
@@ -24,9 +24,8 @@ import (
 	"strings"
 	"time"
 
-
-	"github.com/nuclio/nuclio/pkg/processor/test/suite"
 	"github.com/nuclio/nuclio/pkg/processor/build"
+	"github.com/nuclio/nuclio/pkg/processor/test/suite"
 	"github.com/nuclio/nuclio/test/compare"
 )
 

--- a/pkg/processor/eventsource/rabbitmq/test/rabbitmq_test.go
+++ b/pkg/processor/eventsource/rabbitmq/test/rabbitmq_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/dockerclient"
+	"github.com/nuclio/nuclio/pkg/processor/build"
 	"github.com/nuclio/nuclio/pkg/processor/test/suite"
 
 	"encoding/json"
@@ -30,7 +31,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"io/ioutil"
 	"net/http"
-	"github.com/nuclio/nuclio/pkg/processor/build"
 )
 
 const (
@@ -107,7 +107,7 @@ func (suite *TestSuite) invokeEventRecorder(functionPath string, runtimeType str
 	buildOptions := build.Options{
 		FunctionName: "event_recorder",
 		FunctionPath: path.Join(suite.getFunctionsPath(), functionPath),
-		Runtime: runtimeType,
+		Runtime:      runtimeType,
 	}
 
 	suite.BuildAndRunFunction(&buildOptions,

--- a/pkg/processor/eventsource/rabbitmq/test/rabbitmq_test.go
+++ b/pkg/processor/eventsource/rabbitmq/test/rabbitmq_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"io/ioutil"
 	"net/http"
+	"github.com/nuclio/nuclio/pkg/processor/build"
 )
 
 const (
@@ -103,10 +104,14 @@ func (suite *TestSuite) TestPostEventGolang() {
 }
 
 func (suite *TestSuite) invokeEventRecorder(functionPath string, runtimeType string) {
-	suite.BuildAndRunFunction("event_recorder",
-		path.Join(suite.getFunctionsPath(), functionPath),
-		runtimeType,
-		map[int]int{8080: 8080},
+	buildOptions := build.Options{
+		FunctionName: "event_recorder",
+		FunctionPath: path.Join(suite.getFunctionsPath(), functionPath),
+		Runtime: runtimeType,
+	}
+
+	suite.BuildAndRunFunction(&buildOptions,
+		nil,
 		func() bool {
 
 			message := amqp.Publishing{}

--- a/pkg/processor/runtime/golang/test/golang_test.go
+++ b/pkg/processor/runtime/golang/test/golang_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/processor/eventsource/http/test/suite"
+	"github.com/nuclio/nuclio/pkg/processor/build"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -42,10 +43,14 @@ func (suite *TestSuite) TestOutputs() {
 	headersContentTypeTextPlain := map[string]string{"content-type": "text/plain; charset=utf-8"}
 	// headersContentTypeApplicationJSON := map[string]string{"content-type": "application/json"}
 
-	suite.BuildAndRunFunction("outputter",
-		path.Join(suite.GetGolangDir(), "outputter"),
-		"golang",
-		map[int]int{8080: 8080},
+	buildOptions := build.Options{
+		FunctionName: "outputter",
+		FunctionPath: path.Join(suite.GetGolangDir(), "outputter"),
+		Runtime: "golang",
+	}
+
+	suite.BuildAndRunFunction(&buildOptions,
+		nil,
 		func() bool {
 
 			testRequests := []httpsuite.Request{

--- a/pkg/processor/runtime/golang/test/golang_test.go
+++ b/pkg/processor/runtime/golang/test/golang_test.go
@@ -21,8 +21,8 @@ import (
 	"path"
 	"testing"
 
-	"github.com/nuclio/nuclio/pkg/processor/eventsource/http/test/suite"
 	"github.com/nuclio/nuclio/pkg/processor/build"
+	"github.com/nuclio/nuclio/pkg/processor/eventsource/http/test/suite"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -46,7 +46,7 @@ func (suite *TestSuite) TestOutputs() {
 	buildOptions := build.Options{
 		FunctionName: "outputter",
 		FunctionPath: path.Join(suite.GetGolangDir(), "outputter"),
-		Runtime: "golang",
+		Runtime:      "golang",
 	}
 
 	suite.BuildAndRunFunction(&buildOptions,

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/processor/eventsource/http/test/suite"
+	"github.com/nuclio/nuclio/pkg/processor/build"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -42,10 +43,14 @@ func (suite *TestSuite) TestOutputs() {
 	headersContentTypeTextPlain := map[string]string{"content-type": "text/plain"}
 	headersContentTypeApplicationJSON := map[string]string{"content-type": "application/json"}
 
-	suite.BuildAndRunFunction("outputter",
-		path.Join(suite.getPythonDir(), "outputter"),
-		"python",
-		map[int]int{8080: 8080},
+	buildOptions := build.Options{
+		FunctionName: "outputter",
+		FunctionPath: path.Join(suite.getPythonDir(), "outputter"),
+		Runtime: "python",
+	}
+
+	suite.BuildAndRunFunction(&buildOptions,
+		nil,
 		func() bool {
 
 			testRequests := []httpsuite.Request{

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -21,8 +21,8 @@ import (
 	"path"
 	"testing"
 
-	"github.com/nuclio/nuclio/pkg/processor/eventsource/http/test/suite"
 	"github.com/nuclio/nuclio/pkg/processor/build"
+	"github.com/nuclio/nuclio/pkg/processor/eventsource/http/test/suite"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -46,7 +46,7 @@ func (suite *TestSuite) TestOutputs() {
 	buildOptions := build.Options{
 		FunctionName: "outputter",
 		FunctionPath: path.Join(suite.getPythonDir(), "outputter"),
-		Runtime: "python",
+		Runtime:      "python",
 	}
 
 	suite.BuildAndRunFunction(&buildOptions,

--- a/pkg/processor/worker/worker_test.go
+++ b/pkg/processor/worker/worker_test.go
@@ -19,8 +19,8 @@ package worker
 import (
 	"testing"
 
-	"github.com/nuclio/nuclio/pkg/zap"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/zap"
 
 	"github.com/nuclio/nuclio-sdk"
 	"github.com/stretchr/testify/mock"


### PR DESCRIPTION
`BuildAndRunFunction` and all its derivatives accepts build and run options. This allows callers to pass less fields when they are default and inject more fields (e.g. image name) when they are not.