### PR TITLE
No ingresses by default, remove defaultIngress

### DIFF
--- a/docs/reference/triggers/http.md
+++ b/docs/reference/triggers/http.md
@@ -7,11 +7,21 @@ The HTTP trigger is the only trigger created by default if not configured (by de
 | Path | Type | Description |
 | :--- | :--- | :--- |
 | port | int | The NodePort (or equivalent) on which the function will serve HTTP requests. If empty, chooses a random port within the platform range |
-| defaultIngressPattern | string | A pattern for specifying the default ingress rule to create for the function. Variables in the form of `{{.<NAME>}}` can be specified, with `.Name`, `.Namespace` and `.Version` supported. For example, `/{{.Namespace}}-{{.Name}}/{{.Version}}` will result in a default ingress of `/namespace-name/version`. If not set, a default ingress rule of /{{.Name}}/{{.Version}} is used. If set to an empty string, no default ingress is created |
 | ingresses.(name).host | string | The host to which the ingress maps to |
-| ingresses.(name).paths | list of strings | The paths the ingress handles |
+| ingresses.(name).paths | list of strings | The paths the ingress handles. Variables in the form of `{{.<NAME>}}` can be specified, with `.Name`, `.Namespace` and `.Version` supported. For example, `/{{.Namespace}}-{{.Name}}/{{.Version}}` will result in a default ingress of `/namespace-name/version`. |
 
 ### Examples
+
+Without ingresseses:
+
+```yaml
+triggers:
+  myHttpTrigger:
+    maxWorkers: 4
+    kind: "http"
+    attributes:
+      port: 32001
+```
 
 With ingresseses:
 
@@ -33,28 +43,5 @@ triggers:
           - "/second/path"
         http2:
           paths:
-          - "/wat"
+          - "MyFunctions/{{.Name}}/{{.Version}}"
 ```
-
-No default ingress:
-```yaml
-triggers:
-  myHttpTrigger:
-    maxWorkers: 4
-    kind: "http"
-    attributes:
-      port: 32001
-      defaultIngressPattern: ""
-```
-
-Non-default ingress:
-```yaml
-triggers:
-  myHttpTrigger:
-    maxWorkers: 4
-    kind: "http"
-    attributes:
-      port: 32001
-      defaultIngressPattern: "MyFunctions/{{.Name}}/{{.Version}}"
-```
-


### PR DESCRIPTION
1. Prior to this PR, by default ingresses were created for functions. This is a security concern as most people might not be aware that their functions get exposed
2. The concept of `defaultIngressPattern`, which was an attempt to allow some users to address (1) was not a clean enough interface and was removed
3. Paths in ingresses can now contain formatting