### PR TITLE
Local platform uses store for functions

### DIFF
--- a/pkg/cmdrunner/cmdrunner.go
+++ b/pkg/cmdrunner/cmdrunner.go
@@ -53,6 +53,7 @@ type RunResult struct {
 
 // CmdRunner specifies the interface to an underlying command runner
 type CmdRunner interface {
+
 	// Run runs a command, given runOptions
 	Run(runOptions *RunOptions, format string, vars ...interface{}) (RunResult, error)
 }

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -273,7 +273,7 @@ func (c *ShellClient) ExecInContainer(containerID string, execOptions *ExecOptio
 		execOptions.Command)
 
 	if err != nil {
-		c.logger.WarnWith("Failed to execute command in container",
+		c.logger.DebugWith("Failed to execute command in container",
 			"err", err,
 			"stdout", runResult.Output,
 			"stderr", runResult.Stderr)

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -191,7 +191,7 @@ func (c *ShellClient) RunContainer(imageName string, runOptions *RunOptions) (st
 	envArgument := ""
 	if runOptions.Env != nil {
 		for envName, envValue := range runOptions.Env {
-			labelArgument += fmt.Sprintf("--env %s='%s' ", envName, envValue)
+			envArgument += fmt.Sprintf("--env %s='%s' ", envName, envValue)
 		}
 	}
 
@@ -257,9 +257,18 @@ func (c *ShellClient) RunContainer(imageName string, runOptions *RunOptions) (st
 
 // ExecInContainer will run a command in a container
 func (c *ShellClient) ExecInContainer(containerID string, execOptions *ExecOptions) error {
+
+	envArgument := ""
+	if execOptions.Env != nil {
+		for envName, envValue := range execOptions.Env {
+			envArgument += fmt.Sprintf("--env %s='%s' ", envName, envValue)
+		}
+	}
+
 	runResult, err := c.cmdRunner.Run(
 		&cmdrunner.RunOptions{LogRedactions: c.redactedValues},
-		"docker exec %s %s",
+		"docker exec %s %s %s",
+		envArgument,
 		containerID,
 		execOptions.Command)
 

--- a/pkg/dockerclient/types.go
+++ b/pkg/dockerclient/types.go
@@ -56,6 +56,7 @@ type ExecOptions struct {
 	Command string
 	Stdout  *string
 	Stderr  *string
+	Env     map[string]string
 }
 
 // GetContainerOptions are options for container search

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -271,3 +271,9 @@ func (s *Status) DeepCopyInto(out *Status) {
 	// TODO: proper deep copy
 	*out = *s
 }
+
+// ConfigWithStatus holds the config and status of a function
+type ConfigWithStatus struct {
+	Config
+	Status Status `json:"status,omitempty"`
+}

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -222,8 +222,9 @@ func (suite *functionDeployTestSuite) TestInvokeWithLogging() {
 	}
 
 	err := suite.ExecuteNutcl([]string{"deploy", functionName, "--verbose", "--no-pull"}, namedArgs)
-
 	suite.Require().NoError(err)
+
+	time.Sleep(2 * time.Second)
 
 	// make sure to clean up after the test
 	defer suite.dockerClient.RemoveImage(imageName)

--- a/pkg/nuctl/test/project_test.go
+++ b/pkg/nuctl/test/project_test.go
@@ -33,6 +33,10 @@ func (suite *projectGetTestSuite) TestGet() {
 	numOfProjects := 3
 	var projectNames []string
 
+	// get with nothing created - should pass
+	err := suite.ExecuteNutcl([]string{"get", "project"}, nil)
+	suite.Require().NoError(err)
+
 	for projectIdx := 0; projectIdx < numOfProjects; projectIdx++ {
 		uniqueSuffix := fmt.Sprintf("-%s-%d", xid.New().String(), projectIdx)
 
@@ -64,7 +68,7 @@ func (suite *projectGetTestSuite) TestGet() {
 		}(projectName)
 	}
 
-	err := suite.ExecuteNutcl([]string{"get", "project"}, nil)
+	err = suite.ExecuteNutcl([]string{"get", "project"}, nil)
 	suite.Require().NoError(err)
 
 	// find function names in get result

--- a/pkg/nuctl/test/project_test.go
+++ b/pkg/nuctl/test/project_test.go
@@ -50,6 +50,7 @@ func (suite *projectGetTestSuite) TestGet() {
 			"create",
 			"project",
 			projectName,
+			"--verbose",
 		}, namedArgs)
 
 		suite.Require().NoError(err)
@@ -70,7 +71,7 @@ func (suite *projectGetTestSuite) TestGet() {
 	suite.findPatternsInOutput(projectNames, nil)
 
 	// delete the second project
-	err = suite.ExecuteNutcl([]string{"delete", "proj", projectNames[1]}, nil)
+	err = suite.ExecuteNutcl([]string{"delete", "proj", projectNames[1], "--verbose"}, nil)
 	suite.Require().NoError(err)
 
 	// get again

--- a/pkg/platform/local/function.go
+++ b/pkg/platform/local/function.go
@@ -19,7 +19,6 @@ package local
 import (
 	"fmt"
 
-	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
@@ -29,14 +28,12 @@ import (
 
 type function struct {
 	platform.AbstractFunction
-	container dockerclient.Container
 }
 
 func newFunction(parentLogger logger.Logger,
 	parentPlatform platform.Platform,
 	config *functionconfig.Config,
-	status *functionconfig.Status,
-	container *dockerclient.Container) (*function, error) {
+	status *functionconfig.Status) (*function, error) {
 
 	newFunction := &function{}
 	newAbstractFunction, err := platform.NewAbstractFunction(parentLogger, parentPlatform, config, status, newFunction)
@@ -45,7 +42,6 @@ func newFunction(parentLogger logger.Logger,
 	}
 
 	newFunction.AbstractFunction = *newAbstractFunction
-	newFunction.container = *container
 
 	return newFunction, nil
 }

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -85,6 +85,13 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	createFunctionOptions.FunctionConfig.Spec.Build.Registry = ""
 
 	onAfterConfigUpdated := func(updatedFunctionConfig *functionconfig.Config) error {
+
+		// create the shadow function
+		createFunctionOptions.Logger.DebugWith("Creating shadow function",
+			"name", createFunctionOptions.FunctionConfig.Meta.Name)
+
+		// CREATE IN STORE
+
 		createFunctionOptions.Logger.InfoWith("Cleaning up before deployment")
 
 		getContainerOptions := &dockerclient.GetContainerOptions{
@@ -235,12 +242,12 @@ func (p *Platform) GetNodes() ([]platform.Node, error) {
 
 // CreateProject will create a new project
 func (p *Platform) CreateProject(createProjectOptions *platform.CreateProjectOptions) error {
-	return p.localStore.createOrUpdateResource(&createProjectOptions.ProjectConfig)
+	return p.localStore.createOrUpdateProject(&createProjectOptions.ProjectConfig)
 }
 
 // UpdateProject will update an existing project
 func (p *Platform) UpdateProject(updateProjectOptions *platform.UpdateProjectOptions) error {
-	return p.localStore.createOrUpdateResource(&updateProjectOptions.ProjectConfig)
+	return p.localStore.createOrUpdateProject(&updateProjectOptions.ProjectConfig)
 }
 
 // DeleteProject will delete an existing project
@@ -259,7 +266,7 @@ func (p *Platform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOpt
 		return fmt.Errorf("Project has %d functions, can't delete", len(functions))
 	}
 
-	return p.localStore.deleteResource(&deleteProjectOptions.Meta)
+	return p.localStore.deleteProject(&deleteProjectOptions.Meta)
 }
 
 // GetProjects will list existing projects
@@ -270,17 +277,17 @@ func (p *Platform) GetProjects(getProjectsOptions *platform.GetProjectsOptions) 
 // CreateFunctionEvent will create a new function event that can later be used as a template from
 // which to invoke functions
 func (p *Platform) CreateFunctionEvent(createFunctionEventOptions *platform.CreateFunctionEventOptions) error {
-	return p.localStore.createOrUpdateResource(&createFunctionEventOptions.FunctionEventConfig)
+	return p.localStore.createOrUpdateFunctionEvent(&createFunctionEventOptions.FunctionEventConfig)
 }
 
 // UpdateFunctionEvent will update a previously existing function event
 func (p *Platform) UpdateFunctionEvent(updateFunctionEventOptions *platform.UpdateFunctionEventOptions) error {
-	return p.localStore.createOrUpdateResource(&updateFunctionEventOptions.FunctionEventConfig)
+	return p.localStore.createOrUpdateFunctionEvent(&updateFunctionEventOptions.FunctionEventConfig)
 }
 
 // DeleteFunctionEvent will delete a previously existing function event
 func (p *Platform) DeleteFunctionEvent(deleteFunctionEventOptions *platform.DeleteFunctionEventOptions) error {
-	return p.localStore.deleteResource(&deleteFunctionEventOptions.Meta)
+	return p.localStore.deleteFunctionEvent(&deleteFunctionEventOptions.Meta)
 }
 
 // GetFunctionEvents will list existing function events

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -443,9 +443,6 @@ func (p *Platform) deployFunction(createFunctionOptions *platform.CreateFunction
 
 	p.Logger.InfoWith("Waiting for function to be ready", "timeout", logReadinessTimeout)
 
-	to := 5 * time.Second
-	createFunctionOptions.ReadinessTimeout = &to
-
 	if err = p.dockerClient.AwaitContainerHealth(containerID, createFunctionOptions.ReadinessTimeout); err != nil {
 		var errMessage string
 

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"path"
 	"strconv"
-	"time"
 
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
 	"github.com/nuclio/nuclio/pkg/common"

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -17,6 +17,7 @@ limitations under the License.
 package local
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -24,6 +25,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"time"
 
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
 	"github.com/nuclio/nuclio/pkg/common"
@@ -69,7 +71,7 @@ func NewPlatform(parentLogger logger.Logger) (*Platform, error) {
 	}
 
 	// create a local store for configs and stuff
-	if newPlatform.localStore, err = newStore(parentLogger, newPlatform.dockerClient); err != nil {
+	if newPlatform.localStore, err = newStore(parentLogger, newPlatform, newPlatform.dockerClient); err != nil {
 		return nil, errors.Wrap(err, "Failed to create local store")
 	}
 
@@ -84,13 +86,38 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	createFunctionOptions.FunctionConfig.Spec.RunRegistry = ""
 	createFunctionOptions.FunctionConfig.Spec.Build.Registry = ""
 
-	onAfterConfigUpdated := func(updatedFunctionConfig *functionconfig.Config) error {
+	reportCreationError := func(creationError error) error {
+		createFunctionOptions.Logger.WarnWith("Create function failed failed, setting function status",
+			"err", creationError)
 
-		// create the shadow function
+		errorStack := bytes.Buffer{}
+		errors.PrintErrorStack(&errorStack, creationError, 20)
+
+		// post logs and error
+		return p.localStore.createOrUpdateFunction(&functionconfig.ConfigWithStatus{
+			Config: createFunctionOptions.FunctionConfig,
+			Status: functionconfig.Status{
+				State:   functionconfig.FunctionStateError,
+				Message: errorStack.String(),
+			},
+		})
+	}
+
+	onAfterConfigUpdated := func(updatedFunctionConfig *functionconfig.Config) error {
 		createFunctionOptions.Logger.DebugWith("Creating shadow function",
 			"name", createFunctionOptions.FunctionConfig.Meta.Name)
 
-		// CREATE IN STORE
+		// create the function in the store
+		err := p.localStore.createOrUpdateFunction(&functionconfig.ConfigWithStatus{
+			Config: createFunctionOptions.FunctionConfig,
+			Status: functionconfig.Status{
+				State: functionconfig.FunctionStateBuilding,
+			},
+		})
+
+		if err != nil {
+			return errors.Wrap(err, "Failed to create shadow function")
+		}
 
 		createFunctionOptions.Logger.InfoWith("Cleaning up before deployment")
 
@@ -129,7 +156,31 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	}
 
 	onAfterBuild := func(buildResult *platform.CreateFunctionBuildResult, buildErr error) (*platform.CreateFunctionResult, error) {
-		return p.deployFunction(createFunctionOptions, previousHTTPPort)
+		if buildErr != nil {
+			reportCreationError(buildErr) // nolint: errcheck
+			return nil, buildErr
+		}
+
+		createFunctionResult, deployErr := p.deployFunction(createFunctionOptions, previousHTTPPort)
+		if deployErr != nil {
+			reportCreationError(deployErr) // nolint: errcheck
+			return nil, deployErr
+		}
+
+		// update the function
+		updatedErr := p.localStore.createOrUpdateFunction(&functionconfig.ConfigWithStatus{
+			Config: createFunctionOptions.FunctionConfig,
+			Status: functionconfig.Status{
+				HTTPPort: createFunctionResult.Port,
+				State:    functionconfig.FunctionStateReady,
+			},
+		})
+
+		if updatedErr != nil {
+			return nil, errors.Wrap(updatedErr, "Failed to update function with state")
+		}
+
+		return createFunctionResult, nil
 	}
 
 	// wrap the deployer's deploy with the base HandleDeployFunction to provide lots of
@@ -139,49 +190,31 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 
 // GetFunctions will return deployed functions
 func (p *Platform) GetFunctions(getFunctionsOptions *platform.GetFunctionsOptions) ([]platform.Function, error) {
-	getLabels := common.StringToStringMap(getFunctionsOptions.Labels)
-	getLabels["nuclio.io/platform"] = "local"
-	getLabels["nuclio.io/namespace"] = getFunctionsOptions.Namespace
+	var functions []platform.Function
 
-	getContainerOptions := &dockerclient.GetContainerOptions{
-		Labels:  getLabels,
-		Stopped: true,
-	}
+	// get project filter
+	projectName := common.StringToStringMap(getFunctionsOptions.Labels)["nuclio.io/project-name"]
 
-	// if we need to get only one function, specify its function name
-	if getFunctionsOptions.Name != "" {
-		getContainerOptions.Labels["nuclio.io/function-name"] = getFunctionsOptions.Name
-	}
-
-	containersInfo, err := p.dockerClient.GetContainers(getContainerOptions)
+	// get all the functions in the store. these functions represent both functions that are deployed
+	// and functions that failed to build
+	localStoreFunctions, err := p.localStore.getFunctions(&functionconfig.Meta{
+		Name:      getFunctionsOptions.Name,
+		Namespace: getFunctionsOptions.Namespace,
+	})
 
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get containers")
+		return nil, errors.Wrap(err, "Failed to read functions from local store")
 	}
 
-	var functions []platform.Function
-	for _, containerInfo := range containersInfo {
-		var functionSpec functionconfig.Spec
+	// return a map of functions by name
+	for _, localStoreFunction := range localStoreFunctions {
 
-		// get the JSON encoded spec
-		encodedFunctionSpec, encodedFunctionSpecFound := containerInfo.Config.Labels["nuclio.io/function-spec"]
-		if encodedFunctionSpecFound {
-
-			// try to unmarshal the spec
-			json.Unmarshal([]byte(encodedFunctionSpec), &functionSpec) // nolint: errcheck
+		// filter by project name
+		if projectName != "" && localStoreFunction.GetConfig().Meta.Labels["nuclio.io/project-name"] != projectName {
+			continue
 		}
 
-		// update spec
-		functionSpec.Version = -1
-
-		function, err := p.createFunctionFromContainer(&functionSpec, &containerInfo)
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to create function")
-		}
-
-		// create a local.function object which wraps a dockerclient.containerInfo and
-		// implements platform.Function
-		functions = append(functions, function)
+		functions = append(functions, localStoreFunction)
 	}
 
 	return functions, nil
@@ -194,6 +227,13 @@ func (p *Platform) UpdateFunction(updateFunctionOptions *platform.UpdateFunction
 
 // DeleteFunction will delete a previously deployed function
 func (p *Platform) DeleteFunction(deleteFunctionOptions *platform.DeleteFunctionOptions) error {
+
+	// delete the function from the local store
+	err := p.localStore.deleteFunction(&deleteFunctionOptions.FunctionConfig.Meta)
+	if err != nil {
+		p.Logger.WarnWith("Failed to delete function from local store", "err", err.Error())
+	}
+
 	getContainerOptions := &dockerclient.GetContainerOptions{
 		Labels: map[string]string{
 			"nuclio.io/platform":      "local",
@@ -403,6 +443,9 @@ func (p *Platform) deployFunction(createFunctionOptions *platform.CreateFunction
 
 	p.Logger.InfoWith("Waiting for function to be ready", "timeout", logReadinessTimeout)
 
+	to := 5 * time.Second
+	createFunctionOptions.ReadinessTimeout = &to
+
 	if err = p.dockerClient.AwaitContainerHealth(containerID, createFunctionOptions.ReadinessTimeout); err != nil {
 		var errMessage string
 
@@ -496,65 +539,6 @@ func (p *Platform) getContainerNameByCreateFunctionOptions(createFunctionOptions
 	return fmt.Sprintf("%s-%s",
 		createFunctionOptions.FunctionConfig.Meta.Namespace,
 		createFunctionOptions.FunctionConfig.Meta.Name)
-}
-
-func (p *Platform) createFunctionFromContainer(functionSpec *functionconfig.Spec,
-	container *dockerclient.Container) (*function, error) {
-	functionMeta := functionconfig.Meta{}
-
-	// get stuff from labels
-	functionMeta.Name = container.Config.Labels["nuclio.io/function-name"]
-	functionMeta.Namespace = container.Config.Labels["nuclio.io/namespace"]
-	functionMeta.Labels = map[string]string{}
-
-	// copy labels, except for internal labels
-	for labelName, labelValue := range container.Config.Labels {
-		skipLabel := false
-
-		for _, skippedLabelValue := range []string{
-			"nuclio.io/function-name",
-			"nuclio.io/namespace",
-			"nuclio.io/platform",
-			"nuclio.io/function-spec",
-		} {
-			if labelName == skippedLabelValue {
-				skipLabel = true
-				break
-			}
-		}
-
-		if !skipLabel {
-			functionMeta.Labels[labelName] = labelValue
-		}
-	}
-
-	// try to unmarshal the annotations
-	if marshalledAnnotations, exists := container.Config.Labels["nuclio.io/annotations"]; exists {
-		json.Unmarshal([]byte(marshalledAnnotations), &functionMeta.Annotations) // nolint: errcheck
-	}
-
-	var functionState functionconfig.FunctionState
-	var message string
-
-	if container.State.Status == "exited" && container.State.ExitCode != 0 {
-		functionState = functionconfig.FunctionStateError
-		message, _ = p.dockerClient.GetContainerLogs(container.ID)
-	} else {
-		functionState = functionconfig.FunctionStateReady
-	}
-
-	return newFunction(p.Logger,
-		p,
-		&functionconfig.Config{
-			Meta: functionMeta,
-			Spec: *functionSpec,
-		},
-		&functionconfig.Status{
-			HTTPPort: p.getContainerHTTPTriggerPort(container),
-			State:    functionState,
-			Message:  message,
-		},
-		container)
 }
 
 func (p *Platform) getContainerHTTPTriggerPort(container *dockerclient.Container) int {

--- a/pkg/platform/local/store.go
+++ b/pkg/platform/local/store.go
@@ -28,7 +28,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform"
 
 	"github.com/nuclio/logger"
-q	"github.com/nuclio/nuclio-sdk-go"
+	"github.com/nuclio/nuclio-sdk-go"
 )
 
 const (

--- a/pkg/processor/status/types.go
+++ b/pkg/processor/status/types.go
@@ -22,6 +22,7 @@ import (
 
 // Provider is an interface for entities that have a reportable status
 type Provider interface {
+
 	// Returns the entity's status
 	GetStatus() Status
 }


### PR DESCRIPTION
1. Rather than using information from docker containers to retreive which functions exist in the local platform, the store is used (identical to projects, function events, etc). This allows GETing functions which are currently being built and also allows communicating build errors
2. Store refactored
3. Store uses `exec` rather than run for all commands - faster deleting, writing
4. Store uses base64 encoded contents rather than string - can store pretty much anything without worrying about escaping and such