### PR TITLE
Fix source loading (now source_url is relative)

### DIFF
--- a/cmd/playground/static/assets/app.js
+++ b/cmd/playground/static/assets/app.js
@@ -348,7 +348,7 @@ $(function () {
      */
     function loadSelectedFunction() {
         var fileExtension = selectedFunction.source_url.split('/').pop().split('.').pop();
-        loadSource(selectedFunction.source_url)
+        loadSource(workingUrl + selectedFunction.source_url)
             .done(function (responseText) {
                 // omit "name" of each data binding value in selected function's data bindings
                 var dataBindings = _.mapValues(selectedFunction.data_bindings, function (dataBinding) {


### PR DESCRIPTION
`source_url` used to be absolute so it was used as-is when trying to load the source code of the function.
Now it is relative (starting with a `/` sign) so if index.html is opened locally, the http://host:port needs to be prepended to it.