### PR TITLE
Fix import order, verify import order on "lint" rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ lint:
 		--exclude="comment on" \
 		--exclude="error should be the last" \
 		--deadline=300s \
+		--concurrency 2 \
 		./cmd/... ./pkg/...
 
 	@echo Done.

--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,14 @@ playground:
 
 .PHONY: lint
 lint:
-	go get -u gopkg.in/alecthomas/gometalinter.v1
-	${GOPATH}/bin/gometalinter.v1 --install
-	${GOPATH}/bin/gometalinter.v1 \
+	@echo Verifying imports...
+	@go get -u github.com/pavius/impi/cmd/impi
+	@${GOPATH}/bin/impi -local github.com/nuclio/nuclio/ ./cmd/... ./pkg/...
+
+	@echo Linting...
+	@go get -u gopkg.in/alecthomas/gometalinter.v1
+	@${GOPATH}/bin/gometalinter.v1 --install
+	@${GOPATH}/bin/gometalinter.v1 \
 		--disable-all \
 		--enable=vet \
 		--enable=vetshadow \
@@ -66,7 +71,9 @@ lint:
 		--exclude="comment on" \
 		--exclude="error should be the last" \
 		--deadline=300s \
-		./pkg/... ./cmd/...
+		./cmd/... ./pkg/...
+
+	@echo Done.
 
 .PHONY: test
 test:

--- a/cmd/controller/app/controller_test.go
+++ b/cmd/controller/app/controller_test.go
@@ -19,10 +19,10 @@ package app
 import (
 	"testing"
 
+	"github.com/nuclio/nuclio/pkg/functioncr"
 	"github.com/nuclio/nuclio/pkg/zap"
 
 	"github.com/nuclio/nuclio-sdk"
-	"github.com/nuclio/nuclio/pkg/functioncr"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	v1beta1 "k8s.io/api/apps/v1beta1"

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -24,12 +24,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/processor/config"
 	"github.com/nuclio/nuclio/pkg/processor/eventsource"
-	"github.com/nuclio/nuclio/pkg/processor/statistics"
-	"github.com/nuclio/nuclio/pkg/processor/webadmin"
-	"github.com/nuclio/nuclio/pkg/processor/worker"
-	"github.com/nuclio/nuclio/pkg/zap"
-
-	// Load all sources and runtimes
+	// load all event sources and runtimes
 	_ "github.com/nuclio/nuclio/pkg/processor/eventsource/generator"
 	_ "github.com/nuclio/nuclio/pkg/processor/eventsource/http"
 	_ "github.com/nuclio/nuclio/pkg/processor/eventsource/kafka"
@@ -40,6 +35,10 @@ import (
 	_ "github.com/nuclio/nuclio/pkg/processor/runtime/golang"
 	_ "github.com/nuclio/nuclio/pkg/processor/runtime/python"
 	_ "github.com/nuclio/nuclio/pkg/processor/runtime/shell"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
+	"github.com/nuclio/nuclio/pkg/processor/webadmin"
+	"github.com/nuclio/nuclio/pkg/processor/worker"
+	"github.com/nuclio/nuclio/pkg/zap"
 
 	"github.com/nuclio/nuclio-sdk"
 	"github.com/spf13/viper"

--- a/pkg/nuctl/command/execute.go
+++ b/pkg/nuctl/command/execute.go
@@ -18,9 +18,9 @@ package command
 
 import (
 	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/nuctl"
 	"github.com/nuclio/nuclio/pkg/nuctl/executor"
 
-	"github.com/nuclio/nuclio/pkg/nuctl"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/nuctl/command/get.go
+++ b/pkg/nuctl/command/get.go
@@ -18,9 +18,9 @@ package command
 
 import (
 	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/nuctl"
 	"github.com/nuclio/nuclio/pkg/nuctl/getter"
 
-	"github.com/nuclio/nuclio/pkg/nuctl"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/nuctl/command/nuctl.go
+++ b/pkg/nuctl/command/nuctl.go
@@ -17,11 +17,11 @@ limitations under the License.
 package command
 
 import (
-	"github.com/nuclio/nuclio-sdk"
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/nuctl"
 	"github.com/nuclio/nuclio/pkg/zap"
 
+	"github.com/nuclio/nuclio-sdk"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/nuctl/command/run_test.go
+++ b/pkg/nuctl/command/run_test.go
@@ -21,11 +21,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/nuclio/nuclio-sdk"
 	"github.com/nuclio/nuclio/pkg/nuctl"
 	"github.com/nuclio/nuclio/pkg/nuctl/runner"
 	"github.com/nuclio/nuclio/pkg/zap"
 
+	"github.com/nuclio/nuclio-sdk"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/pkg/nuctl/executor/function.go
+++ b/pkg/nuctl/executor/function.go
@@ -27,12 +27,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mgutz/ansi"
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/nuctl"
 	"github.com/nuclio/nuclio/pkg/util/common"
 	"github.com/nuclio/nuclio/pkg/zap"
 
+	"github.com/mgutz/ansi"
 	"github.com/nuclio/nuclio-sdk"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/playground/resource/function.go
+++ b/pkg/playground/resource/function.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/functioncr"
 	"github.com/nuclio/nuclio/pkg/nuctl"
 	"github.com/nuclio/nuclio/pkg/nuctl/executor"
 	"github.com/nuclio/nuclio/pkg/nuctl/runner"
@@ -35,7 +36,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/zap"
 
 	"github.com/nuclio/nuclio-sdk"
-	"github.com/nuclio/nuclio/pkg/functioncr"
 )
 
 //

--- a/pkg/processor/build/runtime/golang/eventhandlerparser/parse_test.go
+++ b/pkg/processor/build/runtime/golang/eventhandlerparser/parse_test.go
@@ -25,9 +25,9 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/stretchr/testify/suite"
-
 	nucliozap "github.com/nuclio/nuclio/pkg/zap"
+
+	"github.com/stretchr/testify/suite"
 )
 
 var code = `

--- a/pkg/processor/eventsource/generator/eventsource.go
+++ b/pkg/processor/eventsource/generator/eventsource.go
@@ -21,11 +21,12 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/nuclio/nuclio-sdk"
 	"github.com/nuclio/nuclio/pkg/processor"
 	"github.com/nuclio/nuclio/pkg/processor/eventsource"
 	"github.com/nuclio/nuclio/pkg/processor/worker"
 	"github.com/nuclio/nuclio/pkg/util/common"
+
+	"github.com/nuclio/nuclio-sdk"
 )
 
 type generator struct {

--- a/pkg/processor/eventsource/http/factory.go
+++ b/pkg/processor/eventsource/http/factory.go
@@ -17,11 +17,11 @@ limitations under the License.
 package http
 
 import (
-	"github.com/nuclio/nuclio-sdk"
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/processor/eventsource"
 	"github.com/nuclio/nuclio/pkg/processor/worker"
 
+	"github.com/nuclio/nuclio-sdk"
 	"github.com/spf13/viper"
 )
 

--- a/pkg/processor/eventsource/kinesis/shard.go
+++ b/pkg/processor/eventsource/kinesis/shard.go
@@ -1,12 +1,12 @@
 package kinesis
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/processor/worker"
 
-	"fmt"
 	"github.com/nuclio/nuclio-sdk"
 	kinesisclient "github.com/sendgridlabs/go-kinesis"
 )

--- a/pkg/processor/eventsource/poller/types.go
+++ b/pkg/processor/eventsource/poller/types.go
@@ -17,9 +17,9 @@ limitations under the License.
 package poller
 
 import (
-	"github.com/nuclio/nuclio-sdk"
 	"github.com/nuclio/nuclio/pkg/processor/eventsource"
 
+	"github.com/nuclio/nuclio-sdk"
 	"github.com/spf13/viper"
 )
 

--- a/pkg/processor/eventsource/poller/v3ioitempoller/eventsource.go
+++ b/pkg/processor/eventsource/poller/v3ioitempoller/eventsource.go
@@ -21,13 +21,13 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/nuclio/nuclio-sdk"
 	"github.com/nuclio/nuclio/pkg/processor/eventsource"
 	"github.com/nuclio/nuclio/pkg/processor/eventsource/poller"
 	"github.com/nuclio/nuclio/pkg/processor/worker"
 	"github.com/nuclio/nuclio/pkg/util/common"
 
 	"github.com/iguazio/v3io-go-http"
+	"github.com/nuclio/nuclio-sdk"
 )
 
 type v3ioItemPoller struct {

--- a/pkg/processor/eventsource/rabbitmq/test/event_recorder_golang/event_recorder.go
+++ b/pkg/processor/eventsource/rabbitmq/test/event_recorder_golang/event_recorder.go
@@ -30,11 +30,11 @@ limitations under the License.
 package eventrecorder
 
 import (
+	"io/ioutil"
+	"net/http"
 	"os"
 
 	"github.com/nuclio/nuclio-sdk"
-	"io/ioutil"
-	"net/http"
 )
 
 const eventLogFilePath = "/tmp/events.json"

--- a/pkg/processor/eventsource/rabbitmq/test/rabbitmq_test.go
+++ b/pkg/processor/eventsource/rabbitmq/test/rabbitmq_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package test
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"path"
 	"testing"
 	"time"
@@ -26,11 +29,8 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/build"
 	"github.com/nuclio/nuclio/pkg/processor/test/suite"
 
-	"encoding/json"
 	"github.com/streadway/amqp"
 	"github.com/stretchr/testify/suite"
-	"io/ioutil"
-	"net/http"
 )
 
 const (

--- a/pkg/processor/eventsource/registry.go
+++ b/pkg/processor/eventsource/registry.go
@@ -17,9 +17,9 @@ limitations under the License.
 package eventsource
 
 import (
-	"github.com/nuclio/nuclio-sdk"
 	"github.com/nuclio/nuclio/pkg/util/registry"
 
+	"github.com/nuclio/nuclio-sdk"
 	"github.com/spf13/viper"
 )
 

--- a/pkg/processor/runtime/registry.go
+++ b/pkg/processor/runtime/registry.go
@@ -17,9 +17,9 @@ limitations under the License.
 package runtime
 
 import (
-	"github.com/nuclio/nuclio-sdk"
 	"github.com/nuclio/nuclio/pkg/util/registry"
 
+	"github.com/nuclio/nuclio-sdk"
 	"github.com/spf13/viper"
 )
 

--- a/pkg/processor/webadmin/resource/eventsources.go
+++ b/pkg/processor/webadmin/resource/eventsources.go
@@ -19,9 +19,10 @@ package resource
 import (
 	"net/http"
 
-	"github.com/go-chi/chi"
 	"github.com/nuclio/nuclio/pkg/processor/webadmin"
 	"github.com/nuclio/nuclio/pkg/restful"
+
+	"github.com/go-chi/chi"
 )
 
 type eventSourcesResource struct {

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -17,8 +17,9 @@ limitations under the License.
 package worker
 
 import (
-	"github.com/nuclio/nuclio-sdk"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+
+	"github.com/nuclio/nuclio-sdk"
 )
 
 type Worker struct {

--- a/pkg/restful/resource_test.go
+++ b/pkg/restful/resource_test.go
@@ -26,10 +26,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nuclio/nuclio-sdk"
 	"github.com/nuclio/nuclio/pkg/zap"
 
 	"github.com/go-chi/chi"
+	"github.com/nuclio/nuclio-sdk"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/pkg/util/cmdrunner/cmdrunner.go
+++ b/pkg/util/cmdrunner/cmdrunner.go
@@ -19,9 +19,9 @@ package cmdrunner
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/nuclio/nuclio-sdk"
-	"strings"
 )
 
 type CmdRunner struct {

--- a/pkg/util/common/url_test.go
+++ b/pkg/util/common/url_test.go
@@ -1,12 +1,10 @@
 package common
 
 import (
-	"testing"
-
 	"errors"
 	"net/http"
-
 	"os"
+	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/jarcoal/httpmock.v1"

--- a/pkg/util/renderer/renderer.go
+++ b/pkg/util/renderer/renderer.go
@@ -17,13 +17,13 @@ limitations under the License.
 package renderer
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 
 	"github.com/nuclio/nuclio/pkg/errors"
 
-	"bytes"
 	"github.com/ghodss/yaml"
 	"github.com/olekukonko/tablewriter"
 )


### PR DESCRIPTION
Use `impi` (github.com/pavius/impi) to verify correctness of import order.