### PR TITLE
Travis configuration improvements + deprecation fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,21 @@ script:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "development" ]; then
-    export NUCLIO_TAG="unstable";
+    export NUCLIO_TAG="unstable"
     fi
   - if [ "$TRAVIS_TAG" != "" ]; then
-    export NUCLIO_TAG="$TRAVIS_TAG";
+    export NUCLIO_TAG="$TRAVIS_TAG"
     fi
   - echo $TRAVIS_PULL_REQUEST
   - echo $TRAVIS_BRANCH
   - echo $NUCLIO_TAG
   - if [ -n "$NUCLIO_TAG" ]; then
-    docker version;
-    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-    make docker-images push-docker-images;
+    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" &&
+    make docker-images push-docker-images &&
+    if [ "$NUCLIO_TAG" != "unstable" ]; then
+    docker tag "nuclio/playground:$NUCLIO_TAG-amd64" nuclio/playground:stable-amd64 &&
+    docker push nuclio/playground:stable-amd64
+    fi
     fi
   - echo "Done."
 

--- a/pkg/processor/databinding/eventhub/databinding.go
+++ b/pkg/processor/databinding/eventhub/databinding.go
@@ -63,7 +63,7 @@ func (eh *eventhub) Start() error {
 	}
 
 	// Create a sender
-	eh.sender, err = eh.session.NewSender(amqp.LinkAddress(eh.configuration.EventHubName))
+	eh.sender, err = eh.session.NewSender(amqp.LinkSourceAddress(eh.configuration.EventHubName))
 	if err != nil {
 		return errors.Wrap(err, "Failed to create sender")
 	}

--- a/pkg/processor/trigger/eventhubs/partition.go
+++ b/pkg/processor/trigger/eventhubs/partition.go
@@ -60,7 +60,7 @@ func (p *partition) readFromPartition() error {
 
 	address := fmt.Sprintf("/%s/ConsumerGroups/%s/Partitions/%d", p.ehTrigger.configuration.EventHubName, p.ehTrigger.configuration.ConsumerGroup, p.partitionID)
 	receiver, err := session.NewReceiver(
-		amqp.LinkAddress(address),
+		amqp.LinkSourceAddress(address),
 		amqp.LinkCredit(10),
 	)
 	if err != nil {


### PR DESCRIPTION
1. Fail build on push failures (previously they were silently ignored)
2. Tag playground:stable when versions are released, push