### PR TITLE
UI: Update dashboard-controls version to 0.0.61

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -32,7 +32,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "~0.0.60",
+    "iguazio.dashboard-controls": "~0.0.61",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
**Issues fixed**
- Slashes stripped from URL of v3io data binding