### PR TITLE
Fix Golang concurrent deploy + other minor fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+pkg/dashboard/ui/node_modules
+pkg/dashboard/ui/vendor
+pkg/dashboard/ui/dist

--- a/pkg/platform/test/platform_test.go
+++ b/pkg/platform/test/platform_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platform/factory"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type testSuite struct {
+	suite.Suite
+	logger   logger.Logger
+	platform platform.Platform
+}
+
+func (suite *testSuite) SetupTest() {
+	var err error
+
+	// create logger
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err, "Logger should create successfully")
+
+	platformName := os.Getenv("NUCLIO_PLATFORM")
+	if platformName == "" {
+		platformName = "local"
+	}
+
+	suite.platform, err = factory.CreatePlatform(suite.logger, "kube", nil)
+	suite.Require().NoError(err, "Platform should create successfully")
+}
+
+//
+// Function
+//
+
+type functionTestSuite struct {
+	testSuite
+}
+
+func (suite *functionTestSuite) TestCreateConcurrent() {
+
+}
+
+func TestProjectTestSuite(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	// suite.Run(t, new(functionTestSuite))
+}

--- a/pkg/processor/build/runtime/java/docker/Dockerfile.handler-builder
+++ b/pkg/processor/build/runtime/java/docker/Dockerfile.handler-builder
@@ -15,8 +15,8 @@
 FROM openjdk:9-slim
 
 RUN apt-get update \
-    && apt-get install -y curl \
-    && curl -LO https://services.gradle.org/distributions/gradle-4.5.1-bin.zip \
+    && apt-get install -y wget \
+    && wget -q https://services.gradle.org/distributions/gradle-4.5.1-bin.zip \
     && unzip gradle-4.5.1-bin.zip \
     && rm gradle-4.5.1-bin.zip \
     && ln -s /gradle-4.5.1/bin/gradle /usr/local/bin \
@@ -29,6 +29,7 @@ COPY pkg/processor/runtime/java/nuclio-sdk-1.0-SNAPSHOT.jar .
 COPY pkg/processor/runtime/java/src src
 COPY pkg/processor/build/runtime/java/docker/build-handler.sh .
 RUN chmod +x build-handler.sh
+
 # Download dependencies
 RUN gradle compileJava > /dev/null
 

--- a/pkg/processor/build/runtime/java/docker/Dockerfile.user-jar-builder
+++ b/pkg/processor/build/runtime/java/docker/Dockerfile.user-jar-builder
@@ -15,8 +15,8 @@
 FROM openjdk:9-slim
 
 RUN apt-get update \
-    && apt-get install -y curl \
-    && curl -LO https://services.gradle.org/distributions/gradle-4.5.1-bin.zip \
+    && apt-get install -y wget \
+    && wget -q https://services.gradle.org/distributions/gradle-4.5.1-bin.zip \
     && unzip gradle-4.5.1-bin.zip \
     && rm gradle-4.5.1-bin.zip \
     && ln -s /gradle-4.5.1/bin/gradle /usr/local/bin \


### PR DESCRIPTION
1. Golang build used a temporary image to build the handler whose name was not keyed by namespace/name. Concurrent builds would trip over each other
2. Replaced curl with wget in Java builds due to apt hell (broken packages)
3. Added .dockerignore so that building images ignores UI intermediates, if they exist
4. Added platform integration test, currently does nothing but will serve as a base for the integration test reorg