### PR TITLE
Update dashboard-controls to version 0.0.56

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -32,7 +32,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "~0.0.55",
+    "iguazio.dashboard-controls": "~0.0.56",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
Enhancements:
- Dependencies in configuration tab should only be display for Java
- Runtime attributes should not display "Runtime" read-only field
- Revert to regular font in "Build Commands" and "Dependencies"
- Add "URL" label above the input to Archive / Jar
- Change "Image" to "URL" above the textbox of Image
- Make Image / Archive / Jar textbox field smaller

Issues fixed:
- Code editor is empty on selecting Archive
- Runtime Attributes improperly encoded (missing `repositories`)
- Deploy error not displayed when the initial POST request fails