### PR TITLE
Fixed playground source load issue under Kubernetes

### DIFF
--- a/cmd/playground/static/assets/app.js
+++ b/cmd/playground/static/assets/app.js
@@ -469,7 +469,7 @@ $(function () {
                 dataType: 'json',
                 data: JSON.stringify({
                     name: name,
-                    source_url: 'http://127.0.0.1:8070' + url,
+                    source_url: url,
                     registry: '',
                     data_bindings: _.defaultTo(dataBindings, {}),
                     triggers: _.defaultTo(triggers, {}),

--- a/pkg/playground/resource/function.go
+++ b/pkg/playground/resource/function.go
@@ -201,7 +201,7 @@ func (f *function) createDeployOptions() *platform.DeployOptions {
 
 	deployOptions.FunctionConfig.Meta.Name = f.attributes.Name
 	deployOptions.Logger = f.muxLogger
-	deployOptions.FunctionConfig.Spec.Build.Path = f.attributes.SourceURL
+	deployOptions.FunctionConfig.Spec.Build.Path = "http://127.0.0.1:8070" + f.attributes.SourceURL
 	deployOptions.FunctionConfig.Spec.Build.ImageName = f.attributes.Name
 	deployOptions.FunctionConfig.Spec.DataBindings = f.attributes.DataBindings
 	deployOptions.FunctionConfig.Spec.Triggers = f.attributes.Triggers


### PR DESCRIPTION
After deploying a function, it was no longer available due to incorrect handling of the source URL