### PR TITLE
Function configuration allows specifying onbuild image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,19 +25,19 @@ script:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "development" ]; then
-    export NUCLIO_TAG="unstable";
+    export NUCLIO_LABEL="unstable";
     fi
   - if [ "$TRAVIS_TAG" != "" ]; then
-    export NUCLIO_TAG="$TRAVIS_TAG";
+    export NUCLIO_LABEL="$TRAVIS_TAG";
     fi
   - echo $TRAVIS_PULL_REQUEST
   - echo $TRAVIS_BRANCH
-  - echo $NUCLIO_TAG
-  - if [ -n "$NUCLIO_TAG" ]; then
+  - echo $NUCLIO_LABEL
+  - if [ -n "$NUCLIO_LABEL" ]; then
     echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin &&
     make docker-images push-docker-images &&
-    if [ "$NUCLIO_TAG" != "unstable" ]; then
-    docker tag "nuclio/playground:$NUCLIO_TAG-amd64" nuclio/playground:stable-amd64 &&
+    if [ "$NUCLIO_LABEL" != "unstable" ]; then
+    docker tag "nuclio/playground:$NUCLIO_LABEL-amd64" nuclio/playground:stable-amd64 &&
     docker push nuclio/playground:stable-amd64;
     fi
     fi
@@ -53,9 +53,9 @@ deploy:
   api_key:
     secure: XYb8aOndiae7AoLyZU2e4s4GKKyoJjjW8tA+gG0HHD6AhqbaaSx6IofwNbQqOhM0iGOTWeeG3SaW34MPRcjV3FX0fYO8lW2GAynXT6Td5uhJmPtmk/msrfdLlCVYhQ42DoWjvtWwaejJRZCYHNlhAwH6c/peSO7KqN0QaRABfO4CK6Npvt9JMo+hCfxnUmaVBzkbtfXIrBlxkXxVOGn/geUzf+2qpnMw85WMIN8RIXedNBe0UBkBasPJA5hKadckMKDCaIbiQ8KsOF2HK7IGwg/goTMfshuOZn/f8aCC+D5lyCQD3bkuHJqrj+HYCVHalAeESXJGmSHr/xmV+XQ9RoxdSUaO2TBU4r+WPPM1JsNNAvQe4zxEaVXOu41bRbZnccxwCHhPcKwT+KD7IniJMUdRkTadGPx+yZoMGwxtGK6elDyr3yzzYRfjBIcfecaPVifny51bRxWpGwcaoWP0qew86vqMcCz9dQBZUvKA/+zdcKXZHvqbouh+Iv79z7BVaW7aTmcsIhn7miqH5qIOnfJUsZiBAAY5EX7FpXMtSx9cpna+vKsvtRtSnywLsLDiLAPLWE0muTDPDksDsmTT0AvHQENv0bd5U0qnTlaR2Q31Q2e8WY0y7DZrYgruNGTvVtwrrAv4KvBHjO0GJya4NvnZB37yMFTKJouZU/o8qm4=
   file:
-    - $GOPATH/bin/nuctl-$NUCLIO_TAG-linux-amd64
-    - $GOPATH/bin/nuctl-$NUCLIO_TAG-darwin-amd64
-    - $GOPATH/bin/nuctl-$NUCLIO_TAG-windows-amd64
+    - $GOPATH/bin/nuctl-$NUCLIO_LABEL-linux-amd64
+    - $GOPATH/bin/nuctl-$NUCLIO_LABEL-darwin-amd64
+    - $GOPATH/bin/nuctl-$NUCLIO_LABEL-windows-amd64
   skip_cleanup: true
   on:
     tags: true

--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -73,8 +73,9 @@ The `spec` section contains the requirements and attributes and has the followin
 | build.registry | string | The container image repository to which the built image will be pushed |
 | build.noBaseImagePull | string | Do not pull any base images when building, use local images only |
 | build.noCache | string | Do not use any caching when building container images |
-| build.baseImage | string | Currently one of "alpine" or "jessie" |
+| build.baseImage | string | The base image from which the processor image will be built from |
 | build.Commands | list of string | Commands run opaquely as part of container image build |
+| build.onbuildImage | string | Specifies the "Onbuild" image from which the processor image will be built from. Can use {{ .Label }} and {{ .Arch }} for formatting |
 | runRegistry | string | The container image repository from which the platform will pull the image |
 | runtimeAttributes | See reference | Runtime specific attributes, see runtime documentation for specifics |
 | resources | See [reference](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) | Limit resources allocated to deployed function |

--- a/hack/minikube/scripts/push_images.py
+++ b/hack/minikube/scripts/push_images.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
 
     minikube_ip_addr = _run_command('minikube ip').strip() + ':5000'
 
-    tag = '{0}-amd64'.format(os.environ.get('NUCLIO_TAG', 'latest'))
+    tag = '{0}-amd64'.format(os.environ.get('NUCLIO_LABEL', 'latest'))
 
     for image_url in [
         'nuclio/controller',

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -155,6 +155,7 @@ type Build struct {
 	ScriptPaths        []string          `json:"scriptPaths,omitempty"`
 	AddedObjectPaths   map[string]string `json:"addedPaths,omitempty"`
 	Dependencies       []string          `json:"dependencies,omitempty"`
+	OnbuildImage       string            `json:"onbuildImage,omitempty"`
 }
 
 // Spec holds all parameters related to a function's configuration

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -86,4 +86,5 @@ func addBuildFlags(cmd *cobra.Command, config *functionconfig.Config, commands *
 	cmd.Flags().BoolVarP(&config.Spec.Build.NoCleanup, "no-cleanup", "", false, "Don't clean up temporary directories")
 	cmd.Flags().StringVarP(&config.Spec.Build.BaseImage, "base-image", "", "", "Name of the base image (default - per-runtime default)")
 	cmd.Flags().Var(commands, "build-command", "Commands to run when building the processor image")
+	cmd.Flags().StringVarP(&config.Spec.Build.OnbuildImage, "onbuild-image", "", "", "The runtime onbuild image used to build the processor image")
 }

--- a/pkg/processor/build/runtime/dotnetcore/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/dotnetcore/docker/onbuild/Dockerfile
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG NUCLIO_TAG=latest
+ARG NUCLIO_LABEL=latest
 ARG NUCLIO_ARCH=amd64
 
 # Supplies processor
-FROM nuclio/processor:${NUCLIO_TAG}-${NUCLIO_ARCH} as processor
+FROM nuclio/processor:${NUCLIO_LABEL}-${NUCLIO_ARCH} as processor
 
 # Supplies wrapper and nuclio-sdk-dotnetcore
 FROM microsoft/dotnet:2-sdk as builder

--- a/pkg/processor/build/runtime/dotnetcore/runtime.go
+++ b/pkg/processor/build/runtime/dotnetcore/runtime.go
@@ -32,12 +32,10 @@ func (d *dotnetcore) GetName() string {
 // GetProcessorDockerfilePath returns the contents of the appropriate Dockerfile, with which we'll build
 // the processor image
 func (d *dotnetcore) GetProcessorDockerfileContents() string {
-	return `ARG NUCLIO_TAG=latest
+	return `ARG NUCLIO_LABEL=latest
 ARG NUCLIO_ARCH=amd64
-
-# By default, alpine is the base image and we need to use the processor binary built for alpine
 ARG NUCLIO_BASE_IMAGE=microsoft/dotnet:2-runtime
-ARG NUCLIO_ONBUILD_IMAGE=nuclio/handler-builder-dotnetcore-onbuild:${NUCLIO_TAG}-${NUCLIO_ARCH}
+ARG NUCLIO_ONBUILD_IMAGE=nuclio/handler-builder-dotnetcore-onbuild:${NUCLIO_LABEL}-${NUCLIO_ARCH}
 
 # Supplies processor uhttpc, used for healthcheck
 FROM nuclio/uhttpc:0.0.1-amd64 as uhttpc

--- a/pkg/processor/build/runtime/golang/runtime.go
+++ b/pkg/processor/build/runtime/golang/runtime.go
@@ -71,7 +71,7 @@ func (g *golang) GetBuildArgs() (map[string]string, error) {
 
 		// set tag and arch
 		onbuildImage := fmt.Sprintf("nuclio/handler-builder-golang-onbuild:%s-%s",
-			buildArgs["NUCLIO_TAG"],
+			buildArgs["NUCLIO_LABEL"],
 			buildArgs["NUCLIO_ARCH"])
 
 		// set the onbuild image
@@ -84,12 +84,10 @@ func (g *golang) GetBuildArgs() (map[string]string, error) {
 // GetProcessorDockerfilePath returns the contents of the appropriate Dockerfile, with which we'll build
 // the processor image
 func (g *golang) GetProcessorDockerfileContents() string {
-	return `ARG NUCLIO_TAG=latest
+	return `ARG NUCLIO_LABEL=latest
 ARG NUCLIO_ARCH=amd64
-
-# By default, alpine is the base image and we need to use the processor binary built for alpine
 ARG NUCLIO_BASE_IMAGE=alpine:3.6
-ARG NUCLIO_ONBUILD_IMAGE=nuclio/handler-builder-golang-onbuild:${NUCLIO_TAG}-${NUCLIO_ARCH}-alpine
+ARG NUCLIO_ONBUILD_IMAGE=nuclio/handler-builder-golang-onbuild:${NUCLIO_LABEL}-${NUCLIO_ARCH}-alpine
 
 # Supplies processor uhttpc, used for healthcheck
 FROM nuclio/uhttpc:0.0.1-amd64 as uhttpc

--- a/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG NUCLIO_TAG=latest
+ARG NUCLIO_LABEL=latest
 ARG NUCLIO_ARCH=amd64
 
 # Supplies processor
-FROM nuclio/processor:${NUCLIO_TAG}-${NUCLIO_ARCH} as processor
+FROM nuclio/processor:${NUCLIO_LABEL}-${NUCLIO_ARCH} as processor
 
 FROM gradle:4.7.0-jdk9 as user-handler-builder
 

--- a/pkg/processor/build/runtime/java/runtime.go
+++ b/pkg/processor/build/runtime/java/runtime.go
@@ -18,6 +18,7 @@ package java
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -115,12 +116,13 @@ task userHandler(dependsOn: shadowJar)
 // GetProcessorDockerfilePath returns the contents of the appropriate Dockerfile, with which we'll build
 // the processor image
 func (j *java) GetProcessorDockerfileContents() string {
-	return `ARG NUCLIO_TAG=latest
+	return `ARG NUCLIO_LABEL=latest
 ARG NUCLIO_ARCH=amd64
 ARG NUCLIO_BASE_IMAGE=openjdk:9-jre-slim
+ARG NUCLIO_ONBUILD_IMAGE=nuclio/handler-builder-java-onbuild:${NUCLIO_LABEL}-${NUCLIO_ARCH}
 
 # Supplies processor, handler.jar
-FROM nuclio/handler-builder-java-onbuild:${NUCLIO_TAG}-${NUCLIO_ARCH} as builder
+FROM ${NUCLIO_ONBUILD_IMAGE} as builder
 
 # Supplies uhttpc, used for healthcheck
 FROM nuclio/uhttpc:0.0.1-amd64 as uhttpc

--- a/pkg/processor/build/runtime/java/runtime.go
+++ b/pkg/processor/build/runtime/java/runtime.go
@@ -18,7 +18,6 @@ package java
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
 	"path"

--- a/pkg/processor/build/runtime/nodejs/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/nodejs/docker/onbuild/Dockerfile
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG NUCLIO_TAG=latest
+ARG NUCLIO_LABEL=latest
 ARG NUCLIO_ARCH=amd64
 
 # Supplies processor
-FROM nuclio/processor:${NUCLIO_TAG}-${NUCLIO_ARCH} as processor
+FROM nuclio/processor:${NUCLIO_LABEL}-${NUCLIO_ARCH} as processor
 
 # Doesn't do anything but hold processor binary and all NodeJS code required to run the handler
 FROM scratch

--- a/pkg/processor/build/runtime/nodejs/runtime.go
+++ b/pkg/processor/build/runtime/nodejs/runtime.go
@@ -32,16 +32,16 @@ func (n *nodejs) GetName() string {
 // GetProcessorDockerfilePath returns the contents of the appropriate Dockerfile, with which we'll build
 // the processor image
 func (n *nodejs) GetProcessorDockerfileContents() string {
-	return `
-ARG NUCLIO_TAG=latest
+	return `ARG NUCLIO_LABEL=latest
 ARG NUCLIO_ARCH=amd64
 ARG NUCLIO_BASE_IMAGE=node:9.3.0-alpine
+ARG NUCLIO_ONBUILD_IMAGE=nuclio/handler-builder-nodejs-onbuild:${NUCLIO_LABEL}-${NUCLIO_ARCH}
 
 # Supplies processor uhttpc, used for healthcheck
 FROM nuclio/uhttpc:0.0.1-amd64 as uhttpc
 
 # Supplies processor binary, wrapper
-FROM nuclio/handler-builder-nodejs-onbuild:${NUCLIO_TAG}-${NUCLIO_ARCH} as processor
+FROM ${NUCLIO_ONBUILD_IMAGE} as processor
 
 # From the base image
 FROM ${NUCLIO_BASE_IMAGE}

--- a/pkg/processor/build/runtime/python/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/python/docker/onbuild/Dockerfile
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG NUCLIO_TAG=latest
+ARG NUCLIO_LABEL=latest
 ARG NUCLIO_ARCH=amd64
 
 # Supplies processor
-FROM nuclio/processor:${NUCLIO_TAG}-${NUCLIO_ARCH} as processor
+FROM nuclio/processor:${NUCLIO_LABEL}-${NUCLIO_ARCH} as processor
 
 # Doesn't do anything but hold processor binary and all Python code required to run the handler
 FROM scratch

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -71,16 +71,16 @@ func (p *python) GetBuildArgs() (map[string]string, error) {
 // GetProcessorDockerfilePath returns the contents of the appropriate Dockerfile, with which we'll build
 // the processor image
 func (p *python) GetProcessorDockerfileContents() string {
-	return `
-ARG NUCLIO_TAG=latest
+	return `ARG NUCLIO_LABEL=latest
 ARG NUCLIO_ARCH=amd64
 ARG NUCLIO_BASE_IMAGE=python:3.6-alpine
+ARG NUCLIO_ONBUILD_IMAGE=nuclio/handler-builder-python-onbuild:${NUCLIO_LABEL}-${NUCLIO_ARCH}
 
 # Supplies processor uhttpc, used for healthcheck
 FROM nuclio/uhttpc:0.0.1-amd64 as uhttpc
 
 # Supplies processor binary, wrapper
-FROM nuclio/handler-builder-python-onbuild:${NUCLIO_TAG}-${NUCLIO_ARCH} as processor
+FROM ${NUCLIO_ONBUILD_IMAGE} as processor
 
 # From the base image
 FROM ${NUCLIO_BASE_IMAGE}

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -224,10 +224,14 @@ func (ar *AbstractRuntime) setOnbuildImageBuildArg(versionInfo *version.Info, bu
 		}
 
 		var onbuildImageTemplateBuffer bytes.Buffer
-		err = onbuildImageTemplate.Execute(&onbuildImageTemplateBuffer, &map[string]interface{} {
+		err = onbuildImageTemplate.Execute(&onbuildImageTemplateBuffer, &map[string]interface{}{
 			"Label": versionInfo.Label,
-			"Arch": versionInfo.Arch,
+			"Arch":  versionInfo.Arch,
 		})
+
+		if err != nil {
+			return errors.Wrap(err, "Failed to run template")
+		}
 
 		onbuildImage := onbuildImageTemplateBuffer.String()
 

--- a/pkg/processor/build/runtime/runtime_test.go
+++ b/pkg/processor/build/runtime/runtime_test.go
@@ -19,9 +19,10 @@ package runtime
 import (
 	"testing"
 
-	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/version"
+
+	"github.com/nuclio/logger"
 	"github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
 )
@@ -29,7 +30,7 @@ import (
 type testSuite struct {
 	suite.Suite
 	logger logger.Logger
-	ar *AbstractRuntime
+	ar     *AbstractRuntime
 }
 
 func (suite *testSuite) SetupTest() {
@@ -39,13 +40,13 @@ func (suite *testSuite) SetupTest() {
 	suite.Require().NoError(err)
 
 	suite.ar = &AbstractRuntime{
-		Logger: suite.logger,
+		Logger:         suite.logger,
 		FunctionConfig: &functionconfig.Config{},
 	}
 
 	version.Set(&version.Info{
 		Label: "theLabel",
-		Arch: "theArch",
+		Arch:  "theArch",
 	})
 }
 

--- a/pkg/processor/build/runtime/runtime_test.go
+++ b/pkg/processor/build/runtime/runtime_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the Licensg.
+You may obtain a copy of the License at
+
+    http://www.apachg.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the Licensg.
+*/
+
+package runtime
+
+import (
+	"testing"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/version"
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type testSuite struct {
+	suite.Suite
+	logger logger.Logger
+	ar *AbstractRuntime
+}
+
+func (suite *testSuite) SetupTest() {
+	var err error
+
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+
+	suite.ar = &AbstractRuntime{
+		Logger: suite.logger,
+		FunctionConfig: &functionconfig.Config{},
+	}
+
+	version.Set(&version.Info{
+		Label: "theLabel",
+		Arch: "theArch",
+	})
+}
+
+func (suite *testSuite) TestGetBuildArgsDefault() {
+	suite.getBuildArgsAndVerify("", "")
+}
+
+func (suite *testSuite) TestGetBuildArgsBaseImage() {
+	suite.ar.FunctionConfig.Spec.Build.BaseImage = "someCustomBaseImage"
+
+	suite.getBuildArgsAndVerify("someCustomBaseImage", "")
+}
+
+func (suite *testSuite) TestGetBuildArgsAlpineBaseImage() {
+	suite.ar.FunctionConfig.Spec.Build.BaseImage = "alpine"
+
+	suite.getBuildArgsAndVerify("alpine:3.6", "")
+}
+
+func (suite *testSuite) TestGetBuildArgsJessieBaseImage() {
+	suite.ar.FunctionConfig.Spec.Build.BaseImage = "jessie"
+
+	suite.getBuildArgsAndVerify("debian:jessie", "")
+}
+
+func (suite *testSuite) TestGetBuildArgsUnformattedOnbuild() {
+	suite.ar.FunctionConfig.Spec.Build.OnbuildImage = "theOnbuildImage"
+
+	suite.getBuildArgsAndVerify("", "theOnbuildImage")
+}
+
+func (suite *testSuite) TestGetBuildArgsFormattedOnbuild() {
+	suite.ar.FunctionConfig.Spec.Build.OnbuildImage = "theOnbuildImage-{{.Label}}-{{.Arch}}"
+
+	suite.getBuildArgsAndVerify("", "theOnbuildImage-theLabel-theArch")
+}
+
+func (suite *testSuite) getBuildArgsAndVerify(baseImage string, onbuildImage string) {
+
+	// get build args with no custom onbuild and no custom base image
+	buildArgs, err := suite.ar.GetBuildArgs()
+	suite.Require().NoError(err)
+
+	suite.Require().Equal("theLabel", buildArgs["NUCLIO_LABEL"])
+	suite.Require().Equal("theArch", buildArgs["NUCLIO_ARCH"])
+	suite.verifyBuildArgValue(buildArgs, "NUCLIO_BASE_IMAGE", baseImage)
+	suite.verifyBuildArgValue(buildArgs, "NUCLIO_ONBUILD_IMAGE", onbuildImage)
+}
+
+func (suite *testSuite) verifyBuildArgValue(buildArgs map[string]string, keyName string, value string) {
+	if value == "" {
+		suite.Require().NotContains(buildArgs, keyName)
+	} else {
+		suite.Require().Equal(value, buildArgs[keyName])
+	}
+}
+
+func TestRuntimeSuite(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	suite.Run(t, new(testSuite))
+}

--- a/pkg/processor/build/runtime/shell/runtime.go
+++ b/pkg/processor/build/runtime/shell/runtime.go
@@ -32,16 +32,16 @@ func (s *shell) GetName() string {
 // GetProcessorDockerfilePath returns the contents of the appropriate Dockerfile, with which we'll build
 // the processor image
 func (s *shell) GetProcessorDockerfileContents() string {
-	return `
-ARG NUCLIO_TAG=latest
+	return `ARG NUCLIO_LABEL=latest
 ARG NUCLIO_ARCH=amd64
 ARG NUCLIO_BASE_IMAGE=alpine:3.6
+ARG NUCLIO_ONBUILD_IMAGE=nuclio/processor:${NUCLIO_LABEL}-${NUCLIO_ARCH}
 
 # Supplies processor uhttpc, used for healthcheck
 FROM nuclio/uhttpc:0.0.1-amd64 as uhttpc
 
 # Supplies processor binary, wrapper
-FROM nuclio/processor:${NUCLIO_TAG}-${NUCLIO_ARCH} as processor
+FROM ${NUCLIO_ONBUILD_IMAGE} as processor
 
 # From the base image
 FROM ${NUCLIO_BASE_IMAGE}


### PR DESCRIPTION
It is now possible to specify which onbuild image the processor image will be built from. Left blank, it shall use the per runtime default (e.g. `nuclio/handler-builder-golang-onbuild:${NUCLIO_LABEL}-${NUCLIO_ARCH}`). 

This allows users to specify onbuilds which reside in private registries. It is possible to format with `{{ .Label }}` and `{{ .Arch }}`. For example:

`privateregistry.mydomain.com:20202/somerepo/handler-builder-golang-onbuild:{{ .Label }}-{{ .Arch }}`