### PR TITLE
Introduce spec.build.directive, fix build cache utilization and remove uhttpc requirement from Kubernetes

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common
 
 import (
+	"bufio"
 	"os"
 	"strconv"
 	"strings"
@@ -115,3 +116,22 @@ func StripPrefixes(input string, prefixes []string) string {
 
 	return input
 }
+
+func RemoveEmptyLines(input string) string {
+	var nonEmptyLines []string
+
+	scanner := bufio.NewScanner(strings.NewReader(input))
+
+	// iterate over input line by line. if the line is not empty, shove it to the list
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if len(line) != 0 {
+			nonEmptyLines = append(nonEmptyLines, line)
+		}
+	}
+
+	// join the strings with a newline between them
+	return strings.Join(nonEmptyLines, "\n")
+}
+

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -134,4 +134,3 @@ func RemoveEmptyLines(input string) string {
 	// join the strings with a newline between them
 	return strings.Join(nonEmptyLines, "\n")
 }
-

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -171,10 +171,10 @@ func (mp *mockPlatform) GetExternalIPAddresses() ([]string, error) {
 	return args.Get(0).([]string), args.Error(1)
 }
 
-// GetDeployRequiresRegistry returns true if a registry is required for deploy, false otherwise
-func (mp *mockPlatform) GetDeployRequiresRegistry() bool {
+// GetHealthCheckMode returns the healthcheck mode the platform requires
+func (mp *mockPlatform) GetHealthCheckMode() platform.HealthCheckMode {
 	args := mp.Called()
-	return args.Bool(0)
+	return args.Get(0).(platform.HealthCheckMode)
 }
 
 // GetName returns the platform name

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -134,9 +134,15 @@ type LoggerSink struct {
 	Sink  string `json:"sink,omitempty"`
 }
 
-// Platform holds platform specific attributes
+// Platform holds platform specific x
 type Platform struct {
 	Attributes map[string]interface{} `json:"attributes,omitempty"`
+}
+
+// Directive is injected into the image file (e.g. Dockerfile) generated during build
+type Directive struct {
+	Kind string `json:"kind,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 // Build holds all configuration parameters related to building a function
@@ -152,6 +158,7 @@ type Build struct {
 	NoCleanup          bool                   `json:"noCleanup,omitempty"`
 	BaseImage          string                 `json:"baseImage,omitempty"`
 	Commands           []string               `json:"commands,omitempty"`
+	Directives         map[string][]Directive `json:"directives,omitempty"`
 	ScriptPaths        []string               `json:"scriptPaths,omitempty"`
 	AddedObjectPaths   map[string]string      `json:"addedPaths,omitempty"`
 	Dependencies       []string               `json:"dependencies,omitempty"`

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -141,7 +141,7 @@ type Platform struct {
 
 // Directive is injected into the image file (e.g. Dockerfile) generated during build
 type Directive struct {
-	Kind string `json:"kind,omitempty"`
+	Kind  string `json:"kind,omitempty"`
 	Value string `json:"value,omitempty"`
 }
 

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -58,7 +58,7 @@ func NewPlatform(parentLogger logger.Logger, platform platform.Platform) (*Platf
 func (ap *Platform) CreateFunctionBuild(createFunctionBuildOptions *platform.CreateFunctionBuildOptions) (*platform.CreateFunctionBuildResult, error) {
 
 	// execute a build
-	builder, err := build.NewBuilder(createFunctionBuildOptions.Logger, &ap.platform)
+	builder, err := build.NewBuilder(createFunctionBuildOptions.Logger, ap.platform)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create builder")
 	}
@@ -149,9 +149,11 @@ func (ap *Platform) CreateFunctionInvocation(createFunctionInvocationOptions *pl
 	return ap.invoker.invoke(createFunctionInvocationOptions)
 }
 
-// GetDeployRequiresRegistry returns true if a registry is required for deploy, false otherwise
-func (ap *Platform) GetDeployRequiresRegistry() bool {
-	return true
+// GetHealthCheckMode returns the healthcheck mode the platform requires
+func (ap *Platform) GetHealthCheckMode() platform.HealthCheckMode {
+
+	// by default return that some external entity does health checks for us
+	return platform.HealthCheckModeExternal
 }
 
 // CreateProject will probably create a new project

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -255,9 +255,11 @@ func (p *Platform) DeleteFunction(deleteFunctionOptions *platform.DeleteFunction
 	return nil
 }
 
-// GetDeployRequiresRegistry returns true if a registry is required for deploy, false otherwise
-func (p *Platform) GetDeployRequiresRegistry() bool {
-	return false
+// GetHealthCheckMode returns the healthcheck mode the platform requires
+func (ap *Platform) GetHealthCheckMode() platform.HealthCheckMode {
+
+	// The internal client needs to perform the health check
+	return platform.HealthCheckModeInternalClient
 }
 
 // GetName returns the platform name

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -256,7 +256,7 @@ func (p *Platform) DeleteFunction(deleteFunctionOptions *platform.DeleteFunction
 }
 
 // GetHealthCheckMode returns the healthcheck mode the platform requires
-func (ap *Platform) GetHealthCheckMode() platform.HealthCheckMode {
+func (p *Platform) GetHealthCheckMode() platform.HealthCheckMode {
 
 	// The internal client needs to perform the health check
 	return platform.HealthCheckModeInternalClient

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -16,6 +16,16 @@ limitations under the License.
 
 package platform
 
+type HealthCheckMode string
+const (
+
+	// health check should be performed by an internal client
+	HealthCheckModeInternalClient HealthCheckMode = "internalClient"
+
+	// health check should be performed by an outside entity
+	HealthCheckModeExternal = "external"
+)
+
 // Platform defines the interface that any underlying function platform must provide for nuclio
 // to run over it
 type Platform interface {
@@ -87,8 +97,8 @@ type Platform interface {
 	// These addresses are either set through SetExternalIPAddresses or automatically discovered
 	GetExternalIPAddresses() ([]string, error)
 
-	// GetDeployRequiresRegistry returns true if a registry is required for deploy, false otherwise
-	GetDeployRequiresRegistry() bool
+	// GetHealthCheckMode returns the healthcheck mode the platform requires
+	GetHealthCheckMode() HealthCheckMode
 
 	// GetName returns the platform name
 	GetName() string

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -17,6 +17,7 @@ limitations under the License.
 package platform
 
 type HealthCheckMode string
+
 const (
 
 	// health check should be performed by an internal client

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1231,10 +1231,8 @@ func (b *Builder) mergeDirectives(first map[string][]functionconfig.Directive,
 			second,
 		} {
 
-			// iterate over k/v of the input
-			for _, directive := range input[key] {
-				merged[key] = append(merged[key], directive)
-			}
+			// add all directives from input into merged
+			merged[key] = append(merged[key], input[key]...)
 		}
 	}
 

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -21,8 +21,10 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 
 	"github.com/nuclio/logger"
 	"github.com/nuclio/zap"
@@ -30,33 +32,37 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type TestSuite struct {
+//
+// Test suite
+//
+
+type testSuite struct {
 	suite.Suite
-	Logger  logger.Logger
-	Builder *Builder
-	TestID  string
+	logger  logger.Logger
+	builder *Builder
+	testID  string
 }
 
 // SetupSuite is called for suite setup
-func (suite *TestSuite) SetupSuite() {
+func (suite *testSuite) SetupSuite() {
 	var err error
 
-	suite.Logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
 	suite.Require().NoError(err)
 }
 
 // SetupTest is called before each test in the suite
-func (suite *TestSuite) SetupTest() {
+func (suite *testSuite) SetupTest() {
 	var err error
-	suite.TestID = xid.New().String()
+	suite.testID = xid.New().String()
 
-	suite.Builder, err = NewBuilder(suite.Logger, nil)
+	suite.builder, err = NewBuilder(suite.logger, nil)
 	if err != nil {
 		suite.Fail("Instantiating Builder failed:", err)
 	}
 
 	createFunctionOptions := &platform.CreateFunctionOptions{
-		Logger:         suite.Logger,
+		Logger:         suite.logger,
 		FunctionConfig: *functionconfig.NewConfig(),
 	}
 
@@ -65,13 +71,13 @@ func (suite *TestSuite) SetupTest() {
 		FunctionConfig: createFunctionOptions.FunctionConfig,
 	}
 
-	suite.Builder.options = createFunctionBuildOptions
+	suite.builder.options = createFunctionBuildOptions
 }
 
 // Make sure that "Builder.getRuntimeName" properly reads the runtime name from the configuration given by the user
-func (suite *TestSuite) TestGetRuntimeNameFromConfig() {
-	suite.Builder.options.FunctionConfig.Spec.Runtime = "foo"
-	runtimeName, err := suite.Builder.getRuntimeName()
+func (suite *testSuite) TestGetRuntimeNameFromConfig() {
+	suite.builder.options.FunctionConfig.Spec.Runtime = "foo"
+	runtimeName, err := suite.builder.getRuntimeName()
 
 	if err != nil {
 		suite.Fail(err.Error())
@@ -81,10 +87,10 @@ func (suite *TestSuite) TestGetRuntimeNameFromConfig() {
 }
 
 // Make sure that "Builder.getRuntimeName" properly reads the runtime name from the build path if not set by the user
-func (suite *TestSuite) TestGetPythonRuntimeNameFromBuildPath() {
-	suite.Builder.options.FunctionConfig.Spec.Runtime = ""
-	suite.Builder.options.FunctionConfig.Spec.Build.Path = "/foo.py"
-	runtimeName, err := suite.Builder.getRuntimeName()
+func (suite *testSuite) TestGetPythonRuntimeNameFromBuildPath() {
+	suite.builder.options.FunctionConfig.Spec.Runtime = ""
+	suite.builder.options.FunctionConfig.Spec.Build.Path = "/foo.py"
+	runtimeName, err := suite.builder.getRuntimeName()
 
 	suite.Require().NoError(err)
 
@@ -92,10 +98,10 @@ func (suite *TestSuite) TestGetPythonRuntimeNameFromBuildPath() {
 }
 
 // Make sure that "Builder.getRuntimeName" properly reads the runtime name from the build path if not set by the user
-func (suite *TestSuite) TestGetGoRuntimeNameFromBuildPath() {
-	suite.Builder.options.FunctionConfig.Spec.Runtime = ""
-	suite.Builder.options.FunctionConfig.Spec.Build.Path = "/foo.go"
-	runtimeName, err := suite.Builder.getRuntimeName()
+func (suite *testSuite) TestGetGoRuntimeNameFromBuildPath() {
+	suite.builder.options.FunctionConfig.Spec.Runtime = ""
+	suite.builder.options.FunctionConfig.Spec.Build.Path = "/foo.go"
+	runtimeName, err := suite.builder.getRuntimeName()
 
 	suite.Require().NoError(err)
 
@@ -103,37 +109,37 @@ func (suite *TestSuite) TestGetGoRuntimeNameFromBuildPath() {
 }
 
 // Make sure that "Builder.getRuntimeName" returns an error if the user sends an unknown file extension without runtime
-func (suite *TestSuite) TestGetRuntimeNameFromBuildPathFailsOnUnknownExtension() {
-	suite.Builder.options.FunctionConfig.Spec.Runtime = ""
-	suite.Builder.options.FunctionConfig.Spec.Build.Path = "/foo.bar"
-	_, err := suite.Builder.getRuntimeName()
+func (suite *testSuite) TestGetRuntimeNameFromBuildPathFailsOnUnknownExtension() {
+	suite.builder.options.FunctionConfig.Spec.Runtime = ""
+	suite.builder.options.FunctionConfig.Spec.Build.Path = "/foo.bar"
+	_, err := suite.builder.getRuntimeName()
 
 	suite.Require().Error(err, "Unsupported file extension: %s", "bar")
 }
 
 // Make sure that "Builder.getRuntimeName()" fails when the runtime is empty, and the build path is a directory
-func (suite *TestSuite) TestGetRuntimeNameFromBuildDirNoRuntime() {
-	suite.Builder.options.FunctionConfig.Spec.Runtime = ""
-	suite.Builder.options.FunctionConfig.Spec.Build.Path = "/user/"
-	_, err := suite.Builder.getRuntimeName()
+func (suite *testSuite) TestGetRuntimeNameFromBuildDirNoRuntime() {
+	suite.builder.options.FunctionConfig.Spec.Runtime = ""
+	suite.builder.options.FunctionConfig.Spec.Build.Path = "/user/"
+	_, err := suite.builder.getRuntimeName()
 
 	if err == nil {
 		suite.Fail("Builder.getRuntimeName() should fail when given a directory for a build path and no runtime")
 	}
 }
 
-func (suite *TestSuite) TestWriteFunctionSourceCodeToTempFileWritesReturnsFilePath() {
+func (suite *testSuite) TestWriteFunctionSourceCodeToTempFileWritesReturnsFilePath() {
 	functionSourceCode := "echo foo"
 	encodedFunctionSourceCode := base64.StdEncoding.EncodeToString([]byte(functionSourceCode))
-	suite.Builder.options.FunctionConfig.Spec.Runtime = "shell"
-	suite.Builder.options.FunctionConfig.Spec.Build.FunctionSourceCode = encodedFunctionSourceCode
-	suite.Builder.options.FunctionConfig.Spec.Build.Path = ""
+	suite.builder.options.FunctionConfig.Spec.Runtime = "shell"
+	suite.builder.options.FunctionConfig.Spec.Build.FunctionSourceCode = encodedFunctionSourceCode
+	suite.builder.options.FunctionConfig.Spec.Build.Path = ""
 
-	err := suite.Builder.createTempDir()
+	err := suite.builder.createTempDir()
 	suite.Assert().NoError(err)
-	defer suite.Builder.cleanupTempDir()
+	defer suite.builder.cleanupTempDir()
 
-	tempPath, err := suite.Builder.writeFunctionSourceCodeToTempFile(suite.Builder.options.FunctionConfig.Spec.Build.FunctionSourceCode)
+	tempPath, err := suite.builder.writeFunctionSourceCodeToTempFile(suite.builder.options.FunctionConfig.Spec.Build.FunctionSourceCode)
 	suite.Assert().NoError(err)
 	suite.NotNil(tempPath)
 
@@ -143,46 +149,142 @@ func (suite *TestSuite) TestWriteFunctionSourceCodeToTempFileWritesReturnsFilePa
 	suite.Assert().Equal(functionSourceCode, string(resultSourceCode))
 }
 
-func (suite *TestSuite) TestWriteFunctionSourceCodeToTempFileFailsOnUnknownExtension() {
-	suite.Builder.options.FunctionConfig.Spec.Runtime = "bar"
-	suite.Builder.options.FunctionConfig.Spec.Build.FunctionSourceCode = base64.StdEncoding.EncodeToString([]byte("echo foo"))
-	suite.Builder.options.FunctionConfig.Spec.Build.Path = ""
+func (suite *testSuite) TestWriteFunctionSourceCodeToTempFileFailsOnUnknownExtension() {
+	suite.builder.options.FunctionConfig.Spec.Runtime = "bar"
+	suite.builder.options.FunctionConfig.Spec.Build.FunctionSourceCode = base64.StdEncoding.EncodeToString([]byte("echo foo"))
+	suite.builder.options.FunctionConfig.Spec.Build.Path = ""
 
-	err := suite.Builder.createTempDir()
+	err := suite.builder.createTempDir()
 	suite.Assert().NoError(err)
-	defer suite.Builder.cleanupTempDir()
+	defer suite.builder.cleanupTempDir()
 
-	_, err = suite.Builder.writeFunctionSourceCodeToTempFile(suite.Builder.options.FunctionConfig.Spec.Build.FunctionSourceCode)
+	_, err = suite.builder.writeFunctionSourceCodeToTempFile(suite.builder.options.FunctionConfig.Spec.Build.FunctionSourceCode)
 	suite.Assert().Error(err)
 }
 
-func (suite *TestSuite) TestGetImage() {
+func (suite *testSuite) TestGetImage() {
 
 	// user specified
-	suite.Builder.options.FunctionConfig.Spec.Build.Image = "userSpecified"
-	suite.Require().Equal("userSpecified", suite.Builder.getImage())
+	suite.builder.options.FunctionConfig.Spec.Build.Image = "userSpecified"
+	suite.Require().Equal("userSpecified", suite.builder.getImage())
 
 	// set function name and clear image name
-	suite.Builder.options.FunctionConfig.Meta.Name = "test"
-	suite.Builder.options.FunctionConfig.Spec.Build.Image = ""
+	suite.builder.options.FunctionConfig.Meta.Name = "test"
+	suite.builder.options.FunctionConfig.Spec.Build.Image = ""
 
 	// registry has no repository - should see "nuclio/" as repository
-	suite.Builder.options.FunctionConfig.Spec.Build.Registry = "localhost:5000"
-	suite.Require().Equal("nuclio/processor-test", suite.Builder.getImage())
+	suite.builder.options.FunctionConfig.Spec.Build.Registry = "localhost:5000"
+	suite.Require().Equal("nuclio/processor-test", suite.builder.getImage())
 
 	// registry has a repository - should not see "nuclio/" as repository
-	suite.Builder.options.FunctionConfig.Spec.Build.Registry = "registry.hub.docker.com/foo"
-	suite.Require().Equal("processor-test", suite.Builder.getImage())
+	suite.builder.options.FunctionConfig.Spec.Build.Registry = "registry.hub.docker.com/foo"
+	suite.Require().Equal("processor-test", suite.builder.getImage())
 
 	// registry has a repository - should not see "nuclio/" as repository
-	suite.Builder.options.FunctionConfig.Spec.Build.Registry = "index.docker.io/foo"
-	suite.Require().Equal("processor-test", suite.Builder.getImage())
+	suite.builder.options.FunctionConfig.Spec.Build.Registry = "index.docker.io/foo"
+	suite.Require().Equal("processor-test", suite.builder.getImage())
 }
+
+func (suite *testSuite) TestGenerateProcessorDockerfile() {
+
+	// all elements, health check required
+	suite.generateDockerfileAndVerify(true, &runtime.ProcessorDockerfileInfo{
+		BaseImage: "baseImage",
+		OnbuildImage: "onbuildImage",
+		OnbuildArtifactPaths: map[string]string{
+			"onbuildLocal1": "onbuildImage1",
+			"onbuildLocal2": "onbuildImage2",
+		},
+		ImageArtifactPaths: map[string]string{
+			"imageLocal1": "imageImage1",
+			"imageLocal2": "imageImage2",
+		},
+		Directives: map[string][]functionconfig.Directive{
+			"preCopy": {
+				{Kind: "preCopyKind1", Value: "preCopyValue1"},
+				{Kind: "preCopyKind2", Value: "preCopyValue2"},
+			},
+			"postCopy": {
+				{Kind: "postCopyKind1", Value: "postCopyValue1"},
+				{Kind: "postCopyKind2", Value: "postCopyValue2"},
+			},
+		},
+	}, `# From the base image
+FROM baseImage
+# Run the pre-copy directives
+preCopyKind1 preCopyValue1
+preCopyKind2 preCopyValue2
+# Copy health checker
+COPY artifacts/uhttpc /usr/local/bin/uhttpc
+# Readiness probe
+HEALTHCHECK --interval=1s --timeout=3s CMD /usr/local/bin/uhttpc --url http://127.0.0.1:8082/ready || exit 1
+# Copy required objects from the suppliers
+COPY artifactDirNameInStaging/onbuildLocal1 onbuildImage1
+COPY artifactDirNameInStaging/onbuildLocal2 onbuildImage2
+COPY imageLocal1 imageImage1
+COPY imageLocal2 imageImage2
+# Run the post-copy directives
+postCopyKind1 postCopyValue1
+postCopyKind2 postCopyValue2
+# Run processor with configuration and platform configuration
+CMD [ "processor", "--config", "/etc/nuclio/config/processor/processor.yaml", "--platform-config", "/etc/nuclio/config/platform/platform.yaml" ]`)
+
+	// all elements, health check not required
+	suite.generateDockerfileAndVerify(false, &runtime.ProcessorDockerfileInfo{
+		BaseImage: "baseImage",
+		OnbuildImage: "onbuildImage",
+		OnbuildArtifactPaths: map[string]string{
+			"onbuildLocal1": "onbuildImage1",
+			"onbuildLocal2": "onbuildImage2",
+		},
+		ImageArtifactPaths: map[string]string{
+			"imageLocal1": "imageImage1",
+			"imageLocal2": "imageImage2",
+		},
+		Directives: map[string][]functionconfig.Directive{
+			"preCopy": {
+				{Kind: "preCopyKind1", Value: "preCopyValue1"},
+				{Kind: "preCopyKind2", Value: "preCopyValue2"},
+			},
+			"postCopy": {
+				{Kind: "postCopyKind1", Value: "postCopyValue1"},
+				{Kind: "postCopyKind2", Value: "postCopyValue2"},
+			},
+		},
+	}, `# From the base image
+FROM baseImage
+# Run the pre-copy directives
+preCopyKind1 preCopyValue1
+preCopyKind2 preCopyValue2
+# Copy required objects from the suppliers
+COPY artifactDirNameInStaging/onbuildLocal1 onbuildImage1
+COPY artifactDirNameInStaging/onbuildLocal2 onbuildImage2
+COPY imageLocal1 imageImage1
+COPY imageLocal2 imageImage2
+# Run the post-copy directives
+postCopyKind1 postCopyValue1
+postCopyKind2 postCopyValue2
+# Run processor with configuration and platform configuration
+CMD [ "processor", "--config", "/etc/nuclio/config/processor/processor.yaml", "--platform-config", "/etc/nuclio/config/platform/platform.yaml" ]`)
+}
+
+func (suite *testSuite) generateDockerfileAndVerify(healthCheckRequired bool,
+	dockerfileInfo *runtime.ProcessorDockerfileInfo,
+	expectedDockerfile string) {
+
+	dockerfileContents, err := suite.builder.generateSingleStageDockerfileContents("artifactDirNameInStaging",
+		healthCheckRequired,
+		dockerfileInfo)
+
+	suite.Require().NoError(err)
+	suite.Require().Equal(expectedDockerfile, common.RemoveEmptyLines(dockerfileContents))
+}
+
 
 func TestBuilderSuite(t *testing.T) {
 	if testing.Short() {
 		return
 	}
 
-	suite.Run(t, new(TestSuite))
+	suite.Run(t, new(testSuite))
 }

--- a/pkg/processor/build/runtime/golang/test/golang_test.go
+++ b/pkg/processor/build/runtime/golang/test/golang_test.go
@@ -28,17 +28,17 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type TestSuite struct {
+type testSuite struct {
 	buildsuite.TestSuite
 }
 
-func (suite *TestSuite) SetupSuite() {
+func (suite *testSuite) SetupSuite() {
 	suite.TestSuite.SetupSuite()
 
 	suite.TestSuite.RuntimeSuite = suite
 }
 
-func (suite *TestSuite) TestBuildWithCompilationError() {
+func (suite *testSuite) TestBuildWithCompilationError() {
 	var err error
 
 	createFunctionOptions := suite.GetDeployOptions("compilation-error",
@@ -63,7 +63,7 @@ func (suite *TestSuite) TestBuildWithCompilationError() {
 	suite.Require().Contains(buffer.String(), "fmt.NotAFunction")
 }
 
-func (suite *TestSuite) TestBuildWithContextInitializer() {
+func (suite *testSuite) TestBuildWithContextInitializer() {
 	createFunctionOptions := suite.GetDeployOptions("context-init",
 		suite.GetFunctionPath(suite.GetTestFunctionsDir(), "common", "context-init", "golang", "contextinit.go"))
 
@@ -75,7 +75,7 @@ func (suite *TestSuite) TestBuildWithContextInitializer() {
 		})
 }
 
-func (suite *TestSuite) GetFunctionInfo(functionName string) buildsuite.FunctionInfo {
+func (suite *testSuite) GetFunctionInfo(functionName string) buildsuite.FunctionInfo {
 	functionInfo := buildsuite.FunctionInfo{
 		Runtime: "golang",
 	}
@@ -108,5 +108,5 @@ func TestIntegrationSuite(t *testing.T) {
 		return
 	}
 
-	suite.Run(t, new(TestSuite))
+	suite.Run(t, new(testSuite))
 }

--- a/pkg/processor/build/runtime/nodejs/runtime.go
+++ b/pkg/processor/build/runtime/nodejs/runtime.go
@@ -19,6 +19,7 @@ package nodejs
 import (
 	"fmt"
 
+	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 	"github.com/nuclio/nuclio/pkg/version"
 )
@@ -52,8 +53,10 @@ func (n *nodejs) GetProcessorDockerfileInfo(versionInfo *version.Info) (*runtime
 		"handler": "/opt/nuclio",
 	}
 
-	processorDockerfileInfo.Directives = []string{
-		"ENV NODE_PATH=/usr/local/lib/node_modules",
+	processorDockerfileInfo.Directives = map[string][]functionconfig.Directive{
+		"postCopy": {
+			{Kind: "ENV", Value: "NODE_PATH=/usr/local/lib/node_modules"},
+		},
 	}
 
 	return &processorDockerfileInfo, nil

--- a/pkg/processor/build/runtime/python/test/python_test.go
+++ b/pkg/processor/build/runtime/python/test/python_test.go
@@ -137,6 +137,9 @@ func (suite *testSuite) TestDockerCacheUtilized() {
 		// fetch first file
 		fmt.Sprintf("curl -L %s/%s --output %s", serverAddress, firstFilePattern, firstFilePath),
 
+		// indicate that commands from here on out should execute _after_ the copy of artifacts
+		"@nuclio.postCopy",
+
 		// fetch second file
 		fmt.Sprintf("curl -L %s/%s --output %s", serverAddress, secondFilePattern, secondFilePath),
 	}
@@ -152,11 +155,11 @@ func (suite *testSuite) TestDockerCacheUtilized() {
 	httpServer, err := httpsrv.NewServer(serverAddress, nil, []httpsrv.ServedObject{
 		{
 			Contents: firstFileFirstBuildContents,
-			Pattern: firstFilePattern,
+			Pattern:  firstFilePattern,
 		},
 		{
 			Contents: secondFileFirstBuildContents,
-			Pattern: secondFilePattern,
+			Pattern:  secondFilePattern,
 		},
 	})
 
@@ -169,13 +172,12 @@ func (suite *testSuite) TestDockerCacheUtilized() {
 	// do the build. expect to get the first/second file contents of the first build
 	suite.DeployFunctionAndRequest(createFunctionOptions,
 		&httpsuite.Request{
-			RequestMethod:        "GET",
+			RequestMethod: "GET",
 			ExpectedResponseBody: fmt.Sprintf("%s:%s:%s",
 				firstFileFirstBuildContents,
 				secondFileFirstBuildContents,
 				randomString),
 		})
-
 
 	// stop serving
 	httpServer.Stop()
@@ -191,11 +193,11 @@ func (suite *testSuite) TestDockerCacheUtilized() {
 	httpServer, err = httpsrv.NewServer(serverAddress, nil, []httpsrv.ServedObject{
 		{
 			Contents: firstFileSecondBuildContents,
-			Pattern: firstFilePattern,
+			Pattern:  firstFilePattern,
 		},
 		{
 			Contents: secondFileSecondBuildContents,
-			Pattern: secondFilePattern,
+			Pattern:  secondFilePattern,
 		},
 	})
 
@@ -204,7 +206,7 @@ func (suite *testSuite) TestDockerCacheUtilized() {
 	// do the build. expect to get the first/second file contents of the first build
 	suite.DeployFunctionAndRequest(createFunctionOptions,
 		&httpsuite.Request{
-			RequestMethod:        "GET",
+			RequestMethod: "GET",
 			ExpectedResponseBody: fmt.Sprintf("%s:%s:%s",
 				firstFileFirstBuildContents,
 				secondFileFirstBuildContents,
@@ -232,11 +234,11 @@ func (suite *testSuite) TestDockerCacheUtilized() {
 	httpServer, err = httpsrv.NewServer(serverAddress, nil, []httpsrv.ServedObject{
 		{
 			Contents: firstFileThirdBuildContents,
-			Pattern: firstFilePattern,
+			Pattern:  firstFilePattern,
 		},
 		{
 			Contents: secondFileThirdBuildContents,
-			Pattern: secondFilePattern,
+			Pattern:  secondFilePattern,
 		},
 	})
 
@@ -249,7 +251,7 @@ func (suite *testSuite) TestDockerCacheUtilized() {
 	// do the build. expect to get the first/second file contents of the first build
 	suite.DeployFunctionAndRequest(createFunctionOptions,
 		&httpsuite.Request{
-			RequestMethod:        "GET",
+			RequestMethod: "GET",
 			ExpectedResponseBody: fmt.Sprintf("%s:%s:%s",
 				firstFileFirstBuildContents,
 				secondFileThirdBuildContents,

--- a/pkg/processor/build/runtime/python/test/python_test.go
+++ b/pkg/processor/build/runtime/python/test/python_test.go
@@ -17,17 +17,10 @@ limitations under the License.
 package test
 
 import (
-	"encoding/base64"
-	"fmt"
 	"testing"
-	"time"
 
-	"github.com/nuclio/nuclio/pkg/functionconfig"
-	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime/test/suite"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
-	"github.com/nuclio/nuclio/test/httpsrv"
-	"github.com/rs/xid"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -93,181 +86,12 @@ func (suite *testSuite) GetFunctionInfo(functionName string) buildsuite.Function
 	return functionInfo
 }
 
-func (suite *testSuite) TestDockerCacheUtilized() {
-	firstFilePath := "/first-file.txt"
-	secondFilePath := "/second-file.txt"
-	firstFilePattern := "first-file"
-	secondFilePattern := "second-file"
-	serverAddress := "10.0.0.12:7777"
-
-	//
-	// Preparation
-	//
-
-	generateSourceCode := func() (string, string) {
-		randomString := xid.New().String()
-
-		// create a function that returns the contents of both files + something random so that subsequent
-		// runs of this test doesn't hit docker cache (if that's possible)
-		sourceCode := fmt.Sprintf(`def handler(context, event):
-	return open('%s', 'r').read() + ':' + open('%s', 'r').read() + ':%s'
-`, firstFilePath, secondFilePath, randomString)
-
-		return base64.StdEncoding.EncodeToString([]byte(sourceCode)), randomString
-
-	}
-
-	readinessTimeout := 5 * time.Second
-
-	createFunctionOptions := &platform.CreateFunctionOptions{
-		Logger:           suite.Logger,
-		FunctionConfig:   *functionconfig.NewConfig(),
-		ReadinessTimeout: &readinessTimeout,
-	}
-
-	createFunctionOptions.FunctionConfig.Meta.Name = "cache-test"
-	createFunctionOptions.FunctionConfig.Spec.Runtime = "python:3.6"
-	createFunctionOptions.FunctionConfig.Spec.Handler = "cachetest:handler"
-	createFunctionOptions.FunctionConfig.Spec.Build.TempDir = suite.CreateTempDir()
-	createFunctionOptions.FunctionConfig.Spec.Build.Commands = []string{
-
-		// install curl
-		"apk --update --no-cache add curl",
-
-		// fetch first file
-		fmt.Sprintf("curl -L %s/%s --output %s", serverAddress, firstFilePattern, firstFilePath),
-
-		// indicate that commands from here on out should execute _after_ the copy of artifacts
-		"@nuclio.postCopy",
-
-		// fetch second file
-		fmt.Sprintf("curl -L %s/%s --output %s", serverAddress, secondFilePattern, secondFilePath),
-	}
-
-	//
-	// First build
-	//
-
-	firstFileFirstBuildContents := "firstFileFirstBuild"
-	secondFileFirstBuildContents := "secondFileFirstBuild"
-
-	// create an HTTP server that serves the contents
-	httpServer, err := httpsrv.NewServer(serverAddress, nil, []httpsrv.ServedObject{
-		{
-			Contents: firstFileFirstBuildContents,
-			Pattern:  firstFilePattern,
-		},
-		{
-			Contents: secondFileFirstBuildContents,
-			Pattern:  secondFilePattern,
-		},
-	})
-
-	suite.Require().NoError(err)
-
-	// generate (unique) source code
-	sourceCode, randomString := generateSourceCode()
-	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = sourceCode
-
-	// do the build. expect to get the first/second file contents of the first build
-	suite.DeployFunctionAndRequest(createFunctionOptions,
-		&httpsuite.Request{
-			RequestMethod: "GET",
-			ExpectedResponseBody: fmt.Sprintf("%s:%s:%s",
-				firstFileFirstBuildContents,
-				secondFileFirstBuildContents,
-				randomString),
-		})
-
-	// stop serving
-	httpServer.Stop()
-
-	//
-	// Second build: Don't change source code. Expect everything to come from the cache
-	//
-
-	firstFileSecondBuildContents := "firstFileSecondBuild"
-	secondFileSecondBuildContents := "secondFileSecondBuild"
-
-	// create an HTTP server that serves the contents
-	httpServer, err = httpsrv.NewServer(serverAddress, nil, []httpsrv.ServedObject{
-		{
-			Contents: firstFileSecondBuildContents,
-			Pattern:  firstFilePattern,
-		},
-		{
-			Contents: secondFileSecondBuildContents,
-			Pattern:  secondFilePattern,
-		},
-	})
-
-	suite.Require().NoError(err)
-
-	// do the build. expect to get the first/second file contents of the first build
-	suite.DeployFunctionAndRequest(createFunctionOptions,
-		&httpsuite.Request{
-			RequestMethod: "GET",
-			ExpectedResponseBody: fmt.Sprintf("%s:%s:%s",
-				firstFileFirstBuildContents,
-				secondFileFirstBuildContents,
-				randomString),
-		})
-
-	// stop serving
-	httpServer.Stop()
-
-	//
-	// Third build: Change the source code. Expect only the second file contents to change, because the
-	//              first curl should hit the cache (and not execute) whereas the second curl should
-	//              not hit the cache because it should be executed after the source code copy which
-	//              invalidates the cache. To illustrate the underlying Dockerfile should be:
-	//
-	// RUN first curl <-- should come from cache (first execution)
-	// COPY source to somewhere <-- source code changed, will invalidate the cache
-	// RUN second curl <-- should NOT come from the cache because the previous COPY invalidated the cache
-	//
-
-	firstFileThirdBuildContents := "firstFileThirdBuild"
-	secondFileThirdBuildContents := "secondFileThirdBuild"
-
-	// create an HTTP server that serves the contents
-	httpServer, err = httpsrv.NewServer(serverAddress, nil, []httpsrv.ServedObject{
-		{
-			Contents: firstFileThirdBuildContents,
-			Pattern:  firstFilePattern,
-		},
-		{
-			Contents: secondFileThirdBuildContents,
-			Pattern:  secondFilePattern,
-		},
-	})
-
-	suite.Require().NoError(err)
-
-	// generate (unique) source code again. This will cause cache invalidation at some point in the layers
-	sourceCode, randomString = generateSourceCode()
-	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = sourceCode
-
-	// do the build. expect to get the first/second file contents of the first build
-	suite.DeployFunctionAndRequest(createFunctionOptions,
-		&httpsuite.Request{
-			RequestMethod: "GET",
-			ExpectedResponseBody: fmt.Sprintf("%s:%s:%s",
-				firstFileFirstBuildContents,
-				secondFileThirdBuildContents,
-				randomString),
-		})
-
-	// stop serving
-	httpServer.Stop()
-}
-
 func TestIntegrationSuite(t *testing.T) {
 	if testing.Short() {
 		return
 	}
 
-	//suite.Run(t, newTestSuite("python"))
-	//suite.Run(t, newTestSuite("python:2.7"))
+	suite.Run(t, newTestSuite("python"))
+	suite.Run(t, newTestSuite("python:2.7"))
 	suite.Run(t, newTestSuite("python:3.6"))
 }

--- a/pkg/processor/build/runtime/python/test/python_test.go
+++ b/pkg/processor/build/runtime/python/test/python_test.go
@@ -17,10 +17,17 @@ limitations under the License.
 package test
 
 import (
+	"encoding/base64"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime/test/suite"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
+	"github.com/nuclio/nuclio/test/httpsrv"
+	"github.com/rs/xid"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -86,12 +93,179 @@ func (suite *testSuite) GetFunctionInfo(functionName string) buildsuite.Function
 	return functionInfo
 }
 
+func (suite *testSuite) TestDockerCacheUtilized() {
+	firstFilePath := "/first-file.txt"
+	secondFilePath := "/second-file.txt"
+	firstFilePattern := "first-file"
+	secondFilePattern := "second-file"
+	serverAddress := "10.0.0.12:7777"
+
+	//
+	// Preparation
+	//
+
+	generateSourceCode := func() (string, string) {
+		randomString := xid.New().String()
+
+		// create a function that returns the contents of both files + something random so that subsequent
+		// runs of this test doesn't hit docker cache (if that's possible)
+		sourceCode := fmt.Sprintf(`def handler(context, event):
+	return open('%s', 'r').read() + ':' + open('%s', 'r').read() + ':%s'
+`, firstFilePath, secondFilePath, randomString)
+
+		return base64.StdEncoding.EncodeToString([]byte(sourceCode)), randomString
+
+	}
+
+	readinessTimeout := 5 * time.Second
+
+	createFunctionOptions := &platform.CreateFunctionOptions{
+		Logger:           suite.Logger,
+		FunctionConfig:   *functionconfig.NewConfig(),
+		ReadinessTimeout: &readinessTimeout,
+	}
+
+	createFunctionOptions.FunctionConfig.Meta.Name = "cache-test"
+	createFunctionOptions.FunctionConfig.Spec.Runtime = "python:3.6"
+	createFunctionOptions.FunctionConfig.Spec.Handler = "cachetest:handler"
+	createFunctionOptions.FunctionConfig.Spec.Build.TempDir = suite.CreateTempDir()
+	createFunctionOptions.FunctionConfig.Spec.Build.Commands = []string{
+
+		// install curl
+		"apk --update --no-cache add curl",
+
+		// fetch first file
+		fmt.Sprintf("curl -L %s/%s --output %s", serverAddress, firstFilePattern, firstFilePath),
+
+		// fetch second file
+		fmt.Sprintf("curl -L %s/%s --output %s", serverAddress, secondFilePattern, secondFilePath),
+	}
+
+	//
+	// First build
+	//
+
+	firstFileFirstBuildContents := "firstFileFirstBuild"
+	secondFileFirstBuildContents := "secondFileFirstBuild"
+
+	// create an HTTP server that serves the contents
+	httpServer, err := httpsrv.NewServer(serverAddress, nil, []httpsrv.ServedObject{
+		{
+			Contents: firstFileFirstBuildContents,
+			Pattern: firstFilePattern,
+		},
+		{
+			Contents: secondFileFirstBuildContents,
+			Pattern: secondFilePattern,
+		},
+	})
+
+	suite.Require().NoError(err)
+
+	// generate (unique) source code
+	sourceCode, randomString := generateSourceCode()
+	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = sourceCode
+
+	// do the build. expect to get the first/second file contents of the first build
+	suite.DeployFunctionAndRequest(createFunctionOptions,
+		&httpsuite.Request{
+			RequestMethod:        "GET",
+			ExpectedResponseBody: fmt.Sprintf("%s:%s:%s",
+				firstFileFirstBuildContents,
+				secondFileFirstBuildContents,
+				randomString),
+		})
+
+
+	// stop serving
+	httpServer.Stop()
+
+	//
+	// Second build: Don't change source code. Expect everything to come from the cache
+	//
+
+	firstFileSecondBuildContents := "firstFileSecondBuild"
+	secondFileSecondBuildContents := "secondFileSecondBuild"
+
+	// create an HTTP server that serves the contents
+	httpServer, err = httpsrv.NewServer(serverAddress, nil, []httpsrv.ServedObject{
+		{
+			Contents: firstFileSecondBuildContents,
+			Pattern: firstFilePattern,
+		},
+		{
+			Contents: secondFileSecondBuildContents,
+			Pattern: secondFilePattern,
+		},
+	})
+
+	suite.Require().NoError(err)
+
+	// do the build. expect to get the first/second file contents of the first build
+	suite.DeployFunctionAndRequest(createFunctionOptions,
+		&httpsuite.Request{
+			RequestMethod:        "GET",
+			ExpectedResponseBody: fmt.Sprintf("%s:%s:%s",
+				firstFileFirstBuildContents,
+				secondFileFirstBuildContents,
+				randomString),
+		})
+
+	// stop serving
+	httpServer.Stop()
+
+	//
+	// Third build: Change the source code. Expect only the second file contents to change, because the
+	//              first curl should hit the cache (and not execute) whereas the second curl should
+	//              not hit the cache because it should be executed after the source code copy which
+	//              invalidates the cache. To illustrate the underlying Dockerfile should be:
+	//
+	// RUN first curl <-- should come from cache (first execution)
+	// COPY source to somewhere <-- source code changed, will invalidate the cache
+	// RUN second curl <-- should NOT come from the cache because the previous COPY invalidated the cache
+	//
+
+	firstFileThirdBuildContents := "firstFileThirdBuild"
+	secondFileThirdBuildContents := "secondFileThirdBuild"
+
+	// create an HTTP server that serves the contents
+	httpServer, err = httpsrv.NewServer(serverAddress, nil, []httpsrv.ServedObject{
+		{
+			Contents: firstFileThirdBuildContents,
+			Pattern: firstFilePattern,
+		},
+		{
+			Contents: secondFileThirdBuildContents,
+			Pattern: secondFilePattern,
+		},
+	})
+
+	suite.Require().NoError(err)
+
+	// generate (unique) source code again. This will cause cache invalidation at some point in the layers
+	sourceCode, randomString = generateSourceCode()
+	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = sourceCode
+
+	// do the build. expect to get the first/second file contents of the first build
+	suite.DeployFunctionAndRequest(createFunctionOptions,
+		&httpsuite.Request{
+			RequestMethod:        "GET",
+			ExpectedResponseBody: fmt.Sprintf("%s:%s:%s",
+				firstFileFirstBuildContents,
+				secondFileThirdBuildContents,
+				randomString),
+		})
+
+	// stop serving
+	httpServer.Stop()
+}
+
 func TestIntegrationSuite(t *testing.T) {
 	if testing.Short() {
 		return
 	}
 
-	suite.Run(t, newTestSuite("python"))
-	suite.Run(t, newTestSuite("python:2.7"))
+	//suite.Run(t, newTestSuite("python"))
+	//suite.Run(t, newTestSuite("python:2.7"))
 	suite.Run(t, newTestSuite("python:3.6"))
 }

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -36,7 +36,7 @@ type ProcessorDockerfileInfo struct {
 	OnbuildImage         string
 	OnbuildArtifactPaths map[string]string
 	ImageArtifactPaths   map[string]string
-	Directives           []string
+	Directives           map[string][]functionconfig.Directive
 }
 
 type Runtime interface {

--- a/pkg/processor/build/runtime/test/runtime_test.go
+++ b/pkg/processor/build/runtime/test/runtime_test.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
+	"github.com/nuclio/nuclio/test/httpsrv"
+
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/suite"
+)
+
+type testSuite struct {
+	httpsuite.TestSuite
+}
+
+func newTestSuite() *testSuite {
+	return &testSuite{}
+}
+
+func (suite *testSuite) TestDockerCacheUtilized() {
+	firstFilePath := "/first-file.txt"
+	secondFilePath := "/second-file.txt"
+	firstFilePattern := "first-file"
+	secondFilePattern := "second-file"
+	serverAddress := "10.0.0.12:7777"
+
+	//
+	// Preparation
+	//
+
+	generateSourceCode := func() (string, string) {
+		randomString := xid.New().String()
+
+		// create a function that returns the contents of both files + something random so that subsequent
+		// runs of this test doesn't hit docker cache (if that's possible)
+		sourceCode := fmt.Sprintf(`def handler(context, event):
+	return open('%s', 'r').read() + ':' + open('%s', 'r').read() + ':%s'
+`, firstFilePath, secondFilePath, randomString)
+
+		return base64.StdEncoding.EncodeToString([]byte(sourceCode)), randomString
+
+	}
+
+	readinessTimeout := 5 * time.Second
+
+	createFunctionOptions := &platform.CreateFunctionOptions{
+		Logger:           suite.Logger,
+		FunctionConfig:   *functionconfig.NewConfig(),
+		ReadinessTimeout: &readinessTimeout,
+	}
+
+	createFunctionOptions.FunctionConfig.Meta.Name = "cache-test"
+	createFunctionOptions.FunctionConfig.Spec.Runtime = "python:3.6"
+	createFunctionOptions.FunctionConfig.Spec.Handler = "cachetest:handler"
+	createFunctionOptions.FunctionConfig.Spec.Build.TempDir = suite.CreateTempDir()
+	createFunctionOptions.FunctionConfig.Spec.Build.Commands = []string{
+
+		// install curl
+		"apk --update --no-cache add curl",
+
+		// fetch first file
+		fmt.Sprintf("curl -L %s/%s --output %s", serverAddress, firstFilePattern, firstFilePath),
+
+		// indicate that commands from here on out should execute _after_ the copy of artifacts
+		"@nuclio.postCopy",
+
+		// fetch second file
+		fmt.Sprintf("curl -L %s/%s --output %s", serverAddress, secondFilePattern, secondFilePath),
+	}
+
+	//
+	// First build
+	//
+
+	firstFileFirstBuildContents := "firstFileFirstBuild"
+	secondFileFirstBuildContents := "secondFileFirstBuild"
+
+	// create an HTTP server that serves the contents
+	httpServer, err := httpsrv.NewServer(serverAddress, nil, []httpsrv.ServedObject{
+		{
+			Contents: firstFileFirstBuildContents,
+			Pattern:  firstFilePattern,
+		},
+		{
+			Contents: secondFileFirstBuildContents,
+			Pattern:  secondFilePattern,
+		},
+	})
+
+	suite.Require().NoError(err)
+
+	// generate (unique) source code
+	sourceCode, randomString := generateSourceCode()
+	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = sourceCode
+
+	// do the build. expect to get the first/second file contents of the first build
+	suite.DeployFunctionAndRequest(createFunctionOptions,
+		&httpsuite.Request{
+			RequestMethod: "GET",
+			ExpectedResponseBody: fmt.Sprintf("%s:%s:%s",
+				firstFileFirstBuildContents,
+				secondFileFirstBuildContents,
+				randomString),
+		})
+
+	// stop serving
+	httpServer.Stop()
+
+	//
+	// Second build: Don't change source code. Expect everything to come from the cache
+	//
+
+	firstFileSecondBuildContents := "firstFileSecondBuild"
+	secondFileSecondBuildContents := "secondFileSecondBuild"
+
+	// create an HTTP server that serves the contents
+	httpServer, err = httpsrv.NewServer(serverAddress, nil, []httpsrv.ServedObject{
+		{
+			Contents: firstFileSecondBuildContents,
+			Pattern:  firstFilePattern,
+		},
+		{
+			Contents: secondFileSecondBuildContents,
+			Pattern:  secondFilePattern,
+		},
+	})
+
+	suite.Require().NoError(err)
+
+	// do the build. expect to get the first/second file contents of the first build
+	suite.DeployFunctionAndRequest(createFunctionOptions,
+		&httpsuite.Request{
+			RequestMethod: "GET",
+			ExpectedResponseBody: fmt.Sprintf("%s:%s:%s",
+				firstFileFirstBuildContents,
+				secondFileFirstBuildContents,
+				randomString),
+		})
+
+	// stop serving
+	httpServer.Stop()
+
+	//
+	// Third build: Change the source code. Expect only the second file contents to change, because the
+	//              first curl should hit the cache (and not execute) whereas the second curl should
+	//              not hit the cache because it should be executed after the source code copy which
+	//              invalidates the cache. To illustrate the underlying Dockerfile should be:
+	//
+	// RUN first curl <-- should come from cache (first execution)
+	// COPY source to somewhere <-- source code changed, will invalidate the cache
+	// RUN second curl <-- should NOT come from the cache because the previous COPY invalidated the cache
+	//
+
+	firstFileThirdBuildContents := "firstFileThirdBuild"
+	secondFileThirdBuildContents := "secondFileThirdBuild"
+
+	// create an HTTP server that serves the contents
+	httpServer, err = httpsrv.NewServer(serverAddress, nil, []httpsrv.ServedObject{
+		{
+			Contents: firstFileThirdBuildContents,
+			Pattern:  firstFilePattern,
+		},
+		{
+			Contents: secondFileThirdBuildContents,
+			Pattern:  secondFilePattern,
+		},
+	})
+
+	suite.Require().NoError(err)
+
+	// generate (unique) source code again. This will cause cache invalidation at some point in the layers
+	sourceCode, randomString = generateSourceCode()
+	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = sourceCode
+
+	// do the build. expect to get the first/second file contents of the first build
+	suite.DeployFunctionAndRequest(createFunctionOptions,
+		&httpsuite.Request{
+			RequestMethod: "GET",
+			ExpectedResponseBody: fmt.Sprintf("%s:%s:%s",
+				firstFileFirstBuildContents,
+				secondFileThirdBuildContents,
+				randomString),
+		})
+
+	// stop serving
+	httpServer.Stop()
+}
+
+func TestIntegrationSuite(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	suite.Run(t, newTestSuite())
+}

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -17,17 +17,16 @@ limitations under the License.
 package buildsuite
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"path"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
+	"github.com/nuclio/nuclio/test/httpsrv"
 
 	"github.com/mholt/archiver"
 )
@@ -263,16 +262,20 @@ func (suite *TestSuite) DeployFunctionFromURL(createFunctionOptions *platform.Cr
 	functionFileName := path.Base(createFunctionOptions.FunctionConfig.Spec.Build.Path)
 
 	// start an HTTP server to serve the reverser py
-	// TODO: needs to be made unique (find a free port)
-	httpServer := HTTPFileServer{}
-	httpServer.Start(":7777",
-		createFunctionOptions.FunctionConfig.Spec.Build.Path,
-		fmt.Sprintf("/%s", functionFileName))
+	httpServer, err := httpsrv.NewServer("", []httpsrv.ServedFile{
+		{
+			LocalPath: createFunctionOptions.FunctionConfig.Spec.Build.Path,
+			Pattern: fmt.Sprintf("/%s", functionFileName),
+		},
+	}, nil)
 
-	defer httpServer.Shutdown(context.TODO()) // nolint: errcheck
+	suite.Require().NoError(err)
+	defer httpServer.Stop() // nolint: errcheck
 
 	// override path with URL
-	createFunctionOptions.FunctionConfig.Spec.Build.Path = "http://localhost:7777/" + functionFileName
+	createFunctionOptions.FunctionConfig.Spec.Build.Path = fmt.Sprintf("http://%s/%s",
+		httpServer.Addr,
+		functionFileName)
 
 	suite.DeployFunctionAndRequest(createFunctionOptions, request)
 }
@@ -289,15 +292,19 @@ func (suite *TestSuite) compressAndDeployFunctionFromURL(archiveExtension string
 	pathToFunction := "/some/path/to/function/" + path.Base(archivePath)
 
 	// start an HTTP server to serve the reverser py
-	// TODO: needs to be made unique (find a free port)
-	httpServer := HTTPFileServer{}
-	httpServer.Start(":7777",
-		archivePath,
+	httpServer, err := httpsrv.NewServer("", []httpsrv.ServedFile{
+		{
+			LocalPath: archivePath,
+			Pattern: pathToFunction,
+		},
+	}, nil)
+
+	suite.Require().NoError(err)
+	defer httpServer.Stop() // nolint: errcheck
+
+	createFunctionOptions.FunctionConfig.Spec.Build.Path =fmt.Sprintf("http://%s/%s",
+		httpServer.Addr,
 		pathToFunction)
-
-	defer httpServer.Shutdown(context.TODO()) // nolint: errcheck
-
-	createFunctionOptions.FunctionConfig.Spec.Build.Path = "http://localhost:7777" + pathToFunction
 
 	suite.DeployFunctionAndRequest(createFunctionOptions,
 		&httpsuite.Request{
@@ -374,26 +381,4 @@ func (suite *TestSuite) getDeployOptions(functionName string) *platform.CreateFu
 	createFunctionOptions.FunctionConfig.Spec.Runtime = functionInfo.Runtime
 
 	return createFunctionOptions
-}
-
-//
-// HTTP server to test URL fetch
-//
-
-type HTTPFileServer struct {
-	http.Server
-}
-
-func (hfs *HTTPFileServer) Start(addr string, localPath string, pattern string) {
-	hfs.Addr = addr
-
-	// create a new servemux
-	serveMux := http.NewServeMux()
-	serveMux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, localPath)
-	})
-
-	hfs.Handler = serveMux
-
-	go hfs.ListenAndServe() // nolint: errcheck
 }

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -265,7 +265,7 @@ func (suite *TestSuite) DeployFunctionFromURL(createFunctionOptions *platform.Cr
 	httpServer, err := httpsrv.NewServer("", []httpsrv.ServedFile{
 		{
 			LocalPath: createFunctionOptions.FunctionConfig.Spec.Build.Path,
-			Pattern: fmt.Sprintf("/%s", functionFileName),
+			Pattern:   fmt.Sprintf("/%s", functionFileName),
 		},
 	}, nil)
 
@@ -295,14 +295,14 @@ func (suite *TestSuite) compressAndDeployFunctionFromURL(archiveExtension string
 	httpServer, err := httpsrv.NewServer("", []httpsrv.ServedFile{
 		{
 			LocalPath: archivePath,
-			Pattern: pathToFunction,
+			Pattern:   pathToFunction,
 		},
 	}, nil)
 
 	suite.Require().NoError(err)
 	defer httpServer.Stop() // nolint: errcheck
 
-	createFunctionOptions.FunctionConfig.Spec.Build.Path =fmt.Sprintf("http://%s/%s",
+	createFunctionOptions.FunctionConfig.Spec.Build.Path = fmt.Sprintf("http://%s/%s",
 		httpServer.Addr,
 		pathToFunction)
 

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -270,7 +270,7 @@ func (suite *TestSuite) GetDeployOptions(functionName string, functionPath strin
 	createFunctionOptions.FunctionConfig.Spec.Runtime = suite.Runtime
 	createFunctionOptions.FunctionConfig.Spec.Build.Path = functionPath
 
-	suite.TempDir = suite.createTempDir()
+	suite.TempDir = suite.CreateTempDir()
 	createFunctionOptions.FunctionConfig.Spec.Build.TempDir = suite.TempDir
 
 	return createFunctionOptions
@@ -310,7 +310,7 @@ func (suite *TestSuite) GetRuntimeDir() string {
 	return suite.Runtime
 }
 
-func (suite *TestSuite) createTempDir() string {
+func (suite *TestSuite) CreateTempDir() string {
 	tempDir, err := ioutil.TempDir("", "build-test-"+suite.TestID)
 	if err != nil {
 		suite.FailNowf("Failed to create temporary dir %s for test %s", suite.TempDir, suite.TestID)

--- a/test/httpsrv/httpsrv.go
+++ b/test/httpsrv/httpsrv.go
@@ -28,13 +28,13 @@ import (
 // ServedObject represents an object that will be returned at a given pattern
 type ServedObject struct {
 	Contents string
-	Pattern string
+	Pattern  string
 }
 
 // ServedObject represents a file that will be returned at a given pattern
 type ServedFile struct {
 	LocalPath string
-	Pattern string
+	Pattern   string
 }
 
 // Server serves objects and files
@@ -69,7 +69,7 @@ func NewServer(addr string,
 	for _, servedFile := range servedFiles {
 		servedFileCopy := servedFile
 
-		newServeMux.HandleFunc("/" + servedFileCopy.Pattern, func(w http.ResponseWriter, r *http.Request) {
+		newServeMux.HandleFunc("/"+servedFileCopy.Pattern, func(w http.ResponseWriter, r *http.Request) {
 			http.ServeFile(w, r, servedFileCopy.LocalPath)
 		})
 
@@ -79,7 +79,7 @@ func NewServer(addr string,
 	for _, servedObject := range servedObjects {
 		servedObjectCopy := servedObject
 
-		newServeMux.HandleFunc("/" + servedObjectCopy.Pattern, func(w http.ResponseWriter, r *http.Request) {
+		newServeMux.HandleFunc("/"+servedObjectCopy.Pattern, func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte(servedObjectCopy.Contents))
 		})
 	}

--- a/test/httpsrv/httpsrv.go
+++ b/test/httpsrv/httpsrv.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpsrv
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/nuclio/nuclio/pkg/errors"
+)
+
+// ServedObject represents an object that will be returned at a given pattern
+type ServedObject struct {
+	Contents string
+	Pattern string
+}
+
+// ServedObject represents a file that will be returned at a given pattern
+type ServedFile struct {
+	LocalPath string
+	Pattern string
+}
+
+// Server serves objects and files
+type Server struct {
+	http.Server
+}
+
+// NewServer creates an object/file server
+func NewServer(addr string,
+	servedFiles []ServedFile,
+	servedObjects []ServedObject) (*Server, error) {
+	var err error
+
+	newServer := Server{}
+
+	// if user didn't pass an address, generate one
+	if addr == "" {
+		addr, err = generateAddress()
+
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to find free port")
+		}
+	}
+
+	newServer.Addr = addr
+
+	// create a new servemux
+	newServeMux := http.NewServeMux()
+	newServer.Handler = newServeMux
+
+	// register files
+	for _, servedFile := range servedFiles {
+		servedFileCopy := servedFile
+
+		newServeMux.HandleFunc("/" + servedFileCopy.Pattern, func(w http.ResponseWriter, r *http.Request) {
+			http.ServeFile(w, r, servedFileCopy.LocalPath)
+		})
+
+	}
+
+	// register objects
+	for _, servedObject := range servedObjects {
+		servedObjectCopy := servedObject
+
+		newServeMux.HandleFunc("/" + servedObjectCopy.Pattern, func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(servedObjectCopy.Contents))
+		})
+	}
+
+	go newServer.ListenAndServe() // nolint: errcheck
+
+	return &newServer, nil
+}
+
+// Stop stops serving
+func (s *Server) Stop() error {
+	return s.Shutdown(context.TODO())
+}
+
+func generateAddress() (string, error) {
+	freePort, err := findFreePort()
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to find free port")
+	}
+
+	return fmt.Sprintf("127.0.0.1:%s", freePort.Port), nil
+}
+
+func findFreePort() (*net.TCPAddr, error) {
+	return net.ResolveTCPAddr("tcp", "localhost:0")
+}


### PR DESCRIPTION
1. A new build parameter, `directives` was introduced. As opposed to `commands`, this allows users to:
* Specify directives other than `RUN` like `ENV`
* Specify when the directives should run in the build process (`preCopy` or `postCopy` for now). Directives that are placed `preCopy` will not run in subsequent builds even if the source code has changed, as the layer will be taken unaffected from the Docker cache

Users can still specify `commands`, but unless decorated will appear as `preCopy` commands (this is a potentially breaking change for users who run commands expecting source code to already exist in the container)
2. `HEALTHCHECK` and the requirement of `uhttpc` were removed when the platform is Kubernetes. This is only required to run on the local platform, as Kubernetes does not need an internal healthcheck to run - this is done through an external mechanism
