### PR TITLE
UI: Update dashboard-controls version to 0.1.5

### DIFF
--- a/pkg/dashboard/ui/gulpfile.js
+++ b/pkg/dashboard/ui/gulpfile.js
@@ -171,7 +171,9 @@ gulp.task('app.js', function () {
         .pipe(cache({
             path: config.cache_file,
             transformStreams: [
-                babel()
+                babel({
+                    ignore: ['node_modules/iguazio.dashboard-controls/dist/js/iguazio.dashboard-controls.js']
+                })
             ]
         }));
 

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -32,7 +32,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.1.3",
+    "iguazio.dashboard-controls": "^0.1.5",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
Depends on: https://github.com/iguazio/dashboard-controls/pull/197

Also avoids some warning during build.