### PR TITLE
[Doc review] K8s kdaem Linux install: remove TODO comment to add ref to conroller doc

### DIFF
--- a/docs/k8s/install/linux.md
+++ b/docs/k8s/install/linux.md
@@ -72,7 +72,6 @@ and test `kubectl`
     This commands creates the following:
 
     - **A nuclio deployment controller**, which will listen for function changes and ensure that the function deployments are up to speed.
-        <!-- TODO: Add reference to more info. Is this an ingress controller (see /docs/k8s/function-ingress.md)? -->
 
     - **A Docker registry and a deployment proxy**, which will allow you to push function images to an insecure Docker registry on your cluster (at port 31276) rather than to [Docker Hub](https://docs.docker.com/docker-hub/) or to a remote private Docker registry.
 


### PR DESCRIPTION
See info in PR #365.