### PR TITLE
Python runtime features

### DIFF
--- a/pkg/processor/build/test/build_test.go
+++ b/pkg/processor/build/test/build_test.go
@@ -34,7 +34,7 @@ type TestSuite struct {
 
 func (suite *TestSuite) TestBuildFuncFromSourceWithInlineConfig() {
 	createFunctionOptions := &platform.CreateFunctionOptions{
-		Logger:         suite.Logger,
+		Logger: suite.Logger,
 	}
 
 	functionSourceCode := `

--- a/pkg/processor/runtime/python/wrapper.py
+++ b/pkg/processor/runtime/python/wrapper.py
@@ -369,8 +369,13 @@ def response_from_handler_output(logger, handler_output):
 
     # if it's a response object, populate the response
     elif isinstance(handler_output, Response):
-        response['body'] = handler_output.body
-        response['content_type'] = handler_output.content_type
+        if isinstance(handler_output.body, dict):
+            response['body'] = json.dumps(handler_output.body)
+            response['content_type'] = 'application/json'
+        else:
+            response['body'] = handler_output.body
+            response['content_type'] = handler_output.content_type
+
         response['headers'] = handler_output.headers
         response['status_code'] = handler_output.status_code
     else:

--- a/pkg/processor/runtime/python/wrapper.py
+++ b/pkg/processor/runtime/python/wrapper.py
@@ -85,7 +85,7 @@ class Platform(object):
         self.kind = kind
 
     def call_function(self, name, body, method='POST', path='/', headers=None, node=None):
-        connection = http.client.HTTPConnection(f'default-{name}:8080')
+        connection = http.client.HTTPConnection('default-{0}:8080'.format(name))
 
         if isinstance(body, dict):
             body = json.dumps(body)

--- a/pkg/processor/runtime/python/wrapper.py
+++ b/pkg/processor/runtime/python/wrapper.py
@@ -35,6 +35,7 @@ if is_py2:
             HTTPMessage.__init__(self, BytesIO())
 
 else:
+    import http.client
     from http.client import HTTPMessage as Headers
 
 json_ctype = 'application/json'
@@ -78,8 +79,35 @@ class Response:
         return '{}({})'.format(cls, ', '.join(args))
 
 
-# TODO: data_binding
-Context = namedtuple('Context', ['logger', 'data_binding', 'Response'])
+class Platform(object):
+
+    def __init__(self, kind):
+        self.kind = kind
+
+    def call_function(self, name, body, method='POST', path='/', headers=None, node=None):
+        connection = http.client.HTTPConnection(f'default-{name}:8080')
+
+        if isinstance(body, dict):
+            body = json.dumps(body)
+            content_type = 'application/json'
+        else:
+            content_type = 'text/plain'
+
+        connection.request(method, path, body=body, headers={'Content-Type': content_type})
+        connection_response = connection.getresponse()
+
+        response = Response(headers=None, body=connection_response.read(), status_code=connection_response.status)
+
+        return response
+
+
+class Context(object):
+
+    def __init__(self, logger=None, platform=None):
+        self.platform = platform
+        self.logger = logger
+        self.user_data = lambda: None
+        self.Response = Response
 
 
 class JSONEncoder(json.JSONEncoder):
@@ -111,13 +139,21 @@ def create_logger(level=logging.DEBUG):
     return logger
 
 
-def decode_body(body):
+def decode_body(body, content_type):
     """Decode event body"""
+
     if isinstance(body, dict):
         return body
     else:
-        return b64decode(body)
+        decoded_body = b64decode(body)
 
+        if content_type == 'application/json':
+            try:
+                return json.loads(decoded_body)
+            except:
+                return decoded_body
+        else:
+            return decoded_body
 
 def decode_event(data):
     """Decode event encoded as JSON by Go"""
@@ -133,9 +169,11 @@ def decode_event(data):
     for key, value in obj_headers.items():
         headers[key] = value
 
+    content_type = obj['content-type']
+
     return Event(
-        body=decode_body(obj['body']),
-        content_type=obj['content-type'],
+        body=decode_body(obj['body'], content_type),
+        content_type=content_type,
         trigger=trigger,
         fields=obj.get('fields') or {},
         headers=headers,
@@ -204,8 +242,16 @@ def serve_requests(sock, logger, handler):
     """Read event from socket, send out reply"""
 
     buf = []
-    ctx = Context(logger, None, Response)
+
+    platform = Platform(kind="tbd")
+    ctx = Context(logger, platform=platform)
     stream = sock.makefile('w')
+
+    # get handler module
+    handler_module = sys.modules[handler.__module__]
+
+    if hasattr(handler_module, 'init_context'):
+        getattr(handler_module, 'init_context')(ctx)
 
     while True:
 


### PR DESCRIPTION
1. Breaking change: `nuctl --env` is now a repetitive flag rather than command delimited (e.g. `nuctl --env a=b --env c=d` rather than `nuctl --env `a=b,c=d`). The reason is that it was quite difficult (impossible?) to receive values with `=` in them. This is quite common seeing how secrets can be base64 encoded
2. Python3 supports `context.platform.call_function` a small sign of things to come
3. If Python receives `application/json` in content type, it will try to `loads` the body
4. User can now pass dictionaries in `context.Response` for Python
5. If user implements `init_context`, it will be called like in Golang (missing tests)