### PR TITLE
[doc review] README, arch, and k8s getting-started & function-ingress + minor fixes in k8s.io/apimachinery README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,25 @@
 
 # nuclio - "Serverless" for Real-Time Events and Data Processing
 
-nuclio is a new "serverless" project, derived from iguazio's elastic data life-cycle management service for high-performance events and data processing. You can use nuclio as a standalone binary (for example, for IoT devices), package it within a Docker container or integrate it with a container orchestrator like Kubernetes.
-
-nuclio is extremely fast. A single function instance can process hundreds of thousands of HTTP requests or data records per second. This is 10 - 100 times faster than some other frameworks. See [nuclio Architecture](docs/architecture.md) to learn how it works and watch a [technical presentation to the CNCF with demo](https://www.youtube.com/watch?v=xlOp9BR5xcs) (slides can be found [here](https://www.slideshare.net/iguazio/nuclio-overview-october-2017-80356865)).
-
-**Note:** nuclio is still under active development and is not recommended for production use.
-
 #### In This Document
-* [Why Another "Serverless" Project?](#why-another-serverless-project)
-* [Quick Start](#quick-start)
-* [High-Level Architecture](#high-level-architecture)
-* [Function Examples](#function-examples)
-* [Further Reading](#further-reading)
+- [Overview](#overview)
+- [Why Another "Serverless" Project?](#why-another-serverless-project)
+- [Quick-Start Steps](#quick-start-steps)
+- [High-Level Architecture](#high-level-architecture)
+- [Function Examples](#function-examples)
+- [Further Reading](#further-reading)
+
+## Overview
+
+nuclio is a new "serverless" project, derived from iguazio's elastic data life-cycle management service for high-performance events and data processing.
+You can use nuclio as a standalone binary (for example, for IoT devices), package it within a Docker container, or integrate it with a container orchestrator like [Kubernetes](https://kubernetes.io).
+
+nuclio is extremely fast.
+A single function instance can process hundreds of thousands of HTTP requests or data records per second.
+This is 10-100 times faster than some other frameworks.
+To learn more about how nuclio works, see [nuclio Architecture](docs/architecture.md) and watch the [technical CNCF nuclio presentation and demo](https://www.youtube.com/watch?v=xlOp9BR5xcs) (slides can be found [here](https://www.slideshare.net/iguazio/nuclio-overview-october-2017-80356865)).
+
+> **Note:** nuclio is still under active development and is not recommended for production use.
 
 ## Why Another "Serverless" Project?
 
@@ -25,15 +32,17 @@ We considered existing cloud and open-source serverless solutions, but none addr
 
 * Real-time processing with minimal CPU and I/O overhead and maximum parallelism
 * Native integration with a large variety of data sources, triggers, and processing models
-* Abstraction of data resources from the function code to support code portability, simplicity and data-path acceleration
-* Simple debugging, regression testing and multi-versioned CI/CD pipelines
+* Abstraction of data resources from the function code - to support code portability, simplicity and data-path acceleration
+* Simple debugging, regression testing, and multi-versioned CI/CD pipelines
 * Portability across low-power devices, laptops, on-prem clusters and public clouds
 
-We designed nuclio to be extendable, using a modular and layered approach - constantly adding triggers and data sources.  We hope many will join us in developing new modules, developer tools and platforms.
+We designed nuclio to be extendable, using a modular and layered approach that supports constant addition of triggers and data sources.
+We hope many will join us in developing new modules, developer tools, and platforms.
 
-## Quick Start
+## Quick-Start Steps
 
-The simplest way to explore nuclio is to run the nuclio playground (you only need docker):
+The simplest way to explore nuclio is to run its graphical user interface (GUI) of the nuclio [playground](#playground).
+All you need in order to run the playground is Docker:
 
 ```bash
 docker run -p 8070:8070 -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp nuclio/playground:0.1.0-amd64
@@ -41,51 +50,74 @@ docker run -p 8070:8070 -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tm
 
 ![playground](docs/images/playground.png)
 
-Browse to http://localhost:8070, deploy one of the example functions or write your own. The playground, when run outside of an orchestration platform (e.g. Kubernetes or Swarm), will simply deploy to the local docker daemon.
+Browse to http://localhost:8070 and deploy one of the example functions, or write your own function.
+When run outside of an orchestration platform (for example, Kubernetes or Swarm), the playground will simply deploy to the local Docker daemon.
 
-The [Getting Started With nuclio On Kubernetes](docs/k8s/getting-started.md) guide has a complete step-by-step guide to using nuclio over Kubernetes both with the playground and `nuctl` - nuclio's command line interface.
+For a complete step-by-step guide to using nuclio over Kubernetes, either with the playground UI or the nuclio command-line interface (`nuctl`), see [Getting Started with nuclio on Kubernetes](docs/k8s/getting-started.md).
 
 ## High-Level Architecture
 
+The following image illustrates nuclio's high-level architecture:
+
 ![architecture](docs/images/architecture.png)
+
+Following is an outline of the main architecture components.
+For more information about the nuclio architecture, see [nuclio Architecture](docs/architecture.md).
 
 ### Services
 
 #### Processor
-A processor listens on one or more triggers (for example, HTTP, Message Queue, Stream), and executes user functions with one or more parallel workers.
 
-The workers use language-specific runtimes to execute the function (via native calls, shared memory, or shell). Processors use abstract interfaces to integrate with platform facilities for logging, monitoring and configuration, allowing for greater portability and extensibility (such as logging to a screen, file, or log stream).
+A processor listens on one or more triggers (for example, HTTP, Message Queue, or Stream), and executes user functions with one or more parallel workers.
+
+The workers use language-specific runtimes to execute the function (via native calls, shared memory, or shell).
+Processors use abstract interfaces to integrate with platform facilities for logging, monitoring and configuration, allowing for greater portability and extensibility (such as logging to a screen, file, or log stream).
 
 #### Controller
+
 A controller accepts function and event-source specifications, invokes builders and processors through an orchestration platform (such as Kubernetes), and manages function elasticity, life cycle, and versions.
 
 #### Playground
-The playground is a standalone container micro-service accessed through HTTP, it presents a code editor UI for editing, deploying and testing functions. This is the most user-friendly way to work with nuclio. The playground container comes with a version of the builder inside.
+
+The playground is a standalone container microservice that is accessed through HTTP and includes a code-editor GUI for editing, deploying, and testing functions.
+This is the most user-friendly way to work with nuclio.
+The playground container comes packaged with a version of the nuclio [builder](#builder).
 
 #### Builder
-A builder receives raw code and optional build instructions and dependencies, and generates the function artifact - a binary file or a Docker container image, which the builder can also push to a specified image repository. The builder can run in the context of the CLI or as a separate service for automated development pipelines.
+
+A builder receives raw code and optional build instructions and dependencies, and generates the function artifact - a binary file or a Docker container image that the builder can also push to a specified image repository.
+The builder can run in the context of the CLI or as a separate service, for automated development pipelines.
 
 #### Dealer
-A dealer is used with streaming and batch jobs to distribute a set of tasks or data partitions/shards among the available function instances, and guarantee that all tasks are completed successfully. For example, if a function reads from a message stream with 20 partitions, the dealer will guarantee that the partitions are distributed evenly across workers, taking into account the number of function instances and failures.
+
+A dealer is used with streaming and batch jobs to distribute a set of tasks or data partitions/shards among the available function instances, and to guarantee that all tasks are completed successfully.
+For example, if a function reads from a message stream with 20 partitions, the dealer will guarantee that the partitions are distributed evenly across workers, taking into account the number of function instances and failures.
 
 ### Function Concepts
 
 #### Triggers
-Functions can be invoked through a variety of event sources (such as HTTP, RabbitMQ, Kafka, Kinesis, NATS, DynamoDB, iguazio v3io, or schedule), which are defined in the function specification. Event sources are divided into several event classes (req/rep, async, stream, pooling), which define the sources' behavior. Different event sources can plug seamlessly into the same function without sacrificing performance, allowing for portability, code reuse, and flexibility.
+
+Functions can be invoked through a variety of event sources that are defined in the function (such as HTTP, RabbitMQ, Kafka, Kinesis, NATS, DynamoDB, iguazio v3io, or schedule).
+Event sources are divided into several event classes (req/rep, async, stream, pooling), which define the sources' behavior.
+Different event sources can plug seamlessly into the same function without sacrificing performance, allowing for portability, code reuse, and flexibility.
 
 #### Data bindings
-Data-binding rules allow users to specify persistent input/output data resources to be used by the function. (data connections are preserved between executions). Bound data can be in the form of files, objects, records, messages etc. The function specification may include an array of data-binding rules, each specifying the data resource and its credentials and usage parameters. Data-binding abstraction allows using the same function with different data sources of the same type, and enables function portability.
+
+Data-binding rules allow users to specify persistent input/output data resources to be used by the function.
+(Data connections are preserved between executions.)
+Bound data can be in the form of files, objects, records, messages, etc.
+The function specification may include an array of data-binding rules, each specifying the data resource and its credentials and usage parameters.
+Data-binding abstraction allows using the same function with different data sources of the same type, and enables function portability.
 
 #### SDK
-The nuclio SDK is used by function developers to write, test, and submit their code, without the need for the entire nuclio source tree.
 
-For more information about the nuclio architecture, see [nuclio Architecture](docs/architecture.md).
+The nuclio SDK is used by function developers to write, test, and submit their code, without the need for the entire nuclio source tree.
 
 ## Function Examples
 
-The function demonstrated below uses the `Event` and `Context` interfaces to handle inputs and logs, returning a structured HTTP response (can also use a simple string as returned value).
+The following sample function implementation uses the `Event` and `Context` interfaces to handle inputs and logs, returning a structured HTTP response; (it's also possible to use a simple string as the returned value).
 
-in Golang
+In Go
 ```golang
 package handler
 
@@ -104,7 +136,7 @@ func Handler(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
 }
 ```
 
-in Python
+In Python
 ```python
 def handler(context, event):
     response_body = f'Got {event.method} to {event.path} with "{event.body}"'
@@ -119,30 +151,30 @@ def handler(context, event):
                             status_code=201)
 ```
 
-More examples can be found [here](hack/examples/README.md).
+More examples can be found in the **[hack/examples](hack/examples/README.md)** nuclio GitHub directory.
 
 ## Further Reading
 
-* Getting started
-    * [Getting Started With nuclio On Kubernetes](docs/k8s/getting-started.md)
-    * [Getting Started With nuclio On GKE and GCR](docs/k8s/gke/getting-started.md)
-    * Getting Started With nuclio On Raspberry Pi (coming soon)
-* Guides and examples
-    * [Configuring a function](docs/configuring-a-function.md)
-    * [Function Examples](hack/examples/README.md)
-    * [nuctl Reference](docs/nuctl/nuctl.md)
-    * Kubernetes
-        * [Invoking Functions By Name with an Ingress](docs/k8s/function-ingress.md)
-        * [Private Docker Registries](docs/k8s/private-docker-registries.md)
-* Under the hood
-    * [Architecture Details](docs/architecture.md)
-    * Build Process (coming soon)
-    * Deploy Process (coming soon)
-* Project stuff
-    * [Roadmap](ROADMAP.md)
-* Media
-    * [nuclio and the Future of Serverless Computing](https://thenewstack.io/whats-next-serverless/)
-    * [nuclio: The New Serverless Superhero](https://hackernoon.com/nuclio-the-new-serverless-superhero-3aefe1854e9a)
+- Getting started
+    - [Getting Started With nuclio On Kubernetes](docs/k8s/getting-started.md)
+    - [Getting Started With nuclio On GKE and GCR](docs/k8s/gke/getting-started.md)
+    - Getting Started With nuclio On Raspberry Pi (coming soon)
+- Guides and examples
+    - [Configuring a function](docs/configuring-a-function.md)
+    - [Function Examples](hack/examples/README.md)
+    - [nuctl Reference](docs/nuctl/nuctl.md)
+    - Kubernetes
+        - ["Invoking Functions by Name with a Kubernetes Ingress](docs/k8s/function-ingress.md)
+        - [Private Docker Registries](docs/k8s/private-docker-registries.md)
+- Under the hood
+    - [Architecture Details](docs/architecture.md)
+    - Build Process (coming soon)
+    - Deploy Process (coming soon)
+- Project stuff
+    - [Roadmap](ROADMAP.md)
+- Media
+    - [nuclio and the Future of Serverless Computing](https://thenewstack.io/whats-next-serverless/)
+    - [nuclio: The New Serverless Superhero](https://hackernoon.com/nuclio-the-new-serverless-superhero-3aefe1854e9a)
 
-For more questions and help, feel free to join the friendly [nuclio Slack channel](https://lit-oasis-83353.herokuapp.com).
+For support and additional product information, [join](https://lit-oasis-83353.herokuapp.com) the active [nuclio Slack](https://nuclio-io.slack.com) workspace.
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,9 @@
 
 ## Overview
 
-nuclio is a new "serverless" project, derived from iguazio's elastic data life-cycle management service for high-performance events and data processing.
-You can use nuclio as a standalone binary (for example, for IoT devices), package it within a Docker container, or integrate it with a container orchestrator like [Kubernetes](https://kubernetes.io).
+nuclio is a new "serverless" project, derived from iguazio's elastic data life-cycle management service for high-performance events and data processing. You can use nuclio as a standalone binary (for example, for IoT devices), package it within a Docker container, or integrate it with a container orchestrator like [Kubernetes](https://kubernetes.io).
 
-nuclio is extremely fast.
-A single function instance can process hundreds of thousands of HTTP requests or data records per second.
-This is 10-100 times faster than some other frameworks.
-To learn more about how nuclio works, see [nuclio Architecture](docs/architecture.md) and watch the [technical CNCF nuclio presentation and demo](https://www.youtube.com/watch?v=xlOp9BR5xcs) (slides can be found [here](https://www.slideshare.net/iguazio/nuclio-overview-october-2017-80356865)).
+nuclio is extremely fast. A single function instance can process hundreds of thousands of HTTP requests or data records per second. This is 10-100 times faster than some other frameworks. To learn more about how nuclio works, see [nuclio Architecture](docs/architecture.md) and watch the [technical CNCF nuclio presentation and demo](https://www.youtube.com/watch?v=xlOp9BR5xcs) (slides can be found [here](https://www.slideshare.net/iguazio/nuclio-overview-october-2017-80356865)).
 
 > **Note:** nuclio is still under active development and is not recommended for production use.
 
@@ -37,13 +33,11 @@ We considered existing cloud and open-source serverless solutions, but none addr
 * Simple debugging, regression testing, and multi-versioned CI/CD pipelines
 * Portability across low-power devices, laptops, on-prem clusters and public clouds
 
-We designed nuclio to be extendable, using a modular and layered approach that supports constant addition of triggers and data sources.
-We hope many will join us in developing new modules, developer tools, and platforms.
+We designed nuclio to be extendable, using a modular and layered approach that supports constant addition of triggers and data sources. We hope many will join us in developing new modules, developer tools, and platforms.
 
 ## Quick-Start Steps
 
-The simplest way to explore nuclio is to run its graphical user interface (GUI) of the nuclio [playground](#playground).
-All you need in order to run the playground is Docker:
+The simplest way to explore nuclio is to run its graphical user interface (GUI) of the nuclio [playground](#playground). All you need in order to run the playground is Docker:
 
 ```bash
 docker run -p 8070:8070 -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp nuclio/playground:0.1.0-amd64
@@ -51,8 +45,7 @@ docker run -p 8070:8070 -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tm
 
 ![playground](docs/images/playground.png)
 
-Browse to http://localhost:8070 and deploy one of the example functions, or write your own function.
-When run outside of an orchestration platform (for example, Kubernetes or Swarm), the playground will simply deploy to the local Docker daemon.
+Browse to http://localhost:8070 and deploy one of the example functions, or write your own function. When run outside of an orchestration platform (for example, Kubernetes or Swarm), the playground will simply deploy to the local Docker daemon.
 
 For a complete step-by-step guide to using nuclio over Kubernetes, either with the playground UI or the nuclio command-line interface (`nuctl`), see [Getting Started with nuclio on Kubernetes](docs/k8s/getting-started.md).
 
@@ -62,8 +55,7 @@ The following image illustrates nuclio's high-level architecture:
 
 ![architecture](docs/images/architecture.png)
 
-Following is an outline of the main architecture components.
-For more information about the nuclio architecture, see [nuclio Architecture](docs/architecture.md).
+Following is an outline of the main architecture components. For more information about the nuclio architecture, see [nuclio Architecture](docs/architecture.md).
 
 ### Services
 
@@ -71,8 +63,7 @@ For more information about the nuclio architecture, see [nuclio Architecture](do
 
 A processor listens on one or more triggers (for example, HTTP, Message Queue, or Stream), and executes user functions with one or more parallel workers.
 
-The workers use language-specific runtimes to execute the function (via native calls, shared memory, or shell).
-Processors use abstract interfaces to integrate with platform facilities for logging, monitoring and configuration, allowing for greater portability and extensibility (such as logging to a screen, file, or log stream).
+The workers use language-specific runtimes to execute the function (via native calls, shared memory, or shell). Processors use abstract interfaces to integrate with platform facilities for logging, monitoring and configuration, allowing for greater portability and extensibility (such as logging to a screen, file, or log stream).
 
 #### Controller
 
@@ -80,14 +71,11 @@ A controller accepts function and event-source specifications, invokes builders 
 
 #### Playground
 
-The playground is a standalone container microservice that is accessed through HTTP and includes a code-editor GUI for editing, deploying, and testing functions.
-This is the most user-friendly way to work with nuclio.
-The playground container comes packaged with a version of the nuclio [builder](#builder).
+The playground is a standalone container microservice that is accessed through HTTP and includes a code-editor GUI for editing, deploying, and testing functions. This is the most user-friendly way to work with nuclio. The playground container comes packaged with a version of the nuclio [builder](#builder).
 
 #### Builder
 
-A builder receives raw code and optional build instructions and dependencies, and generates the function artifact - a binary file or a Docker container image that the builder can also push to a specified image repository.
-The builder can run in the context of the CLI or as a separate service, for automated development pipelines.
+A builder receives raw code and optional build instructions and dependencies, and generates the function artifact - a binary file or a Docker container image that the builder can also push to a specified image repository. The builder can run in the context of the CLI or as a separate service, for automated development pipelines.
 
 #### Dealer
 
@@ -98,17 +86,11 @@ For example, if a function reads from a message stream with 20 partitions, the d
 
 #### Triggers
 
-Functions can be invoked through a variety of event sources that are defined in the function (such as HTTP, RabbitMQ, Kafka, Kinesis, NATS, DynamoDB, iguazio v3io, or schedule).
-Event sources are divided into several event classes (req/rep, async, stream, pooling), which define the sources' behavior.
-Different event sources can plug seamlessly into the same function without sacrificing performance, allowing for portability, code reuse, and flexibility.
+Functions can be invoked through a variety of event sources that are defined in the function (such as HTTP, RabbitMQ, Kafka, Kinesis, NATS, DynamoDB, iguazio v3io, or schedule). Event sources are divided into several event classes (req/rep, async, stream, pooling), which define the sources' behavior. Different event sources can plug seamlessly into the same function without sacrificing performance, allowing for portability, code reuse, and flexibility.
 
 #### Data bindings
 
-Data-binding rules allow users to specify persistent input/output data resources to be used by the function.
-(Data connections are preserved between executions.)
-Bound data can be in the form of files, objects, records, messages, etc.
-The function specification may include an array of data-binding rules, each specifying the data resource and its credentials and usage parameters.
-Data-binding abstraction allows using the same function with different data sources of the same type, and enables function portability.
+Data-binding rules allow users to specify persistent input/output data resources to be used by the function. (Data connections are preserved between executions.) Bound data can be in the form of files, objects, records, messages, etc. The function specification may include an array of data-binding rules, each specifying the data resource and its credentials and usage parameters. Data-binding abstraction allows using the same function with different data sources of the same type, and enables function portability.
 
 #### SDK
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <p align="center"><img src="docs/images/logo.png" width="180"/></p>
 
 # nuclio - "Serverless" for Real-Time Events and Data Processing
+<!-- TODO: Link to the nuclio web site and its documentation section. -->
 
 #### In This Document
 - [Overview](#overview)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,9 +1,9 @@
 # nuclio Architecture
 
-**In This Document**  
+**In This Document**
 - [Function Processors](#function-processors)
 - [Event Sources and Mapping](#event-sources-and-mapping)
-- [Function Build and Deployment flow](#function-build-and-deployment-flow)
+- [Function Build and Deployment Flow](#function-build-and-deployment-flow)
 
 ## Function Processors
 
@@ -12,7 +12,8 @@ The processor feeds functions with events, provides context and data, collects l
 
 Processors can be compiled into a single binary (when using Go or C), or packaged into a container with all the required code dependencies.
 Processor containers can run as standalone Docker containers, or on top of a container-orchestration platform such as Kubernetes.
-Each function has its own function processors. Function Processors will be scaled-out automatically (by adding more container instances) to address high event frequency.
+Each function has its own function processors.
+Function Processors will be scaled-out automatically (by adding more container instances) to address high event frequency.
 
 ### Processor Architecture
 
@@ -25,81 +26,128 @@ The processor has four main components:
 #### Event-Source Listeners
 
 Event-source listeners can listen on sockets and message queues, or periodically fetch events from external event or data sources.
-Received events share a common schema, which decouples the function logic from the event source implementation or specific structure, and pushed to one or more parallel runtime workers.  
-The event listeners also guarantee exactly-once or at-least-once event execution and handle failures &mdash; for example, by storing stream checkpoints, acknowledging or retrying message-queue events, or responding to HTTP client requests.
+Received events share a common schema, which decouples the function logic from the event source implementation or specific structure, and pushed to one or more parallel runtime workers.
+
+The event listeners also guarantee exactly-once or at-least-once event execution and handle failures - for example, by storing stream checkpoints, acknowledging or retrying message-queue events, or responding to HTTP client requests.
 
 #### Runtime Engine
 
-The runtime engine ("runtime") initializes the function environment (variables, context, log, data bindings, etc.), feeds event objects into functions workers, and returns responses to the event sources.  
+The runtime engine ("runtime") initializes the function environment (variables, context, log, data bindings, etc.), feeds event objects into functions workers, and returns responses to the event sources.
+
 Runtimes can have multiple independent parallel workers (for example, Go routines, Python asyncio, Akka, or threads) to enable non-blocking operations and maximize CPU utilization.
 
-nuclio currently supports three types of processor runtime implementations:  
-1.	**Native** &mdash; for real-time and inline Go or C-based routines.
+nuclio currently supports three types of processor runtime implementations:
 
-2.	**SHMEM** &mdash; for shared-memory languages, such as Python, Java, and Node.js.  
+1.	**Native** - for real-time and inline Go or C-based routines.
+
+2.	**SHMEM** - for shared-memory languages, such as Python, Java, and Node.js.
     The processor communicates with the SHMEM function runtime through zero-copy shared-memory channels.
 
-3.	**Shell** &mdash; for command-line execution functions or binaries ("executables").  
-    Upon receiving an event, the processor runs the executable in a command-line shell, using the relevant command and environment variables, and then maps the executable's standard-output (`stdout`) or standard-error (`stderr`) logs to the function results.  
-    **Note:** The shell runtime supports only file data bindings.
+3.	**Shell** - for command-line execution functions or binaries ("executables").
+    Upon receiving an event, the processor runs the executable in a command-line shell, using the relevant command and environment variables, and then maps the executable's standard-output (`stdout`) or standard-error (`stderr`) logs to the function results.
+
+    > **Note:** The shell runtime supports only file data bindings.
 
 #### Data Bindings
 
 Functions can benefit from persistent data connections to external files, objects, databases, or messaging systems.
-The runtime initializes the data-service connection based on the type, URL, properties, and credentials specified in the function specification, and serves them to the function through the context object.  
+The runtime initializes the data-service connection based on the type, URL, properties, and credentials specified in the function specification, and serves them to the function through the context object.
+
 Data bindings simplify development by eliminating the need to integrate with SDKs or manage connections and credentials.
-They also enable function reuse and portability, because different data services of the same class are mapped to the function using the same APIs.  
+They also enable function reuse and portability, because different data services of the same class are mapped to the function using the same APIs.
 Data bindings can also handle aspects of data prefetching, caching, and micro-batching, to reduce execution latency and increase I/O performance.
+
 Data bindings and event sources are designed with zero-copy, zero-serialization, and non-blocking operation, and enable real-time performance without the need for any special function code.
 
 #### Control Framework
 
-The control framework initializes and controls the different processor components, provides logging for the processor and the function (stored in different log streams), monitors execution statistics, and serves a mini portal for remote management.  
+The control framework initializes and controls the different processor components, provides logging for the processor and the function (stored in different log streams), monitors execution statistics, and serves a mini portal for remote management.
+
 The control framework interacts with the underlining platform through abstract interfaces, allowing for portability across different IoT devices, container orchestrators, and cloud platforms.
 The platform-specific processor configuration is done through a **processor.yaml** file in the working directory.
 Function developers should not modify this file.
-The underlying function processor interfaces to the required platform services are all abstracted such that the same function processor may be ported between different deployments types.
+The underlying interfaces of the function processors to the required platform services are all abstracted in a way that enables porting the same function processor among different deployments types.
 
 ## Event Sources and Mapping
 
-Functions are event driven, they respond to event triggers, data messages or records that are accepted from the event source and pushed to the function runtime engine. Event sources can be divided to few classes based on their behavior and flow management, there can be multiple event sources implementations under each class, nuclio supports the following event classes:
-1.	**Synchronous Request/Response** &mdash; Client issues a request and waits for an immediate response, for example HTTP Request or RPC calls
-2.	**Asynchronous Message Queue Request** &mdash; Messages are published to an exchange and distributed to subscribers, for example RabbitMQ, MQTT, Email, or scheduled events
-3.	**Message or Record Streams** &mdash; An ordered set of messages or record updates (must be processed sequentially), for example Kafka, AWS Kinesis, iguazio V3IO stream
-4.	**Record or Data Polling (ETL)** &mdash; Retrieve a filtered set of records or data objects from an external data source or database, can be done periodically or triggered on data changes
+Functions are event-driven.
+They respond to event triggers, data messages, or records that are accepted from the event source and pushed to the function runtime engine.
+
+Event sources can be divided into classes, based on their behavior and flow management.
+Each class can have multiple event-source implementations.
+nuclio supports the following event classes:
+
+1.	**Synchronous Request/Response** - the client issues a request and waits for an immediate response.
+    For example, HTTP requests or Remote Procedure Calls (RPCs).
+2.	**Asynchronous Message-Queue Request** - messages are published to an exchange and distributed to subscribers.
+    For example, RabbitMQ, MQTT, emails, or scheduled events.
+3.	**Message or Record Streams** - an ordered set of messages or record updates is processed sequentially.
+    For example, Kafka, AWS Kinesis or iguazio V3IO streams.
+4.	**Record or Data Polling (ETL)** - a filtered set of records or data objects is retrieved from an external data source or database.
+    The retrieval can be done periodically or triggered by data changes.
 
 ![Event examples](images/event-src.png)
 
-New event classes and event sources can be added to the processor framework
+New event classes and event sources can be added to the processor framework.
 
 ### Event-Source Mapping
 
-Event sources are mapped to specific function version, for example the API gateway Web URL "/" may be mapped to the "production" version, and the URL "/beta" may be mapped to the "beta" version of the same function. The user need to specify the event mapping in the function specification or using event mapping CRUD API calls or CLI commands (the current CLI version doesn't yet support event mapping, and still requires some manual configuration).
+Event sources are mapped to a specific function version.
+For example, the API gateway web URL "/" may be mapped to the "production" version, and the URL "/beta" may be mapped to the "beta" version of the same function.
+The user needs to specify the event mapping in the function specification, or by using event mapping CRUD API calls or CLI commands.
+(The current CLI version does not yet support event mapping, and still requires some manual configuration.)
 
-A function may have several event sources associated with it, And the same event may trigger invocation of different functions.
-The event source mapping can utilize either the exact function version or its alias (see details under versioning). It also include information such as name, class, type, credentials, and class specific properties.
+Multiple event sources can be associated with the same function, and the same event can trigger the invocation of multiple functions.
+
+The event-source mapping can utilize either the exact function version or its alias (see details under [versioning](#funciton-versioning)).
+The mapping also includes information such as the function name, class, type, credentials, and class-specific properties.
 
 ### Event Load-Balancing, Sharding, and Dealers
 
-Some jobs involve distributing data or work items across multiple function processor instances, for example a Kafka stream can be broken to several partitions, and each partition should only be processed by a single processor simultaneously. Or in a case of sharded data sets we may want to scale-out the processing of the data set across many processing elements, this require a resource scheduling entity which will distribute data partitions to the available processors, track the execution and completion.
-Nuclio include a "dealer" entity which can dynamically distribute N resources (shards, partitions, tasks, etc.) to M processors, and handle aspects of failures, scale up or scale down of resources and processors.
+Some jobs involve distributing data or work items across multiple function processor instances.
+For example, a Kafka stream can be divided into several partitions, and each partition should only be processed by a single processor at any given time.
+Or in the case of a sharded dataset, you might want to scale-out the processing of the dataset across multiple processing elements, which requires a resource-scheduling entity that will distribute data partitions to the available processors and track the execution and completion.
 
-### Event Object (Used by Function)
+nuclio includes a "dealer" entity that can dynamically distribute N resources (shards, partitions, tasks, etc.) to M processors, and can handle aspects of failures and scale-up or scale-down of resources and processors.
 
-Functions are called with two elements, the context object and the event object. The event object describes the data and metadata of the incoming event, it is generalized in a way that decouple the actual event source from the function, the same function can be driven by multiple types of event sources. A Function can accept a single event or an array of events (e.g., when using a stream).
-Event object is accessed through interfaces (methods), to enable zero-copy, eliminate serialization overhead and add robustness, they can also be consumed as a JSON object which may add some serialization and deserialization overhead.
-There are common event object interfaces such as `EventID`, `Body`, `ContentType`, `Headers`, `Fields`, and `AsJson`. There are also event object interfaces which are class specific.
+### Event Object (Used by the Function)
+
+Functions are called with two elements, the context object and the event object.
+The event object describes the data and metadata of the incoming event.
+It is generalized in a way that decouples the actual event source from the function.
+A single function can be driven by multiple types of event sources.
+A function can accept a single event or an array of events (for example, when using a stream).
+
+An event object is accessed through interfaces (methods).
+To enable zero-copy, eliminate serialization overhead, and add robustness, an event object can also be consumed as a JSON object, which might add some serialization and deserialization overhead.
+There are common event-object interfaces, such as `EventID`, `Body`, `ContentType`, `Headers`, `Fields`, and `AsJson`.
+There are also event-object interfaces that are class-specific.
+
 
 ## Function Build and Deployment Flow
 
-The development flow starts with an implementation of the function in one of the supported languages followed by building the artifacts (a code binary, package, or container image), deploying the function on the destination cluster and feeding that with events and data, as illustrated in the following diagram.
+You begin the development flow by implementing the function in one of the supported languages.
+You then build the function artifacts (a code binary, package, or container image), deploy the function on the destination cluster, and feed it with events and data, as illustrated in the following diagram.
 
 ![deployment-flow](images/build-deploy.png)
 
-Each function has a function spec per version, the function spec includes different aspects of the function such as its code, its data binding, environment resources, credentials and its event sources. The function spec can be written in YAML or JSON, and can be specified or overwritten using command line options. The function spec is used by the builder for the compilation phased and the controller to the deduce the right operating requirements for the function.
+Each function has a version-specific function specification ("spec").
+The function spec defines different aspects of the function, such as its code, data binding, environment resources, credentials, and event sources.<br/>
+The function spec can be written in YAML or JSON, and can also be defined or overwritten using command-line options.<br/>
+The builder uses the function spec in the compilation phase, and the controller uses the spec to identify the operating requirements for the function.
 
-The user can control whether to build and deploy in a single operation or to run each step separately. A `build` command only compiles the function and builds the artifact, so it can later be used by one or more deployments of the function. The `run` command can accept sources, build and deploy the function or alternatively skip the build and deploy an existing artifact.
+The user can control whether to build and deploy the function in a single operation, or whether to perform each step separately.<br/>
+The `build` command compiles the function and builds the artifact, so it can later be used by one or more deployments of the function.<br/>
+The `run` command can accept sources, and can either both build and deploy the function, or skip the build and deploy an existing artifact.
 
-A user can control the exact build flags through an optional **build.yaml** file placed in the same directory with the function sources.
-nuclio supports versioning. Users can publish a new version of a function and tagged with aliases to reference it. nuclio provides the ability to run different versions of the same function simultaneously (for example in the case of production version and beta one). The event source mapping can either specify the exact function version or utilize the aliasing thus removing the need to change the event source mapping when a newer version is published.
+The user can control the exact build flags through an optional **build.yaml** file that is located in the same directory as the function sources.
+
+## Function Versioning
+
+nuclio supports function versioning.
+You can publish a new version of a function and tag it with aliases for referencing the function.
+
+nuclio provides the ability to run different versions of the same function simultaneously (for example, production and beta versions).
+
+The event-source mapping can either specify the exact function version, or utilize a defined alias and thus eliminate the need to change the mapping when a newer version of the function is published.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,13 +7,9 @@
 
 ## Function Processors
 
-Function processors provide an environment for executing functions.
-The processor feeds functions with events, provides context and data, collects logs and statistics, and manages the function's life cycle.
+Function processors provide an environment for executing functions. The processor feeds functions with events, provides context and data, collects logs and statistics, and manages the function's life cycle.
 
-Processors can be compiled into a single binary (when using Go or C), or packaged into a container with all the required code dependencies.
-Processor containers can run as standalone Docker containers, or on top of a container-orchestration platform such as Kubernetes.
-Each function has its own function processors.
-Function Processors will be scaled-out automatically (by adding more container instances) to address high event frequency.
+Processors can be compiled into a single binary (when using Go or C), or packaged into a container with all the required code dependencies. Processor containers can run as standalone Docker containers, or on top of a container-orchestration platform such as Kubernetes. Each function has its own function processors. Function Processors will be scaled-out automatically (by adding more container instances) to address high event frequency.
 
 ### Processor Architecture
 
@@ -25,8 +21,7 @@ The processor has four main components:
 
 #### Event-Source Listeners
 
-Event-source listeners can listen on sockets and message queues, or periodically fetch events from external event or data sources.
-Received events share a common schema, which decouples the function logic from the event source implementation or specific structure, and pushed to one or more parallel runtime workers.
+Event-source listeners can listen on sockets and message queues, or periodically fetch events from external event or data sources. Received events share a common schema, which decouples the function logic from the event source implementation or specific structure, and pushed to one or more parallel runtime workers.
 
 The event listeners also guarantee exactly-once or at-least-once event execution and handle failures - for example, by storing stream checkpoints, acknowledging or retrying message-queue events, or responding to HTTP client requests.
 
@@ -39,52 +34,35 @@ Runtimes can have multiple independent parallel workers (for example, Go routine
 nuclio currently supports three types of processor runtime implementations:
 
 1.	**Native** - for real-time and inline Go or C-based routines.
-
-2.	**SHMEM** - for shared-memory languages, such as Python, Java, and Node.js.
-    The processor communicates with the SHMEM function runtime through zero-copy shared-memory channels.
-
-3.	**Shell** - for command-line execution functions or binaries ("executables").
-    Upon receiving an event, the processor runs the executable in a command-line shell, using the relevant command and environment variables, and then maps the executable's standard-output (`stdout`) or standard-error (`stderr`) logs to the function results.
+2.	**SHMEM** - for shared-memory languages, such as Python, Java, and Node.js. The processor communicates with the SHMEM function runtime through zero-copy shared-memory channels.
+3.	**Shell** - for command-line execution functions or binaries ("executables"). Upon receiving an event, the processor runs the executable in a command-line shell, using the relevant command and environment variables, and then maps the executable's standard-output (`stdout`) or standard-error (`stderr`) logs to the function results.
 
     > **Note:** The shell runtime supports only file data bindings.
 
 #### Data Bindings
 
-Functions can benefit from persistent data connections to external files, objects, databases, or messaging systems.
-The runtime initializes the data-service connection based on the type, URL, properties, and credentials specified in the function specification, and serves them to the function through the context object.
+Functions can benefit from persistent data connections to external files, objects, databases, or messaging systems. The runtime initializes the data-service connection based on the type, URL, properties, and credentials specified in the function specification, and serves them to the function through the context object.
 
-Data bindings simplify development by eliminating the need to integrate with SDKs or manage connections and credentials.
-They also enable function reuse and portability, because different data services of the same class are mapped to the function using the same APIs.
-Data bindings can also handle aspects of data prefetching, caching, and micro-batching, to reduce execution latency and increase I/O performance.
+Data bindings simplify development by eliminating the need to integrate with SDKs or manage connections and credentials. They also enable function reuse and portability, because different data services of the same class are mapped to the function using the same APIs.
 
-Data bindings and event sources are designed with zero-copy, zero-serialization, and non-blocking operation, and enable real-time performance without the need for any special function code.
+Data bindings can also handle aspects of data prefetching, caching, and micro-batching, to reduce execution latency and increase I/O performance. Data bindings and event sources are designed with zero-copy, zero-serialization, and non-blocking operation, and enable real-time performance without the need for any special function code.
 
 #### Control Framework
 
 The control framework initializes and controls the different processor components, provides logging for the processor and the function (stored in different log streams), monitors execution statistics, and serves a mini portal for remote management.
 
-The control framework interacts with the underlining platform through abstract interfaces, allowing for portability across different IoT devices, container orchestrators, and cloud platforms.
-The platform-specific processor configuration is done through a **processor.yaml** file in the working directory.
-Function developers should not modify this file.
-The underlying interfaces of the function processors to the required platform services are all abstracted in a way that enables porting the same function processor among different deployments types.
+The control framework interacts with the underlining platform through abstract interfaces, allowing for portability across different IoT devices, container orchestrators, and cloud platforms. The platform-specific processor configuration is done through a **processor.yaml** file in the working directory. Function developers should not modify this file. The underlying interfaces of the function processors to the required platform services are all abstracted in a way that enables porting the same function processor among different deployments types.
 
 ## Event Sources and Mapping
 
-Functions are event-driven.
-They respond to event triggers, data messages, or records that are accepted from the event source and pushed to the function runtime engine.
+Functions are event-driven. They respond to event triggers, data messages, or records that are accepted from the event source and pushed to the function runtime engine.
 
-Event sources can be divided into classes, based on their behavior and flow management.
-Each class can have multiple event-source implementations.
-nuclio supports the following event classes:
+Event sources can be divided into classes, based on their behavior and flow management. Each class can have multiple event-source implementations. nuclio supports the following event classes:
 
-1.	**Synchronous Request/Response** - the client issues a request and waits for an immediate response.
-    For example, HTTP requests or Remote Procedure Calls (RPCs).
-2.	**Asynchronous Message-Queue Request** - messages are published to an exchange and distributed to subscribers.
-    For example, RabbitMQ, MQTT, emails, or scheduled events.
-3.	**Message or Record Streams** - an ordered set of messages or record updates is processed sequentially.
-    For example, Kafka, AWS Kinesis or iguazio V3IO streams.
-4.	**Record or Data Polling (ETL)** - a filtered set of records or data objects is retrieved from an external data source or database.
-    The retrieval can be done periodically or triggered by data changes.
+1.	**Synchronous Request/Response** - the client issues a request and waits for an immediate response. For example, HTTP requests or Remote Procedure Calls (RPCs).
+2.	**Asynchronous Message-Queue Request** - messages are published to an exchange and distributed to subscribers. For example, RabbitMQ, MQTT, emails, or scheduled events.
+3.	**Message or Record Streams** - an ordered set of messages or record updates is processed sequentially. For example, Kafka, AWS Kinesis or iguazio V3IO streams.
+4.	**Record or Data Polling (ETL)** - a filtered set of records or data objects is retrieved from an external data source or database. The retrieval can be done periodically or triggered by data changes.
 
 ![Event examples](images/event-src.png)
 
@@ -92,47 +70,32 @@ New event classes and event sources can be added to the processor framework.
 
 ### Event-Source Mapping
 
-Event sources are mapped to a specific function version.
-For example, the API gateway web URL "/" may be mapped to the "production" version, and the URL "/beta" may be mapped to the "beta" version of the same function.
-The user needs to specify the event mapping in the function specification, or by using event mapping CRUD API calls or CLI commands.
-(The current CLI version does not yet support event mapping, and still requires some manual configuration.)
+Event sources are mapped to a specific function version. For example, the API gateway web URL "/" may be mapped to the "production" version, and the URL "/beta" may be mapped to the "beta" version of the same function. The user needs to specify the event mapping in the function specification, or by using event mapping CRUD API calls or CLI commands. (The current CLI version does not yet support event mapping, and still requires some manual configuration.)
 
 Multiple event sources can be associated with the same function, and the same event can trigger the invocation of multiple functions.
 
-The event-source mapping can utilize either the exact function version or its alias (see details under [versioning](#funciton-versioning)).
-The mapping also includes information such as the function name, class, type, credentials, and class-specific properties.
+The event-source mapping can utilize either the exact function version or its alias (see details under [versioning](#funciton-versioning)). The mapping also includes information such as the function name, class, type, credentials, and class-specific properties.
 
 ### Event Load-Balancing, Sharding, and Dealers
 
-Some jobs involve distributing data or work items across multiple function processor instances.
-For example, a Kafka stream can be divided into several partitions, and each partition should only be processed by a single processor at any given time.
-Or in the case of a sharded dataset, you might want to scale-out the processing of the dataset across multiple processing elements, which requires a resource-scheduling entity that will distribute data partitions to the available processors and track the execution and completion.
+Some jobs involve distributing data or work items across multiple function processor instances. For example, a Kafka stream can be divided into several partitions, and each partition should only be processed by a single processor at any given time. Or in the case of a sharded dataset, you might want to scale-out the processing of the dataset across multiple processing elements, which requires a resource-scheduling entity that will distribute data partitions to the available processors and track the execution and completion.
 
 nuclio includes a "dealer" entity that can dynamically distribute N resources (shards, partitions, tasks, etc.) to M processors, and can handle aspects of failures and scale-up or scale-down of resources and processors.
 
 ### Event Object (Used by the Function)
 
-Functions are called with two elements, the context object and the event object.
-The event object describes the data and metadata of the incoming event.
-It is generalized in a way that decouples the actual event source from the function.
-A single function can be driven by multiple types of event sources.
-A function can accept a single event or an array of events (for example, when using a stream).
+Functions are called with two elements, the context object and the event object. The event object describes the data and metadata of the incoming event. It is generalized in a way that decouples the actual event source from the function. A single function can be driven by multiple types of event sources. A function can accept a single event or an array of events (for example, when using a stream).
 
-An event object is accessed through interfaces (methods).
-To enable zero-copy, eliminate serialization overhead, and add robustness, an event object can also be consumed as a JSON object, which might add some serialization and deserialization overhead.
-There are common event-object interfaces, such as `EventID`, `Body`, `ContentType`, `Headers`, `Fields`, and `AsJson`.
-There are also event-object interfaces that are class-specific.
+An event object is accessed through interfaces (methods). To enable zero-copy, eliminate serialization overhead, and add robustness, an event object can also be consumed as a JSON object, which might add some serialization and deserialization overhead. There are common event-object interfaces, such as `EventID`, `Body`, `ContentType`, `Headers`, `Fields`, and `AsJson`. There are also event-object interfaces that are class-specific.
 
 
 ## Function Build and Deployment Flow
 
-You begin the development flow by implementing the function in one of the supported languages.
-You then build the function artifacts (a code binary, package, or container image), deploy the function on the destination cluster, and feed it with events and data, as illustrated in the following diagram.
+You begin the development flow by implementing the function in one of the supported languages. You then build the function artifacts (a code binary, package, or container image), deploy the function on the destination cluster, and feed it with events and data, as illustrated in the following diagram.
 
 ![deployment-flow](images/build-deploy.png)
 
-Each function has a version-specific function specification ("spec").
-The function spec defines different aspects of the function, such as its code, data binding, environment resources, credentials, and event sources.<br/>
+Each function has a version-specific function specification ("spec"). The function spec defines different aspects of the function, such as its code, data binding, environment resources, credentials, and event sources.<br/>
 The function spec can be written in YAML or JSON, and can also be defined or overwritten using command-line options.<br/>
 The builder uses the function spec in the compilation phase, and the controller uses the spec to identify the operating requirements for the function.
 
@@ -144,8 +107,7 @@ The user can control the exact build flags through an optional **build.yaml** fi
 
 ## Function Versioning
 
-nuclio supports function versioning.
-You can publish a new version of a function and tag it with aliases for referencing the function.
+nuclio supports function versioning. You can publish a new version of a function and tag it with aliases for referencing the function.
 
 nuclio provides the ability to run different versions of the same function simultaneously (for example, production and beta versions).
 

--- a/docs/k8s/function-ingress.md
+++ b/docs/k8s/function-ingress.md
@@ -9,31 +9,22 @@
 
 ## Overview
 
-If you followed the [Getting Started with nuclio on Kubernetes](getting-started.md) guide, you invoked functions using their HTTP interface with `nuctl` and the nuclio playground.
-By default, each function deployed to Kubernetes declares a [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/) that is responsible for routing requests to the functions' HTTP trigger port.
-It does this using a [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport), which is a unique cluster-wide port that is assigned to the function.
+If you followed the [Getting Started with nuclio on Kubernetes](getting-started.md) guide, you invoked functions using their HTTP interface with `nuctl` and the nuclio playground. By default, each function deployed to Kubernetes declares a [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/) that is responsible for routing requests to the functions' HTTP trigger port. It does this using a [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport), which is a unique cluster-wide port that is assigned to the function.
 
-This means that an underlying HTTP client calls `http://<your cluster IP>:<some unique port>`.
-You can try this out yourself:
-first, find out the NodePort assigned to your function, by using the `nuctl get function` command of the `nuctl` CLI or the `kubectl get svc` command of the Kubernetes CLI.
-Then, use Curl to send an HTTP request to this port.
+This means that an underlying HTTP client calls `http://<your cluster IP>:<some unique port>`. You can try this out yourself: first, find out the NodePort assigned to your function, by using the `nuctl get function` command of the `nuctl` CLI or the `kubectl get svc` command of the Kubernetes CLI. Then, use Curl to send an HTTP request to this port.
 
-In addition to configuring a service, nuclio creates a [Kubernetes ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for your function's HTTP trigger, with the path specified as `<function name>/latest`.
-However, without an ingress controller running in your cluster, this will have no effect.
-An Ingress controller will listen for changed ingresses and reconfigure some type of reverse proxy to route requests based on rules specified in the ingress.
+In addition to configuring a service, nuclio creates a [Kubernetes ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for your function's HTTP trigger, with the path specified as `<function name>/latest`. However, without an ingress controller running in your cluster, this will have no effect. An Ingress controller will listen for changed ingresses and reconfigure some type of reverse proxy to route requests based on rules specified in the ingress.
 
 ## Setting Up an Ingress Controller
 
-In this guide, you will set up a [Træfik](https://docs.traefik.io/) controller, but any type of Kubernetes ingress controller should work.
-You can read [Træfik's excellent documentation](https://docs.traefik.io/user-guide/kubernetes/), but for the purposes of this guide you can simply run the following commands to set up the controller:
+In this guide, you will set up a [Træfik](https://docs.traefik.io/) controller, but any type of Kubernetes ingress controller should work. You can read [Træfik's excellent documentation](https://docs.traefik.io/user-guide/kubernetes/), but for the purposes of this guide you can simply run the following commands to set up the controller:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/containous/traefik/master/examples/k8s/traefik-rbac.yaml
 kubectl apply -f https://raw.githubusercontent.com/containous/traefik/master/examples/k8s/traefik-deployment.yaml
 ```
 
-Verify that the controller is up by running by running the `kubectl --namespace=kube-system get pods` command, and then run the `kubectl describe service --namespace=kube-system traefik-ingress-service` command to get the ingress NodePort.
-Following is a sample output for NodePort 30019:
+Verify that the controller is up by running by running the `kubectl --namespace=kube-system get pods` command, and then run the `kubectl describe service --namespace=kube-system traefik-ingress-service` command to get the ingress NodePort. Following is a sample output for NodePort 30019:
 
 ```bash
 ...
@@ -66,10 +57,7 @@ curl $(minikube ip):30019/helloworld/latest
 
 ## Customizing Function Ingress
 
-By default, functions initialize the HTTP trigger and register `<function name>/latest`.
-However, you might want to add paths for functions to organize them in namespaces/groups, or even choose through which domain your functions can be triggered.
-To do this, you can configure your HTTP trigger in the [function's configuration](/docs/configuring-a-function.md).
-For example:
+By default, functions initialize the HTTP trigger and register `<function name>/latest`. However, you might want to add paths for functions to organize them in namespaces/groups, or even choose through which domain your functions can be triggered. To do this, you can configure your HTTP trigger in the [function's configuration](/docs/configuring-a-function.md). For example:
 
 ```yaml
   ...
@@ -104,8 +92,7 @@ Note that since the `i1` configuration explicitly specifies `some.host.com` as t
 
 ## Deploying an Ingress Example
 
-Let's put this into practice and deploy the [ingress example](/hack/examples/golang/ingress/ingress.go).
-This is the **function.yaml** file for the example:
+Let's put this into practice and deploy the [ingress example](/hack/examples/golang/ingress/ingress.go). This is the **function.yaml** file for the example:
 
 ```yaml
 apiVersion: "nuclio.io/v1"
@@ -137,16 +124,12 @@ func Ingress(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
 
 ### Deploy the Function
 
-Deploy the function with the `nuctl` CLI.
-If you did not use Minikube, replace `$(minikube ip):5000` in the following command with your cluster IP:
+Deploy the function with the `nuctl` CLI. If you did not use Minikube, replace `$(minikube ip):5000` in the following command with your cluster IP:
 ```bash
 nuctl deploy -p https://raw.githubusercontent.com/nuclio/nuclio/master/hack/examples/golang/ingress/ingress.go --registry $(minikube ip):5000 ingress --run-registry localhost:5000 --verbose
 ```
 
-Behind the scenes, `nuctl` populates a function CR, which is picked up by the nuclio `controller`.
-The `controller` iterates through all the triggers and looks for the required ingresses.
-For each ingress, the controller creates a Kubernetes Ingress object, which triggers the Træfik ingress controller to reconfigure the reverse proxy.
-Following are sample `controller` logs:
+Behind the scenes, `nuctl` populates a function CR, which is picked up by the nuclio `controller`. The `controller` iterates through all the triggers and looks for the required ingresses. For each ingress, the controller creates a Kubernetes Ingress object, which triggers the Træfik ingress controller to reconfigure the reverse proxy. Following are sample `controller` logs:
 
 ```
 controller.functiondep (D) Adding ingress {"function": "helloworld", "host": "", "paths": ["/helloworld/latest"]}
@@ -174,16 +157,14 @@ Handler called
 
 ### Configure a Custom Host
 
-Add `my.host.com` to your local **/etc/hosts** file so that it resolves to your cluster IP.
-The following command assumes the use of Minikube:
+Add `my.host.com` to your local **/etc/hosts** file so that it resolves to your cluster IP. The following command assumes the use of Minikube:
 ```bash
 echo "$(minikube ip) my.host.com" | sudo tee -a /etc/hosts
 ```
 
 ### Invoke the Function with Curl
 
-Now, do some invocations with Curl.
-The following examples assume the use of Minikube (except were your configured host is used) and NodePort 30019.
+Now, do some invocations with Curl. The following examples assume the use of Minikube (except were your configured host is used) and NodePort 30019.
 
 > **Note:** The parenthesized "works" and error indications at the end of each line signify the expected outcome and are not part of the command.
 

--- a/docs/k8s/function-ingress.md
+++ b/docs/k8s/function-ingress.md
@@ -1,20 +1,39 @@
-# Invoking Functions By Name With Kubernetes Ingresses
+# Invoking Functions by Name with a Kubernetes Ingress
 
-If you followed the [getting started guide](getting-started.md), you invoked functions using their HTTP interface with `nuctl` and the playground. By default, each function deployed to Kubernetes declares a [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/) responsible for routing requests to the functions HTTP trigger port. It does this using a [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) - a cluster-wide unique port assigned to the function.
+#### In This Document
 
-This means that an underlying HTTP client called `http://<your cluster IP>:<some unique port>`. You can try this out yourself by first finding out the `NodePort` assigned to your function with `nuctl get function` (or with `kubectl get svc`) and using `curl` to send an HTTP request to this port.
+- [Overview](#overview)
+- [Setting Up an Ingress Controller](#setting-up-an-ingress-controller)
+- [Customizing Function Ingress](#customizing-function-ingress)
+- [Deploying an Ingress Example](#deploying-an-ingress-example)
 
-In addition to configuring a service, nuclio will also create a [Kubernetes ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for your function's HTTP trigger - with the path specified as `<function name>/latest`. However, without an ingress controller running in your cluster this will have no effect. An Ingress controller will listen for changed ingresses and re-configure a reverse proxy of some sort to route requests based on rules specified in the ingress.
+## Overview
 
-## Setting Up An Ingress Controller
-In this guide we'll set up [Træfik](https://docs.traefik.io/) though any Kubernetes ingress controller should work. You can head over to [Træfik's excellent documentation](https://docs.traefik.io/user-guide/kubernetes/) but assuming you don't want to use helm it just boils down to:
+If you followed the [Getting Started with nuclio on Kubernetes](getting-started.md) guide, you invoked functions using their HTTP interface with `nuctl` and the nuclio playground.
+By default, each function deployed to Kubernetes declares a [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/) that is responsible for routing requests to the functions' HTTP trigger port.
+It does this using a [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport), which is a unique cluster-wide port that is assigned to the function.
+
+This means that an underlying HTTP client calls `http://<your cluster IP>:<some unique port>`.
+You can try this out yourself:
+first, find out the NodePort assigned to your function, by using the `nuctl get function` command of the `nuctl` CLI or the `kubectl get svc` command of the Kubernetes CLI.
+Then, use Curl to send an HTTP request to this port.
+
+In addition to configuring a service, nuclio creates a [Kubernetes ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for your function's HTTP trigger, with the path specified as `<function name>/latest`.
+However, without an ingress controller running in your cluster, this will have no effect.
+An Ingress controller will listen for changed ingresses and reconfigure some type of reverse proxy to route requests based on rules specified in the ingress.
+
+## Setting Up an Ingress Controller
+
+In this guide, you will set up a [Træfik](https://docs.traefik.io/) controller, but any type of Kubernetes ingress controller should work.
+You can read [Træfik's excellent documentation](https://docs.traefik.io/user-guide/kubernetes/), but for the purposes of this guide you can simply run the following commands to set up the controller:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/containous/traefik/master/examples/k8s/traefik-rbac.yaml
 kubectl apply -f https://raw.githubusercontent.com/containous/traefik/master/examples/k8s/traefik-deployment.yaml
 ```
 
-Check that the controller is up by running `kubectl --namespace=kube-system get pods` then run `kubectl describe service --namespace=kube-system traefik-ingress-service` to get the ingress `NodePort`:
+Verify that the controller is up by running by running the `kubectl --namespace=kube-system get pods` command, and then run the `kubectl describe service --namespace=kube-system traefik-ingress-service` command to get the ingress NodePort.
+Following is a sample output for NodePort 30019:
 
 ```bash
 ...
@@ -27,19 +46,30 @@ TargetPort:               8080/TCP
 ...
 ```
 
-Træfik's reverse proxy NodePort in this case is `30019` and we need to make sure to send all of our requests there. Let's deploy a function normally:
+> **Note:** You must ensure that all your requests are sent to the returned NodePort.
 
+Run the following command to deploy the sample `helloworld` function; (the command assumes the use of Minikube):
 ```bash
 nuctl deploy -p https://raw.githubusercontent.com/nuclio/nuclio/master/hack/examples/golang/helloworld/helloworld.go --registry $(minikube ip):5000 helloworld --run-registry localhost:5000
 ```
 
-And now invoke it by its path (specify your cluster IP if not using minikube):
+And now, invoke the function by its path.
+Replace `<NodePort>` with the NodePort of your ingress controller, and replace `${minikube ip)` with your cluster IP if you are not using Minikube:
 ```bash
 curl $(minikube ip):<NodePort>/helloworld/latest
 ```
 
+For example, for NodePort 30019, run this command:
+```bash
+curl $(minikube ip):30019/helloworld/latest
+```
+
 ## Customizing Function Ingress
-By default, functions will initialize the HTTP trigger and register `<function name>/latest`. However, we might want to add paths for functions to organize them in namespaces/groups or even choose through which domain our functions can be triggered. To do this, we can configure our HTTP trigger in the [function's configuration](/docs/configuring-a-function.md):
+
+By default, functions initialize the HTTP trigger and register `<function name>/latest`.
+However, you might want to add paths for functions to organize them in namespaces/groups, or even choose through which domain your functions can be triggered.
+To do this, you can configure your HTTP trigger in the [function's configuration](/docs/configuring-a-function.md).
+For example:
 
 ```yaml
   ...
@@ -61,19 +91,21 @@ By default, functions will initialize the HTTP trigger and register `<function n
             - "/wat"
 ```
 
-If our `helloworld` function were configured as such and assuming that Træfik's NodePort is 30019, it would be accessible through:
-* `<cluster ip>:30019/helloworld/latest`
-* `some.host.com:30019/helloworld/latest`
-* `some.host.com:30019/first/path`
-* `some.host.com:30019/second/path`
-* `<cluster ip>:30019/wat`
-* `some.host.com:30019/wat`
+If your `helloworld` function was configured in this way, and assuming that Træfik's NodePort is 30019, the function would be accessible through any of the following URLs:
 
-Note that since the `i1` explicitly specifies `some.host.com` as the `host` for the paths, they will _not_ be accessible through the cluster IP (i.e. `<cluster ip>:30019/first/path` will return 404).
+- `<cluster ip>:30019/helloworld/latest`
+- `some.host.com:30019/helloworld/latest`
+- `some.host.com:30019/first/path`
+- `some.host.com:30019/second/path`
+- `<cluster ip>:30019/wat`
+- `some.host.com:30019/wat`
+
+Note that since the `i1` configuration explicitly specifies `some.host.com` as the `host` for the paths, the function will _not_ be accessible through the cluster IP; i.e., `<cluster ip>:30019/first/path` will return a `404` error.
 
 ## Deploying an Ingress Example
 
-Let's try to put this into practice and deploy the [ingress example](/hack/examples/golang/ingress/ingress.go). The function.yaml is defined as:
+Let's put this into practice and deploy the [ingress example](/hack/examples/golang/ingress/ingress.go).
+This is the **function.yaml** file for the example:
 
 ```yaml
 apiVersion: "nuclio.io/v1"
@@ -96,19 +128,25 @@ spec:
             - /first/from/host
 ```
 
-And the handler as: 
-```
+And this is the definition of the `Ingress` handler function: 
+```golang
 func Ingress(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
 	return "Handler called", nil
 }
 ```
 
-Deploy it with nuctl (assuming minikube):
+### Deploy the Function
+
+Deploy the function with the `nuctl` CLI.
+If you did not use Minikube, replace `$(minikube ip):5000` in the following command with your cluster IP:
 ```bash
 nuctl deploy -p https://raw.githubusercontent.com/nuclio/nuclio/master/hack/examples/golang/ingress/ingress.go --registry $(minikube ip):5000 ingress --run-registry localhost:5000 --verbose
 ```
 
-Behind the scenes, `nuctl` will populate a function CR which is picked up by the nuclio `controller`. The `controller` will iterate over all triggers and look for required ingresses. For each such ingress it creates a Kubernetes Ingress object. This triggers the Træfik ingress controller to reconfigure the reverse proxy. We can see the nuclio `controller` logs below:
+Behind the scenes, `nuctl` populates a function CR, which is picked up by the nuclio `controller`.
+The `controller` iterates through all the triggers and looks for the required ingresses.
+For each ingress, the controller creates a Kubernetes Ingress object, which triggers the Træfik ingress controller to reconfigure the reverse proxy.
+Following are sample `controller` logs:
 
 ```
 controller.functiondep (D) Adding ingress {"function": "helloworld", "host": "", "paths": ["/helloworld/latest"]}
@@ -116,10 +154,14 @@ controller.functiondep (D) Adding ingress {"function": "helloworld", "host": "my
 controller.functiondep (D) Adding ingress {"function": "helloworld", "host": "", "paths": ["/first/path", "/second/path"]
 ```
 
-Lets invoke the function with `nuctl`, which will use the node port:
+### Invoke the Function with nuctl
+
+Invoke the function with `nuctl`, which will use the configured NodePort:
 ```bash
 nuctl invoke ingress
-
+```
+Following is a sample output for this command:
+```bash
 > Response headers:
 Server = nuclio
 Date = Thu, 02 Nov 2017 02:11:32 GMT
@@ -130,13 +172,22 @@ Content-Length = 14
 Handler called
 ```
 
-Now lets add `my.host.com` to our local `hosts` file so that it resolves to our cluster IP (assuming minikube):
+### Configure a Custom Host
+
+Add `my.host.com` to your local **/etc/hosts** file so that it resolves to your cluster IP.
+The following command assumes the use of Minikube:
 ```bash
 echo "$(minikube ip) my.host.com" | sudo tee -a /etc/hosts
 ```
 
-And now do some invocations with curl:
-```
+### Invoke the Function with Curl
+
+Now, do some invocations with Curl.
+The following examples assume the use of Minikube (except were your configured host is used) and NodePort 30019.
+
+> **Note:** The parenthesized "works" and error indications at the end of each line signify the expected outcome and are not part of the command.
+
+```bash
 curl $(minikube ip):30019/ingress/latest (works)
 curl my.host.com:30019/ingress/latest (works)
 
@@ -144,5 +195,6 @@ curl $(minikube ip):30019/first/path (works)
 curl my.host.com:30019/first/path (works)
 
 curl my.host.com:30019/first/from/host (works)
-curl $(minikube ip):30019/first/from/host (404)
+curl $(minikube ip):30019/first/from/host (404 error)
 ```
+

--- a/docs/k8s/getting-started.md
+++ b/docs/k8s/getting-started.md
@@ -39,7 +39,7 @@ When the function deployment is completed, you can click **Invoke** to invoke th
 
 ## Deploying a Function with nuctl, the nuclio Command-Line Tool
 
-First, ensure that you have Golang v1.8+ (https://golang.org/doc/install) and Docker (https://docs.docker.com/engine/installation), and create a Go workspace (for example, in `~/nuclio`):
+First, ensure that you have Go (Golang) v1.8+ (https://golang.org/doc/install) and Docker (https://docs.docker.com/engine/installation), and create a Go workspace (for example, in `~/nuclio`):
 
 ```bash
 export GOPATH=~/nuclio && mkdir -p $GOPATH
@@ -55,7 +55,7 @@ Before Docker images can be pushed to your built-in registry, you need to add yo
 For example, if you are using Minikube, you might add `$(minikube ip):5000`.
 If you are using Docker for Mac OS, you can find the IP address under **Preferences > Daemon**.
 
-Deploy the Golang `helloworld` sample function; you can add the `--verbose` flag if you want to peek under the hood:
+Deploy the `helloworld` Go sample function; you can add the `--verbose` flag if you want to peek under the hood:
 ```bash
 nuctl deploy -p https://raw.githubusercontent.com/nuclio/nuclio/master/hack/examples/golang/helloworld/helloworld.go --registry $(minikube ip):5000 helloworld --run-registry localhost:5000
 ```
@@ -65,7 +65,9 @@ And finally, execute the function:
 nuctl invoke helloworld
 ```
 
-Further reading
+## What's Next?
+
+See the following resources to make the best of your new nuclio environment:
 
 1. [Configuring a function](/docs/configuring-a-function.md)
 2. [Invoking functions by name with an ingress](function-ingress.md)

--- a/docs/k8s/getting-started.md
+++ b/docs/k8s/getting-started.md
@@ -8,16 +8,14 @@
 
 ## Overview
 
-To start deploying functions, you need a remote Kubernetes **v1.7+** cluster; (nuclio uses CRDs, which were introduced in Kubernetes v1.7).
-You can prepare the cluster in one of three ways:
+To start deploying functions, you need a remote Kubernetes **v1.7+** cluster; (nuclio uses CRDs, which were introduced in Kubernetes v1.7). You can prepare the cluster in one of three ways:
 
 1. [Using Minikube on a local virtual machine (VM)](install/minikube.md).
    This method is recommended for beginners.
 2. [From scratch, using kubeadm on Ubuntu](install/linux.md).
 3. [On an existing Kubernetes cluster](install/existing.md).
 
-To keep things simple, this guide assumes that you are using Minikube.
-If you select to use another method, simply replace `$(minikube ip)` references in the commands with your cluster IP.
+To keep things simple, this guide assumes that you are using Minikube. If you select to use another method, simply replace `$(minikube ip)` references in the commands with your cluster IP.
 
 With a functioning Kubernetes cluster, a Docker registry, and a working local `kubectl` CLI, you can go ahead and install the nuclio services on the cluster:
 
@@ -26,16 +24,12 @@ kubectl apply -f https://raw.githubusercontent.com/nuclio/nuclio/master/hack/k8s
 kubectl apply -f https://raw.githubusercontent.com/nuclio/nuclio/master/hack/k8s/resources/playground.yaml
 ```
 
-Use the command `kubectl get pods` to verify that both the controller and playground have a status of `Running`.
-For more information about `kubectl`, see the [Kubernetes documentation](https://kubernetes.io/docs/user-guide/kubectl-overview/).
+Use the command `kubectl get pods` to verify that both the controller and playground have a status of `Running`. For more information about `kubectl`, see the [Kubernetes documentation](https://kubernetes.io/docs/user-guide/kubectl-overview/).
 
 ## Deploying a Function with the nuclio Playground
 
 Browse to `http://$(minikube ip):32050`.
-You should be greeted by the nuclio playground.
-Choose one of the built-in examples, and click **Deploy**.
-The first build will populate the local Docker cache with base images and other files, so it might take a while, depending on your network.
-When the function deployment is completed, you can click **Invoke** to invoke the function with a body.
+You should be greeted by the nuclio playground. Choose one of the built-in examples, and click **Deploy**. The first build will populate the local Docker cache with base images and other files, so it might take a while, depending on your network. When the function deployment is completed, you can click **Invoke** to invoke the function with a body.
 
 ## Deploying a Function with nuctl, the nuclio Command-Line Tool
 
@@ -51,9 +45,7 @@ go get -u github.com/nuclio/nuclio/cmd/nuctl
 PATH=$PATH:$GOPATH/bin
 ```
 
-Before Docker images can be pushed to your built-in registry, you need to add your integrated Docker registry address to the list of insecure registries.
-For example, if you are using Minikube, you might add `$(minikube ip):5000`.
-If you are using Docker for Mac OS, you can find the IP address under **Preferences > Daemon**.
+Before Docker images can be pushed to your built-in registry, you need to add your integrated Docker registry address to the list of insecure registries. For example, if you are using Minikube, you might add `$(minikube ip):5000`. If you are using Docker for Mac OS, you can find the IP address under **Preferences > Daemon**.
 
 Deploy the `helloworld` Go sample function; you can add the `--verbose` flag if you want to peek under the hood:
 ```bash

--- a/docs/k8s/getting-started.md
+++ b/docs/k8s/getting-started.md
@@ -1,53 +1,73 @@
-# Getting Started With nuclio On Kubernetes
+# Getting Started with nuclio on Kubernetes
 
-To start deploying functions we'll need a remote Kubernetes **1.7+** cluster (nuclio uses CRDs, introduced in 1.7) which we can prepare in one of three ways:
+#### In This Document
 
-1. [On a local VM with minikube](install/minikube.md) - recommended for beginners
-2. [From scratch with kubeadm on Ubuntu](install/linux.md)
-3. [On an existing Kubernetes cluster](install/existing.md)
+- [Overview](#overview)
+- [Deploying a Function with the nuclio Playground](#deploying-a-function-with-the-nuclio-playground)
+- [Deploying a Function with nuctl, the nuclio Command-Line Tool](#deploying-a-function-with-nuctl-the-nuclio-command-line-tool)
 
-For the sake of simplicity, this guide will assume you're using minikube - just replace `$(minikube ip)` with your cluster IP in the commands listed here if you're not using minikube.
+## Overview
 
-With a functioning Kuberenetes cluster, docker registry and a working local kubectl, we can go ahead and install the nuclio services on the cluster:
+To start deploying functions, you need a remote Kubernetes **v1.7+** cluster; (nuclio uses CRDs, which were introduced in Kubernetes v1.7).
+You can prepare the cluster in one of three ways:
+
+1. [Using Minikube on a local virtual machine (VM)](install/minikube.md).
+   This method is recommended for beginners.
+2. [From scratch, using kubeadm on Ubuntu](install/linux.md).
+3. [On an existing Kubernetes cluster](install/existing.md).
+
+To keep things simple, this guide assumes that you are using Minikube.
+If you select to use another method, simply replace `$(minikube ip)` references in the commands with your cluster IP.
+
+With a functioning Kubernetes cluster, a Docker registry, and a working local `kubectl` CLI, you can go ahead and install the nuclio services on the cluster:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/nuclio/nuclio/master/hack/k8s/resources/controller.yaml
 kubectl apply -f https://raw.githubusercontent.com/nuclio/nuclio/master/hack/k8s/resources/playground.yaml
 ```
 
-Use `kubectl get pods` to verify both controller and playground have a status of `Running`.
+Use the command `kubectl get pods` to verify that both the controller and playground have a status of `Running`.
+For more information about `kubectl`, see the [Kubernetes documentation](https://kubernetes.io/docs/user-guide/kubectl-overview/).
 
-#### Deploying a Function With The nuclio Playground
+## Deploying a Function with the nuclio Playground
 
-Browse to `http://$(minikube ip):32050` - you should be greeted by the nuclio playground. Choose one of the built in examples and click deploy. The first build will populate the local docker cache with base images and such, so it might take a while depending on your network. Once the function has been deployed, you can invoke it with a body by clicking "Invoke".
+Browse to `http://$(minikube ip):32050`.
+You should be greeted by the nuclio playground.
+Choose one of the built-in examples, and click **Deploy**.
+The first build will populate the local Docker cache with base images and other files, so it might take a while, depending on your network.
+When the function deployment is completed, you can click **Invoke** to invoke the function with a body.
 
-#### Deploying a Function With nuctl, The nuclio Command Line Tool
+## Deploying a Function with nuctl, the nuclio Command-Line Tool
 
-First, make sure you have Golang 1.8+ (https://golang.org/doc/install) and Docker (https://docs.docker.com/engine/installation). Create a Go workspace (e.g. in `~/nuclio`):
+First, ensure that you have Golang v1.8+ (https://golang.org/doc/install) and Docker (https://docs.docker.com/engine/installation), and create a Go workspace (for example, in `~/nuclio`):
 
 ```bash
 export GOPATH=~/nuclio && mkdir -p $GOPATH
 ```
 
-Now build nuctl, the nuclio command line tool and add `$GOPATH/bin` to path for this session:
+Then, build [`nuctl`](/docs/nuctl/nuctl.md), the nuclio command-line tool (CLI), and add `$GOPATH/bin` to the path for this session:
 ```bash
 go get -u github.com/nuclio/nuclio/cmd/nuctl
 PATH=$PATH:$GOPATH/bin
 ```
 
-Before docker images can be pushed to our built in registry, we need to add our integrated docker registry address (e.g. `$(minikube ip):5000` if you're using minikube) to the list of insecure registries. If you're using Docker for Mac you can find this under `Preferences -> Daemon`.
+Before Docker images can be pushed to your built-in registry, you need to add your integrated Docker registry address to the list of insecure registries.
+For example, if you are using Minikube, you might add `$(minikube ip):5000`.
+If you are using Docker for Mac OS, you can find the IP address under **Preferences > Daemon**.
 
-Deploy the Golang hello world example (you can add `--verbose` if you want to peek under the hood):
+Deploy the Golang `helloworld` sample function; you can add the `--verbose` flag if you want to peek under the hood:
 ```bash
 nuctl deploy -p https://raw.githubusercontent.com/nuclio/nuclio/master/hack/examples/golang/helloworld/helloworld.go --registry $(minikube ip):5000 helloworld --run-registry localhost:5000
 ```
 
-And finally execute it:
+And finally, execute the function:
 ```bash
 nuctl invoke helloworld
 ```
 
-Further reading:
+Further reading
+
 1. [Configuring a function](/docs/configuring-a-function.md)
 2. [Invoking functions by name with an ingress](function-ingress.md)
 3. [More function examples](/hack/examples/README.md)
+

--- a/vendor/k8s.io/apimachinery/README.md
+++ b/vendor/k8s.io/apimachinery/README.md
@@ -6,13 +6,13 @@ Scheme, typing, encoding, decoding, and conversion packages for Kubernetes and K
 ## Purpose
 
 This library is a shared dependency for servers and clients to work with Kubernetes API infrastructure without direct 
-type dependencies.  It's first comsumers are `k8s.io/kubernetes`, `k8s.io/client-go`, and `k8s.io/apiserver`.
+type dependencies. It's first consumers are `k8s.io/kubernetes`, `k8s.io/client-go`, and `k8s.io/apiserver`.
 
 
 ## Compatibility
 
-There are *NO compatibility guarantees* for this repository.  It is in direct support of Kubernetes, so branches
-will track Kubernetes and be compatible with that repo.  As we more cleanly separate the layers, we will review the
+There are *NO compatibility guarantees* for this repository. It is in direct support of Kubernetes, so branches
+will track Kubernetes and be compatible with that repo. As we more cleanly separate the layers, we will review the
 compatibility guarantee.
 
 
@@ -24,6 +24,6 @@ Code changes are made in that location, merged into `k8s.io/kubernetes` and late
 
 ## Things you should *NOT* do
 
- 1. Add API types to this repo.  This is for the machinery, not for the types.
- 2. Directly modify any files under `pkg` in this repo.  Those are driven from `k8s.io/kuberenetes/staging/src/k8s.io/apimachinery`.
- 3. Expect compatibility.  This repo is direct support of Kubernetes and the API isn't yet stable enough for API guarantees.
+ 1. Add API types to this repo. This is for the machinery, not for the types.
+ 2. Directly modify any files under `pkg` in this repo. Those are driven from `k8s.io/kubernetes/staging/src/k8s.io/apimachinery`.
+ 3. Expect compatibility. This repo is direct support of Kubernetes and the API isn't yet stable enough for API guarantees.


### PR DESCRIPTION
@pavius Note that I place each sentence on a separate line (except for short sentences that can fit within 80 chars), to simplify future diffs (minimize the need for scrolling). I should have probably done this in a separate dedicated PR to simplify the current diffs.

Please verify specifically the editing that I did in relation to code and console snippets (mostly placeholder references and splitting output from commands).