### PR TITLE
Ellipsis + tooltips on overflow of key-value pairs

### DIFF
--- a/cmd/playground/static/assets/.eslintrc.json
+++ b/cmd/playground/static/assets/.eslintrc.json
@@ -163,6 +163,9 @@
             {
                 "builtinGlobals": true,
                 "allow": [
+                    "name", // because it exists in window.name
+                    "event", // because it exists in window.event
+                    "result",
                     "done",
                     "resolve",
                     "reject",

--- a/cmd/playground/static/assets/app.css
+++ b/cmd/playground/static/assets/app.css
@@ -48,6 +48,11 @@ ul, li {
     align-items: center;
     justify-content: space-between;
 }
+.text-ellipsis {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
 
 /* pane splitter */
 .split {

--- a/cmd/playground/static/assets/app.js
+++ b/cmd/playground/static/assets/app.js
@@ -702,8 +702,8 @@ $(function () {
             }
             else {
                 pairList.append('<li>' + _(pairs).map(function (value, key) {
-                    return '<span class="pair-key">' + key + '</span>' +
-                           '<span class="pair-value">' + value + '</span>';
+                    return '<span class="pair-key text-ellipsis" title="' + key + '">' + key + '</span>' +
+                           '<span class="pair-value text-ellipsis" title="' + value + '">' + value + '</span>';
                 }).join('</li><li>') + '</li>');
 
                 var listItems = pairList.find('li'); // all list items
@@ -711,7 +711,7 @@ $(function () {
                 // for each key-value pair - append a remove button to its list item DOM element
                 listItems.each(function () {
                     var listItem = $(this);
-                    var key = listItem.find('[class=pair-key]').text();
+                    var key = listItem.find('[class^=pair-key]').text();
                     $('<button/>', {
                         'class': 'remove-pair-button',
                         title: 'Remove',


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/13918850/32184258-686c1f2a-bda4-11e7-88f7-11caf9ba0dba.png)

Also in this PR:
Changing function expressions to function statements and change some order of code and rename some variables to reduce shadowing (eslint "no-shadow" rule)