### PR TITLE
Support setting external IP in dashboard

### DIFF
--- a/cmd/dashboard/README.md
+++ b/cmd/dashboard/README.md
@@ -1,6 +1,10 @@
-# Dashboard
+# Dashboard HTTP API
+Table of contents:
+- [Function](#function)
+- [Project](#project)
+- [Misc](#misc)
 
-## HTTP API
+## Function
 
 ### Listing all functions
 #### Request 
@@ -208,6 +212,8 @@ Updating a function is similar to creating a function. The only differences are:
 #### Response
 * Status code: 204
 
+## Project
+
 ### Listing all projects
 #### Request 
 * URL: `GET /projects`
@@ -328,3 +334,43 @@ Only projects with no functions can be deleted. Attempting to delete a project w
 ```
 #### Response
 * Status code: 204
+
+## Misc
+
+### Getting version
+#### Request 
+* URL: `GET /versions`
+
+#### Response
+* Status code: 200
+* Body:
+```json
+{
+    "dashboard": {
+        "arch": "amd64",
+        "gitCommit": "<some commit hash>",
+        "label": "latest",
+        "os": "darwin"
+    }
+}
+```
+
+### Getting external IP addresses
+The user must know through which URL a function can be invoked in case load balancing / ingresses are not used. If the user concatenates one of the external IP addresses returned by this endpoint with the function's HTTP port, as specified in its spec/status - this will form a valid invocation URL.
+
+#### Request 
+* URL: `GET /external_ip_addresses`
+
+#### Response
+* Status code: 200
+* Body:
+```json
+{
+    "externalIPAddresses": {
+        "addresses": [
+            ""
+        ]
+    }
+}
+```
+

--- a/cmd/dashboard/app/dashboard.go
+++ b/cmd/dashboard/app/dashboard.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	"strings"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/dashboard"
@@ -35,7 +36,8 @@ func Run(listenAddress string,
 	defaultRunRegistryURL string,
 	platformType string,
 	noPullBaseImages bool,
-	defaultCredRefreshIntervalString string) error {
+	defaultCredRefreshIntervalString string,
+	externalIPAddresses string) error {
 
 	logger, err := nucliozap.NewNuclioZapCmd("dashboard", nucliozap.DebugLevel)
 	if err != nil {
@@ -63,6 +65,9 @@ func Run(listenAddress string,
 		ListenAddress: listenAddress,
 	}
 
+	// "10.0.0.1,10.0.0.2" -> ["10.0.0.1", "10.0.0.2"]
+	splitExternalIPAddresses := strings.Split(externalIPAddresses, ",")
+
 	server, err := dashboard.NewServer(logger,
 		assetsDir,
 		dockerKeyDir,
@@ -71,7 +76,8 @@ func Run(listenAddress string,
 		platformInstance,
 		noPullBaseImages,
 		webServerConfiguration,
-		getDefaultCredRefreshInterval(logger, defaultCredRefreshIntervalString))
+		getDefaultCredRefreshInterval(logger, defaultCredRefreshIntervalString),
+		splitExternalIPAddresses)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create server")
 	}

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -36,6 +36,7 @@ func main() {
 	defaultRunRegistryURL := flag.String("run-registry", os.Getenv("NUCLIO_DASHBOARD_RUN_REGISTRY_URL"), "Default run registry URL")
 	noPullBaseImages := flag.Bool("no-pull", defaultNoPullBaseImages, "Default run registry URL")
 	credsRefreshInterval := flag.String("creds-refresh-interval", os.Getenv("NUCLIO_DASHBOARD_CREDS_REFRESH_INTERVAL"), "Default credential refresh interval, or 'none' (12h by default)")
+	externalIPAddresses := flag.String("external-ip-addresses", os.Getenv("NUCLIO_DASHBOARD_EXTERNAL_IP_ADDRESSES"), "Comma delimited list of external IP addresses")
 
 	flag.Parse()
 
@@ -46,7 +47,8 @@ func main() {
 		*defaultRunRegistryURL,
 		*platformType,
 		*noPullBaseImages,
-		*credsRefreshInterval); err != nil {
+		*credsRefreshInterval,
+		*externalIPAddresses); err != nil {
 
 		errors.PrintErrorStack(os.Stderr, err, 5)
 

--- a/hack/aks/resources/nuclio.yaml
+++ b/hack/aks/resources/nuclio.yaml
@@ -31,6 +31,23 @@ spec:
 
 ---
 
+# Define a "project" custom resource definition - extending the k8s API to allow management of "project" resources
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Project resource
+kind: CustomResourceDefinition
+metadata:
+  name: projects.nuclio.io
+spec:
+  group: nuclio.io
+  names:
+    kind: Project
+    plural: projects
+    singular: project
+  scope: Namespaced
+  version: v1beta1
+
+---
+
 # All nuclio services are bound to the "nuclio" service account. In RBAC enabled setups, this service account is
 # bound to specific roles limiting what the services can do
 apiVersion: v1
@@ -116,6 +133,59 @@ metadata:
 spec:
   selector:
     nuclio.io/app: playground
+  ports:
+  - name: admin
+    port: 8070
+    protocol: TCP
+
+---
+
+# The nuclio dashboard is a WIP replacement for the playground
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: nuclio-dashboard
+  namespace: nuclio
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        nuclio.io/env: test
+        nuclio.io/app: dashboard
+        nuclio.io/class: service
+      annotations:
+        nuclio.io/version: 0.2.8
+    spec:
+      containers:
+      - name: nuclio-dashboard
+        image: nuclio/dashboard:0.2.8-amd64
+        ports:
+        - containerPort: 8070
+        volumeMounts:
+        - mountPath: /var/run/docker.sock
+          name: docker-sock
+        - name: registry-credentials
+          mountPath: "/etc/nuclio/dashboard/registry-credentials"
+          readOnly: true
+      volumes:
+      - name: docker-sock
+        hostPath:
+          path: /var/run/docker.sock
+      - name: registry-credentials
+        secret:
+          secretName: registry-credentials
+          optional: true
+      serviceAccountName: nuclio
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nuclio-dashboard
+  namespace: nuclio
+spec:
+  selector:
+    nuclio.io/app: dashboard
   ports:
   - name: admin
     port: 8070

--- a/hack/gke/resources/nuclio.yaml
+++ b/hack/gke/resources/nuclio.yaml
@@ -31,6 +31,23 @@ spec:
 
 ---
 
+# Define a "project" custom resource definition - extending the k8s API to allow management of "project" resources
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Project resource
+kind: CustomResourceDefinition
+metadata:
+  name: projects.nuclio.io
+spec:
+  group: nuclio.io
+  names:
+    kind: Project
+    plural: projects
+    singular: project
+  scope: Namespaced
+  version: v1beta1
+
+---
+
 # All nuclio services are bound to the "nuclio" service account. In RBAC enabled setups, this service account is
 # bound to specific roles limiting what the services can do
 apiVersion: v1
@@ -122,6 +139,65 @@ metadata:
 spec:
   selector:
     nuclio.io/app: playground
+  ports:
+  - name: admin
+    port: 8070
+    protocol: TCP
+
+---
+
+# The nuclio dashboard is a WIP replacement for the playground
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: nuclio-dashboard
+  namespace: nuclio
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        nuclio.io/env: test
+        nuclio.io/app: dashboard
+        nuclio.io/class: service
+      annotations:
+        nuclio.io/version: 0.2.8
+    spec:
+      containers:
+      - name: nuclio-dashboard
+        image: nuclio/dashboard:0.2.8-amd64
+        ports:
+        - containerPort: 8070
+        volumeMounts:
+        - mountPath: /var/run/docker.sock
+          name: docker-sock
+        - name: registry-credentials
+          mountPath: "/etc/nuclio/dashboard/registry-credentials"
+          readOnly: true
+        env:
+        - name: NUCLIO_DASHBOARD_REGISTRY_URL
+          valueFrom:
+            configMapKeyRef:
+              name: "nuclio-registry"
+              key: "registry_url"
+      volumes:
+      - name: docker-sock
+        hostPath:
+          path: /var/run/docker.sock
+      - name: registry-credentials
+        secret:
+          secretName: registry-credentials
+          optional: true
+      serviceAccountName: nuclio
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nuclio-dashboard
+  namespace: nuclio
+spec:
+  selector:
+    nuclio.io/app: dashboard
   ports:
   - name: admin
     port: 8070

--- a/hack/k8s/resources/nuclio-rbac.yaml
+++ b/hack/k8s/resources/nuclio-rbac.yaml
@@ -61,7 +61,7 @@ metadata:
   name: nuclio-functioncr-admin
 rules:
 - apiGroups: ["nuclio.io"]
-  resources: ["functions"]
+  resources: ["functions", "projects"]
   verbs: ["*"]
 
 ---

--- a/hack/k8s/resources/nuclio.yaml
+++ b/hack/k8s/resources/nuclio.yaml
@@ -31,6 +31,23 @@ spec:
 
 ---
 
+# Define a "project" custom resource definition - extending the k8s API to allow management of "project" resources
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Project resource
+kind: CustomResourceDefinition
+metadata:
+  name: projects.nuclio.io
+spec:
+  group: nuclio.io
+  names:
+    kind: Project
+    plural: projects
+    singular: project
+  scope: Namespaced
+  version: v1beta1
+
+---
+
 # All nuclio services are bound to the "nuclio" service account. In RBAC enabled setups, this service account is
 # bound to specific roles limiting what the services can do
 apiVersion: v1
@@ -122,3 +139,54 @@ spec:
     protocol: TCP
 
 ---
+
+# The nuclio dashboard is a WIP replacement for the playground
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: nuclio-dashboard
+  namespace: nuclio
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        nuclio.io/env: test
+        nuclio.io/app: dashboard
+        nuclio.io/class: service
+      annotations:
+        nuclio.io/version: 0.2.8
+    spec:
+      containers:
+      - name: nuclio-dashboard
+        image: nuclio/dashboard:0.2.8-amd64
+        ports:
+        - containerPort: 8070
+        volumeMounts:
+        - mountPath: /var/run/docker.sock
+          name: docker-sock
+        - name: registry-credentials
+          mountPath: "/etc/nuclio/dashboard/registry-credentials"
+          readOnly: true
+      volumes:
+      - name: docker-sock
+        hostPath:
+          path: /var/run/docker.sock
+      - name: registry-credentials
+        secret:
+          secretName: registry-credentials
+          optional: true
+      serviceAccountName: nuclio
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nuclio-dashboard
+  namespace: nuclio
+spec:
+  selector:
+    nuclio.io/app: dashboard
+  ports:
+  - name: admin
+    port: 8070
+    protocol: TCP

--- a/pkg/dashboard/resource/externalipaddresses.go
+++ b/pkg/dashboard/resource/externalipaddresses.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"net/http"
+
+	"github.com/nuclio/nuclio/pkg/dashboard"
+	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/restful"
+)
+
+type externalIPAddressesResource struct {
+	*resource
+}
+
+// GetAll returns all externalIPAddressess
+func (eiar *externalIPAddressesResource) GetAll(request *http.Request) (map[string]restful.Attributes, error) {
+	externalIPAddresses, err := eiar.getPlatform().GetExternalIPAddresses()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get external IP addresses")
+	}
+
+	response := map[string]restful.Attributes{
+		"externalIPAddresses": {
+			"addresses": externalIPAddresses,
+		},
+	}
+
+	return response, nil
+}
+
+// register the resource
+var externalIPAddressesResourceInstance = &externalIPAddressesResource{
+	resource: newResource("external_ip_addresses", []restful.ResourceMethod{
+		restful.ResourceMethodGetList,
+	}),
+}
+
+func init() {
+	externalIPAddressesResourceInstance.Resource = externalIPAddressesResourceInstance
+	externalIPAddressesResourceInstance.Register(dashboard.DashboardResourceRegistrySingleton)
+}

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -34,20 +34,12 @@ import (
 
 type functionResource struct {
 	*resource
-	platform platform.Platform
 }
 
 type functionInfo struct {
 	Meta   *functionconfig.Meta   `json:"metadata,omitempty"`
 	Spec   *functionconfig.Spec   `json:"spec,omitempty"`
 	Status *functionconfig.Status `json:"status,omitempty"`
-}
-
-// OnAfterInitialize is called after initialization
-func (fr *functionResource) OnAfterInitialize() error {
-	fr.platform = fr.getPlatform()
-
-	return nil
 }
 
 // GetAll returns all functions
@@ -71,7 +63,7 @@ func (fr *functionResource) GetAll(request *http.Request) (map[string]restful.At
 		getFunctionsOptions.Labels = fmt.Sprintf("nuclio.io/project-name=%s", projectNameFilter)
 	}
 
-	functions, err := fr.platform.GetFunctions(getFunctionsOptions)
+	functions, err := fr.getPlatform().GetFunctions(getFunctionsOptions)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get functions")
@@ -94,7 +86,7 @@ func (fr *functionResource) GetByID(request *http.Request, id string) (restful.A
 		return nil, nuclio.NewErrBadRequest("Namespace must exist")
 	}
 
-	function, err := fr.platform.GetFunctions(&platform.GetFunctionsOptions{
+	function, err := fr.getPlatform().GetFunctions(&platform.GetFunctionsOptions{
 		Namespace: fr.getNamespaceFromRequest(request),
 		Name:      id,
 	})
@@ -134,7 +126,7 @@ func (fr *functionResource) Create(request *http.Request) (id string, attributes
 		}
 
 		// just deploy. the status is async through polling
-		_, err := fr.platform.CreateFunction(&platform.CreateFunctionOptions{
+		_, err := fr.getPlatform().CreateFunction(&platform.CreateFunctionOptions{
 			Logger: fr.Logger,
 			FunctionConfig: functionconfig.Config{
 				Meta: *functionInfo.Meta,
@@ -198,7 +190,7 @@ func (fr *functionResource) deleteFunction(request *http.Request) (string,
 	deleteFunctionOptions := platform.DeleteFunctionOptions{}
 	deleteFunctionOptions.FunctionConfig.Meta = *functionInfo.Meta
 
-	err = fr.platform.DeleteFunction(&deleteFunctionOptions)
+	err = fr.getPlatform().DeleteFunction(&deleteFunctionOptions)
 	if err != nil {
 		return "", nil, nil, true, http.StatusInternalServerError, err
 	}

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -31,19 +31,11 @@ import (
 
 type projectResource struct {
 	*resource
-	platform platform.Platform
 }
 
 type projectInfo struct {
 	Meta *platform.ProjectMeta `json:"metadata,omitempty"`
 	Spec *platform.ProjectSpec `json:"spec,omitempty"`
-}
-
-// OnAfterInitialize is called after initialization
-func (fr *projectResource) OnAfterInitialize() error {
-	fr.platform = fr.getPlatform()
-
-	return nil
 }
 
 // GetAll returns all projects
@@ -56,7 +48,7 @@ func (fr *projectResource) GetAll(request *http.Request) (map[string]restful.Att
 		return nil, nuclio.NewErrBadRequest("Namespace must exist")
 	}
 
-	projects, err := fr.platform.GetProjects(&platform.GetProjectsOptions{
+	projects, err := fr.getPlatform().GetProjects(&platform.GetProjectsOptions{
 		Meta: platform.ProjectMeta{
 			Name:      request.Header.Get("x-nuclio-project-name"),
 			Namespace: fr.getNamespaceFromRequest(request),
@@ -84,7 +76,7 @@ func (fr *projectResource) GetByID(request *http.Request, id string) (restful.At
 		return nil, nuclio.NewErrBadRequest("Namespace must exist")
 	}
 
-	project, err := fr.platform.GetProjects(&platform.GetProjectsOptions{
+	project, err := fr.getPlatform().GetProjects(&platform.GetProjectsOptions{
 		Meta: platform.ProjectMeta{
 			Name:      id,
 			Namespace: fr.getNamespaceFromRequest(request),
@@ -111,7 +103,7 @@ func (fr *projectResource) Create(request *http.Request) (id string, attributes 
 	}
 
 	// just deploy. the status is async through polling
-	err := fr.platform.CreateProject(&platform.CreateProjectOptions{
+	err := fr.getPlatform().CreateProject(&platform.CreateProjectOptions{
 		ProjectConfig: platform.ProjectConfig{
 			Meta: *projectInfo.Meta,
 			Spec: *projectInfo.Spec,
@@ -162,7 +154,7 @@ func (fr *projectResource) deleteProject(request *http.Request) (string,
 	deleteProjectOptions := platform.DeleteProjectOptions{}
 	deleteProjectOptions.Meta = *projectInfo.Meta
 
-	err = fr.platform.DeleteProject(&deleteProjectOptions)
+	err = fr.getPlatform().DeleteProject(&deleteProjectOptions)
 	if err != nil {
 		return "", nil, nil, true, http.StatusInternalServerError, err
 	}

--- a/pkg/dashboard/resource/version.go
+++ b/pkg/dashboard/resource/version.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"net/http"
+
+	"github.com/nuclio/nuclio-sdk-go"
+	"github.com/nuclio/nuclio/pkg/dashboard"
+	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/restful"
+	"github.com/nuclio/nuclio/pkg/version"
+)
+
+type versionResource struct {
+	*resource
+}
+
+// GetAll returns all versions
+func (vr *versionResource) GetAll(request *http.Request) (map[string]restful.Attributes, error) {
+	versionInfo, err := version.Get()
+	if err != nil {
+		return nil, nuclio.WrapErrInternalServerError(errors.Wrap(err, "Failed to get version"))
+	}
+
+	response := map[string]restful.Attributes{
+		"dashboard": {
+			"label":     versionInfo.Label,
+			"gitCommit": versionInfo.GitCommit,
+			"os":        versionInfo.OS,
+			"arch":      versionInfo.Arch,
+		},
+	}
+
+	return response, nil
+}
+
+// register the resource
+var versionResourceInstance = &versionResource{
+	resource: newResource("versions", []restful.ResourceMethod{
+		restful.ResourceMethodGetList,
+	}),
+}
+
+func init() {
+	versionResourceInstance.Resource = versionResourceInstance
+	versionResourceInstance.Register(dashboard.DashboardResourceRegistrySingleton)
+}

--- a/pkg/dashboard/resource/version.go
+++ b/pkg/dashboard/resource/version.go
@@ -19,11 +19,12 @@ package resource
 import (
 	"net/http"
 
-	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/nuclio/nuclio/pkg/dashboard"
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/restful"
 	"github.com/nuclio/nuclio/pkg/version"
+
+	"github.com/nuclio/nuclio-sdk-go"
 )
 
 type versionResource struct {

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -47,6 +47,7 @@ type Server struct {
 	dockerCreds           *dockercreds.DockerCreds
 	Platform              platform.Platform
 	NoPullBaseImages      bool
+	externalIPAddresses   []string
 }
 
 func NewServer(parentLogger logger.Logger,
@@ -57,7 +58,8 @@ func NewServer(parentLogger logger.Logger,
 	platform platform.Platform,
 	noPullBaseImages bool,
 	configuration *platformconfig.WebServer,
-	defaultCredRefreshInterval *time.Duration) (*Server, error) {
+	defaultCredRefreshInterval *time.Duration,
+	externalIPAddresses []string) (*Server, error) {
 
 	var err error
 
@@ -80,6 +82,7 @@ func NewServer(parentLogger logger.Logger,
 		dockerCreds:           newDockerCreds,
 		Platform:              platform,
 		NoPullBaseImages:      noPullBaseImages,
+		externalIPAddresses:   externalIPAddresses,
 	}
 
 	// create server
@@ -127,6 +130,10 @@ func (s *Server) GetRegistryURL() string {
 
 func (s *Server) GetRunRegistryURL() string {
 	return s.defaultRunRegistryURL
+}
+
+func (s *Server) GetExternalIPAddresses() []string {
+	return s.externalIPAddresses
 }
 
 func (s *Server) InstallMiddleware(router chi.Router) error {

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -114,6 +114,11 @@ func NewServer(parentLogger logger.Logger,
 		defaultCredRefreshInterval = &noDefaultCredRefreshInterval
 	}
 
+	// set external IPs, if specified
+	if len(externalIPAddresses) != 0 {
+		newServer.Platform.SetExternalIPAddresses(externalIPAddresses)
+	}
+
 	newServer.Logger.InfoWith("Initialized",
 		"assetsDir", assetsDir,
 		"dockerKeyDir", dockerKeyDir,

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -30,9 +30,10 @@ import (
 //
 
 type Platform struct {
-	Logger   logger.Logger
-	platform platform.Platform
-	invoker  *invoker
+	Logger              logger.Logger
+	platform            platform.Platform
+	invoker             *invoker
+	ExternalIPAddresses []string
 }
 
 func NewPlatform(parentLogger logger.Logger, platform platform.Platform) (*Platform, error) {
@@ -165,4 +166,18 @@ func (ap *Platform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOp
 // CreateProjectInvocation will invoke a previously deployed function
 func (ap *Platform) GetProjects(getProjectsOptions *platform.GetProjectsOptions) ([]platform.Project, error) {
 	return nil, errors.New("Unsupported")
+}
+
+// SetExternalIPAddresses configures the IP addresses invocations will use, if "via" is set to "external-ip".
+// If this is not invoked, each platform will try to discover these addresses automatically
+func (ap *Platform) SetExternalIPAddresses(externalIPAddresses []string) error {
+	ap.ExternalIPAddresses = externalIPAddresses
+
+	return nil
+}
+
+// GetExternalIPAddresses returns the external IP addresses invocations will use, if "via" is set to "external-ip".
+// These addresses are either set through SetExternalIPAddresses or automatically discovered
+func (ap *Platform) GetExternalIPAddresses() ([]string, error) {
+	return ap.ExternalIPAddresses, nil
 }

--- a/pkg/platform/function.go
+++ b/pkg/platform/function.go
@@ -17,6 +17,7 @@ limitations under the License.
 package platform
 
 import (
+	"math/rand"
 	"strconv"
 
 	"github.com/nuclio/nuclio/pkg/errors"
@@ -106,4 +107,17 @@ func (af *AbstractFunction) GetReplicas() (int, int) {
 // GetState returns the state of the function
 func (af *AbstractFunction) GetStatus() *functionconfig.Status {
 	return nil
+}
+
+func (af *AbstractFunction) GetExternalIPInvocationURL() (string, int, error) {
+	externalIPAddresses, err := af.Platform.GetExternalIPAddresses()
+	if err != nil || len(externalIPAddresses) == 0 {
+		return "", 0, errors.New("No external IP addresses found")
+	}
+
+	// get a random external IP address
+	chosenExternalIPAddress := externalIPAddresses[rand.Intn(len(externalIPAddresses))]
+
+	// return it and the port
+	return chosenExternalIPAddress, af.Config.Spec.HTTPPort, nil
 }

--- a/pkg/platform/kube/function.go
+++ b/pkg/platform/kube/function.go
@@ -18,8 +18,6 @@ package kube
 
 import (
 	"fmt"
-	"net/url"
-	"strings"
 	"sync"
 
 	"github.com/nuclio/nuclio/pkg/errors"
@@ -225,33 +223,13 @@ func (f *function) getIngressInvokeURL() (string, int, string) {
 }
 
 func (f *function) getExternalIPInvokeURL() (string, int, string) {
-	nodes, err := f.Platform.GetNodes()
+	host, port, err := f.GetExternalIPInvocationURL()
 	if err != nil {
 		return "", 0, ""
 	}
 
-	// try to get an external IP address from one of the nodes. if that doesn't work,
-	// try to get an internal IP
-	for _, addressType := range []platform.AddressType{
-		platform.AddressTypeExternalIP,
-		platform.AddressTypeInternalIP} {
-
-		for _, node := range nodes {
-			for _, address := range node.GetAddresses() {
-				if address.Type == addressType {
-					return address.Address, f.Config.Spec.HTTPPort, ""
-				}
-			}
-		}
-	}
-
-	// try to take from kube host as configured
-	kubeURL, err := url.Parse(f.consumer.kubeHost)
-	if err == nil && kubeURL.Host != "" {
-		return strings.Split(kubeURL.Host, ":")[0], f.Config.Spec.HTTPPort, ""
-	}
-
-	return "", 0, ""
+	// return it and the port
+	return host, port, ""
 }
 
 func (f *function) getDomainNameInvokeURL() (string, int, string) {

--- a/pkg/platform/local/function.go
+++ b/pkg/platform/local/function.go
@@ -18,11 +18,10 @@ package local
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 
-	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/dockerclient"
+	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 
@@ -69,18 +68,12 @@ func (f *function) GetStatus() *functionconfig.Status {
 
 // GetInvokeURL gets the IP of the cluster hosting the function
 func (f *function) GetInvokeURL(invokeViaType platform.InvokeViaType) (string, error) {
-	var host string
-
-	if common.RunningInContainer() {
-		host = "172.17.0.1"
+	host, port, err := f.GetExternalIPInvocationURL()
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to get external IP invocation URL")
 	}
 
-	// Check if situation is dockerized, if so set host to given NUCLIO_TEST_HOST value
-	if os.Getenv("NUCLIO_TEST_HOST") != "" {
-		host = os.Getenv("NUCLIO_TEST_HOST")
-	}
-
-	return fmt.Sprintf("%s:%d", host, f.Config.Spec.HTTPPort), nil
+	return fmt.Sprintf("%s:%d", host, port), nil
 }
 
 // GetIngresses returns all ingresses for this function

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -62,6 +62,14 @@ type Platform interface {
 	// Misc
 	//
 
+	// SetExternalIPAddresses configures the IP addresses invocations will use, if "via" is set to "external-ip".
+	// If this is not invoked, each platform will try to discover these addresses automatically
+	SetExternalIPAddresses(externalIPAddresses []string) error
+
+	// GetExternalIPAddresses returns the external IP addresses invocations will use, if "via" is set to "external-ip".
+	// These addresses are either set through SetExternalIPAddresses or automatically discovered
+	GetExternalIPAddresses() ([]string, error)
+
 	// GetDeployRequiresRegistry returns true if a registry is required for deploy, false otherwise
 	GetDeployRequiresRegistry() bool
 

--- a/pkg/restful/server.go
+++ b/pkg/restful/server.go
@@ -34,7 +34,7 @@ type Server struct {
 	ListenAddress    string
 	Router           chi.Router
 	resourceRegistry *registry.Registry
-	conreteServer    interface{}
+	concreteServer   interface{}
 }
 
 type resourceInitializer interface {
@@ -43,7 +43,7 @@ type resourceInitializer interface {
 
 func NewServer(parentLogger logger.Logger,
 	resourceRegistry *registry.Registry,
-	conreteServer interface{},
+	concreteServer interface{},
 	configuration *platformconfig.WebServer) (*Server, error) {
 
 	var err error
@@ -51,7 +51,7 @@ func NewServer(parentLogger logger.Logger,
 	newServer := &Server{
 		Logger:           parentLogger.GetChild("server"),
 		resourceRegistry: resourceRegistry,
-		conreteServer:    conreteServer,
+		concreteServer:   concreteServer,
 	}
 
 	newServer.Router, err = newServer.createRouter()
@@ -69,7 +69,7 @@ func NewServer(parentLogger logger.Logger,
 		resourceInstance, _ := newServer.resourceRegistry.Get(resourceName)
 
 		// create the resource router and add it
-		resourceRouter, err := resourceInstance.(resourceInitializer).Initialize(newServer.Logger, newServer.conreteServer)
+		resourceRouter, err := resourceInstance.(resourceInitializer).Initialize(newServer.Logger, newServer.concreteServer)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed to create resource router for %s", resourceName)
 		}


### PR DESCRIPTION
1. Dashboard supports `/external_ip_addresses` - returns IP addresses that can be used to invoke functions
2. Dashboard supports `/versions` - returns versions of components (dashboard only for now)
3. Platform uses one of the supplied external IP addresses to invoke functions