### PR TITLE
More playground fixtures, smaller images and some goodies

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -253,8 +253,8 @@ func (c *Controller) publishFunction(function *functioncr.Function) error {
 	c.logger.InfoWith("Publishing function", "function", function)
 
 	// update the function name
-	publishedFunction.Name = fmt.Sprintf("%s-%d",
-		publishedFunction.Name, publishedFunction.Spec.Version)
+	publishedFunction.Name = fmt.Sprintf("%s%s%d",
+		publishedFunction.Name, functioncr.GetVersionSeparator(), publishedFunction.Spec.Version)
 
 	// clear version and alias
 	publishedFunction.ResourceVersion = ""

--- a/cmd/playground/Dockerfile
+++ b/cmd/playground/Dockerfile
@@ -14,7 +14,16 @@
 
 FROM alpine:3.6
 
-RUN apk add --no-cache ca-certificates git docker
+ARG DOCKER_CLI_VERSION="17.09.0-ce"
+
+ENV DOWNLOAD_URL="https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_CLI_VERSION.tgz"
+
+RUN apk --update --no-cache add ca-certificates git curl \
+    && mkdir -p /tmp/download \
+    && curl -L $DOWNLOAD_URL | tar -xz -C /tmp/download \
+    && mv /tmp/download/docker/docker /usr/local/bin/ \
+    && rm -rf /tmp/download \
+    && apk del curl
 
 COPY _output/playground /usr/local/bin
 COPY static /etc/nuclio/playground/assets

--- a/pkg/platform/kube/functioncr/function.go
+++ b/pkg/platform/kube/functioncr/function.go
@@ -69,17 +69,20 @@ func (f *Function) GetNameAndVersion() (name string, version *int, err error) {
 		return
 	}
 
-	if lastHyphenIdx := strings.LastIndex(name, "-"); lastHyphenIdx > 0 {
+	separator := GetVersionSeparator()
+	separatorLen := len(separator)
+
+	if lastSeparatorIdx := strings.LastIndex(name, separator); lastSeparatorIdx > 0 {
 		var versionValue int
 
 		// get the string that follows the last hyphen
-		versionValue, err = strconv.Atoi(name[lastHyphenIdx+1:])
+		versionValue, err = strconv.Atoi(name[lastSeparatorIdx+separatorLen:])
 		if err != nil {
 			return
 		}
 
 		version = &versionValue
-		name = name[:lastHyphenIdx]
+		name = name[:lastSeparatorIdx]
 	}
 
 	return name, version, nil
@@ -96,4 +99,8 @@ func FromSpecFile(specFilePath string, f *Function) error {
 	}
 
 	return yaml.Unmarshal(specFileContents, f)
+}
+
+func GetVersionSeparator() string {
+	return "---"
 }

--- a/pkg/platform/kube/functioncr/function_test.go
+++ b/pkg/platform/kube/functioncr/function_test.go
@@ -37,7 +37,7 @@ func (suite *FunctionTestSuite) TestOnlyName() {
 }
 
 func (suite *FunctionTestSuite) TestNameAndVersion() {
-	suite.function.Name = "111ValidName123-30"
+	suite.function.Name = "111ValidName123---30"
 
 	name, version, err := suite.function.GetNameAndVersion()
 	suite.Require().NoError(err)
@@ -54,7 +54,7 @@ func (suite *FunctionTestSuite) TestInvalidName() {
 	_, _, err = suite.function.GetNameAndVersion()
 	suite.Require().Error(err)
 
-	suite.function.Name = "valid-invalidversion"
+	suite.function.Name = "valid---invalidversion"
 	_, _, err = suite.function.GetNameAndVersion()
 	suite.Require().Error(err)
 }

--- a/pkg/playground/fixtures/source.go
+++ b/pkg/playground/fixtures/source.go
@@ -15,17 +15,17 @@ func Echo(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
 	return nuclio.Response{
 		StatusCode:  200,
 		ContentType: "application/text",
-		Body:        []byte(event.GetBody()),
+		Body:		 []byte(event.GetBody()),
 	}, nil
 }
 `,
 	"responder.py": `def handler(context, event):
-    context.logger.info('Responding')
+	context.logger.info('Responding')
 
-    return context.Response(
-            body='Some response body',
-            headers=None,
-            content_type='text/plain',
-            status_code=200)
+	# return a response, where the body is some environment variable and headers is another
+	return context.Response(body='Response: {0}'.format(os.environ.get('ENV_VAR1'),
+							headers={'x-env-var-2': os.environ.get('ENV_VAR2')},
+							content_type='text/plain',
+							status_code=200)
 `,
 }

--- a/pkg/playground/fixtures/source.go
+++ b/pkg/playground/fixtures/source.go
@@ -53,4 +53,89 @@ def handler(context, event):
 							content_type='text/plain',
 							status_code=200)
 `,
+	"rabbitmq.go": `//
+// Listens to a RabbitMQ queue and records any messages posted to a given queue.
+// Can retreive these recorded messages through HTTP GET, demonstrating how a single
+// function can be invoked from different event sources.
+//
+
+// @nuclio.configure
+//
+// processor.yaml:
+//   event_sources:
+//     test_rmq:
+//       class: "async"
+//       kind: "rabbit-mq"
+//       enabled: true
+//       url: "amqp://<user>:<password>@<rabbitmq-host>:5672"
+//       exchange: "<exchange name>"
+//       queue_name: "<queue name">
+//
+
+package eventrecorder
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/nuclio/nuclio-sdk"
+)
+
+const eventLogFilePath = "/tmp/events.json"
+
+func Handler(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
+	context.Logger.InfoWith("Received event", "body", string(event.GetBody()))
+
+	// if we got the event from rabbit
+	if event.GetSource().GetClass() == "async" && event.GetSource().GetKind() == "rabbitMq" {
+
+		eventLogFile, err := os.OpenFile(eventLogFilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+		if err != nil {
+			return nil, err
+		}
+
+		defer eventLogFile.Close()
+
+		// write the body followed by ', '
+		for _, dataToWrite := range [][]byte{
+			event.GetBody(),
+			[]byte(", "),
+		} {
+
+			// write the thing to write
+			if _, err = eventLogFile.Write(dataToWrite); err != nil {
+				return nil, err
+			}
+		}
+
+		// all's well
+		return nil, nil
+	}
+
+	// open the log for read
+	eventLogFile, err := os.OpenFile(eventLogFilePath, os.O_RDONLY, 0600)
+	if err != nil {
+		return nil, err
+	}
+
+	defer eventLogFile.Close()
+
+	// read the entire file
+	eventLogFileContents, err := ioutil.ReadAll(eventLogFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// chop off the last 2 chars and enclose in a [ ]
+	eventLogFileContentsString := "[" + string(eventLogFileContents[:len(eventLogFileContents)-2]) + "]"
+
+	// return the contents as JSON
+	return nuclio.Response{
+		StatusCode:  http.StatusOK,
+		ContentType: "application/json",
+		Body:        []byte(eventLogFileContentsString),
+	}, nil
+}
+`,
 }

--- a/pkg/playground/fixtures/source.go
+++ b/pkg/playground/fixtures/source.go
@@ -55,7 +55,7 @@ def handler(context, event):
 `,
 	"rabbitmq.go": `//
 // Listens to a RabbitMQ queue and records any messages posted to a given queue.
-// Can retreive these recorded messages through HTTP GET, demonstrating how a single
+// Can retrieve these recorded messages through HTTP GET, demonstrating how a single
 // function can be invoked from different event sources.
 //
 

--- a/pkg/playground/fixtures/source.go
+++ b/pkg/playground/fixtures/source.go
@@ -2,29 +2,54 @@ package fixtures
 
 // Sources contains a map of built in source fixtures
 var Sources = map[string]string{
-	"echo.go": `package echo
+	"echo.go": `//
+// Super simple Golang function that echoes back the body it receives
+//
+// Note: The first build takes longer as it performs one time initializations (e.g.
+// pulls golang:1.8-alpine3.6 from docker hub).
+//
 
-import (
-	"github.com/nuclio/nuclio-sdk"
-)
+package echo
 
-// Echo will reply with whatever you POST to it
+import "github.com/nuclio/nuclio-sdk"
+
 func Echo(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
-	context.Logger.Info("Echoing body")
-
-	return nuclio.Response{
-		StatusCode:  200,
-		ContentType: "application/text",
-		Body:		 []byte(event.GetBody()),
-	}, nil
+	return event.GetBody(), nil
 }
 `,
-	"responder.py": `def handler(context, event):
-	context.logger.info('Responding')
+	"encrypt.py": `#
+# Uses simplecrypt to encrypt the body with a key bound to the function as
+# an environment variable. We ask pip to install simplecrypt as part of the
+# build process, along with some OS level packages (using apk).
+#
+# Note: It takes a minute or so to install all the dependencies.
+#       Why not star https://github.com/nuclio/nuclio while you wait?
+#
 
-	# return a response, where the body is some environment variable and headers is another
-	return context.Response(body='Response: {0}'.format(os.environ.get('ENV_VAR1'),
-							headers={'x-env-var-2': os.environ.get('ENV_VAR2')},
+# @nuclio.configure
+#
+# build.yaml:
+#   commands:
+#     - apk update
+#     - apk add --no-cache gcc g++ make libffi-dev openssl-dev
+#     - pip install simple-crypt
+#
+
+import os
+import simplecrypt
+
+def handler(context, event):
+	context.logger.info('Using secret to encrypt body')
+
+	# get the encryption key
+	encryption_key = os.environ.get('ENCRYPT_KEY', 'some-default-key')
+
+	# encrypt the body
+	encrypted_body = simplecrypt.encrypt(encryption_key, event.body)
+
+	# return the encrypted body, and some hard-coded header
+	return context.Response(body=str(encrypted_body),
+							headers={'x-encrypt-algo': 'aes256'},
 							content_type='text/plain',
 							status_code=200)
 `,

--- a/pkg/playground/resource/function.go
+++ b/pkg/playground/resource/function.go
@@ -210,6 +210,13 @@ func (fr *functionResource) OnAfterInitialize() {
 			},
 		},
 	}
+
+	fr.functions["rabbitmq"] = &function{
+		attributes: functionAttributes{
+			Name:      "rabbitmq",
+			SourceURL: "/sources/rabbitmq.go",
+		},
+	}
 }
 
 func (fr *functionResource) GetAll(request *http.Request) map[string]restful.Attributes {

--- a/pkg/playground/resource/function.go
+++ b/pkg/playground/resource/function.go
@@ -201,7 +201,7 @@ func (fr *functionResource) OnAfterInitialize() {
 		},
 	}
 
-	fr.functions["responder"] = &function{
+	fr.functions["encrypt"] = &function{
 		attributes: functionAttributes{
 			Name:      "encrypt",
 			SourceURL: "/sources/encrypt.py",

--- a/pkg/playground/resource/function.go
+++ b/pkg/playground/resource/function.go
@@ -203,11 +203,10 @@ func (fr *functionResource) OnAfterInitialize() {
 
 	fr.functions["responder"] = &function{
 		attributes: functionAttributes{
-			Name:      "responder",
-			SourceURL: "/sources/responder.py",
+			Name:      "encrypt",
+			SourceURL: "/sources/encrypt.py",
 			Env: map[string]string{
-				"ENV_VAR1": "value-1",
-				"ENV_VAR2": "value-2",
+				"ENCRYPT_KEY": "correct_horse_battery_staple",
 			},
 		},
 	}

--- a/pkg/playground/resource/function.go
+++ b/pkg/playground/resource/function.go
@@ -205,6 +205,10 @@ func (fr *functionResource) OnAfterInitialize() {
 		attributes: functionAttributes{
 			Name:      "responder",
 			SourceURL: "/sources/responder.py",
+			Env: map[string]string{
+				"ENV_VAR1": "value-1",
+				"ENV_VAR2": "value-2",
+			},
 		},
 	}
 }

--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.8
+FROM golang:1.8-alpine3.6
 
 # this script builds the processor and shoves the build logs into /processor_build.log
 COPY build-processor.sh /usr/local/bin/build-processor

--- a/pkg/processor/build/runtime/golang/docker/onbuild/build-processor.sh
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/build-processor.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # Copyright 2017 The Nuclio Authors.
 #

--- a/pkg/processor/build/runtime/python/docker/processor-py/Dockerfile
+++ b/pkg/processor/build/runtime/python/docker/processor-py/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3-alpine3.6
 
 COPY cmd/processor/_output/processor /usr/local/bin/processor
 COPY pkg/processor/runtime/python/wrapper.py /opt/nuclio/wrapper.py

--- a/pkg/processor/runtime/python/wrapper.py
+++ b/pkg/processor/runtime/python/wrapper.py
@@ -140,7 +140,7 @@ def load_handler(handler):
 
     handler is in the format 'module.sub:handler_name'
     """
-    match = re.match('^(\w+(\.\w+)*):(\w+)$', handler)
+    match = re.match('^([\w|-]+(\.[\w|-]+)*):(\w+)$', handler)
     if not match:
         raise ValueError('malformed handler')
 


### PR DESCRIPTION
1. Playground fixtures changed (echo, encrypt and rabbitmq)
2. Playground image reduced from 150MB to 75MB by pulling just docker client rather than docker
3. Go on build image reduced from 700MB to 250MB by using an alpine based image
4. Processor-py now based on alpine3.6 - fixes an issue where user-driven apk installs would erroneously fail due to "no space left on device". This is due to an apk issue fixed in 3.6
5. Function names can now include hyphens (versioned functions end with three hyphens: `func---0`)