### PR TITLE
If --run-image is passed to deploy, don't prepend run-registry

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -175,7 +175,7 @@ func (c *Controller) handleFunctionCRAdd(function *functioncr.Function) error {
 	c.logger.WarnWith("Failed to add function custom resource", "err", err)
 
 	// indicate error state
-	c.setFunctionState(function, functionconfig.FunctionStateError, err.Error())
+	c.setFunctionState(function, functionconfig.FunctionStateError, errors.GetErrorStackString(err, 10))
 
 	// try to update the function
 	if updateFunctionErr := c.updateFunctioncr(function); updateFunctionErr != nil {
@@ -268,7 +268,7 @@ func (c *Controller) handleFunctionCRUpdate(function *functioncr.Function) error
 	// whatever the error, try to update the function CR
 	c.logger.WarnWith("Failed to update function custom resource", "err", err)
 
-	c.setFunctionState(function, functionconfig.FunctionStateError, err.Error())
+	c.setFunctionState(function, functionconfig.FunctionStateError, errors.GetErrorStackString(err, 10))
 
 	// try to update the function
 	if updateFunctionError := c.updateFunctioncr(function); updateFunctionError != nil {

--- a/cmd/controller/app/controller_test.go
+++ b/cmd/controller/app/controller_test.go
@@ -235,7 +235,7 @@ func (suite *ControllerCreateTestSuite) TestCreateErrorFunctionUpdated() {
 	// verify that fields were updated on function cr
 	verifyUpdatedFunctioncr := func(f *functioncr.Function) bool {
 		suite.Require().Equal(functionconfig.FunctionStateError, f.Status.State)
-		suite.Require().Equal("Validation failed", f.Status.Message)
+		suite.Require().Contains(f.Status.Message, "Validation failed")
 
 		return true
 	}

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -65,7 +65,7 @@ func NewShellClient(parentLogger logger.Logger, runner cmdrunner.CmdRunner) (*Sh
 
 // Build will build a docker image, given build options
 func (c *ShellClient) Build(buildOptions *BuildOptions) error {
-	c.logger.DebugWith("Building image", "image", buildOptions.ImageName)
+	c.logger.DebugWith("Building image", "image", buildOptions.Image)
 
 	// if context dir is not passed, use the dir containing the dockerfile
 	if buildOptions.ContextDir == "" && buildOptions.DockerfilePath != "" {
@@ -84,7 +84,7 @@ func (c *ShellClient) Build(buildOptions *BuildOptions) error {
 
 	_, err := c.runCommand(&cmdrunner.RunOptions{WorkingDir: &buildOptions.ContextDir},
 		"docker build --force-rm -t %s -f %s %s .",
-		buildOptions.ImageName,
+		buildOptions.Image,
 		buildOptions.DockerfilePath,
 		cacheOption)
 
@@ -117,16 +117,16 @@ func (c *ShellClient) CopyObjectsFromImage(imageName string, objectsToCopy map[s
 
 // PushImage pushes a local image to a remote docker repository
 func (c *ShellClient) PushImage(imageName string, registryURL string) error {
-	taggedImageName := registryURL + "/" + imageName
+	taggedImage := registryURL + "/" + imageName
 
-	c.logger.InfoWith("Pushing image", "from", imageName, "to", taggedImageName)
+	c.logger.InfoWith("Pushing image", "from", imageName, "to", taggedImage)
 
-	_, err := c.runCommand(nil, "docker tag %s %s", imageName, taggedImageName)
+	_, err := c.runCommand(nil, "docker tag %s %s", imageName, taggedImage)
 	if err != nil {
 		return errors.Wrap(err, "Failed to tag image")
 	}
 
-	_, err = c.runCommand(nil, "docker push %s", taggedImageName)
+	_, err = c.runCommand(nil, "docker push %s", taggedImage)
 	if err != nil {
 		return errors.Wrap(err, "Failed to push image")
 	}

--- a/pkg/dockerclient/types.go
+++ b/pkg/dockerclient/types.go
@@ -29,7 +29,7 @@ type LogInOptions struct {
 
 // BuildOptions are options for building a docker image
 type BuildOptions struct {
-	ImageName      string
+	Image          string
 	ContextDir     string
 	DockerfilePath string
 	NoCache        bool

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -24,6 +24,7 @@ package errors
 //     %+v   extended format. Will print stack trace of errors
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -172,6 +173,15 @@ func GetErrorStack(err error, depth int) []error {
 		errors = errors[:depth]
 	}
 	return errors
+}
+
+// GetErrorStackString returns the error stack as a string
+func GetErrorStackString(err error, depth int) string {
+	buffer := bytes.Buffer{}
+
+	PrintErrorStack(&buffer, err, depth)
+
+	return buffer.String()
 }
 
 // PrintErrorStack prints the error stack into out upto depth levels

--- a/pkg/functionconfig/reader_test.go
+++ b/pkg/functionconfig/reader_test.go
@@ -66,7 +66,7 @@ func (suite *TypesTestSuite) TestToDeployOptions() {
 	//  - command1
 	//  - command2
 	//  - command3
-	//  baseImageName: someBaseImage
+	//  baseImage: someBaseImage
 	//`
 
 	//deployOptions := platform.NewDeployOptions(nil)

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -126,12 +126,11 @@ type Build struct {
 	NuclioSourceURL    string            `json:"nuclioSourceURL,omitempty"`
 	TempDir            string            `json:"tempDir,omitempty"`
 	Registry           string            `json:"registry,omitempty"`
-	ImageName          string            `json:"imageName,omitempty"`
-	ImageVersion       string            `json:"imageVersion,omitempty"`
+	Image              string            `json:"image,omitempty"`
 	NoBaseImagesPull   bool              `json:"noBaseImagesPull,omitempty"`
 	NoCache            bool              `json:"noCache,omitempty"`
 	NoCleanup          bool              `json:"noCleanup,omitempty"`
-	BaseImageName      string            `json:"baseImageName,omitempty"`
+	BaseImage          string            `json:"baseImage,omitempty"`
 	Commands           []string          `json:"commands,omitempty"`
 	ScriptPaths        []string          `json:"scriptPaths,omitempty"`
 	AddedObjectPaths   map[string]string `json:"addedPaths,omitempty"`
@@ -146,7 +145,7 @@ type Spec struct {
 	Runtime           string                  `json:"runtime,omitempty"`
 	Env               []v1.EnvVar             `json:"env,omitempty"`
 	Resources         v1.ResourceRequirements `json:"resources,omitempty"`
-	ImageName         string                  `json:"image,omitempty"`
+	Image             string                  `json:"image,omitempty"`
 	HTTPPort          int                     `json:"httpPort,omitempty"`
 	Replicas          int                     `json:"replicas,omitempty"`
 	MinReplicas       int                     `json:"minReplicas,omitempty"`
@@ -199,7 +198,6 @@ func NewConfig() *Config {
 			Build: Build{
 				NuclioSourceURL: "https://github.com/nuclio/nuclio.git",
 				OutputType:      "docker",
-				ImageVersion:    "latest",
 			},
 		},
 	}

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -77,14 +77,13 @@ func newBuildCommandeer(rootCommandeer *RootCommandeer) *buildCommandeer {
 func addBuildFlags(cmd *cobra.Command, config *functionconfig.Config, commands *stringSliceFlag) { // nolint
 	cmd.Flags().StringVarP(&config.Spec.Build.Path, "path", "p", "", "Path to the function's source code")
 	cmd.Flags().StringVarP(&config.Spec.Build.FunctionConfigPath, "file", "f", "", "Path to a function-configuration file")
-	cmd.Flags().StringVarP(&config.Spec.Build.ImageName, "image", "i", "", "Name of a Docker image (default - the function name)")
-	cmd.Flags().StringVar(&config.Spec.Build.ImageVersion, "version", "latest", "Version of the Docker image")
+	cmd.Flags().StringVarP(&config.Spec.Build.Image, "image", "i", "", "Name of a Docker image (default - the function name)")
 	cmd.Flags().StringVarP(&config.Spec.Build.OutputType, "output", "o", "docker", "Type of the build output - \"docker\" or \"binary\"")
 	cmd.Flags().StringVarP(&config.Spec.Build.Registry, "registry", "r", os.Getenv("NUCTL_REGISTRY"), "URL of a container registry (env: NUCTL_REGISTRY)")
 	cmd.Flags().StringVarP(&config.Spec.Runtime, "runtime", "", "", "Runtime (for example, \"golang\", \"golang:1.8\", \"python:2.7\")")
 	cmd.Flags().StringVarP(&config.Spec.Handler, "handler", "", "", "Name of a function handler")
 	cmd.Flags().BoolVarP(&config.Spec.Build.NoBaseImagesPull, "no-pull", "", false, "Don't pull base images - use local versions")
 	cmd.Flags().BoolVarP(&config.Spec.Build.NoCleanup, "no-cleanup", "", false, "Don't clean up temporary directories")
-	cmd.Flags().StringVarP(&config.Spec.Build.BaseImageName, "base-image", "", "", "Name of the base image (default - per-runtime default)")
+	cmd.Flags().StringVarP(&config.Spec.Build.BaseImage, "base-image", "", "", "Name of the base image (default - per-runtime default)")
 	cmd.Flags().Var(commands, "build-command", "Commands to run when building the processor image")
 }

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -97,15 +97,7 @@ func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 
-			err := validateFunctionConfig(args,
-				rootCommandeer.platform.GetDeployRequiresRegistry(),
-				&commandeer.functionConfig)
-
-			if err != nil {
-				return err
-			}
-
-			_, err = rootCommandeer.platform.DeployFunction(&platform.DeployOptions{
+			_, err := rootCommandeer.platform.DeployFunction(&platform.DeployOptions{
 				Logger:           rootCommandeer.loggerInstance,
 				FunctionConfig:   commandeer.functionConfig,
 				ReadinessTimeout: &commandeer.readinessTimeout,
@@ -120,17 +112,6 @@ func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
 	commandeer.cmd = cmd
 
 	return commandeer
-}
-
-func validateFunctionConfig(args []string,
-	registryRequired bool,
-	functionConfig *functionconfig.Config) error {
-
-	if functionConfig.Spec.Build.Registry == "" && registryRequired {
-		return errors.New("A registry is required; can also be specified in spec.image or via a NUCTL_REGISTRY environment variable")
-	}
-
-	return nil
 }
 
 func addDeployFlags(cmd *cobra.Command,
@@ -149,7 +130,7 @@ func addDeployFlags(cmd *cobra.Command,
 	cmd.Flags().BoolVar(&functionConfig.Spec.Publish, "publish", false, "Publish the function")
 	cmd.Flags().StringVar(&commandeer.encodedDataBindings, "data-bindings", "{}", "JSON-encoded data bindings for the function")
 	cmd.Flags().StringVar(&commandeer.encodedTriggers, "triggers", "{}", "JSON-encoded triggers for the function")
-	cmd.Flags().StringVar(&functionConfig.Spec.ImageName, "run-image", "", "Name of an existing image to deploy (default - build a new image to deploy)")
+	cmd.Flags().StringVar(&functionConfig.Spec.Image, "run-image", "", "Name of an existing image to deploy (default - build a new image to deploy)")
 	cmd.Flags().StringVar(&functionConfig.Spec.RunRegistry, "run-registry", os.Getenv("NUCTL_RUN_REGISTRY"), "URL of a registry for pulling the image, if differs from -r/--registry (env: NUCTL_RUN_REGISTRY)")
 	cmd.Flags().StringVar(&commandeer.encodedRuntimeAttributes, "runtime-attrs", "{}", "JSON-encoded runtime attributes for the function")
 	cmd.Flags().DurationVar(&commandeer.readinessTimeout, "readiness-timeout", 30*time.Second, "maximum wait time for the function to be ready")

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -76,11 +76,17 @@ func (ap *Platform) HandleDeployFunction(deployOptions *platform.DeployOptions,
 	deployOptions.Logger.InfoWith("Deploying function", "name", deployOptions.FunctionConfig.Meta.Name)
 
 	// check if we need to build the image
-	if deployOptions.FunctionConfig.Spec.ImageName == "" {
+	if deployOptions.FunctionConfig.Spec.Image == "" {
 		buildResult, err = builder(deployOptions)
 
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to build image before deploy")
+		}
+	} else {
+
+		// verify user passed runtime
+		if deployOptions.FunctionConfig.Spec.Runtime == "" {
+			return nil, errors.New("If image is passed, runtime must be specified")
 		}
 	}
 
@@ -130,7 +136,7 @@ func (ap *Platform) BuildFunctionBeforeDeploy(deployOptions *platform.DeployOpti
 
 	// use the function configuration augmented by the builder
 	deployOptions.FunctionConfig = buildResult.UpdatedFunctionConfig
-	deployOptions.FunctionConfig.Spec.ImageName = buildResult.ImageName
+	deployOptions.FunctionConfig.Spec.Image = buildResult.Image
 
 	// if run registry isn't set, set it
 	if deployOptions.FunctionConfig.Spec.RunRegistry == "" {

--- a/pkg/platform/kube/deployer.go
+++ b/pkg/platform/kube/deployer.go
@@ -99,9 +99,16 @@ func (d *deployer) populateFunctioncr(functionConfig *functionconfig.Config,
 	// set alias as "latest" for now
 	functioncrInstance.Spec.Alias = "latest"
 
-	functioncrInstance.Spec.ImageName = fmt.Sprintf("%s/%s",
-		functionConfig.Spec.RunRegistry,
-		functionConfig.Spec.ImageName)
+	// there are two cases here:
+	// 1. user specified --run-image: in this case, we will get here with a full URL in the image field (e.g.
+	//    localhost:5000/foo:latest)
+	// 2. user didn't specify --run-image and a build was performed. in such a case, image is set to the image
+	//    name:tag (e.g. foo:latest) and we need to prepend run registry
+
+	// if, for some reason, the run registry is specified, prepend that
+	if functionConfig.Spec.RunRegistry != "" {
+		functioncrInstance.Spec.Image = fmt.Sprintf("%s/%s", functionConfig.Spec.RunRegistry, functioncrInstance.Spec.Image)
+	}
 
 	// update status
 	functioncrInstance.Status.Status = *functionStatus

--- a/pkg/platform/kube/functiondep/client.go
+++ b/pkg/platform/kube/functiondep/client.go
@@ -780,7 +780,7 @@ func (c *Client) populateDeploymentContainer(labels map[string]string,
 	platformConfigVolumeMount.Name = platformConfigVolumeName
 	platformConfigVolumeMount.MountPath = "/etc/nuclio/config/platform"
 
-	container.Image = function.Spec.ImageName
+	container.Image = function.Spec.Image
 	container.Resources = function.Spec.Resources
 	container.Env = c.getFunctionEnvironment(labels, function)
 	container.VolumeMounts = []v1.VolumeMount{processorConfigVolumeMount, platformConfigVolumeMount}

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -264,7 +264,7 @@ func (p *Platform) deployFunction(deployOptions *platform.DeployOptions) (*platf
 	}
 
 	// run the docker image
-	containerID, err := p.dockerClient.RunContainer(deployOptions.FunctionConfig.Spec.ImageName, &dockerclient.RunOptions{
+	containerID, err := p.dockerClient.RunContainer(deployOptions.FunctionConfig.Spec.Image, &dockerclient.RunOptions{
 		Ports:  map[int]int{functionHTTPPort: 8080},
 		Env:    envMap,
 		Labels: labels,

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -50,7 +50,7 @@ type DeleteOptions struct {
 
 // BuildResult holds information detected/generated as a result of a build process
 type BuildResult struct {
-	ImageName string
+	Image string
 
 	// the function configuration read by the builder either from function.yaml or inline configuration
 	UpdatedFunctionConfig functionconfig.Config

--- a/pkg/playground/resource/function.go
+++ b/pkg/playground/resource/function.go
@@ -318,8 +318,8 @@ func (fr *functionResource) OnAfterInitialize() error {
 			Spec: functionconfig.Spec{
 				Runtime: "python:3.6",
 				Build: functionconfig.Build{
-					Path:          "/sources/tensor.py",
-					BaseImageName: "jessie",
+					Path:      "/sources/tensor.py",
+					BaseImage: "jessie",
 					Commands: []string{
 						"apt-get update && apt-get install -y wget",
 						"wget http://download.tensorflow.org/models/image/imagenet/inception-2015-12-05.tgz",

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -166,18 +166,18 @@ func (b *Builder) Build(options *platform.BuildOptions) (*platform.BuildResult, 
 	}
 
 	// build the processor image
-	processorImageName, err := b.buildProcessorImage()
+	processorImage, err := b.buildProcessorImage()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to build processor image")
 	}
 
 	// push the processor image
-	if err := b.pushProcessorImage(processorImageName); err != nil {
+	if err := b.pushProcessorImage(processorImage); err != nil {
 		return nil, errors.Wrap(err, "Failed to push processor image")
 	}
 
 	buildResult := &platform.BuildResult{
-		ImageName:             processorImageName,
+		Image: processorImage,
 		UpdatedFunctionConfig: b.options.FunctionConfig,
 	}
 
@@ -310,7 +310,7 @@ func (b *Builder) validateAndEnrichConfiguration() error {
 
 	// if output image name isn't set, set it to a derivative of the name
 	if b.processorImage.imageName == "" {
-		b.processorImage.imageName = b.getImageName()
+		b.processorImage.imageName = b.getImage()
 	}
 
 	// if tag isn't set - set latest
@@ -321,10 +321,10 @@ func (b *Builder) validateAndEnrichConfiguration() error {
 	return nil
 }
 
-func (b *Builder) getImageName() string {
+func (b *Builder) getImage() string {
 	var imageName string
 
-	if b.options.FunctionConfig.Spec.Build.ImageName == "" {
+	if b.options.FunctionConfig.Spec.Build.Image == "" {
 		repository := "nuclio/"
 
 		// try to see if the registry URL has a repository specified (e.g. localhost:5000/foo). If so,
@@ -338,7 +338,7 @@ func (b *Builder) getImageName() string {
 
 		imageName = fmt.Sprintf("%sprocessor-%s", repository, b.GetFunctionName())
 	} else {
-		imageName = b.options.FunctionConfig.Spec.Build.ImageName
+		imageName = b.options.FunctionConfig.Spec.Build.Image
 	}
 
 	return imageName
@@ -348,7 +348,7 @@ func (b *Builder) resolveFunctionPath(functionPath string) (string, error) {
 
 	// function can either be in the path, received inline or an executable via handler
 	if b.options.FunctionConfig.Spec.Build.Path == "" &&
-		b.options.FunctionConfig.Spec.ImageName == "" {
+		b.options.FunctionConfig.Spec.Image == "" {
 
 		if b.options.FunctionConfig.Spec.Runtime != "shell" {
 			return "", errors.New("Function path must be provided when specified runtime isn't shell")
@@ -661,7 +661,7 @@ func (b *Builder) buildProcessorImage() (string, error) {
 	imageName := fmt.Sprintf("%s:%s", b.processorImage.imageName, b.processorImage.imageTag)
 
 	err = b.dockerClient.Build(&dockerclient.BuildOptions{
-		ImageName:      imageName,
+		Image:          imageName,
 		DockerfilePath: processorDockerfilePathInStaging,
 		NoCache:        b.options.FunctionConfig.Spec.Build.NoCache,
 	})
@@ -672,13 +672,13 @@ func (b *Builder) buildProcessorImage() (string, error) {
 func (b *Builder) createProcessorDockerfile() (string, error) {
 
 	// get the base image name (based on version, base image name, etc)
-	baseImageName, err := b.runtime.GetProcessorBaseImageName()
+	baseImage, err := b.runtime.GetProcessorBaseImage()
 	if err != nil {
 		return "", errors.Wrap(err, "Could not find a proper base image for processor")
 	}
 
 	// prepare pre/post-copy instructions for the processor
-	preCopyBuildInstructions, err := b.getPreCopyBuildInstructions(baseImageName)
+	preCopyBuildInstructions, err := b.getPreCopyBuildInstructions(baseImage)
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to prepare pre-copy build commands")
 	}
@@ -692,7 +692,7 @@ func (b *Builder) createProcessorDockerfile() (string, error) {
 		"pathBase":                  path.Base,
 		"isDir":                     common.IsDir,
 		"objectsToCopy":             b.getObjectsToCopyToProcessorImage,
-		"baseImageName":             func() string { return baseImageName },
+		"baseImage":                 func() string { return baseImage },
 		"preCopyBuildInstructions":  func() []string { return preCopyBuildInstructions },
 		"postCopyBuildInstructions": func() []string { return postCopyBuildInstructions },
 	}
@@ -712,7 +712,7 @@ func (b *Builder) createProcessorDockerfile() (string, error) {
 	}
 
 	b.logger.DebugWith("Creating processor Dockerfile from template",
-		"baseImage", baseImageName,
+		"baseImage", baseImage,
 		"preCopyInstructions", preCopyBuildInstructions,
 		"postCopyInstructions", postCopyBuildInstructions,
 		"dest", processorDockerfilePathInStaging)
@@ -936,9 +936,9 @@ func (b *Builder) createTempFileFromYAML(fileName string, unmarshalledYAMLConten
 	return tempFileName, nil
 }
 
-func (b *Builder) pushProcessorImage(processorImageName string) error {
+func (b *Builder) pushProcessorImage(processorImage string) error {
 	if b.options.FunctionConfig.Spec.Build.Registry != "" {
-		return b.dockerClient.PushImage(processorImageName, b.options.FunctionConfig.Spec.Build.Registry)
+		return b.dockerClient.PushImage(processorImage, b.options.FunctionConfig.Spec.Build.Registry)
 	}
 
 	return nil

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -179,27 +179,27 @@ func (suite *TestSuite) TestReplaceBuildCommandDirectivesIgnoresUnknownDirective
 	suite.Require().EqualValues(commands, result)
 }
 
-func (suite *TestSuite) TestGetImageName() {
+func (suite *TestSuite) TestGetImage() {
 
 	// user specified
-	suite.Builder.options.FunctionConfig.Spec.Build.ImageName = "userSpecified"
-	suite.Require().Equal("userSpecified", suite.Builder.getImageName())
+	suite.Builder.options.FunctionConfig.Spec.Build.Image = "userSpecified"
+	suite.Require().Equal("userSpecified", suite.Builder.getImage())
 
 	// set function name and clear image name
 	suite.Builder.options.FunctionConfig.Meta.Name = "test"
-	suite.Builder.options.FunctionConfig.Spec.Build.ImageName = ""
+	suite.Builder.options.FunctionConfig.Spec.Build.Image = ""
 
 	// registry has no repository - should see "nuclio/" as repository
 	suite.Builder.options.FunctionConfig.Spec.Build.Registry = "localhost:5000"
-	suite.Require().Equal("nuclio/processor-test", suite.Builder.getImageName())
+	suite.Require().Equal("nuclio/processor-test", suite.Builder.getImage())
 
 	// registry has a repository - should not see "nuclio/" as repository
 	suite.Builder.options.FunctionConfig.Spec.Build.Registry = "registry.hub.docker.com/foo"
-	suite.Require().Equal("processor-test", suite.Builder.getImageName())
+	suite.Require().Equal("processor-test", suite.Builder.getImage())
 
 	// registry has a repository - should not see "nuclio/" as repository
 	suite.Builder.options.FunctionConfig.Spec.Build.Registry = "index.docker.io/foo"
-	suite.Require().Equal("processor-test", suite.Builder.getImageName())
+	suite.Require().Equal("processor-test", suite.Builder.getImage())
 }
 
 func TestBuilderSuite(t *testing.T) {

--- a/pkg/processor/build/runtime/nodejs/runtime.go
+++ b/pkg/processor/build/runtime/nodejs/runtime.go
@@ -73,7 +73,7 @@ func (n *nodejs) getFunctionHandler() string {
 	return fmt.Sprintf("%s:%s", functionFileName, "handler")
 }
 
-func (n *nodejs) GetProcessorBaseImageName() (string, error) {
+func (n *nodejs) GetProcessorBaseImage() (string, error) {
 	versionInfo, err := version.Get()
 
 	if err != nil {

--- a/pkg/processor/build/runtime/pypy/runtime.go
+++ b/pkg/processor/build/runtime/pypy/runtime.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	defaultRuntimeVersion = "2-5.9"
-	defaultBaseImageName  = "jessie"
+	defaultBaseImage      = "jessie"
 )
 
 var (
@@ -37,7 +37,7 @@ var (
 	}
 
 	supportedImages = map[string]bool{
-		defaultBaseImageName: true,
+		defaultBaseImage: true,
 	}
 )
 
@@ -45,8 +45,8 @@ type pypy struct {
 	*runtime.AbstractRuntime
 }
 
-// GetProcessorBaseImageName returns the image name of the default processor base image
-func (p *pypy) GetProcessorBaseImageName() (string, error) {
+// GetProcessorBaseImage returns the image name of the default processor base image
+func (p *pypy) GetProcessorBaseImage() (string, error) {
 
 	// get the version we're running so we can pull the compatible image
 	versionInfo, err := version.Get()
@@ -57,9 +57,9 @@ func (p *pypy) GetProcessorBaseImageName() (string, error) {
 	_, runtimeVersion := p.GetRuntimeNameAndVersion()
 
 	// try to get base image name
-	baseImageName, err := getBaseImageName(versionInfo,
+	baseImage, err := getBaseImage(versionInfo,
 		runtimeVersion,
-		p.FunctionConfig.Spec.Build.BaseImageName)
+		p.FunctionConfig.Spec.Build.BaseImage)
 
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to get base image name")
@@ -67,12 +67,12 @@ func (p *pypy) GetProcessorBaseImageName() (string, error) {
 
 	// make sure the image exists. don't pull if instructed not to
 	if !p.FunctionConfig.Spec.Build.NoBaseImagesPull {
-		if err := p.DockerClient.PullImage(baseImageName); err != nil {
-			return "", errors.Wrapf(err, "Can't pull %q", baseImageName)
+		if err := p.DockerClient.PullImage(baseImage); err != nil {
+			return "", errors.Wrapf(err, "Can't pull %q", baseImage)
 		}
 	}
 
-	return baseImageName, nil
+	return baseImage, nil
 }
 
 // DetectFunctionHandlers returns a list of all the handlers
@@ -119,9 +119,9 @@ func (p *pypy) getFunctionHandler() string {
 	return fmt.Sprintf("%s:%s", functionFileName, "handler")
 }
 
-func getBaseImageName(versionInfo *version.Info,
+func getBaseImage(versionInfo *version.Info,
 	runtimeVersion string,
-	baseImageName string) (string, error) {
+	baseImage string) (string, error) {
 
 	// if the runtime version contains any value, use it. otherwise default to 3.6
 	if runtimeVersion == "" {
@@ -129,8 +129,8 @@ func getBaseImageName(versionInfo *version.Info,
 	}
 
 	// if base image name not passed, use our
-	if baseImageName == "" {
-		baseImageName = defaultBaseImageName
+	if baseImage == "" {
+		baseImage = defaultBaseImage
 	}
 
 	// check runtime
@@ -139,13 +139,13 @@ func getBaseImageName(versionInfo *version.Info,
 	}
 
 	// check base image
-	if ok := supportedImages[baseImageName]; !ok {
-		return "", fmt.Errorf("Base image not supported: %s", baseImageName)
+	if ok := supportedImages[baseImage]; !ok {
+		return "", fmt.Errorf("Base image not supported: %s", baseImage)
 	}
 
 	return fmt.Sprintf("nuclio/handler-pypy%s-%s:%s-%s",
 		runtimeVersion,
-		baseImageName,
+		baseImage,
 		versionInfo.Label,
 		versionInfo.Arch), nil
 }

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -30,8 +30,8 @@ type python struct {
 	*runtime.AbstractRuntime
 }
 
-// GetProcessorBaseImageName returns the image name of the default processor base image
-func (p *python) GetProcessorBaseImageName() (string, error) {
+// GetProcessorBaseImage returns the image name of the default processor base image
+func (p *python) GetProcessorBaseImage() (string, error) {
 
 	// get the version we're running so we can pull the compatible image
 	versionInfo, err := version.Get()
@@ -42,9 +42,9 @@ func (p *python) GetProcessorBaseImageName() (string, error) {
 	_, runtimeVersion := p.GetRuntimeNameAndVersion()
 
 	// try to get base image name
-	baseImageName, err := getBaseImageName(versionInfo,
+	baseImage, err := getBaseImage(versionInfo,
 		runtimeVersion,
-		p.FunctionConfig.Spec.Build.BaseImageName)
+		p.FunctionConfig.Spec.Build.BaseImage)
 
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to get base image name")
@@ -52,12 +52,12 @@ func (p *python) GetProcessorBaseImageName() (string, error) {
 
 	// make sure the image exists. don't pull if instructed not to
 	if !p.FunctionConfig.Spec.Build.NoBaseImagesPull {
-		if err := p.DockerClient.PullImage(baseImageName); err != nil {
-			return "", errors.Wrapf(err, "Can't pull %q", baseImageName)
+		if err := p.DockerClient.PullImage(baseImage); err != nil {
+			return "", errors.Wrapf(err, "Can't pull %q", baseImage)
 		}
 	}
 
-	return baseImageName, nil
+	return baseImage, nil
 }
 
 // DetectFunctionHandlers returns a list of all the handlers
@@ -99,9 +99,9 @@ func (p *python) getFunctionHandler() string {
 	return fmt.Sprintf("%s:%s", functionFileName, "handler")
 }
 
-func getBaseImageName(versionInfo *version.Info,
+func getBaseImage(versionInfo *version.Info,
 	runtimeVersion string,
-	baseImageName string) (string, error) {
+	baseImage string) (string, error) {
 
 	// if the runtime version contains any value, use it. otherwise default to 3.6
 	if runtimeVersion == "" {
@@ -109,8 +109,8 @@ func getBaseImageName(versionInfo *version.Info,
 	}
 
 	// if base image name not passed, use alpine
-	if baseImageName == "" {
-		baseImageName = "alpine"
+	if baseImage == "" {
+		baseImage = "alpine"
 	}
 
 	// check runtime
@@ -121,15 +121,15 @@ func getBaseImageName(versionInfo *version.Info,
 	}
 
 	// check base image
-	switch baseImageName {
+	switch baseImage {
 	case "alpine", "jessie":
 	default:
-		return "", fmt.Errorf("Base image not supported: %s", baseImageName)
+		return "", fmt.Errorf("Base image not supported: %s", baseImage)
 	}
 
 	return fmt.Sprintf("nuclio/processor-py%s-%s:%s-%s",
 		runtimeVersion,
-		baseImageName,
+		baseImage,
 		versionInfo.Label,
 		versionInfo.Arch), nil
 }

--- a/pkg/processor/build/runtime/python/runtime_test.go
+++ b/pkg/processor/build/runtime/python/runtime_test.go
@@ -28,11 +28,11 @@ type PythonTestSuite struct {
 	suite.Suite
 }
 
-func (suite *PythonTestSuite) TestBaseImageName() {
+func (suite *PythonTestSuite) TestBaseImage() {
 
 	for _, params := range []struct {
 		runtimeVersion    string
-		baseImageName     string
+		baseImage         string
 		label             string
 		arch              string
 		expectedBaseImage string
@@ -99,12 +99,12 @@ func (suite *PythonTestSuite) TestBaseImageName() {
 			Arch:  params.arch,
 		}
 
-		baseImageName, err := getBaseImageName(&versionInfo, params.runtimeVersion, params.baseImageName)
+		baseImage, err := getBaseImage(&versionInfo, params.runtimeVersion, params.baseImage)
 
 		if params.expectedBaseImage == "" {
 			suite.Require().Error(err)
 		} else {
-			suite.Require().Equal(params.expectedBaseImage, baseImageName)
+			suite.Require().Equal(params.expectedBaseImage, baseImage)
 			suite.Require().NoError(err)
 		}
 	}

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -31,8 +31,8 @@ import (
 
 type Runtime interface {
 
-	// GetProcessorBaseImageName returns the image name of the default processor base image
-	GetProcessorBaseImageName() (string, error)
+	// GetProcessorBaseImage returns the image name of the default processor base image
+	GetProcessorBaseImage() (string, error)
 
 	// DetectFunctionHandlers returns a list of all the handlers
 	// in that directory given a path holding a function (or functions)

--- a/pkg/processor/build/runtime/shell/runtime.go
+++ b/pkg/processor/build/runtime/shell/runtime.go
@@ -30,8 +30,8 @@ type shell struct {
 	*runtime.AbstractRuntime
 }
 
-// GetProcessorBaseImageName returns the image name of the default processor base image
-func (s *shell) GetProcessorBaseImageName() (string, error) {
+// GetProcessorBaseImage returns the image name of the default processor base image
+func (s *shell) GetProcessorBaseImage() (string, error) {
 	versionInfo, err := version.Get()
 
 	if err != nil {

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -133,11 +133,11 @@ func (suite *TestSuite) TestBuildArchiveFromURL() {
 	}
 }
 
-func (suite *TestSuite) TestBuildCustomImageName() {
+func (suite *TestSuite) TestBuildCustomImage() {
 	deployOptions := suite.getDeployOptions("reverser")
 
 	// update image name
-	deployOptions.FunctionConfig.Spec.Build.ImageName = "myname" + suite.TestID
+	deployOptions.FunctionConfig.Spec.Build.Image = "myname" + suite.TestID
 
 	deployResult := suite.DeployFunctionAndRequest(deployOptions,
 		&httpsuite.Request{
@@ -145,7 +145,7 @@ func (suite *TestSuite) TestBuildCustomImageName() {
 			ExpectedResponseBody: "fedcba",
 		})
 
-	suite.Require().Equal(deployOptions.FunctionConfig.Spec.Build.ImageName+":latest", deployResult.ImageName)
+	suite.Require().Equal(deployOptions.FunctionConfig.Spec.Build.Image+":latest", deployResult.Image)
 }
 
 func (suite *TestSuite) TestBuildCustomHTTPPort() {
@@ -209,7 +209,7 @@ func (suite *TestSuite) TestBuildLongInitializationReadinessTimeoutReached() {
 	suite.Require().NoError(err)
 
 	// clean up the processor image we built
-	err = suite.DockerClient.RemoveImage(deployOptions.FunctionConfig.Spec.ImageName)
+	err = suite.DockerClient.RemoveImage(deployOptions.FunctionConfig.Spec.Image)
 	suite.Require().NoError(err)
 }
 

--- a/pkg/processor/build/template.go
+++ b/pkg/processor/build/template.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package build
 
-var processorImageDockerfileTemplate = `FROM {{baseImageName}}
+var processorImageDockerfileTemplate = `FROM {{baseImage}}
 
 {{if preCopyBuildInstructions}}
 {{range preCopyBuildInstructions}}

--- a/pkg/processor/build/test/build_test.go
+++ b/pkg/processor/build/test/build_test.go
@@ -52,7 +52,7 @@ func (suite *TestSuite) TestBuildJessiePassesNonInteractiveFlag() {
 
 	deployOptions.FunctionConfig.Spec.Runtime = "python:2.7"
 	deployOptions.FunctionConfig.Spec.Handler = "printer:handler"
-	deployOptions.FunctionConfig.Spec.Build.BaseImageName = "jessie"
+	deployOptions.FunctionConfig.Spec.Build.BaseImage = "jessie"
 
 	deployOptions.FunctionConfig.Spec.Build.Commands = append(deployOptions.FunctionConfig.Spec.Build.Commands, "apt-get -qq update")
 	deployOptions.FunctionConfig.Spec.Build.Commands = append(deployOptions.FunctionConfig.Spec.Build.Commands, "apt-get -qq install curl")

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -190,7 +190,7 @@ func (suite *TestSuite) DeployFunction(deployOptions *platform.DeployOptions,
 
 	// remove the image when we're done
 	if os.Getenv(keepDockerEnvKey) == "" {
-		defer suite.DockerClient.RemoveImage(deployResult.ImageName)
+		defer suite.DockerClient.RemoveImage(deployResult.Image)
 	}
 
 	// give the container some time - after 10 seconds, give up


### PR DESCRIPTION
Also:
1. Renamed `ImageName` to just `Image` in the code, to be canonical and consistent
2. Controller will write the full stack when it fails to deploy a function to the CRD message, making it available to the deployer