### PR TITLE
Local platform sets default namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ after_success:
     if [ "$NUCLIO_LABEL" != "unstable" ]; then
     docker tag "nuclio/playground:$NUCLIO_LABEL-amd64" nuclio/playground:stable-amd64 &&
     docker push nuclio/playground:stable-amd64;
+    docker tag "nuclio/dashboard:$NUCLIO_LABEL-amd64" nuclio/dashboard:stable-amd64 &&
+    docker push nuclio/dashboard:stable-amd64;
     fi
     fi
   - echo "Done."

--- a/cmd/dashboard/app/dashboard.go
+++ b/cmd/dashboard/app/dashboard.go
@@ -53,7 +53,11 @@ func Run(listenAddress string,
 	logger.InfoWith("Starting",
 		"name", platformInstance.GetName(),
 		"noPull", noPullBaseImages,
-		"defaultCredRefreshInterval", defaultCredRefreshIntervalString)
+		"defaultCredRefreshInterval", defaultCredRefreshIntervalString,
+		"defaultNamespace", defaultNamespace)
+
+	// see if the platform has anything to say about the namespace
+	defaultNamespace = platformInstance.ResolveDefaultNamespace(defaultNamespace)
 
 	version.Log(logger)
 

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"os"
 
 	"github.com/nuclio/nuclio/cmd/dashboard/app"
@@ -60,17 +59,8 @@ func main() {
 	externalIPAddresses := flag.String("external-ip-addresses", externalIPAddressesDefault, "Comma delimited list of external IP addresses")
 	namespace := flag.String("namespace", "", "Namespace in which all actions apply to, if not passed in request")
 
-	// get the namespace from args -> env -> default (*)
-	resolvedNamespace := getNamespace(*namespace)
-
-	// if the namespace is set to @nuclio.selfNamespace, use the namespace we're in right now
-	if resolvedNamespace == "@nuclio.selfNamespace" {
-
-		// get namespace from within the pod. if found, return that
-		if namespacePod, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
-			resolvedNamespace = string(namespacePod)
-		}
-	}
+	// get the namespace from args -> env -> default
+	*namespace = getNamespace(*namespace)
 
 	flag.Parse()
 
@@ -82,7 +72,7 @@ func main() {
 		*noPullBaseImages,
 		*credsRefreshInterval,
 		*externalIPAddresses,
-		resolvedNamespace); err != nil {
+		*namespace); err != nil {
 
 		errors.PrintErrorStack(os.Stderr, err, 5)
 

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -189,6 +189,12 @@ func (mp *mockPlatform) GetNodes() ([]platform.Node, error) {
 	return args.Get(0).([]platform.Node), args.Error(1)
 }
 
+// ResolveDefaultNamespace returns the proper default resource namespace, given the current default namespace
+func (mp *mockPlatform) ResolveDefaultNamespace(defaultNamespace string) string {
+	args := mp.Called()
+	return args.Get(0).(string)
+}
+
 //
 // Test suite
 //

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -209,6 +209,11 @@ func (ap *Platform) GetExternalIPAddresses() ([]string, error) {
 	return ap.ExternalIPAddresses, nil
 }
 
+// ResolveDefaultNamespace returns the proper default resource namespace, given the current default namespace
+func (ap *Platform) ResolveDefaultNamespace(defaultNamespace string) string {
+	return ""
+}
+
 func (ap *Platform) functionBuildRequired(createFunctionOptions *platform.CreateFunctionOptions) (bool, error) {
 
 	// if the function contains source code, an image name or a path somewhere - we need to rebuild. the shell

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -581,7 +581,7 @@ func (p *Platform) GetExternalIPAddresses() ([]string, error) {
 }
 
 // ResolveDefaultNamespace returns the proper default resource namespace, given the current default namespace
-func (ap *Platform) ResolveDefaultNamespace(defaultNamespace string) string {
+func (p *Platform) ResolveDefaultNamespace(defaultNamespace string) string {
 	if defaultNamespace == "@nuclio.selfNamespace" {
 
 		// get namespace from within the pod. if found, return that

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -19,6 +19,7 @@ package kube
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -577,6 +578,19 @@ func (p *Platform) GetExternalIPAddresses() ([]string, error) {
 	}
 
 	return nil, errors.New("No external addresses found")
+}
+
+// ResolveDefaultNamespace returns the proper default resource namespace, given the current default namespace
+func (ap *Platform) ResolveDefaultNamespace(defaultNamespace string) string {
+	if defaultNamespace == "@nuclio.selfNamespace" {
+
+		// get namespace from within the pod. if found, return that
+		if namespacePod, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+			return string(namespacePod)
+		}
+	}
+
+	return defaultNamespace
 }
 
 func getKubeconfigFromHomeDir() string {

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -354,6 +354,15 @@ func (p *Platform) GetExternalIPAddresses() ([]string, error) {
 	return []string{""}, nil
 }
 
+// ResolveDefaultNamespace returns the proper default resource namespace, given the current default namespace
+func (ap *Platform) ResolveDefaultNamespace(defaultNamespace string) string {
+	if defaultNamespace == "@nuclio.selfNamespace" {
+		return "nuclio"
+	}
+
+	return defaultNamespace
+}
+
 func (p *Platform) getFreeLocalPort() (int, error) {
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -355,7 +355,7 @@ func (p *Platform) GetExternalIPAddresses() ([]string, error) {
 }
 
 // ResolveDefaultNamespace returns the proper default resource namespace, given the current default namespace
-func (ap *Platform) ResolveDefaultNamespace(defaultNamespace string) string {
+func (p *Platform) ResolveDefaultNamespace(defaultNamespace string) string {
 	if defaultNamespace == "@nuclio.selfNamespace" {
 		return "nuclio"
 	}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -95,4 +95,7 @@ type Platform interface {
 
 	// GetNodes returns a slice of nodes currently in the cluster
 	GetNodes() ([]Node, error)
+
+	// ResolveDefaultNamespace returns the proper default resource namespace, given the current default namespace
+	ResolveDefaultNamespace(string) string
 }


### PR DESCRIPTION
1. Local platform explicitly uses "nuclio" as default namespace
2. Dashboard tagged as stable on release