### PR TITLE
Playground uses platform invoker, kube invoker uses DNS

### DIFF
--- a/cmd/playground/static/assets/app.js
+++ b/cmd/playground/static/assets/app.js
@@ -991,8 +991,7 @@ $(function () {
      */
     function invokeFunction() {
         var path = '/' + _.trimStart($inputPath.val(), '/ ');
-        var httpPort = _.get(selectedFunction, 'spec.httpPort', 0);
-        var url = workingUrl + '/tunnel/' + loadedUrl.get('hostname') + ':' + httpPort + path;
+        var url = workingUrl + '/invocations';
         var method = $('#input-method').val();
         var body = isFileInput ? $invokeFile.get(0).files.item(0) : inputBodyEditor.getText();
         var contentType = isFileInput ? body.type : $inputContentType.val();
@@ -1008,6 +1007,9 @@ $(function () {
             contentType: contentType,
             processData: false,
             beforeSend: function (xhr) {
+                xhr.setRequestHeader('x-nuclio-path', path);
+                xhr.setRequestHeader('x-nuclio-function-name', _.get(selectedFunction, 'metadata.name'));
+                xhr.setRequestHeader('x-nuclio-function-namespace', _.get(selectedFunction, 'metadata.namespace', 'default'));
                 xhr.setRequestHeader('x-nuclio-log-level', level);
             }
         })

--- a/pkg/nuctl/command/invoke.go
+++ b/pkg/nuctl/command/invoke.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/mgutz/ansi"
@@ -61,9 +62,14 @@ func newInvokeCommandeer(rootCommandeer *RootCommandeer) *invokeCommandeer {
 			commandeer.invokeOptions.Name = args[0]
 			commandeer.invokeOptions.Namespace = rootCommandeer.namespace
 			commandeer.invokeOptions.Body = []byte(commandeer.body)
+			commandeer.invokeOptions.Headers = http.Header{}
 
-			commandeer.invokeOptions.Headers = common.StringToStringMap(commandeer.headers)
-			commandeer.invokeOptions.Headers["Content-Type"] = commandeer.contentType
+			// set headers
+			for headerName, headerValue := range common.StringToStringMap(commandeer.headers) {
+				commandeer.invokeOptions.Headers.Set(headerName, headerValue)
+			}
+
+			commandeer.invokeOptions.Headers.Set("Content-Type", commandeer.contentType)
 
 			// verify correctness of logger level
 			switch commandeer.invokeOptions.LogLevelName {

--- a/pkg/nuctl/command/invoke.go
+++ b/pkg/nuctl/command/invoke.go
@@ -24,13 +24,13 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/mgutz/ansi"
-	"github.com/nuclio/nuclio-sdk"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/zap"
 
+	"github.com/mgutz/ansi"
+	"github.com/nuclio/nuclio-sdk"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/platform/abstract/invoker.go
+++ b/pkg/platform/abstract/invoker.go
@@ -18,6 +18,7 @@ package abstract
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -55,7 +56,7 @@ func (i *invoker) invoke(invokeOptions *platform.InvokeOptions) (*platform.Invok
 	})
 
 	if len(functions) == 0 {
-		return nil, errors.Wrap(err, "Function not found")
+		return nil, fmt.Errorf("Function not found: %s @ %s", invokeOptions.Name, invokeOptions.Namespace)
 	}
 
 	// use the first function found (should always be one, but if there's more just use first)
@@ -103,9 +104,8 @@ func (i *invoker) invoke(invokeOptions *platform.InvokeOptions) (*platform.Invok
 		req.Header.Set("X-nuclio-log-level", invokeOptions.LogLevelName)
 	}
 
-	for headerName, headerValue := range invokeOptions.Headers {
-		req.Header.Set(headerName, headerValue)
-	}
+	// set headers
+	req.Header = invokeOptions.Headers
 
 	response, err := client.Do(req)
 	if err != nil {

--- a/pkg/platform/abstract/invoker.go
+++ b/pkg/platform/abstract/invoker.go
@@ -55,6 +55,10 @@ func (i *invoker) invoke(invokeOptions *platform.InvokeOptions) (*platform.Invok
 		Namespace: invokeOptions.Namespace,
 	})
 
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get functions")
+	}
+
 	if len(functions) == 0 {
 		return nil, fmt.Errorf("Function not found: %s @ %s", invokeOptions.Name, invokeOptions.Namespace)
 	}

--- a/pkg/platform/abstract/invoker.go
+++ b/pkg/platform/abstract/invoker.go
@@ -18,19 +18,13 @@ package abstract
 
 import (
 	"bytes"
-	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
-	"strings"
 
-	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/platform"
-	"github.com/nuclio/nuclio/pkg/zap"
 
-	"github.com/mgutz/ansi"
 	"github.com/nuclio/nuclio-sdk"
 )
 
@@ -49,7 +43,7 @@ func newInvoker(parentLogger nuclio.Logger, platform platform.Platform) (*invoke
 	return newinvoker, nil
 }
 
-func (i *invoker) invoke(invokeOptions *platform.InvokeOptions, writer io.Writer) error {
+func (i *invoker) invoke(invokeOptions *platform.InvokeOptions) (*platform.InvokeResult, error) {
 
 	// save options
 	i.invokeOptions = invokeOptions
@@ -61,7 +55,7 @@ func (i *invoker) invoke(invokeOptions *platform.InvokeOptions, writer io.Writer
 	})
 
 	if len(functions) == 0 {
-		return errors.Wrap(err, "Function not found")
+		return nil, errors.Wrap(err, "Function not found")
 	}
 
 	// use the first function found (should always be one, but if there's more just use first)
@@ -69,13 +63,13 @@ func (i *invoker) invoke(invokeOptions *platform.InvokeOptions, writer io.Writer
 
 	// make sure to initialize the function (some underlying functions are lazy load)
 	if err = function.Initialize(nil); err != nil {
-		return errors.Wrap(err, "Failed to initialize function")
+		return nil, errors.Wrap(err, "Failed to initialize function")
 	}
 
 	// get where the function resides
 	invokeURL, err := function.GetInvokeURL(invokeOptions.Via)
 	if err != nil {
-		return errors.Wrap(err, "Failed to get invoke URL")
+		return nil, errors.Wrap(err, "Failed to get invoke URL")
 	}
 
 	fullpath := "http://" + invokeURL
@@ -89,7 +83,7 @@ func (i *invoker) invoke(invokeOptions *platform.InvokeOptions, writer io.Writer
 
 	// set body for post
 	if invokeOptions.Method == "POST" {
-		body = bytes.NewBuffer([]byte(invokeOptions.Body))
+		body = bytes.NewBuffer(invokeOptions.Body)
 	}
 
 	i.logger.InfoWith("Executing function",
@@ -101,167 +95,36 @@ func (i *invoker) invoke(invokeOptions *platform.InvokeOptions, writer io.Writer
 	// issue the request
 	req, err = http.NewRequest(invokeOptions.Method, fullpath, body)
 	if err != nil {
-		return errors.Wrap(err, "Failed to create HTTP request")
+		return nil, errors.Wrap(err, "Failed to create HTTP request")
 	}
-
-	req.Header.Set("Content-Type", invokeOptions.ContentType)
 
 	// request logs from a given verbosity unless we're specified no logs should be returned
 	if invokeOptions.LogLevelName != "none" {
 		req.Header.Set("X-nuclio-log-level", invokeOptions.LogLevelName)
 	}
 
-	headers := common.StringToStringMap(invokeOptions.Headers)
-	for k, v := range headers {
-		req.Header.Set(k, v)
+	for headerName, headerValue := range invokeOptions.Headers {
+		req.Header.Set(headerName, headerValue)
 	}
 
 	response, err := client.Do(req)
 	if err != nil {
-		return errors.Wrap(err, "Failed to send HTTP request")
+		return nil, errors.Wrap(err, "Failed to send HTTP request")
 	}
 
 	defer response.Body.Close()
 
 	i.logger.InfoWith("Got response", "status", response.Status)
 
-	// try to output the logs (ignore errors)
-	if invokeOptions.LogLevelName != "none" {
-		i.outputFunctionLogs(response, writer)
-	}
-
-	// output the headers
-	i.outputResponseHeaders(response, writer)
-
-	// output the boy
-	i.outputResponseBody(response, writer)
-
-	return nil
-}
-
-func (i *invoker) outputFunctionLogs(response *http.Response, writer io.Writer) error {
-
-	// the function logs should return as JSON
-	functionLogs := []map[string]interface{}{}
-
-	// wrap the contents in [] so that it appears as a JSON array
-	encodedFunctionLogs := response.Header.Get("X-nuclio-logs")
-
-	// parse the JSON into function logs
-	err := json.Unmarshal([]byte(encodedFunctionLogs), &functionLogs)
-	if err != nil {
-		return errors.Wrap(err, "Failed to parse logs")
-	}
-
-	// if there are no logs, return now
-	if len(functionLogs) == 0 {
-		return nil
-	}
-
-	// create a logger whose name is that of the function and whose severity was chosen by command line
-	// arguments during invocation
-	functionLogger, err := nucliozap.NewNuclioZap(i.invokeOptions.Name,
-		"console",
-		writer,
-		writer,
-		nucliozap.DebugLevel)
-
-	if err != nil {
-		return errors.Wrap(err, "Failed to create function logger")
-	}
-
-	i.logger.Info(">>> Start of function logs")
-
-	// iterate through all the logs
-	for _, functionLog := range functionLogs {
-		message := functionLog["message"].(string)
-		levelName := functionLog["level"].(string)
-		delete(functionLog, "message")
-		delete(functionLog, "level")
-		delete(functionLog, "name")
-
-		// convert args map to a slice of interfaces
-		args := i.stringInterfaceMapToInterfaceSlice(functionLog)
-
-		// output to log by level
-		i.getOutputByLevelName(functionLogger, levelName)(message, args...)
-	}
-
-	if len(functionLogs) != 0 {
-		i.logger.Info("<<< End of function logs")
-	}
-
-	return nil
-}
-
-func (i *invoker) stringInterfaceMapToInterfaceSlice(input map[string]interface{}) []interface{} {
-	output := []interface{}{}
-
-	// convert the map to a flat slice of interfaces
-	for argName, argValue := range input {
-		output = append(output, argName)
-		output = append(output, argValue)
-	}
-
-	return output
-}
-
-func (i *invoker) getOutputByLevelName(logger nuclio.Logger, levelName string) func(interface{}, ...interface{}) {
-	switch levelName {
-	case "info":
-		return i.logger.InfoWith
-	case "warn":
-		return i.logger.WarnWith
-	case "error":
-		return i.logger.ErrorWith
-	default:
-		return i.logger.DebugWith
-	}
-}
-
-func (i *invoker) outputResponseHeaders(response *http.Response, writer io.Writer) error {
-	fmt.Fprintf(writer, "\n%s\n", ansi.Color("> Response headers:", "blue+h"))
-
-	for headerName, headerValue := range response.Header {
-
-		// skip the log headers
-		if strings.ToLower(headerName) == strings.ToLower("X-Nuclio-Logs") {
-			continue
-		}
-
-		fmt.Fprintf(writer, "%s = %s\n", headerName, headerValue[0])
-	}
-
-	return nil
-}
-
-func (i *invoker) outputResponseBody(response *http.Response, writer io.Writer) error {
-	var responseBodyString string
-
+	// read the body
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return err
+		return nil, errors.Wrap(err, "Failed to read response body")
 	}
 
-	// Print raw body
-	fmt.Fprintf(writer, "\n%s\n", ansi.Color("> Response body:", "blue+h"))
-
-	// check if response is json
-	if response.Header.Get("Content-Type") == "application/json" {
-		var indentedBody bytes.Buffer
-
-		err = json.Indent(&indentedBody, responseBody, "", "    ")
-		if err != nil {
-			responseBodyString = string(responseBody)
-		} else {
-			responseBodyString = indentedBody.String()
-		}
-
-	} else {
-		responseBodyString = string(responseBody)
-	}
-
-	fmt.Fprintln(writer, responseBodyString)
-
-	return nil
+	return &platform.InvokeResult{
+		Headers:    response.Header,
+		Body:       responseBody,
+		StatusCode: response.StatusCode,
+	}, nil
 }

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -17,8 +17,6 @@ limitations under the License.
 package abstract
 
 import (
-	"io"
-
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/processor/build"
@@ -135,8 +133,8 @@ func (ap *Platform) HandleDeployFunction(deployOptions *platform.DeployOptions,
 }
 
 // InvokeFunction will invoke a previously deployed function
-func (ap *Platform) InvokeFunction(invokeOptions *platform.InvokeOptions, writer io.Writer) error {
-	return ap.invoker.invoke(invokeOptions, writer)
+func (ap *Platform) InvokeFunction(invokeOptions *platform.InvokeOptions) (*platform.InvokeResult, error) {
+	return ap.invoker.invoke(invokeOptions)
 }
 
 // GetDeployRequiresRegistry returns true if a registry is required for deploy, false otherwise

--- a/pkg/platform/kube/function.go
+++ b/pkg/platform/kube/function.go
@@ -180,6 +180,8 @@ func (f *function) getInvokeURLFields(invokeViaType platform.InvokeViaType) (str
 			host, port, path = f.getIngressInvokeURL()
 		case platform.InvokeViaExternalIP:
 			host, port, path = f.getExternalIPInvokeURL()
+		case platform.InvokeViaDomainName:
+			host, port, path = f.getDomainNameInvokeURL()
 		}
 
 		// if host is empty and we were configured to a specific via type, return an error
@@ -248,4 +250,15 @@ func (f *function) getExternalIPInvokeURL() (string, int, string) {
 	}
 
 	return "", 0, ""
+}
+
+func (f *function) getDomainNameInvokeURL() (string, int, string) {
+	namespace := f.functioncrInstance.ObjectMeta.Namespace
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	domainName := fmt.Sprintf("%s.%s.svc.cluster.local", f.functioncrInstance.ObjectMeta.Name, namespace)
+
+	return domainName, 8080, ""
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -16,10 +16,6 @@ limitations under the License.
 
 package platform
 
-import (
-	"io"
-)
-
 // Platform defines the interface that any underlying function platform must provide for nuclio
 // to run over it
 type Platform interface {
@@ -37,7 +33,7 @@ type Platform interface {
 	DeleteFunction(deleteOptions *DeleteOptions) error
 
 	// InvokeFunction will invoke a previously deployed function
-	InvokeFunction(invokeOptions *InvokeOptions, writer io.Writer) error
+	InvokeFunction(invokeOptions *InvokeOptions) (*InvokeResult, error)
 
 	// InvokeFunction will invoke a previously deployed function
 	GetFunctions(getOptions *GetOptions) ([]Function, error)

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -80,14 +80,14 @@ const (
 
 // InvokeOptions is the base for all platform invoke options
 type InvokeOptions struct {
-	Name         string
-	Namespace    string
-	Path         string
-	Method       string
-	Body         []byte
-	Headers      map[string]string
-	LogLevelName string
-	Via          InvokeViaType
+	Name             string
+	Namespace        string
+	Path             string
+	Method           string
+	Body             []byte
+	Headers          http.Header
+	LogLevelName     string
+	Via              InvokeViaType
 }
 
 // InvokeResult holds the result of a single invocation

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -18,6 +18,8 @@ package platform
 
 // use k8s structure definitions for now. In the future, duplicate them for cleanliness
 import (
+	"net/http"
+
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 
 	"github.com/nuclio/nuclio-sdk"
@@ -73,20 +75,26 @@ const (
 	InvokeViaAny InvokeViaType = iota
 	InvokeViaExternalIP
 	InvokeViaLoadBalancer
+	InvokeViaDomainName
 )
 
 // InvokeOptions is the base for all platform invoke options
 type InvokeOptions struct {
 	Name         string
 	Namespace    string
-	ClusterIP    string
-	ContentType  string
 	Path         string
 	Method       string
-	Body         string
-	Headers      string
+	Body         []byte
+	Headers      map[string]string
 	LogLevelName string
 	Via          InvokeViaType
+}
+
+// InvokeResult holds the result of a single invocation
+type InvokeResult struct {
+	Headers    http.Header
+	Body       []byte
+	StatusCode int
 }
 
 // AddressType

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -80,14 +80,14 @@ const (
 
 // InvokeOptions is the base for all platform invoke options
 type InvokeOptions struct {
-	Name             string
-	Namespace        string
-	Path             string
-	Method           string
-	Body             []byte
-	Headers          http.Header
-	LogLevelName     string
-	Via              InvokeViaType
+	Name         string
+	Namespace    string
+	Path         string
+	Method       string
+	Body         []byte
+	Headers      http.Header
+	LogLevelName string
+	Via          InvokeViaType
 }
 
 // InvokeResult holds the result of a single invocation

--- a/pkg/playground/resource/invocation.go
+++ b/pkg/playground/resource/invocation.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"net/http"
+
+	"github.com/nuclio/nuclio/pkg/playground"
+	"github.com/nuclio/nuclio/pkg/restful"
+)
+
+type invocationResource struct {
+	*resource
+}
+
+// called after initialization
+func (tr *invocationResource) OnAfterInitialize() {
+
+	// all methods
+	for _, registrar := range []func(string, http.HandlerFunc){
+		tr.GetRouter().Get,
+		tr.GetRouter().Post,
+		tr.GetRouter().Put,
+		tr.GetRouter().Delete,
+		tr.GetRouter().Patch,
+		tr.GetRouter().Options,
+	} {
+		registrar("/*", tr.handleRequest)
+	}
+}
+
+func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, request *http.Request) {
+	//
+	//path := request.Header.Get("x-nuclio-path")
+	//invokerIPAddress := request.Header.Get("x-nuclio-invoker-ip-address")
+	//functionNodePort := request.Header.Get("x-nuclio-function-nodeport")
+	//functionName := request.Header.Get("x-nuclio-function-name")
+	//functionNamespace := request.Header.Get("x-nuclio-function-namespace")
+	//
+	//// resolve the function host
+	//invocationResult, err := tr.getPlatform().InvokeFunction(&platform.InvokeOptions{
+	//	Name: functionName,
+	//	Namespace: functionNamespace,
+	//	ContentType: request.Header.Get("content-type"),
+	//	Path: path,
+	//	Method: request.Method,
+	//	Body: "this is the body",
+	//	Via: platform.InvokeViaDomainName,
+	//})
+	//
+	//// get host and URL from request
+	//host, path, err := tr.getTunneledHostAndPath(request.URL.Path)
+	//if err != nil {
+	//	responseWriter.Write([]byte(`{"error": Invalid path - expected /invocation/<host>/<path>""}`))
+	//	responseWriter.WriteHeader(http.StatusBadRequest)
+	//	return
+	//}
+	//
+	//tr.Logger.DebugWith("Tunneling request",
+	//	"url", request.URL.Path,
+	//	"host", host,
+	//	"path", path)
+	//
+	//// create a url from the path
+	//fullURL := fmt.Sprintf("http://%s%s", host, path)
+	//
+	//// create a request
+	//invocationedRequest, err := http.NewRequest(request.Method, fullURL, request.Body)
+	//if err != nil {
+	//	tr.Logger.WarnWith("Failed to create invocationed request", "err", err)
+	//	responseWriter.WriteHeader(http.StatusInternalServerError)
+	//	return
+	//}
+	//
+	//// set headers
+	//invocationedRequest.Header = request.Header
+	//
+	//// do the invocationing
+	//invocationedHTTPResponse, err := http.DefaultClient.Do(invocationedRequest)
+	//if err != nil {
+	//	tr.Logger.WarnWith("Failed to invocation request", "err", err)
+	//	responseWriter.WriteHeader(http.StatusInternalServerError)
+	//	return
+	//}
+	//
+	//responseBody, err := ioutil.ReadAll(invocationedHTTPResponse.Body)
+	//if err != nil {
+	//	tr.Logger.WarnWith("Failed to read invocationed response", "err", err)
+	//	responseWriter.WriteHeader(http.StatusInternalServerError)
+	//	return
+	//}
+	//
+	//// set headers
+	//for headerName, headerValue := range invocationedHTTPResponse.Header {
+	//	responseWriter.Header()[headerName] = headerValue
+	//}
+	//
+	//responseWriter.WriteHeader(invocationedHTTPResponse.StatusCode)
+	//responseWriter.Write(responseBody)
+}
+
+// register the resource
+var invocationResourceInstance = &invocationResource{
+	resource: newResource("invocation", []restful.ResourceMethod{}),
+}
+
+func init() {
+	invocationResourceInstance.Resource = invocationResourceInstance
+	invocationResourceInstance.Register(playground.PlaygroundResourceRegistrySingleton)
+}

--- a/pkg/playground/resource/invocation.go
+++ b/pkg/playground/resource/invocation.go
@@ -68,13 +68,13 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 
 	// resolve the function host
 	invocationResult, err := tr.getPlatform().InvokeFunction(&platform.InvokeOptions{
-		Name:             functionName,
-		Namespace:        functionNamespace,
-		Path:             path,
-		Method:           request.Method,
-		Headers:          request.Header,
-		Body:             requestBody,
-		Via:              platform.InvokeViaDomainName,
+		Name:      functionName,
+		Namespace: functionNamespace,
+		Path:      path,
+		Method:    request.Method,
+		Headers:   request.Header,
+		Body:      requestBody,
+		Via:       platform.InvokeViaDomainName,
 	})
 
 	if err != nil {


### PR DESCRIPTION
Fixes #495.

1. Platform's `InvokeFunction` no longer outputs the result to an `io.Writer`, but returns a structured `InvokeResult`
2. Kubernetes platform supports invoke via domain name - this resolves the function cluster IP through `<function name>.<function namespace>.svc.cluster.local`
3. Playground uses a new resource, `/invocations`, to invoke functions. This resource expects the function name, namespace and path as headers (`x-nuclio-function-name`, `x-nuclio-function-namespace` and ``x-nuclio-function-path`) and utilizes the same mechanism as `nuctl` to invoke functions (implemented as part of the platform) - get them and then invoke them. Utilizes the new invocation mode introduced in (1)

