### PR TITLE
Support for CloudEvents 0.1 spec (structured and binary)

### DIFF
--- a/pkg/processor/build/runtime/shell/test/shell_test.go
+++ b/pkg/processor/build/runtime/shell/test/shell_test.go
@@ -77,7 +77,7 @@ func (suite *TestSuite) TestBuildBinaryWithArgumentsFromEvent() {
 	suite.DeployFunctionAndRequest(createFunctionOptions,
 		&httpsuite.Request{
 			RequestMethod: "GET",
-			RequestHeaders: map[string]string{
+			RequestHeaders: map[string]interface{}{
 				"x-nuclio-arguments": "123456",
 			},
 			ExpectedResponseBody: "123456\n",
@@ -104,7 +104,7 @@ func (suite *TestSuite) TestBuildBinaryWithResponseHeaders() {
 	suite.DeployFunctionAndRequest(createFunctionOptions,
 		&httpsuite.Request{
 			RequestMethod: "GET",
-			RequestHeaders: map[string]string{
+			RequestHeaders: map[string]interface{}{
 				"x-nuclio-arguments": "123456",
 			},
 			ExpectedResponseBody:    "123456\n",

--- a/pkg/processor/cloudevent/binary.go
+++ b/pkg/processor/cloudevent/binary.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevent
+
+import (
+	"time"
+
+	"github.com/nuclio/nuclio-sdk-go"
+)
+
+// Binary wraps a nuclio.Event with a cloudevent whose data is encoded in the nuclio.Event body.
+type Binary struct {
+	wrappedEvent
+}
+
+// SetEvent wraps a nuclio event
+func (s *Binary) SetEvent(event nuclio.Event) error {
+	s.event = event
+
+	// set trigger info provider to ourselves
+	s.event.SetTriggerInfoProvider(s)
+
+	return nil
+}
+
+// GetID returns the ID of the event
+func (s *Binary) GetID() nuclio.ID {
+	return nuclio.ID(s.event.GetHeaderString("CE-EventID"))
+}
+
+// get the class of source (sync, async, etc)
+func (s *Binary) GetClass() string {
+	return "unsupported"
+}
+
+// get specific kind of source (http, rabbit mq, etc)
+func (s *Binary) GetKind() string {
+	return s.event.GetHeaderString("CE-Source")
+}
+
+// GetTimestamp returns when the event originated
+func (s *Binary) GetTimestamp() time.Time {
+	parsedTime, err := time.Parse(time.RFC3339, s.event.GetHeaderString("CE-EventTime"))
+	if err != nil {
+		return time.Time{}
+	}
+
+	return parsedTime
+}
+
+// GetType returns the type of event
+func (s *Binary) GetType() string {
+	return s.event.GetHeaderString("CE-EventType")
+}
+
+// GetTypeVersion returns the version of the type
+func (s *Binary) GetTypeVersion() string {
+	return s.event.GetHeaderString("CE-EventTypeVersion")
+}
+
+// GetVersion returns the version of the event
+func (s *Binary) GetVersion() string {
+	return s.event.GetHeaderString("CE-CloudEventsVersion")
+}

--- a/pkg/processor/cloudevent/binary_test.go
+++ b/pkg/processor/cloudevent/binary_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevent
+
+import (
+	"testing"
+	"time"
+
+	// "time"
+
+	"github.com/nuclio/nuclio-sdk-go"
+	"github.com/stretchr/testify/suite"
+)
+
+type binaryTestSuite struct {
+	suite.Suite
+	binaryEvent Binary
+	mockEvent   mockEvent
+}
+
+func (suite *binaryTestSuite) TestSuccess() {
+	suite.mockEvent.On("SetTriggerInfoProvider", &suite.binaryEvent)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	body := []byte("testBody")
+	contentType := "testContentType"
+
+	suite.mockEvent.On("GetBody").Return(body)
+	suite.mockEvent.On("GetHeaderString", "CE-EventType").Return("testEventType")
+	suite.mockEvent.On("GetHeaderString", "CE-EventID").Return("testEventID")
+	suite.mockEvent.On("GetHeaderString", "CE-EventTypeVersion").Return("testEventTypeVersion")
+	suite.mockEvent.On("GetHeaderString", "CE-CloudEventsVersion").Return("testCloudEventsVersion")
+	suite.mockEvent.On("GetHeaderString", "CE-Source").Return("testSource")
+	suite.mockEvent.On("GetHeaderString", "CE-Source").Return("testSource")
+	suite.mockEvent.On("GetHeaderString", "CE-EventTime").Return(now)
+	suite.mockEvent.On("GetContentType").Return(contentType)
+
+	// set the event
+	err := suite.binaryEvent.SetEvent(&suite.mockEvent)
+	suite.Require().NoError(err)
+
+	// verify fields coming from the cloud event
+	suite.Require().Equal("testEventType", suite.binaryEvent.GetType())
+	suite.Require().Equal("testEventTypeVersion", suite.binaryEvent.GetTypeVersion())
+	suite.Require().Equal("testCloudEventsVersion", suite.binaryEvent.GetVersion())
+	suite.Require().Equal("testSource", suite.binaryEvent.GetTriggerInfo().GetKind())
+	suite.Require().Equal(nuclio.ID("testEventID"), suite.binaryEvent.GetID())
+	suite.Require().Equal(now, suite.binaryEvent.GetTimestamp().Format(time.RFC3339))
+	suite.Require().Equal("testContentType", suite.binaryEvent.GetContentType())
+	suite.Require().Equal(body, suite.binaryEvent.GetBody())
+
+	// verify expectations
+	suite.mockEvent.AssertExpectations(suite.T())
+}
+
+func TestBinaryTestSuite(t *testing.T) {
+	suite.Run(t, new(binaryTestSuite))
+}

--- a/pkg/processor/cloudevent/binary_test.go
+++ b/pkg/processor/cloudevent/binary_test.go
@@ -20,8 +20,6 @@ import (
 	"testing"
 	"time"
 
-	// "time"
-
 	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/stretchr/testify/suite"
 )

--- a/pkg/processor/cloudevent/mockevent.go
+++ b/pkg/processor/cloudevent/mockevent.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevent
+
+import (
+	"time"
+
+	"github.com/nuclio/nuclio-sdk-go"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockEvent struct {
+	mock.Mock
+	triggerInfoProvider nuclio.TriggerInfoProvider
+}
+
+// GetID returns the ID of the event
+func (me *mockEvent) GetID() nuclio.ID {
+	args := me.Called()
+	return args.Get(0).(nuclio.ID)
+}
+
+// SetID sets the ID of the event
+func (me *mockEvent) SetID(id nuclio.ID) {
+	me.Called()
+}
+
+// SetTriggerInfoProvider sets the information about the trigger who triggered this event
+func (me *mockEvent) SetTriggerInfoProvider(triggerInfoProvider nuclio.TriggerInfoProvider) {
+	me.Called(triggerInfoProvider)
+	me.triggerInfoProvider = triggerInfoProvider
+}
+
+// GetTriggerInfo retruns a trigger info provider
+func (me *mockEvent) GetTriggerInfo() nuclio.TriggerInfoProvider {
+	return me.triggerInfoProvider
+}
+
+// GetContentType returns the content type of the body
+func (me *mockEvent) GetContentType() string {
+	args := me.Called()
+	return args.String(0)
+}
+
+// GetBody returns the body of the event
+func (me *mockEvent) GetBody() []byte {
+	args := me.Called()
+	return args.Get(0).([]byte)
+}
+
+// GetHeader returns the header by name as an interface{}
+func (me *mockEvent) GetHeader(key string) interface{} {
+	args := me.Called(key)
+	return args.String(0)
+}
+
+// GetHeaderByteSlice returns the header by name as a byte slice
+func (me *mockEvent) GetHeaderByteSlice(key string) []byte {
+	args := me.Called(key)
+	return args.Get(0).([]byte)
+}
+
+// GetHeaderString returns the header by name as a string
+func (me *mockEvent) GetHeaderString(key string) string {
+	args := me.Called(key)
+	return args.String(0)
+}
+
+// GetHeaderInt returns the field by name as an integer
+func (me *mockEvent) GetHeaderInt(key string) (int, error) {
+	args := me.Called(key)
+	return args.Int(0), args.Error(1)
+}
+
+// GetHeaders loads all headers into a map of string / interface{}
+func (me *mockEvent) GetHeaders() map[string]interface{} {
+	args := me.Called()
+	return args.Get(0).(map[string]interface{})
+}
+
+// GetField returns the field by name as an interface{}
+func (me *mockEvent) GetField(key string) interface{} {
+	args := me.Called(key)
+	return args.Get(0).(interface{})
+}
+
+// GetFieldByteSlice returns the field by name as a byte slice
+func (me *mockEvent) GetFieldByteSlice(key string) []byte {
+	args := me.Called(key)
+	return args.Get(0).([]byte)
+}
+
+// GetFieldString returns the field by name as a string
+func (me *mockEvent) GetFieldString(key string) string {
+	args := me.Called(key)
+	return args.String(0)
+}
+
+// GetFieldInt returns the field by name as an integer
+func (me *mockEvent) GetFieldInt(key string) (int, error) {
+	args := me.Called(key)
+	return args.Int(0), args.Error(1)
+}
+
+// GetFields loads all fields into a map of string / interface{}
+func (me *mockEvent) GetFields() map[string]interface{} {
+	args := me.Called()
+	return args.Get(0).(map[string]interface{})
+}
+
+// GetTimestamp returns when the event originated
+func (me *mockEvent) GetTimestamp() time.Time {
+	args := me.Called()
+	return args.Get(0).(time.Time)
+}
+
+// GetPath returns the path of the event
+func (me *mockEvent) GetPath() string {
+	args := me.Called()
+	return args.String(0)
+}
+
+// GetURL returns the URL of the event
+func (me *mockEvent) GetURL() string {
+	args := me.Called()
+	return args.String(0)
+}
+
+// GetMethod returns the method of the event, if applicable
+func (me *mockEvent) GetMethod() string {
+	args := me.Called()
+	return args.String(0)
+}
+
+// GetShardID returns the ID of the shard from which this event arrived, if applicable
+func (me *mockEvent) GetShardID() int {
+	args := me.Called()
+	return args.Int(0)
+}
+
+// GetTotalNumShards returns the total number of shards, if applicable
+func (me *mockEvent) GetTotalNumShards() int {
+	args := me.Called()
+	return args.Int(0)
+}
+
+// GetType returns the type of event
+func (me *mockEvent) GetType() string {
+	args := me.Called()
+	return args.String(0)
+}
+
+// GetTypeVersion returns the version of the type
+func (me *mockEvent) GetTypeVersion() string {
+	args := me.Called()
+	return args.String(0)
+}
+
+// GetVersion returns the version of the event
+func (me *mockEvent) GetVersion() string {
+	args := me.Called()
+	return args.String(0)
+}

--- a/pkg/processor/cloudevent/mockevent.go
+++ b/pkg/processor/cloudevent/mockevent.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-type mockEvent struct {
+type mockEvent struct { // nolint: deadcode
 	mock.Mock
 	triggerInfoProvider nuclio.TriggerInfoProvider
 }

--- a/pkg/processor/cloudevent/structured.go
+++ b/pkg/processor/cloudevent/structured.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevent
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/nuclio/nuclio-sdk-go"
+)
+
+// Structured wraps a nuclio.Event with a cloudevent whose data is encoded in the nuclio.Event body.
+type Structured struct {
+	wrappedEvent
+	cloudEvent cloudEvent
+}
+
+// SetEvent wraps a nuclio event
+func (s *Structured) SetEvent(event nuclio.Event) error {
+	s.event = event
+
+	// set trigger info provider to ourselves
+	s.event.SetTriggerInfoProvider(s)
+
+	body := string(event.GetBody())
+
+	// parse the event body into the cloud event
+	return json.Unmarshal([]byte(body), &s.cloudEvent)
+}
+
+// GetID returns the ID of the event
+func (s *Structured) GetID() nuclio.ID {
+	return nuclio.ID(s.cloudEvent.EventID)
+}
+
+// get the class of source (sync, async, etc)
+func (s *Structured) GetClass() string {
+	return "unsupported"
+}
+
+// get specific kind of source (http, rabbit mq, etc)
+func (s *Structured) GetKind() string {
+	return s.cloudEvent.Source
+}
+
+// GetTimestamp returns when the event originated
+func (s *Structured) GetTimestamp() time.Time {
+	return s.cloudEvent.EventTime
+}
+
+// GetContentType returns the content type of the body
+func (s *Structured) GetContentType() string {
+	return s.cloudEvent.ContentType
+}
+
+// GetBody returns the body of the event
+func (s *Structured) GetBody() []byte {
+	switch typedBody := s.cloudEvent.Data.(type) {
+	case string:
+		return []byte(typedBody)
+	case map[string]interface{}:
+
+		// TODO: support bodies
+		return nil
+	}
+
+	return nil
+}
+
+// GetHeaders loads all headers into a map of string / interface{}
+func (s *Structured) GetHeaders() map[string]interface{} {
+	return s.cloudEvent.Extensions
+}
+
+// GetType returns the type of event
+func (s *Structured) GetType() string {
+	return s.cloudEvent.EventType
+}
+
+// GetTypeVersion returns the version of the type
+func (s *Structured) GetTypeVersion() string {
+	return s.cloudEvent.EventTypeVersion
+}
+
+// GetVersion returns the version of the event
+func (s *Structured) GetVersion() string {
+	return s.cloudEvent.CloudEventsVersion
+}

--- a/pkg/processor/cloudevent/structured_test.go
+++ b/pkg/processor/cloudevent/structured_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevent
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/nuclio/nuclio-sdk-go"
+	"github.com/stretchr/testify/suite"
+)
+
+type structuredTestSuite struct {
+	suite.Suite
+	structuredEvent Structured
+	mockEvent mockEvent
+}
+
+func (suite *structuredTestSuite) TestSuccess() {
+	suite.mockEvent.On("SetTriggerInfoProvider", &suite.structuredEvent)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// format the structured body
+	structuredBody := fmt.Sprintf(`{
+	"eventType": "testEventType",
+	"eventTypeVersion": "testEventTypeVersion",
+	"cloudEventsVersion": "testCloudEventsVersion",
+	"source": "testSource",
+	"eventID": "testEventID",
+	"eventTime": "%s",
+	"contentType": "testContentType",
+	"extensions": {"testExtensionKey1": "testExtensionValue1", "testExtensionKey2": 2},
+	"data": "testData"
+}`, now)
+
+	suite.mockEvent.On("GetBody").Return([]byte(structuredBody))
+
+	// set the event - will parse the body
+	err := suite.structuredEvent.SetEvent(&suite.mockEvent)
+	suite.Require().NoError(err)
+
+	// verify fields coming from the cloud event
+	suite.Require().Equal("testEventType", suite.structuredEvent.GetType())
+	suite.Require().Equal("testEventTypeVersion", suite.structuredEvent.GetTypeVersion())
+	suite.Require().Equal("testCloudEventsVersion", suite.structuredEvent.GetVersion())
+	suite.Require().Equal("testSource", suite.structuredEvent.GetTriggerInfo().GetKind())
+	suite.Require().Equal(nuclio.ID("testEventID"), suite.structuredEvent.GetID())
+	suite.Require().Equal(now, suite.structuredEvent.GetTimestamp().Format(time.RFC3339))
+	suite.Require().Equal("testContentType", suite.structuredEvent.GetContentType())
+	suite.Require().Equal([]byte("testData"), suite.structuredEvent.GetBody())
+
+	// verify expectations
+	suite.mockEvent.AssertExpectations(suite.T())
+}
+
+func TestStructuredTestSuite(t *testing.T) {
+	suite.Run(t, new(structuredTestSuite))
+}

--- a/pkg/processor/cloudevent/structured_test.go
+++ b/pkg/processor/cloudevent/structured_test.go
@@ -28,7 +28,7 @@ import (
 type structuredTestSuite struct {
 	suite.Suite
 	structuredEvent Structured
-	mockEvent mockEvent
+	mockEvent       mockEvent
 }
 
 func (suite *structuredTestSuite) TestSuccess() {

--- a/pkg/processor/cloudevent/types.go
+++ b/pkg/processor/cloudevent/types.go
@@ -21,13 +21,13 @@ import (
 )
 
 type cloudEvent struct {
-	EventType string `json:"eventType,omitempty"`
-	EventTypeVersion string `json:"eventTypeVersion,omitempty"`
-	CloudEventsVersion string `json:"cloudEventsVersion,omitempty"`
-	Source string `json:"source,omitempty"`
-	EventID string `json:"eventID,omitempty"`
-	EventTime time.Time `json:"eventTime,omitempty"`
-	ContentType string `json:"contentType,omitempty"`
-	Extensions map[string]interface{} `json:"extensions,omitempty"`
-	Data interface{} `json:"data,omitempty"`
+	EventType          string                 `json:"eventType,omitempty"`
+	EventTypeVersion   string                 `json:"eventTypeVersion,omitempty"`
+	CloudEventsVersion string                 `json:"cloudEventsVersion,omitempty"`
+	Source             string                 `json:"source,omitempty"`
+	EventID            string                 `json:"eventID,omitempty"`
+	EventTime          time.Time              `json:"eventTime,omitempty"`
+	ContentType        string                 `json:"contentType,omitempty"`
+	Extensions         map[string]interface{} `json:"extensions,omitempty"`
+	Data               interface{}            `json:"data,omitempty"`
 }

--- a/pkg/processor/cloudevent/types.go
+++ b/pkg/processor/cloudevent/types.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevent
+
+import (
+	"time"
+)
+
+type cloudEvent struct {
+	EventType string `json:"eventType,omitempty"`
+	EventTypeVersion string `json:"eventTypeVersion,omitempty"`
+	CloudEventsVersion string `json:"cloudEventsVersion,omitempty"`
+	Source string `json:"source,omitempty"`
+	EventID string `json:"eventID,omitempty"`
+	EventTime time.Time `json:"eventTime,omitempty"`
+	ContentType string `json:"contentType,omitempty"`
+	Extensions map[string]interface{} `json:"extensions,omitempty"`
+	Data interface{} `json:"data,omitempty"`
+}

--- a/pkg/processor/cloudevent/wrappedevent.go
+++ b/pkg/processor/cloudevent/wrappedevent.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevent
+
+import (
+	"time"
+
+	"github.com/nuclio/nuclio-sdk-go"
+)
+
+type wrappedEvent struct {
+	event nuclio.Event
+}
+
+// GetID returns the ID of the event
+func (we *wrappedEvent) GetID() nuclio.ID {
+	return we.event.GetID()
+}
+
+// SetID sets the ID of the event
+func (we *wrappedEvent) SetID(id nuclio.ID) {
+	we.event.SetID(id)
+}
+
+// SetTriggerInfoProvider sets the information about the trigger who triggered this event
+func (we *wrappedEvent) SetTriggerInfoProvider(triggerInfoProvider nuclio.TriggerInfoProvider) {
+	we.event.SetTriggerInfoProvider(triggerInfoProvider)
+}
+
+// GetTriggerInfo retruns a trigger info provider
+func (we *wrappedEvent) GetTriggerInfo() nuclio.TriggerInfoProvider {
+	return we.event.GetTriggerInfo()
+}
+
+// GetContentType returns the content type of the body
+func (we *wrappedEvent) GetContentType() string {
+	return we.event.GetContentType()
+}
+
+// GetBody returns the body of the event
+func (we *wrappedEvent) GetBody() []byte {
+	return we.event.GetBody()
+}
+
+// GetHeader returns the header by name as an interface{}
+func (we *wrappedEvent) GetHeader(key string) interface{} {
+	return we.event.GetHeader(key)
+}
+
+// GetHeaderByteSlice returns the header by name as a byte slice
+func (we *wrappedEvent) GetHeaderByteSlice(key string) []byte {
+	return we.event.GetHeaderByteSlice(key)
+}
+
+// GetHeaderString returns the header by name as a string
+func (we *wrappedEvent) GetHeaderString(key string) string {
+	return we.event.GetHeaderString(key)
+}
+
+// GetHeaderInt returns the field by name as an integer
+func (we *wrappedEvent) GetHeaderInt(key string) (int, error) {
+	return we.event.GetHeaderInt(key)
+}
+
+// GetHeaders loads all headers into a map of string / interface{}
+func (we *wrappedEvent) GetHeaders() map[string]interface{} {
+	return we.event.GetHeaders()
+}
+
+// GetField returns the field by name as an interface{}
+func (we *wrappedEvent) GetField(key string) interface{} {
+	return we.event.GetField(key)
+}
+
+// GetFieldByteSlice returns the field by name as a byte slice
+func (we *wrappedEvent) GetFieldByteSlice(key string) []byte {
+	return we.event.GetFieldByteSlice(key)
+}
+
+// GetFieldString returns the field by name as a string
+func (we *wrappedEvent) GetFieldString(key string) string {
+	return we.event.GetFieldString(key)
+}
+
+// GetFieldInt returns the field by name as an integer
+func (we *wrappedEvent) GetFieldInt(key string) (int, error) {
+	return we.event.GetFieldInt(key)
+}
+
+// GetFields loads all fields into a map of string / interface{}
+func (we *wrappedEvent) GetFields() map[string]interface{} {
+	return we.event.GetFields()
+}
+
+// GetTimestamp returns when the event originated
+func (we *wrappedEvent) GetTimestamp() time.Time {
+	return we.event.GetTimestamp()
+}
+
+// GetPath returns the path of the event
+func (we *wrappedEvent) GetPath() string {
+	return we.event.GetPath()
+}
+
+// GetURL returns the URL of the event
+func (we *wrappedEvent) GetURL() string {
+	return we.event.GetURL()
+}
+
+// GetPath returns the method of the event, if applicable
+func (we *wrappedEvent) GetMethod() string {
+	return we.event.GetMethod()
+}
+
+// GetShardID returns the ID of the shard from which this event arrived, if applicable
+func (we *wrappedEvent) GetShardID() int {
+	return we.event.GetShardID()
+}
+
+// GetTotalNumShards returns the total number of shards, if applicable
+func (we *wrappedEvent) GetTotalNumShards() int {
+	return we.event.GetTotalNumShards()
+}
+
+// GetType returns the type of event
+func (we *wrappedEvent) GetType() string {
+	return we.event.GetType()
+}
+
+// GetTypeVersion returns the version of the type
+func (we *wrappedEvent) GetTypeVersion() string {
+	return we.event.GetTypeVersion()
+}
+
+// GetVersion returns the version of the event
+func (we *wrappedEvent) GetVersion() string {
+	return we.event.GetVersion()
+}

--- a/pkg/processor/runtime/dotnetcore/test/dotnetcore_test.go
+++ b/pkg/processor/runtime/dotnetcore/test/dotnetcore_test.go
@@ -73,7 +73,7 @@ func (suite *TestSuite) TestOutputs() {
 			},
 			{
 				Name:           "response object",
-				RequestHeaders: map[string]string{"a": "1", "b": "2"},
+				RequestHeaders: map[string]interface{}{"a": "1", "b": "2"},
 				RequestBody:    "return_response",
 				ExpectedResponseHeaders: map[string]string{
 					"a":            "1",

--- a/pkg/processor/runtime/golang/builtin.go
+++ b/pkg/processor/runtime/golang/builtin.go
@@ -20,5 +20,16 @@ import "github.com/nuclio/nuclio-sdk-go"
 
 // this is used for running a standalone processor during development
 func builtInHandler(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
+	context.Logger.InfoWith("Got event",
+		"Type", event.GetType(),
+		"TypeVersion", event.GetTypeVersion(),
+		"Version", event.GetVersion(),
+		"Source", event.GetTriggerInfo().GetKind(),
+		"ID", event.GetID(),
+		"Time", event.GetTimestamp().String(),
+		"Headers", event.GetHeaders(),
+		"ContentType", event.GetContentType(),
+		"Body", string(event.GetBody()))
+
 	return "Built in handler called", nil
 }

--- a/pkg/processor/runtime/golang/test/golang_test.go
+++ b/pkg/processor/runtime/golang/test/golang_test.go
@@ -24,11 +24,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
-	"github.com/satori/go.uuid"
 
+	"github.com/nuclio/nuclio-sdk-go"
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/pkg/processor/runtime/java/test/java_test.go
+++ b/pkg/processor/runtime/java/test/java_test.go
@@ -75,7 +75,7 @@ func (suite *TestSuite) TestOutputs() {
 			},
 			{
 				Name:                       "return response",
-				RequestHeaders:             map[string]string{"a": "1", "b": "2"},
+				RequestHeaders:             map[string]interface{}{"a": "1", "b": "2"},
 				RequestBody:                "return_response",
 				ExpectedResponseHeaders:    headersFromResponse,
 				ExpectedResponseBody:       "response body",

--- a/pkg/processor/runtime/nodejs/test/nodejs_test.go
+++ b/pkg/processor/runtime/nodejs/test/nodejs_test.go
@@ -85,7 +85,7 @@ func (suite *TestSuite) TestOutputs() {
 			},
 			{
 				Name:                       "return response",
-				RequestHeaders:             map[string]string{"a": "1", "b": "2"},
+				RequestHeaders:             map[string]interface{}{"a": "1", "b": "2"},
 				RequestBody:                "return_response",
 				ExpectedResponseHeaders:    headersFromResponse,
 				ExpectedResponseBody:       "response body",

--- a/pkg/processor/runtime/pypy/interface.go
+++ b/pkg/processor/runtime/pypy/interface.go
@@ -71,7 +71,7 @@ func logError(message string, args ...interface{}) {
 func eventID(ptr unsafe.Pointer) *C.char {
 	event := *(*nuclio.Event)(ptr)
 
-	return C.CString(event.GetID().String())
+	return C.CString(string(event.GetID()))
 }
 
 // nolint

--- a/pkg/processor/runtime/pypy/test/pypy_test.go
+++ b/pkg/processor/runtime/pypy/test/pypy_test.go
@@ -92,7 +92,7 @@ func (suite *TestSuite) TestOutputs() {
 			},
 			{
 				Name:                       "return response",
-				RequestHeaders:             map[string]string{"a": "1", "b": "2"},
+				RequestHeaders:             map[string]interface{}{"a": "1", "b": "2"},
 				RequestBody:                "return_response",
 				ExpectedResponseHeaders:    headersFromResponse,
 				ExpectedResponseBody:       "response body",

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -111,7 +111,7 @@ func (suite *TestSuite) testOutputs(runtime string) {
 			},
 			{
 				Name:                       "return response",
-				RequestHeaders:             map[string]string{"a": "1", "b": "2"},
+				RequestHeaders:             map[string]interface{}{"a": "1", "b": "2"},
 				RequestBody:                "return_response",
 				ExpectedResponseHeaders:    headersFromResponse,
 				ExpectedResponseBody:       "response body",

--- a/pkg/processor/runtime/rpc/encode.go
+++ b/pkg/processor/runtime/rpc/encode.go
@@ -51,7 +51,7 @@ func (je *EventJSONEncoder) Encode(event nuclio.Event) error {
 		},
 		"fields":     event.GetFields(),
 		"headers":    event.GetHeaders(),
-		"id":         event.GetID().String(),
+		"id":         event.GetID(),
 		"method":     event.GetMethod(),
 		"path":       event.GetPath(),
 		"size":       len(event.GetBody()),

--- a/pkg/processor/runtime/rpc/encode_test.go
+++ b/pkg/processor/runtime/rpc/encode_test.go
@@ -24,11 +24,12 @@ import (
 
 	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/nuclio/zap"
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/suite"
 )
 
 var (
-	testID                  = nuclio.NewID()
+	testID                  = nuclio.ID(uuid.NewV4().String())
 	testTriggerInfoProvider = &TestTriggerInfoProvider{}
 	// Make sure all values here are strings
 	testHeaders = map[string]interface{}{
@@ -49,7 +50,7 @@ type TestEvent struct {
 }
 
 func (te *TestEvent) GetID() nuclio.ID {
-	return testID
+	return nuclio.ID(testID)
 }
 
 func (te *TestEvent) GetContentType() string {

--- a/pkg/processor/runtime/shell/test/shell_test.go
+++ b/pkg/processor/runtime/shell/test/shell_test.go
@@ -91,7 +91,7 @@ func (suite *TestSuite) TestOutputs() {
 			},
 			{
 				Name: "return overridden arguments",
-				RequestHeaders: map[string]string{
+				RequestHeaders: map[string]interface{}{
 					"x-nuclio-arguments": "overridefirst overridesecond",
 				},
 				RequestBody:                "return_arguments",

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -282,15 +282,6 @@ func (suite *TestSuite) GetFunctionPath(functionRelativePath ...string) string {
 	return path.Join(functionPath...)
 }
 
-func (suite *TestSuite) createTempDir() string {
-	tempDir, err := ioutil.TempDir("", "build-test-"+suite.TestID)
-	if err != nil {
-		suite.FailNowf("Failed to create temporary dir %s for test %s", suite.TempDir, suite.TestID)
-	}
-
-	return tempDir
-}
-
 // adds some commonly-used fields to the given CreateFunctionOptions
 func (suite *TestSuite) PopulateDeployOptions(createFunctionOptions *platform.CreateFunctionOptions) {
 
@@ -305,6 +296,15 @@ func (suite *TestSuite) PopulateDeployOptions(createFunctionOptions *platform.Cr
 
 	// Does the test call for cleaning up the temp dir, and thus needs to check this on teardown
 	suite.CleanupTemp = !createFunctionOptions.FunctionConfig.Spec.Build.NoCleanup
+}
+
+func (suite *TestSuite) createTempDir() string {
+	tempDir, err := ioutil.TempDir("", "build-test-"+suite.TestID)
+	if err != nil {
+		suite.FailNowf("Failed to create temporary dir %s for test %s", suite.TempDir, suite.TestID)
+	}
+
+	return tempDir
 }
 
 // return appropriate CreateFunctionOptions for given blast configuration

--- a/pkg/processor/trigger/cron/event.go
+++ b/pkg/processor/trigger/cron/event.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cron
 
 import (
+	"fmt"
+
 	"github.com/nuclio/nuclio-sdk-go"
 )
 
@@ -35,11 +37,15 @@ func (e *Event) GetHeader(key string) interface{} {
 }
 
 func (e *Event) GetHeaderByteSlice(key string) []byte {
-	return e.Headers[key].([]byte)
+	return []byte(e.GetHeaderString(key))
 }
 
 func (e *Event) GetHeaderString(key string) string {
-	return e.Headers[key].(string)
+	if headerValue, headerExists := e.Headers[key]; headerExists {
+		return fmt.Sprintf("%v", headerValue)
+	}
+
+	return ""
 }
 
 func (e *Event) GetHeaders() map[string]interface{} {

--- a/pkg/processor/trigger/http/event.go
+++ b/pkg/processor/trigger/http/event.go
@@ -29,7 +29,7 @@ type Event struct {
 
 // GetContentType returns the content type of the body
 func (e *Event) GetContentType() string {
-	return string(e.ctx.Request.Header.ContentType())
+	return e.GetHeaderString("Content-Type")
 }
 
 // GetBody returns the body of the event

--- a/pkg/processor/trigger/http/test/suite/suite.go
+++ b/pkg/processor/trigger/http/test/suite/suite.go
@@ -36,7 +36,7 @@ type Request struct {
 	Name string
 
 	RequestBody     string
-	RequestHeaders  map[string]string
+	RequestHeaders  map[string]interface{}
 	RequestLogLevel *string
 	RequestMethod   string
 	RequestPath     string
@@ -130,7 +130,7 @@ func (suite *TestSuite) SendRequestVerifyResponse(request *Request) bool {
 	// if there are request headers, add them
 	if request.RequestHeaders != nil {
 		for requestHeaderName, requestHeaderValue := range request.RequestHeaders {
-			httpRequest.Header.Add(requestHeaderName, requestHeaderValue)
+			httpRequest.Header.Add(requestHeaderName, fmt.Sprintf("%v", requestHeaderValue))
 		}
 	} else {
 		httpRequest.Header.Add("Content-Type", "text/plain")
@@ -178,7 +178,7 @@ func (suite *TestSuite) SendRequestVerifyResponse(request *Request) bool {
 	case string:
 		suite.Require().Equal(typedExpectedResponseBody, string(body))
 
-		// if it's a map - assume JSON
+	// if it's a map - assume JSON
 	case map[string]interface{}:
 
 		// verify content type is JSON
@@ -192,6 +192,8 @@ func (suite *TestSuite) SendRequestVerifyResponse(request *Request) bool {
 		suite.Require().True(compare.CompareNoOrder(typedExpectedResponseBody, unmarshalledBody))
 	case *regexp.Regexp:
 		suite.Require().Regexp(typedExpectedResponseBody, string(body))
+	case func([]byte):
+		typedExpectedResponseBody(body)
 	}
 
 	// if there are logs expected, verify them

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -25,10 +25,10 @@ import (
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/worker"
-	"github.com/satori/go.uuid"
 
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
+	"github.com/satori/go.uuid"
 )
 
 type Trigger interface {

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -199,15 +199,15 @@ func (at *AbstractTrigger) SubmitEventToWorker(functionLogger logger.Logger,
 		// set the event to the structured event
 		event = structuredEvent
 
-	// if body does not encode a structured cloudevent, check if this is a binary cloud event by checking the
-	// existence of the "CE-CloudEventsVersion" header
+		// if body does not encode a structured cloudevent, check if this is a binary cloud event by checking the
+		// existence of the "CE-CloudEventsVersion" header
 	} else if event.GetHeaderString("CE-CloudEventsVersion") != "" {
 
 		// use the structured cloudevent stored in the worker to wrap this existing event
 		// event = workerInstance.GetBinaryCloudEvent(event)
 
-	// not a cloud event
- 	} else {
+		// not a cloud event
+	} else {
 		event.SetID(nuclio.ID(uuid.NewV4().String()))
 
 		// set trigger info provider (ourselves)

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -189,22 +189,30 @@ func (at *AbstractTrigger) SubmitEventToWorker(functionLogger logger.Logger,
 	if strings.HasPrefix(event.GetContentType(), "application/cloudevents") {
 
 		// use the structured cloudevent stored in the worker to wrap this existing event
-		structuredEvent := workerInstance.GetStructuredCloudEvent()
+		structuredCloudEvent := workerInstance.GetStructuredCloudEvent()
 
 		// wrap the received event
-		if err := structuredEvent.SetEvent(event); err != nil {
+		if err := structuredCloudEvent.SetEvent(event); err != nil {
 			return nil, errors.Wrap(err, "Failed to wrap structured cloud event")
 		}
 
 		// set the event to the structured event
-		event = structuredEvent
+		event = structuredCloudEvent
 
 		// if body does not encode a structured cloudevent, check if this is a binary cloud event by checking the
 		// existence of the "CE-CloudEventsVersion" header
 	} else if event.GetHeaderString("CE-CloudEventsVersion") != "" {
 
 		// use the structured cloudevent stored in the worker to wrap this existing event
-		// event = workerInstance.GetBinaryCloudEvent(event)
+		binaryCloudEvent := workerInstance.GetBinaryCloudEvent()
+
+		// wrap the received event
+		if err := binaryCloudEvent.SetEvent(event); err != nil {
+			return nil, errors.Wrap(err, "Failed to wrap binary cloud event")
+		}
+
+		// set the event to the structured event
+		event = binaryCloudEvent
 
 		// not a cloud event
 	} else {

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -27,11 +27,11 @@ import (
 
 // Worker holds all the required state and context to handle a single request
 type Worker struct {
-	logger     logger.Logger
-	context    nuclio.Context
-	index      int
-	runtime    runtime.Runtime
-	statistics Statistics
+	logger               logger.Logger
+	context              nuclio.Context
+	index                int
+	runtime              runtime.Runtime
+	statistics           Statistics
 	structuredCloudEvent cloudevent.Structured
 }
 

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -33,6 +33,7 @@ type Worker struct {
 	runtime              runtime.Runtime
 	statistics           Statistics
 	structuredCloudEvent cloudevent.Structured
+	binaryCloudEvent     cloudevent.Binary
 }
 
 // NewWorker creates a new worker
@@ -102,4 +103,8 @@ func (w *Worker) Stop() error {
 
 func (w *Worker) GetStructuredCloudEvent() *cloudevent.Structured {
 	return &w.structuredCloudEvent
+}
+
+func (w *Worker) GetBinaryCloudEvent() *cloudevent.Binary {
+	return &w.binaryCloudEvent
 }

--- a/test/_functions/common/event-returner/golang/eventreturner.go
+++ b/test/_functions/common/event-returner/golang/eventreturner.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/nuclio/nuclio-sdk-go"
+)
+
+func EventReturner(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
+	eventFields := struct {
+		ID             nuclio.ID              `json:"id,omitempty"`
+		TriggerClass   string                 `json:"triggerClass,omitempty"`
+		TriggerKind    string                 `json:"eventType,omitempty"`
+		ContentType    string                 `json:"ContentType,omitempty"`
+		Headers        map[string]interface{} `json:"Headers,omitempty"`
+		Timestamp      time.Time              `json:"Timestamp,omitempty"`
+		Path           string                 `json:"path,omitempty"`
+		URL            string                 `json:"url,omitempty"`
+		Method         string                 `json:"method,omitempty"`
+		ShardID        int                    `json:"shardID,omitempty"`
+		TotalNumShards int                    `json:"totalNumShards,omitempty"`
+		Type           string                 `json:"type,omitempty"`
+		TypeVersion    string                 `json:"typeVersion,omitempty"`
+		Version        string                 `json:"version,omitempty"`
+		Body           []byte                 `json:"body,omitempty"`
+	} {
+		ID: event.GetID(),
+		TriggerClass: event.GetTriggerInfo().GetClass(),
+		TriggerKind: event.GetTriggerInfo().GetKind(),
+		ContentType: event.GetContentType(),
+		Headers: event.GetHeaders(),
+		Timestamp: event.GetTimestamp(),
+		Path: event.GetPath(),
+		URL: event.GetURL(),
+		Method: event.GetMethod(),
+		ShardID: event.GetShardID(),
+		TotalNumShards: event.GetTotalNumShards(),
+		Type: event.GetType(),
+		TypeVersion: event.GetTypeVersion(),
+		Version: event.GetVersion(),
+		Body: event.GetBody(),
+	}
+
+	return json.Marshal(&eventFields)
+}


### PR DESCRIPTION
Logic is currently:

```
	# check if this is a structured cloud event
	if event.headers["Content-Type"].startsWith("application/cloudevents"):

		# parse body as structured cloud event
		event = StructuredCloudEvent(event.body)

	# if there's a cloud events version, create a binary cloud event
	else if "CE-CloudEventsVersion" in event.headers:

		# read cloud event headers to populate various fields
		event = BinaryCloudEvent(event)
	else:

		event = event
```

Allows posting CloudEvents (both structured and binary) such that the function will receive an `event` that returns the fields specified by the cloud event.