### PR TITLE
Shell runtime can run binaries, added examples to playground

### DIFF
--- a/hack/examples/README.md
+++ b/hack/examples/README.md
@@ -26,3 +26,6 @@ To help you make the most of nuclio, the following function examples are provide
 
 - [TensorFlow](python/tensorflow) (`tensorflow`): A function that uses the inception model of the [TensorFlow](https://www.tensorflow.org/) open-source machine-learning library to classify images. The function demonstrates advanced uses of nuclio with a custom base image, third-party Python packages, pre-loading data into function memory (the AI Model), structured logging, and exception handling.
 
+## Shell examples
+
+- [Image convert](shell/img-convert) (`img-convert`): A wrapper script around ImageMagick's "convert" executable, capable of generating thumbnails from received images (among other things). 

--- a/hack/examples/python/sentiments/sentiments.py
+++ b/hack/examples/python/sentiments/sentiments.py
@@ -32,11 +32,12 @@
 
 from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
 
-def sentiment(context, event):
+def analyze(context, event):
     body = event.body.decode('utf-8')
+    context.logger.debug_with('Analyzing ', 'sentence', body)
 
-    context.logger.debug('checking the sentance: ' + body)
     analyzer = SentimentIntensityAnalyzer()
+
     score = analyzer.polarity_scores(body)
 
     return str(score)

--- a/hack/examples/shell/img-convert/img-convert.sh
+++ b/hack/examples/shell/img-convert/img-convert.sh
@@ -1,0 +1,37 @@
+#
+# Demonstrates running a shell script. In this case, ImageMagick is installed on build and "convert"
+# is called for each event with stdin as the input (by default, this is fed with the event body).
+#
+# NOTE:
+#
+# This can be achieved without a wrapper script by specifying the "convert" binary as the handler. To do this
+# with nuctl you would run (pass --platform local if you're using the local platform):
+#
+# nuctl deploy -p /dev/null convert \
+#     --runtime shell \
+#     --handler convert \
+#     --runtime-attrs '{"arguments": "- -resize 50% fd:1"}' \
+#     --build-command "apk --update --no-cache add imagemagick"
+#
+# Doing so gives you much greater flexibility than a wrapper script because the arguments can be changed per event.
+# If X-nuclio-arguments does not exist in the event headers, the default arguments passed to convert tells it to
+# reduce the image to 50%. To run any other mode or any other setting, simply provide this header (note that this is
+# unsanitized). For example, to reduce the received image to 10% of its size, set X-nuclio-arguments to
+# "- -resize 10% fd:1"
+#
+
+# @nuclio.configure
+#
+# function.yaml:
+#   apiVersion: "nuclio.io/v1"
+#   kind: "Function"
+#   spec:
+#     runtime: "shell"
+#     handler: "img-convert.sh:main"
+#
+#     build:
+#       commands:
+#       - "apk --update --no-cache add imagemagick"
+#
+
+convert - -resize 50% fd:1

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -113,24 +113,25 @@ type Build struct {
 
 // Spec holds all parameters related to a function's configuration
 type Spec struct {
-	Description  string                  `json:"description,omitempty"`
-	Disabled     bool                    `json:"disable,omitempty"`
-	Publish      bool                    `json:"publish,omitempty"`
-	Handler      string                  `json:"handler,omitempty"`
-	Runtime      string                  `json:"runtime,omitempty"`
-	Env          []v1.EnvVar             `json:"env,omitempty"`
-	Resources    v1.ResourceRequirements `json:"resources,omitempty"`
-	ImageName    string                  `json:"image,omitempty"`
-	HTTPPort     int                     `json:"httpPort,omitempty"`
-	Replicas     int                     `json:"replicas,omitempty"`
-	MinReplicas  int                     `json:"minReplicas,omitempty"`
-	MaxReplicas  int                     `json:"maxReplicas,omitempty"`
-	DataBindings map[string]DataBinding  `json:"dataBindings,omitempty"`
-	Triggers     map[string]Trigger      `json:"triggers,omitempty"`
-	Version      int                     `json:"version,omitempty"`
-	Alias        string                  `json:"alias,omitempty"`
-	Build        Build                   `json:"build,omitempty"`
-	RunRegistry  string                  `json:"runRegistry,omitempty"`
+	Description       string                  `json:"description,omitempty"`
+	Disabled          bool                    `json:"disable,omitempty"`
+	Publish           bool                    `json:"publish,omitempty"`
+	Handler           string                  `json:"handler,omitempty"`
+	Runtime           string                  `json:"runtime,omitempty"`
+	Env               []v1.EnvVar             `json:"env,omitempty"`
+	Resources         v1.ResourceRequirements `json:"resources,omitempty"`
+	ImageName         string                  `json:"image,omitempty"`
+	HTTPPort          int                     `json:"httpPort,omitempty"`
+	Replicas          int                     `json:"replicas,omitempty"`
+	MinReplicas       int                     `json:"minReplicas,omitempty"`
+	MaxReplicas       int                     `json:"maxReplicas,omitempty"`
+	DataBindings      map[string]DataBinding  `json:"dataBindings,omitempty"`
+	Triggers          map[string]Trigger      `json:"triggers,omitempty"`
+	Version           int                     `json:"version,omitempty"`
+	Alias             string                  `json:"alias,omitempty"`
+	Build             Build                   `json:"build,omitempty"`
+	RunRegistry       string                  `json:"runRegistry,omitempty"`
+	RuntimeAttributes map[string]interface{}  `json:"runtimeAttributes,omitempty"`
 }
 
 func (s *Spec) GetRuntimeNameAndVersion() (string, string) {

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -30,14 +30,15 @@ import (
 )
 
 type deployCommandeer struct {
-	cmd                 *cobra.Command
-	rootCommandeer      *RootCommandeer
-	functionConfig      functionconfig.Config
-	commands            stringSliceFlag
-	encodedDataBindings string
-	encodedTriggers     string
-	encodedLabels       string
-	encodedEnv          string
+	cmd                      *cobra.Command
+	rootCommandeer           *RootCommandeer
+	functionConfig           functionconfig.Config
+	commands                 stringSliceFlag
+	encodedDataBindings      string
+	encodedTriggers          string
+	encodedLabels            string
+	encodedEnv               string
+	encodedRuntimeAttributes string
 }
 
 func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
@@ -61,6 +62,12 @@ func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
 			if err := json.Unmarshal([]byte(commandeer.encodedTriggers),
 				&commandeer.functionConfig.Spec.Triggers); err != nil {
 				return errors.Wrap(err, "Failed to decode triggers")
+			}
+
+			// decode the JSON runtime attributes
+			if err := json.Unmarshal([]byte(commandeer.encodedRuntimeAttributes),
+				&commandeer.functionConfig.Spec.RuntimeAttributes); err != nil {
+				return errors.Wrap(err, "Failed to decode runtime attributes")
 			}
 
 			// decode labels
@@ -180,4 +187,5 @@ func addDeployFlags(cmd *cobra.Command,
 	cmd.Flags().StringVar(&commandeer.encodedTriggers, "triggers", "{}", "JSON encoded triggers for the function")
 	cmd.Flags().StringVar(&functionConfig.Spec.ImageName, "run-image", "", "If specified, this is the image that the deploy will use, rather than try to build one")
 	cmd.Flags().StringVar(&functionConfig.Spec.RunRegistry, "run-registry", os.Getenv("NUCTL_RUN_REGISTRY"), "The registry URL to pull the image from, if differs from -r (env: NUCTL_RUN_REGISTRY)")
+	cmd.Flags().StringVar(&commandeer.encodedRuntimeAttributes, "runtime-attrs", "{}", "JSON encoded runtime attributes for the function")
 }

--- a/pkg/playground/fixtures/source.go
+++ b/pkg/playground/fixtures/source.go
@@ -223,4 +223,455 @@ def _build_response(context, body, status_code):
                             content_type='text/plain',
                             status_code=status_code)
 `,
+	"regexscan.go": `//
+// Accept a string (event.body) and scan for compliance using a list of regex patterns (SSN, Credit Cards, ..)
+// will return a list of compliance violations in Json or "Passed"
+// demonstrate the use of structured and unstructured log with different levels
+// can be extended to write results to a stream/object storage
+//
+
+package main
+
+import (
+	"encoding/json"
+	"regexp"
+
+	"github.com/nuclio/nuclio-sdk"
+)
+
+// list of regular expression filters
+var rx = map[string]*regexp.Regexp{
+	"SSN":         regexp.MustCompile("\\b\\d{3}-\\d{2}-\\d{4}\\b"),
+	"Credit card": regexp.MustCompile("\\b(?:\\d[ -]*?){13,16}\\b")}
+
+func RegxCheck(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
+
+	// Unstructured debug message
+	context.Logger.Debug("Process document %s, length %d", event.GetPath(), event.GetSize())
+
+	data := string(event.GetBody())
+	matchList := []string{}
+
+	// Test content against a list of RegEx filters
+	for k, v := range rx {
+		if v.MatchString(string(data)) {
+			matchList = append(matchList, "Contains "+k)
+		}
+	}
+
+	// If we found a filter match add structured warning log message and respond with match list
+	if len(matchList) > 0 {
+		context.Logger.WarnWith("Document content warning", "path", event.GetPath(), "content", matchList)
+		return json.Marshal(matchList)
+	}
+
+	return "Passed", nil
+}`,
+	"sentiments.py": `#
+# uses vader lib (will be installed automatically via build commands) to identify sentiments in the body string
+# return score result in the form of: {'neg': 0.0, 'neu': 0.323, 'pos': 0.677, 'compound': 0.6369}
+#
+
+from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+
+def analyze(context, event):
+    body = event.body.decode('utf-8')
+    context.logger.debug_with('Analyzing ', 'sentence', body)
+
+    analyzer = SentimentIntensityAnalyzer()
+
+    score = analyzer.polarity_scores(body)
+
+    return str(score)
+`,
+	"tensorflow.py": `#
+# This function uses TensorFlow to perform image recognition.
+# It takes advantage of nuclio's inline configuration to indicate
+# its pip dependencies, as well as the linux distribution
+# to use for the deployed function's container.
+#
+# You can try invoking this function by passing any .jpg image's URL
+# in the request's body. For instance:
+# http://www.lpcsathletics.org/wp-content/uploads/2017/08/soccer-5.jpg
+#
+# This example is based on the example in TensorFlow's official repository:
+# https://github.com/tensorflow/models/blob/master/tutorials/image/imagenet/classify_image.py
+#
+# Simple image classification with Inception
+#
+# Runs image classification with Inception trained on ImageNet 2012
+# Challenge data set.
+#
+# This program creates a graph from a saved GraphDef protocol buffer,
+# and runs inference on an input JPEG image. It outputs human readable
+# strings of the top 5 predictions along with their probabilities.
+#
+
+import os
+import os.path
+import re
+import requests
+import shutil
+import tarfile
+import traceback
+import threading
+
+import numpy as np
+import tensorflow as tf
+
+
+def classify(context, event):
+    # we're going to need a unique temporary location to handle each event,
+    # as we download a file as part of each function invocation
+    temp_dir = Helpers.create_temporary_dir(context, event)
+
+    # wrap everything with error handling such that any exception raised
+    # at any point will still return a proper response
+    try:
+
+        # if we're not ready to handle this request yet, deny it
+        if not FunctionState.done_loading:
+            context.logger.warn_with('Model data not done loading yet, denying request')
+            raise NuclioResponseError('Model data not loaded yet, cannot serve this request',
+                                      requests.codes.service_unavailable)
+
+        # read the event's body to determine the target image URL
+        # TODO: in the future this can also take binary image data if provided with an appropriate content-type
+        image_url = event.body.decode('utf-8').strip()
+
+        # download the image to our temporary location
+        image_target_path = os.path.join(temp_dir, 'downloaded_image.jpg')
+        Helpers.download_file(context, image_url, image_target_path)
+
+        # run the inference on the image
+        results = Helpers.run_inference(context, image_target_path, 5, 0.01)
+
+        # return a response with the result
+        return context.Response(body=str(results),
+                                headers={},
+                                content_type='text/plain',
+                                status_code=requests.codes.ok)
+
+    # convert any NuclioResponseError to a response to be returned from our handler.
+    # the response's description and status will appropriately convey the underlying error's nature
+    except NuclioResponseError as error:
+        return error.as_response(context)
+
+    # if anything we didn't count on happens, respond with internal server error
+    except Exception as error:
+        context.logger.warn_with('Unexpected error occurred, responding with internal server error',
+                                 exc=str(error))
+
+        message = 'Unexpected error occurred: {0}\n{1}'.format(error, traceback.format_exc())
+        return NuclioResponseError(message).as_response(context)
+
+    # clean up after ourselves regardless of whether we succeeded or failed
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+class NuclioResponseError(Exception):
+    def __init__(self, description, status_code=requests.codes.internal_server_error):
+        self._description = description
+        self._status_code = status_code
+
+    def as_response(self, context):
+        return context.Response(body=self._description,
+                                headers={},
+                                content_type='text/plain',
+                                status_code=self._status_code)
+
+
+class FunctionState(object):
+    """
+    This class has classvars that are set by methods invoked during file import,
+    such that handler invocations can re-use them.
+    """
+
+    # holds the TensorFlow graph def
+    graph = None
+
+    # holds the node id to human string mapping
+    node_lookup = None
+
+    # holds a boolean indicating if we're ready to handle an invocation or haven't finished yet
+    done_loading = False
+
+
+class Paths(object):
+    # the remote URL to fetch the trained model from
+    model_url = os.getenv('DATA_MODEL_URL',
+                          'http://download.tensorflow.org/models/image/imagenet/inception-2015-12-05.tgz')
+
+    # the directory in the deployed function container where the data model is saved
+    model_dir = os.getenv('MODEL_DIR', '/tmp/tfmodel/')
+
+    # paths of files within the model archive used to create the graph
+    label_lookup_path = os.path.join(model_dir,
+                                     os.getenv('LABEL_LOOKUP_FILENAME',
+                                               'imagenet_synset_to_human_label_map.txt'))
+
+    uid_lookup_path = os.path.join(model_dir,
+                                   os.getenv('UID_LOOKUP_FILENAME',
+                                             'imagenet_2012_challenge_label_map_proto.pbtxt'))
+
+    graph_def_path = os.path.join(model_dir,
+                                  os.getenv('GRAPH_DEF_FILENAME',
+                                            'classify_image_graph_def.pb'))
+
+
+class Helpers(object):
+    @staticmethod
+    def create_temporary_dir(context, event):
+        """
+        Creates a uniquely-named temporary directory (based on the given event's id) and returns its path.
+        """
+        temp_dir = '/tmp/nuclio-event-{0}'.format(event.id)
+        os.makedirs(temp_dir)
+
+        context.logger.debug_with('Created temporary directory', path=temp_dir)
+
+        return temp_dir
+
+    @staticmethod
+    def ensure_model_exists():
+        """
+        Downloads and extracts the model data if it isn't already present.
+        """
+        target_filename = Paths.model_url.split('/')[-1]
+        target_path = os.path.join(Paths.model_dir, target_filename)
+
+        # only download the model if we don't already have it extracted
+        if not os.path.isfile(Paths.graph_def_path):
+            Helpers.download_file(None, Paths.model_url, target_path)
+
+            # extract the downloaded model data archive and clean it up afterwards
+            tarfile.open(target_path, 'r:gz').extractall(Paths.model_dir)
+            os.remove(target_path)
+
+    @staticmethod
+    def download_file(context, url, target_path):
+        """
+        Downloads the given remote URL to the specified path.
+        """
+
+        # make sure the target directory exists
+        os.makedirs(os.path.dirname(target_path), exist_ok=True)
+
+        try:
+            with requests.get(url, stream=True) as response:
+                response.raise_for_status()
+
+                with open(target_path, 'wb') as f:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
+
+        except Exception as error:
+            if context is not None:
+                context.logger.warn_with('Failed to download file',
+                                         url=url,
+                                         target_path=target_path,
+                                         exc=str(error))
+
+            raise NuclioResponseError('Failed to download file: {0}'.format(url),
+                                      requests.codes.service_unavailable)
+
+        if context is not None:
+            context.logger.info_with('Downloaded file successfully',
+                                     size_bytes=os.stat(target_path).st_size,
+                                     target_path=target_path)
+
+    @staticmethod
+    def run_inference(context, image_path, num_predictions, confidence_threshold):
+        """
+        Runs inference on the image in the given path.
+        Returns a list of up to N=num_prediction tuples (prediction human name, confidence score).
+        Only takes predictions whose confidence score meets the provided confidence threshold.
+        """
+
+        # read the image binary data
+        with tf.gfile.FastGFile(image_path, 'rb') as f:
+            image_data = f.read()
+
+        # run the graph's softmax tensor on the image data
+        with tf.Session(graph=FunctionState.graph) as session:
+            softmax_tensor = session.graph.get_tensor_by_name('softmax:0')
+            predictions = session.run(softmax_tensor, {'DecodeJpeg/contents:0': image_data})
+            predictions = np.squeeze(predictions)
+
+        results = []
+
+        # take the num_predictions highest scoring predictions
+        top_predictions = reversed(predictions.argsort()[-num_predictions:])
+
+        # look up each predicition's human-readable name and add it to the
+        # results if it meets the confidence threshold
+        for node_id in top_predictions:
+            name = FunctionState.node_lookup[node_id]
+
+            score = predictions[node_id]
+            meets_threshold = score > confidence_threshold
+            context.logger.info_with('Found prediction', name=name, score=score, meets_threshold=meets_threshold)
+
+            if meets_threshold:
+                results.append((name, score))
+
+        return results
+
+    @staticmethod
+    def on_import():
+        """
+        This function is called when the file is imported, so that model data
+        is downloaded, extracted and loaded to memory only once per function deployment.
+        """
+
+        # before anything else we must ensure that we have model data
+        Helpers.ensure_model_exists()
+
+        # load the graph def from trained model data
+        FunctionState.graph = Helpers.load_graph_def()
+
+        # load the node ID to human-readable string mapping
+        FunctionState.node_lookup = Helpers.load_node_lookup()
+
+        # signal that we're ready
+        FunctionState.done_loading = True
+
+    @staticmethod
+    def load_graph_def():
+        """
+        Imports the GraphDef data into TensorFlow's default graph, and returns it.
+        """
+
+        # verify that the declared graph def file actually exists
+        if not tf.gfile.Exists(Paths.graph_def_path):
+            raise NuclioResponseError('Failed to find graph def file', requests.codes.service_unavailable)
+
+        # load the TensorFlow GraphDef
+        with tf.gfile.FastGFile(Paths.graph_def_path, 'rb') as f:
+            graph_def = tf.GraphDef()
+            graph_def.ParseFromString(f.read())
+
+            tf.import_graph_def(graph_def, name='')
+
+        return tf.get_default_graph()
+
+    @staticmethod
+    def load_node_lookup():
+        """
+        Composes the mapping between node IDs and human-readable strings. Returns the composed mapping.
+        """
+
+        # load the mappings from which we can build our mapping
+        string_uid_to_labels = Helpers._load_label_lookup()
+        node_id_to_string_uids = Helpers._load_uid_lookup()
+
+        # compose the final mapping of integer node ID to human-readable string
+        result = {}
+        for node_id, string_uid in node_id_to_string_uids.items():
+            label = string_uid_to_labels.get(string_uid)
+
+            if label is None:
+                raise NuclioResponseError('Failed to compose node lookup')
+
+            result[node_id] = label
+
+        return result
+
+    @staticmethod
+    def _load_label_lookup():
+        """
+        Loads and parses the mapping between string UIDs and human-readable strings. Returns the parsed mapping.
+        """
+
+        # verify that the declared label lookup file actually exists
+        if not tf.gfile.Exists(Paths.label_lookup_path):
+            raise NuclioResponseError('Failed to find Label lookup file', requests.codes.service_unavailable)
+
+        # load the raw mapping data
+        with tf.gfile.GFile(Paths.label_lookup_path) as f:
+            lookup_lines = f.readlines()
+
+        result = {}
+
+        # parse the raw data to a mapping between string UIDs and labels
+        # each line is expected to look like this:
+        # n12557064	kidney bean, frijol, frijole
+        line_pattern = re.compile(r'(n\d+)\s+([ \S,]+)')
+
+        for line in lookup_lines:
+            matches = line_pattern.findall(line)
+
+            # extract the uid and label from the matches
+            # in our example, uid will be "n12557064" and label will be "kidney bean, frijol, frijole"
+            uid = matches[0][0]
+            label = matches[0][1]
+
+            # insert the UID and label to our mapping
+            result[uid] = label
+
+        return result
+
+    @staticmethod
+    def _load_uid_lookup():
+        """
+        Loads and parses the mapping between node IDs and string UIDs. Returns the parsed mapping.
+        """
+
+        # verify that the declared uid lookup file actually exists
+        if not tf.gfile.Exists(Paths.uid_lookup_path):
+            raise NuclioResponseError('Failed to find UID lookup file', requests.codes.service_unavailable)
+
+        # load the raw mapping data
+        with tf.gfile.GFile(Paths.uid_lookup_path) as f:
+            lookup_lines = f.readlines()
+
+        result = {}
+
+        # parse the raw data to a mapping between integer node IDs and string UIDs
+        # this file is expected to contains entries such as this:
+        #
+        # entry
+        # {
+        #   target_class: 443
+        #   target_class_string: "n01491361"
+        # }
+        #
+        # to parse it, we'll iterate over the lines, and for each line that begins with "  target_class:"
+        # we'll assume that the next line has the corresponding "target_class_string"
+        for i, line in enumerate(lookup_lines):
+
+            # we found a line that starts a new entry in our mapping
+            if line.startswith('  target_class:'):
+                # target_class represents an integer value for node ID - convert it to an integer
+                target_class = int(line.split(': ')[1])
+
+                # take the string UID from the next line,
+                # and clean up the quotes wrapping it (and the trailing newline)
+                next_line = lookup_lines[i + 1]
+                target_class_string = next_line.split(': ')[1].strip('"\n ')
+
+                # insert the node ID and string UID to our mapping
+                result[target_class] = target_class_string
+
+        return result
+
+
+# perform the loading in another thread to not block import - the function
+# handler will gracefully decline requests until we're ready to handle them
+t = threading.Thread(target=Helpers.on_import)
+t.start()
+`, "convert.sh": `#
+# Installs ImageMagick and calls "convert" directly with the event body (e.g. an contents of an image) as stdin.
+#
+# If X-nuclio-arguments does not exist in the event headers, the default arguments passed to convert tells it to
+# reduce the image to 50%. To run any other mode or any other setting, simply provide this header (note that this is
+# unsanitized). For example, to reduce the received image to 10% of its size, set X-nuclio-arguments to
+# "- -resize 10% fd:1"
+#
+# Invoke with curl and httpie:
+#
+# curl https://blog.golang.org/gopher/header.jpg | http localhost:<port> > thumb.jpg x-nuclio-arguments:"- -resize 20% fd:1"
+`,
 }

--- a/pkg/playground/resource/function.go
+++ b/pkg/playground/resource/function.go
@@ -228,8 +228,7 @@ func (fr *functionResource) OnAfterInitialize() {
 				Build: functionconfig.Build{
 					Path: "/sources/encrypt.py",
 					Commands: []string{
-						"apk update",
-						"apk add --no-cache gcc g++ make libffi-dev openssl-dev",
+						"apk --update --no-cache add gcc g++ make libffi-dev openssl-dev",
 						"pip install simple-crypt",
 					},
 				},
@@ -268,6 +267,65 @@ func (fr *functionResource) OnAfterInitialize() {
 					Path: "/sources/face.py",
 					Commands: []string{
 						"pip install cognitive_face tabulate inflection",
+					},
+				},
+			},
+		},
+		{
+			Meta: functionconfig.Meta{
+				Name: "regexscan",
+			},
+			Spec: functionconfig.Spec{
+				Build: functionconfig.Build{
+					Path: "/sources/regexscan.go",
+				},
+			},
+		},
+		{
+			Meta: functionconfig.Meta{
+				Name: "sentiments",
+			},
+			Spec: functionconfig.Spec{
+				Runtime: "python:3.6",
+				Handler: "sentiments:analyze",
+				Build: functionconfig.Build{
+					Path: "/sources/sentiments.py",
+					Commands: []string{
+						"pip install requests vaderSentiment",
+					},
+				},
+			},
+		},
+		{
+			Meta: functionconfig.Meta{
+				Name: "tensorflow",
+			},
+			Spec: functionconfig.Spec{
+				Runtime: "python:3.6",
+				Handler: "tensorflow:classify",
+				Build: functionconfig.Build{
+					Path:          "/sources/tensorflow.py",
+					BaseImageName: "jessie",
+					Commands: []string{
+						"pip install requests numpy tensorflow",
+					},
+				},
+			},
+		},
+		{
+			Meta: functionconfig.Meta{
+				Name: "img-convert",
+			},
+			Spec: functionconfig.Spec{
+				Runtime: "shell",
+				Handler: "convert",
+				RuntimeAttributes: map[string]interface{}{
+					"arguments": "- -resize 50% fd:1",
+				},
+				Build: functionconfig.Build{
+					Path: "/sources/convert.sh",
+					Commands: []string{
+						"apk --update --no-cache add imagemagick",
 					},
 				},
 			},

--- a/pkg/processor/build/runtime/shell/test/reverser/reverser.sh
+++ b/pkg/processor/build/runtime/shell/test/reverser/reverser.sh
@@ -1,0 +1,15 @@
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+rev /dev/stdin

--- a/pkg/processor/build/runtime/shell/test/shell_test.go
+++ b/pkg/processor/build/runtime/shell/test/shell_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+	"path"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/processor/build/runtime/test/suite"
+	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type TestSuite struct {
+	buildsuite.TestSuite
+}
+
+func (suite *TestSuite) SetupSuite() {
+	suite.TestSuite.SetupSuite()
+
+	suite.Runtime = "shell"
+	suite.FunctionDir = path.Join(suite.GetProcessorBuildDir(), "shell", "test")
+}
+
+func (suite *TestSuite) TestBuildScriptFile() {
+	deployOptions := suite.GetDeployOptions("reverser",
+		suite.GetFunctionPath("reverser", "reverser.sh"))
+
+	deployOptions.FunctionConfig.Spec.Handler = "reverser.sh:main"
+
+	suite.DeployFunctionAndRequest(deployOptions,
+		&httpsuite.Request{
+			RequestMethod:        "POST",
+			RequestBody:          "abcdef",
+			ExpectedResponseBody: "fedcba",
+		})
+}
+
+func (suite *TestSuite) TestBuildScriptDir() {
+	deployOptions := suite.GetDeployOptions("reverser",
+		suite.GetFunctionPath("reverser"))
+
+	deployOptions.FunctionConfig.Spec.Handler = "reverser.sh:main"
+
+	suite.DeployFunctionAndRequest(deployOptions,
+		&httpsuite.Request{
+			RequestMethod:        "POST",
+			RequestBody:          "abcdef",
+			ExpectedResponseBody: "fedcba",
+		})
+}
+
+func (suite *TestSuite) TestBuildScriptURL() {
+
+	// start an HTTP server to serve the reverser py
+	// TODO: needs to be made unique (find a free port)
+	httpServer := buildsuite.HTTPFileServer{}
+	httpServer.Start(":7777",
+		path.Join(suite.FunctionDir, "reverser", "reverser.sh"),
+		"/some/path/reverser.sh")
+
+	defer httpServer.Shutdown(context.TODO())
+
+	deployOptions := suite.GetDeployOptions("reverser",
+		"http://localhost:7777/some/path/reverser.sh")
+
+	deployOptions.FunctionConfig.Spec.Handler = "reverser.sh:main"
+
+	suite.DeployFunctionAndRequest(deployOptions,
+		&httpsuite.Request{
+			RequestMethod:        "POST",
+			RequestBody:          "abcdef",
+			ExpectedResponseBody: "fedcba",
+		})
+}
+
+func (suite *TestSuite) TestBuildBinaryWithArguments() {
+	deployOptions := suite.GetDeployOptions("echoer", "/dev/null")
+
+	deployOptions.FunctionConfig.Spec.Handler = "echo"
+	deployOptions.FunctionConfig.Spec.RuntimeAttributes = map[string]interface{} {
+		"arguments": "abcdef",
+	}
+
+	suite.DeployFunctionAndRequest(deployOptions,
+		&httpsuite.Request{
+			RequestMethod:        "GET",
+			ExpectedResponseBody: "abcdef\n",
+		})
+}
+
+func TestIntegrationSuite(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	suite.Run(t, new(TestSuite))
+}

--- a/pkg/processor/build/runtime/shell/test/shell_test.go
+++ b/pkg/processor/build/runtime/shell/test/shell_test.go
@@ -107,7 +107,7 @@ func (suite *TestSuite) TestBuildBinaryWithArguments() {
 	deployOptions := suite.GetDeployOptions("echoer", "/dev/null")
 
 	deployOptions.FunctionConfig.Spec.Handler = "echo"
-	deployOptions.FunctionConfig.Spec.RuntimeAttributes = map[string]interface{} {
+	deployOptions.FunctionConfig.Spec.RuntimeAttributes = map[string]interface{}{
 		"arguments": "abcdef",
 	}
 
@@ -122,14 +122,14 @@ func (suite *TestSuite) TestBuildBinaryWithArgumentsFromEvent() {
 	deployOptions := suite.GetDeployOptions("echoer", "/dev/null")
 
 	deployOptions.FunctionConfig.Spec.Handler = "echo"
-	deployOptions.FunctionConfig.Spec.RuntimeAttributes = map[string]interface{} {
+	deployOptions.FunctionConfig.Spec.RuntimeAttributes = map[string]interface{}{
 		"arguments": "abcdef",
 	}
 
 	suite.DeployFunctionAndRequest(deployOptions,
 		&httpsuite.Request{
-			RequestMethod:        "GET",
-			RequestHeaders:       map[string]string{
+			RequestMethod: "GET",
+			RequestHeaders: map[string]string{
 				"x-nuclio-arguments": "123456",
 			},
 			ExpectedResponseBody: "123456\n",

--- a/pkg/processor/build/runtime/shell/test/shell_test.go
+++ b/pkg/processor/build/runtime/shell/test/shell_test.go
@@ -90,6 +90,19 @@ func (suite *TestSuite) TestBuildScriptURL() {
 		})
 }
 
+func (suite *TestSuite) TestBuildBinaryWithStdin() {
+	deployOptions := suite.GetDeployOptions("reverser", "/dev/null")
+
+	deployOptions.FunctionConfig.Spec.Handler = "rev"
+
+	suite.DeployFunctionAndRequest(deployOptions,
+		&httpsuite.Request{
+			RequestMethod:        "POST",
+			RequestBody:          "abcdef",
+			ExpectedResponseBody: "fedcba",
+		})
+}
+
 func (suite *TestSuite) TestBuildBinaryWithArguments() {
 	deployOptions := suite.GetDeployOptions("echoer", "/dev/null")
 
@@ -102,6 +115,24 @@ func (suite *TestSuite) TestBuildBinaryWithArguments() {
 		&httpsuite.Request{
 			RequestMethod:        "GET",
 			ExpectedResponseBody: "abcdef\n",
+		})
+}
+
+func (suite *TestSuite) TestBuildBinaryWithArgumentsFromEvent() {
+	deployOptions := suite.GetDeployOptions("echoer", "/dev/null")
+
+	deployOptions.FunctionConfig.Spec.Handler = "echo"
+	deployOptions.FunctionConfig.Spec.RuntimeAttributes = map[string]interface{} {
+		"arguments": "abcdef",
+	}
+
+	suite.DeployFunctionAndRequest(deployOptions,
+		&httpsuite.Request{
+			RequestMethod:        "GET",
+			RequestHeaders:       map[string]string{
+				"x-nuclio-arguments": "123456",
+			},
+			ExpectedResponseBody: "123456\n",
 		})
 }
 

--- a/pkg/processor/runtime/python/wrapper.py
+++ b/pkg/processor/runtime/python/wrapper.py
@@ -90,7 +90,7 @@ def create_logger(level=logging.DEBUG):
     logger.addHandler(handler)
 
     # Add info_with and friends to logger
-    for name in ['critical', 'fatal', 'error', 'warning', 'info', 'debug']:
+    for name in ['critical', 'fatal', 'error', 'warn', 'info', 'debug']:
         add_structured_log_method(logger, name)
 
     return logger

--- a/pkg/processor/runtime/shell/runtime.go
+++ b/pkg/processor/runtime/shell/runtime.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 
@@ -34,7 +35,7 @@ import (
 type shell struct {
 	*runtime.AbstractRuntime
 	configuration *runtime.Configuration
-	handlerPath   string
+	command       string
 	env           []string
 	ctx           context.Context
 }
@@ -57,29 +58,30 @@ func NewRuntime(parentLogger nuclio.Logger, configuration *runtime.Configuration
 	}
 
 	// update it with some stuff so that we don't have to do this each invocation
-	newShellRuntime.handlerPath = newShellRuntime.getHandlerPath()
+	newShellRuntime.command = newShellRuntime.getCommand()
 	newShellRuntime.env = newShellRuntime.getEnvFromConfiguration()
-
-	// set permissions of handler such that if it wasn't executable before, it's executable now
-	os.Chmod(newShellRuntime.handlerPath, 0755)
 
 	return newShellRuntime, nil
 }
 
 func (s *shell) ProcessEvent(event nuclio.Event, functionLogger nuclio.Logger) (interface{}, error) {
+	command := s.command
+
+	command += " " + s.getCommandArguments(event)
+
 	s.Logger.DebugWith("Executing shell",
 		"name", s.configuration.Meta.Name,
 		"version", s.configuration.Spec.Version,
 		"eventID", event.GetID(),
-		"handlerPath", s.handlerPath)
+		"bodyLen", len(event.GetBody()),
+		"command", command)
 
-	// create a timeout context
-	ctx, cancel := context.WithTimeout(s.ctx, 10*time.Second)
+	// create a timeout context (TODO: from configuration)
+	ctx, cancel := context.WithTimeout(s.ctx, 60*time.Second)
 	defer cancel()
 
 	// create a command
-	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", s.handlerPath)
-
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.Stdin = strings.NewReader(string(event.GetBody()))
 
 	// set the command env
@@ -95,24 +97,53 @@ func (s *shell) ProcessEvent(event nuclio.Event, functionLogger nuclio.Logger) (
 	}
 
 	s.Logger.DebugWith("Shell executed",
-		"out", string(out),
 		"eventID", event.GetID())
 
 	return out, nil
 }
 
-func (s *shell) getHandlerPath() string {
+func (s *shell) getCommand() string {
+	var command string
 	handler := s.configuration.Spec.Handler
-	targetName := strings.Split(handler, ":")[0]
+	moduleName := strings.Split(handler, ":")[0]
 
-	shellHandlerPath := os.Getenv("NUCLIO_SHELL_HANDLER_DIR")
-	if shellHandlerPath == "" {
-		shellHandlerPath = "/opt/nuclio/"
+	// if there's a directory passed as an environment telling us where to look for the module, use it. otherwise
+	// use /opt/nuclio
+	shellHandlerDir := os.Getenv("NUCLIO_SHELL_HANDLER_DIR")
+	if shellHandlerDir == "" {
+		shellHandlerDir = "/opt/nuclio/"
 	}
 
-	command := path.Join(shellHandlerPath, targetName)
+	shellHandlerPath := path.Join(shellHandlerDir, moduleName)
+
+	// is there really a file there? could be user set module to something on the path
+	if common.FileExists(shellHandlerPath) {
+
+		// set permissions of handler such that if it wasn't executable before, it's executable now
+		os.Chmod(shellHandlerPath, 0755)
+
+		command = shellHandlerPath
+	} else {
+
+		// the command is simply the module name
+		command = moduleName
+	}
 
 	return command
+}
+
+func (s *shell) getCommandArguments(event nuclio.Event) string {
+
+	if arguments := event.GetHeaderString("x-nuclio-arguments"); arguments != "" {
+		return arguments
+	}
+
+	// append arguments, if any
+	if arguments, argumentsExists := s.configuration.Spec.RuntimeAttributes["arguments"]; argumentsExists {
+		return arguments.(string)
+	}
+
+	return ""
 }
 
 func (s *shell) getEnvFromConfiguration() []string {
@@ -128,6 +159,5 @@ func (s *shell) getEnvFromEvent(event nuclio.Event) []string {
 		fmt.Sprintf("NUCLIO_EVENT_ID=%s", event.GetID()),
 		fmt.Sprintf("NUCLIO_EVENT_SOURCE_CLASS=%s", event.GetSource().GetClass()),
 		fmt.Sprintf("NUCLIO_EVENT_SOURCE_KIND=%s", event.GetSource().GetKind()),
-		fmt.Sprintf("NUCLIO_EVENT_BODY=%s", event.GetBody()),
 	}
 }


### PR DESCRIPTION
1. Function configuration supports "RuntimeAttributes" for runtime specific attributes (nuctl receives this as `--runtime-attrs`)
2. Shell runtime can call any binary in the image
3. Added integration tests for shell, missing from previous PR
4. Added a shell example
5. Playground has most examples