### PR TITLE
Re-enable processor web interface

### DIFF
--- a/cmd/playground/app/playground.go
+++ b/cmd/playground/app/playground.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/platform/factory"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/playground"
 	"github.com/nuclio/nuclio/pkg/version"
 	"github.com/nuclio/nuclio/pkg/zap"
@@ -54,6 +55,12 @@ func Run(listenAddress string,
 
 	version.Log(logger)
 
+	// create a web server configuration
+	webServerConfiguration := &platformconfig.WebServer{
+		Enabled: true,
+		ListenAddress: listenAddress,
+	}
+
 	server, err := playground.NewServer(logger,
 		assetsDir,
 		sourcesDir,
@@ -62,13 +69,11 @@ func Run(listenAddress string,
 		defaultRunRegistryURL,
 		platformInstance,
 		noPullBaseImages,
+		webServerConfiguration,
 		getDefaultCredRefreshInterval(logger, defaultCredRefreshIntervalString))
 	if err != nil {
 		return errors.Wrap(err, "Failed to create server")
 	}
-
-	server.Enabled = true
-	server.ListenAddress = listenAddress
 
 	err = server.Start()
 	if err != nil {

--- a/cmd/playground/app/playground.go
+++ b/cmd/playground/app/playground.go
@@ -57,7 +57,7 @@ func Run(listenAddress string,
 
 	// create a web server configuration
 	webServerConfiguration := &platformconfig.WebServer{
-		Enabled: true,
+		Enabled:       true,
 		ListenAddress: listenAddress,
 	}
 

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -49,7 +49,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/zap"
 
 	"github.com/nuclio/nuclio-sdk"
-	"github.com/spf13/viper"
 )
 
 // Processor is responsible to process events
@@ -282,13 +281,8 @@ func (p *Processor) createDefaultHTTPTrigger(processorConfiguration *processor.C
 
 func (p *Processor) createWebAdminServer(platformConfiguration *platformconfig.Configuration) (*webadmin.Server, error) {
 
-	// create the server's configuration from our platform config
-	serverConfiguration := viper.New()
-	serverConfiguration.Set("enabled", platformConfiguration.WebAdmin.Enabled)
-	serverConfiguration.Set("listen_address", platformConfiguration.WebAdmin.ListenAddress)
-
 	// create the server
-	return webadmin.NewServer(p.logger, p, serverConfiguration)
+	return webadmin.NewServer(p.logger, p, platformConfiguration.WebAdmin)
 }
 
 func (p *Processor) createMetricPushers(platformConfiguration *platformconfig.Configuration) ([]*statistics.MetricPusher, error) {
@@ -317,7 +311,7 @@ func (p *Processor) createMetricPushers(platformConfiguration *platformconfig.Co
 
 func (p *Processor) getDefaultPlatformConfiguration() *platformconfig.Configuration {
 	return &platformconfig.Configuration{
-		WebAdmin: platformconfig.WebAdmin{
+		WebAdmin: platformconfig.WebServer{
 			Enabled: false,
 		},
 		Logger: platformconfig.Logger{

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -282,7 +282,7 @@ func (p *Processor) createDefaultHTTPTrigger(processorConfiguration *processor.C
 func (p *Processor) createWebAdminServer(platformConfiguration *platformconfig.Configuration) (*webadmin.Server, error) {
 
 	// create the server
-	return webadmin.NewServer(p.logger, p, platformConfiguration.WebAdmin)
+	return webadmin.NewServer(p.logger, p, &platformConfiguration.WebAdmin)
 }
 
 func (p *Processor) createMetricPushers(platformConfiguration *platformconfig.Configuration) ([]*statistics.MetricPusher, error) {

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -23,9 +23,9 @@ import (
 )
 
 type Configuration struct {
-	WebAdmin WebAdmin `json:"webAdmin,omitempty"`
-	Logger   Logger   `json:"logger,omitempty"`
-	Metrics  Metrics  `json:"metrics,omitempty"`
+	WebAdmin WebServer `json:"webAdmin,omitempty"`
+	Logger   Logger    `json:"logger,omitempty"`
+	Metrics  Metrics   `json:"metrics,omitempty"`
 }
 
 func (config *Configuration) GetSystemLoggerSinks() ([]LoggerSinkWithLevel, error) {

--- a/pkg/platformconfig/reader.go
+++ b/pkg/platformconfig/reader.go
@@ -35,7 +35,7 @@ func NewReader() (*Reader, error) {
 func (r *Reader) Read(reader io.Reader, configType string, config *Configuration) error {
 	configBytes, err := ioutil.ReadAll(reader)
 	if err != nil {
-		return errors.Wrap(err, "Failed to read processor configuration")
+		return errors.Wrap(err, "Failed to read platform configuration")
 	}
 
 	return yaml.Unmarshal(configBytes, config)

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -43,7 +43,7 @@ type Logger struct {
 	Functions []LoggerSinkBinding   `json:"functions,omitempty"`
 }
 
-type WebAdmin struct {
+type WebServer struct {
 	Enabled       bool   `json:"enabled,omitempty"`
 	ListenAddress string `json:"listenAddress,omitempty"`
 }

--- a/pkg/playground/server.go
+++ b/pkg/playground/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/dockercreds"
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/restful"
 
 	"github.com/go-chi/chi"
@@ -54,6 +55,7 @@ func NewServer(parentLogger nuclio.Logger,
 	defaultRunRegistryURL string,
 	platform platform.Platform,
 	noPullBaseImages bool,
+	configuration *platformconfig.WebServer,
 	defaultCredRefreshInterval *time.Duration) (*Server, error) {
 
 	var err error
@@ -81,7 +83,7 @@ func NewServer(parentLogger nuclio.Logger,
 	}
 
 	// create server
-	newServer.Server, err = restful.NewServer(parentLogger, PlaygroundResourceRegistrySingleton, newServer)
+	newServer.Server, err = restful.NewServer(parentLogger, PlaygroundResourceRegistrySingleton, newServer, configuration)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create restful server")
 	}

--- a/pkg/processor/webadmin/resource/triggers.go
+++ b/pkg/processor/webadmin/resource/triggers.go
@@ -29,16 +29,16 @@ type triggersResource struct {
 	*resource
 }
 
-func (esr *triggersResource) GetAll(request *http.Request) map[string]restful.Attributes {
+func (tr *triggersResource) GetAll(request *http.Request) map[string]restful.Attributes {
 	triggers := map[string]restful.Attributes{}
 
 	// iterate over triggers
 	// TODO: when this is dynamic (create/delete support), add some locking
-	for _, trigger := range esr.getProcessor().GetTriggers() {
+	for _, trigger := range tr.getProcessor().GetTriggers() {
 		configuration := trigger.GetConfig()
 
 		// extract the ID from the configuration (get and remove)
-		id := esr.extractIDFromConfiguration(configuration)
+		id := tr.extractIDFromConfiguration(configuration)
 
 		// set the trigger with its ID as key
 		triggers[id] = configuration
@@ -47,12 +47,12 @@ func (esr *triggersResource) GetAll(request *http.Request) map[string]restful.At
 	return triggers
 }
 
-func (esr *triggersResource) GetByID(request *http.Request, id string) restful.Attributes {
-	for _, trigger := range esr.getProcessor().GetTriggers() {
+func (tr *triggersResource) GetByID(request *http.Request, id string) restful.Attributes {
+	for _, trigger := range tr.getProcessor().GetTriggers() {
 		configuration := trigger.GetConfig()
 
 		// extract the ID from the configuration (get and remove)
-		triggerID := esr.extractIDFromConfiguration(configuration)
+		triggerID := tr.extractIDFromConfiguration(configuration)
 
 		if id == triggerID {
 			return configuration
@@ -63,18 +63,18 @@ func (esr *triggersResource) GetByID(request *http.Request, id string) restful.A
 }
 
 // returns a list of custom routes for the resource
-func (esr *triggersResource) GetCustomRoutes() map[string]restful.CustomRoute {
+func (tr *triggersResource) GetCustomRoutes() map[string]restful.CustomRoute {
 
 	// just for demonstration. when stats are supported, this will be wired
 	return map[string]restful.CustomRoute{
 		"/{id}/stats": {
 			Method:    http.MethodGet,
-			RouteFunc: esr.getStatistics,
+			RouteFunc: tr.getStatistics,
 		},
 	}
 }
 
-func (esr *triggersResource) getStatistics(request *http.Request) (string, map[string]restful.Attributes, bool, int, error) {
+func (tr *triggersResource) getStatistics(request *http.Request) (string, map[string]restful.Attributes, bool, int, error) {
 	resourceID := chi.URLParam(request, "id")
 
 	return "statistics", map[string]restful.Attributes{
@@ -82,7 +82,7 @@ func (esr *triggersResource) getStatistics(request *http.Request) (string, map[s
 	}, true, http.StatusOK, nil
 }
 
-func (esr *triggersResource) extractIDFromConfiguration(configuration map[string]interface{}) string {
+func (tr *triggersResource) extractIDFromConfiguration(configuration map[string]interface{}) string {
 	id := configuration["ID"].(string)
 
 	delete(configuration, "ID")

--- a/pkg/processor/webadmin/server.go
+++ b/pkg/processor/webadmin/server.go
@@ -29,7 +29,7 @@ type Server struct {
 	Processor interface{}
 }
 
-func NewServer(parentLogger nuclio.Logger, processor interface{}, configuration platformconfig.WebServer) (*Server, error) {
+func NewServer(parentLogger nuclio.Logger, processor interface{}, configuration *platformconfig.WebServer) (*Server, error) {
 	var err error
 
 	newServer := &Server{Processor: processor}
@@ -38,24 +38,11 @@ func NewServer(parentLogger nuclio.Logger, processor interface{}, configuration 
 	logger := parentLogger.GetChild("webadmin")
 
 	// create server
-	newServer.Server, err = restful.NewServer(logger, WebAdminResourceRegistrySingleton, newServer)
+	newServer.Server, err = restful.NewServer(logger, WebAdminResourceRegistrySingleton, newServer, configuration)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create restful server")
-	}
-
-	err = newServer.readConfiguration(configuration)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to read configuration")
 	}
 
 	return newServer, nil
 }
 
-func (s *Server) readConfiguration(configuration platformconfig.WebServer) error {
-
-	// set configuration
-	s.Enabled = configuration.Enabled
-	s.ListenAddress = configuration.ListenAddress
-
-	return nil
-}

--- a/pkg/processor/webadmin/server.go
+++ b/pkg/processor/webadmin/server.go
@@ -18,10 +18,10 @@ package webadmin
 
 import (
 	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/restful"
 
 	"github.com/nuclio/nuclio-sdk"
-	"github.com/nuclio/nuclio/pkg/platformconfig"
 )
 
 type Server struct {

--- a/pkg/processor/webadmin/server.go
+++ b/pkg/processor/webadmin/server.go
@@ -21,7 +21,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/restful"
 
 	"github.com/nuclio/nuclio-sdk"
-	"github.com/spf13/viper"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
 )
 
 type Server struct {
@@ -29,7 +29,7 @@ type Server struct {
 	Processor interface{}
 }
 
-func NewServer(parentLogger nuclio.Logger, processor interface{}, configuration *viper.Viper) (*Server, error) {
+func NewServer(parentLogger nuclio.Logger, processor interface{}, configuration platformconfig.WebServer) (*Server, error) {
 	var err error
 
 	newServer := &Server{Processor: processor}
@@ -51,17 +51,11 @@ func NewServer(parentLogger nuclio.Logger, processor interface{}, configuration 
 	return newServer, nil
 }
 
-func (s *Server) readConfiguration(configuration *viper.Viper) error {
-
-	// by default web admin is enabled
-	configuration.SetDefault("enabled", true)
-
-	// by default web admin listens on port 8081
-	configuration.SetDefault("listen_address", ":8081")
+func (s *Server) readConfiguration(configuration platformconfig.WebServer) error {
 
 	// set configuration
-	s.Enabled = configuration.GetBool("enabled")
-	s.ListenAddress = configuration.GetString("listen_address")
+	s.Enabled = configuration.Enabled
+	s.ListenAddress = configuration.ListenAddress
 
 	return nil
 }

--- a/pkg/processor/webadmin/server.go
+++ b/pkg/processor/webadmin/server.go
@@ -34,8 +34,11 @@ func NewServer(parentLogger nuclio.Logger, processor interface{}, configuration 
 
 	newServer := &Server{Processor: processor}
 
+	// namespace our logger
+	logger := parentLogger.GetChild("webadmin")
+
 	// create server
-	newServer.Server, err = restful.NewServer(parentLogger, WebAdminResourceRegistrySingleton, newServer)
+	newServer.Server, err = restful.NewServer(logger, WebAdminResourceRegistrySingleton, newServer)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create restful server")
 	}

--- a/pkg/processor/webadmin/server.go
+++ b/pkg/processor/webadmin/server.go
@@ -45,4 +45,3 @@ func NewServer(parentLogger nuclio.Logger, processor interface{}, configuration 
 
 	return newServer, nil
 }
-

--- a/pkg/restful/server.go
+++ b/pkg/restful/server.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/registry"
 
 	"github.com/go-chi/chi"
@@ -42,7 +43,8 @@ type resourceInitializer interface {
 
 func NewServer(parentLogger nuclio.Logger,
 	resourceRegistry *registry.Registry,
-	conreteServer interface{}) (*Server, error) {
+	conreteServer interface{},
+	configuration *platformconfig.WebServer) (*Server, error) {
 
 	var err error
 
@@ -55,6 +57,11 @@ func NewServer(parentLogger nuclio.Logger,
 	newServer.Router, err = newServer.createRouter()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create router")
+	}
+
+	err = newServer.readConfiguration(configuration)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to read configuration")
 	}
 
 	return newServer, nil
@@ -112,6 +119,15 @@ func (s *Server) createRouter() (chi.Router, error) {
 	s.InstallMiddleware(router)
 
 	return router, nil
+}
+
+func (s *Server) readConfiguration(configuration *platformconfig.WebServer) error {
+
+	// set configuration
+	s.Enabled = configuration.Enabled
+	s.ListenAddress = configuration.ListenAddress
+
+	return nil
 }
 
 // middleware that sets content type to JSON content type

--- a/pkg/restful/server.go
+++ b/pkg/restful/server.go
@@ -64,6 +64,7 @@ func (s *Server) Start() error {
 
 	// if we're not enabled, we're done here
 	if !s.Enabled {
+		s.Logger.Debug("Server disabled, not listening")
 		return nil
 	}
 


### PR DESCRIPTION
- `platformconfig.Configuration.WebAdmin`'s struct type was renamed from `WebAdmin` to `WebServer` (field name left as-is), now fed to `restful.Server`'s constructor instead of just `webadmin.Server`'s
- The `WebServer` configuration struct is used for both the playground's and the processor's web interfaces
- The processor's web interface can be enabled from platform configuration and currently serves `GET /health` and `GET /triggers`
- Added log message if the web interface is disabled
- Completed rename of `eventsource.go` resource to `triggers.go`