### PR TITLE
Functions receive platform config - respect only metrics

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -49,8 +49,13 @@ type Controller struct {
 	ignoredFunctionCRChanges changeIgnorer
 }
 
-func NewController(namespace string, configurationPath string) (*Controller, error) {
+func NewController(namespace string, kubeconfigPath string) (*Controller, error) {
 	var err error
+
+	// replace "*" with "", which is actually "all" in kube-speak
+	if namespace == "*" {
+		namespace = ""
+	}
 
 	newController := &Controller{
 		namespace:             namespace,
@@ -70,7 +75,7 @@ func NewController(namespace string, configurationPath string) (*Controller, err
 	// holds changes that the controller itself triggered and needs to ignore
 	newController.ignoredFunctionCRChanges = controller.NewIgnoredChanges(newController.logger)
 
-	newController.restConfig, err = newController.getClientConfig(configurationPath)
+	newController.restConfig, err = newController.getClientConfig(kubeconfigPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get client configuration")
 	}
@@ -149,9 +154,9 @@ func (c *Controller) Start() error {
 	}
 }
 
-func (c *Controller) getClientConfig(configurationPath string) (*rest.Config, error) {
-	if configurationPath != "" {
-		return clientcmd.BuildConfigFromFlags("", configurationPath)
+func (c *Controller) getClientConfig(kubeconfigPath string) (*rest.Config, error) {
+	if kubeconfigPath != "" {
+		return clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	}
 
 	return rest.InClusterConfig()

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -57,10 +57,13 @@ type Processor struct {
 }
 
 // NewProcessor returns a new Processor
-func NewProcessor(configurationPath string) (*Processor, error) {
+func NewProcessor(configurationPath string, platformConfigurationPath string) (*Processor, error) {
 	var err error
 
 	newProcessor := &Processor{}
+
+	// read platform configuration
+	platformConfigurationPath
 
 	// create loggers for both the processor and the function invoked by the processor - they may
 	// be headed to two different places

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -168,7 +168,7 @@ func (p *Processor) readPlatformConfiguration(configurationPath string) (*platfo
 		return nil, false, errors.Wrap(err, "Failed to create platform configuration reader")
 	}
 
-	// if there's no configuartion file, return a default configuration. otherwise try to parse it
+	// if there's no configuration file, return a default configuration. otherwise try to parse it
 	platformConfigurationFile, err := os.Open(configurationPath)
 	if err != nil {
 		return p.getDefaultPlatformConfiguration(), false, nil

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -30,6 +30,7 @@ import (
 
 func run() error {
 	configPath := flag.String("config", "", "Path of configuration file")
+	platformConfigPath := flag.String("platform-config", "", "Path of platform configuration file")
 	listRuntimes := flag.Bool("list-runtimes", false, "Show runtimes and exit")
 	flag.Parse()
 
@@ -42,7 +43,7 @@ func run() error {
 		os.Exit(0)
 	}
 
-	processor, err := app.NewProcessor(*configPath)
+	processor, err := app.NewProcessor(*configPath, *platformConfigPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -17,87 +17,12 @@ limitations under the License.
 package common
 
 import (
-	"encoding/json"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/errors"
-
-	"github.com/spf13/viper"
 )
-
-// StringMapToString converts a map of a: x, b: y to a string in the form of "a=x,b=y"
-func StringMapToString(source map[string]string) string {
-	list := []string{}
-
-	for k, v := range source {
-		list = append(list, k+"="+v)
-	}
-
-	return strings.Join(list, ",")
-}
-
-// StringToStringMap converts a string in the form of a=x,b=y to a map of a: x, b: y
-func StringToStringMap(source string) map[string]string {
-	separatedString := strings.Split(source, ",")
-	result := map[string]string{}
-
-	for _, keyAndValie := range separatedString {
-		kv := strings.Split(keyAndValie, "=")
-
-		if len(kv) > 1 {
-			result[kv[0]] = kv[1]
-		}
-	}
-
-	return result
-}
-
-// GetObjectSlice extracts a list of objects from a viper instance. there may be a better way to do this with viper
-// but i've yet to find it (TODO: post issue?)
-func GetObjectSlice(configuration *viper.Viper, key string) []map[string]interface{} {
-	objectsAsMapStringInterface := []map[string]interface{}{}
-
-	keyValue := configuration.Get(key)
-	if keyValue == nil {
-		return []map[string]interface{}{}
-	}
-
-	// get as slice of interfaces
-	objectsAsInterfaces := keyValue.([]interface{})
-
-	// iterate over objects as interfaces
-	for _, objectAsInterface := range objectsAsInterfaces {
-		objectAsMapStringInterface := map[string]interface{}{}
-
-		// convert each object to a map of its fields (interface/interface)
-		objectFieldsAsMapInterfaceInterface := objectAsInterface.(map[interface{}]interface{})
-
-		// iterate over fields, convert key to string and keep value as interface, shove to
-		// objectAsMapStringInterface
-		for objectFieldKey, objectFieldValue := range objectFieldsAsMapInterfaceInterface {
-			objectAsMapStringInterface[objectFieldKey.(string)] = objectFieldValue
-		}
-
-		// add object to map
-		objectsAsMapStringInterface = append(objectsAsMapStringInterface, objectAsMapStringInterface)
-	}
-
-	return objectsAsMapStringInterface
-}
-
-// StructureToMap converts a strcuture to a map, flattening all members
-func StructureToMap(input interface{}) map[string]interface{} {
-	var decodedInput interface{}
-
-	// TODO: find a more elegent mechanism than JSON encode/decode
-	encodedInput, _ := json.Marshal(input)
-	json.Unmarshal(encodedInput, &decodedInput)
-
-	return decodedInput.(map[string]interface{})
-}
 
 // IsFile returns true if the object @ path is a file
 func IsFile(path string) bool {
@@ -158,32 +83,4 @@ func RetryUntilSuccessful(duration time.Duration, interval time.Duration, callba
 	}
 
 	return errors.New("Timed out waiting until successful")
-}
-
-// MapInterfaceInterfaceToMapStringInterface recursively converts map[interface{}]interface{} to map[string]interface{}
-func MapInterfaceInterfaceToMapStringInterface(mapInterfaceInterface map[interface{}]interface{}) map[string]interface{} {
-	stringInterfaceMap := map[string]interface{}{}
-
-	for key, value := range mapInterfaceInterface {
-
-		switch typedValue := value.(type) {
-		case map[interface{}]interface{}:
-			stringInterfaceMap[key.(string)] = MapInterfaceInterfaceToMapStringInterface(typedValue)
-		default:
-			stringInterfaceMap[key.(string)] = value
-		}
-	}
-
-	return stringInterfaceMap
-}
-
-// MapToSlice converts {key1: val1, key2: val2 ...} to [key1, val1, key2, val2 ...]
-func MapToSlice(m map[string]interface{}) []interface{} {
-	out := make([]interface{}, 0, len(m)*2)
-	for key, value := range m {
-		out = append(out, key)
-		out = append(out, value)
-	}
-
-	return out
 }

--- a/pkg/common/map.go
+++ b/pkg/common/map.go
@@ -1,0 +1,91 @@
+package common
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+)
+
+// StringMapToString converts a map of a: x, b: y to a string in the form of "a=x,b=y"
+func StringMapToString(source map[string]string) string {
+	list := []string{}
+
+	for k, v := range source {
+		list = append(list, k+"="+v)
+	}
+
+	return strings.Join(list, ",")
+}
+
+// StringToStringMap converts a string in the form of a=x,b=y to a map of a: x, b: y
+func StringToStringMap(source string) map[string]string {
+	separatedString := strings.Split(source, ",")
+	result := map[string]string{}
+
+	for _, keyAndValie := range separatedString {
+		kv := strings.Split(keyAndValie, "=")
+
+		if len(kv) > 1 {
+			result[kv[0]] = kv[1]
+		}
+	}
+
+	return result
+}
+
+// StructureToMap converts a strcuture to a map, flattening all members
+func StructureToMap(input interface{}) map[string]interface{} {
+	var decodedInput interface{}
+
+	// TODO: find a more elegent mechanism than JSON encode/decode
+	encodedInput, _ := json.Marshal(input)
+	json.Unmarshal(encodedInput, &decodedInput)
+
+	return decodedInput.(map[string]interface{})
+}
+
+// MapInterfaceInterfaceToMapStringInterface recursively converts map[interface{}]interface{} to map[string]interface{}
+func MapInterfaceInterfaceToMapStringInterface(mapInterfaceInterface map[interface{}]interface{}) map[string]interface{} {
+	stringInterfaceMap := map[string]interface{}{}
+
+	for key, value := range mapInterfaceInterface {
+
+		switch typedValue := value.(type) {
+		case map[interface{}]interface{}:
+			stringInterfaceMap[key.(string)] = MapInterfaceInterfaceToMapStringInterface(typedValue)
+		default:
+			stringInterfaceMap[key.(string)] = value
+		}
+	}
+
+	return stringInterfaceMap
+}
+
+// MapToSlice converts {key1: val1, key2: val2 ...} to [key1, val1, key2, val2 ...]
+func MapToSlice(m map[string]interface{}) []interface{} {
+	out := make([]interface{}, 0, len(m)*2)
+	for key, value := range m {
+		out = append(out, key)
+		out = append(out, value)
+	}
+
+	return out
+}
+
+// MapStringInterfaceGetIntOrDefault will return the key as an integer or return a default
+func MapStringInterfaceGetOrDefault(mapStringInterface map[string]interface{}, key string, defaultValue interface{}) interface{} {
+
+	value, found := mapStringInterface[key]
+
+	// if the key wasn't found, return the default value
+	if !found {
+		return defaultValue
+	}
+
+	// if the default value isn't the same type of the key, return the default
+	if reflect.TypeOf(value) != reflect.TypeOf(defaultValue) {
+		return defaultValue
+	}
+
+	return value
+}

--- a/pkg/common/map_test.go
+++ b/pkg/common/map_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type MapTestSuite struct {
+	suite.Suite
+}
+
+func (ts *MapTestSuite) TestMapStringInterfaceGetOrDefault() {
+	source := map[string]interface{}{
+		"k_str1":  "str1",
+		"k_str2":  "str2",
+		"k_int1":  1,
+		"k_bool1": true,
+	}
+
+	vs := MapStringInterfaceGetOrDefault(source, "k_str1", "default").(string)
+	ts.Require().Equal("str1", vs)
+
+	vs = MapStringInterfaceGetOrDefault(source, "k_str2", "default").(string)
+	ts.Require().Equal("str2", vs)
+
+	vs = MapStringInterfaceGetOrDefault(source, "k_str1__", "default").(string)
+	ts.Require().Equal("default", vs)
+
+	vi := MapStringInterfaceGetOrDefault(source, "k_int1", 100).(int)
+	ts.Require().Equal(1, vi)
+
+	vi = MapStringInterfaceGetOrDefault(source, "k_int1__", 100).(int)
+	ts.Require().Equal(100, vi)
+
+	vi = MapStringInterfaceGetOrDefault(source, "k_str2", 1).(int)
+	ts.Require().Equal(1, vi)
+
+	vb := MapStringInterfaceGetOrDefault(source, "k_bool1", false).(bool)
+	ts.Require().Equal(true, vb)
+}
+
+func TestMapTestSuite(t *testing.T) {
+	suite.Run(t, new(MapTestSuite))
+}

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -106,8 +106,14 @@ func GetIngressesFromTriggers(triggers map[string]Trigger) (ingresses map[string
 // Ingress holds configuration for an ingress - an entity that can route HTTP requests
 // to the function
 type Ingress struct {
-	Host  string
-	Paths []string
+	Host  string   `json:"host,omitempty"`
+	Paths []string `json:"paths,omitempty"`
+}
+
+// LoggerSink overrides the default platform configuration for function loggers
+type LoggerSink struct {
+	Level string `json:"level,omitempty"`
+	Sink  string `json:"sink,omitempty"`
 }
 
 // Build holds all configuration parameters related to building a function
@@ -150,6 +156,7 @@ type Spec struct {
 	Build             Build                   `json:"build,omitempty"`
 	RunRegistry       string                  `json:"runRegistry,omitempty"`
 	RuntimeAttributes map[string]interface{}  `json:"runtimeAttributes,omitempty"`
+	LoggerSinks       []LoggerSink            `json:"loggerSinks,omitempty"`
 }
 
 func (s *Spec) GetRuntimeNameAndVersion() (string, string) {

--- a/pkg/platform/kube/functiondep/client.go
+++ b/pkg/platform/kube/functiondep/client.go
@@ -42,6 +42,7 @@ import (
 const (
 	containerHTTPPort         = 8080
 	processorConfigVolumeName = "processor-config-volume"
+	platformConfigVolumeName  = "platform-config-volume"
 	containerHTTPPortName     = "http"
 )
 
@@ -385,11 +386,7 @@ func (c *Client) createOrUpdateDeployment(labels map[string]string,
 		container := v1.Container{Name: "nuclio"}
 		c.populateDeploymentContainer(labels, function, &container)
 
-		volume := v1.Volume{}
-		volume.Name = processorConfigVolumeName
-		configMapVolumeSource := v1.ConfigMapVolumeSource{}
-		configMapVolumeSource.Name = c.configMapNameFromFunctionName(function.Name)
-		volume.ConfigMap = &configMapVolumeSource
+		volumes := c.getConfigurationVolumes(function)
 
 		return c.clientSet.AppsV1beta1().Deployments(function.Namespace).Create(&apps_v1beta1.Deployment{
 
@@ -411,7 +408,7 @@ func (c *Client) createOrUpdateDeployment(labels map[string]string,
 						Containers: []v1.Container{
 							container,
 						},
-						Volumes: []v1.Volume{volume},
+						Volumes: volumes,
 					},
 				},
 			},
@@ -717,14 +714,18 @@ func (c *Client) populateDeploymentContainer(labels map[string]string,
 	function *functioncr.Function,
 	container *v1.Container) {
 
-	volumeMount := v1.VolumeMount{}
-	volumeMount.Name = processorConfigVolumeName
-	volumeMount.MountPath = "/etc/nuclio"
+	processorConfigVolumeMount := v1.VolumeMount{}
+	processorConfigVolumeMount.Name = processorConfigVolumeName
+	processorConfigVolumeMount.MountPath = "/etc/nuclio/config/processor"
+
+	platformConfigVolumeMount := v1.VolumeMount{}
+	platformConfigVolumeMount.Name = platformConfigVolumeName
+	platformConfigVolumeMount.MountPath = "/etc/nuclio/config/platform"
 
 	container.Image = function.Spec.ImageName
 	container.Resources = function.Spec.Resources
 	container.Env = c.getFunctionEnvironment(labels, function)
-	container.VolumeMounts = []v1.VolumeMount{volumeMount}
+	container.VolumeMounts = []v1.VolumeMount{processorConfigVolumeMount, platformConfigVolumeMount}
 	container.Ports = []v1.ContainerPort{
 		{
 			ContainerPort: containerHTTPPort,
@@ -770,4 +771,28 @@ func (c *Client) populateConfigMap(labels map[string]string,
 
 func (c *Client) configMapNameFromFunctionName(functionName string) string {
 	return functionName
+}
+
+func (c *Client) getConfigurationVolumes(function *functioncr.Function) []v1.Volume {
+	trueVal := true
+
+	// processor configuration
+	processorConfigVolume := v1.Volume{}
+	processorConfigVolume.Name = processorConfigVolumeName
+	processorConfigMapVolumeSource := v1.ConfigMapVolumeSource{}
+	processorConfigMapVolumeSource.Name = c.configMapNameFromFunctionName(function.Name)
+	processorConfigVolume.ConfigMap = &processorConfigMapVolumeSource
+
+	// platform configuration
+	platformConfigVolume := v1.Volume{}
+	platformConfigVolume.Name = platformConfigVolumeName
+	platformConfigMapVolumeSource := v1.ConfigMapVolumeSource{}
+	platformConfigMapVolumeSource.Name = "platform-config"
+	platformConfigMapVolumeSource.Optional = &trueVal
+	platformConfigVolume.ConfigMap = &platformConfigMapVolumeSource
+
+	return []v1.Volume{
+		processorConfigVolume,
+		platformConfigVolume,
+	}
 }

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -246,7 +246,7 @@ func (p *Platform) deployFunction(deployOptions *platform.DeployOptions) (*platf
 		Env:    envMap,
 		Labels: labels,
 		Volumes: map[string]string{
-			localProcessorConfigPath: path.Join("/", "etc", "nuclio", "processor.yaml"),
+			localProcessorConfigPath: path.Join("/", "etc", "nuclio", "config", "processor", "processor.yaml"),
 		},
 	})
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platformconfig
+
+import (
+	"fmt"
+
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+)
+
+type Config struct {
+	WebAdmin WebAdmin `json:"webAdmin,omitempty"`
+	Logger   Logger   `json:"logger,omitempty"`
+	Metrics  Metrics  `json:"metrics,omitempty"`
+}
+
+func (config *Config) GetSystemLoggerSinks() ([]LoggerSinkWithLevel, error) {
+	return config.getLoggerSinksWithLevel(config.Logger.System)
+}
+
+func (config *Config) GetFunctionLoggerSinks(functionConfig *functionconfig.Config) ([]LoggerSinkWithLevel, error) {
+	var loggerSinkBindings []LoggerSinkBinding
+
+	// if the function specifies logger sinks, use that. otherwise use the default platform-specified logger
+	// sinks
+	if len(functionConfig.Spec.LoggerSinks) > 0 {
+		for _, loggerSink := range functionConfig.Spec.LoggerSinks {
+			loggerSinkBindings = append(loggerSinkBindings, LoggerSinkBinding{
+				Level: loggerSink.Level,
+				Sink:  loggerSink.Sink,
+			})
+		}
+	} else {
+		loggerSinkBindings = config.Logger.Functions
+	}
+
+	return config.getLoggerSinksWithLevel(loggerSinkBindings)
+}
+
+func (config *Config) getLoggerSinksWithLevel(loggerSinkBindings []LoggerSinkBinding) ([]LoggerSinkWithLevel, error) {
+	var result []LoggerSinkWithLevel
+
+	// iterate over system bindings, look for logger sink by name
+	for _, sinkBinding := range loggerSinkBindings {
+
+		// get sink by name
+		sink, sinkFound := config.Logger.Sinks[sinkBinding.Sink]
+		if !sinkFound {
+			return nil, fmt.Errorf("Failed to find logger sink %s", sinkBinding.Sink)
+		}
+
+		result = append(result, LoggerSinkWithLevel{
+			Level: sinkBinding.Level,
+			Sink:  sink,
+		})
+	}
+
+	return result, nil
+}

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -71,9 +71,9 @@ metrics:
       url: 10.0.0.1:30
       attributes:
         someInterval: 10s
-  systemSinks:
+  system:
   - mypush
-  functionSinks:
+  functions:
   - mypush
 `
 

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -1,0 +1,344 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platformconfig
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/zap"
+	"github.com/nuclio/nuclio/test/compare"
+
+	"github.com/nuclio/nuclio-sdk"
+	"github.com/stretchr/testify/suite"
+)
+
+type PlatformConfigTestSuite struct {
+	suite.Suite
+	logger nuclio.Logger
+	reader *Reader
+}
+
+func (suite *PlatformConfigTestSuite) SetupTest() {
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
+	suite.reader, _ = NewReader(suite.logger)
+}
+
+func (suite *PlatformConfigTestSuite) TestReadConfiguration() {
+	configurationContents := `
+webAdmin:
+  enabled: true
+  listenAddress: :8081
+logger:
+  sinks:
+    stdout:
+      driver: stdout
+    staging-es:
+      driver: elasticsearch
+      url: http://10.0.0.1:9200
+    prod-es:
+      driver: elasticsearch
+      url: http://20.0.1:9200
+      attributes:
+        dontCrash: true
+  system:
+  - level: debug
+    sink: prod-es
+  - level: info
+    sink: stdout
+  functions:
+  - level: info
+    sink: stdout
+metrics:
+  sinks:
+    mypush:
+      driver: prometheusPush
+      url: 10.0.0.1:30
+      attributes:
+        someInterval: 10s
+  enabled: true
+  defaultSink: mypush
+`
+
+	var readConfiguration, expectedConfiguration Config
+
+	// init expected
+	expectedConfiguration.WebAdmin.Enabled = true
+	expectedConfiguration.WebAdmin.ListenAddress = ":8081"
+
+	// logger
+	expectedConfiguration.Logger.System = append(expectedConfiguration.Logger.System, LoggerSinkBinding{
+		Level: "debug",
+		Sink:  "prod-es",
+	})
+
+	expectedConfiguration.Logger.System = append(expectedConfiguration.Logger.System, LoggerSinkBinding{
+		Level: "info",
+		Sink:  "stdout",
+	})
+
+	expectedConfiguration.Logger.Functions = append(expectedConfiguration.Logger.Functions, LoggerSinkBinding{
+		Level: "info",
+		Sink:  "stdout",
+	})
+
+	// logger sinks
+	expectedConfiguration.Logger.Sinks = map[string]LoggerSink{}
+
+	expectedConfiguration.Logger.Sinks["stdout"] = LoggerSink{
+		Driver: "stdout",
+	}
+
+	expectedConfiguration.Logger.Sinks["staging-es"] = LoggerSink{
+		Driver: "elasticsearch",
+		URL:    "http://10.0.0.1:9200",
+	}
+
+	expectedConfiguration.Logger.Sinks["prod-es"] = LoggerSink{
+		Driver: "elasticsearch",
+		URL:    "http://20.0.1:9200",
+		Attributes: map[string]interface{}{
+			"dontCrash": true,
+		},
+	}
+
+	// metric
+	expectedConfiguration.Metrics.Enabled = true
+	expectedConfiguration.Metrics.DefaultSink = "mypush"
+
+	// metric sinks
+	expectedConfiguration.Metrics.Sinks = map[string]MetricSink{}
+
+	expectedConfiguration.Metrics.Sinks["mypush"] = MetricSink{
+		Driver: "prometheusPush",
+		URL:    "10.0.0.1:30",
+		Attributes: map[string]interface{}{
+			"someInterval": "10s",
+		},
+	}
+
+	// read configuration
+	err := suite.reader.Read(bytes.NewBufferString(configurationContents), "yaml", &readConfiguration)
+	suite.Require().NoError(err)
+
+	suite.Require().True(compare.CompareNoOrder(expectedConfiguration, readConfiguration))
+}
+
+func (suite *PlatformConfigTestSuite) TestGetSystemLoggerSinks() {
+	configurationContents := `
+logger:
+  sinks:
+    stdout:
+      driver: stdout
+    staging-es:
+      driver: elasticsearch
+      url: http://10.0.0.1:9200
+    prod-es:
+      driver: elasticsearch
+      url: http://20.0.1:9200
+  system:
+  - level: debug
+    sink: prod-es
+  - level: info
+    sink: stdout
+`
+
+	var readConfiguration Config
+
+	// read configuration
+	err := suite.reader.Read(bytes.NewBufferString(configurationContents), "yaml", &readConfiguration)
+	suite.Require().NoError(err)
+
+	systemLoggerSinks, err := readConfiguration.GetSystemLoggerSinks()
+	suite.Require().NoError(err)
+
+	expectedSystemLoggerSinks := []LoggerSinkWithLevel{
+		{
+			Level: "debug",
+			Sink: LoggerSink{
+				Driver: "elasticsearch",
+				URL:    "http://20.0.1:9200",
+			},
+		},
+		{
+			Level: "info",
+			Sink: LoggerSink{
+				Driver: "stdout",
+			},
+		},
+	}
+
+	suite.Require().True(compare.CompareNoOrder(expectedSystemLoggerSinks, systemLoggerSinks))
+}
+
+func (suite *PlatformConfigTestSuite) TestGetSystemLoggerSinksInvalidSink() {
+	configurationContents := `
+logger:
+  sinks:
+    stdout:
+      driver: stdout
+    staging-es:
+      driver: elasticsearch
+      url: http://10.0.0.1:9200
+    prod-es:
+      driver: elasticsearch
+      url: http://20.0.1:9200
+  system:
+  - level: debug
+    sink: blah
+  - level: info
+    sink: stdout
+`
+
+	var readConfiguration Config
+
+	// read configuration
+	err := suite.reader.Read(bytes.NewBufferString(configurationContents), "yaml", &readConfiguration)
+	suite.Require().NoError(err)
+
+	_, err = readConfiguration.GetSystemLoggerSinks()
+	suite.Require().Error(err)
+}
+
+func (suite *PlatformConfigTestSuite) TestGetFunctionLoggerSinksNoFunctionConfig() {
+	configurationContents := `
+logger:
+  sinks:
+    stdout:
+      driver: stdout
+    staging-es:
+      driver: elasticsearch
+      url: http://10.0.0.1:9200
+    prod-es:
+      driver: elasticsearch
+      url: http://20.0.1:9200
+  functions:
+  - level: info
+    sink: stdout
+`
+
+	var readConfiguration Config
+
+	// read configuration
+	err := suite.reader.Read(bytes.NewBufferString(configurationContents), "yaml", &readConfiguration)
+	suite.Require().NoError(err)
+
+	functionLoggerSinks, err := readConfiguration.GetFunctionLoggerSinks(functionconfig.NewConfig())
+	suite.Require().NoError(err)
+
+	expectedFunctionLoggerSinks := []LoggerSinkWithLevel{
+		{
+			Level: "info",
+			Sink: LoggerSink{
+				Driver: "stdout",
+			},
+		},
+	}
+
+	suite.Require().True(compare.CompareNoOrder(expectedFunctionLoggerSinks, functionLoggerSinks))
+}
+
+
+func (suite *PlatformConfigTestSuite) TestGetFunctionLoggerSinksWithFunctionConfig() {
+	configurationContents := `
+logger:
+  sinks:
+    stdout:
+      driver: stdout
+    staging-es:
+      driver: elasticsearch
+      url: http://10.0.0.1:9200
+    prod-es:
+      driver: elasticsearch
+      url: http://20.0.1:9200
+  functions:
+  - level: info
+    sink: stdout
+`
+
+	var readConfiguration Config
+
+	// read configuration
+	err := suite.reader.Read(bytes.NewBufferString(configurationContents), "yaml", &readConfiguration)
+	suite.Require().NoError(err)
+
+	functionConfig := functionconfig.NewConfig()
+	functionConfig.Spec.LoggerSinks = []functionconfig.LoggerSink{
+		{
+			Level: "debug",
+			Sink: "staging-es",
+		},
+		{
+			Level: "warn",
+			Sink: "stdout",
+		},
+	}
+
+	functionLoggerSinks, err := readConfiguration.GetFunctionLoggerSinks(functionConfig)
+	suite.Require().NoError(err)
+
+	expectedFunctionLoggerSinks := []LoggerSinkWithLevel{
+		{
+			Level: "warn",
+			Sink: LoggerSink{
+				Driver: "stdout",
+			},
+		},
+		{
+			Level: "debug",
+			Sink: LoggerSink{
+				Driver: "elasticsearch",
+				URL:    "http://10.0.0.1:9200",
+			},
+		},
+	}
+
+	suite.Require().True(compare.CompareNoOrder(expectedFunctionLoggerSinks, functionLoggerSinks))
+}
+
+
+func (suite *PlatformConfigTestSuite) TestGetFunctionLoggerSinksInvalidSink() {
+	configurationContents := `
+logger:
+  sinks:
+    stdout:
+      driver: stdout
+    staging-es:
+      driver: elasticsearch
+      url: http://10.0.0.1:9200
+    prod-es:
+      driver: elasticsearch
+      url: http://20.0.1:9200
+  functions:
+  - level: info
+    sink: blah
+`
+
+	var readConfiguration Config
+
+	// read configuration
+	err := suite.reader.Read(bytes.NewBufferString(configurationContents), "yaml", &readConfiguration)
+	suite.Require().NoError(err)
+
+	_, err = readConfiguration.GetFunctionLoggerSinks(functionconfig.NewConfig())
+	suite.Require().Error(err)
+}
+
+func TestRegistryTestSuite(t *testing.T) {
+	suite.Run(t, new(PlatformConfigTestSuite))
+}

--- a/pkg/platformconfig/reader.go
+++ b/pkg/platformconfig/reader.go
@@ -22,21 +22,16 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/nuclio/nuclio/pkg/errors"
-
-	"github.com/nuclio/nuclio-sdk"
 )
 
 type Reader struct {
-	logger nuclio.Logger
 }
 
-func NewReader(parentLogger nuclio.Logger) (*Reader, error) {
-	return &Reader{
-		logger: parentLogger.GetChild("reader"),
-	}, nil
+func NewReader() (*Reader, error) {
+	return &Reader{}, nil
 }
 
-func (r *Reader) Read(reader io.Reader, configType string, config *Config) error {
+func (r *Reader) Read(reader io.Reader, configType string, config *Configuration) error {
 	configBytes, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return errors.Wrap(err, "Failed to read processor configuration")

--- a/pkg/platformconfig/reader.go
+++ b/pkg/platformconfig/reader.go
@@ -1,1 +1,46 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package platformconfig
+
+import (
+	"io"
+	"io/ioutil"
+
+	"github.com/ghodss/yaml"
+	"github.com/nuclio/nuclio/pkg/errors"
+
+	"github.com/nuclio/nuclio-sdk"
+)
+
+type Reader struct {
+	logger nuclio.Logger
+}
+
+func NewReader(parentLogger nuclio.Logger) (*Reader, error) {
+	return &Reader{
+		logger: parentLogger.GetChild("reader"),
+	}, nil
+}
+
+func (r *Reader) Read(reader io.Reader, configType string, config *Config) error {
+	configBytes, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return errors.Wrap(err, "Failed to read processor configuration")
+	}
+
+	return yaml.Unmarshal(configBytes, config)
+}

--- a/pkg/platformconfig/reader.go
+++ b/pkg/platformconfig/reader.go
@@ -20,8 +20,9 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/ghodss/yaml"
 	"github.com/nuclio/nuclio/pkg/errors"
+
+	"github.com/ghodss/yaml"
 )
 
 type Reader struct {

--- a/pkg/platformconfig/reader.go
+++ b/pkg/platformconfig/reader.go
@@ -1,0 +1,1 @@
+package platformconfig

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -1,0 +1,46 @@
+package platformconfig
+
+type LoggerSink struct {
+	Driver     string                 `json:"driver,omitempty"`
+	URL        string                 `json:"url,omitempty"`
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
+}
+
+type SystemLogger struct {
+	Level string `json:"level,omitempty"`
+	Sink  string `json:"sink,omitempty"`
+}
+
+type FunctionsLogger struct {
+	DefaultLevel string `json:"defaultLevel,omitempty"`
+	DefaultSink  string `json:"defaultSink,omitempty"`
+}
+
+type Logger struct {
+	Sinks     map[string]LoggerSink `json:"sinks,omitempty"`
+	System    SystemLogger          `json:"system,omitempty"`
+	Functions FunctionsLogger       `json:"functions,omitempty"`
+}
+
+type WebAdmin struct {
+	Enabled       bool   `json:"enabled,omitempty"`
+	ListenAddress string `json:"listenAddress,omitempty"`
+}
+
+type MetricSink struct {
+	Driver     string                 `json:"driver,omitempty"`
+	URL        string                 `json:"url,omitempty"`
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
+}
+
+type Metrics struct {
+	Sinks       map[string]MetricSink `json:"sinks,omitempty"`
+	Enabled     bool                  `json:"enabled,omitempty"`
+	DefaultSink string                `json:"defaultSink,omitempty"`
+}
+
+type Config struct {
+	WebAdmin WebAdmin `json:"webAdmin,omitempty"`
+	Logger   Logger   `json:"logger,omitempty"`
+	Metrics  Metrics  `json:"metrics,omitempty"`
+}

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package platformconfig
 
 type LoggerSink struct {
@@ -6,7 +22,12 @@ type LoggerSink struct {
 	Attributes map[string]interface{} `json:"attributes,omitempty"`
 }
 
-type SystemLogger struct {
+type LoggerSinkWithLevel struct {
+	Level string
+	Sink  LoggerSink
+}
+
+type LoggerSinkBinding struct {
 	Level string `json:"level,omitempty"`
 	Sink  string `json:"sink,omitempty"`
 }
@@ -18,8 +39,8 @@ type FunctionsLogger struct {
 
 type Logger struct {
 	Sinks     map[string]LoggerSink `json:"sinks,omitempty"`
-	System    SystemLogger          `json:"system,omitempty"`
-	Functions FunctionsLogger       `json:"functions,omitempty"`
+	System    []LoggerSinkBinding   `json:"system,omitempty"`
+	Functions []LoggerSinkBinding   `json:"functions,omitempty"`
 }
 
 type WebAdmin struct {
@@ -37,10 +58,4 @@ type Metrics struct {
 	Sinks       map[string]MetricSink `json:"sinks,omitempty"`
 	Enabled     bool                  `json:"enabled,omitempty"`
 	DefaultSink string                `json:"defaultSink,omitempty"`
-}
-
-type Config struct {
-	WebAdmin WebAdmin `json:"webAdmin,omitempty"`
-	Logger   Logger   `json:"logger,omitempty"`
-	Metrics  Metrics  `json:"metrics,omitempty"`
 }

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -55,7 +55,7 @@ type MetricSink struct {
 }
 
 type Metrics struct {
-	Sinks       map[string]MetricSink `json:"sinks,omitempty"`
-	Enabled     bool                  `json:"enabled,omitempty"`
-	DefaultSink string                `json:"defaultSink,omitempty"`
+	Sinks     map[string]MetricSink `json:"sinks,omitempty"`
+	System    []string              `json:"system,omitempty"`
+	Functions []string              `json:"functions,omitempty"`
 }

--- a/pkg/processor/build/template.go
+++ b/pkg/processor/build/template.go
@@ -28,5 +28,5 @@ RUN {{.}}
 {{end}}
 {{end}}
 
-CMD [ "processor", "--config", "/etc/nuclio/processor.yaml", "--platform", "/etc/nuclio/platform.yaml" ]
+CMD [ "processor", "--config", "/etc/nuclio/config/processor/processor.yaml", "--platform-config", "/etc/nuclio/config/platform/platform.yaml" ]
 `

--- a/pkg/processor/build/template.go
+++ b/pkg/processor/build/template.go
@@ -28,5 +28,5 @@ RUN {{.}}
 {{end}}
 {{end}}
 
-CMD [ "processor", "--config", "/etc/nuclio/processor.yaml" ]
+CMD [ "processor", "--config", "/etc/nuclio/processor.yaml", "--platform", "/etc/nuclio/platform.yaml" ]
 `

--- a/pkg/processor/runtime/shell/test/shell_test.go
+++ b/pkg/processor/runtime/shell/test/shell_test.go
@@ -45,7 +45,7 @@ func (suite *TestSuite) TestOutputs() {
 
 	expectedResponseHeaders := map[string]string{
 		"content-type": "text/plain; charset=utf-8",
-		"header1": "value1",
+		"header1":      "value1",
 	}
 
 	deployOptions := suite.GetDeployOptions("outputter",

--- a/pkg/processor/statistics/metricpusher.go
+++ b/pkg/processor/statistics/metricpusher.go
@@ -35,13 +35,13 @@ type triggerProvider interface {
 }
 
 type MetricPusher struct {
-	logger              nuclio.Logger
-	metricRegistry      *prometheus.Registry
-	jobName             string
-	instanceName        string
-	pushGatewayURL      string
-	pushInterval 		time.Duration
-	gatherers           []Gatherer
+	logger         nuclio.Logger
+	metricRegistry *prometheus.Registry
+	jobName        string
+	instanceName   string
+	pushGatewayURL string
+	pushInterval   time.Duration
+	gatherers      []Gatherer
 }
 
 func NewMetricPusher(parentLogger nuclio.Logger,

--- a/pkg/processor/statistics/metricpusher.go
+++ b/pkg/processor/statistics/metricpusher.go
@@ -20,13 +20,14 @@ import (
 	"os"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
 
 	"github.com/nuclio/nuclio-sdk"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
-	"github.com/spf13/viper"
 )
 
 type triggerProvider interface {
@@ -39,14 +40,13 @@ type MetricPusher struct {
 	jobName             string
 	instanceName        string
 	pushGatewayURL      string
-	pushIntervalSeconds int
+	pushInterval 		time.Duration
 	gatherers           []Gatherer
-	enabled             bool
 }
 
 func NewMetricPusher(parentLogger nuclio.Logger,
 	triggerProvider triggerProvider,
-	configuration *viper.Viper) (*MetricPusher, error) {
+	metricSinkConfiguration *platformconfig.MetricSink) (*MetricPusher, error) {
 
 	newMetricPusher := &MetricPusher{
 		logger:         parentLogger.GetChild("metrics"),
@@ -54,7 +54,7 @@ func NewMetricPusher(parentLogger nuclio.Logger,
 	}
 
 	// read configuration
-	if err := newMetricPusher.readConfiguration(configuration); err != nil {
+	if err := newMetricPusher.readConfiguration(metricSinkConfiguration); err != nil {
 		return nil, errors.Wrap(err, "Failed to read configuration")
 	}
 
@@ -64,48 +64,40 @@ func NewMetricPusher(parentLogger nuclio.Logger,
 	}
 
 	newMetricPusher.logger.InfoWith("Metrics pusher created",
-		"enabeld", newMetricPusher.enabled,
 		"jobName", newMetricPusher.jobName,
 		"instanceName", newMetricPusher.instanceName,
 		"pushGatewayURL", newMetricPusher.pushGatewayURL,
-		"pushInterval", newMetricPusher.pushIntervalSeconds)
+		"pushInterval", newMetricPusher.pushInterval)
 
 	return newMetricPusher, nil
 }
 
 func (mp *MetricPusher) Start() error {
-	if !mp.enabled {
-		mp.logger.InfoWith("Disabled, will not push metrics")
-		return nil
-	}
-
 	go mp.periodicallyPushMetrics()
 
 	return nil
 }
 
-func (mp *MetricPusher) readConfiguration(configuration *viper.Viper) error {
-	pushGatewayURLDefault := os.Getenv("NUCLIO_PROM_PUSH_GATEWAY_URL")
-	if pushGatewayURLDefault == "" {
-		pushGatewayURLDefault = "http://prometheus-prometheus-pushgateway:9091"
+func (mp *MetricPusher) readConfiguration(metricSinkConfiguration *platformconfig.MetricSink) error {
+	var err error
+	mp.pushGatewayURL = metricSinkConfiguration.URL
+
+	intervalString := common.MapStringInterfaceGetOrDefault(metricSinkConfiguration.Attributes,
+		"interval",
+		"10s").(string)
+
+	mp.pushInterval, err = time.ParseDuration(intervalString)
+	if err != nil {
+		return errors.Wrap(err, "Failed to parse metric interval")
 	}
 
-	pushInterval := os.Getenv("NUCLIO_PROM_PUSH_INTERVAL")
-	if pushInterval == "" {
-		pushInterval = "10"
-	}
+	mp.jobName = common.MapStringInterfaceGetOrDefault(metricSinkConfiguration.Attributes,
+		"jobName",
+		os.Getenv("NUCLIO_FUNCTION_NAME")).(string)
 
-	configuration.SetDefault("job_name", os.Getenv("NUCLIO_FUNCTION_NAME"))
-	configuration.SetDefault("instance", os.Getenv("NUCLIO_FUNCTION_INSTANCE"))
-	configuration.SetDefault("push_gateway_url", pushGatewayURLDefault)
-	configuration.SetDefault("push_interval", pushInterval)
-	configuration.SetDefault("enabled", true)
-
-	mp.enabled = configuration.GetBool("enabled")
-	mp.pushGatewayURL = configuration.GetString("push_gateway_url")
-	mp.jobName = configuration.GetString("job_name")
-	mp.instanceName = configuration.GetString("instance")
-	mp.pushIntervalSeconds = configuration.GetInt("push_interval")
+	mp.instanceName = common.MapStringInterfaceGetOrDefault(metricSinkConfiguration.Attributes,
+		"instance",
+		os.Getenv("NUCLIO_FUNCTION_INSTANCE")).(string)
 
 	return nil
 }
@@ -141,7 +133,7 @@ func (mp *MetricPusher) periodicallyPushMetrics() {
 	for {
 
 		// every mp.pushInterval seconds
-		time.Sleep(time.Duration(mp.pushIntervalSeconds) * time.Second)
+		time.Sleep(mp.pushInterval)
 
 		// gather the metrics from the triggers - this will update the metrics
 		// from counters internally held by triggers and their child objects
@@ -150,10 +142,9 @@ func (mp *MetricPusher) periodicallyPushMetrics() {
 		// AddFromGatherer is used here rather than FromGatherer to not delete a
 		// previously pushed success timestamp in case of a failure of this
 		// backup.
-		push.AddFromGatherer(mp.jobName, nil, mp.pushGatewayURL, mp.metricRegistry)
-
-		// TODO: log a warning here when prometheus is configured via a platform configuration
-		// mp.logger.WarnWith("Failed to push metrics", "err", err)
+		if err := push.AddFromGatherer(mp.jobName, nil, mp.pushGatewayURL, mp.metricRegistry); err != nil {
+			mp.logger.WarnWith("Failed to push metrics", "err", err)
+		}
 	}
 }
 


### PR DESCRIPTION
1. On deploy, the processor attempts to open /etc/nuclio/configs/platform/platform.yaml`. This has the following format:

```
webAdmin:
  enabled: true
  listenAddress: :8081
logger:
  sinks:
    stdout:
      driver: stdout
    staging-es:
      driver: elasticsearch
      url: http://10.0.0.1:9200
    prod-es:
      driver: elasticsearch
      url: http://20.0.1:9200
      attributes:
        dontCrash: true
  system:
  - level: debug
    sink: prod-es
  - level: info
    sink: stdout
  functions:
  - level: info
    sink: stdout
metrics:
  sinks:
    mypush:
      driver: prometheusPush
      url: 10.0.0.1:30
      attributes:
        interval: 10s
  system:
  - mypush
  functions:
  - mypush
```

If the file doesn't exist, sane defaults are loaded (logs to stdout, metrics and webadmin disabled).

At the moment, only `metrics` is respected by the processor though the `platformconfig` module handles all aspects of this configuration.

2. Controller, on deployment, will attempt to map the `platform-config` configmap in the function's namespace to `/etc/nuclio/configs/platform/platform.yaml`. If this configmap exists, it should contain a valid platform configuration

3. Controller can be configured to listen for function changes on specific namespaces, as per the `NUCLIO_CONTROLLER_NAMESPACE` environment variable:
3.1. Lack of this env variable or `*` means listen on all namespaces
3.2. A value of `@nuclio.selfNamespace` means the controller will only listen for functions created on its namespace
3.3. Any other value (e.g. "default", "foo") will listen for function changes on that namespace