### PR TITLE
Python: support different base images, support Python 2. Bump Go to 1.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH=$(NUCLIO_TAG)-$(NUCLIO_ARCH)
 # Docker image names
 NUCLIO_DOCKER_CONTROLLER_IMAGE_NAME=nuclio/controller:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
 NUCLIO_DOCKER_PLAYGROUND_IMAGE_NAME=nuclio/playground:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
-NUCLIO_DOCKER_HANDLER_BUILDER_GOLANG_ONBUILD_IMAGE_NAME=nuclio/handler-builder-golang-onbuild:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
 
 # inject version info
 NUCLIO_BUILD_ARGS := --build-arg NUCLIO_VERSION_INFO_FILE_CONTENTS="$(NUCLIO_VERSION_INFO)"
@@ -149,8 +148,12 @@ processor-py: processor
 		--build-arg NUCLIO_PYTHON_OS=slim-jessie \
 		-t $(NUCLIO_DOCKER_PROCESSOR_PY3_JESSIE_IMAGE_NAME) .
 
+NUCLIO_DOCKER_HANDLER_BUILDER_GOLANG_ONBUILD_IMAGE_NAME=nuclio/handler-builder-golang-onbuild:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
+
 handler-builder-golang-onbuild: ensure-gopath
-	docker build --build-arg NUCLIO_ARCH=$(NUCLIO_ARCH) -f pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile -t $(NUCLIO_DOCKER_HANDLER_BUILDER_GOLANG_ONBUILD_IMAGE_NAME) .
+	docker build --build-arg NUCLIO_ARCH=$(NUCLIO_ARCH) \
+		-f pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile \
+		-t $(NUCLIO_DOCKER_HANDLER_BUILDER_GOLANG_ONBUILD_IMAGE_NAME) .
 
 #
 # Testing

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH=$(NUCLIO_TAG)-$(NUCLIO_ARCH)
 # Docker image names
 NUCLIO_DOCKER_CONTROLLER_IMAGE_NAME=nuclio/controller:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
 NUCLIO_DOCKER_PLAYGROUND_IMAGE_NAME=nuclio/playground:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
-NUCLIO_DOCKER_PROCESSOR_PY_IMAGE_NAME=nuclio/processor-py:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
 NUCLIO_DOCKER_HANDLER_BUILDER_GOLANG_ONBUILD_IMAGE_NAME=nuclio/handler-builder-golang-onbuild:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
 
 # inject version info
@@ -114,8 +113,41 @@ playground: ensure-gopath
 # Base images
 #
 
+NUCLIO_PROCESSOR_PY_DOCKERFILE_PATH = pkg/processor/build/runtime/python/docker/processor-py/Dockerfile
+NUCLIO_DOCKER_PROCESSOR_PY2_ALPINE_IMAGE_NAME=nuclio/processor-py2.7-alpine:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
+NUCLIO_DOCKER_PROCESSOR_PY3_ALPINE_IMAGE_NAME=nuclio/processor-py3.6-alpine:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
+NUCLIO_DOCKER_PROCESSOR_PY2_JESSIE_IMAGE_NAME=nuclio/processor-py2.7-jessie:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
+NUCLIO_DOCKER_PROCESSOR_PY3_JESSIE_IMAGE_NAME=nuclio/processor-py3.6-jessie:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
+
 processor-py: processor
-	docker build $(NUCLIO_BUILD_ARGS) -f pkg/processor/build/runtime/python/docker/processor-py/Dockerfile -t $(NUCLIO_DOCKER_PROCESSOR_PY_IMAGE_NAME) .
+
+	# build python 2.7/alpine
+	docker build $(NUCLIO_BUILD_ARGS) \
+		-f ${NUCLIO_PROCESSOR_PY_DOCKERFILE_PATH} \
+		--build-arg NUCLIO_PYTHON_VERSION=2.7 \
+		--build-arg NUCLIO_PYTHON_OS=alpine3.6 \
+		-t $(NUCLIO_DOCKER_PROCESSOR_PY2_ALPINE_IMAGE_NAME) .
+
+	# build python 3/alpine
+	docker build $(NUCLIO_BUILD_ARGS) \
+		-f ${NUCLIO_PROCESSOR_PY_DOCKERFILE_PATH} \
+		--build-arg NUCLIO_PYTHON_VERSION=3.6 \
+		--build-arg NUCLIO_PYTHON_OS=alpine3.6 \
+		-t $(NUCLIO_DOCKER_PROCESSOR_PY3_ALPINE_IMAGE_NAME) .
+
+	# build python 2/jesse
+	docker build $(NUCLIO_BUILD_ARGS) \
+		-f ${NUCLIO_PROCESSOR_PY_DOCKERFILE_PATH} \
+		--build-arg NUCLIO_PYTHON_VERSION=2.7 \
+		--build-arg NUCLIO_PYTHON_OS=slim-jessie \
+		-t $(NUCLIO_DOCKER_PROCESSOR_PY2_JESSIE_IMAGE_NAME) .
+
+	# build python 3/jesse
+	docker build $(NUCLIO_BUILD_ARGS) \
+		-f ${NUCLIO_PROCESSOR_PY_DOCKERFILE_PATH} \
+		--build-arg NUCLIO_PYTHON_VERSION=3.6 \
+		--build-arg NUCLIO_PYTHON_OS=slim-jessie \
+		-t $(NUCLIO_DOCKER_PROCESSOR_PY3_JESSIE_IMAGE_NAME) .
 
 handler-builder-golang-onbuild: ensure-gopath
 	docker build --build-arg NUCLIO_ARCH=$(NUCLIO_ARCH) -f pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile -t $(NUCLIO_DOCKER_HANDLER_BUILDER_GOLANG_ONBUILD_IMAGE_NAME) .

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/nuclio/nuclio/pkg/common"
@@ -39,7 +40,6 @@ import (
 
 	"github.com/nuclio/nuclio-sdk"
 	"gopkg.in/yaml.v2"
-	"strings"
 )
 
 const (

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -121,6 +121,12 @@ func (b *Builder) Build(options *platform.BuildOptions) (*platform.BuildResult, 
 		return nil, errors.Wrap(err, "Failed to read configuration")
 	}
 
+	// create a staging directory
+	b.stagingDir, err = b.createStagingDir()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed create staging directory")
+	}
+
 	// create a runtime based on the configuration
 	b.runtime, err = b.createRuntime()
 	if err != nil {
@@ -393,18 +399,22 @@ func (b *Builder) createRuntime() (runtime.Runtime, error) {
 	return runtimeInstance, nil
 }
 
-func (b *Builder) prepareStagingDir() error {
-	var err error
-
-	b.logger.InfoWith("Staging files and preparing base images")
+func (b *Builder) createStagingDir() (string, error) {
 
 	// create a staging directory
-	b.stagingDir, err = ioutil.TempDir("", "nuclio-build-")
+	stagingDir, err := ioutil.TempDir("", "nuclio-build-")
 	if err != nil {
-		return errors.Wrap(err, "Failed to create staging dir")
+		return "", errors.Wrap(err, "Failed to create staging dir")
 	}
 
 	b.logger.DebugWith("Created staging directory", "dir", b.stagingDir)
+
+	return stagingDir, nil
+}
+
+func (b *Builder) prepareStagingDir() error {
+
+	b.logger.InfoWith("Staging files and preparing base images")
 
 	// first, tell the specific runtime to do its thing
 	if err := b.runtime.OnAfterStagingDirCreated(b.stagingDir); err != nil {

--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
@@ -16,9 +16,8 @@ FROM golang:1.8-alpine3.6
 
 RUN apk --update --no-cache add \
     make \
-    gcc \
     git \
-    make \
+    gcc \
     musl-dev
 
 #

--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.8-alpine3.6
+FROM golang:1.9-alpine3.6
 
 RUN apk --update --no-cache add \
     make \

--- a/pkg/processor/build/runtime/golang/factory.go
+++ b/pkg/processor/build/runtime/golang/factory.go
@@ -18,6 +18,7 @@ package golang
 
 import (
 	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 
 	"github.com/nuclio/nuclio-sdk"
@@ -25,8 +26,11 @@ import (
 
 type factory struct{}
 
-func (f *factory) Create(logger nuclio.Logger, configuration runtime.Configuration) (runtime.Runtime, error) {
-	abstractRuntime, err := runtime.NewAbstractRuntime(logger, configuration)
+func (f *factory) Create(logger nuclio.Logger,
+	stagingDir string,
+	functionConfig *functionconfig.Config) (runtime.Runtime, error) {
+
+	abstractRuntime, err := runtime.NewAbstractRuntime(logger, stagingDir, functionConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create abstract runtime")
 	}

--- a/pkg/processor/build/runtime/python/docker/processor-py/Dockerfile
+++ b/pkg/processor/build/runtime/python/docker/processor-py/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3-alpine3.6
+ARG NUCLIO_PYTHON_VERSION=3
+ARG NUCLIO_PYTHON_OS=alpine3.6
+
+FROM python:${NUCLIO_PYTHON_VERSION}-${NUCLIO_PYTHON_OS}
 
 COPY cmd/processor/_output/processor /usr/local/bin/processor
 COPY pkg/processor/runtime/python/wrapper.py /opt/nuclio/wrapper.py

--- a/pkg/processor/build/runtime/python/factory.go
+++ b/pkg/processor/build/runtime/python/factory.go
@@ -18,6 +18,7 @@ package python
 
 import (
 	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 
 	"github.com/nuclio/nuclio-sdk"
@@ -25,8 +26,11 @@ import (
 
 type factory struct{}
 
-func (f *factory) Create(logger nuclio.Logger, configuration runtime.Configuration) (runtime.Runtime, error) {
-	abstractRuntime, err := runtime.NewAbstractRuntime(logger, configuration)
+func (f *factory) Create(logger nuclio.Logger,
+	stagingDir string,
+	functionConfig *functionconfig.Config) (runtime.Runtime, error) {
+
+	abstractRuntime, err := runtime.NewAbstractRuntime(logger, stagingDir, functionConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create abstract runtime")
 	}

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -21,9 +21,9 @@ import (
 	"path"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 	"github.com/nuclio/nuclio/pkg/version"
-	"github.com/pkg/errors"
 )
 
 type python struct {

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -23,29 +23,39 @@ import (
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 	"github.com/nuclio/nuclio/pkg/version"
+	"github.com/pkg/errors"
 )
 
 type python struct {
 	*runtime.AbstractRuntime
 }
 
-// GetDefaultProcessorBaseImageName returns the image name of the default processor base image
-func (p *python) GetDefaultProcessorBaseImageName() string {
+// GetProcessorBaseImageName returns the image name of the default processor base image
+func (p *python) GetProcessorBaseImageName() (string, error) {
 
 	// get the version we're running so we can pull the compatible image
 	versionInfo, err := version.Get()
 	if err != nil {
-		return "TODO"
+		return "", errors.Wrap(err, "Failed to get version")
 	}
 
-	baseImageName := fmt.Sprintf("nuclio/processor-py:%s-%s", versionInfo.Label, versionInfo.Arch)
+	_, runtimeVersion := p.GetRuntimeNameAndVersion()
+
+	// try to get base image name
+	baseImageName, err := getBaseImageName(versionInfo,
+		runtimeVersion,
+		p.FunctionConfig.Spec.Build.BaseImageName)
+
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to get base image name")
+	}
 
 	// make sure the image exists. don't pull if instructed not to
-	if !p.Configuration.GetNoBaseImagePull() {
+	if !p.FunctionConfig.Spec.Build.NoBaseImagesPull {
 		p.DockerClient.PullImage(baseImageName)
 	}
 
-	return baseImageName
+	return baseImageName, nil
 }
 
 // DetectFunctionHandlers returns a list of all the handlers
@@ -58,7 +68,7 @@ func (p *python) DetectFunctionHandlers(functionPath string) ([]string, error) {
 // the key can be a dir, a file or a url of a file
 // the value is an absolute path into the docker image
 func (p *python) GetProcessorImageObjectPaths() map[string]string {
-	functionPath := p.Configuration.GetFunctionPath()
+	functionPath := p.FunctionConfig.Spec.Build.Path
 
 	if common.IsFile(functionPath) {
 		return map[string]string{
@@ -84,10 +94,45 @@ func (p *python) GetName() string {
 func (p *python) getFunctionHandler() string {
 
 	// use the function path: /some/path/func.py -> func
-	functionFileName := path.Base(p.Configuration.GetFunctionPath())
+	functionFileName := path.Base(p.FunctionConfig.Spec.Build.Path)
 	functionFileName = functionFileName[:len(functionFileName)-len(path.Ext(functionFileName))]
 
 	// take that file name without extension and add a default "handler"
 	// TODO: parse the python sources for this
 	return fmt.Sprintf("%s:%s", functionFileName, "handler")
+}
+
+func getBaseImageName(versionInfo *version.Info,
+	runtimeVersion string,
+	baseImageName string) (string, error) {
+
+	// if the runtime version contains any value, use it. otherwise default to 3.6
+	if runtimeVersion == "" {
+		runtimeVersion = "3.6"
+	}
+
+	// if base image name not passed, use alpine
+	if baseImageName == "" {
+		baseImageName = "alpine"
+	}
+
+	// check runtime
+	switch runtimeVersion {
+	case "2.7", "3.6":
+	default:
+		return "", fmt.Errorf("Runtime version not supported: %s", runtimeVersion)
+	}
+
+	// check base image
+	switch baseImageName {
+	case "alpine", "jesse":
+	default:
+		return "", fmt.Errorf("Base image not supported: %s", runtimeVersion)
+	}
+
+	return fmt.Sprintf("nuclio/processor-py%s-%s:%s-%s",
+		runtimeVersion,
+		baseImageName,
+		versionInfo.Label,
+		versionInfo.Arch), nil
 }

--- a/pkg/processor/build/runtime/python/runtime_test.go
+++ b/pkg/processor/build/runtime/python/runtime_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package python
+
+import (
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/version"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type PythonTestSuite struct {
+	suite.Suite
+}
+
+func (suite *PythonTestSuite) TestBaseImageName() {
+
+	for _, params := range []struct {
+		runtimeVersion string
+		baseImageName string
+		label string
+		arch string
+		expectedBaseImage string
+	} {
+		{
+			"",
+			"",
+			"latest",
+			"amd64",
+			"nuclio/processor-py3.6-alpine:latest-amd64",
+		},
+		{
+			"2.7",
+			"",
+			"latest",
+			"amd64",
+			"nuclio/processor-py2.7-alpine:latest-amd64",
+		},
+		{
+			"2.7",
+			"jesse",
+			"latest",
+			"amd64",
+			"nuclio/processor-py2.7-jesse:latest-amd64",
+		},
+		{
+			"",
+			"jesse",
+			"latest",
+			"amd64",
+			"nuclio/processor-py3.6-jesse:latest-amd64",
+		},
+		{
+			"",
+			"",
+			"label",
+			"arch",
+			"nuclio/processor-py3.6-alpine:label-arch",
+		},
+		{
+			"3.1",
+			"",
+			"label",
+			"arch",
+			"",
+		},
+		{
+			"",
+			"foo",
+			"label",
+			"arch",
+			"",
+		},
+	} {
+		versionInfo := version.Info{
+			Label: params.label,
+			Arch: params.arch,
+		}
+
+		baseImageName, err := getBaseImageName(&versionInfo, params.runtimeVersion, params.baseImageName)
+
+		if params.expectedBaseImage == "" {
+			suite.Require().Error(err)
+		} else {
+			suite.Require().Equal(params.expectedBaseImage, baseImageName)
+			suite.Require().NoError(err)
+		}
+	}
+}
+
+func TestWriterTestSuite(t *testing.T) {
+	suite.Run(t, new(PythonTestSuite))
+}

--- a/pkg/processor/build/runtime/python/runtime_test.go
+++ b/pkg/processor/build/runtime/python/runtime_test.go
@@ -31,12 +31,12 @@ type PythonTestSuite struct {
 func (suite *PythonTestSuite) TestBaseImageName() {
 
 	for _, params := range []struct {
-		runtimeVersion string
-		baseImageName string
-		label string
-		arch string
+		runtimeVersion    string
+		baseImageName     string
+		label             string
+		arch              string
 		expectedBaseImage string
-	} {
+	}{
 		{
 			"",
 			"",
@@ -89,7 +89,7 @@ func (suite *PythonTestSuite) TestBaseImageName() {
 	} {
 		versionInfo := version.Info{
 			Label: params.label,
-			Arch: params.arch,
+			Arch:  params.arch,
 		}
 
 		baseImageName, err := getBaseImageName(&versionInfo, params.runtimeVersion, params.baseImageName)

--- a/pkg/processor/build/runtime/python/test/python2/printer.py
+++ b/pkg/processor/build/runtime/python/test/python2/printer.py
@@ -1,0 +1,20 @@
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def handler(context, event):
+    """Just print using Python 2 style printing"""
+
+    print 'Hello there'
+
+    return 'printed'

--- a/pkg/processor/build/runtime/python/test/python_test.go
+++ b/pkg/processor/build/runtime/python/test/python_test.go
@@ -118,6 +118,21 @@ func (suite *TestSuite) TestBuildDirWithInlineFunctionConfig() {
 		})
 }
 
+func (suite *TestSuite) TestBuildPy2() {
+	deployOptions := suite.GetDeployOptions("printer",
+		suite.GetFunctionPath("python2", "printer.py"))
+
+	deployOptions.FunctionConfig.Spec.Runtime = "python:2.7"
+	deployOptions.FunctionConfig.Spec.Handler = "printer:handler"
+
+	suite.DeployFunctionAndRequest(deployOptions,
+		&httpsuite.Request{
+			RequestMethod:        "POST",
+			RequestBody:          "",
+			ExpectedResponseBody: "printed",
+		})
+}
+
 func TestIntegrationSuite(t *testing.T) {
 	if testing.Short() {
 		return

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -22,12 +22,16 @@ import (
 	"github.com/nuclio/nuclio/pkg/errors"
 
 	"github.com/nuclio/nuclio-sdk"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/common"
+	"path"
+	"strings"
 )
 
 type Runtime interface {
 
-	// GetDefaultProcessorBaseImageName returns the image name of the default processor base image
-	GetDefaultProcessorBaseImageName() string
+	// GetProcessorBaseImageName returns the image name of the default processor base image
+	GetProcessorBaseImageName() (string, error)
 
 	// DetectFunctionHandlers returns a list of all the handlers
 	// in that directory given a path holding a function (or functions)
@@ -49,42 +53,27 @@ type Runtime interface {
 	GetName() string
 }
 
-type Configuration interface {
-	GetFunctionPath() string
-
-	GetFunctionDir() string
-
-	GetFunctionName() string
-
-	GetFunctionHandler() string
-
-	GetNuclioSourceDir() string
-
-	GetNuclioSourceURL() string
-
-	GetStagingDir() string
-
-	GetNoBaseImagePull() bool
-}
-
 type Factory interface {
-	Create(logger nuclio.Logger,
-		configuration Configuration) (Runtime, error)
+	Create(nuclio.Logger, string, *functionconfig.Config) (Runtime, error)
 }
 
 type AbstractRuntime struct {
-	Logger        nuclio.Logger
-	Configuration Configuration
-	DockerClient  dockerclient.Client
-	CmdRunner     cmdrunner.CmdRunner
+	Logger         nuclio.Logger
+	StagingDir     string
+	FunctionConfig *functionconfig.Config
+	DockerClient   dockerclient.Client
+	CmdRunner      cmdrunner.CmdRunner
 }
 
-func NewAbstractRuntime(logger nuclio.Logger, configuration Configuration) (*AbstractRuntime, error) {
+func NewAbstractRuntime(logger nuclio.Logger,
+	stagingDir string,
+	functionConfig *functionconfig.Config) (*AbstractRuntime, error) {
 	var err error
 
 	newRuntime := &AbstractRuntime{
-		Logger:        logger,
-		Configuration: configuration,
+		Logger:         logger,
+		StagingDir:     stagingDir,
+		FunctionConfig: functionConfig,
 	}
 
 	// create a docker client
@@ -111,4 +100,32 @@ func (ar *AbstractRuntime) OnAfterStagingDirCreated(stagingDir string) error {
 // the value is an absolute path into the docker image
 func (ar *AbstractRuntime) GetProcessorImageObjectPaths() map[string]string {
 	return nil
+}
+
+func (ar *AbstractRuntime) GetFunctionDir() string {
+
+	// if the function directory was passed, just return that. if the function path was passed, return the directory
+	// the function is in
+	if common.IsDir(ar.FunctionConfig.Spec.Build.Path) {
+		return ar.FunctionConfig.Spec.Build.Path
+	}
+
+	return path.Dir(ar.FunctionConfig.Spec.Build.Path)
+}
+
+// GetRuntimeNameAndVersion returns name and version of runtime from runtime.
+// e.g. go:1.8 -> go, 1.8
+func (ar *AbstractRuntime) GetRuntimeNameAndVersion() (string, string) {
+	nameAndVersion := strings.Split(ar.FunctionConfig.Spec.Runtime, ":")
+
+	switch len(nameAndVersion) {
+
+	// if both are passed (e.g. python:3.6) - return them both
+	case 2:
+		return nameAndVersion[0], nameAndVersion[1]
+
+	// otherwise - return the first element (e.g. go -> go)
+	default:
+		return nameAndVersion[0], ""
+	}
 }

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -17,15 +17,16 @@ limitations under the License.
 package runtime
 
 import (
-	"github.com/nuclio/nuclio/pkg/cmdrunner"
-	"github.com/nuclio/nuclio/pkg/dockerclient"
-	"github.com/nuclio/nuclio/pkg/errors"
-
-	"github.com/nuclio/nuclio-sdk"
-	"github.com/nuclio/nuclio/pkg/functionconfig"
-	"github.com/nuclio/nuclio/pkg/common"
 	"path"
 	"strings"
+
+	"github.com/nuclio/nuclio/pkg/cmdrunner"
+	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/dockerclient"
+	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+
+	"github.com/nuclio/nuclio-sdk"
 )
 
 type Runtime interface {


### PR DESCRIPTION
- Users can specify `python:2.7` or `python:3.6` runtimes (`python` falls back to `python:3.6`)
- Users can specify `baseImageName` as either `jesse` or `alpine` for Python. `baseImageName` for Golang remains unrestricted
- Go functions are now compiled with Go 1.9