### PR TITLE
Support docker registry secret

### DIFF
--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -25,12 +25,6 @@ import (
 )
 
 func main() {
-
-	defaultRegistry := os.Getenv("NUCLIO_PLAYGROUND_REGISTRY_URL")
-	if defaultRegistry == "" {
-		defaultRegistry = "127.0.0.1:5000"
-	}
-
 	defaultNoPullBaseImages := os.Getenv("NUCLIO_PLAYGROUND_NO_PULL_BASE_IMAGES") == "true"
 
 	listenAddress := flag.String("listen-addr", ":8070", "IP/port on which the playground listens")
@@ -38,7 +32,7 @@ func main() {
 	sourcesDir := flag.String("sources-dir", "", "Directory to save sources")
 	dockerKeyDir := flag.String("docker-key-dir", "", "Directory to look for docker keys for secure registries")
 	platformType := flag.String("platform", "auto", "One of kube/local/auto")
-	defaultRegistryURL := flag.String("registry", defaultRegistry, "Default registry URL")
+	defaultRegistryURL := flag.String("registry", os.Getenv("NUCLIO_PLAYGROUND_REGISTRY_URL"), "Default registry URL")
 	defaultRunRegistryURL := flag.String("run-registry", os.Getenv("NUCLIO_PLAYGROUND_RUN_REGISTRY_URL"), "Default run registry URL")
 	noPullBaseImages := flag.Bool("no-pull", defaultNoPullBaseImages, "Default run registry URL")
 	credsRefreshInterval := flag.String("creds-refresh-interval", os.Getenv("NUCLIO_PLAYGROUND_CREDS_REFRESH_INTERVAL"), "Default credential refresh interval, or 'none' (12h by default)")

--- a/pkg/dockercreds/dockercred.go
+++ b/pkg/dockercreds/dockercred.go
@@ -36,7 +36,7 @@ type dockerCred struct {
 
 func newDockerCred(dockerCreds *DockerCreds, path string,
 	defaultRefreshInterval *time.Duration) (*dockerCred, error) {
-	fallbackDuration := time.Duration(time.Hour * 12)
+	fallbackDuration := time.Hour * 12
 
 	if defaultRefreshInterval == nil {
 		defaultRefreshInterval = &fallbackDuration
@@ -116,7 +116,7 @@ func (dc *dockerCred) readKubernetesDockerRegistrySecretFormat(contents []byte) 
 
 	// declare the marshalled auth
 	unmarshalledSecret := struct {
-		Auths map[string]struct{
+		Auths map[string]struct {
 			Username string `json:"username"`
 			Password string `json:"password"`
 		} `json:"auths"`

--- a/pkg/dockercreds/dockercred.go
+++ b/pkg/dockercreds/dockercred.go
@@ -17,6 +17,8 @@ limitations under the License.
 package dockercreds
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"io/ioutil"
 	"path"
 	"strings"
@@ -30,13 +32,24 @@ type dockerCred struct {
 	path                   string
 	dockerCreds            *DockerCreds
 	defaultRefreshInterval *time.Duration
-	username               string
-	password               string
-	url                    string
+	secret                 secret
+}
+
+type secret struct {
+	username string
+	password string
+	url string
+	refreshInterval *time.Duration
 }
 
 func newDockerCred(dockerCreds *DockerCreds, path string,
 	defaultRefreshInterval *time.Duration) (*dockerCred, error) {
+	fallbackDuration := time.Duration(time.Hour * 12)
+
+	if defaultRefreshInterval == nil {
+		defaultRefreshInterval = &fallbackDuration
+	}
+
 	newDockerCred := &dockerCred{
 		path:                   path,
 		dockerCreds:            dockerCreds,
@@ -55,28 +68,40 @@ func (dc *dockerCred) initialize() error {
 
 	fileName := path.Base(dc.path)
 
-	password, err := ioutil.ReadFile(dc.path)
+	contents, err := ioutil.ReadFile(dc.path)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to read docker key file @ %s", dc.path)
 	}
 
-	// get the URL and username
-	username, url, refreshIntervalString, err := extractMetaFromKeyPath(fileName)
+	// try to read legacy format
+	dc.secret, err = dc.readLegacySecretFormat(fileName, contents)
+
+	// failed, try to read docker registry format
 	if err != nil {
-		return errors.Wrapf(err, "Failed to get user / url from path @ %s", dc.path)
+		dc.secret, err = dc.readKubernetesDockerRegistrySecretFormat(contents)
+	}
+
+	// we're out of supported formats, bail
+	if err != nil {
+		return errors.Wrap(err, "Failed to read secret")
+	}
+
+	// if we didn't get a refresh interval in the cred file name, try the default
+	if dc.secret.refreshInterval == nil {
+		dc.secret.refreshInterval = dc.defaultRefreshInterval
+	}
+
+	// if user didn't specify "https://" in the url, add it. otherwise don't
+	if !strings.HasPrefix(dc.secret.url, "https://") {
+		dc.secret.url = "https://" + dc.secret.url
 	}
 
 	dc.dockerCreds.logger.InfoWith("Initializing docker credential",
 		"path", dc.path,
-		"username", username,
-		"passwordLen", len(password),
-		"url", url,
-		"refreshInterval", refreshIntervalString)
-
-	// save in members
-	dc.username = username
-	dc.password = string(password)
-	dc.url = url
+		"username", dc.secret.username,
+		"passwordLen", len(dc.secret.password),
+		"url", dc.secret.url,
+		"refreshInterval", dc.secret.refreshInterval)
 
 	// try to login
 	if err = dc.login(); err != nil {
@@ -87,7 +112,62 @@ func (dc *dockerCred) initialize() error {
 			"path", dc.path)
 	}
 
-	refreshInterval, err := parseRefreshInterval(refreshIntervalString)
+	if dc.secret.refreshInterval != nil {
+		dc.refreshCredentials(*dc.secret.refreshInterval)
+	}
+
+	return nil
+}
+
+func (dc *dockerCred) readKubernetesDockerRegistrySecretFormat(contents []byte) (secret, error) {
+	var parsedSecret secret
+
+	// decode base64 body
+	decodedContents, err := base64.StdEncoding.DecodeString(string(contents))
+	if err != nil {
+		return parsedSecret, errors.Wrap(err, "Failed to decode contents")
+	}
+
+	// declare the marshalled auth
+	unmarshalledSecret := struct {
+		Auths map[string]struct{
+			Username string `json:"username"`
+			Password string `json:"password"`
+		} `json:"auths"`
+	}{}
+
+	if err := json.Unmarshal(decodedContents, &unmarshalledSecret); err != nil {
+		return parsedSecret, errors.Wrap(err, "Failed to unmarshal secret")
+	}
+
+	// if we have more than one key, this is unexpected, bail
+	if len(unmarshalledSecret.Auths) != 1 {
+		return parsedSecret, errors.New("Expected only one key under 'auths'")
+	}
+
+	// set secret (will iterate once)
+	for url, secret := range unmarshalledSecret.Auths {
+		parsedSecret.url = url
+		parsedSecret.username = secret.Username
+		parsedSecret.password = secret.Password
+	}
+
+	return parsedSecret, nil
+}
+
+func (dc *dockerCred) readLegacySecretFormat(fileName string, contents []byte) (secret, error) {
+	var parsedSecret secret
+	var err error
+	var refreshIntervalString string
+
+	// get the URL and username - check if this is the legacy secret format (file name is encoded as
+	// username---registry---interval.json
+	parsedSecret.username, parsedSecret.url, refreshIntervalString, err = extractMetaFromKeyPath(fileName)
+	if err != nil {
+		return parsedSecret, errors.Wrap(err, "Failed to read legacy format secret")
+	}
+
+	parsedSecret.refreshInterval, err = parseRefreshInterval(refreshIntervalString)
 	if err != nil {
 
 		// if failed, we still want to try with the default refresh interval
@@ -97,16 +177,9 @@ func (dc *dockerCred) initialize() error {
 			"refreshInterval", refreshIntervalString)
 	}
 
-	// if we didn't get a refresh interval in the cred file name, try the default
-	if refreshInterval == nil {
-		refreshInterval = dc.defaultRefreshInterval
-	}
+	parsedSecret.password = string(contents)
 
-	if refreshInterval != nil {
-		dc.refreshCredentials(*refreshInterval)
-	}
-
-	return nil
+	return parsedSecret, nil
 }
 
 func extractMetaFromKeyPath(keyPath string) (string, string, string, error) {
@@ -141,13 +214,13 @@ func extractMetaFromKeyPath(keyPath string) (string, string, string, error) {
 func (dc *dockerCred) login() error {
 	dc.dockerCreds.logger.DebugWith("Logging in",
 		"url", dc.path,
-		"user", dc.username)
+		"user", dc.secret.username)
 
 	// try to login
 	return dc.dockerCreds.dockerClient.LogIn(&dockerclient.LogInOptions{
-		Username: dc.username,
-		Password: dc.password,
-		URL:      "https://" + dc.url,
+		Username: dc.secret.username,
+		Password: dc.secret.password,
+		URL:      dc.secret.url,
 	})
 }
 

--- a/pkg/dockercreds/dockercreds.go
+++ b/pkg/dockercreds/dockercreds.go
@@ -28,9 +28,9 @@ import (
 )
 
 type Credentials struct {
-	Username string
-	Password string
-	URL string
+	Username        string
+	Password        string
+	URL             string
 	RefreshInterval *time.Duration
 }
 

--- a/pkg/dockercreds/dockercreds.go
+++ b/pkg/dockercreds/dockercreds.go
@@ -27,6 +27,13 @@ import (
 	"github.com/nuclio/nuclio-sdk"
 )
 
+type Credentials struct {
+	Username string
+	Password string
+	URL string
+	RefreshInterval *time.Duration
+}
+
 // DockerCreds initializes docker client credentials
 type DockerCreds struct {
 	logger          nuclio.Logger
@@ -70,4 +77,14 @@ func (dc *DockerCreds) LoadFromDir(keyDir string) error {
 	}
 
 	return nil
+}
+
+func (dc *DockerCreds) GetCredentials() []Credentials {
+	var credentials []Credentials
+
+	for _, dockerCred := range dc.dockerCreds {
+		credentials = append(credentials, dockerCred.credentials)
+	}
+
+	return credentials
 }

--- a/pkg/dockercreds/dockercreds.go
+++ b/pkg/dockercreds/dockercreds.go
@@ -40,7 +40,7 @@ func NewDockerCreds(parentLogger nuclio.Logger,
 	refreshInterval *time.Duration) (*DockerCreds, error) {
 
 	return &DockerCreds{
-		logger:          parentLogger.GetChild("loginner"),
+		logger:          parentLogger.GetChild("dockercreds"),
 		dockerClient:    dockerClient,
 		refreshInterval: refreshInterval,
 	}, nil

--- a/pkg/dockercreds/dockercreds_test.go
+++ b/pkg/dockercreds/dockercreds_test.go
@@ -184,7 +184,7 @@ type dirNode struct {
 
 type LogInFromDirTestSuite struct {
 	DockerCredsTestSuite
-	tempDir string
+	tempDir           string
 	kubernetesSecrets []string
 }
 

--- a/pkg/playground/server.go
+++ b/pkg/playground/server.go
@@ -96,6 +96,24 @@ func NewServer(parentLogger nuclio.Logger,
 		newServer.Logger.WarnWith("Failed to login with docker keys", "err", err.Error())
 	}
 
+	// if the docker registry was not specified, try to take from credentials. this way the user only needs
+	// to specify the secret to that registry and URL will be taken from there
+	if newServer.defaultRegistryURL == "" {
+		credentials := newServer.dockerCreds.GetCredentials()
+
+		if len(credentials) >= 1 {
+			newServer.defaultRegistryURL = credentials[0].URL
+
+			newServer.Logger.InfoWith("Using registry from credentials",
+				"url", newServer.defaultRegistryURL)
+		}
+
+		// if we're still without a valid registry, use a hardcoded one (TODO: remove this)
+		if newServer.defaultRegistryURL == "" {
+			newServer.defaultRegistryURL = "localhost:5000"
+		}
+	}
+
 	// for logging purposes, duration can't be nil (stringer is called on nil and panics)
 	if defaultCredRefreshInterval == nil {
 		noDefaultCredRefreshInterval := 0 * time.Second

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -130,7 +130,7 @@ func (suite *TestSuite) TestGetImageSpecificCommandsReturnsEmptyOnUnknownBaseIma
 func (suite *TestSuite) TestGetImageSpecificCommandsAddsCaCertificatesFlagForAlpine() {
 	result := suite.Builder.getImageSpecificCommands("alpine")
 
-	suite.Require().EqualValues([]string{"apk update && apk add --update ca-certificates && rm -rf /var/cache/apk/*",}, result)
+	suite.Require().EqualValues([]string{"apk update && apk add --update ca-certificates && rm -rf /var/cache/apk/*"}, result)
 }
 
 func (suite *TestSuite) TestGetImageSpecificEnvVarsReturnsEmptyOnUnknownBaseImage() {
@@ -143,7 +143,7 @@ func (suite *TestSuite) TestGetImageSpecificEnvVarsReturnsEmptyOnUnknownBaseImag
 func (suite *TestSuite) TestGetImageSpecificEnvVarsAddsNonInteractiveFlagForJessie() {
 	result := suite.Builder.getImageSpecificEnvVars("jessie")
 
-	suite.Require().EqualValues([]string{"DEBIAN_FRONTEND noninteractive",}, result)
+	suite.Require().EqualValues([]string{"DEBIAN_FRONTEND noninteractive"}, result)
 }
 
 func (suite *TestSuite) TestReplaceBuildCommandDirectivesReturnsNewDirectives() {


### PR DESCRIPTION
Introduces two usability features:
1. Users can provide a secret in the form created by `kubectl create secret docker-registry` rather than the legacy format (which is still supported for backwards compatibility). Fixes #523
2. If users do not pass a docker registry URL (previously done via configmaps in k8s), the first URL from the secrets is used