### PR TITLE
Local platform properly supports environment variables

### DIFF
--- a/pkg/dockerclient/dockerclient.go
+++ b/pkg/dockerclient/dockerclient.go
@@ -44,6 +44,7 @@ type RunOptions struct {
 	Ports         map[int]int
 	ContainerName string
 	NetworkType   string
+	Env           map[string]string
 	Labels        map[string]string
 }
 
@@ -180,12 +181,20 @@ func (c *Client) RunContainer(imageName string, runOptions *RunOptions) (string,
 		}
 	}
 
+	envArgument := ""
+	if runOptions.Env != nil {
+		for envName, envValue := range runOptions.Env {
+			labelArgument += fmt.Sprintf("--env %s=%s ", envName, envValue)
+		}
+	}
+
 	out, err := c.cmdRunner.Run(nil,
-		"docker run -d %s %s %s %s %s",
+		"docker run -d %s %s %s %s %s %s",
 		portsArgument,
 		nameArgument,
 		netArgument,
 		labelArgument,
+		envArgument,
 		imageName)
 
 	if err != nil {

--- a/pkg/nuctl/test/build_test.go
+++ b/pkg/nuctl/test/build_test.go
@@ -32,7 +32,7 @@ type BuildTestSuite struct {
 func (suite *BuildTestSuite) TestBuild() {
 	imageName := fmt.Sprintf("nuclio/build-test-%s", xid.New().String())
 
-	err := suite.ExecuteNutcl([]string{"build", "example", "--verbose"},
+	err := suite.ExecuteNutcl([]string{"build", "example", "--verbose", "--no-pull"},
 		map[string]string{
 			"path":           path.Join(suite.GetNuclioSourceDir(), "pkg", "nuctl", "test", "reverser"),
 			"nuclio-src-dir": suite.GetNuclioSourceDir(),
@@ -45,7 +45,7 @@ func (suite *BuildTestSuite) TestBuild() {
 	defer suite.dockerClient.RemoveImage(imageName)
 
 	// use deploy with the image we just created
-	err = suite.ExecuteNutcl([]string{"deploy", "example", "--verbose", "--no-pull"},
+	err = suite.ExecuteNutcl([]string{"deploy", "example", "--verbose"},
 		map[string]string{
 			"run-image": imageName,
 		})

--- a/pkg/nuctl/test/build_test.go
+++ b/pkg/nuctl/test/build_test.go
@@ -45,7 +45,7 @@ func (suite *BuildTestSuite) TestBuild() {
 	defer suite.dockerClient.RemoveImage(imageName)
 
 	// use deploy with the image we just created
-	err = suite.ExecuteNutcl([]string{"deploy", "example", "--verbose"},
+	err = suite.ExecuteNutcl([]string{"deploy", "example", "--verbose", "--no-pull"},
 		map[string]string{
 			"run-image": imageName,
 		})

--- a/pkg/nuctl/test/env/env.py
+++ b/pkg/nuctl/test/env/env.py
@@ -1,0 +1,27 @@
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+
+def handler(context, event):
+    """Return given env vars as body"""
+
+    env1 = os.environ.get('FIRST_ENV')
+    env2 = os.environ.get('SECOND_ENV')
+
+    return context.Response(body=f'first: "{env1}"; second: "{env2}"',
+                            headers=None,
+                            content_type='text/plain',
+                            status_code=200)

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -4,6 +4,7 @@ import (
 	"net"
 
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/platform"
@@ -163,14 +164,21 @@ func (p *Platform) deployFunction(deployOptions *platform.DeployOptions) (*platf
 
 	p.Logger.DebugWith("Found free local port", "port", freeLocalPort)
 
+	labels := map[string]string{
+		"nuclio-platform":      "local",
+		"nuclio-namespace":     deployOptions.Common.Namespace,
+		"nuclio-function-name": deployOptions.Common.Identifier,
+	}
+
+	for labelName, labelValue := range common.StringToStringMap(deployOptions.Labels) {
+		labels[labelName] = labelValue
+	}
+
 	// run the docker image
 	_, err = p.dockerClient.RunContainer(deployOptions.ImageName, &dockerclient.RunOptions{
-		Ports: map[int]int{freeLocalPort: 8080},
-		Labels: map[string]string{
-			"nuclio-platform":      "local",
-			"nuclio-namespace":     deployOptions.Common.Namespace,
-			"nuclio-function-name": deployOptions.Common.Identifier,
-		},
+		Ports:  map[int]int{freeLocalPort: 8080},
+		Env:    common.StringToStringMap(deployOptions.Env),
+		Labels: labels,
 	})
 
 	if err != nil {

--- a/pkg/processor/eventsource/http/eventsource.go
+++ b/pkg/processor/eventsource/http/eventsource.go
@@ -18,7 +18,6 @@ package http
 
 import (
 	net_http "net/http"
-	"os"
 	"strconv"
 	"time"
 
@@ -31,12 +30,6 @@ import (
 	"github.com/nuclio/nuclio-sdk"
 	"github.com/valyala/fasthttp"
 )
-
-var returnErrorInBody bool
-
-func init() {
-	returnErrorInBody = len(os.Getenv("NUCLIO_DISABLE_ERROR_IN_BODY")) == 0
-}
 
 type http struct {
 	eventsource.AbstractEventSource
@@ -165,9 +158,6 @@ func (h *http) requestHandler(ctx *fasthttp.RequestCtx) {
 			ctx.Response.SetStatusCode(net_http.StatusInternalServerError)
 		}
 
-		if returnErrorInBody {
-			errors.PrintErrorStack(ctx, submitError, -1)
-		}
 		return
 	}
 
@@ -187,10 +177,6 @@ func (h *http) requestHandler(ctx *fasthttp.RequestCtx) {
 		}
 
 		ctx.Response.SetStatusCode(statusCode)
-		if returnErrorInBody {
-			errors.PrintErrorStack(ctx, submitError, -1)
-		}
-
 		return
 	}
 

--- a/pkg/processor/runtime/python/runtime.go
+++ b/pkg/processor/runtime/python/runtime.go
@@ -162,7 +162,9 @@ func (py *python) runWrapper() error {
 	}
 	py.Logger.DebugWith("Using Python executable", "path", pythonExePath)
 
-	env := py.getEnvFromConfiguration()
+	// pass global environment onto the process, and sprinkle in some added env vars
+	env := os.Environ()
+	env = append(env, py.getEnvFromConfiguration()...)
 	envPath := fmt.Sprintf("PYTHONPATH=%s", py.getPythonPath())
 	py.Logger.DebugWith("Setting PYTHONPATH", "value", envPath)
 	env = append(env, envPath)


### PR DESCRIPTION
1. Properly inject environment variables to docker containers spun up by the local platform
2. Fix Python runtime to inject all environment variables into the spawned wrapper process
3. Revert a change introduced in #243 that broke tests and behavior when a panic occurred in Go handlers