### PR TITLE
User can control the default ingress rule

### DIFF
--- a/docs/reference/triggers/http.md
+++ b/docs/reference/triggers/http.md
@@ -7,11 +7,13 @@ The HTTP trigger is the only trigger created by default if not configured (by de
 | Path | Type | Description | 
 | --- | --- | --- |  
 | port | int | The NodePort (or equivalent) on which the function will serve HTTP requests. If empty, chooses a random port within the platform range |
+| defaultIngressPattern | string | A pattern for specifying the default ingress rule to create for the function. Variables in the form of `{{.<NAME>}}` can be specified, with `.Name`, `.Namespace` and `.Version` supported. For example, `/{{.Namespace}}-{{.Name}}/{{.Version}}` will result in a default ingress of `/namespace-name/version`. If not set, a default ingress rule of /{{.Name}}/{{.Version}} is used. If set to an empty string, no default ingress is created |
 | ingresses.(name).host | string | The host to which the ingress maps to |
 | ingresses.(name).paths | list of strings | The paths the ingress handles |
 
-#### Example
+#### Examples
 
+With ingresseses:
 ```yaml
 triggers:
   myHttpTrigger:
@@ -31,4 +33,26 @@ triggers:
         http2:
           paths:
           - "/wat"
+```
+
+No default ingress:
+```yaml
+triggers:
+  myHttpTrigger:
+    maxWorkers: 4
+    kind: "http"
+    attributes:
+      port: 32001
+      defaultIngressPattern: ""
+```
+
+Non-default ingress:
+```yaml
+triggers:
+  myHttpTrigger:
+    maxWorkers: 4
+    kind: "http"
+    attributes:
+      port: 32001
+      defaultIngressPattern: "MyFunctions/{{.Name}}/{{.Version}}"
 ```

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -63,12 +63,27 @@ type Trigger struct {
 	Attributes map[string]interface{} `json:"attributes,omitempty"`
 }
 
-// GetIngresses returns the ingresses of a trigger, if applicable
-func (t *Trigger) GetIngresses() (ingresses map[string]Ingress) {
-	ingresses = map[string]Ingress{}
+// GetTriggersByKind returns a map of triggers by their kind
+func GetTriggersByKind(triggers map[string]Trigger, kind string) map[string]Trigger {
+	matchingTrigger := map[string]Trigger{}
 
-	if t.Kind == "http" {
-		if encodedIngresses, found := t.Attributes["ingresses"]; found {
+	for triggerName, trigger := range triggers {
+		if trigger.Kind == kind {
+			matchingTrigger[triggerName] = trigger
+		}
+	}
+
+	return matchingTrigger
+}
+
+// GetIngressesFromTriggers returns all ingresses from a map of triggers
+func GetIngressesFromTriggers(triggers map[string]Trigger) map[string]Ingress {
+	ingresses := map[string]Ingress{}
+
+	for _, trigger := range GetTriggersByKind(triggers, "http") {
+
+		// if there are attributes
+		if encodedIngresses, found := trigger.Attributes["ingresses"]; found {
 
 			// iterate over the encoded ingresses map and created ingress structures
 			for encodedIngressName, encodedIngress := range encodedIngresses.(map[string]interface{}) {
@@ -94,26 +109,6 @@ func (t *Trigger) GetIngresses() (ingresses map[string]Ingress) {
 				ingresses[encodedIngressName] = ingress
 			}
 		}
-	}
-
-	return
-}
-
-// GetIngressesFromTriggers returns all ingresses from a map of triggers
-func GetIngressesFromTriggers(triggers map[string]Trigger) (ingresses map[string]Ingress) {
-	ingresses = map[string]Ingress{}
-
-	// helper to extend maps
-	extendIngressMap := func(dest, source map[string]Ingress) map[string]Ingress {
-		for name, ingress := range source {
-			dest[name] = ingress
-		}
-
-		return dest
-	}
-
-	for _, trigger := range triggers {
-		ingresses = extendIngressMap(ingresses, trigger.GetIngresses())
 	}
 
 	return ingresses

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package functionres
+
+import (
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+	ext_v1beta1 "k8s.io/api/extensions/v1beta1"
+)
+
+type lazyTestSuite struct {
+	suite.Suite
+	logger logger.Logger
+	client lazyClient
+}
+
+func (suite *lazyTestSuite) SetupTest() {
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
+	suite.client.logger = suite.logger
+}
+
+func (suite *lazyTestSuite) TestDefaultIngressPatternNoTriggers() {
+	ingressSpec := ext_v1beta1.IngressSpec{}
+
+	// function instance has no triggers
+	functionInstance := nuclioio.Function{}
+	functionInstance.Name = "func-name"
+	functionInstance.Spec.Triggers = map[string]functionconfig.Trigger{}
+
+	// get labels
+	labels := map[string]string{
+		"version": "latest",
+	}
+
+	err := suite.client.populateIngressSpec(labels,
+		&functionInstance,
+		&ingressSpec)
+
+	suite.Require().NoError(err)
+
+	suite.Require().Equal("", ingressSpec.Rules[0].Host)
+	suite.Require().Equal("/func-name/latest", ingressSpec.Rules[0].HTTP.Paths[0].Path)
+}
+
+func (suite *lazyTestSuite) TestDefaultIngressPatternNoneSpecified() {
+	ingressSpec := ext_v1beta1.IngressSpec{}
+
+	// function instance has no triggers
+	functionInstance := nuclioio.Function{}
+	functionInstance.Name = "func-name"
+	functionInstance.Spec.Triggers = map[string]functionconfig.Trigger{
+		"mh": {
+			Kind: "http",
+		},
+	}
+
+	// get labels
+	labels := map[string]string{
+		"version": "latest",
+	}
+
+	err := suite.client.populateIngressSpec(labels,
+		&functionInstance,
+		&ingressSpec)
+
+	suite.Require().NoError(err)
+
+	suite.Require().Equal("", ingressSpec.Rules[0].Host)
+	suite.Require().Equal("/func-name/latest", ingressSpec.Rules[0].HTTP.Paths[0].Path)
+}
+
+func (suite *lazyTestSuite) TestDefaultIngressPatternEmptySpecified() {
+	ingressSpec := ext_v1beta1.IngressSpec{}
+
+	// function instance has no triggers
+	functionInstance := nuclioio.Function{}
+	functionInstance.Name = "func-name"
+	functionInstance.Spec.Triggers = map[string]functionconfig.Trigger{
+		"mh": {
+			Kind: "http",
+			Attributes: map[string]interface{}{
+				"defaultIngressPattern": "",
+			},
+		},
+	}
+
+	// get labels
+	labels := map[string]string{
+		"version": "latest",
+	}
+
+	err := suite.client.populateIngressSpec(labels,
+		&functionInstance,
+		&ingressSpec)
+
+	suite.Require().NoError(err)
+
+	suite.Require().Len(ingressSpec.Rules, 0)
+}
+
+func (suite *lazyTestSuite) TestDefaultIngressPatternSpecified() {
+	ingressSpec := ext_v1beta1.IngressSpec{}
+
+	// function instance has no triggers
+	functionInstance := nuclioio.Function{}
+	functionInstance.Name = "func-name"
+	functionInstance.Namespace = "func-namespace"
+	functionInstance.Spec.Triggers = map[string]functionconfig.Trigger{
+		"mh": {
+			Kind: "http",
+			Attributes: map[string]interface{}{
+				"defaultIngressPattern": "/{{.Namespace}}/{{.Name}}/{{.Version}}/wat",
+			},
+		},
+	}
+
+	// get labels
+	labels := map[string]string{
+		"version": "latest",
+	}
+
+	err := suite.client.populateIngressSpec(labels,
+		&functionInstance,
+		&ingressSpec)
+
+	suite.Require().NoError(err)
+
+	suite.Require().Equal("/func-namespace/func-name/latest/wat", ingressSpec.Rules[0].HTTP.Paths[0].Path)
+}
+
+func TestRegistryTestSuite(t *testing.T) {
+	suite.Run(t, new(lazyTestSuite))
+}

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -49,7 +49,7 @@ func (suite *lazyTestSuite) TestDefaultIngressPatternNoTriggers() {
 
 	// get labels
 	labels := map[string]string{
-		"version": "latest",
+		"nuclio.io/function-version": "latest",
 	}
 
 	err := suite.client.populateIngressSpec(labels,
@@ -76,7 +76,7 @@ func (suite *lazyTestSuite) TestDefaultIngressPatternNoneSpecified() {
 
 	// get labels
 	labels := map[string]string{
-		"version": "latest",
+		"nuclio.io/function-version": "latest",
 	}
 
 	err := suite.client.populateIngressSpec(labels,
@@ -106,7 +106,7 @@ func (suite *lazyTestSuite) TestDefaultIngressPatternEmptySpecified() {
 
 	// get labels
 	labels := map[string]string{
-		"version": "latest",
+		"nuclio.io/function-version": "latest",
 	}
 
 	err := suite.client.populateIngressSpec(labels,
@@ -136,7 +136,7 @@ func (suite *lazyTestSuite) TestDefaultIngressPatternSpecified() {
 
 	// get labels
 	labels := map[string]string{
-		"version": "latest",
+		"nuclio.io/function-version": "latest",
 	}
 
 	err := suite.client.populateIngressSpec(labels,
@@ -148,6 +148,6 @@ func (suite *lazyTestSuite) TestDefaultIngressPatternSpecified() {
 	suite.Require().Equal("/func-namespace/func-name/latest/wat", ingressSpec.Rules[0].HTTP.Paths[0].Path)
 }
 
-func TestRegistryTestSuite(t *testing.T) {
+func TestLazyTestSuite(t *testing.T) {
 	suite.Run(t, new(lazyTestSuite))
 }


### PR DESCRIPTION
This PR introduces the concept of `defaultIngressPattern`, configurable as part of the HTTP trigger. Prior to this change, a `/function-name/function-version` ingress rule would always be created. In some cases, users do not want to expose functions via ingresses or perhaps control this pattern. This is possible with this PR. The user can:
1. Do nothing, and behavior will be backwards compatible
2. Specify an empty string for `defaultIngressPattern` - in which case no ingress rule will be created
3. Specify a pattern for `defaultIngressPattern` to control the default ingress rule (more on this in the changed docs)

In addition, a few bugs were fixed in this area:
1. Ingress rules were incorrectly created since 0.2.8. They would be in the form of `/function-name/` rather than `/function-name/function-version`
2. Ingresses can now be updated

Fixes #697.