### PR TITLE
Fix return response for Python 2.7

### DIFF
--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -39,7 +39,17 @@ func (suite *TestSuite) SetupTest() {
 	suite.FunctionDir = path.Join(suite.GetNuclioSourceDir(), "pkg", "processor", "runtime", "python", "test")
 }
 
-func (suite *TestSuite) TestOutputs() {
+func (suite *TestSuite) TestOutputs27() {
+	suite.testOutputs("python:2.7")
+}
+
+func (suite *TestSuite) TestOutputs36() {
+	suite.testOutputs("python:3.6")
+}
+
+func (suite *TestSuite) testOutputs(runtime string) {
+	suite.Runtime = runtime
+
 	statusOK := http.StatusOK
 	statusCreated := http.StatusCreated
 	statusInternalError := http.StatusInternalServerError

--- a/pkg/processor/runtime/python/wrapper.py
+++ b/pkg/processor/runtime/python/wrapper.py
@@ -302,7 +302,7 @@ def response_from_handler_output(logger, handler_output):
     elif isinstance(handler_output, tuple) and len(handler_output) == 2:
         response['status_code'] = handler_output[0]
 
-        if type(handler_output[1]) is str:
+        if isinstance(handler_output[1], str):
             response['body'] = handler_output[1]
         else:
             response['body'] = json_encode(handler_output[1])

--- a/pkg/processor/runtime/python/wrapper.py
+++ b/pkg/processor/runtime/python/wrapper.py
@@ -226,7 +226,7 @@ def serve_requests(sock, logger, handler):
                 stream.write('m' + json.dumps({'duration': duration}) + '\n')
                 stream.flush()
 
-                response = response_from_handler_output(handler_output)
+                response = response_from_handler_output(logger, handler_output)
 
                 # try to json encode the response
                 encoded_response = json_encode(response)
@@ -282,7 +282,7 @@ def should_encode_body(response):
     return isinstance(response['body'], cls)
 
 
-def response_from_handler_output(handler_output):
+def response_from_handler_output(logger, handler_output):
     """Given a handler output's type, generates a response towards the
     processor"""
 
@@ -295,11 +295,11 @@ def response_from_handler_output(handler_output):
     }
 
     # if the type of the output is a string, just return that and 200
-    if type(handler_output) is str:
+    if isinstance(handler_output, str):
         response['body'] = handler_output
 
     # if it's a tuple of 2 elements, first is status second is body
-    elif type(handler_output) is tuple and len(handler_output) == 2:
+    elif isinstance(handler_output, tuple) and len(handler_output) == 2:
         response['status_code'] = handler_output[0]
 
         if type(handler_output[1]) is str:
@@ -309,12 +309,12 @@ def response_from_handler_output(handler_output):
             response['content_type'] = json_ctype
 
     # if it's a dict, populate the response and set content type to json
-    elif type(handler_output) is dict or type(handler_output) is list:
+    elif isinstance(handler_output, dict) or isinstance(handler_output, list):
         response['content_type'] = json_ctype
         response['body'] = json_encode(handler_output)
 
     # if it's a response object, populate the response
-    elif type(handler_output) is Response:
+    elif isinstance(handler_output, Response):
         response['body'] = handler_output.body
         response['content_type'] = handler_output.content_type
         response['headers'] = handler_output.headers
@@ -362,7 +362,7 @@ def main():
         serve_requests(sock, logger, event_handler)
 
     except Exception as err:
-        logger.warning(
+        logger.warn(
             'Caught unhandled exception while initializing "{0}": {1}'.format(
              err, traceback.format_exc()))
         raise SystemExit(1)


### PR DESCRIPTION
Returning context.Response under Python 2.7 would result in an internal errior