### PR TITLE
Change the way HTTP port is conveyed

### DIFF
--- a/cmd/playground/static/assets/app.js
+++ b/cmd/playground/static/assets/app.js
@@ -1508,7 +1508,7 @@ $(function () {
         loadSource(path)
             .done(function (responseText) {
                 var enabled              = !_.get(selectedFunction, 'spec.disable', false);
-                var httpPort             = _.get(selectedFunction, 'spec.httpPort', 0);
+                var httpPort             = _.get(selectedFunction, 'status.httpPort', 0);
                 var triggers             = _.get(selectedFunction, 'spec.triggers', {});
                 var dataBindings         = _.get(selectedFunction, 'spec.dataBindings', {});
                 var runtimeAttributes    = _.get(selectedFunction, 'spec.runtimeAttributes', {});
@@ -1677,9 +1677,6 @@ $(function () {
                 triggers: triggersInput.getKeyValuePairs()
             });
 
-            // populate conditional properties
-            populatePort();
-
             // disable "Invoke" pane, until function is successfully deployed
             disableInvokePane(true);
 
@@ -1704,25 +1701,6 @@ $(function () {
                             showErrorToast('Deploy failed... (' + jqXHR.responseText + ')');
                     }
                 });
-        }
-
-        /**
-         * Populate `spec.httpPort` if a trigger of kind `'http'` exists and have a `port` attribute
-         *
-         * @private
-         */
-        function populatePort() {
-            var httpPort = _.chain(triggersInput.getKeyValuePairs())
-                .pickBy(['kind', 'http'])
-                .values()
-                .first()
-                .get('attributes.port')
-                .value();
-
-            // if HTTP trigger was added, inject its port number to the functions `httpPort` property
-            if (_.isNumber(httpPort)) {
-                _.set(selectedFunction, 'spec.httpPort', httpPort);
-            }
         }
 
         /**
@@ -1987,7 +1965,7 @@ $(function () {
      * @param {boolean} [hide=false] - `true` for hiding, otherwise showing
      */
     function hideFunctionUrl(hide) {
-        var httpPort = _.get(selectedFunction, 'spec.httpPort', 0);
+        var httpPort = _.get(selectedFunction, 'status.httpPort', 0);
         $('#input-url').html(hide ? '' : loadedUrl.get('protocol', 'hostname') + ':' + httpPort);
     }
 
@@ -2091,8 +2069,8 @@ $(function () {
                         }
 
                         // store the port for newly created function
-                        var httpPort = _.get(pollResult, 'spec.httpPort', 0);
-                        _.set(selectedFunction, 'spec.httpPort', httpPort);
+                        var httpPort = _.get(pollResult, 'status.httpPort', 0);
+                        _.set(selectedFunction, 'status.httpPort', httpPort);
 
                         // enable controls of "Invoke" pane and display a message about it
                         disableInvokePane(false);

--- a/docs/reference/triggers/http.md
+++ b/docs/reference/triggers/http.md
@@ -6,6 +6,7 @@ The HTTP trigger is the only trigger created by default if not configured (by de
 
 | Path | Type | Description | 
 | --- | --- | --- |  
+| port | int | The NodePort (or equivalent) on which the function will serve HTTP requests. If empty, chooses a random port within the platform range |
 | ingresses.(name).host | string | The host to which the ingress maps to |
 | ingresses.(name).paths | list of strings | The paths the ingress handles |
 
@@ -17,6 +18,7 @@ triggers:
     maxWorkers: 4
     kind: "http"
     attributes:
+      port: 32001
   
       # see "Invoking Functions By Name With Kubernetes Ingresses" for more details
       # on configuring ingresses

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -287,7 +287,8 @@ func (suite *functionTestSuite) TestGetDetailSuccessful() {
 		"resources": {},
 		"build": {},
 		"replicas": 10
-	}
+	},
+	"status": {}
 }`
 
 	suite.sendRequest("GET",
@@ -352,7 +353,8 @@ func (suite *functionTestSuite) TestGetListSuccessful() {
 			"resources": {},
 			"build": {},
 			"runtime": "r1"
-		}
+		},
+		"status": {}
 	},
 	"f2": {
 		"metadata": {
@@ -363,7 +365,8 @@ func (suite *functionTestSuite) TestGetListSuccessful() {
 			"resources": {},
 			"build": {},
 			"runtime": "r2"
-		}
+		},
+		"status": {}
 	}
 }`
 

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -154,7 +154,6 @@ type Spec struct {
 	Resources         v1.ResourceRequirements `json:"resources,omitempty"`
 	Image             string                  `json:"image,omitempty"`
 	ImageHash         string                  `json:"imageHash,omitempty"`
-	HTTPPort          int                     `json:"httpPort,omitempty"`
 	Replicas          int                     `json:"replicas,omitempty"`
 	MinReplicas       int                     `json:"minReplicas,omitempty"`
 	MaxReplicas       int                     `json:"maxReplicas,omitempty"`
@@ -186,6 +185,20 @@ func (s *Spec) GetRuntimeNameAndVersion() (string, string) {
 	default:
 		return "", ""
 	}
+}
+
+func (s *Spec) GetHTTPPort() int {
+	if s.Triggers == nil {
+		return 0
+	}
+
+	for _, trigger := range s.Triggers {
+		if trigger.Kind == "http" {
+			return trigger.Attributes["port"].(int)
+		}
+	}
+
+	return 0
 }
 
 // Meta identifies a function
@@ -227,9 +240,10 @@ const (
 
 // Status holds the status of the function
 type Status struct {
-	State   FunctionState            `json:"state,omitempty"`
-	Message string                   `json:"message,omitempty"`
-	Logs    []map[string]interface{} `json:"logs,omitempty"`
+	State    FunctionState            `json:"state,omitempty"`
+	Message  string                   `json:"message,omitempty"`
+	Logs     []map[string]interface{} `json:"logs,omitempty"`
+	HTTPPort int                      `json:"httpPort,omitempty"`
 }
 
 // to appease k8s

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -194,7 +194,10 @@ func (s *Spec) GetHTTPPort() int {
 
 	for _, trigger := range s.Triggers {
 		if trigger.Kind == "http" {
-			return trigger.Attributes["port"].(int)
+			httpPort, httpPortValid := trigger.Attributes["port"].(int)
+			if httpPortValid {
+				return httpPort
+			}
 		}
 	}
 

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -194,9 +194,14 @@ func (s *Spec) GetHTTPPort() int {
 
 	for _, trigger := range s.Triggers {
 		if trigger.Kind == "http" {
-			httpPort, httpPortValid := trigger.Attributes["port"].(int)
+			httpPort, httpPortValid := trigger.Attributes["port"]
 			if httpPortValid {
-				return httpPort
+				switch typedHTTPPort := httpPort.(type) {
+				case float64:
+					return int(typedHTTPPort)
+				case int:
+					return typedHTTPPort
+				}
 			}
 		}
 	}

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -129,7 +129,6 @@ func addDeployFlags(cmd *cobra.Command,
 	cmd.Flags().StringVarP(&commandeer.encodedLabels, "labels", "l", "", "Additional function labels (lbl1=val1[,lbl2=val2,...])")
 	cmd.Flags().StringVarP(&commandeer.encodedEnv, "env", "e", "", "Environment variables (env1=val1[,env2=val2,...])")
 	cmd.Flags().BoolVarP(&functionConfig.Spec.Disabled, "disabled", "d", false, "Start the function as disabled (don't run yet)")
-	cmd.Flags().IntVar(&functionConfig.Spec.HTTPPort, "port", 0, "Public HTTP port (NodePort)")
 	cmd.Flags().IntVarP(&functionConfig.Spec.Replicas, "replicas", "", 1, "Set to 1 to use a static number of replicas")
 	cmd.Flags().IntVar(&functionConfig.Spec.MinReplicas, "min-replicas", 0, "Minimal number of function replicas")
 	cmd.Flags().IntVar(&functionConfig.Spec.MaxReplicas, "max-replicas", 0, "Maximal number of function replicas")

--- a/pkg/nuctl/command/get.go
+++ b/pkg/nuctl/command/get.go
@@ -146,7 +146,7 @@ func (g *getFunctionCommandeer) renderFunctions(functions []platform.Function, f
 				function.GetConfig().Meta.Name,
 				function.GetConfig().Meta.Labels["nuclio.io/project-name"],
 				string(function.GetStatus().State),
-				strconv.Itoa(function.GetConfig().Spec.HTTPPort),
+				strconv.Itoa(function.GetStatus().HTTPPort),
 				fmt.Sprintf("%d/%d", availableReplicas, specifiedReplicas),
 			}
 

--- a/pkg/platform/function.go
+++ b/pkg/platform/function.go
@@ -55,17 +55,23 @@ type Function interface {
 type AbstractFunction struct {
 	Logger   logger.Logger
 	Config   functionconfig.Config
+	Status   functionconfig.Status
 	Platform Platform
+	function Function
 }
 
 func NewAbstractFunction(parentLogger logger.Logger,
 	parentPlatform Platform,
-	config *functionconfig.Config) (*AbstractFunction, error) {
+	config *functionconfig.Config,
+	status *functionconfig.Status,
+	function Function) (*AbstractFunction, error) {
 
 	return &AbstractFunction{
 		Logger:   parentLogger.GetChild("function"),
 		Config:   *config,
+		Status:   *status,
 		Platform: parentPlatform,
+		function: function,
 	}, nil
 }
 
@@ -106,7 +112,7 @@ func (af *AbstractFunction) GetReplicas() (int, int) {
 
 // GetState returns the state of the function
 func (af *AbstractFunction) GetStatus() *functionconfig.Status {
-	return nil
+	return &af.Status
 }
 
 func (af *AbstractFunction) GetExternalIPInvocationURL() (string, int, error) {
@@ -119,5 +125,5 @@ func (af *AbstractFunction) GetExternalIPInvocationURL() (string, int, error) {
 	chosenExternalIPAddress := externalIPAddresses[rand.Intn(len(externalIPAddresses))]
 
 	// return it and the port
-	return chosenExternalIPAddress, af.Config.Spec.HTTPPort, nil
+	return chosenExternalIPAddress, af.function.GetStatus().HTTPPort, nil
 }

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -720,9 +720,9 @@ func (lc *lazyClient) populateServiceSpec(labels map[string]string,
 	// 2. this is an existing service (spec.Ports is not an empty list) BUT not if the service already has a node port
 	//    and the function specifies 0 (meaning auto assign). This is to prevent cases where service already has a node
 	//    port and then updating it causes node port change
-	if len(spec.Ports) == 0 || !(spec.Ports[0].NodePort != 0 && function.Spec.HTTPPort == 0) {
+	if len(spec.Ports) == 0 || !(spec.Ports[0].NodePort != 0 && function.Spec.GetHTTPPort() == 0) {
 		spec.Ports = []v1.ServicePort{
-			{Name: containerHTTPPortName, Port: int32(containerHTTPPort), NodePort: int32(function.Spec.HTTPPort)},
+			{Name: containerHTTPPortName, Port: int32(containerHTTPPort), NodePort: int32(function.Spec.GetHTTPPort())},
 		}
 	}
 }
@@ -915,20 +915,20 @@ func (lr *lazyResources) Deployment() (*apps_v1beta1.Deployment, error) {
 
 // ConfigMap returns the configmap
 func (lr *lazyResources) ConfigMap() (*v1.ConfigMap, error) {
-	return nil, nil
+	return lr.configMap, nil
 }
 
 // Service returns the service
 func (lr *lazyResources) Service() (*v1.Service, error) {
-	return nil, nil
+	return lr.service, nil
 }
 
 // HorizontalPodAutoscaler returns the hpa
 func (lr *lazyResources) HorizontalPodAutoscaler() (*autos_v1.HorizontalPodAutoscaler, error) {
-	return nil, nil
+	return lr.horizontalPodAutoscaler, nil
 }
 
 // Ingress returns the ingress
 func (lr *lazyResources) Ingress() (*ext_v1beta1.Ingress, error) {
-	return nil, nil
+	return lr.ingress, nil
 }

--- a/pkg/platform/kube/getter.go
+++ b/pkg/platform/kube/getter.go
@@ -18,7 +18,6 @@ package kube
 
 import (
 	"github.com/nuclio/nuclio/pkg/errors"
-	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 
@@ -80,17 +79,8 @@ func (g *getter) get(consumer *consumer, getFunctionsOptions *platform.GetFuncti
 
 		newFunction, err := newFunction(g.logger,
 			g.platform,
-			&functionconfig.Config{
-				Meta: functionconfig.Meta{
-					Name:      functionInstance.Name,
-					Namespace: functionInstance.Namespace,
-					Labels:    functionInstance.Labels,
-				},
-				Spec: functionconfig.Spec{
-					Version:  -1,
-					HTTPPort: functionInstance.Spec.HTTPPort,
-				},
-			}, &functionInstance, consumer)
+			&functionInstance,
+			consumer)
 
 		if err != nil {
 			return nil, err

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -97,7 +97,8 @@ func NewPlatform(parentLogger logger.Logger, kubeconfigPath string) (*Platform, 
 func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunctionOptions) (*platform.CreateFunctionResult, error) {
 	var existingFunctionInstance *nuclioio.Function
 
-	// the builder will first create or update
+	// the builder will may update configuration, so we have to create the function in the platform only after
+	// the builder does that
 	onAfterConfigUpdated := func(updatedFunctionConfig *functionconfig.Config) error {
 		var err error
 

--- a/pkg/platform/local/function.go
+++ b/pkg/platform/local/function.go
@@ -18,7 +18,6 @@ package local
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/errors"
@@ -36,16 +35,17 @@ type function struct {
 func newFunction(parentLogger logger.Logger,
 	parentPlatform platform.Platform,
 	config *functionconfig.Config,
+	status *functionconfig.Status,
 	container *dockerclient.Container) (*function, error) {
-	newAbstractFunction, err := platform.NewAbstractFunction(parentLogger, parentPlatform, config)
+
+	newFunction := &function{}
+	newAbstractFunction, err := platform.NewAbstractFunction(parentLogger, parentPlatform, config, status, newFunction)
 	if err != nil {
 		return nil, err
 	}
 
-	newFunction := &function{
-		AbstractFunction: *newAbstractFunction,
-		container:        *container,
-	}
+	newFunction.AbstractFunction = *newAbstractFunction
+	newFunction.container = *container
 
 	return newFunction, nil
 }
@@ -54,16 +54,7 @@ func newFunction(parentLogger logger.Logger,
 func (f *function) Initialize([]string) error {
 	var err error
 
-	f.Config.Spec.HTTPPort, err = strconv.Atoi(f.container.HostConfig.PortBindings["8080/tcp"][0].HostPort)
-
 	return err
-}
-
-// GetState returns the state of the function
-func (f *function) GetStatus() *functionconfig.Status {
-	return &functionconfig.Status{
-		State: functionconfig.FunctionStateReady,
-	}
 }
 
 // GetInvokeURL gets the IP of the cluster hosting the function

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -78,6 +78,7 @@ func NewPlatform(parentLogger logger.Logger) (*Platform, error) {
 
 // CreateFunction will simply run a docker image
 func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunctionOptions) (*platform.CreateFunctionResult, error) {
+	var previousHTTPPort int
 
 	// local currently doesn't support registries of any kind. remove push / run registry
 	createFunctionOptions.FunctionConfig.Spec.RunRegistry = ""
@@ -103,6 +104,8 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 
 			// iterate over containers and delete
 			for _, container := range containers {
+				previousHTTPPort = p.getContainerHTTPTriggerPort(&container)
+
 				err = p.dockerClient.RemoveContainer(container.Name)
 				if err != nil {
 					return errors.Wrap(err, "Failed to delete existing function")
@@ -114,7 +117,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	}
 
 	onAfterBuild := func(buildResult *platform.CreateFunctionBuildResult, buildErr error) (*platform.CreateFunctionResult, error) {
-		return p.deployFunction(createFunctionOptions)
+		return p.deployFunction(createFunctionOptions, previousHTTPPort)
 	}
 
 	// wrap the deployer's deploy with the base HandleDeployFunction to provide lots of
@@ -301,13 +304,18 @@ func (p *Platform) getFreeLocalPort() (int, error) {
 	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
-func (p *Platform) deployFunction(createFunctionOptions *platform.CreateFunctionOptions) (*platform.CreateFunctionResult, error) {
+func (p *Platform) deployFunction(createFunctionOptions *platform.CreateFunctionOptions,
+	previousHTTPPort int) (*platform.CreateFunctionResult, error) {
 
-	// get function port - either from configuration or from a free port
-	functionHTTPPort, err := p.getFunctionHTTPPort(createFunctionOptions)
+	// get function port - either from configuration, from the previous deployment or from a free port
+	functionHTTPPort, err := p.getFunctionHTTPPort(createFunctionOptions, previousHTTPPort)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get function HTTP port")
 	}
+
+	createFunctionOptions.Logger.DebugWith("Function port allocated",
+		"port", functionHTTPPort,
+		"previousHTTPPort", previousHTTPPort)
 
 	labels := map[string]string{
 		"nuclio.io/platform":      "local",
@@ -406,7 +414,8 @@ func (p *Platform) encodeFunctionSpec(spec *functionconfig.Spec) string {
 	return string(encodedFunctionSpec)
 }
 
-func (p *Platform) getFunctionHTTPPort(createFunctionOptions *platform.CreateFunctionOptions) (int, error) {
+func (p *Platform) getFunctionHTTPPort(createFunctionOptions *platform.CreateFunctionOptions,
+	previousHTTPPort int) (int, error) {
 
 	// if the configuration specified an HTTP port - use that
 	if createFunctionOptions.FunctionConfig.Spec.GetHTTPPort() != 0 {
@@ -415,6 +424,11 @@ func (p *Platform) getFunctionHTTPPort(createFunctionOptions *platform.CreateFun
 			createFunctionOptions.FunctionConfig.Spec.GetHTTPPort())
 
 		return createFunctionOptions.FunctionConfig.Spec.GetHTTPPort(), nil
+	}
+
+	// if there was a previous deployment and no configuration - use that
+	if previousHTTPPort != 0 {
+		return previousHTTPPort, nil
 	}
 
 	// get a free local port
@@ -464,8 +478,6 @@ func (p *Platform) createFunctionFromContainer(functionSpec *functionconfig.Spec
 		}
 	}
 
-	httpPort, _ := strconv.Atoi(container.HostConfig.PortBindings["8080/tcp"][0].HostPort)
-
 	return newFunction(p.Logger,
 		p,
 		&functionconfig.Config{
@@ -473,8 +485,19 @@ func (p *Platform) createFunctionFromContainer(functionSpec *functionconfig.Spec
 			Spec: *functionSpec,
 		},
 		&functionconfig.Status{
-			HTTPPort: httpPort,
+			HTTPPort: p.getContainerHTTPTriggerPort(container),
 			State:    functionconfig.FunctionStateReady,
 		},
 		container)
+}
+
+func (p *Platform) getContainerHTTPTriggerPort(container *dockerclient.Container) int {
+	ports := container.HostConfig.PortBindings["8080/tcp"]
+	if len(ports) == 0 {
+		return 0
+	}
+
+	httpPort, _ := strconv.Atoi(ports[0].HostPort)
+
+	return httpPort
 }

--- a/pkg/playground/resource/function.go
+++ b/pkg/playground/resource/function.go
@@ -95,7 +95,7 @@ func (f *function) Deploy() error {
 		f.attributes.Status.Message = fmt.Sprintf("Failed (%s)", errors.Cause(err).Error())
 		f.muxLogger.WarnWith("Failed to deploy function", "err", errors.Cause(err))
 	} else {
-		f.attributes.Spec.HTTPPort = deployResult.Port
+		f.attributes.Status.HTTPPort = deployResult.Port
 		f.attributes.Status.State = functionconfig.FunctionStateReady
 	}
 

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -185,10 +185,10 @@ func (suite *TestSuite) TestBuildCustomHTTPPort() {
 
 	createFunctionOptions := suite.getDeployOptions("reverser")
 
-	createFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger {
+	createFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{
 		"http": {
 			Kind: "http",
-			Attributes: map[string]interface{} {
+			Attributes: map[string]interface{}{
 				"port": httpPort,
 			},
 		},

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
 
@@ -179,20 +180,27 @@ func (suite *TestSuite) TestBuildCustomImage() {
 	suite.Require().Equal(createFunctionOptions.FunctionConfig.Spec.Build.Image+":latest", deployResult.Image)
 }
 
-//func (suite *TestSuite) TestBuildCustomHTTPPort() {
-//	httpPort := 31000
-//
-//	createFunctionOptions := suite.getDeployOptions("reverser")
-//
-//	createFunctionOptions.FunctionConfig.Spec.HTTPPort = httpPort
-//
-//	suite.DeployFunctionAndRequest(createFunctionOptions,
-//		&httpsuite.Request{
-//			RequestBody:          "abcdef",
-//			ExpectedResponseBody: "fedcba",
-//			RequestPort:          httpPort,
-//		})
-//}
+func (suite *TestSuite) TestBuildCustomHTTPPort() {
+	httpPort := 31000
+
+	createFunctionOptions := suite.getDeployOptions("reverser")
+
+	createFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger {
+		"http": {
+			Kind: "http",
+			Attributes: map[string]interface{} {
+				"port": httpPort,
+			},
+		},
+	}
+
+	suite.DeployFunctionAndRequest(createFunctionOptions,
+		&httpsuite.Request{
+			RequestBody:          "abcdef",
+			ExpectedResponseBody: "fedcba",
+			RequestPort:          httpPort,
+		})
+}
 
 func (suite *TestSuite) TestBuildSpecifyingFunctionConfig() {
 	createFunctionOptions := suite.getDeployOptions("json-parser-with-function-config")

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -179,20 +179,20 @@ func (suite *TestSuite) TestBuildCustomImage() {
 	suite.Require().Equal(createFunctionOptions.FunctionConfig.Spec.Build.Image+":latest", deployResult.Image)
 }
 
-func (suite *TestSuite) TestBuildCustomHTTPPort() {
-	httpPort := 31000
-
-	createFunctionOptions := suite.getDeployOptions("reverser")
-
-	createFunctionOptions.FunctionConfig.Spec.HTTPPort = httpPort
-
-	suite.DeployFunctionAndRequest(createFunctionOptions,
-		&httpsuite.Request{
-			RequestBody:          "abcdef",
-			ExpectedResponseBody: "fedcba",
-			RequestPort:          httpPort,
-		})
-}
+//func (suite *TestSuite) TestBuildCustomHTTPPort() {
+//	httpPort := 31000
+//
+//	createFunctionOptions := suite.getDeployOptions("reverser")
+//
+//	createFunctionOptions.FunctionConfig.Spec.HTTPPort = httpPort
+//
+//	suite.DeployFunctionAndRequest(createFunctionOptions,
+//		&httpsuite.Request{
+//			RequestBody:          "abcdef",
+//			ExpectedResponseBody: "fedcba",
+//			RequestPort:          httpPort,
+//		})
+//}
 
 func (suite *TestSuite) TestBuildSpecifyingFunctionConfig() {
 	createFunctionOptions := suite.getDeployOptions("json-parser-with-function-config")

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -316,11 +316,13 @@ func (suite *TestSuite) blastConfigurationToDeployOptions(request *BlastConfigur
 	// Configure deployOptipns properties, number of MaxWorkers like in the default stress request - 32
 	createFunctionOptions.FunctionConfig.Meta.Name = fmt.Sprintf("%s-%s", createFunctionOptions.FunctionConfig.Meta.Name, suite.TestID)
 	createFunctionOptions.FunctionConfig.Spec.Build.NoBaseImagesPull = true
-	createFunctionOptions.FunctionConfig.Spec.HTTPPort = 8080
 	defaultHTTPTriggerConfiguration := functionconfig.Trigger{
 		Kind:       "http",
 		MaxWorkers: 32,
 		URL:        ":8080",
+		Attributes: map[string]interface{}{
+			"port": 8080,
+		},
 	}
 	createFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{"trigger": defaultHTTPTriggerConfiguration}
 	createFunctionOptions.FunctionConfig.Spec.Handler = request.Handler


### PR DESCRIPTION
This PR eliminates `spec.httpPort` in favor of `status.httpPort`. This is more than a field rename:
1. In Kubernetes, the function CRD will contain the deployed port - no need to look up the service. This makes the port gettable via the dashboard, which is what triggered this effort
2. Fixes `nuctl get` not displaying NodePort when running with Kubernetes
3. HTTP trigger contains a new `port` attribute
4. All port persistency behavior retained. If function is redeployed both in local and k8s platforms, the previous port is used except if the new function has an HTTP trigger configured with `port`