### PR TITLE
Playground refreshes docker credentials

### DIFF
--- a/cmd/playground/app/playground.go
+++ b/cmd/playground/app/playground.go
@@ -89,7 +89,7 @@ func getDefaultCredRefreshInterval(logger *nucliozap.NuclioZap, defaultCredRefre
 
 	// if unspecified, default to 12 hours
 	if defaultCredRefreshIntervalString == "" {
-		defaultCredRefreshInterval = defaultInterval
+		return &defaultInterval
 	}
 
 	// try to parse the refresh interval - if failed
@@ -99,7 +99,7 @@ func getDefaultCredRefreshInterval(logger *nucliozap.NuclioZap, defaultCredRefre
 			"given", defaultCredRefreshIntervalString,
 			"default", defaultInterval)
 
-		defaultCredRefreshInterval = defaultInterval
+		return &defaultInterval
 	}
 
 	return &defaultCredRefreshInterval

--- a/cmd/playground/app/playground.go
+++ b/cmd/playground/app/playground.go
@@ -17,6 +17,8 @@ limitations under the License.
 package app
 
 import (
+	"time"
+
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/platform/factory"
 	"github.com/nuclio/nuclio/pkg/playground"
@@ -31,7 +33,8 @@ func Run(listenAddress string,
 	defaultRegistryURL string,
 	defaultRunRegistryURL string,
 	platformType string,
-	noPullBaseImages bool) error {
+	noPullBaseImages bool,
+	defaultCredRefreshIntervalString string) error {
 
 	logger, err := nucliozap.NewNuclioZapCmd("playground", nucliozap.DebugLevel)
 	if err != nil {
@@ -44,7 +47,10 @@ func Run(listenAddress string,
 		return errors.Wrap(err, "Failed to create platform")
 	}
 
-	logger.InfoWith("Starting", "name", platformInstance.GetName(), "noPull", noPullBaseImages)
+	logger.InfoWith("Starting",
+		"name", platformInstance.GetName(),
+		"noPull", noPullBaseImages,
+		"defaultCredRefreshInterval", defaultCredRefreshIntervalString)
 
 	version.Log(logger)
 
@@ -55,7 +61,8 @@ func Run(listenAddress string,
 		defaultRegistryURL,
 		defaultRunRegistryURL,
 		platformInstance,
-		noPullBaseImages)
+		noPullBaseImages,
+		getDefaultCredRefreshInterval(logger, defaultCredRefreshIntervalString))
 	if err != nil {
 		return errors.Wrap(err, "Failed to create server")
 	}
@@ -69,4 +76,31 @@ func Run(listenAddress string,
 	}
 
 	select {}
+}
+
+func getDefaultCredRefreshInterval(logger *nucliozap.NuclioZap, defaultCredRefreshIntervalString string) *time.Duration {
+	var defaultCredRefreshInterval time.Duration
+	defaultInterval := 12 * time.Hour
+
+	// if set to "none" - no refresh interval
+	if defaultCredRefreshIntervalString == "none" {
+		return nil
+	}
+
+	// if unspecified, default to 12 hours
+	if defaultCredRefreshIntervalString == "" {
+		defaultCredRefreshInterval = defaultInterval
+	}
+
+	// try to parse the refresh interval - if failed
+	defaultCredRefreshInterval, err := time.ParseDuration(defaultCredRefreshIntervalString)
+	if err != nil {
+		logger.WarnWith("Failed to parse default credential refresh interval, defaulting",
+			"given", defaultCredRefreshIntervalString,
+			"default", defaultInterval)
+
+		defaultCredRefreshInterval = defaultInterval
+	}
+
+	return &defaultCredRefreshInterval
 }

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -41,6 +41,7 @@ func main() {
 	defaultRegistryURL := flag.String("registry", defaultRegistry, "Default registry URL")
 	defaultRunRegistryURL := flag.String("run-registry", os.Getenv("NUCLIO_PLAYGROUND_RUN_REGISTRY_URL"), "Default run registry URL")
 	noPullBaseImages := flag.Bool("no-pull", defaultNoPullBaseImages, "Default run registry URL")
+	credsRefreshInterval := flag.String("creds-refresh-interval", os.Getenv("NUCLIO_PLAYGROUND_CREDS_REFRESH_INTERVAL"), "Default credential refresh interval, or 'none' (12h by default)")
 
 	flag.Parse()
 
@@ -51,7 +52,8 @@ func main() {
 		*defaultRegistryURL,
 		*defaultRunRegistryURL,
 		*platformType,
-		*noPullBaseImages); err != nil {
+		*noPullBaseImages,
+		*credsRefreshInterval); err != nil {
 		os.Exit(1)
 	}
 

--- a/pkg/dockercreds/dockercred.go
+++ b/pkg/dockercreds/dockercred.go
@@ -79,7 +79,7 @@ func (dc *dockerCred) initialize() error {
 	dc.url = url
 
 	// try to login
-	if err := dc.login(); err != nil {
+	if err = dc.login(); err != nil {
 		return err
 	}
 
@@ -129,9 +129,9 @@ func extractMetaFromKeyPath(keyPath string) (string, string, string, error) {
 	// return the user and URL
 	if len(meta) == 2 {
 		return meta[0], meta[1], "", nil
-	} else {
-		return meta[0], meta[1], meta[2], nil
 	}
+
+	return meta[0], meta[1], meta[2], nil
 }
 
 func (dc *dockerCred) login() error {
@@ -142,7 +142,7 @@ func (dc *dockerCred) login() error {
 	// try to login
 	return dc.dockerCreds.dockerClient.LogIn(&dockerclient.LogInOptions{
 		Username: dc.username,
-		Password: string(dc.password),
+		Password: dc.password,
 		URL:      "https://" + dc.url,
 	})
 }
@@ -169,11 +169,8 @@ func (dc *dockerCred) refreshCredentials(refreshInterval time.Duration) {
 	refreshTicker := time.NewTicker(refreshInterval)
 
 	go func() {
-		for {
-			select {
-			case <-refreshTicker.C:
-				dc.login()
-			}
+		for range refreshTicker.C {
+			dc.login()
 		}
 	}()
 }

--- a/pkg/dockercreds/dockercred.go
+++ b/pkg/dockercreds/dockercred.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockercreds
+
+import (
+	"io/ioutil"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/dockerclient"
+	"github.com/nuclio/nuclio/pkg/errors"
+)
+
+type dockerCred struct {
+	path string
+	dockerCreds *DockerCreds
+	defaultRefreshInterval *time.Duration
+	username string
+	password string
+	url string
+}
+
+func newDockerCred(dockerCreds *DockerCreds, path string,
+	defaultRefreshInterval *time.Duration) (*dockerCred, error) {
+	newDockerCred := &dockerCred{
+		path: path,
+		dockerCreds: dockerCreds,
+		defaultRefreshInterval: defaultRefreshInterval,
+	}
+
+	if err := newDockerCred.initialize(); err != nil {
+		return nil, err
+	}
+
+	return newDockerCred, nil
+}
+
+func (dc *dockerCred) initialize() error {
+	var err error
+
+	fileName := path.Base(dc.path)
+
+	password, err := ioutil.ReadFile(dc.path)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to read docker key file @ %s", dc.path)
+	}
+
+	// get the URL and username
+	username, url, refreshIntervalString, err := extractMetaFromKeyPath(fileName)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to get user / url from path @ %s", dc.path)
+	}
+
+	dc.dockerCreds.logger.InfoWith("Initializing docker credential",
+		"path", dc.path,
+		"username", username,
+		"passwordLen", len(password),
+		"url", url,
+		"refreshInterval", refreshIntervalString)
+
+	// save in members
+	dc.username = username
+	dc.password = string(password)
+	dc.url = url
+
+	// try to login
+	if err := dc.login(); err != nil {
+		return err
+	}
+
+	refreshInterval, err := parseRefreshInterval(refreshIntervalString)
+	if err != nil {
+
+		// if failed, we still want to try with the default refresh interval
+		dc.dockerCreds.logger.WarnWith("Failed to read given refresh interval, trying default",
+			"err", err,
+			"path", dc.path,
+			"refreshInterval", refreshIntervalString)
+	}
+
+	// if we didn't get a refresh interval in the cred file name, try the default
+	if refreshInterval == nil {
+		refreshInterval = dc.defaultRefreshInterval
+	}
+
+	if refreshInterval != nil {
+		dc.refreshCredentials(*refreshInterval)
+	}
+
+	return nil
+}
+
+func extractMetaFromKeyPath(keyPath string) (string, string, string, error) {
+	dockerKeyBase := path.Base(keyPath)
+	dockerKeyExt := path.Ext(dockerKeyBase)
+
+	// get just the file name
+	dockerKeyFileWithoutExt := dockerKeyBase[:len(dockerKeyBase)-len(dockerKeyExt)]
+
+	// expect user@url in the ext
+	meta := strings.Split(dockerKeyFileWithoutExt, "---")
+	if len(meta) < 2 || len(meta) > 3 {
+		return "", "", "", errors.New("Expected file name to contain either user---url or user--url---refresh")
+	}
+
+	if len(meta[0]) == 0 {
+		return "", "", "", errors.New("Username is empty")
+	}
+
+	if len(meta[1]) == 0 {
+		return "", "", "", errors.New("URL is empty")
+	}
+
+	// return the user and URL
+	if len(meta) == 2 {
+		return meta[0], meta[1], "", nil
+	} else {
+		return meta[0], meta[1], meta[2], nil
+	}
+}
+
+func (dc *dockerCred) login() error {
+	dc.dockerCreds.logger.DebugWith("Logging in",
+		"url", dc.path,
+		"user", dc.username)
+
+	// try to login
+	return dc.dockerCreds.dockerClient.LogIn(&dockerclient.LogInOptions{
+		Username: dc.username,
+		Password: string(dc.password),
+		URL:      "https://" + dc.url,
+	})
+}
+
+func parseRefreshInterval(refreshInterval string) (*time.Duration, error) {
+	if refreshInterval == "" {
+		return nil, nil
+	}
+
+	refreshIntervalDuration, err := time.ParseDuration(refreshInterval)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to parse refresh interval duration")
+	}
+
+	return &refreshIntervalDuration, nil
+}
+
+func (dc *dockerCred) refreshCredentials(refreshInterval time.Duration) {
+	dc.dockerCreds.logger.InfoWith("Refreshing credentials periodically",
+		"path", dc.path,
+		"refreshInterval", refreshInterval)
+
+	refreshTicker := time.NewTicker(refreshInterval)
+
+	go func() {
+		for {
+			select {
+			case <- refreshTicker.C:
+				dc.login()
+			}
+		}
+	}()
+}

--- a/pkg/dockercreds/dockercred.go
+++ b/pkg/dockercreds/dockercred.go
@@ -27,19 +27,19 @@ import (
 )
 
 type dockerCred struct {
-	path string
-	dockerCreds *DockerCreds
+	path                   string
+	dockerCreds            *DockerCreds
 	defaultRefreshInterval *time.Duration
-	username string
-	password string
-	url string
+	username               string
+	password               string
+	url                    string
 }
 
 func newDockerCred(dockerCreds *DockerCreds, path string,
 	defaultRefreshInterval *time.Duration) (*dockerCred, error) {
 	newDockerCred := &dockerCred{
-		path: path,
-		dockerCreds: dockerCreds,
+		path:                   path,
+		dockerCreds:            dockerCreds,
 		defaultRefreshInterval: defaultRefreshInterval,
 	}
 
@@ -171,7 +171,7 @@ func (dc *dockerCred) refreshCredentials(refreshInterval time.Duration) {
 	go func() {
 		for {
 			select {
-			case <- refreshTicker.C:
+			case <-refreshTicker.C:
 				dc.login()
 			}
 		}

--- a/pkg/dockercreds/dockercred.go
+++ b/pkg/dockercreds/dockercred.go
@@ -80,7 +80,11 @@ func (dc *dockerCred) initialize() error {
 
 	// try to login
 	if err = dc.login(); err != nil {
-		return err
+
+		// warn about failed login, but still try to refresh
+		dc.dockerCreds.logger.WarnWith("Failed to log in",
+			"err", err,
+			"path", dc.path)
 	}
 
 	refreshInterval, err := parseRefreshInterval(refreshIntervalString)

--- a/pkg/dockercreds/dockercreds.go
+++ b/pkg/dockercreds/dockercreds.go
@@ -40,8 +40,8 @@ func NewDockerCreds(parentLogger nuclio.Logger,
 	refreshInterval *time.Duration) (*DockerCreds, error) {
 
 	return &DockerCreds{
-		logger:       parentLogger.GetChild("loginner"),
-		dockerClient: dockerClient,
+		logger:          parentLogger.GetChild("loginner"),
+		dockerClient:    dockerClient,
 		refreshInterval: refreshInterval,
 	}, nil
 }

--- a/pkg/dockercreds/dockercreds.go
+++ b/pkg/dockercreds/dockercreds.go
@@ -19,7 +19,7 @@ package dockercreds
 import (
 	"io/ioutil"
 	"path"
-	"strings"
+	"time"
 
 	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/errors"
@@ -29,16 +29,20 @@ import (
 
 // DockerCreds initializes docker client credentials
 type DockerCreds struct {
-	logger       nuclio.Logger
-	dockerClient dockerclient.Client
+	logger          nuclio.Logger
+	dockerClient    dockerclient.Client
+	refreshInterval *time.Duration
+	dockerCreds     []*dockerCred
 }
 
 func NewDockerCreds(parentLogger nuclio.Logger,
-	dockerClient dockerclient.Client) (*DockerCreds, error) {
+	dockerClient dockerclient.Client,
+	refreshInterval *time.Duration) (*DockerCreds, error) {
 
 	return &DockerCreds{
 		logger:       parentLogger.GetChild("loginner"),
 		dockerClient: dockerClient,
+		refreshInterval: refreshInterval,
 	}, nil
 }
 
@@ -53,71 +57,17 @@ func (dc *DockerCreds) LoadFromDir(keyDir string) error {
 			continue
 		}
 
-		dockerKeyFileName := dockerKeyFileInfo.Name()
-		dockerKeyFilePath := path.Join(keyDir, dockerKeyFileName)
+		// create the full path of the docker credentials
+		dockerKeyFilePath := path.Join(keyDir, dockerKeyFileInfo.Name())
 
-		password, err := ioutil.ReadFile(dockerKeyFilePath)
+		dockerCred, err := newDockerCred(dc, dockerKeyFilePath, dc.refreshInterval)
 		if err != nil {
-			dc.logger.WarnWith("Failed to read docker key file",
-				"err", err.Error(),
-				"path", dockerKeyFileInfo.Name())
-
+			dc.logger.WarnWith("Failed to create docker cred", "err", err)
 			continue
 		}
 
-		// get the URL and username
-		username, url, err := dc.getUserAndURLFromKeyPath(dockerKeyFileName)
-		if err != nil {
-			dc.logger.WarnWith("Failed to get user / url from path",
-				"err", err.Error(),
-				"path", dockerKeyFileInfo.Name())
-
-			continue
-		}
-
-		dc.logger.InfoWith("Logging in to registry",
-			"path", dockerKeyFilePath,
-			"username", username,
-			"passwordLen", len(password),
-			"url", url)
-
-		// try to login
-		err = dc.dockerClient.LogIn(&dockerclient.LogInOptions{
-			Username: username,
-			Password: string(password),
-			URL:      "https://" + url,
-		})
-
-		if err != nil {
-			dc.logger.WarnWith("Failed to log in to docker", "err", err.Error())
-			continue
-		}
+		dc.dockerCreds = append(dc.dockerCreds, dockerCred)
 	}
 
 	return nil
-}
-
-func (dc *DockerCreds) getUserAndURLFromKeyPath(keyPath string) (string, string, error) {
-	dockerKeyBase := path.Base(keyPath)
-	dockerKeyExt := path.Ext(dockerKeyBase)
-
-	// get just the file name
-	dockerKeyFileWithoutExt := dockerKeyBase[:len(dockerKeyBase)-len(dockerKeyExt)]
-
-	// expect user@url in the ext
-	userAndURL := strings.Split(dockerKeyFileWithoutExt, "---")
-	if len(userAndURL) != 2 {
-		return "", "", errors.New("Expected file name to contain user---url")
-	}
-
-	if len(userAndURL[0]) == 0 {
-		return "", "", errors.New("Username is empty")
-	}
-
-	if len(userAndURL[1]) == 0 {
-		return "", "", errors.New("URL is empty")
-	}
-
-	// return the user and URL
-	return userAndURL[0], userAndURL[1], nil
 }


### PR DESCRIPTION
Fixes #494.

1. Interval is by default 12 hours
2. If file contains "interval" (in the format of `<name>---<url>---<interval>.json`) it overrides default
3. Playground can receive the default refresh interval either in args (`--creds-refresh-interval`) or environment variable (`NUCLIO_PLAYGROUND_CREDS_REFRESH_INTERVAL`)