### PR TITLE
Build Temp Directory Cleanup

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -132,6 +132,10 @@ func IsDirEmpty(path string) bool {
 		return os.IsNotExist(err) // Either the path doesn't exist, or there was an error accessing it in the first place
 	}
 	defer f.Close()
+	
+	if !IsDir(path) {
+		return false
+	}
 
 	_, err = f.Readdirnames(1)
 	return err == io.EOF // Either not empty or error, suits both cases

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -128,6 +129,18 @@ func IsDir(path string) bool {
 func FileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// IsDirEmpty returns true if the directory @ path is empty, or does not exist
+func IsDirEmpty(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return os.IsNotExist(err) // Either the
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1)
+	return err == io.EOF // Either not empty or error, suits both cases
 }
 
 // StringSliceToIntSlice converts slices of strings to slices of int. e.g. ["1", "3"] -> [1, 3]

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -18,7 +18,6 @@ package common
 
 import (
 	"encoding/json"
-	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -123,22 +122,6 @@ func IsDir(path string) bool {
 func FileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
-}
-
-// IsDirEmpty returns true if the directory @ path is empty, or does not exist
-func IsDirEmpty(path string) bool {
-	f, err := os.Open(path)
-	if err != nil {
-		return os.IsNotExist(err) // Either the path doesn't exist, or there was an error accessing it in the first place
-	}
-	defer f.Close()
-	
-	if !IsDir(path) {
-		return false
-	}
-
-	_, err = f.Readdirnames(1)
-	return err == io.EOF // Either not empty or error, suits both cases
 }
 
 // StringSliceToIntSlice converts slices of strings to slices of int. e.g. ["1", "3"] -> [1, 3]

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -129,7 +129,7 @@ func FileExists(path string) bool {
 func IsDirEmpty(path string) bool {
 	f, err := os.Open(path)
 	if err != nil {
-		return os.IsNotExist(err) // Either the
+		return os.IsNotExist(err) // Either the path doesn't exist, or there was an error accessing it in the first place
 	}
 	defer f.Close()
 

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -148,6 +148,7 @@ type Spec struct {
 	Build             Build                   `json:"build,omitempty"`
 	RunRegistry       string                  `json:"runRegistry,omitempty"`
 	RuntimeAttributes map[string]interface{}  `json:"runtimeAttributes,omitempty"`
+	NoCleanup         bool                    `json:"noCleanup,omitempty"`
 }
 
 func (s *Spec) GetRuntimeNameAndVersion() (string, string) {

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -121,6 +121,7 @@ type Build struct {
 	ImageName          string            `json:"imageName,omitempty"`
 	ImageVersion       string            `json:"imageVersion,omitempty"`
 	NoBaseImagesPull   bool              `json:"noBaseImagesPull,omitempty"`
+	NoCleanup          bool              `json:"noCleanup,omitempty"`
 	BaseImageName      string            `json:"baseImageName,omitempty"`
 	Commands           []string          `json:"commands,omitempty"`
 	ScriptPaths        []string          `json:"scriptPaths,omitempty"`
@@ -148,7 +149,6 @@ type Spec struct {
 	Build             Build                   `json:"build,omitempty"`
 	RunRegistry       string                  `json:"runRegistry,omitempty"`
 	RuntimeAttributes map[string]interface{}  `json:"runtimeAttributes,omitempty"`
-	NoCleanup         bool                    `json:"noCleanup,omitempty"`
 }
 
 func (s *Spec) GetRuntimeNameAndVersion() (string, string) {

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -117,6 +117,7 @@ type Build struct {
 	OutputType         string            `json:"outputType,omitempty"`
 	NuclioSourceDir    string            `json:"nuclioSourceDir,omitempty"`
 	NuclioSourceURL    string            `json:"nuclioSourceURL,omitempty"`
+	TempDir            string            `json:"tempDir,omitempty"`
 	Registry           string            `json:"registry,omitempty"`
 	ImageName          string            `json:"imageName,omitempty"`
 	ImageVersion       string            `json:"imageVersion,omitempty"`

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -92,7 +92,7 @@ func addBuildFlags(cmd *cobra.Command, config *functionconfig.Config, commands *
 	cmd.Flags().StringVarP(&config.Spec.Runtime, "runtime", "", "", "Runtime (for example, \"golang\", \"golang:1.8\", \"python:2.7\")")
 	cmd.Flags().StringVarP(&config.Spec.Handler, "handler", "", "", "Name of a function handler")
 	cmd.Flags().BoolVarP(&config.Spec.Build.NoBaseImagesPull, "no-pull", "", false, "Don't pull base images - use local versions")
-	cmd.Flags().BoolVarP(&config.Spec.Build.NoCleanup, "no-cleanup", "", false, "Don't clean up temp directories")
+	cmd.Flags().BoolVarP(&config.Spec.Build.NoCleanup, "no-cleanup", "", false, "Don't clean up temporary directories")
 	cmd.Flags().StringVarP(&config.Spec.Build.BaseImageName, "base-image", "", "", "Name of the base image (default - per-runtime default)")
 	cmd.Flags().Var(commands, "build-command", "Commands to run when building the processor image")
 }

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -92,7 +92,7 @@ func addBuildFlags(cmd *cobra.Command, config *functionconfig.Config, commands *
 	cmd.Flags().StringVarP(&config.Spec.Runtime, "runtime", "", "", "Runtime (for example, \"golang\", \"golang:1.8\", \"python:2.7\")")
 	cmd.Flags().StringVarP(&config.Spec.Handler, "handler", "", "", "Name of a function handler")
 	cmd.Flags().BoolVarP(&config.Spec.Build.NoBaseImagesPull, "no-pull", "", false, "Don't pull base images - use local versions")
-	cmd.Flags().BoolVarP(&config.Spec.NoCleanup, "no-cleanup", "", false, "Don't clean up temp directories")
+	cmd.Flags().BoolVarP(&config.Spec.Build.NoCleanup, "no-cleanup", "", false, "Don't clean up temp directories")
 	cmd.Flags().StringVarP(&config.Spec.Build.BaseImageName, "base-image", "", "", "Name of the base image (default - per-runtime default)")
 	cmd.Flags().Var(commands, "build-command", "Commands to run when building the processor image")
 }

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -92,6 +92,7 @@ func addBuildFlags(cmd *cobra.Command, config *functionconfig.Config, commands *
 	cmd.Flags().StringVarP(&config.Spec.Runtime, "runtime", "", "", "Runtime (for example, \"golang\", \"golang:1.8\", \"python:2.7\")")
 	cmd.Flags().StringVarP(&config.Spec.Handler, "handler", "", "", "Name of a function handler")
 	cmd.Flags().BoolVarP(&config.Spec.Build.NoBaseImagesPull, "no-pull", "", false, "Don't pull base images - use local versions")
+	cmd.Flags().BoolVarP(&config.Spec.NoCleanup, "no-cleanup", "", false, "Don't clean up temp directories")
 	cmd.Flags().StringVarP(&config.Spec.Build.BaseImageName, "base-image", "", "", "Name of the base image (default - per-runtime default)")
 	cmd.Flags().Var(commands, "build-command", "Commands to run when building the processor image")
 }

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -303,7 +303,7 @@ func (b *Builder) resolveFunctionPath(functionPath string) (string, error) {
 	if common.IsURL(functionPath) {
 		tempDir, err := b.mkDirUnderTemp("download")
 		if err != nil {
-			return "", errors.Wrapf(err, "Failed to create staging dir for download: %s", tempDir)
+			return "", errors.Wrapf(err, "Failed to create temporary dir for download: %s", tempDir)
 		}
 
 		tempFileName := path.Join(tempDir, path.Base(functionPath))
@@ -343,7 +343,7 @@ func (b *Builder) decompressFunctionArchive(functionPath string) (string, error)
 	// create a staging directory
 	decompressDir, err := b.mkDirUnderTemp("decompress")
 	if err != nil {
-		return "", errors.Wrapf(err, "Failed to create temp directory for decompressing archive %v", functionPath)
+		return "", errors.Wrapf(err, "Failed to create temporary directory for decompressing archive %v", functionPath)
 	}
 
 	decompressor, err := util.NewDecompressor(b.logger)
@@ -461,7 +461,7 @@ func (b *Builder) createStagingDir() error {
 		return errors.Wrapf(err, "Failed to create temporary dir %s", b.tempDir)
 	}
 
-	b.logger.DebugWith("Created base temp directory", "dir", b.tempDir)
+	b.logger.DebugWith("Created base temporary directory", "dir", b.tempDir)
 
 	b.stagingDir, err = b.mkDirUnderTemp("staging")
 	if err != nil {
@@ -555,10 +555,10 @@ func (b *Builder) mkDirUnderTemp(name string) (string, error) {
 	err := os.Mkdir(dir, 0744)
 
 	if err != nil {
-		return "", errors.Wrapf(err, "Failed to create temp subdirectory %s", dir)
+		return "", errors.Wrapf(err, "Failed to create temporary subdirectory %s", dir)
 	}
 
-	b.logger.DebugWith("Created temp directory", "dir", dir)
+	b.logger.DebugWith("Created temporary directory", "dir", dir)
 
 	return dir, nil
 }
@@ -571,10 +571,10 @@ func (b *Builder) cleanupTempDir() error {
 
 	err := os.RemoveAll(b.tempDir)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to clean up temp dir %s", b.tempDir)
+		return errors.Wrapf(err, "Failed to clean up temporary dir %s", b.tempDir)
 	}
 
-	b.logger.DebugWith("Successfully cleaned up temp directory",
+	b.logger.DebugWith("Successfully cleaned up temporary directory",
 		"dir", b.tempDir)
 	return nil
 }
@@ -622,7 +622,7 @@ func (b *Builder) createProcessorDockerfile() (string, error) {
 		return "", errors.Wrap(err, "Failed to parse processor image Dockerfile template")
 	}
 
-	processorDockerfilePathInStaging := filepath.Join(b.GetStagingDir(), "Dockerfile.processor")
+	processorDockerfilePathInStaging := filepath.Join(b.stagingDir, "Dockerfile.processor")
 	processorDockerfileInStaging, err := os.Create(processorDockerfilePathInStaging)
 	if err != nil {
 		return "", errors.Wrapf(err, "Can't create processor docker file at %s", processorDockerfilePathInStaging)

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -112,14 +112,14 @@ func (b *Builder) Build(options *platform.BuildOptions) (*platform.BuildResult, 
 	// create base temp directory
 	err = b.createTempDir()
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create base temp directory")
+		return nil, errors.Wrap(err, "Failed to create base temp dir")
 	}
 	defer b.cleanupTempDir()
 
 	// create staging directory
 	err = b.createStagingDir()
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create staging directory")
+		return nil, errors.Wrap(err, "Failed to create staging dir")
 	}
 
 	// resolve the function path - download in case its a URL
@@ -465,7 +465,7 @@ func (b *Builder) createTempDir() error {
 		return errors.Wrapf(err, "Failed to create temporary dir %s", b.tempDir)
 	}
 
-	b.logger.DebugWith("Created base temporary directory", "dir", b.tempDir)
+	b.logger.DebugWith("Created base temporary dir", "dir", b.tempDir)
 
 	return nil
 }
@@ -561,14 +561,14 @@ func (b *Builder) mkDirUnderTemp(name string) (string, error) {
 
 	dir := path.Join(b.tempDir, name)
 
-	// temp directory needs executable permission for docker to be able to pull from it
+	// temp dir needs executable permission for docker to be able to pull from it
 	err := os.Mkdir(dir, 0744)
 
 	if err != nil {
-		return "", errors.Wrapf(err, "Failed to create temporary subdirectory %s", dir)
+		return "", errors.Wrapf(err, "Failed to create temporary subdir %s", dir)
 	}
 
-	b.logger.DebugWith("Created temporary directory", "dir", dir)
+	b.logger.DebugWith("Created temporary dir", "dir", dir)
 
 	return dir, nil
 }
@@ -584,7 +584,7 @@ func (b *Builder) cleanupTempDir() error {
 		return errors.Wrapf(err, "Failed to clean up temporary dir %s", b.tempDir)
 	}
 
-	b.logger.DebugWith("Successfully cleaned up temporary directory",
+	b.logger.DebugWith("Successfully cleaned up temporary dir",
 		"dir", b.tempDir)
 	return nil
 }

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -118,6 +118,10 @@ func (b *Builder) Build(options *platform.BuildOptions) (*platform.BuildResult, 
 		return nil, errors.Wrap(err, "Failed create staging directory")
 	}
 
+	if !options.FunctionConfig.Spec.NoCleanup {
+		defer b.cleanupTempDir()
+	}
+
 	// resolve the function path - download in case its a URL
 	b.options.FunctionConfig.Spec.Build.Path, err = b.resolveFunctionPath(b.options.FunctionConfig.Spec.Build.Path)
 	if err != nil {
@@ -537,6 +541,17 @@ func (b *Builder) copyObjectsToStagingDir() error {
 		}
 	}
 
+	return nil
+}
+
+func (b *Builder) cleanupTempDir() error {
+	err := os.RemoveAll(b.tempDir)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to clean up temp dir %s", b.tempDir)
+	}
+
+	b.logger.DebugWith("Successfully cleaned up temp directory",
+		"dir", b.tempDir)
 	return nil
 }
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -117,7 +117,7 @@ func (b *Builder) Build(options *platform.BuildOptions) (*platform.BuildResult, 
 	defer b.cleanupTempDir()
 
 	// create staging directory
-	b.stagingDir, err = b.createStagingDir()
+	err = b.createStagingDir()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create staging directory")
 	}
@@ -470,15 +470,17 @@ func (b *Builder) createTempDir() error {
 	return nil
 }
 
-func (b *Builder) createStagingDir() (string, error) {
-	stagingDir, err := b.mkDirUnderTemp("staging")
+func (b *Builder) createStagingDir() error {
+	var err error
+
+	b.stagingDir, err = b.mkDirUnderTemp("staging")
 	if err != nil {
-		return "", errors.Wrapf(err, "Failed to create staging dir: %s", b.stagingDir)
+		return errors.Wrapf(err, "Failed to create staging dir: %s", b.stagingDir)
 	}
 
-	b.logger.DebugWith("Created staging directory", "dir", b.stagingDir)
+	b.logger.DebugWith("Created staging dir", "dir", b.stagingDir)
 
-	return stagingDir, nil
+	return nil
 }
 
 func (b *Builder) prepareStagingDir() error {

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -118,7 +118,7 @@ func (b *Builder) Build(options *platform.BuildOptions) (*platform.BuildResult, 
 		return nil, errors.Wrap(err, "Failed create staging directory")
 	}
 
-	if !options.FunctionConfig.Spec.NoCleanup {
+	if !options.FunctionConfig.Spec.Build.NoCleanup {
 		defer b.cleanupTempDir()
 	}
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -452,8 +452,17 @@ func (b *Builder) getRuntimeName() (string, error) {
 
 func (b *Builder) createStagingDir() (string, error) {
 
-	// create a staging directory
-	tempDir, err := ioutil.TempDir("", "nuclio-build-")
+	var tempDir string
+	var err error
+
+	// either use injected tempdir or generate a new one
+	if b.options.FunctionConfig.Spec.Build.TempDir != "" {
+		tempDir = b.options.FunctionConfig.Spec.Build.TempDir
+		err = os.MkdirAll(tempDir, 0744)
+	} else {
+		tempDir, err = ioutil.TempDir("", "nuclio-build-")
+	}
+
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed to create temp dir %s", tempDir)
 	}

--- a/pkg/processor/build/runtime/golang/eventhandlerparser/parse_test.go
+++ b/pkg/processor/build/runtime/golang/eventhandlerparser/parse_test.go
@@ -81,7 +81,7 @@ type ParseSuite struct {
 
 func (suite *ParseSuite) SetupSuite() {
 	zap, err := nucliozap.NewNuclioZapTest("parsereventhandler-test")
-	suite.Require().NoError(err, "Can't craete logger")
+	suite.Require().NoError(err, "Can't create logger")
 	suite.parser = NewEventHandlerParser(zap)
 }
 

--- a/pkg/processor/build/runtime/golang/eventhandlerparser/parse_test.go
+++ b/pkg/processor/build/runtime/golang/eventhandlerparser/parse_test.go
@@ -103,7 +103,7 @@ func (suite *ParseSuite) TestBadCode() {
 
 func (suite *ParseSuite) TestFindHandlersInDirectory() {
 	handlerDir, err := ioutil.TempDir("", "parse-test")
-	suite.Require().NoError(err, "Can't create temp directory")
+	suite.Require().NoError(err, "Can't create temporary directory")
 	n := 3
 
 	for i := 0; i < n; i++ {
@@ -118,7 +118,7 @@ func (suite *ParseSuite) TestFindHandlersInDirectory() {
 
 func (suite *ParseSuite) TestFindHandlersInFile() {
 	handlerDir, err := ioutil.TempDir("", "parse-test")
-	suite.Require().NoError(err, "Can't create temp directory")
+	suite.Require().NoError(err, "Can't create temporary directory")
 
 	handlerPath := suite.createHandler(handlerDir, 0)
 
@@ -130,7 +130,7 @@ func (suite *ParseSuite) TestFindHandlersInFile() {
 
 func (suite *ParseSuite) parseCode(code string) ([]string, []string, error) {
 	tmp, err := ioutil.TempDir("", "test-parse")
-	suite.Require().NoError(err, "Can't create temp directory file")
+	suite.Require().NoError(err, "Can't create temporary directory file")
 	defer os.RemoveAll(tmp)
 
 	fileName := filepath.Join(tmp, "handler.go")

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -57,6 +57,7 @@ type TestSuite struct {
 	FunctionDir  string
 	containerID  string
 	TempDir      string
+	CleanupTemp  bool
 }
 
 // SetupSuite is called for suite setup
@@ -115,7 +116,7 @@ func (suite *TestSuite) TearDownTest() {
 		}
 	}
 
-	if !common.IsDirEmpty(suite.TempDir) {
+	if suite.CleanupTemp && !common.IsDirEmpty(suite.TempDir) {
 		suite.Failf("", "temp dir %s was not cleaned", suite.TempDir)
 	}
 }
@@ -128,6 +129,9 @@ func (suite *TestSuite) DeployFunction(deployOptions *platform.DeployOptions,
 	deployOptions.FunctionConfig.Meta.Name = fmt.Sprintf("%s-%s", deployOptions.FunctionConfig.Meta.Name, suite.TestID)
 	deployOptions.FunctionConfig.Spec.Build.NuclioSourceDir = suite.GetNuclioSourceDir()
 	deployOptions.FunctionConfig.Spec.Build.NoBaseImagesPull = true
+
+	// Does the test call for cleaning up the temp dir, and thus needs to check this on teardown
+	suite.CleanupTemp = !deployOptions.FunctionConfig.Spec.Build.NoCleanup
 
 	// deploy the function
 	deployResult, err := suite.Platform.DeployFunction(deployOptions)


### PR DESCRIPTION
Fixes #405 
All staging directories created in builder are now under a single "temp directory", and cleaned up at the end of Build()