### PR TITLE
Faster local platform storage access

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -32,7 +32,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "~0.0.24",
+    "iguazio.dashboard-controls": "~0.0.25",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",

--- a/pkg/dockerclient/dockerclient.go
+++ b/pkg/dockerclient/dockerclient.go
@@ -41,6 +41,9 @@ type Client interface {
 	// RunContainer will run a container based on an image and run options
 	RunContainer(imageName string, runOptions *RunOptions) (string, error)
 
+	// ExecInContainer will run a command in a container
+	ExecInContainer(containerID string, execOptions *ExecOptions) error
+
 	// RemoveContainer removes a container given a container ID
 	RemoveContainer(containerID string) error
 

--- a/pkg/dockerclient/mock.go
+++ b/pkg/dockerclient/mock.go
@@ -65,6 +65,11 @@ func (mdc *MockDockerClient) RunContainer(imageName string, runOptions *RunOptio
 	return "", nil
 }
 
+// ExecInContainer will run a command in a container
+func (mdc *MockDockerClient) ExecInContainer(containerID string, execOptions *ExecOptions) error {
+	return nil
+}
+
 // RemoveContainer removes a container given a container ID
 func (mdc *MockDockerClient) RemoveContainer(containerID string) error {
 	return nil

--- a/pkg/dockerclient/types.go
+++ b/pkg/dockerclient/types.go
@@ -51,6 +51,13 @@ type RunOptions struct {
 	ImageMayNotExist bool
 }
 
+// ExecOptions are options for executing a command in a container
+type ExecOptions struct {
+	Command string
+	Stdout  *string
+	Stderr  *string
+}
+
 // GetContainerOptions are options for container search
 type GetContainerOptions struct {
 	Name    string

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -529,7 +529,7 @@ func (p *Platform) createFunctionFromContainer(functionSpec *functionconfig.Spec
 	var functionState functionconfig.FunctionState
 	var message string
 
-	if !container.State.Running {
+	if container.State.Status == "exited" && container.State.ExitCode != 0 {
 		functionState = functionconfig.FunctionStateError
 		message, _ = p.dockerClient.GetContainerLogs(container.ID)
 	} else {

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -138,6 +138,7 @@ func (p *Platform) GetFunctions(getFunctionsOptions *platform.GetFunctionsOption
 
 	getContainerOptions := &dockerclient.GetContainerOptions{
 		Labels: getLabels,
+		Stopped: true,
 	}
 
 	// if we need to get only one function, specify its function name
@@ -525,6 +526,16 @@ func (p *Platform) createFunctionFromContainer(functionSpec *functionconfig.Spec
 		json.Unmarshal([]byte(marshalledAnnotations), &functionMeta.Annotations) // nolint: errcheck
 	}
 
+	var functionState functionconfig.FunctionState
+	var message string
+
+	if !container.State.Running {
+		functionState = functionconfig.FunctionStateError
+		message, _ = p.dockerClient.GetContainerLogs(container.ID)
+	} else {
+		functionState = functionconfig.FunctionStateReady
+	}
+
 	return newFunction(p.Logger,
 		p,
 		&functionconfig.Config{
@@ -533,7 +544,8 @@ func (p *Platform) createFunctionFromContainer(functionSpec *functionconfig.Spec
 		},
 		&functionconfig.Status{
 			HTTPPort: p.getContainerHTTPTriggerPort(container),
-			State:    functionconfig.FunctionStateReady,
+			State:    functionState,
+			Message:  message,
 		},
 		container)
 }

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -137,7 +137,7 @@ func (p *Platform) GetFunctions(getFunctionsOptions *platform.GetFunctionsOption
 	getLabels["nuclio.io/namespace"] = getFunctionsOptions.Namespace
 
 	getContainerOptions := &dockerclient.GetContainerOptions{
-		Labels: getLabels,
+		Labels:  getLabels,
 		Stopped: true,
 	}
 

--- a/pkg/platform/local/store.go
+++ b/pkg/platform/local/store.go
@@ -207,11 +207,11 @@ func (s *store) getResources(resourceMeta interface{}) ([]interface{}, error) {
 			return nil, errors.Wrap(err, "Failed to execute cat command")
 		}
 
-		// run a container that simply volumizes the volume with the storage and sleeps for 90 days
+		// run a container that simply volumizes the volume with the storage and sleeps for 6 hours
 		_, err = s.dockerClient.RunContainer("alpine:3.6", &dockerclient.RunOptions{
 			Volumes:          map[string]string{volumeName: baseDir},
 			Remove:           true,
-			Command:          `/bin/sh -c "/bin/sleep 90d"`,
+			Command:          `/bin/sh -c "/bin/sleep 6h"`,
 			Stdout:           &commandStdout,
 			ImageMayNotExist: true,
 			ContainerName:    containerName,

--- a/pkg/platform/local/store.go
+++ b/pkg/platform/local/store.go
@@ -33,6 +33,7 @@ import (
 
 const (
 	volumeName         = "nuclio-local-storage"
+	containerName      = "nuclio-local-storage-reader"
 	baseDir            = "/etc/nuclio/store"
 	processorConfigDir = baseDir + "/processor-configs"
 	projectsDir        = baseDir + "/projects"
@@ -167,7 +168,7 @@ func (s *store) getResources(resourceMeta interface{}) ([]interface{}, error) {
 	}
 
 	var resourcePath string
-	var commandStdout string
+	var commandStdout, commandStderr string
 
 	resourceName := s.resourceMetaToName(resourceMeta)
 
@@ -178,22 +179,49 @@ func (s *store) getResources(resourceMeta interface{}) ([]interface{}, error) {
 		resourcePath = path.Join(s.resourceMetaToNamespaceDir(resourceMeta), "*")
 	}
 
-	// generate a command
-	command := fmt.Sprintf(`/bin/sh -c "/bin/cat %s"`, resourcePath)
+	// execute a cat within a container called `containerName`. if it fails because the container doesn't exist,
+	// try to run the container. if it fails because it's already created, run exec again (could be that multiple
+	// calls to getResources occurred at the same time). Repeat this 3 times
+	for attemptIdx := 0; attemptIdx < 3; attemptIdx++ {
+		commandStdout = ""
+		commandStderr = ""
 
-	// run in docker, volumizing
-	_, err := s.dockerClient.RunContainer("alpine:3.6", &dockerclient.RunOptions{
-		Volumes:          map[string]string{volumeName: baseDir},
-		Remove:           true,
-		Command:          command,
-		Stdout:           &commandStdout,
-		Attach:           true,
-		ImageMayNotExist: true,
-	})
+		err := s.dockerClient.ExecInContainer(containerName, &dockerclient.ExecOptions{
+			Command: fmt.Sprintf(`/bin/sh -c "/bin/cat %s"`, resourcePath),
+			Stdout:  &commandStdout,
+			Stderr:  &commandStderr,
+		})
 
-	// if there was an error, and it wasn't because the file wasn't created yet - bail
-	if err != nil && !strings.Contains(err.Error(), "No such file or directory") {
-		return nil, errors.Wrap(err, "Failed to run cat command")
+		// if command succeeded, we're done. commandStdout holds the content of the requested file
+		if err == nil {
+			break
+		}
+
+		// if there was an error
+		// and it wasn't because the file wasn't created yet
+		// and it wasn't because the container doesn't exist
+		// return the error
+		if err != nil &&
+			!strings.Contains(err.Error(), "No such file or directory") &&
+			!strings.Contains(err.Error(), "No such container") {
+			return nil, errors.Wrap(err, "Failed to execute cat command")
+		}
+
+		// run a container that simply volumizes the volume with the storage and sleeps for 90 days
+		_, err = s.dockerClient.RunContainer("alpine:3.6", &dockerclient.RunOptions{
+			Volumes:          map[string]string{volumeName: baseDir},
+			Remove:           true,
+			Command:          `/bin/sh -c "/bin/sleep 90d"`,
+			Stdout:           &commandStdout,
+			ImageMayNotExist: true,
+			ContainerName:    containerName,
+		})
+
+		// if we failed and the error is not that it already exists, return the error
+		if err != nil &&
+			!strings.Contains(err.Error(), "is already in use by container") {
+			return nil, errors.Wrap(err, "Failed to run container with storage volume")
+		}
 	}
 
 	var resources []interface{}


### PR DESCRIPTION
1. Faster local platform storage access: Rather than run a new container each time in order to read resources like projects, function events, etc - the local platform will try to exec the command to read in a container with a known name. If this fails due to container not existing, it will run a container that pauses for 6 hours and re-run the exec. This means that subsequent reads are much faster (around 150ms vs 1200ms)
2. In the local platform, functions whose containers came up but failed to reach operational are now returned as part of get functions