### PR TITLE
UI: Update dashboard-controls version to 0.0.60 + More

### DIFF
--- a/pkg/dashboard/ui/build.config.js
+++ b/pkg/dashboard/ui/build.config.js
@@ -147,7 +147,7 @@ module.exports = {
             'vendor/ng-dialog/js/ngDialog.js',
             'vendor/malihu-custom-scrollbar-plugin/jquery.mCustomScrollbar.concat.min.js',
             'vendor/ng-scrollbars/dist/scrollbars.min.js',
-            'node_modules/monaco-editor/min/vs/loader.js',
+            'node_modules/iguazio.dashboard-controls/node_modules/monaco-editor/min/vs/loader.js',
             'vendor/ng-file-upload/ng-file-upload.js',
             'vendor/ng-file-upload/FileAPI.js'
         ],

--- a/pkg/dashboard/ui/gulpfile.js
+++ b/pkg/dashboard/ui/gulpfile.js
@@ -211,7 +211,7 @@ gulp.task('app.js', function () {
  * Temporary task to copy the monaco-editor files to the assets directory
  */
 gulp.task('monaco', function(){
-    gulp.src(['node_modules/monaco-editor/**/*']).pipe(gulp.dest(config.assets_dir + '/monaco-editor'));
+    gulp.src(['node_modules/iguazio.dashboard-controls/node_modules/monaco-editor/**/*']).pipe(gulp.dest(config.assets_dir + '/monaco-editor'));
 });
 
 /**

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -32,7 +32,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "~0.0.58",
+    "iguazio.dashboard-controls": "~0.0.60",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",

--- a/pkg/dashboard/ui/src/app/app.controller.js
+++ b/pkg/dashboard/ui/src/app/app.controller.js
@@ -7,6 +7,6 @@
     function AppController() {
         var ctrl = this;
 
-        ctrl.pageTitle = 'Dashboard | nuclio';
+        ctrl.pageTitle = 'Dashboard | Nuclio';
     }
 }());


### PR DESCRIPTION
**Enhancements**
- Make either "Interval" or "Schedule" required, not both (for cron triggers)
- "Namespace" field is not required anymore
- Capitalize "Nuclio" in web page's title (seen on the browser's tab)
- Better handle monaco dependency

**Issues fixed**
- Can't vertically scroll Status tab (annoys when deploy panel is open)
- Split "URL" and "Container ID" by last slash of `spec.dataBinding.(name).url`