### PR TITLE
Local platform uses "127.0.0.1" instead of "localhost"

### DIFF
--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -137,7 +137,7 @@ func (p *Platform) GetName() string {
 }
 
 func (p *Platform) getFreeLocalPort() (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
On some systems (actually, one) it was observed that "localhost" resolve to an actual IP address. To prevent this, the local platform uses 127.0.0.1 as the address to localhost - rather than assuming "localhost" resolves to "127.0.0.1".