### PR TITLE
More offline support related features

### DIFF
--- a/docs/tasks/configuring-a-platform.md
+++ b/docs/tasks/configuring-a-platform.md
@@ -53,7 +53,7 @@ logger:
     sink: myAppInsightsLogger
 ```
 
-First, you declared the two sinks: `myStdoutLogger` and `myElasticSearchLogger`. Then, you bound `system:debug` (which catches all logs at the severity level and higher) to `myStdoutLogger`, and `system:warning`, `functions:debug` to `myElasticSearchLogger`.
+First, you declared the two sinks: `myStdoutLogger` and `myAppInsightsLogger`. Then, you bound `system:debug` (which catches all logs at the severity level and higher) to `myStdoutLogger`, and `system:warning`, `functions:debug` to `myAppInsightsLogger`.
 
 #### Supported log sinks
 

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -156,6 +156,7 @@ type Build struct {
 	AddedObjectPaths   map[string]string `json:"addedPaths,omitempty"`
 	Dependencies       []string          `json:"dependencies,omitempty"`
 	OnbuildImage       string            `json:"onbuildImage,omitempty"`
+	Offline            bool              `json:"offline,omitempty"`
 }
 
 // Spec holds all parameters related to a function's configuration

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -141,22 +141,23 @@ type Platform struct {
 
 // Build holds all configuration parameters related to building a function
 type Build struct {
-	Path               string            `json:"path,omitempty"`
-	FunctionSourceCode string            `json:"functionSourceCode,omitempty"`
-	FunctionConfigPath string            `json:"functionConfigPath,omitempty"`
-	TempDir            string            `json:"tempDir,omitempty"`
-	Registry           string            `json:"registry,omitempty"`
-	Image              string            `json:"image,omitempty"`
-	NoBaseImagesPull   bool              `json:"noBaseImagesPull,omitempty"`
-	NoCache            bool              `json:"noCache,omitempty"`
-	NoCleanup          bool              `json:"noCleanup,omitempty"`
-	BaseImage          string            `json:"baseImage,omitempty"`
-	Commands           []string          `json:"commands,omitempty"`
-	ScriptPaths        []string          `json:"scriptPaths,omitempty"`
-	AddedObjectPaths   map[string]string `json:"addedPaths,omitempty"`
-	Dependencies       []string          `json:"dependencies,omitempty"`
-	OnbuildImage       string            `json:"onbuildImage,omitempty"`
-	Offline            bool              `json:"offline,omitempty"`
+	Path               string                 `json:"path,omitempty"`
+	FunctionSourceCode string                 `json:"functionSourceCode,omitempty"`
+	FunctionConfigPath string                 `json:"functionConfigPath,omitempty"`
+	TempDir            string                 `json:"tempDir,omitempty"`
+	Registry           string                 `json:"registry,omitempty"`
+	Image              string                 `json:"image,omitempty"`
+	NoBaseImagesPull   bool                   `json:"noBaseImagesPull,omitempty"`
+	NoCache            bool                   `json:"noCache,omitempty"`
+	NoCleanup          bool                   `json:"noCleanup,omitempty"`
+	BaseImage          string                 `json:"baseImage,omitempty"`
+	Commands           []string               `json:"commands,omitempty"`
+	ScriptPaths        []string               `json:"scriptPaths,omitempty"`
+	AddedObjectPaths   map[string]string      `json:"addedPaths,omitempty"`
+	Dependencies       []string               `json:"dependencies,omitempty"`
+	OnbuildImage       string                 `json:"onbuildImage,omitempty"`
+	Offline            bool                   `json:"offline,omitempty"`
+	RuntimeAttributes  map[string]interface{} `json:"offline,omitempty"`
 }
 
 // Spec holds all parameters related to a function's configuration

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -87,4 +87,5 @@ func addBuildFlags(cmd *cobra.Command, config *functionconfig.Config, commands *
 	cmd.Flags().StringVarP(&config.Spec.Build.BaseImage, "base-image", "", "", "Name of the base image (default - per-runtime default)")
 	cmd.Flags().Var(commands, "build-command", "Commands to run when building the processor image")
 	cmd.Flags().StringVarP(&config.Spec.Build.OnbuildImage, "onbuild-image", "", "", "The runtime onbuild image used to build the processor image")
+	cmd.Flags().BoolVarP(&config.Spec.Build.Offline, "offline", "", false, "Don't assume internet connectivity exists")
 }

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -17,6 +17,7 @@ limitations under the License.
 package command
 
 import (
+	"encoding/json"
 	"os"
 
 	"github.com/nuclio/nuclio/pkg/errors"
@@ -27,10 +28,11 @@ import (
 )
 
 type buildCommandeer struct {
-	cmd            *cobra.Command
-	rootCommandeer *RootCommandeer
-	commands       stringSliceFlag
-	functionConfig functionconfig.Config
+	cmd                      *cobra.Command
+	rootCommandeer           *RootCommandeer
+	commands                 stringSliceFlag
+	functionConfig           functionconfig.Config
+	encodedRuntimeAttributes string
 }
 
 func newBuildCommandeer(rootCommandeer *RootCommandeer) *buildCommandeer {
@@ -58,6 +60,12 @@ func newBuildCommandeer(rootCommandeer *RootCommandeer) *buildCommandeer {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 
+			// decode the JSON build runtime attributes
+			if err := json.Unmarshal([]byte(commandeer.encodedRuntimeAttributes),
+				&commandeer.functionConfig.Spec.Build.RuntimeAttributes); err != nil {
+				return errors.Wrap(err, "Failed to decode build runtime attributes")
+			}
+
 			_, err := rootCommandeer.platform.CreateFunctionBuild(&platform.CreateFunctionBuildOptions{
 				Logger:         rootCommandeer.loggerInstance,
 				FunctionConfig: commandeer.functionConfig,
@@ -67,14 +75,14 @@ func newBuildCommandeer(rootCommandeer *RootCommandeer) *buildCommandeer {
 		},
 	}
 
-	addBuildFlags(cmd, &commandeer.functionConfig, &commandeer.commands)
+	addBuildFlags(cmd, &commandeer.functionConfig, &commandeer.commands, &commandeer.encodedRuntimeAttributes)
 
 	commandeer.cmd = cmd
 
 	return commandeer
 }
 
-func addBuildFlags(cmd *cobra.Command, config *functionconfig.Config, commands *stringSliceFlag) { // nolint
+func addBuildFlags(cmd *cobra.Command, config *functionconfig.Config, commands *stringSliceFlag, encodedRuntimeAttributes *string) { // nolint
 	cmd.Flags().StringVarP(&config.Spec.Build.Path, "path", "p", "", "Path to the function's source code")
 	cmd.Flags().StringVarP(&config.Spec.Build.FunctionSourceCode, "source", "", "", "The function's source code (overrides \"path\")")
 	cmd.Flags().StringVarP(&config.Spec.Build.FunctionConfigPath, "file", "f", "", "Path to a function-configuration file")
@@ -88,4 +96,5 @@ func addBuildFlags(cmd *cobra.Command, config *functionconfig.Config, commands *
 	cmd.Flags().Var(commands, "build-command", "Commands to run when building the processor image")
 	cmd.Flags().StringVarP(&config.Spec.Build.OnbuildImage, "onbuild-image", "", "", "The runtime onbuild image used to build the processor image")
 	cmd.Flags().BoolVarP(&config.Spec.Build.Offline, "offline", "", false, "Don't assume internet connectivity exists")
+	cmd.Flags().StringVar(encodedRuntimeAttributes, "build-runtime-attrs", "{}", "JSON-encoded build runtime attributes for the function")
 }

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -49,6 +49,7 @@ type deployCommandeer struct {
 	resourceRequests              stringSliceFlag
 	encodedEnv                    stringSliceFlag
 	encodedFunctionPlatformConfig string
+	encodedBuildRuntimeAttributes string
 }
 
 func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
@@ -108,6 +109,12 @@ func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
 				return errors.Wrap(err, "Failed to decode runtime attributes")
 			}
 
+			// decode the JSON build runtime attributes
+			if err := json.Unmarshal([]byte(commandeer.encodedBuildRuntimeAttributes),
+				&commandeer.functionConfig.Spec.Build.RuntimeAttributes); err != nil {
+				return errors.Wrap(err, "Failed to decode build runtime attributes")
+			}
+
 			// decode labels
 			commandeer.functionConfig.Meta.Labels = common.StringToStringMap(commandeer.encodedLabels, "=")
 
@@ -159,7 +166,7 @@ func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
 func addDeployFlags(cmd *cobra.Command,
 	functionConfig *functionconfig.Config,
 	commandeer *deployCommandeer) {
-	addBuildFlags(cmd, functionConfig, &commandeer.commands)
+	addBuildFlags(cmd, functionConfig, &commandeer.commands, &commandeer.encodedBuildRuntimeAttributes)
 
 	cmd.Flags().StringVar(&functionConfig.Spec.Description, "desc", "", "Function description")
 	cmd.Flags().StringVarP(&commandeer.encodedLabels, "labels", "l", "", "Additional function labels (lbl1=val1[,lbl2=val2,...])")

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -714,6 +714,10 @@ func (b *Builder) buildProcessorImage() (string, error) {
 		return "", errors.Wrap(err, "Failed to get build args")
 	}
 
+	if b.options.FunctionConfig.Spec.Build.Offline {
+		buildArgs["NUCLIO_BUILD_OFFLINE"] = "true"
+	}
+
 	imageName := fmt.Sprintf("%s:%s", b.processorImage.imageName, b.processorImage.imageTag)
 
 	err = b.dockerClient.Build(&dockerclient.BuildOptions{

--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
@@ -32,7 +32,8 @@ RUN mkdir -p /opt/nuclio
 
 # Make the processor binary
 RUN mkdir -p /home/nuclio/bin \
-    && GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-s -w" -o /home/nuclio/bin/processor cmd/processor/main.go
+    && GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-s -w" -o /home/nuclio/bin/processor cmd/processor/main.go \
+    && rm -rf /go/src/github/nuclio/nuclio
 
 FROM golang:1.10
 

--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
@@ -32,9 +32,7 @@ RUN mkdir -p /opt/nuclio
 
 # Make the processor binary
 RUN mkdir -p /home/nuclio/bin \
-    && GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-s -w" -o /home/nuclio/bin/processor cmd/processor/main.go \
-    && rm -rf /go/src
-
+    && GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-s -w" -o /home/nuclio/bin/processor cmd/processor/main.go
 
 FROM golang:1.10
 
@@ -48,12 +46,19 @@ ENV GOARCH ${NUCLIO_ARCH}
 
 # Copy processor binary
 COPY --from=processor /home/nuclio/bin/processor /home/nuclio/bin/processor
+COPY --from=processor /go/src/github.com/v3io/v3io-go-http /go/src/github.com/v3io/v3io-go-http
+COPY --from=processor /go/src/github.com/nuclio/logger /go/src/github.com/nuclio/logger
+COPY --from=processor /go/src/github.com/nuclio/nuclio-sdk-go /go/src/github.com/nuclio/nuclio-sdk-go
+COPY --from=processor /go/src/github.com/nuclio/amqp /go/src/github.com/nuclio/amqp
 
-# This script builds the processor and redirects the build logs into /home/nuclio/src/handler_build.log
+# This script builds the processor
 COPY pkg/processor/build/runtime/golang/docker/onbuild/build-handler.sh /
 
 # Copy handler sources to container, build-handler will move it to the right place
 ONBUILD COPY handler /go/src/github.com/nuclio/handler
 
+# Specify an onbuild arg to specify offline
+ONBUILD ARG NUCLIO_BUILD_OFFLINE
+
 # Run build
-ONBUILD RUN /home/nuclio/src/build-handler.sh
+ONBUILD RUN /build-handler.sh

--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile.alpine
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile.alpine
@@ -37,8 +37,7 @@ RUN mkdir -p /opt/nuclio
 
 # make the processor binary
 RUN mkdir -p /home/nuclio/bin \
-    && GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-s -w" -o /home/nuclio/bin/processor cmd/processor/main.go \
-    && rm -rf /go/src
+    && GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-s -w" -o /home/nuclio/bin/processor cmd/processor/main.go
 
 FROM golang:1.10-alpine3.7
 
@@ -55,14 +54,21 @@ RUN apk --update --no-cache add \
 ARG NUCLIO_ARCH
 ENV GOARCH ${NUCLIO_ARCH}
 
-# Copy processor binary
+# Copy processor binary and nuclio-sdk-go
 COPY --from=processor /home/nuclio/bin/processor /home/nuclio/bin/processor
+COPY --from=processor /go/src/github.com/v3io/v3io-go-http /go/src/github.com/v3io/v3io-go-http
+COPY --from=processor /go/src/github.com/nuclio/logger /go/src/github.com/nuclio/logger
+COPY --from=processor /go/src/github.com/nuclio/nuclio-sdk-go /go/src/github.com/nuclio/nuclio-sdk-go
+COPY --from=processor /go/src/github.com/nuclio/amqp /go/src/github.com/nuclio/amqp
 
-# This script builds the processor and redirects the build logs into /handler_build.log
+# This script builds the processor
 COPY pkg/processor/build/runtime/golang/docker/onbuild/build-handler.sh /
 
 # Copy handler sources to container, build-handler will move it to the right place
 ONBUILD COPY handler /go/src/github.com/nuclio/handler
+
+# Specify an onbuild arg to specify offline
+ONBUILD ARG NUCLIO_BUILD_OFFLINE
 
 # Run build
 ONBUILD RUN /build-handler.sh

--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile.alpine
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile.alpine
@@ -37,7 +37,8 @@ RUN mkdir -p /opt/nuclio
 
 # make the processor binary
 RUN mkdir -p /home/nuclio/bin \
-    && GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-s -w" -o /home/nuclio/bin/processor cmd/processor/main.go
+    && GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-s -w" -o /home/nuclio/bin/processor cmd/processor/main.go \
+    && rm -rf /go/src/github/nuclio/nuclio
 
 FROM golang:1.10-alpine3.7
 

--- a/pkg/processor/build/runtime/golang/docker/onbuild/build-handler.sh
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/build-handler.sh
@@ -23,10 +23,14 @@ set -e
 
 cd /go/src/github.com/nuclio/handler
 
-# Get dependencies, ignore vendor
-deps=$(go list ./... | grep -v /vendor)
-if [ -n "${deps}" ]; then
-    go get -d ${deps}
+# if specified to build offline, skip go get
+if [ "${NUCLIO_BUILD_OFFLINE}" != "true" ]; then
+
+    # Get dependencies, ignore vendor
+    deps=$(go list ./... | grep -v /vendor)
+    if [ -n "${deps}" ]; then
+        go get -d ${deps}
+    fi
 fi
 
 # if go deps succeeded, build

--- a/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
@@ -18,7 +18,19 @@ ARG NUCLIO_ARCH=amd64
 # Supplies processor
 FROM nuclio/processor:${NUCLIO_LABEL}-${NUCLIO_ARCH} as processor
 
-FROM gradle:4.7.0-jdk9 as user-handler-builder
+FROM openjdk:9-slim as user-handler-builder
+
+RUN apt-get update \
+    && apt-get install -y curl \
+    && curl -LO https://services.gradle.org/distributions/gradle-4.5.1-bin.zip \
+    && unzip gradle-4.5.1-bin.zip \
+    && rm gradle-4.5.1-bin.zip \
+    && ln -s /gradle-4.5.1/bin/gradle /usr/local/bin \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /home/gradle
+
+WORKDIR /home/gradle
 
 # Copy processor
 COPY --from=processor /home/nuclio/bin/processor /home/gradle/bin/processor
@@ -59,12 +71,12 @@ ONBUILD RUN mv /home/gradle/src/userHandler/build/libs/user-handler.jar /home/gr
 COPY pkg/processor/runtime/java/build.gradle \
     pkg/processor/runtime/java/nuclio-sdk-1.0-SNAPSHOT.jar \
     pkg/processor/runtime/java/docker \
+    pkg/processor/build/runtime/java/docker/onbuild/build-handler.sh \
     /home/gradle/src/wrapper/
 
 # Download dependencies
 RUN cd /home/gradle/src/wrapper \
-    && gradle compileJava
+    && gradle --build-cache compileJava
 
 # Build nuclio-java-wrapper.jar
-ONBUILD RUN cd /home/gradle/src/wrapper \
-    && gradle wrapperJar
+ONBUILD RUN /home/gradle/src/wrapper/build-handler.sh

--- a/pkg/processor/build/runtime/java/docker/onbuild/build-handler.sh
+++ b/pkg/processor/build/runtime/java/docker/onbuild/build-handler.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# by default, pass no flags to gradle
+GRADLE_FLAGS=""
+
+# if specified to build offline, set the offline flag
+if [ "${NUCLIO_BUILD_OFFLINE}" = "true" ]; then
+    GRADLE_FLAGS += "--offline "
+fi
+
+cd /home/gradle/src/wrapper \
+    && gradle ${GRADLE_FLAGS} wrapperJar

--- a/pkg/processor/build/runtime/java/test/java_test.go
+++ b/pkg/processor/build/runtime/java/test/java_test.go
@@ -75,6 +75,23 @@ func (suite *TestSuite) TestBuildWithCustomGradleScript() {
 		})
 }
 
+func (suite *TestSuite) TestBuildWithCustomRepositories() {
+	createFunctionOptions := suite.GetDeployOptions("reverser",
+		suite.GetFunctionPath(suite.GetTestFunctionsDir(), "common", "reverser", "java", "Reverser.java"))
+
+	createFunctionOptions.FunctionConfig.Spec.Runtime = "java"
+	createFunctionOptions.FunctionConfig.Spec.Handler = "Reverser"
+	createFunctionOptions.FunctionConfig.Spec.Build.RuntimeAttributes = map[string]interface{}{
+		"repositories": []string{"mavenCentral()", "jcenter()"},
+	}
+
+	suite.DeployFunctionAndRequest(createFunctionOptions,
+		&httpsuite.Request{
+			RequestBody:          "abcd",
+			ExpectedResponseBody: "dcba",
+		})
+}
+
 func (suite *TestSuite) getDeployOptions(functionName string) *platform.CreateFunctionOptions {
 	functionInfo := suite.RuntimeSuite.GetFunctionInfo(functionName)
 

--- a/test/_functions/golang/slugger/slugger.go
+++ b/test/_functions/golang/slugger/slugger.go
@@ -23,7 +23,5 @@ import (
 )
 
 func Slugger(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
-
-
 	return slug.Make(string(event.GetBody())), nil
 }


### PR DESCRIPTION
1. Supported `spec.build.offline` to indicate that this build should not assume internet connectivity. Currently used by Golang (which skips `go get`) and Java (which runs `gradle --offline`)
2. Supported `spec.build.runtimeAttributes`, used by `Java` to specify `repositories`. This replaces the default `mavenCentral()` if passed
3. Fixed Java offline build by employing `--build-cache`
4. Java onbuild image size reduced