### PR TITLE
"New" button, collapse/expand

### DIFF
--- a/cmd/playground/static/assets/app.css
+++ b/cmd/playground/static/assets/app.css
@@ -636,7 +636,7 @@ ul, li {
 }
 #create-new-pop-up {
     position: absolute;
-    top: 38px;
+    top: 42px;
     right: 10px;
     z-index: 800;
     background-color: #fff;

--- a/cmd/playground/static/assets/app.css
+++ b/cmd/playground/static/assets/app.css
@@ -65,6 +65,7 @@ ul, li {
     overflow-x: hidden;
 }
 .gutter {
+    position: relative;
     background-color: #d2d2d2;
     background-repeat: no-repeat;
     background-position: 50%;
@@ -95,11 +96,11 @@ ul, li {
 }
 .collapse-handle.right {
     top: calc(50% - 10px);
-    left: -1px;
+    left: 0;
 }
 .collapse-handle.right.collapsed {
     top: calc(50% - 10px);
-    left: -10px;
+    left: -3px;
 }
 .collapse-handle.left {
     top: calc(50% - 10px);
@@ -118,11 +119,11 @@ ul, li {
     left: calc(50% - 10px);
 }
 .collapse-handle.down {
-    top: -5px;
+    top: -3px;
     left: calc(50% - 10px);
 }
 .collapse-handle.down.collapsed {
-    top: -15px;
+    top: -7px;
     left: calc(50% - 10px);
 }
 .collapse-handle::before {
@@ -130,7 +131,7 @@ ul, li {
     display: inline-block;
     color: #000;
     font-family: Arial, sans-serif;
-    font-size: medium;
+    font-size: 12px;
     font-style: normal;
     font-weight: normal;
     line-height: 1;
@@ -145,16 +146,18 @@ ul, li {
     padding: 0 2px 0 0;
 }
 .collapse-handle.left::before, .collapse-handle.right.collapsed::before {
-    content: '\25C2';
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
-    padding: 0 0 0 2px;
+    content: '\25B8';
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    padding: 0 2px 0 0;
+    transform: scaleX(-1);
 }
 .collapse-handle.up::before, .collapse-handle.down.collapsed::before {
-    content: '\25B4';
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    content: '\25BE';
+    border-bottom-right-radius: 4px;
+    border-bottom-left-radius: 4px;
     padding: 0 2px 0 2px;
+    transform: scaleY(-1);
 }
 .collapse-handle.down::before, .collapse-handle.up.collapsed::before {
     content: '\25BE';
@@ -736,7 +739,7 @@ ul, li {
 /* Log */
 #log-section {
     position: relative;
-    z-index: 500;
+    z-index: 50;
     width: 100%;
     height: 100%;
     overflow-y: scroll;

--- a/cmd/playground/static/assets/app.css
+++ b/cmd/playground/static/assets/app.css
@@ -461,7 +461,7 @@ ul, li {
 #functions h2 {
     display: inline-block;
     color: #f2f2f2;
-    font-size: large;
+    font-size: x-large;
     font-weight: 300;
     padding: 0 5px;
 }
@@ -586,7 +586,7 @@ ul, li {
     color: #a1afd0;
     display: inline-block;
     padding: 15px 24px 0;
-    font-size: medium;
+    font-size: large;
     font-weight: 300;
     cursor: pointer;
     height: 32px;
@@ -614,11 +614,13 @@ ul, li {
 }
 #save-function {
     margin: 0 20px;
+    font-size: large;
 }
 #create-new-button {
     color: #fff;
     background-color: #21d4ac;
     border-color: #21d4ac;
+    font-size: large;
 }
 #create-new-button:hover {
     background-color: #1db390;

--- a/cmd/playground/static/assets/app.css
+++ b/cmd/playground/static/assets/app.css
@@ -432,23 +432,17 @@ ul, li {
     /*background: -webkit-linear-gradient(left, #101833 0%,#495a81 100%); !* Chrome10-25,Safari5.1-6 *!*/
     /*background: linear-gradient(to right, #101833 0%,#495a81 100%); !* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ *!*/
     /*filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#101833', endColorstr='#495a81',GradientType=1 ); !* IE6-9 *!*/
-    padding: 10px 20px;
-    margin: 0;
     height: 100px;
-    line-height: 1em;
-    display: flex;
-    flex-flow: row nowrap;
-    justify-content: space-between;
-    align-items: center;
 }
 #logo {
     flex: 0 auto;
     background-image: url('images/nuclio-logo-white-text.png');
     background-size: contain;
     background-repeat: no-repeat;
+    background-position: center;
     height: 100%;
     width: 175px;
-    margin-right: 15px;
+    margin: 0 15px;
 }
 #header h1 {
     flex: 0 auto;

--- a/cmd/playground/static/assets/app.css
+++ b/cmd/playground/static/assets/app.css
@@ -461,6 +461,47 @@ ul, li {
 }
 
 /* Top bar */
+#top-bar {
+    background-color: #495a81;
+    height: 50px;
+    position: relative;
+    box-shadow: inset 2px 2px 5px rgba(0,0,0,0.15);
+    padding-left: 5px;
+}
+#top-bar > * {
+    flex: 0 33.3%;
+}
+#top-bar h2 {
+    display: inline-block;
+    color: #f2f2f2;
+    font-size: large;
+    font-weight: 300;
+    padding: 0 5px;
+}
+#function-name {
+    cursor: pointer;
+}
+#function-name.blank {
+    color: #a1afd0;
+    padding: 0 3px;
+}
+
+/* Function switcher */
+#switch-function-button {
+    color: #a1afd0;
+    font-size: medium;
+    vertical-align: baseline;
+    padding: 0 5px;
+}
+#switch-function-button:hover, #function-name:hover ~ #switch-function-button:not(.active) {
+    color: #495a81;
+    background-color: #a1afd0;
+}
+#switch-function-button:active, #switch-function-button.active {
+    color: #495a81;
+    background-color: #8c9dc5;
+    box-shadow: inset 1px 1px 2px rgba(0,0,0,0.15);
+}
 #switch-function-title {
     background-color: #f2f2f2;
     padding: 5px 12px;
@@ -548,63 +589,7 @@ ul, li {
     overflow: auto;
 }
 
-#save-function {
-    margin: 0 20px;
-}
-
-#create-new-function {
-    color: #fff;
-    background-color: #21d4ac;
-    border-color: #21d4ac;
-}
-#create-new-function:hover {
-    background-color: #1db390;
-    border-color: #1db390;
-}
-#create-new-function:focus {
-    background-color: #21d4ac;
-    border-color: #18997b;
-}
-#create-new-function:active {
-    border-color: #21d4ac;
-}
-
-/* Main section */
-#main {
-    position: absolute;
-    top: 100px;
-    bottom: 0;
-    width: 100%;
-    padding: 0;
-    margin: 0;
-}
-
-/* Tabs */
-#tabs {
-    background-color: #495a81;
-    height: 50px;
-    position: relative;
-    box-shadow: inset 2px 2px 5px rgba(0,0,0,0.15);
-}
-
-#tabs h2 {
-    display: inline-block;
-    color: #f2f2f2;
-    font-size: large;
-    font-weight: 300;
-    padding: 0 5px 0 15px;
-}
-#tabs a {
-    text-decoration: none;
-    color: #f2f2f2;
-    font-size: x-small;
-}
-#tabs a:hover {
-    color: #c2c2c2;
-}
-#tabs a:active {
-    color: #a2a2a2;
-}
+/* Tabs headers */
 #tabs > ul {
     display: inline-flex;
     flex-flow: row wrap;
@@ -632,45 +617,57 @@ ul, li {
     border-bottom: 3px solid #4dc4f3;
     cursor: default;
 }
-#tabs ~ section {
+
+/* action buttons */
+#buttons {
+    margin: 5px 10px;
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: flex-end;
+}
+#save-function {
+    margin: 0 20px;
+}
+#create-new-function {
+    color: #fff;
+    background-color: #21d4ac;
+    border-color: #21d4ac;
+}
+#create-new-function:hover {
+    background-color: #1db390;
+    border-color: #1db390;
+}
+#create-new-function:focus {
+    background-color: #21d4ac;
+    border-color: #18997b;
+}
+#create-new-function:active {
+    border-color: #21d4ac;
+}
+
+/* Main section */
+#main {
     position: absolute;
-    top: 50px;
+    top: 150px;
+    bottom: 0;
     width: 100%;
-    height: calc(100% - 50px);
+    padding: 0;
+    margin: 0;
+}
+
+/* Tab contents */
+#main > section {
+    position: absolute;
+    width: 100%;
+    height: 100%;
     background-color: #f2f2f2;
     opacity: 0;
     z-index: 10;
     box-shadow: inset 2px 2px 5px rgba(0,0,0,0.15);
 }
-#tabs ~ section.active {
+#main > section.active {
     opacity: 1;
     z-index: 20;
-}
-#function-name {
-    cursor: pointer;
-}
-#function-name.blank {
-    color: #a1afd0;
-    padding: 0 3px;
-}
-#switch-function-button {
-    color: #a1afd0;
-    font-size: medium;
-    vertical-align: baseline;
-    padding: 0 5px;
-}
-#switch-function-button:hover, #function-name:hover ~ #switch-function-button:not(.active) {
-    color: #495a81;
-    background-color: #a1afd0;
-}
-#switch-function-button:active, #switch-function-button.active {
-    color: #495a81;
-    background-color: #8c9dc5;
-    box-shadow: inset 1px 1px 2px rgba(0,0,0,0.15);
-}
-
-#buttons {
-    margin: 5px 10px;
 }
 
 /* "Code" tab */

--- a/cmd/playground/static/assets/app.css
+++ b/cmd/playground/static/assets/app.css
@@ -805,8 +805,8 @@ ul, li {
     margin-top: 10px;
 }
 #commands {
-    width: 300px;
-    height: 100px;
+    width: 400px;
+    height: 150px;
 }
 
 /* "Triggers" tab */

--- a/cmd/playground/static/assets/app.css
+++ b/cmd/playground/static/assets/app.css
@@ -615,28 +615,54 @@ ul, li {
 /* action buttons */
 #buttons {
     margin: 5px 10px;
-    display: flex;
-    flex-flow: row wrap;
-    justify-content: flex-end;
+}
+#buttons > button {
+    float: right;
 }
 #save-function {
     margin: 0 20px;
 }
-#create-new-function {
+#create-new-button {
     color: #fff;
     background-color: #21d4ac;
     border-color: #21d4ac;
 }
-#create-new-function:hover {
+#create-new-button:hover {
     background-color: #1db390;
     border-color: #1db390;
 }
-#create-new-function:focus {
+#create-new-button:focus {
     background-color: #21d4ac;
     border-color: #18997b;
 }
-#create-new-function:active {
+#create-new-button:active {
     border-color: #21d4ac;
+}
+#create-new-pop-up {
+    position: absolute;
+    top: 38px;
+    right: 10px;
+    z-index: 800;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    width: 320px;
+    display: none;
+}
+#create-new-form {
+    padding: 10px 15px;
+}
+#create-new-title {
+    background-color: #f2f2f2;
+    padding: 5px 12px;
+}
+#create-new-close {
+    font-size: x-large;
+    font-family: Arial, sans-serif;
+    cursor: pointer;
+}
+#create-new-name {
+    width: 120px;
 }
 
 /* Main section */

--- a/cmd/playground/static/assets/app.css
+++ b/cmd/playground/static/assets/app.css
@@ -461,7 +461,7 @@ ul, li {
 #functions h2 {
     display: inline-block;
     color: #f2f2f2;
-    font-size: x-large;
+    font-size: large;
     font-weight: 300;
     padding: 0 5px;
 }
@@ -614,6 +614,7 @@ ul, li {
 }
 #save-function {
     margin: 0 20px;
+    vertical-align: baseline;
     font-size: large;
 }
 #create-new-button {

--- a/cmd/playground/static/assets/app.css
+++ b/cmd/playground/static/assets/app.css
@@ -54,6 +54,11 @@ ul, li {
     white-space: nowrap;
     text-overflow: ellipsis;
 }
+.wrap-around {
+    overflow: hidden;
+    white-space: normal;
+    word-break: break-all;
+}
 
 /* pane splitter */
 .split {
@@ -420,6 +425,7 @@ ul, li {
     padding-left: 3px;
     text-align: left;
     vertical-align: middle;
+    cursor: pointer;
 }
 .pairList {
     margin: 5px 0;

--- a/cmd/playground/static/assets/app.css
+++ b/cmd/playground/static/assets/app.css
@@ -579,7 +579,7 @@ ul, li {
     cursor: pointer;
 }
 #function-list-items {
-    max-height: 105px;
+    max-height: 210px;
     overflow: auto;
 }
 

--- a/cmd/playground/static/assets/app.css
+++ b/cmd/playground/static/assets/app.css
@@ -842,5 +842,5 @@ ul, li {
     padding: 10px 20%;
 }
 #triggers-editor {
-    min-height: 60px;
+    height: 100%;
 }

--- a/cmd/playground/static/assets/app.css
+++ b/cmd/playground/static/assets/app.css
@@ -464,6 +464,7 @@ ul, li {
     font-size: large;
     font-weight: 300;
     padding: 0 5px;
+    line-height: 50px;
 }
 #function-name {
     cursor: pointer;
@@ -613,9 +614,9 @@ ul, li {
     float: right;
 }
 #save-function {
-    margin: 0 20px;
-    vertical-align: baseline;
+    margin: 8px 30px;
     font-size: large;
+    float: right;
 }
 #create-new-button {
     color: #fff;

--- a/cmd/playground/static/assets/app.css
+++ b/cmd/playground/static/assets/app.css
@@ -360,8 +360,9 @@ ul, li {
     display: inline-block;
     padding: 7px 15px;
     top: 10px;
-    right: 10px;
+    right: 120px;
     border-radius: 3px;
+    z-index: 999;
 }
 #toast.success {
     background-color: hsla(115, 60%, 75%, 1);
@@ -431,47 +432,33 @@ ul, li {
     margin: 5px 0;
 }
 
-/* Header */
-#header {
-    background: #101833; /* Old browsers */
-    /*background: -moz-linear-gradient(left, #101833 0%, #495a81 100%); !* FF3.6-15 *!*/
-    /*background: -webkit-linear-gradient(left, #101833 0%,#495a81 100%); !* Chrome10-25,Safari5.1-6 *!*/
-    /*background: linear-gradient(to right, #101833 0%,#495a81 100%); !* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ *!*/
-    /*filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#101833', endColorstr='#495a81',GradientType=1 ); !* IE6-9 *!*/
-    height: 100px;
-}
-#logo {
-    flex: 0 auto;
-    background-image: url('images/nuclio-logo-white-text.png');
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-position: center;
-    height: 100%;
-    width: 175px;
-    margin: 0 15px;
-}
-#header h1 {
-    flex: 0 auto;
-    letter-spacing: 3px;
-    font-weight: 300;
-    font-size: xx-large;
-    color: #f3f3f6;
-    display: inline-block;
-    margin-right: 15px;
-}
-
 /* Top bar */
 #top-bar {
-    background-color: #495a81;
+    background: #101833; /* Old browsers */
+    background: -moz-linear-gradient(left, #101833 30%, #495a81 45%); /* FF3.6-15 */
+    background: -webkit-linear-gradient(left, #101833 30%,#495a81 45%); /* Chrome10-25,Safari5.1-6 */
+    background: linear-gradient(to right, #101833 30%,#495a81 45%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#101833', endColorstr='#495a81', GradientType=1 ); /* IE6-9 */
     height: 50px;
     position: relative;
     box-shadow: inset 2px 2px 5px rgba(0,0,0,0.15);
-    padding-left: 5px;
 }
 #top-bar > * {
-    flex: 0 33.3%;
+    flex: 1 25%;
 }
-#top-bar h2 {
+#logo {
+    background-image: url('images/nuclio-logo-white-text.png');
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: left center;
+    height: 80%;
+    margin-left: 15px;
+    flex: 1 10%;
+}
+#functions {
+    flex: 1 35%;
+}
+#functions h2 {
     display: inline-block;
     color: #f2f2f2;
     font-size: large;
@@ -674,7 +661,7 @@ ul, li {
 /* Main section */
 #main {
     position: absolute;
-    top: 150px;
+    top: 50px;
     bottom: 0;
     width: 100%;
     padding: 0;
@@ -821,7 +808,7 @@ ul, li {
 #configure-tab h2 {
     font-size: medium;
     font-weight: 300;
-    margin-top: 10px;
+    margin-top: 20px;
     margin-bottom: 10px;
 }
 #configure-tab h2:first-of-type {
@@ -830,8 +817,12 @@ ul, li {
 #enabled {
     margin: 10px 0;
 }
-#data-bindings-editor {
-    min-height: 60px;
+#config-data-bindings-new-value {
+    display: inline-block;
+    vertical-align: top;
+}
+#config-data-bindings-new-value li:not(:last-child) {
+    margin-bottom: 10px;
 }
 #commands-wrapper {
     margin-top: 10px;

--- a/cmd/playground/static/assets/app.js
+++ b/cmd/playground/static/assets/app.js
@@ -1273,11 +1273,13 @@ $(function () {
         direction: 'vertical',
         onDrag: _.debounce(emitWindowResize, SPLITTER_ON_DRAG_DEBOUNCE),
         onDragEnd: function () {
-            if (verticalSplitter.getSizes()[1] !== 0) {
-                $('.collapse-handle[data-for=vertical]').removeClass('collapsed');
+            var $handle = $('.gutter.gutter-vertical .collapse-handle');
+            var size = verticalSplitter.getSizes()[1];
+            if (size > 2 && $handle.hasClass('collapsed')) {
+                $handle.removeClass('collapsed');
             }
-            else {
-                $('.collapse-handle[data-for=vertical]').addClass('collapsed');
+            else if (size < 2 && !$handle.hasClass('collapsed')) {
+                $handle.addClass('collapsed');
             }
         }
     });
@@ -1289,29 +1291,48 @@ $(function () {
         snapOffset: SPLITTER_SNAP_OFFSET,
         onDrag: _.debounce(emitWindowResize, SPLITTER_ON_DRAG_DEBOUNCE),
         onDragEnd: function () {
-            if (verticalSplitter.getSizes()[1] !== 0) {
-                $('.collapse-handle[data-for=horizontal]').removeClass('collapsed');
+            var $handle = $('.gutter.gutter-horizontal .collapse-handle');
+            var size = horizontalSplitter.getSizes()[1];
+            if (size > 2 && $handle.hasClass('collapsed')) {
+                $handle.removeClass('collapsed');
             }
-            else {
-                $('.collapse-handle[data-for=horizontal]').addClass('collapsed');
+            else if (size < 2 && !$handle.hasClass('collapsed')) {
+                $handle.addClass('collapsed');
             }
         }
     });
 
-    $('.collapse-handle').click(function (event) {
-        event.preventDefault();
-        event.stopPropagation();
-        var $handle = $(this);
-        var splitter = $handle.attr('data-for') === 'vertical' ? verticalSplitter : horizontalSplitter;
-        if ($handle.hasClass('collapsed')) {
-            $handle.removeClass('collapsed');
-            splitter.setSizes([60, 40]);
-        }
-        else {
-            $handle.addClass('collapsed');
-            splitter.collapse(1);
-        }
-    });
+    /**
+     * Creates a click event handler for a collapse/expand button of a splitter
+     * @param {Object} splitter - the splitter which collapse/expand need to be performed
+     * @returns {function} a function that gets a click event and toggles collapsed/expanded state of splitter
+     */
+    function createCollapseExpandHandler(splitter) {
+        return function (event) {
+            event.preventDefault();
+            event.stopPropagation();
+            var $handle = $(this);
+            if ($handle.hasClass('collapsed')) {
+                $handle.removeClass('collapsed');
+                splitter.setSizes([60, 40]);
+            }
+            else {
+                $handle.addClass('collapsed');
+                splitter.collapse(1);
+            }
+        };
+    }
+
+    // Create a collapse/expand button for horizontal splitter, register a click callback to it, and append it to gutter
+    $('<i class="collapse-handle right"></i>')
+        .click(createCollapseExpandHandler(horizontalSplitter))
+        .appendTo($('.gutter.gutter-horizontal'));
+
+    // Create a collapse/expand button for vertical splitter, register a click callback to it, and append it to gutter
+    $('<i class="collapse-handle down"></i>')
+        .click(createCollapseExpandHandler(verticalSplitter))
+        .appendTo($('.gutter.gutter-vertical'));
+
     /* eslint-enable no-magic-numbers */
     /* eslint-enable new-cap */
 });

--- a/cmd/playground/static/assets/app.js
+++ b/cmd/playground/static/assets/app.js
@@ -556,6 +556,8 @@ $(function () {
             metadata: { name: newName },
             spec: { build: { path: SOURCES_PATH + '/' + newName + '.' + extension } }
         };
+        disableInvokeTab(true);
+        loadedUrl.parse('');
     }
 
     /**

--- a/cmd/playground/static/assets/app.js
+++ b/cmd/playground/static/assets/app.js
@@ -228,7 +228,7 @@ $(function () {
     //
 
     var initialTabIndex = 0;
-    var $tabContents = $('#tabs ~ section');
+    var $tabContents = $('#main > section');
     var $tabHeaders = $('#tabs > ul > li');
     var $selectedTabHeader = $tabHeaders.eq(initialTabIndex);
     var $selectedTabContent = $tabContents.eq(initialTabIndex);

--- a/cmd/playground/static/assets/app.js
+++ b/cmd/playground/static/assets/app.js
@@ -1039,16 +1039,28 @@ $(function () {
                 // for each key-value pair - append a remove button to its list item DOM element
                 listItems.each(function () {
                     var $listItem = $(this);
-                    var key = $listItem.find('[class^=pair-key]').text();
+                    var $key = $listItem.find('.pair-key');
+                    var $value = $listItem.find('.pair-value');
+
                     $('<button/>', {
                         'class': 'remove-pair-button',
                         title: 'Remove',
                         click: function () {
-                            removePairByKey(key);
+                            removePairByKey($key.text());
                         }
                     })
                         .html('&times;')
                         .appendTo($listItem);
+
+                    $key.click(function () {
+                        $(this).toggleClass('text-ellipsis');
+                        $(this).toggleClass('wrap-around');
+                    });
+
+                    $value.click(function () {
+                        $(this).toggleClass('text-ellipsis');
+                        $(this).toggleClass('wrap-around');
+                    });
                 });
 
                 // prepend the headers list item before the data list items

--- a/cmd/playground/static/index.html
+++ b/cmd/playground/static/index.html
@@ -81,7 +81,6 @@
 
                 <!-- Invoke tab: start -->
                 <section id="invoke-section" class="split split-horizontal">
-                    <i class="collapse-handle right" data-for="horizontal"></i>
                     <div id="invoke-section-wrapper">
                         <div class="space-between">
                             <select class="dropdown" id="input-method" title="HTTP method">
@@ -130,7 +129,6 @@
 
             <!-- footer: start -->
             <footer id="footer" class="split">
-                <i class="collapse-handle down" data-for="vertical"></i>
                 <section id="log-section">
                     <div id="log-header" class="space-between">
                         <h2>Log</h2>

--- a/cmd/playground/static/index.html
+++ b/cmd/playground/static/index.html
@@ -64,8 +64,22 @@
         </nav>
 
         <div id="buttons">
+            <button class="button" id="create-new-button">New</button>
             <button class="button" id="save-function">Save</button>
-            <button class="button" id="create-new-function">Create</button>
+            <div id="create-new-pop-up" class="space-between">
+                <header id="create-new-title" class="space-between">
+                    <span>Create a new function</span>
+                    <i id="create-new-close" title="Close">&times;</i>
+                </header>
+                <section id="create-new-form" class="space-between">
+                    <input type="text" id="create-new-name" class="text-input" title="Name of new function" placeholder="Enter name...">
+                    <select id="create-new-type" class="dropdown">
+                        <option selected value="py">Python</option>
+                        <option value="go">GoLang</option>
+                    </select>
+                    <button id="create-new-apply" class="button">Create</button>
+                </section>
+            </div>
         </div>
     </section>
     <!-- top bar: end -->
@@ -159,7 +173,7 @@
                    placeholder="Enter function namespace...">
 
             <h2>Data bindings</h2>
-            <div id="data-bindings-editor"></div>
+            <div id="config-data-bindings"></div>
 
             <h2>Labels</h2>
             <div id="labels"></div>

--- a/cmd/playground/static/index.html
+++ b/cmd/playground/static/index.html
@@ -16,18 +16,14 @@
     <span id="toast"></span>
     <!-- toast: end-->
 
-    <!-- header: start -->
-    <header id="header">
-        <div id="logo"></div>
-    </header>
-    <!-- header: end -->
-
     <!-- top bar: start -->
     <section id="top-bar" class="space-between">
-        <div>
+        <div id="logo"></div>
+        <div id="functions">
             <h2>Functions&nbsp; &rsaquo;</h2>
             <h2 id="function-name" class="blank">(select function)</h2>
             <button id="switch-function-button" class="button only-text" title="Switch function">&dtrif;</button>
+            <button class="button" id="save-function">Save</button>
 
             <div id="function-list">
                 <header id="switch-function-title" class="space-between">
@@ -65,7 +61,6 @@
 
         <div id="buttons">
             <button class="button" id="create-new-button">New</button>
-            <button class="button" id="save-function">Save</button>
             <div id="create-new-pop-up" class="space-between">
                 <header id="create-new-title" class="space-between">
                     <span>Create a new function</span>
@@ -173,7 +168,7 @@
                    placeholder="Enter function namespace...">
 
             <h2>Data bindings</h2>
-            <div id="data-bindings-editor"></div>
+            <div id="config-data-bindings"></div>
 
             <h2>Labels</h2>
             <div id="labels"></div>

--- a/cmd/playground/static/index.html
+++ b/cmd/playground/static/index.html
@@ -173,7 +173,7 @@
                    placeholder="Enter function namespace...">
 
             <h2>Data bindings</h2>
-            <div id="config-data-bindings"></div>
+            <div id="data-bindings-editor"></div>
 
             <h2>Labels</h2>
             <div id="labels"></div>

--- a/cmd/playground/static/index.html
+++ b/cmd/playground/static/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-    <title>nuclio - playground</title>
+    <title>playground | nuclio</title>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,500" rel="stylesheet">
     <link rel="stylesheet" type="text/css" media="screen" href="assets/app.css">
     <link rel="stylesheet" type="text/css" media="screen" href="assets/vendor/jquery.scrollbar.css">

--- a/cmd/playground/static/index.html
+++ b/cmd/playground/static/index.html
@@ -70,7 +70,7 @@
                     <input type="text" id="create-new-name" class="text-input" title="Name of new function" placeholder="Enter name...">
                     <select id="create-new-type" class="dropdown">
                         <option selected value="py">Python</option>
-                        <option value="go">GoLang</option>
+                        <option value="go">Go</option>
                     </select>
                     <button id="create-new-apply" class="button">Create</button>
                 </section>

--- a/cmd/playground/static/index.html
+++ b/cmd/playground/static/index.html
@@ -22,52 +22,56 @@
     </header>
     <!-- header: end -->
 
-    <!-- main: start -->
-    <main id="main">
+    <!-- top bar: start -->
+    <section id="top-bar" class="space-between">
+        <div>
+            <h2>Functions&nbsp; &rsaquo;</h2>
+            <h2 id="function-name" class="blank">(select function)</h2>
+            <button id="switch-function-button" class="button only-text" title="Switch function">&dtrif;</button>
 
-        <!-- tab headers: start -->
-        <nav id="tabs" class="space-between">
-            <div>
-                <h2>
-                    Functions&nbsp; &rsaquo; &nbsp;<span id="function-name" class="blank">(select function)</span>
-                    <button id="switch-function-button" class="button only-text" title="Switch function">&dtrif;</button>
-                </h2>
-                <div id="function-list">
-                    <header id="switch-function-title" class="space-between">
-                        <span>Switch function</span>
-                        <i id="switch-function-close" title="Close">&times;</i>
-                    </header>
-                    <div id="functions-filter">
-                        <i id="filter-icon"></i>
-                        <input id="functions-filter-box"
-                               type="text"
-                               class="text-input"
-                               maxlength="30"
-                               title="Find function or create a new one&hellip;"
-                               placeholder="Find function or create a new one&hellip;">
-                        <i id="filter-clear" title="Clear">&times;</i>
-                    </div>
-                    <div id="empty-list-message">No function found&hellip;</div>
-                    <div id="loading-message">Loading&hellip;</div>
-                    <div id="function-list-items" class="scrollbar-macosx"></div>
-                    <div class="option create-new">Create new: <span id="new-name"></span>
-                        <div id="create-new-buttons" class="space-between">
-                            <button id="new-go">.go</button>
-                            <button id="new-py">.py</button></div>
-                        </div>
+            <div id="function-list">
+                <header id="switch-function-title" class="space-between">
+                    <span>Switch function</span>
+                    <i id="switch-function-close" title="Close">&times;</i>
+                </header>
+                <div id="functions-filter">
+                    <i id="filter-icon"></i>
+                    <input id="functions-filter-box"
+                           type="text"
+                           class="text-input"
+                           maxlength="30"
+                           title="Find function or create a new one&hellip;"
+                           placeholder="Find function or create a new one&hellip;">
+                    <i id="filter-clear" title="Clear">&times;</i>
+                </div>
+                <div id="empty-list-message">No function found&hellip;</div>
+                <div id="loading-message">Loading&hellip;</div>
+                <div id="function-list-items" class="scrollbar-macosx"></div>
+                <div class="option create-new">Create new: <span id="new-name"></span>
+                    <div id="create-new-buttons" class="space-between">
+                        <button id="new-go">.go</button>
+                        <button id="new-py">.py</button></div>
                 </div>
             </div>
+        </div>
+
+        <nav id="tabs">
             <ul>
                 <li>Code</li>
                 <li>Configure</li>
                 <li>Triggers</li>
             </ul>
-            <div id="buttons">
-                <button class="button" id="save-function">Save</button>
-                <button class="button" id="create-new-function">Create</button>
-            </div>
         </nav>
-        <!-- tab headers: end -->
+
+        <div id="buttons">
+            <button class="button" id="save-function">Save</button>
+            <button class="button" id="create-new-function">Create</button>
+        </div>
+    </section>
+    <!-- top bar: end -->
+
+    <!-- main: start -->
+    <main id="main">
 
         <!-- Code tab: start -->
         <section id="code-tab">


### PR DESCRIPTION
- Disable invoke pane on creating a new function
- Collapse/expand for panes in "Code" tab works properly
- Web-page title changed to: "playground | nuclio"
- Function list in switcher pop-up has more height now
- "Create" button renamed to "New", creation pop-up added
- Move "Save" next to functions list/switcher
- New "Data bindings" UI/UX
- Toggle ellipsis/wrap-around on click of key/value
- Condensed top bar with larger font size
- Bind configuration fields that were not bound on loading function
- Minor CSS cleanup & improvements