### PR TITLE
conditionally pull base images in playground

### DIFF
--- a/cmd/playground/app/playground.go
+++ b/cmd/playground/app/playground.go
@@ -30,7 +30,8 @@ func Run(listenAddress string,
 	dockerKeyDir string,
 	defaultRegistryURL string,
 	defaultRunRegistryURL string,
-	platformType string) error {
+	platformType string,
+	noPullBaseImages bool) error {
 
 	logger, err := nucliozap.NewNuclioZapCmd("playground", nucliozap.DebugLevel)
 	if err != nil {
@@ -43,7 +44,7 @@ func Run(listenAddress string,
 		return errors.Wrap(err, "Failed to create platform")
 	}
 
-	logger.InfoWith("Starting", "name", platformInstance.GetName())
+	logger.InfoWith("Starting", "name", platformInstance.GetName(), "noPull", noPullBaseImages)
 
 	version.Log(logger)
 
@@ -53,7 +54,8 @@ func Run(listenAddress string,
 		dockerKeyDir,
 		defaultRegistryURL,
 		defaultRunRegistryURL,
-		platformInstance)
+		platformInstance,
+		noPullBaseImages)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create server")
 	}

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -31,6 +31,8 @@ func main() {
 		defaultRegistry = "127.0.0.1:5000"
 	}
 
+	defaultNoPullBaseImages := os.Getenv("NUCLIO_PLAYGROUND_NO_PULL_BASE_IMAGES") == "true"
+
 	listenAddress := flag.String("listen-addr", ":8070", "Path of configuration file")
 	assetsDir := flag.String("assets-dir", "", "Path of configuration file")
 	sourcesDir := flag.String("sources-dir", "", "Directory to save sources")
@@ -38,6 +40,7 @@ func main() {
 	platformType := flag.String("platform", "auto", "One of kube/local/auto")
 	defaultRegistryURL := flag.String("registry", defaultRegistry, "Default registry URL")
 	defaultRunRegistryURL := flag.String("run-registry", os.Getenv("NUCLIO_PLAYGROUND_RUN_REGISTRY_URL"), "Default run registry URL")
+	noPullBaseImages := flag.Bool("no-pull", defaultNoPullBaseImages, "Default run registry URL")
 
 	flag.Parse()
 
@@ -47,7 +50,8 @@ func main() {
 		*dockerKeyDir,
 		*defaultRegistryURL,
 		*defaultRunRegistryURL,
-		*platformType); err != nil {
+		*platformType,
+		*noPullBaseImages); err != nil {
 		os.Exit(1)
 	}
 

--- a/pkg/playground/resource/function.go
+++ b/pkg/playground/resource/function.go
@@ -207,6 +207,7 @@ func (f *function) createDeployOptions() *platform.DeployOptions {
 	deployOptions.FunctionConfig.Spec.Triggers = f.attributes.Triggers
 	deployOptions.FunctionConfig.Meta.Labels = f.attributes.Labels
 	deployOptions.FunctionConfig.Spec.Replicas = 1
+	deployOptions.FunctionConfig.Spec.Build.NoBaseImagesPull = server.NoPullBaseImages
 
 	// if user provided registry, use that. Otherwise use default
 	deployOptions.FunctionConfig.Spec.Build.Registry = server.GetRegistryURL()

--- a/pkg/playground/server.go
+++ b/pkg/playground/server.go
@@ -42,6 +42,7 @@ type Server struct {
 	dockerClient          dockerclient.Client
 	dockerCreds           *dockercreds.DockerCreds
 	Platform              platform.Platform
+	NoPullBaseImages      bool
 }
 
 func NewServer(parentLogger nuclio.Logger,
@@ -50,7 +51,8 @@ func NewServer(parentLogger nuclio.Logger,
 	dockerKeyDir string,
 	defaultRegistryURL string,
 	defaultRunRegistryURL string,
-	platform platform.Platform) (*Server, error) {
+	platform platform.Platform,
+	noPullBaseImages bool) (*Server, error) {
 
 	var err error
 
@@ -73,6 +75,7 @@ func NewServer(parentLogger nuclio.Logger,
 		dockerClient:          newDockerClient,
 		dockerCreds:           newDockerCreds,
 		Platform:              platform,
+		NoPullBaseImages:      noPullBaseImages,
 	}
 
 	// create server


### PR DESCRIPTION
Fixes #291 (no need for nuclio URL given that Go plugin is now used).

Running the playground as:
`docker run -p 8070:8070 -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -e NUCLIO_PLAYGROUND_NO_PULL_BASE_IMAGES=true nuclio/playground:0.0.1-amd64`

will not pull images - will only uses local docker images.