### PR TITLE
Playground: fix issue with keyboard nav on filtered function list

### DIFF
--- a/cmd/playground/static/assets/app.js
+++ b/cmd/playground/static/assets/app.js
@@ -515,7 +515,7 @@ $(function () {
      */
     function navigateFunctionList(event) {
         // get currently selected option among all list items
-        var $options = $functionListItems.children();
+        var $options = $functionListItems.children(':visible');
         var currentFocusedOption = findFocusedOption();
         var currentFocusedIndex = $options.index(currentFocusedOption);
         var nextFocusedIndex = -1;


### PR DESCRIPTION
Keyboard navigation with up/down arrow keys broke when filtering the function list