### PR TITLE
remove non existing eventVersion API

### DIFF
--- a/pkg/processor/runtime/pypy/interface.go
+++ b/pkg/processor/runtime/pypy/interface.go
@@ -67,12 +67,6 @@ func logError(message string, args ...interface{}) {
 }
 
 // nolint
-//export eventVersion
-func eventVersion(ptr unsafe.Pointer) C.longlong {
-	return 1
-}
-
-// nolint
 //export eventID
 func eventID(ptr unsafe.Pointer) *C.char {
 	event := *(*nuclio.Event)(ptr)

--- a/pkg/processor/runtime/pypy/interface.h
+++ b/pkg/processor/runtime/pypy/interface.h
@@ -26,7 +26,6 @@ struct API {
   response_t *(*handle_event)(void *context, void *event);
   char *(*set_handler)(char *);
 
-  long long (*eventVersion)(void *);
   char *(*eventID)(void *);
   char *(*eventTriggerClass)(void *);
   char *(*eventTriggerKind)(void *);
@@ -48,7 +47,6 @@ struct API {
 struct API api;
 
 // exported from interface.go
-extern long long eventVersion(void *);
 extern char *eventID(void *);
 extern long long eventSize(void *);
 extern char *eventTriggerClass(void *);
@@ -74,7 +72,6 @@ response_t *handle_event(void *context, void *event) {
 char *set_handler(char *handler) { return api.set_handler(handler); }
 
 void fill_api() {
-  api.eventVersion = eventVersion;
   api.eventID = eventID;
   api.eventTriggerClass = eventTriggerClass;
   api.eventTriggerKind = eventTriggerKind;

--- a/pkg/processor/runtime/pypy/nuclio_interface.py
+++ b/pkg/processor/runtime/pypy/nuclio_interface.py
@@ -55,7 +55,6 @@ struct API {
   char *(*set_handler)(char *handler);
 
   // Event interface
-  long int (*eventVersion)(void *ptr);
   char *(*eventID)(void *ptr);
   char *(*eventTriggerClass)(void *ptr);
   char *(*eventTriggerKind)(void *ptr);


### PR DESCRIPTION
For some reason the API to pypy was exposing `eventVersion` which was always 1 and doesn't exist in the Go version of the API.