### PR TITLE
Update dashboard-controls version to 0.0.53

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -32,7 +32,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "~0.0.52",
+    "iguazio.dashboard-controls": "~0.0.53",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- nuclio: Fixed visual bugs in breadcrumbs
- nuclio: Triggers: Port and host in ingresses are not mandatory
- nuclio: Refactor function export logic
- Number input: fix validation issues