### PR TITLE
Playground: fix suggesting to create new function with existing name

### DIFF
--- a/cmd/playground/static/assets/app.js
+++ b/cmd/playground/static/assets/app.js
@@ -591,8 +591,8 @@ $(function () {
             if (_.startsWith($element.text(), inputValue)) {
                 $element.show(0);
 
-                // test if this is an exact match
-                if ($element.text() === inputValue) {
+                // test if this is an exact match (omitting the runtime, taking the name only)
+                if ($element.text().replace(/\s+\(\w+\)/, '') === inputValue) {
                     exactMatch = true;
                 }
             }


### PR DESCRIPTION
On function list, when entering a name in the filter box and it
already exists, it should not display the "Create new" option at the
bottom of the list.