### PR TITLE
Support dashboard function templates

### DIFF
--- a/cmd/dashboard/README.md
+++ b/cmd/dashboard/README.md
@@ -2,6 +2,7 @@
 Table of contents:
 - [Function](#function)
 - [Project](#project)
+- [Function template](#function-template)
 - [Misc](#misc)
 
 ## Function
@@ -334,6 +335,38 @@ Only projects with no functions can be deleted. Attempting to delete a project w
 ```
 #### Response
 * Status code: 204
+
+## Function template
+
+### Listing all function templates
+#### Request 
+* URL: `GET /function_templates`
+* Headers: 
+  * `x-nuclio-filter-contents`: Substring that appears either in name or configuration of the function (optional)
+
+#### Response
+* Status code: 200
+* Body:
+```json
+{
+	"Hello World": {
+		"metadata": {
+			"labels": {
+				"a": "b",
+				"c": "d"
+			}
+		},
+		"spec": {
+			"handler": "main.Handler",
+			"runtime": "golang",
+			"resources": {},
+			"build": {
+				"functionSourceCode": "CnBhY2thZ2UgbWFpbgoKaW1wb3J0ICgKCSJnaXRodWIuY29tL251Y2xpby9udWNsaW8tc2RrLWdvIgopCgpmdW5jIEhhbmRsZXIoY29udGV4dCAqbnVjbGlvLkNvbnRleHQsIGV2ZW50IG51Y2xpby5FdmVudCkgKGludGVyZmFjZXt9LCBlcnJvcikgewoJY29udGV4dC5Mb2dnZXIuSW5mbygiVGhpcyBpcyBhbiB1bnN0cnVjdXJlZCAlcyIsICJsb2ciKQoKCXJldHVybiBudWNsaW8uUmVzcG9uc2V7CgkJU3RhdHVzQ29kZTogIDIwMCwKCQlDb250ZW50VHlwZTogImFwcGxpY2F0aW9uL3RleHQiLAoJCUJvZHk6ICAgICAgICBbXWJ5dGUoIkhlbGxvLCBmcm9tIG51Y2xpbyA6XSIpLAoJfSwgbmlsCn0="
+			}
+		}
+	}
+}
+```
 
 ## Misc
 

--- a/pkg/dashboard/functiontemplates/filter.go
+++ b/pkg/dashboard/functiontemplates/filter.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package functiontemplates
+
+import "strings"
+
+type Filter struct {
+	Contains string
+}
+
+func (ftf *Filter) functionTemplatePasses(template *FunctionTemplate) bool {
+	if ftf.empty() {
+		return true
+	}
+
+	stringsToSearch := []string{
+		template.Name,
+		string(template.serializedTemplate),
+	}
+
+	for _, stringToSearch := range stringsToSearch {
+		if strings.Contains(stringToSearch, ftf.Contains) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ftf *Filter) empty() bool {
+	return ftf.Contains == ""
+}

--- a/pkg/dashboard/functiontemplates/functiontemplates.go
+++ b/pkg/dashboard/functiontemplates/functiontemplates.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package functiontemplates
+
+import "github.com/nuclio/nuclio/pkg/functionconfig"
+
+// FunctionTemplates holds the function templates
+var FunctionTemplates = []*FunctionTemplate{
+	{
+		Name: "Hello World",
+		Configuration: functionconfig.Config{
+			Meta: functionconfig.Meta{
+				Labels: map[string]string{
+					"a": "b",
+					"c": "d",
+				},
+			},
+			Spec: functionconfig.Spec{
+				Handler: "main.Handler",
+				Runtime: "golang",
+			},
+		},
+		sourceCode: `
+package main
+
+import (
+	"github.com/nuclio/nuclio-sdk-go"
+)
+
+func Handler(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
+	context.Logger.Info("This is an unstrucured %s", "log")
+
+	return nuclio.Response{
+		StatusCode:  200,
+		ContentType: "application/text",
+		Body:        []byte("Hello, from nuclio :]"),
+	}, nil
+}`,
+	},
+}

--- a/pkg/dashboard/functiontemplates/repository.go
+++ b/pkg/dashboard/functiontemplates/repository.go
@@ -19,9 +19,10 @@ package functiontemplates
 import (
 	"encoding/base64"
 
+	"github.com/nuclio/nuclio/pkg/errors"
+
 	"github.com/ghodss/yaml"
 	"github.com/nuclio/logger"
-	"github.com/nuclio/nuclio/pkg/errors"
 )
 
 type Repository struct {

--- a/pkg/dashboard/functiontemplates/repository.go
+++ b/pkg/dashboard/functiontemplates/repository.go
@@ -47,7 +47,7 @@ func (r *Repository) GetFunctionTemplates(filter *Filter) []*FunctionTemplate {
 	var passingFunctionTemplates []*FunctionTemplate
 
 	for _, functionTemplate := range r.functionTemplates {
-		if filter.functionTemplatePasses(functionTemplate) {
+		if filter == nil || filter.functionTemplatePasses(functionTemplate) {
 			passingFunctionTemplates = append(passingFunctionTemplates, functionTemplate)
 		}
 	}

--- a/pkg/dashboard/functiontemplates/repository.go
+++ b/pkg/dashboard/functiontemplates/repository.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package functiontemplates
+
+import (
+	"encoding/base64"
+
+	"github.com/ghodss/yaml"
+	"github.com/nuclio/logger"
+	"github.com/nuclio/nuclio/pkg/errors"
+)
+
+type Repository struct {
+	logger            logger.Logger
+	functionTemplates []*FunctionTemplate
+}
+
+func NewRepository(parentLogger logger.Logger, functionTemplates []*FunctionTemplate) (*Repository, error) {
+	newRepository := &Repository{
+		logger:            parentLogger.GetChild("repository"),
+		functionTemplates: functionTemplates,
+	}
+
+	// populate encoded field of templates so that when we are queried we have this ready
+	if err := newRepository.enrichFunctionTemplates(newRepository.functionTemplates); err != nil {
+		return nil, errors.Wrap(err, "Failed to populated serialized templates")
+	}
+
+	return newRepository, nil
+}
+
+func (r *Repository) GetFunctionTemplates(filter *Filter) []*FunctionTemplate {
+	var passingFunctionTemplates []*FunctionTemplate
+
+	for _, functionTemplate := range r.functionTemplates {
+		if filter.functionTemplatePasses(functionTemplate) {
+			passingFunctionTemplates = append(passingFunctionTemplates, functionTemplate)
+		}
+	}
+
+	return passingFunctionTemplates
+}
+
+func (r *Repository) enrichFunctionTemplates(functionTemplates []*FunctionTemplate) error {
+	var err error
+
+	for _, functionTemplate := range functionTemplates {
+
+		// encode source code into configuration
+		functionTemplate.Configuration.Spec.Build.FunctionSourceCode = base64.StdEncoding.EncodeToString(
+			[]byte(functionTemplate.sourceCode))
+
+		functionTemplate.serializedTemplate, err = yaml.Marshal(functionTemplate.Configuration)
+		if err != nil {
+			return errors.Wrap(err, "Fauled to serialize configuration")
+		}
+	}
+
+	return nil
+}

--- a/pkg/dashboard/functiontemplates/repository_test.go
+++ b/pkg/dashboard/functiontemplates/repository_test.go
@@ -43,7 +43,7 @@ func (suite *repositoryTestSuite) TestFilteredGet() {
 			Configuration: functionconfig.Config{
 				Spec: functionconfig.Spec{
 					Description: "Template 1 description",
-					Runtime: "template-1-runtime",
+					Runtime:     "template-1-runtime",
 				},
 			},
 			sourceCode: "template 1 source code",
@@ -53,7 +53,7 @@ func (suite *repositoryTestSuite) TestFilteredGet() {
 			Configuration: functionconfig.Config{
 				Spec: functionconfig.Spec{
 					Description: "Template 2 description",
-					Runtime: "template-2-runtime",
+					Runtime:     "template-2-runtime",
 				},
 			},
 			sourceCode: "template 2 source code",

--- a/pkg/dashboard/functiontemplates/repository_test.go
+++ b/pkg/dashboard/functiontemplates/repository_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package functiontemplates
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type repositoryTestSuite struct {
+	suite.Suite
+	logger logger.Logger
+}
+
+func (suite *repositoryTestSuite) SetupSuite() {
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
+}
+
+func (suite *repositoryTestSuite) TestFilteredGet() {
+	functionTemplates := []*FunctionTemplate{
+		{
+			Name: "template1",
+			Configuration: functionconfig.Config{
+				Spec: functionconfig.Spec{
+					Description: "Template 1 description",
+					Runtime: "template-1-runtime",
+				},
+			},
+			sourceCode: "template 1 source code",
+		},
+		{
+			Name: "template2",
+			Configuration: functionconfig.Config{
+				Spec: functionconfig.Spec{
+					Description: "Template 2 description",
+					Runtime: "template-2-runtime",
+				},
+			},
+			sourceCode: "template 2 source code",
+		},
+	}
+
+	// create repositiory
+	repository, err := NewRepository(suite.logger, functionTemplates)
+	suite.Require().NoError(err, "Failed to create repository")
+
+	// get all templates (nil filter)
+	matchedFunctionTemplates := repository.GetFunctionTemplates(nil)
+	suite.Require().Len(matchedFunctionTemplates, 2)
+
+	// verify that returned value holds function source
+	for functionTemplatesIdx, functionTemplate := range functionTemplates {
+		decodedSourceCode, err := base64.StdEncoding.DecodeString(matchedFunctionTemplates[functionTemplatesIdx].Configuration.Spec.Build.FunctionSourceCode)
+		suite.Require().NoError(err, "Failed to decode function source")
+		suite.Require().Equal(functionTemplate.sourceCode, string(decodedSourceCode))
+	}
+
+	// get, filtered by name. expect template2
+	matchedFunctionTemplates = repository.GetFunctionTemplates(&Filter{"template2"})
+	suite.Require().Len(matchedFunctionTemplates, 1)
+	suite.Require().Equal("template2", matchedFunctionTemplates[0].Name)
+
+	// get, filtered by configuration. expect template1
+	matchedFunctionTemplates = repository.GetFunctionTemplates(&Filter{"template-1-"})
+	suite.Require().Len(matchedFunctionTemplates, 1)
+	suite.Require().Equal("template1", matchedFunctionTemplates[0].Name)
+}
+
+func TestRepository(t *testing.T) {
+	suite.Run(t, new(repositoryTestSuite))
+}

--- a/pkg/dashboard/functiontemplates/types.go
+++ b/pkg/dashboard/functiontemplates/types.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package functiontemplates
+
+import "github.com/nuclio/nuclio/pkg/functionconfig"
+
+// FunctionTemplate holds a template of a function
+type FunctionTemplate struct {
+	Name               string
+	Configuration      functionconfig.Config
+	serializedTemplate []byte
+	sourceCode         string
+}

--- a/pkg/dashboard/resource/function_template.go
+++ b/pkg/dashboard/resource/function_template.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"net/http"
+
+	"github.com/nuclio/nuclio/pkg/dashboard"
+	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/restful"
+
+	"github.com/nuclio/nuclio-sdk-go"
+)
+
+type functionTemplateResource struct {
+	*resource
+}
+
+// GetAll returns all functionTemplates
+func (vr *functionTemplateResource) GetAll(request *http.Request) (map[string]restful.Attributes, error) {
+	functionTemplateInfo, err := functionTemplate.Get()
+	if err != nil {
+		return nil, nuclio.WrapErrInternalServerError(errors.Wrap(err, "Failed to get functionTemplate"))
+	}
+
+	response := map[string]restful.Attributes{
+		"dashboard": {
+			"label":     functionTemplateInfo.Label,
+			"gitCommit": functionTemplateInfo.GitCommit,
+			"os":        functionTemplateInfo.OS,
+			"arch":      functionTemplateInfo.Arch,
+		},
+	}
+
+	return response, nil
+}
+
+// register the resource
+var functionTemplateResourceInstance = &functionTemplateResource{
+	resource: newResource("function_templates", []restful.ResourceMethod{
+		restful.ResourceMethodGetList,
+	}),
+}
+
+func init() {
+	functionTemplateResourceInstance.Resource = functionTemplateResourceInstance
+	functionTemplateResourceInstance.Register(dashboard.DashboardResourceRegistrySingleton)
+}

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -307,7 +307,13 @@ func (c *ShellClient) AwaitContainerHealth(containerID string, timeout *time.Dur
 	case <-timeoutChan:
 		timedOut = true
 
-		c.logger.WarnWith("Container wasn't healthy within timeout", "timeout", timeout)
+		containerLogs, err := c.GetContainerLogs(containerID)
+		if err != nil {
+			c.logger.ErrorWith("Container wasn't healthy within timeout (failed to get logs)", "timeout", timeout, "err", err)
+		} else {
+			c.logger.WarnWith("Container wasn't healthy within timeout", "timeout", timeout, "logs", containerLogs)
+		}
+
 		return errors.New("Container wasn't healthy in time")
 	}
 

--- a/pkg/functionconfig/handler.go
+++ b/pkg/functionconfig/handler.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package functionconfig
+
+import (
+	"fmt"
+	"strings"
+)
+
+func ParseHandler(handler string) (string, string, error) {
+
+	// take the handler name, if a module was provided
+	moduleAndEntrypoint := strings.Split(handler, ":")
+	switch len(moduleAndEntrypoint) {
+
+	// entrypoint only
+	case 1:
+		return "", moduleAndEntrypoint[0], nil
+
+		// module:entrypoint
+	case 2:
+		return moduleAndEntrypoint[0], moduleAndEntrypoint[1], nil
+
+	default:
+		return "", "", fmt.Errorf("Invalid handler name %s", handler)
+	}
+}

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -243,10 +243,10 @@ func (b *Builder) initializeSupportedRuntimes() {
 	b.runtimeInfo = map[string]runtimeInfo{}
 
 	b.runtimeInfo["shell"] = runtimeInfo{"sh", "#"}
+	b.runtimeInfo["pypy"] = runtimeInfo{"py", "#"}
 	b.runtimeInfo["golang"] = runtimeInfo{"go", "//"}
 	b.runtimeInfo["python"] = runtimeInfo{"py", "#"}
 	b.runtimeInfo["nodejs"] = runtimeInfo{"js", "//"}
-	b.runtimeInfo["pypy"] = runtimeInfo{"py", "//"}
 }
 
 func (b *Builder) readConfiguration() (string, error) {

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -17,6 +17,7 @@ limitations under the Licensg.
 package build
 
 import (
+	"encoding/base64"
 	"io/ioutil"
 	"testing"
 
@@ -123,8 +124,9 @@ func (suite *TestSuite) TestGetRuntimeNameFromBuildDirNoRuntime() {
 
 func (suite *TestSuite) TestWriteFunctionSourceCodeToTempFileWritesReturnsFilePath() {
 	functionSourceCode := "echo foo"
+	encodedFunctionSourceCode := base64.StdEncoding.EncodeToString([]byte(functionSourceCode))
 	suite.Builder.options.FunctionConfig.Spec.Runtime = "shell"
-	suite.Builder.options.FunctionConfig.Spec.Build.FunctionSourceCode = functionSourceCode
+	suite.Builder.options.FunctionConfig.Spec.Build.FunctionSourceCode = encodedFunctionSourceCode
 	suite.Builder.options.FunctionConfig.Spec.Build.Path = ""
 
 	err := suite.Builder.createTempDir()
@@ -143,7 +145,7 @@ func (suite *TestSuite) TestWriteFunctionSourceCodeToTempFileWritesReturnsFilePa
 
 func (suite *TestSuite) TestWriteFunctionSourceCodeToTempFileFailsOnUnknownExtension() {
 	suite.Builder.options.FunctionConfig.Spec.Runtime = "bar"
-	suite.Builder.options.FunctionConfig.Spec.Build.FunctionSourceCode = "echo foo"
+	suite.Builder.options.FunctionConfig.Spec.Build.FunctionSourceCode = base64.StdEncoding.EncodeToString([]byte("echo foo"))
 	suite.Builder.options.FunctionConfig.Spec.Build.Path = ""
 
 	err := suite.Builder.createTempDir()

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -18,6 +18,7 @@ package buildsuite
 
 import (
 	"context"
+	"encoding/base64"
 	"io/ioutil"
 	"net/http"
 	"path"
@@ -139,7 +140,7 @@ func (suite *TestSuite) TestBuildFuncFromSourceString() {
 	functionSourceCode, err := ioutil.ReadFile(createFunctionOptions.FunctionConfig.Spec.Build.Path)
 	suite.Assert().NoError(err)
 
-	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = string(functionSourceCode)
+	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = base64.StdEncoding.EncodeToString(functionSourceCode)
 	createFunctionOptions.FunctionConfig.Spec.Build.Path = ""
 
 	switch createFunctionOptions.FunctionConfig.Spec.Runtime {

--- a/pkg/processor/build/test/build_test.go
+++ b/pkg/processor/build/test/build_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package buildsuite
 
 import (
+	"encoding/base64"
 	"path"
 	"testing"
 
@@ -38,9 +39,7 @@ func (suite *TestSuite) TestBuildFuncFromSourceWithInlineConfig() {
 		FunctionConfig: *functionconfig.NewConfig(),
 	}
 
-	createFunctionOptions.FunctionConfig.Spec.Runtime = "shell"
-	createFunctionOptions.FunctionConfig.Spec.Build.Path = ""
-	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = `
+	functionSourceCode := `
 # @nuclio.configure
 #
 # function.yaml:
@@ -52,6 +51,11 @@ func (suite *TestSuite) TestBuildFuncFromSourceWithInlineConfig() {
 #       value: foo
 
 echo $MESSAGE`
+
+	createFunctionOptions.FunctionConfig.Spec.Runtime = "shell"
+	createFunctionOptions.FunctionConfig.Spec.Build.Path = ""
+	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = base64.StdEncoding.EncodeToString(
+		[]byte(functionSourceCode))
 
 	suite.DeployFunctionAndRequest(createFunctionOptions,
 		&httpsuite.Request{

--- a/pkg/processor/runtime/golang/handler.go
+++ b/pkg/processor/runtime/golang/handler.go
@@ -1,9 +1,7 @@
 package golang
 
 import (
-	"fmt"
-	"strings"
-
+	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 
 	"github.com/nuclio/logger"
@@ -63,19 +61,5 @@ func (ah *abstractHandler) parseName(handlerName string) (string, string, error)
 		handlerName = "main:Handler"
 	}
 
-	// take the handler name, if a module was provided
-	moduleAndEntrypoint := strings.Split(handlerName, ":")
-	switch len(moduleAndEntrypoint) {
-
-	// entrypoint only
-	case 1:
-		return "", moduleAndEntrypoint[0], nil
-
-		// module:entrypoint
-	case 2:
-		return moduleAndEntrypoint[0], moduleAndEntrypoint[1], nil
-
-	default:
-		return "", "", fmt.Errorf("Invalid handler name %s", handlerName)
-	}
+	return functionconfig.ParseHandler(handlerName)
 }

--- a/pkg/processor/runtime/nodejs/runtime.go
+++ b/pkg/processor/runtime/nodejs/runtime.go
@@ -95,6 +95,8 @@ func (n *nodejs) getEnvFromConfiguration() []string {
 }
 
 func (n *nodejs) getHandler() (string, string, error) {
+	// TODO: support file names, use functionconfig.ParseHandler
+
 	parts := strings.Split(n.configuration.Spec.Handler, ":")
 
 	handlerFileName := "handler.js"

--- a/pkg/processor/runtime/shell/runtime.go
+++ b/pkg/processor/runtime/shell/runtime.go
@@ -118,9 +118,14 @@ func (s *shell) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (
 func (s *shell) getCommand() (string, error) {
 	var command string
 
-	moduleName, _, err := functionconfig.ParseHandler(s.configuration.Spec.Handler)
+	moduleName, entrypoint, err := functionconfig.ParseHandler(s.configuration.Spec.Handler)
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to parse handler")
+	}
+
+	// if there's only one segment in the handler, in shell's case, it's the module name
+	if moduleName == "" {
+		moduleName = entrypoint
 	}
 
 	// if there's a directory passed as an environment telling us where to look for the module, use it. otherwise


### PR DESCRIPTION
1. Dashboard supports function templates (only one for now)
2. FunctionSourceCode must be provided in base64 encoding
3. When FunctionSourceCode is provided, the generated file name is taken from the handler (e.g. if handler is `foo:my_handler` and the runtime is a `python` variant, the file name will be `foo.py`
4. Minor code cleanup around builder to reduce duplication in the face of adding runtimes