### PR TITLE
Update dashboard-controls to version 0.0.57

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -32,7 +32,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "~0.0.56",
+    "iguazio.dashboard-controls": "~0.0.57",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
**Enhancements**
- URL field for Jar/Archive/Image is larger (Code tab)

**Issued fixed**
- Code Entry Type not initializing according to `spec.build.codeEntryType` (Code Tab)