### PR TITLE
Local platform respects configured HTTP port

### DIFF
--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -212,7 +212,7 @@ func (p *Platform) getFreeLocalPort() (int, error) {
 
 func (p *Platform) deployFunction(deployOptions *platform.DeployOptions) (*platform.DeployResult, error) {
 
-	// get function port - either from configuraiton or from a free port
+	// get function port - either from configuration or from a free port
 	functionHTTPPort, err := p.getFunctionHTTPPort(deployOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get function HTTP port")

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -212,15 +212,11 @@ func (p *Platform) getFreeLocalPort() (int, error) {
 
 func (p *Platform) deployFunction(deployOptions *platform.DeployOptions) (*platform.DeployResult, error) {
 
-	// get a free local port
-	// TODO: retry docker run if fails - there is a race on the local port since once getFreeLocalPort returns
-	// the port becomes available
-	freeLocalPort, err := p.getFreeLocalPort()
+	// get function port - either from configuraiton or from a free port
+	functionHTTPPort, err := p.getFunctionHTTPPort(deployOptions)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get free local port")
+		return nil, errors.Wrap(err, "Failed to get function HTTP port")
 	}
-
-	p.Logger.DebugWith("Found free local port", "port", freeLocalPort)
 
 	labels := map[string]string{
 		"nuclio-platform":      "local",
@@ -246,7 +242,7 @@ func (p *Platform) deployFunction(deployOptions *platform.DeployOptions) (*platf
 
 	// run the docker image
 	containerID, err := p.dockerClient.RunContainer(deployOptions.FunctionConfig.Spec.ImageName, &dockerclient.RunOptions{
-		Ports:  map[int]int{freeLocalPort: 8080},
+		Ports:  map[int]int{functionHTTPPort: 8080},
 		Env:    envMap,
 		Labels: labels,
 		Volumes: map[string]string{
@@ -259,7 +255,7 @@ func (p *Platform) deployFunction(deployOptions *platform.DeployOptions) (*platf
 	}
 
 	return &platform.DeployResult{
-		Port:        freeLocalPort,
+		Port:        functionHTTPPort,
 		ContainerID: containerID,
 	}, nil
 }
@@ -303,4 +299,26 @@ func (p *Platform) encodeFunctionSpec(spec *functionconfig.Spec) string {
 	encodedFunctionSpec, _ := json.Marshal(spec)
 
 	return string(encodedFunctionSpec)
+}
+
+func (p *Platform) getFunctionHTTPPort(deployOptions *platform.DeployOptions) (int, error) {
+
+	// if the configuration specified an HTTP port - use that
+	if deployOptions.FunctionConfig.Spec.HTTPPort != 0 {
+		p.Logger.DebugWith("Configuration specified HTTP port",
+			"port",
+			deployOptions.FunctionConfig.Spec.HTTPPort)
+
+		return deployOptions.FunctionConfig.Spec.HTTPPort, nil
+	}
+
+	// get a free local port
+	freeLocalPort, err := p.getFreeLocalPort()
+	if err != nil {
+		return -1, errors.Wrap(err, "Failed to get free local port")
+	}
+
+	p.Logger.DebugWith("Found free local port", "port", freeLocalPort)
+
+	return freeLocalPort, nil
 }

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -147,6 +147,23 @@ func (suite *TestSuite) TestBuildCustomImageName() {
 	suite.Require().Equal(deployOptions.FunctionConfig.Spec.Build.ImageName+":latest", deployResult.ImageName)
 }
 
+func (suite *TestSuite) TestBuildCustomHTTPPort() {
+	httpPort := 31000
+
+	deployOptions := suite.getDeployOptions("reverser")
+
+	deployOptions.FunctionConfig.Spec.HTTPPort = httpPort
+
+	deployResult := suite.DeployFunctionAndRequest(deployOptions,
+		&httpsuite.Request{
+			RequestBody:          "abcdef",
+			ExpectedResponseBody: "fedcba",
+			RequestPort:          httpPort,
+		})
+
+	suite.Require().Equal(deployOptions.FunctionConfig.Spec.Build.ImageName+":latest", deployResult.ImageName)
+}
+
 func (suite *TestSuite) compressAndDeployFunctionFromURL(archiveExtension string,
 	compressor func(string, []string) error) {
 

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -154,14 +154,12 @@ func (suite *TestSuite) TestBuildCustomHTTPPort() {
 
 	deployOptions.FunctionConfig.Spec.HTTPPort = httpPort
 
-	deployResult := suite.DeployFunctionAndRequest(deployOptions,
+	suite.DeployFunctionAndRequest(deployOptions,
 		&httpsuite.Request{
 			RequestBody:          "abcdef",
 			ExpectedResponseBody: "fedcba",
 			RequestPort:          httpPort,
 		})
-
-	suite.Require().Equal(deployOptions.FunctionConfig.Spec.Build.ImageName+":latest", deployResult.ImageName)
 }
 
 func (suite *TestSuite) compressAndDeployFunctionFromURL(archiveExtension string,


### PR DESCRIPTION
If function configuration contains Spec.HttpPort, the local platform will use this port. If it's not set (or set to zero), the previous behavior will apply and a free port will be generated.