### PR TITLE
Send test output to log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ lint: ensure-gopath
 
 .PHONY: test
 test: ensure-gopath
-	go test -v ./cmd/... ./pkg/... -p 1
+	./run-tests.sh
 
 .PHONY: test-python
 test-python: ensure-gopath

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Run tests, send output to log
+
+# Fail on pipe since we use tee
+set -o pipefail
+# Exit on first error
+set -e
+
+log_file=/tmp/nuclio-test-$(date +%Y-%m-%dT%H:%M:%S).log
+trap "echo; echo Log file at ${log_file}" EXIT
+2>&1 make test | tee ${log_file}


### PR DESCRIPTION
This saves tests output to log as well as streaming to console. Makes it much easier to search for errors in the logs.