### PR TITLE
nuctl has better support for a few flags

### DIFF
--- a/pkg/cmdrunner/shellrunner_test.go
+++ b/pkg/cmdrunner/shellrunner_test.go
@@ -70,7 +70,7 @@ func (suite *ShellRunnerTestSuite) TestRunAndCaptureOutputStdoutReturnsStdoutAnd
 func (suite *ShellRunnerTestSuite) TestRunAndCaptureOutputCombinedRedactsStrings() {
 	cmd := exec.Command(suite.shellRunner.shell, "-c", `echo "foo1 foo2 secret" ; echo "foo3password">&2`)
 	suite.runOptions.CaptureOutputMode = CaptureOutputModeCombined
-	suite.runOptions.LogRedactions = []string{"password", "secret",}
+	suite.runOptions.LogRedactions = []string{"password", "secret"}
 
 	var runResult RunResult
 	err := suite.shellRunner.runAndCaptureOutput(cmd, suite.runOptions, &runResult)
@@ -83,7 +83,7 @@ func (suite *ShellRunnerTestSuite) TestRunAndCaptureOutputCombinedRedactsStrings
 func (suite *ShellRunnerTestSuite) TestRunAndCaptureOutputCombinedRedactsStringsFromStdoutAndStderr() {
 	cmd := exec.Command(suite.shellRunner.shell, "-c", `echo "foo1 foo2 secret" ; echo "foo3password">&2`)
 	suite.runOptions.CaptureOutputMode = CaptureOutputModeStdout
-	suite.runOptions.LogRedactions = []string{"password", "secret",}
+	suite.runOptions.LogRedactions = []string{"password", "secret"}
 
 	var runResult RunResult
 	err := suite.shellRunner.runAndCaptureOutput(cmd, suite.runOptions, &runResult)

--- a/pkg/dockerclient/shell_test.go
+++ b/pkg/dockerclient/shell_test.go
@@ -49,9 +49,9 @@ func (mcr *mockCmdRunner) Run(options *cmdrunner.RunOptions, format string, vars
 	}
 
 	return cmdrunner.RunResult{
-		ExitCode: mcr.expectedExitCode,
-		Output:   common.Redact(options.LogRedactions, mcr.expectedStdout),
-		Stderr:   common.Redact(options.LogRedactions, mcr.expectedStderr)},
+			ExitCode: mcr.expectedExitCode,
+			Output:   common.Redact(options.LogRedactions, mcr.expectedStdout),
+			Stderr:   common.Redact(options.LogRedactions, mcr.expectedStderr)},
 		nil
 }
 

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -17,7 +17,6 @@ limitations under the License.
 package command
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/nuclio/nuclio/pkg/errors"
@@ -46,17 +45,11 @@ func newBuildCommandeer(rootCommandeer *RootCommandeer) *buildCommandeer {
 		Short:   "Build a function",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			// if we got positional arguments
-			switch len(args) {
-			case 0:
-				return fmt.Errorf("Missing function path")
-			case 1: /* noop */
-			default:
-				return fmt.Errorf("Too many arguments")
+			// update build stuff
+			if len(args) == 1 {
+				commandeer.functionConfig.Meta.Name = args[0]
 			}
 
-			// update build stuff
-			commandeer.functionConfig.Meta.Name = args[0]
 			commandeer.functionConfig.Meta.Namespace = rootCommandeer.namespace
 			commandeer.functionConfig.Spec.Build.Commands = commandeer.commands
 
@@ -87,8 +80,6 @@ func addBuildFlags(cmd *cobra.Command, config *functionconfig.Config, commands *
 	cmd.Flags().StringVar(&config.Spec.Build.ImageVersion, "version", "latest", "Version of the Docker image")
 	cmd.Flags().StringVarP(&config.Spec.Build.OutputType, "output", "o", "docker", "Type of the build output - \"docker\" or \"binary\"")
 	cmd.Flags().StringVarP(&config.Spec.Build.Registry, "registry", "r", os.Getenv("NUCTL_REGISTRY"), "URL of a container registry (env: NUCTL_REGISTRY)")
-	cmd.Flags().StringVar(&config.Spec.Build.NuclioSourceDir, "nuclio-src-dir", "", "Path to a local directory that contains nuclio sources (avoid cloning)")
-	cmd.Flags().StringVar(&config.Spec.Build.NuclioSourceURL, "nuclio-src-url", "https://github.com/nuclio/nuclio.git", "URL of nuclio sources for git clone")
 	cmd.Flags().StringVarP(&config.Spec.Runtime, "runtime", "", "", "Runtime (for example, \"golang\", \"golang:1.8\", \"python:2.7\")")
 	cmd.Flags().StringVarP(&config.Spec.Handler, "handler", "", "", "Name of a function handler")
 	cmd.Flags().BoolVarP(&config.Spec.Build.NoBaseImagesPull, "no-pull", "", false, "Don't pull base images - use local versions")

--- a/pkg/nuctl/test/build_test.go
+++ b/pkg/nuctl/test/build_test.go
@@ -48,7 +48,7 @@ func (suite *BuildTestSuite) SetupSuite() {
 func (suite *BuildTestSuite) TestBuild() {
 	imageName := fmt.Sprintf("nuclio/build-test-%s", xid.New().String())
 
-	err := suite.ExecuteNutcl([]string{"build", "example", "--verbose", "--no-pull"},
+	err := suite.ExecuteNutcl([]string{"build", "reverser", "--verbose", "--no-pull"},
 		map[string]string{
 			"path":    path.Join(suite.GetFunctionsDir(), "common", "reverser", "golang"),
 			"image":   imageName,
@@ -61,7 +61,7 @@ func (suite *BuildTestSuite) TestBuild() {
 	defer suite.dockerClient.RemoveImage(imageName)
 
 	// use deploy with the image we just created
-	err = suite.ExecuteNutcl([]string{"deploy", "example", "--verbose"},
+	err = suite.ExecuteNutcl([]string{"deploy", "reverser", "--verbose"},
 		map[string]string{
 			"run-image": imageName,
 			"runtime":   "golang",
@@ -71,13 +71,13 @@ func (suite *BuildTestSuite) TestBuild() {
 	suite.Require().NoError(err)
 
 	// use nutctl to delete the function when we're done
-	defer suite.ExecuteNutcl([]string{"delete", "fu", "example"}, nil)
+	defer suite.ExecuteNutcl([]string{"delete", "fu", "reverser"}, nil)
 
 	// try a few times to invoke, until it succeeds
 	err = common.RetryUntilSuccessful(60*time.Second, 1*time.Second, func() bool {
 
 		// invoke the function
-		err = suite.ExecuteNutcl([]string{"invoke", "example"},
+		err = suite.ExecuteNutcl([]string{"invoke", "reverser"},
 			map[string]string{
 				"method": "POST",
 				"body":   "-reverse this string+",

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -54,7 +54,7 @@ func NewPlatform(parentLogger logger.Logger, platform platform.Platform) (*Platf
 func (ap *Platform) BuildFunction(buildOptions *platform.BuildOptions) (*platform.BuildResult, error) {
 
 	// execute a build
-	builder, err := build.NewBuilder(buildOptions.Logger)
+	builder, err := build.NewBuilder(buildOptions.Logger, &ap.platform)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create builder")
 	}

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -58,6 +58,8 @@ const (
 type Builder struct {
 	logger logger.Logger
 
+	platform *platform.Platform
+
 	options *platform.BuildOptions
 
 	// the selected runtime
@@ -91,11 +93,12 @@ type Builder struct {
 	}
 }
 
-func NewBuilder(parentLogger logger.Logger) (*Builder, error) {
+func NewBuilder(parentLogger logger.Logger, platform *platform.Platform) (*Builder, error) {
 	var err error
 
 	newBuilder := &Builder{
 		logger: parentLogger,
+		platform: platform,
 	}
 
 	newBuilder.dockerClient, err = dockerclient.NewShellClient(newBuilder.logger, nil)
@@ -118,6 +121,7 @@ func (b *Builder) Build(options *platform.BuildOptions) (*platform.BuildResult, 
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create base temp dir")
 	}
+
 	defer b.cleanupTempDir()
 
 	// create staging directory
@@ -152,7 +156,7 @@ func (b *Builder) Build(options *platform.BuildOptions) (*platform.BuildResult, 
 
 	// once we're done reading our configuration, we may still have to fill in the blanks
 	// because the user isn't obligated to always pass all the configuration
-	if err = b.enrichConfiguration(); err != nil {
+	if err = b.validateAndEnrichConfiguration(); err != nil {
 		return nil, errors.Wrap(err, "Failed to enrich configuration")
 	}
 
@@ -238,6 +242,11 @@ func (b *Builder) readConfiguration() (string, error) {
 
 func (b *Builder) providedFunctionConfigFilePath() string {
 
+	// if the user provided a configuration path, use that
+	if b.options.FunctionConfig.Spec.Build.FunctionConfigPath != "" {
+		return b.options.FunctionConfig.Spec.Build.FunctionConfigPath
+	}
+
 	// if the user only provided a function file, check if it had a function configuration file
 	// in an inline configuration block (@nuclio.configure)
 	if common.IsFile(b.options.FunctionConfig.Spec.Build.Path) {
@@ -267,7 +276,15 @@ func (b *Builder) providedFunctionConfigFilePath() string {
 	return functionConfigPath
 }
 
-func (b *Builder) enrichConfiguration() error {
+func (b *Builder) validateAndEnrichConfiguration() error {
+	if b.options.FunctionConfig.Meta.Name == "" {
+		return errors.New("Function must have a name")
+	}
+
+	// if the run registry wasn't specified, take the build registry
+	if b.options.FunctionConfig.Spec.RunRegistry == "" {
+		b.options.FunctionConfig.Spec.RunRegistry = b.options.FunctionConfig.Spec.Build.Registry
+	}
 
 	// if runtime wasn't passed, use the default from the created runtime
 	if b.options.FunctionConfig.Spec.Runtime == "" {
@@ -347,6 +364,21 @@ func (b *Builder) getImageName() string {
 }
 
 func (b *Builder) resolveFunctionPath(functionPath string) (string, error) {
+
+	// function can either be in the path, received inline or an executable via handler
+	if b.options.FunctionConfig.Spec.Build.Path == "" &&
+		b.options.FunctionConfig.Spec.ImageName == "" {
+
+		if b.options.FunctionConfig.Spec.Runtime != "shell" {
+			return "", errors.New("Function path must be provided when specified runtime isn't shell")
+
+		}
+
+		// did user give handler to an executable
+		if b.options.FunctionConfig.Spec.Handler == "" {
+			return "", errors.New("If shell runtime is specified, function path or handler name must be provided")
+		}
+	}
 
 	// if the function path is a URL - first download the file
 	if common.IsURL(functionPath) {

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -97,7 +97,7 @@ func NewBuilder(parentLogger logger.Logger, platform *platform.Platform) (*Build
 	var err error
 
 	newBuilder := &Builder{
-		logger: parentLogger,
+		logger:   parentLogger,
 		platform: platform,
 	}
 

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -48,7 +48,7 @@ func (suite *TestSuite) SetupTest() {
 	var err error
 	suite.TestID = xid.New().String()
 
-	suite.Builder, err = NewBuilder(suite.Logger)
+	suite.Builder, err = NewBuilder(suite.Logger, nil)
 	if err != nil {
 		suite.Fail("Instantiating Builder failed:", err)
 	}

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -162,6 +162,19 @@ func (suite *TestSuite) TestBuildCustomHTTPPort() {
 		})
 }
 
+func (suite *TestSuite) TestBuildSpecifyingFunctionConfig() {
+	deployOptions := suite.getDeployOptions("json-parser-with-function-config")
+
+	deployOptions.FunctionConfig.Meta.Name = ""
+	deployOptions.FunctionConfig.Spec.Runtime = ""
+
+	suite.DeployFunctionAndRequest(deployOptions,
+		&httpsuite.Request{
+			RequestBody:          `{"a": 100, "return_this": "returned value"}`,
+			ExpectedResponseBody: "returned value",
+		})
+}
+
 func (suite *TestSuite) compressAndDeployFunctionFromURL(archiveExtension string,
 	compressor func(string, []string) error) {
 

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -176,7 +176,12 @@ func (suite *TestSuite) TearDownTest() {
 func (suite *TestSuite) DeployFunction(deployOptions *platform.DeployOptions,
 	onAfterContainerRun func(deployResult *platform.DeployResult) bool) *platform.DeployResult {
 
-	deployOptions.FunctionConfig.Meta.Name = fmt.Sprintf("%s-%s", deployOptions.FunctionConfig.Meta.Name, suite.TestID)
+	// give the name a unique prefix, except if name isn't set
+	// TODO: will affect concurrent runs
+	if deployOptions.FunctionConfig.Meta.Name != "" {
+		deployOptions.FunctionConfig.Meta.Name = fmt.Sprintf("%s-%s", deployOptions.FunctionConfig.Meta.Name, suite.TestID)
+	}
+
 	deployOptions.FunctionConfig.Spec.Build.NoBaseImagesPull = true
 
 	// Does the test call for cleaning up the temp dir, and thus needs to check this on teardown

--- a/test/_functions/common/json-parser-with-function-config/golang/function.yaml
+++ b/test/_functions/common/json-parser-with-function-config/golang/function.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-meta:
+metadata:
   name: parser
 spec:
   runtime: golang

--- a/test/_functions/common/json-parser-with-function-config/nodejs/function.yaml
+++ b/test/_functions/common/json-parser-with-function-config/nodejs/function.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-meta:
+metadata:
   name: parser
 spec:
   runtime: nodejs

--- a/test/_functions/common/json-parser-with-function-config/python/function.yaml
+++ b/test/_functions/common/json-parser-with-function-config/python/function.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-meta:
+metadata:
   name: parser
 spec:
   runtime: python

--- a/test/_functions/common/json-parser-with-function-config/shell/function.yaml
+++ b/test/_functions/common/json-parser-with-function-config/shell/function.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-meta:
+metadata:
   name: parser
 spec:
   runtime: shell

--- a/test/_functions/common/json-parser-with-inline-function-config/shell/parser.sh
+++ b/test/_functions/common/json-parser-with-inline-function-config/shell/parser.sh
@@ -17,7 +17,7 @@
 # @nuclio.configure
 #
 # function.yaml:
-#   meta:
+#   metadata:
 #     name: parser
 #   spec:
 #     runtime: shell


### PR DESCRIPTION
1. Path (-p) must be passed in nuctl build
2. Function configuration path (-f) supported
3. Source directory (--nuclio-src-dir and --nuclio-src-url) removed. Have been unused for a while

Fixes #567 #566 #565