### PR TITLE
All docker images rely on binaries built in docker, rather than locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .vagrant
 .vscode
 __pycache__
-_output
 test/http-bench/out/
 
 *.log

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ NUCLIO_DOCKER_PROCESSOR_PY3_ALPINE_IMAGE_NAME=nuclio/processor-py3.6-alpine:$(NU
 NUCLIO_DOCKER_PROCESSOR_PY2_JESSIE_IMAGE_NAME=nuclio/processor-py2.7-jessie:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
 NUCLIO_DOCKER_PROCESSOR_PY3_JESSIE_IMAGE_NAME=nuclio/processor-py3.6-jessie:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
 
-processor-py:
+processor-py: processor
 
 	# build python 2.7/alpine
 	docker build $(NUCLIO_BUILD_ARGS_VERSION_INFO_FILE) \

--- a/Makefile
+++ b/Makefile
@@ -23,32 +23,27 @@ NUCLIO_ARCH := $(if $(NUCLIO_ARCH),$(NUCLIO_ARCH),$(NUCLIO_DEFAULT_ARCH))
 NUCLIO_TAG := $(if $(NUCLIO_TAG),$(NUCLIO_TAG),latest)
 NUCLIO_VERSION_GIT_COMMIT = $(shell git rev-parse HEAD)
 
-NUCLIO_VERSION_INFO := {\"git_commit\": \"$(NUCLIO_VERSION_GIT_COMMIT)\",  \
+NUCLIO_VERSION_INFO = {\"git_commit\": \"$(NUCLIO_VERSION_GIT_COMMIT)\",  \
 \"label\": \"$(NUCLIO_TAG)\",  \
 \"os\": \"$(NUCLIO_OS)\",  \
-\"arch\": \"$(NUCLIO_ARCH)\",  \
-\"go_version\": \"$(GO_VERSION)\"}
+\"arch\": \"$(NUCLIO_ARCH)\"}
 
 # Add labels to docker images
-NUCLIO_DOCKER_LABELS=--label nuclio.version_info="$(NUCLIO_VERSION_INFO)"
+NUCLIO_DOCKER_LABELS = --label nuclio.version_info="$(NUCLIO_VERSION_INFO)"
 
 NUCLIO_DOCKER_IMAGE_TAG=$(NUCLIO_TAG)
 NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH=$(NUCLIO_TAG)-$(NUCLIO_ARCH)
-
-# Docker image names
-NUCLIO_DOCKER_CONTROLLER_IMAGE_NAME=nuclio/controller:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
-NUCLIO_DOCKER_PLAYGROUND_IMAGE_NAME=nuclio/playground:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
-
-# inject version info
-NUCLIO_BUILD_ARGS := --build-arg NUCLIO_VERSION_INFO_FILE_CONTENTS="$(NUCLIO_VERSION_INFO)"
 
 # Link flags
 GO_LINK_FLAGS := -s -w
 GO_LINK_FLAGS_INJECT_VERSION := -s -w -X github.com/nuclio/nuclio/pkg/version.gitCommit=$(NUCLIO_VERSION_GIT_COMMIT) \
 	-X github.com/nuclio/nuclio/pkg/version.label=$(NUCLIO_TAG) \
 	-X github.com/nuclio/nuclio/pkg/version.os=$(NUCLIO_OS) \
-	-X github.com/nuclio/nuclio/pkg/version.arch=$(NUCLIO_ARCH) \
-	-X github.com/nuclio/nuclio/pkg/version.goVersion=$(GO_VERSION)
+	-X github.com/nuclio/nuclio/pkg/version.arch=$(NUCLIO_ARCH)
+
+# inject version info as file
+NUCLIO_BUILD_ARGS_VERSION_INFO_FILE = --build-arg NUCLIO_VERSION_INFO_FILE_CONTENTS="$(NUCLIO_VERSION_INFO)"
+
 
 #
 # Build helpers
@@ -60,16 +55,6 @@ GO_BUILD_TOOL = GOOS=$(NUCLIO_OS) \
 	go build -a \
 	-installsuffix cgo \
 	-ldflags="$(GO_LINK_FLAGS_INJECT_VERSION)"
-
-# dockerized binaries get built with the specified OS/arch and don't inject version
-GO_BUILD_DOCKERIZED_BINARY = GOOS=linux \
-	GOARCH=$(NUCLIO_ARCH) \
-	go build -a \
-	-installsuffix cgo \
-	-ldflags="$(GO_LINK_FLAGS)"
-
-# dockerized services behave the same as dockerized binaries
-GO_BUILD_DOCKERIZED_SERVICE := $(GO_BUILD_DOCKERIZED_BINARY)
 
 #
 # Rules
@@ -99,30 +84,34 @@ nuctl: ensure-gopath
 	@rm -f $(NUCTL_TARGET)
 	@ln -sF $(NUCTL_OUTPUT) $(NUCTL_TARGET)
 
-#
-# Dockerized binaries
-#
-
 processor: ensure-gopath
-	$(GO_BUILD_DOCKERIZED_BINARY) -o cmd/processor/_output/processor cmd/processor/main.go
-
+	$(eval NUCLIO_OS := linux)
+	docker build -f cmd/processor/Dockerfile -t nuclio/processor .
 
 #
 # Dockerized services
 #
 
+NUCLIO_DOCKER_CONTROLLER_IMAGE_NAME=nuclio/controller:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
+
 controller: ensure-gopath
-	$(GO_BUILD_DOCKERIZED_SERVICE) -o cmd/controller/_output/controller cmd/controller/main.go
-	cd cmd/controller && docker build $(NUCLIO_BUILD_ARGS) -t $(NUCLIO_DOCKER_CONTROLLER_IMAGE_NAME) $(NUCLIO_DOCKER_LABLES) .
-	rm -rf cmd/controller/_output
+	$(eval NUCLIO_OS := linux)
+	docker build $(NUCLIO_BUILD_ARGS_VERSION_INFO_FILE) \
+		-f cmd/controller/Dockerfile \
+		-t $(NUCLIO_DOCKER_CONTROLLER_IMAGE_NAME) \
+		$(NUCLIO_DOCKER_LABELS) .
 
 controller-push:
 	docker push $(NUCLIO_DOCKER_CONTROLLER_IMAGE_NAME)
 
+NUCLIO_DOCKER_PLAYGROUND_IMAGE_NAME=nuclio/playground:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
+
 playground: ensure-gopath
-	$(GO_BUILD_DOCKERIZED_SERVICE) -o cmd/playground/_output/playground cmd/playground/main.go
-	cd cmd/playground && docker build $(NUCLIO_BUILD_ARGS) -t $(NUCLIO_DOCKER_PLAYGROUND_IMAGE_NAME) $(NUCLIO_DOCKER_LABLES) .
-	rm -rf cmd/playground/_output
+	$(eval NUCLIO_OS := linux)
+	docker build $(NUCLIO_BUILD_ARGS_VERSION_INFO_FILE) \
+		-f cmd/playground/Dockerfile \
+		-t $(NUCLIO_DOCKER_PLAYGROUND_IMAGE_NAME) \
+		$(NUCLIO_DOCKER_LABELS) .
 
 playground-push:
 	docker push $(NUCLIO_DOCKER_PLAYGROUND_IMAGE_NAME)
@@ -137,31 +126,31 @@ NUCLIO_DOCKER_PROCESSOR_PY3_ALPINE_IMAGE_NAME=nuclio/processor-py3.6-alpine:$(NU
 NUCLIO_DOCKER_PROCESSOR_PY2_JESSIE_IMAGE_NAME=nuclio/processor-py2.7-jessie:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
 NUCLIO_DOCKER_PROCESSOR_PY3_JESSIE_IMAGE_NAME=nuclio/processor-py3.6-jessie:$(NUCLIO_DOCKER_IMAGE_TAG_WITH_ARCH)
 
-processor-py: processor
+processor-py:
 
 	# build python 2.7/alpine
-	docker build $(NUCLIO_BUILD_ARGS) \
+	docker build $(NUCLIO_BUILD_ARGS_VERSION_INFO_FILE) \
 		-f ${NUCLIO_PROCESSOR_PY_DOCKERFILE_PATH} \
 		--build-arg NUCLIO_PYTHON_VERSION=2.7 \
 		--build-arg NUCLIO_PYTHON_OS=alpine3.6 \
 		-t $(NUCLIO_DOCKER_PROCESSOR_PY2_ALPINE_IMAGE_NAME) .
 
 	# build python 3/alpine
-	docker build $(NUCLIO_BUILD_ARGS) \
+	docker build $(NUCLIO_BUILD_ARGS_VERSION_INFO_FILE) \
 		-f ${NUCLIO_PROCESSOR_PY_DOCKERFILE_PATH} \
 		--build-arg NUCLIO_PYTHON_VERSION=3.6 \
 		--build-arg NUCLIO_PYTHON_OS=alpine3.6 \
 		-t $(NUCLIO_DOCKER_PROCESSOR_PY3_ALPINE_IMAGE_NAME) .
 
 	# build python 2/jesse
-	docker build $(NUCLIO_BUILD_ARGS) \
+	docker build $(NUCLIO_BUILD_ARGS_VERSION_INFO_FILE) \
 		-f ${NUCLIO_PROCESSOR_PY_DOCKERFILE_PATH} \
 		--build-arg NUCLIO_PYTHON_VERSION=2.7 \
 		--build-arg NUCLIO_PYTHON_OS=slim-jessie \
 		-t $(NUCLIO_DOCKER_PROCESSOR_PY2_JESSIE_IMAGE_NAME) .
 
 	# build python 3/jesse
-	docker build $(NUCLIO_BUILD_ARGS) \
+	docker build $(NUCLIO_BUILD_ARGS_VERSION_INFO_FILE) \
 		-f ${NUCLIO_PROCESSOR_PY_DOCKERFILE_PATH} \
 		--build-arg NUCLIO_PYTHON_VERSION=3.6 \
 		--build-arg NUCLIO_PYTHON_OS=slim-jessie \

--- a/cmd/playground/Dockerfile
+++ b/cmd/playground/Dockerfile
@@ -12,6 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# Build stage: builds the playground binary
+#
+
+FROM golang:1.9.2 as build
+
+# copy source tree
+WORKDIR /go/src/github.com/nuclio/nuclio
+COPY . .
+
+# build the playground
+RUN go get github.com/nuclio/nuclio-sdk \
+    && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags="-s -w" -o playground cmd/playground/main.go
+
+#
+# Output stage: Creates version file, copies binary to an alpine based image
+#
+
 FROM alpine:3.6
 
 ARG DOCKER_CLI_VERSION="17.09.0-ce"
@@ -25,8 +43,9 @@ RUN apk --update --no-cache add ca-certificates git curl \
     && rm -rf /tmp/download \
     && apk del curl
 
-COPY _output/playground /usr/local/bin
-COPY static /etc/nuclio/playground/assets
+# copy playground binary from build stage
+COPY --from=build /go/src/github.com/nuclio/nuclio/playground /usr/local/bin
+COPY cmd/playground/static /etc/nuclio/playground/assets
 
 RUN mkdir -p /etc/nuclio/playground/sources
 

--- a/cmd/processor/Dockerfile
+++ b/cmd/processor/Dockerfile
@@ -12,33 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#
-# Build stage: builds the controller binary
-#
-
-FROM golang:1.9.2 as build
+FROM golang:1.9.2
 
 # copy source tree
 WORKDIR /go/src/github.com/nuclio/nuclio
 COPY . .
 
-# build the controller
+# build the processor
 RUN go get github.com/nuclio/nuclio-sdk \
-    && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags="-s -w" -o controller cmd/controller/main.go
-
-#
-# Output stage: Creates version file, copies binary to an alpine based image
-#
-
-FROM alpine:3.6
-
-RUN apk add --no-cache ca-certificates
-
-# copy controller binary from build stage
-COPY --from=build /go/src/github.com/nuclio/nuclio/controller /usr/local/bin
-
-# generate a version file
-ARG NUCLIO_VERSION_INFO_FILE_CONTENTS
-RUN mkdir -p /etc/nuclio && echo ${NUCLIO_VERSION_INFO_FILE_CONTENTS} > /etc/nuclio/version_info.json
-
-CMD [ "controller" ]
+    && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags="-s -w" -o processor cmd/processor/main.go

--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
@@ -15,7 +15,6 @@
 FROM golang:1.9-alpine3.6
 
 RUN apk --update --no-cache add \
-    make \
     git \
     gcc \
     musl-dev
@@ -44,17 +43,16 @@ ONBUILD RUN /build-handler.sh
 # Create processor binary
 #
 
+WORKDIR /go/src/github.com/nuclio/nuclio
+COPY . .
+
 RUN go get -v github.com/nuclio/nuclio-sdk
 
 # create
 RUN mkdir -p /etc/nuclio
 RUN mkdir -p /opt/nuclio
 
-# copy nuclio source to GOPATH
-COPY . /go/src/github.com/nuclio/nuclio
-
 # make the processor binary
-RUN cd /go/src/github.com/nuclio/nuclio \
-    && make processor \
-    && cp -v cmd/processor/_output/processor /usr/local/bin \
+RUN GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-s -w" -o processor cmd/processor/main.go \
+    && cp -v /go/src/github.com/nuclio/nuclio/processor /usr/local/bin \
     && rm -r /go/src/github.com/nuclio/nuclio

--- a/pkg/processor/build/runtime/python/docker/processor-py/Dockerfile
+++ b/pkg/processor/build/runtime/python/docker/processor-py/Dockerfile
@@ -1,9 +1,33 @@
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ARG NUCLIO_PYTHON_VERSION=3
 ARG NUCLIO_PYTHON_OS=alpine3.6
 
+#
+# Build stage: builds the processor binary
+#
+
+FROM nuclio/processor as build
+
+#
+# Output stage
+#
+
 FROM python:${NUCLIO_PYTHON_VERSION}-${NUCLIO_PYTHON_OS}
 
-COPY cmd/processor/_output/processor /usr/local/bin/processor
+COPY --from=build /go/src/github.com/nuclio/nuclio/processor /usr/local/bin/processor
 COPY pkg/processor/runtime/python/wrapper.py /opt/nuclio/wrapper.py
 
 # generate a version file


### PR DESCRIPTION
Controller, playground and processor-py build appropriate binaries in multi-stage builds rather than via make.