### PR TITLE
Update dashboard-controls version to 0.1.2 + Fix to Path

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -32,7 +32,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "~0.0.63",
+    "iguazio.dashboard-controls": "~0.1.2",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",

--- a/pkg/dashboard/ui/src/app/shared/services/nuclio-event-data.servie.js
+++ b/pkg/dashboard/ui/src/app/shared/services/nuclio-event-data.servie.js
@@ -85,7 +85,7 @@
         function invokeFunction(eventData) {
             var headers = {
                 'Content-Type': eventData.spec.attributes.headers['Content-Type'],
-                'x-nuclio-path': eventData.spec.attributes.headers['x-nuclio-path'],
+                'x-nuclio-path': eventData.spec.attributes.path,
                 'x-nuclio-function-name': eventData.metadata.labels['nuclio.io/function-name'],
                 'x-nuclio-invoke-via': 'external-ip'
             };


### PR DESCRIPTION
**Enhancements**
- Preparation to integration of Nuclio dashboard in Iguazio dashboard.

**Issues fixed**
- Path was not handled right for function events and invocations.