### PR TITLE
Delete existing functions by name in local platform

### DIFF
--- a/pkg/dockerclient/types.go
+++ b/pkg/dockerclient/types.go
@@ -52,7 +52,9 @@ type RunOptions struct {
 
 // GetContainerOptions are options for container search
 type GetContainerOptions struct {
-	Labels map[string]string
+	Name    string
+	Labels  map[string]string
+	Stopped bool
 }
 
 // ContainerJSONBase contains response of Engine API:


### PR DESCRIPTION
Following a recent PR that set the container name to `namespace-name` in the local platform, if a function failed to deploy subsequent deploys would fail. This is because the local platform looked for existing functions via running containers with given labels. 

This PR changes the search for existing functions to be based on the container name.