### PR TITLE
Dashboard backend supports default namespace

### DIFF
--- a/cmd/dashboard/app/dashboard.go
+++ b/cmd/dashboard/app/dashboard.go
@@ -36,7 +36,8 @@ func Run(listenAddress string,
 	platformType string,
 	noPullBaseImages bool,
 	defaultCredRefreshIntervalString string,
-	externalIPAddresses string) error {
+	externalIPAddresses string,
+	defaultNamespace string) error {
 
 	logger, err := nucliozap.NewNuclioZapCmd("dashboard", nucliozap.DebugLevel)
 	if err != nil {
@@ -75,7 +76,8 @@ func Run(listenAddress string,
 		noPullBaseImages,
 		webServerConfiguration,
 		getDefaultCredRefreshInterval(logger, defaultCredRefreshIntervalString),
-		splitExternalIPAddresses)
+		splitExternalIPAddresses,
+		defaultNamespace)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create server")
 	}

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -299,7 +299,9 @@ func (fr *functionResource) functionToAttributes(function platform.Function) res
 }
 
 func (fr *functionResource) getNamespaceFromRequest(request *http.Request) string {
-	return request.Header.Get("x-nuclio-function-namespace")
+
+	// get the namespace provided by the user or the default namespace
+	return fr.getNamespaceOrDefault(request.Header.Get("x-nuclio-function-namespace"))
 }
 
 func (fr *functionResource) getFunctionInfoFromRequest(request *http.Request) (*functionInfo, error) {
@@ -314,6 +316,11 @@ func (fr *functionResource) getFunctionInfoFromRequest(request *http.Request) (*
 	err = json.Unmarshal(body, &functionInfoInstance)
 	if err != nil {
 		return nil, nuclio.WrapErrBadRequest(errors.Wrap(err, "Failed to parse JSON body"))
+	}
+
+	// override namespace if applicable
+	if functionInfoInstance.Meta != nil {
+		functionInfoInstance.Meta.Namespace = fr.getNamespaceOrDefault(functionInfoInstance.Meta.Namespace)
 	}
 
 	// meta must exist

--- a/pkg/dashboard/resource/functionevent.go
+++ b/pkg/dashboard/resource/functionevent.go
@@ -248,7 +248,7 @@ func (fer *functionEventResource) functionEventToAttributes(functionEvent platfo
 }
 
 func (fer *functionEventResource) getNamespaceFromRequest(request *http.Request) string {
-	return request.Header.Get("x-nuclio-function-event-namespace")
+	return fer.getNamespaceOrDefault(request.Header.Get("x-nuclio-function-event-namespace"))
 }
 
 func (fer *functionEventResource) getFunctionNameFromRequest(request *http.Request) string {
@@ -267,6 +267,11 @@ func (fer *functionEventResource) getFunctionEventInfoFromRequest(request *http.
 	err = json.Unmarshal(body, &functionEventInfoInstance)
 	if err != nil {
 		return nil, nuclio.WrapErrBadRequest(errors.Wrap(err, "Failed to parse JSON body"))
+	}
+
+	// override namespace if applicable
+	if functionEventInfoInstance.Meta != nil {
+		functionEventInfoInstance.Meta.Namespace = fer.getNamespaceOrDefault(functionEventInfoInstance.Meta.Namespace)
 	}
 
 	// meta must exist

--- a/pkg/dashboard/resource/invocation.go
+++ b/pkg/dashboard/resource/invocation.go
@@ -52,8 +52,10 @@ func (tr *invocationResource) OnAfterInitialize() error {
 func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, request *http.Request) {
 	path := request.Header.Get("x-nuclio-path")
 	functionName := request.Header.Get("x-nuclio-function-name")
-	functionNamespace := request.Header.Get("x-nuclio-function-namespace")
 	invokeVia := tr.getInvokeVia(request.Header.Get("x-nuclio-invoke-via"))
+
+	// get namespace from request or use the provided default
+	functionNamespace := tr.getNamespaceOrDefault(request.Header.Get("x-nuclio-function-namespace"))
 
 	// if user prefixed path with "/", remove it
 	path = strings.TrimLeft(path, "/")

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -238,7 +238,7 @@ func (pr *projectResource) projectToAttributes(project platform.Project) restful
 }
 
 func (pr *projectResource) getNamespaceFromRequest(request *http.Request) string {
-	return request.Header.Get("x-nuclio-project-namespace")
+	return pr.getNamespaceOrDefault(request.Header.Get("x-nuclio-project-namespace"))
 }
 
 func (pr *projectResource) getProjectInfoFromRequest(request *http.Request, nameRequired bool) (*projectInfo, error) {
@@ -253,6 +253,11 @@ func (pr *projectResource) getProjectInfoFromRequest(request *http.Request, name
 	err = json.Unmarshal(body, &projectInfoInstance)
 	if err != nil {
 		return nil, nuclio.WrapErrBadRequest(errors.Wrap(err, "Failed to parse JSON body"))
+	}
+
+	// override namespace if applicable
+	if projectInfoInstance.Meta != nil {
+		projectInfoInstance.Meta.Namespace = pr.getNamespaceOrDefault(projectInfoInstance.Meta.Namespace)
 	}
 
 	// meta must exist

--- a/pkg/dashboard/resource/resource.go
+++ b/pkg/dashboard/resource/resource.go
@@ -24,6 +24,7 @@ import (
 
 type resource struct {
 	*restful.AbstractResource
+	defaultNamespace string
 }
 
 func newResource(name string, resourceMethods []restful.ResourceMethod) *resource {
@@ -34,4 +35,15 @@ func newResource(name string, resourceMethods []restful.ResourceMethod) *resourc
 
 func (r *resource) getPlatform() platform.Platform {
 	return r.GetServer().(*dashboard.Server).Platform
+}
+
+func (r *resource) getNamespaceOrDefault(providedNamespace string) string {
+
+	// if provided a namespace, use that
+	if providedNamespace != "" {
+		return providedNamespace
+	}
+
+	// get the default namespace we were created with
+	return r.GetServer().(*dashboard.Server).GetDefaultNamespace()
 }

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -45,6 +45,7 @@ type Server struct {
 	Platform              platform.Platform
 	NoPullBaseImages      bool
 	externalIPAddresses   []string
+	defaultNamespace      string
 }
 
 func NewServer(parentLogger logger.Logger,
@@ -55,7 +56,8 @@ func NewServer(parentLogger logger.Logger,
 	noPullBaseImages bool,
 	configuration *platformconfig.WebServer,
 	defaultCredRefreshInterval *time.Duration,
-	externalIPAddresses []string) (*Server, error) {
+	externalIPAddresses []string,
+	defaultNamespace string) (*Server, error) {
 
 	var err error
 
@@ -78,6 +80,7 @@ func NewServer(parentLogger logger.Logger,
 		Platform:              platform,
 		NoPullBaseImages:      noPullBaseImages,
 		externalIPAddresses:   externalIPAddresses,
+		defaultNamespace:      defaultNamespace,
 	}
 
 	// create server
@@ -119,7 +122,8 @@ func NewServer(parentLogger logger.Logger,
 		"dockerKeyDir", dockerKeyDir,
 		"defaultRegistryURL", defaultRegistryURL,
 		"defaultRunRegistryURL", defaultRunRegistryURL,
-		"defaultCredRefreshInterval", defaultCredRefreshInterval)
+		"defaultCredRefreshInterval", defaultCredRefreshInterval,
+		"defaultNamespace", defaultNamespace)
 
 	return newServer, nil
 }
@@ -134,6 +138,10 @@ func (s *Server) GetRunRegistryURL() string {
 
 func (s *Server) GetExternalIPAddresses() []string {
 	return s.externalIPAddresses
+}
+
+func (s *Server) GetDefaultNamespace() string {
+	return s.defaultNamespace
 }
 
 func (s *Server) InstallMiddleware(router chi.Router) error {

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -217,7 +217,8 @@ func (suite *dashboardTestSuite) SetupTest() {
 		true,
 		&platformconfig.WebServer{Enabled: &trueValue},
 		nil,
-		nil)
+		nil,
+		"")
 
 	if err != nil {
 		panic("Failed to create server")

--- a/pkg/dockercreds/dockercreds_test.go
+++ b/pkg/dockercreds/dockercreds_test.go
@@ -271,6 +271,7 @@ func (suite *LogInFromDirTestSuite) TearDownTest() {
 func (suite *LogInFromDirTestSuite) TestLoginSuccessful() {
 
 	suite.createFilesInDir(suite.tempDir, []interface{}{
+		dirNode{".data", []interface{}{}},
 		fileNode{".dockerjsonconfig1", suite.kubernetesAuthsSecrets[0]},
 		fileNode{".dockerjsonconfig2", suite.kubernetesAuthsSecrets[1]},
 		fileNode{".dockerjsonconfig3", suite.kubernetesNoAuthsSecrets[0]},
@@ -418,6 +419,10 @@ func (suite *LogInFromDirTestSuite) createFilesInDir(baseDir string, nodes []int
 
 		case dirNode:
 			dirPath := path.Join(baseDir, typedNode.name)
+
+			if err := os.MkdirAll(dirPath, 0644); err != nil {
+				return err
+			}
 
 			if err := suite.createFilesInDir(dirPath, typedNode.nodes); err != nil {
 				return err


### PR DESCRIPTION
1. If dashboard does not receive the namespace in the request, rather than returning 400 it will try to use the default namespace. Currently the default namespace is automatically detected at startup as the namespace the dashboard is in (k8s). In local platform, there is no default namespace
2. Removed a logged warning when loading registry credentials