### PR TITLE
Allow path based HTTP routing to functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/nuclio/nuclio.svg)](https://travis-ci.org/nuclio/nuclio)
+[![Build Status](https://travis-ci.org/nuclio/nuclio.svg?branch=master)](https://travis-ci.org/nuclio/nuclio)
 [![Go Report Card](https://goreportcard.com/badge/github.com/nuclio/nuclio)](https://goreportcard.com/report/github.com/nuclio/nuclio)
 [![Slack](https://img.shields.io/badge/slack-join%20chat%20%E2%86%92-e01563.svg)](https://lit-oasis-83353.herokuapp.com/)
 

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -33,6 +33,7 @@ type deployCommandeer struct {
 	commands            stringSliceFlag
 	encodedDataBindings string
 	encodedTriggers     string
+	encodedIngresses    string
 }
 
 func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
@@ -57,6 +58,12 @@ func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
 			if err := json.Unmarshal([]byte(commandeer.encodedTriggers),
 				&commandeer.deployOptions.Triggers); err != nil {
 				return errors.Wrap(err, "Failed to decode triggers")
+			}
+
+			// decode the JSON ingresses
+			if err := json.Unmarshal([]byte(commandeer.encodedIngresses),
+				&commandeer.deployOptions.Ingresses); err != nil {
+				return errors.Wrap(err, "Failed to decode ingresses")
 			}
 
 			// update build stuff
@@ -85,7 +92,8 @@ func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
 		commandeer.deployOptions,
 		&commandeer.commands,
 		&commandeer.encodedDataBindings,
-		&commandeer.encodedTriggers)
+		&commandeer.encodedTriggers,
+		&commandeer.encodedIngresses)
 
 	commandeer.cmd = cmd
 
@@ -152,7 +160,8 @@ func addDeployFlags(cmd *cobra.Command,
 	options *platform.DeployOptions,
 	commands *stringSliceFlag,
 	encodedDataBindings *string,
-	encodedTriggers *string) {
+	encodedTriggers *string,
+	encodedIngresses *string) {
 	addBuildFlags(cmd, &options.Build, commands)
 
 	cmd.Flags().StringVar(&options.Description, "desc", "", "Function description")
@@ -167,6 +176,7 @@ func addDeployFlags(cmd *cobra.Command,
 	cmd.Flags().BoolVar(&options.Publish, "publish", false, "Publish the function")
 	cmd.Flags().StringVar(encodedDataBindings, "data-bindings", "{}", "JSON encoded data bindings for the function")
 	cmd.Flags().StringVar(encodedTriggers, "triggers", "{}", "JSON encoded triggers for the function")
+	cmd.Flags().StringVar(encodedIngresses, "ingresses", "{}", "JSON encoded ingresses for the function")
 	cmd.Flags().StringVar(&options.ImageName, "run-image", "", "If specified, this is the image that the deploy will use, rather than try to build one")
 	cmd.Flags().StringVar(&options.RunRegistry, "run-registry", os.Getenv("NUCTL_RUN_REGISTRY"), "The registry URL to pull the image from, if differs from -r (env: NUCTL_RUN_REGISTRY)")
 }

--- a/pkg/nuctl/command/update.go
+++ b/pkg/nuctl/command/update.go
@@ -56,6 +56,7 @@ type updateFunctionCommandeer struct {
 	*updateCommandeer
 	encodedDataBindings string
 	encodedTriggers     string
+	encodedIngresses    string
 }
 
 func newUpdateFunctionCommandeer(updateCommandeer *updateCommandeer) *updateFunctionCommandeer {
@@ -88,6 +89,12 @@ func newUpdateFunctionCommandeer(updateCommandeer *updateCommandeer) *updateFunc
 				return errors.Wrap(err, "Failed to decode triggers")
 			}
 
+			// decode the JSON ingresses
+			if err := json.Unmarshal([]byte(commandeer.encodedIngresses),
+				&commandeer.updateOptions.Deploy.Ingresses); err != nil {
+				return errors.Wrap(err, "Failed to decode ingresses")
+			}
+
 			// update build stuff
 			commandeer.updateOptions.Deploy.Build.Commands = commandeer.commands
 
@@ -105,7 +112,8 @@ func newUpdateFunctionCommandeer(updateCommandeer *updateCommandeer) *updateFunc
 		&commandeer.updateOptions.Deploy,
 		&commandeer.commands,
 		&commandeer.encodedDataBindings,
-		&commandeer.encodedTriggers)
+		&commandeer.encodedTriggers,
+		&commandeer.encodedIngresses)
 
 	commandeer.cmd = cmd
 

--- a/pkg/platform/function.go
+++ b/pkg/platform/function.go
@@ -30,4 +30,7 @@ type Function interface {
 
 	// GetClusterIP gets the IP of the cluster hosting the function
 	GetClusterIP() string
+
+	// get ingresses
+	GetIngresses() map[string]Ingress
 }

--- a/pkg/platform/kube/function.go
+++ b/pkg/platform/kube/function.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/kube/functioncr"
 
 	"k8s.io/api/apps/v1beta1"
@@ -92,4 +93,9 @@ func (f *function) GetClusterIP() string {
 
 	// TODO: ?
 	return ""
+}
+
+// GetIngresses returns all ingresses for this function
+func (f *function) GetIngresses() map[string]platform.Ingress {
+	return f.Spec.Ingresses
 }

--- a/pkg/platform/kube/functioncr/types.go
+++ b/pkg/platform/kube/functioncr/types.go
@@ -66,6 +66,7 @@ type FunctionSpec struct {
 	MaxReplicas  int32                           `json:"maxReplicas,omitempty"`
 	DataBindings map[string]platform.DataBinding `json:"dataBindings,omitempty"`
 	Triggers     map[string]platform.Trigger     `json:"triggers,omitempty"`
+	Ingresses    map[string]platform.Ingress     `json:"ingresses,omitempty"`
 	HTTPPort     int32                           `json:"httpPort,omitempty"`
 }
 

--- a/pkg/platform/kube/functiondep/client.go
+++ b/pkg/platform/kube/functiondep/client.go
@@ -23,21 +23,25 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/kube/functioncr"
 	"github.com/nuclio/nuclio/pkg/processor/config"
 
 	"github.com/nuclio/nuclio-sdk"
-	v1beta1 "k8s.io/api/apps/v1beta1"
+	apps_v1beta1 "k8s.io/api/apps/v1beta1"
 	autos_v1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/api/core/v1"
+	ext_v1beta1 "k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 )
 
 const (
 	containerHTTPPort         = 8080
 	processorConfigVolumeName = "processor-config-volume"
+	containerHTTPPortName     = "http"
 )
 
 type Client struct {
@@ -61,7 +65,7 @@ func NewClient(parentLogger nuclio.Logger,
 	return newClient, nil
 }
 
-func (c *Client) List(namespace string) ([]v1beta1.Deployment, error) {
+func (c *Client) List(namespace string) ([]apps_v1beta1.Deployment, error) {
 	listOptions := meta_v1.ListOptions{
 		LabelSelector: c.classLabelSelector,
 	}
@@ -76,8 +80,8 @@ func (c *Client) List(namespace string) ([]v1beta1.Deployment, error) {
 	return result.Items, nil
 }
 
-func (c *Client) Get(namespace string, name string) (*v1beta1.Deployment, error) {
-	var result *v1beta1.Deployment
+func (c *Client) Get(namespace string, name string) (*apps_v1beta1.Deployment, error) {
+	var result *apps_v1beta1.Deployment
 
 	result, err := c.clientSet.AppsV1beta1().Deployments(namespace).Get(name, meta_v1.GetOptions{})
 	c.logger.DebugWith("Got deployment",
@@ -98,7 +102,7 @@ func (c *Client) Get(namespace string, name string) (*v1beta1.Deployment, error)
 	return result, err
 }
 
-func (c *Client) CreateOrUpdate(function *functioncr.Function) (*v1beta1.Deployment, error) {
+func (c *Client) CreateOrUpdate(function *functioncr.Function) (*apps_v1beta1.Deployment, error) {
 
 	// get labels from the function and add class labels
 	labels := c.getFunctionLabels(function)
@@ -127,6 +131,12 @@ func (c *Client) CreateOrUpdate(function *functioncr.Function) (*v1beta1.Deploym
 		return nil, errors.Wrap(err, "Failed to create/update HPA")
 	}
 
+	// create or update ingress
+	_, err = c.createOrUpdateIngress(labels, function)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create/update ingress")
+	}
+
 	c.logger.Debug("Deployment created/updated")
 
 	return deployment, nil
@@ -138,8 +148,18 @@ func (c *Client) Delete(namespace string, name string) error {
 		PropagationPolicy: &propogationPolicy,
 	}
 
+	// Delete ingress
+	err := c.clientSet.ExtensionsV1beta1().Ingresses(namespace).Delete(name, deleteOptions)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return errors.Wrap(err, "Failed to delete ingress")
+		}
+	} else {
+		c.logger.DebugWith("Deleted ingress", "namespace", namespace, "name", name)
+	}
+
 	// Delete HPA if exists
-	err := c.clientSet.AutoscalingV1().HorizontalPodAutoscalers(namespace).Delete(name, deleteOptions)
+	err = c.clientSet.AutoscalingV1().HorizontalPodAutoscalers(namespace).Delete(name, deleteOptions)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return errors.Wrap(err, "Failed to delete HPA")
@@ -288,6 +308,10 @@ func (c *Client) createOrUpdateConfigMap(function *functioncr.Function) (*v1.Con
 		createConfigMap,
 		updateConfigMap)
 
+	if err != nil {
+		return nil, err
+	}
+
 	return resource.(*v1.ConfigMap), err
 }
 
@@ -332,11 +356,15 @@ func (c *Client) createOrUpdateService(labels map[string]string,
 		createService,
 		updateService)
 
+	if err != nil {
+		return nil, err
+	}
+
 	return resource.(*v1.Service), err
 }
 
 func (c *Client) createOrUpdateDeployment(labels map[string]string,
-	function *functioncr.Function) (*v1beta1.Deployment, error) {
+	function *functioncr.Function) (*apps_v1beta1.Deployment, error) {
 
 	replicas := int32(c.getFunctionReplicas(function))
 	annotations, err := c.getFunctionAnnotations(function)
@@ -349,7 +377,7 @@ func (c *Client) createOrUpdateDeployment(labels map[string]string,
 	}
 
 	deploymentIsDeleting := func(resource interface{}) bool {
-		return (resource).(*v1beta1.Deployment).ObjectMeta.DeletionTimestamp != nil
+		return (resource).(*apps_v1beta1.Deployment).ObjectMeta.DeletionTimestamp != nil
 	}
 
 	createDeployment := func() (interface{}, error) {
@@ -362,7 +390,7 @@ func (c *Client) createOrUpdateDeployment(labels map[string]string,
 		configMapVolumeSource.Name = c.configMapNameFromFunctionName(function.Name)
 		volume.ConfigMap = &configMapVolumeSource
 
-		return c.clientSet.AppsV1beta1().Deployments(function.Namespace).Create(&v1beta1.Deployment{
+		return c.clientSet.AppsV1beta1().Deployments(function.Namespace).Create(&apps_v1beta1.Deployment{
 
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:        function.Name,
@@ -370,7 +398,7 @@ func (c *Client) createOrUpdateDeployment(labels map[string]string,
 				Labels:      labels,
 				Annotations: annotations,
 			},
-			Spec: v1beta1.DeploymentSpec{
+			Spec: apps_v1beta1.DeploymentSpec{
 				Replicas: &replicas,
 				Template: v1.PodTemplateSpec{
 					ObjectMeta: meta_v1.ObjectMeta{
@@ -390,7 +418,7 @@ func (c *Client) createOrUpdateDeployment(labels map[string]string,
 	}
 
 	updateDeployment := func(resource interface{}) (interface{}, error) {
-		deployment := resource.(*v1beta1.Deployment)
+		deployment := resource.(*apps_v1beta1.Deployment)
 
 		deployment.Labels = labels
 		deployment.Annotations = annotations
@@ -407,7 +435,11 @@ func (c *Client) createOrUpdateDeployment(labels map[string]string,
 		createDeployment,
 		updateDeployment)
 
-	return resource.(*v1beta1.Deployment), err
+	if err != nil {
+		return nil, err
+	}
+
+	return resource.(*apps_v1beta1.Deployment), err
 }
 
 func (c *Client) createOrUpdateHorizontalPodAutoscaler(labels map[string]string,
@@ -446,7 +478,7 @@ func (c *Client) createOrUpdateHorizontalPodAutoscaler(labels map[string]string,
 				MaxReplicas:                    maxReplicas,
 				TargetCPUUtilizationPercentage: &targetCPU,
 				ScaleTargetRef: autos_v1.CrossVersionObjectReference{
-					APIVersion: "apps/v1beta1",
+					APIVersion: "apps/apps_v1beta1",
 					Kind:       "Deployment",
 					Name:       function.Name,
 				},
@@ -471,7 +503,60 @@ func (c *Client) createOrUpdateHorizontalPodAutoscaler(labels map[string]string,
 		createHorizontalPodAutoscaler,
 		updateHorizontalPodAutoscaler)
 
+	if err != nil {
+		return nil, err
+	}
+
 	return resource.(*autos_v1.HorizontalPodAutoscaler), err
+}
+
+func (c *Client) createOrUpdateIngress(labels map[string]string,
+	function *functioncr.Function) (*ext_v1beta1.Ingress, error) {
+
+	getIngress := func() (interface{}, error) {
+		return c.clientSet.ExtensionsV1beta1().Ingresses(function.Namespace).Get(function.Name, meta_v1.GetOptions{})
+	}
+
+	ingressIsDeleting := func(resource interface{}) bool {
+		return (resource).(*ext_v1beta1.Ingress).ObjectMeta.DeletionTimestamp != nil
+	}
+
+	createIngress := func() (interface{}, error) {
+		spec := ext_v1beta1.IngressSpec{}
+
+		c.populateIngressSpec(labels, function, &spec)
+
+		return c.clientSet.ExtensionsV1beta1().Ingresses(function.Namespace).Create(&ext_v1beta1.Ingress{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      function.Name,
+				Namespace: function.Namespace,
+				Labels:    labels,
+			},
+			Spec: spec,
+		})
+	}
+
+	updateIngress := func(resource interface{}) (interface{}, error) {
+		ingress := resource.(*ext_v1beta1.Ingress)
+
+		// update existing
+		ingress.Labels = labels
+		c.populateIngressSpec(labels, function, &ingress.Spec)
+
+		return c.clientSet.ExtensionsV1beta1().Ingresses(function.Namespace).Update(ingress)
+	}
+
+	resource, err := c.createOrUpdateResource("ingress",
+		getIngress,
+		ingressIsDeleting,
+		createIngress,
+		updateIngress)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resource.(*ext_v1beta1.Ingress), err
 }
 
 func (c *Client) initClassLabels() {
@@ -538,16 +623,6 @@ func (c *Client) getFunctionEnvironment(labels map[string]string,
 	env = append(env, v1.EnvVar{Name: "NUCLIO_FUNCTION_NAME", Value: labels["name"]})
 	env = append(env, v1.EnvVar{Name: "NUCLIO_FUNCTION_VERSION", Value: labels["version"]})
 
-	// future stuff:
-	// env = append(env, v1.EnvVar{Name: "NUCLIO_FUNCTION_MEMORY_SIZE", Value: "TBD"})
-	// env = append(env, v1.EnvVar{Name: "NUCLIO_REGION", Value: "local"})
-	// env = append(env, v1.EnvVar{Name: "NUCLIO_LOG_STREAM_NAME", Value: "local"})
-	// env = append(env, v1.EnvVar{Name: "NUCLIO_DLQ_STREAM_NAME", Value: ""})
-	// env = append(env, v1.EnvVar{Name: "IGZ_ACCESS_KEY", Value: "TBD"})
-	// env = append(env, v1.EnvVar{Name: "IGZ_ACCESS_SECRET", Value: "TBD"})
-	// env = append(env, v1.EnvVar{Name: "IGZ_SESSION_TOKEN", Value: "TBD"})
-	// env = append(env, v1.EnvVar{Name: "IGZ_SECURITY_TOKEN", Value: "TBD"})
-
 	return env
 }
 
@@ -580,9 +655,62 @@ func (c *Client) populateServiceSpec(labels map[string]string,
 	//    port and then updating it causes node port change
 	if len(spec.Ports) == 0 || !(spec.Ports[0].NodePort != 0 && function.Spec.HTTPPort == 0) {
 		spec.Ports = []v1.ServicePort{
-			{Name: "web", Port: int32(containerHTTPPort), NodePort: function.Spec.HTTPPort},
+			{Name: containerHTTPPortName, Port: int32(containerHTTPPort), NodePort: function.Spec.HTTPPort},
 		}
 	}
+}
+
+func (c *Client) populateIngressSpec(labels map[string]string,
+	function *functioncr.Function,
+	spec *ext_v1beta1.IngressSpec) {
+
+	c.logger.DebugWith("Preparing ingress")
+
+	// by default, register an ingress with <function>/<version>
+	defaultIngress := &platform.Ingress{
+		Paths: []string{fmt.Sprintf("/%s/%s", function.Name, labels["version"])},
+	}
+
+	c.addIngressToSpec(function, defaultIngress, spec)
+
+	for _, ingress := range function.Spec.Ingresses {
+		c.addIngressToSpec(function, &ingress, spec)
+	}
+}
+
+func (c *Client) addIngressToSpec(function *functioncr.Function,
+	ingress *platform.Ingress,
+	spec *ext_v1beta1.IngressSpec) {
+
+	c.logger.DebugWith("Adding ingress",
+		"function", function.Name,
+		"host", ingress.Host,
+		"paths", ingress.Paths)
+
+	ingressRule := ext_v1beta1.IngressRule{
+		Host: ingress.Host,
+	}
+
+	ingressRule.IngressRuleValue.HTTP = &ext_v1beta1.HTTPIngressRuleValue{}
+
+	// populate the ingress rule value
+	for _, path := range ingress.Paths {
+		httpIngressPath := ext_v1beta1.HTTPIngressPath{
+			Path: path,
+			Backend: ext_v1beta1.IngressBackend{
+				ServiceName: function.Name,
+				ServicePort: intstr.IntOrString{
+					Type:   intstr.String,
+					StrVal: containerHTTPPortName,
+				},
+			},
+		}
+
+		// add path
+		ingressRule.IngressRuleValue.HTTP.Paths = append(ingressRule.IngressRuleValue.HTTP.Paths, httpIngressPath)
+	}
+
+	spec.Rules = append(spec.Rules, ingressRule)
 }
 
 func (c *Client) populateDeploymentContainer(labels map[string]string,

--- a/pkg/platform/local/function.go
+++ b/pkg/platform/local/function.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/nuclio/nuclio/pkg/dockerclient"
+	"github.com/nuclio/nuclio/pkg/platform"
 )
 
 type function struct {
@@ -54,4 +55,11 @@ func (f *function) GetReplicas() (int, int) {
 // GetClusterIP gets the IP of the cluster hosting the function
 func (f *function) GetClusterIP() string {
 	return "localhost"
+}
+
+// GetIngresses returns all ingresses for this function
+func (f *function) GetIngresses() map[string]platform.Ingress {
+
+	// local platform doesn't support ingress
+	return map[string]platform.Ingress{}
 }

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -3,14 +3,12 @@ package local
 import (
 	"io/ioutil"
 	"net"
-	"os"
 	"path"
 
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/errors"
-	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/abstract"
 	"github.com/nuclio/nuclio/pkg/processor/config"
@@ -181,30 +179,7 @@ func (p *Platform) deployFunction(deployOptions *platform.DeployOptions) (*platf
 
 	// use function config path which is either passed by the user or detected during build (e.g. inline)
 	if deployOptions.Build.FunctionConfigPath != "" {
-		var functionConfigFile *os.File
-		var functionconfigReader *functionconfig.Reader
-
-		functionConfigFile, err = os.Open(deployOptions.Build.FunctionConfigPath)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Failed to open function configuraition file: %s", functionConfigFile)
-		}
-
-		defer functionConfigFile.Close()
-
-		functionconfigReader, err = functionconfig.NewReader(p.Logger)
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to create functionconfig reader")
-		}
-
-		// read the configuration
-		if err = functionconfigReader.Read(functionConfigFile, "yaml"); err != nil {
-			return nil, errors.Wrap(err, "Failed to read function configuration file")
-		}
-
-		// to build options
-		if err = functionconfigReader.ToDeployOptions(deployOptions); err != nil {
-			return nil, errors.Wrap(err, "Failed to get build options from function configuration")
-		}
+		p.FunctionConfigToDeployOptions(deployOptions.Build.FunctionConfigPath, deployOptions)
 	}
 
 	// create processor configuration at a temporary location unless user specified a configuration

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -20,13 +20,20 @@ type Trigger struct {
 	Class         string                 `json:"class"`
 	Kind          string                 `json:"kind"`
 	Disabled      bool                   `json:"disabled,omitempty"`
-	MaxWorkers    int                    `json:"max_workers,omitempty"`
+	MaxWorkers    int                    `json:"maxWorkers,omitempty"`
 	URL           string                 `json:"url,omitempty"`
 	Paths         []string               `json:"paths,omitempty"`
-	NumPartitions int                    `json:"num_partitions,omitempty"`
+	NumPartitions int                    `json:"numPartitions,omitempty"`
 	User          string                 `json:"user,omitempty"`
 	Secret        string                 `json:"secret,omitempty"`
 	Attributes    map[string]interface{} `json:"attributes,omitempty"`
+}
+
+// Ingress holds configuration for an ingress - an entity that can route HTTP requests
+// to the function
+type Ingress struct {
+	Host  string
+	Paths []string
 }
 
 // CommonOptions is the base for all platform options. It's never instantiated directly
@@ -130,6 +137,7 @@ type DeployOptions struct {
 	RunRegistry  string                 `json:"runRegistry,omitempty"`
 	DataBindings map[string]DataBinding `json:"dataBindings,omitempty"`
 	Triggers     map[string]Trigger     `json:"triggers,omitempty"`
+	Ingresses    map[string]Ingress     `json:"ingresses,omitempty"`
 
 	// platform specific
 	Platform interface{}

--- a/pkg/processor/build/runtime/golang/test/incrementor-with-function-config/function.yaml
+++ b/pkg/processor/build/runtime/golang/test/incrementor-with-function-config/function.yaml
@@ -14,7 +14,7 @@
 
 triggers:
 
-  incrementor_http:
+  ihttp:
     maxWorkers: 4
     kind: "http"
 


### PR DESCRIPTION
1. Fixes #293 
2. Fixes a bug where kuberentes based platform did not actually apply the function configuration
3. Fixes `-o wide` in `nuctl get`