### PR TITLE
Add FunctionSourceCode to function build config

### DIFF
--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -120,6 +120,7 @@ type LoggerSink struct {
 // Build holds all configuration parameters related to building a function
 type Build struct {
 	Path               string            `json:"path,omitempty"`
+	FunctionSourceCode string            `json:"functionSourceCode,omitempty"`
 	FunctionConfigPath string            `json:"functionConfigPath,omitempty"`
 	OutputType         string            `json:"outputType,omitempty"`
 	NuclioSourceDir    string            `json:"nuclioSourceDir,omitempty"`

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -76,6 +76,7 @@ func newBuildCommandeer(rootCommandeer *RootCommandeer) *buildCommandeer {
 
 func addBuildFlags(cmd *cobra.Command, config *functionconfig.Config, commands *stringSliceFlag) { // nolint
 	cmd.Flags().StringVarP(&config.Spec.Build.Path, "path", "p", "", "Path to the function's source code")
+	cmd.Flags().StringVarP(&config.Spec.Build.FunctionSourceCode, "source", "", "", "The function's source code (overrides \"path\")")
 	cmd.Flags().StringVarP(&config.Spec.Build.FunctionConfigPath, "file", "f", "", "Path to a function-configuration file")
 	cmd.Flags().StringVarP(&config.Spec.Build.ImageName, "image", "i", "", "Name of a Docker image (default - the function name)")
 	cmd.Flags().StringVar(&config.Spec.Build.ImageVersion, "version", "latest", "Version of the Docker image")

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -130,10 +130,20 @@ func (b *Builder) Build(options *platform.BuildOptions) (*platform.BuildResult, 
 		return nil, errors.Wrap(err, "Failed to create staging dir")
 	}
 
-	// resolve the function path - download in case its a URL
-	b.options.FunctionConfig.Spec.Build.Path, err = b.resolveFunctionPath(b.options.FunctionConfig.Spec.Build.Path)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to resolve function path")
+	if b.options.FunctionConfig.Spec.Build.FunctionSourceCode != "" {
+
+		// if user gave function as source code rather than a path - write it to a temporary file
+		b.options.FunctionConfig.Spec.Build.Path, err = b.writeFunctionSourceCodeToTempFile(b.options.FunctionConfig.Spec.Build.FunctionSourceCode)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to save function code to temporary file")
+		}
+	} else {
+
+		// resolve the function path - download in case its a URL
+		b.options.FunctionConfig.Spec.Build.Path, err = b.resolveFunctionPath(b.options.FunctionConfig.Spec.Build.Path)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to resolve function path")
+		}
 	}
 
 	// parse the inline blocks in the file - blocks of comments starting with @nuclio.<something>. this may be used
@@ -361,6 +371,27 @@ func (b *Builder) getImageName() string {
 	}
 
 	return imageName
+}
+
+func (b *Builder) writeFunctionSourceCodeToTempFile(functionSourceCode string) (string, error) {
+	tempDir, err := b.mkDirUnderTemp("source")
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to create temporary dir for function code: %s", tempDir)
+	}
+
+	runtimeExtension, err := b.getRuntimeFileExtensionByName(b.options.FunctionConfig.Spec.Runtime)
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to get file extension for runtime %s", b.options.FunctionConfig.Spec.Runtime)
+	}
+
+	sourceFile := fmt.Sprintf("%s/handler%s", tempDir, runtimeExtension)
+
+	err = ioutil.WriteFile(sourceFile, []byte(functionSourceCode), os.FileMode(0644))
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to write given source code to file %s", sourceFile)
+	}
+
+	return sourceFile, nil
 }
 
 func (b *Builder) resolveFunctionPath(functionPath string) (string, error) {
@@ -987,6 +1018,21 @@ func (b *Builder) getRuntimeNameByFileExtension(functionPath string) (string, er
 	default:
 		return "", fmt.Errorf("Unsupported file extension: %s", functionFileExtension)
 	}
+}
+
+func (b *Builder) getRuntimeFileExtensionByName(runtimeName string) (string, error) {
+	switch runtimeName {
+	case golangRuntimeName:
+		return ".go", nil
+	case nodejsRuntimeName:
+		return ".js", nil
+	case pypyRuntimeName, pythonRuntimeName:
+		return ".py", nil
+	case shellRuntimeName:
+		return ".sh", nil
+	}
+
+	return "", fmt.Errorf("Unsupported runtime name: %s", runtimeName)
 }
 
 func (b *Builder) getRuntimeCommentPattern(runtimeName string) (string, error) {

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -374,6 +374,10 @@ func (b *Builder) getImageName() string {
 }
 
 func (b *Builder) writeFunctionSourceCodeToTempFile(functionSourceCode string) (string, error) {
+	if b.options.FunctionConfig.Spec.Runtime == "" {
+		return "", errors.New("Runtime must be explicitly defined when using Function Source Code")
+	}
+
 	tempDir, err := b.mkDirUnderTemp("source")
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed to create temporary dir for function code: %s", tempDir)

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -388,8 +388,10 @@ func (b *Builder) writeFunctionSourceCodeToTempFile(functionSourceCode string) (
 		return "", errors.Wrapf(err, "Failed to get file extension for runtime %s", b.options.FunctionConfig.Spec.Runtime)
 	}
 
-	sourceFile := fmt.Sprintf("%s/handler%s", tempDir, runtimeExtension)
+	sourceFileName := fmt.Sprintf("handler%s", runtimeExtension)
+	sourceFile := path.Join(tempDir, sourceFileName)
 
+	b.logger.DebugWith("Writing function source code to temporary file", "functionPath", sourceFile)
 	err = ioutil.WriteFile(sourceFile, []byte(functionSourceCode), os.FileMode(0644))
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed to write given source code to file %s", sourceFile)

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -17,6 +17,7 @@ limitations under the Licensg.
 package build
 
 import (
+	"io/ioutil"
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
@@ -118,6 +119,39 @@ func (suite *TestSuite) TestGetRuntimeNameFromBuildDirNoRuntime() {
 	if err == nil {
 		suite.Fail("Builder.getRuntimeName() should fail when given a directory for a build path and no runtime")
 	}
+}
+
+func (suite *TestSuite) TestWriteFunctionSourceCodeToTempFileWritesReturnsFilePath() {
+	functionSourceCode := "echo foo"
+	suite.Builder.options.FunctionConfig.Spec.Runtime = "shell"
+	suite.Builder.options.FunctionConfig.Spec.Build.FunctionSourceCode = functionSourceCode
+	suite.Builder.options.FunctionConfig.Spec.Build.Path = ""
+
+	err := suite.Builder.createTempDir()
+	suite.Assert().NoError(err)
+	defer suite.Builder.cleanupTempDir()
+
+	tempPath, err := suite.Builder.writeFunctionSourceCodeToTempFile(suite.Builder.options.FunctionConfig.Spec.Build.FunctionSourceCode)
+	suite.Assert().NoError(err)
+	suite.NotNil(tempPath)
+
+	resultSourceCode, err := ioutil.ReadFile(tempPath)
+	suite.Assert().NoError(err)
+
+	suite.Assert().Equal(functionSourceCode, string(resultSourceCode))
+}
+
+func (suite *TestSuite) TestWriteFunctionSourceCodeToTempFileFailsOnUnknownExtension() {
+	suite.Builder.options.FunctionConfig.Spec.Runtime = "bar"
+	suite.Builder.options.FunctionConfig.Spec.Build.FunctionSourceCode = "echo foo"
+	suite.Builder.options.FunctionConfig.Spec.Build.Path = ""
+
+	err := suite.Builder.createTempDir()
+	suite.Assert().NoError(err)
+	defer suite.Builder.cleanupTempDir()
+
+	_, err = suite.Builder.writeFunctionSourceCodeToTempFile(suite.Builder.options.FunctionConfig.Spec.Build.FunctionSourceCode)
+	suite.Assert().Error(err)
 }
 
 func (suite *TestSuite) TestGetImageSpecificCommandsReturnsEmptyOnUnknownBaseImage() {

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -133,6 +133,21 @@ func (suite *TestSuite) TestBuildArchiveFromURL() {
 	}
 }
 
+func (suite *TestSuite) TestBuildFuncFromSourceString() {
+	deployOptions := suite.getDeployOptions("reverser")
+
+	functionSourceCode, err := ioutil.ReadFile(deployOptions.FunctionConfig.Spec.Build.Path)
+	suite.Assert().NoError(err)
+
+	deployOptions.FunctionConfig.Spec.Build.FunctionSourceCode = string(functionSourceCode)
+	deployOptions.FunctionConfig.Spec.Build.Path = ""
+
+	suite.DeployFunctionAndRequest(deployOptions,
+		&httpsuite.Request{
+			RequestBody:          "abcdef",
+			ExpectedResponseBody: "fedcba",
+		})
+}
 func (suite *TestSuite) TestBuildCustomImageName() {
 	deployOptions := suite.getDeployOptions("reverser")
 

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -142,6 +142,12 @@ func (suite *TestSuite) TestBuildFuncFromSourceString() {
 	deployOptions.FunctionConfig.Spec.Build.FunctionSourceCode = string(functionSourceCode)
 	deployOptions.FunctionConfig.Spec.Build.Path = ""
 
+	if deployOptions.FunctionConfig.Spec.Runtime == "shell" {
+		deployOptions.FunctionConfig.Spec.Handler = "handler:main"
+	} else {
+		deployOptions.FunctionConfig.Spec.Handler = "handler:handler"
+	}
+
 	suite.DeployFunctionAndRequest(deployOptions,
 		&httpsuite.Request{
 			RequestBody:          "abcdef",

--- a/pkg/processor/build/test/build_test.go
+++ b/pkg/processor/build/test/build_test.go
@@ -32,25 +32,6 @@ type TestSuite struct {
 	httpsuite.TestSuite
 }
 
-func (suite *TestSuite) TestBuildFuncFromSourceString() {
-	deployOptions := &platform.DeployOptions{
-		Logger:         suite.Logger,
-		FunctionConfig: *functionconfig.NewConfig(),
-	}
-
-	deployOptions.FunctionConfig.Meta.Name = "echo-foo"
-	deployOptions.FunctionConfig.Spec.Runtime = "shell"
-	deployOptions.FunctionConfig.Spec.Build.Path = ""
-	deployOptions.FunctionConfig.Spec.Build.FunctionSourceCode = "echo foo"
-
-	suite.DeployFunctionAndRequest(deployOptions,
-		&httpsuite.Request{
-			RequestMethod:        "POST",
-			RequestBody:          "",
-			ExpectedResponseBody: "foo\n",
-		})
-}
-
 func (suite *TestSuite) TestBuildFuncFromSourceWithInlineConfig() {
 	deployOptions := &platform.DeployOptions{
 		Logger:         suite.Logger,


### PR DESCRIPTION
FunctionSourceCode overrides the path to the handler file/directory, and instead holds the handler's code as a string
As part of the build process the function source code is written to <temp dir>/source/handler.<runtime-specific extension>
Fixes #562