### PR TITLE
Various dashboard HTTP REST API / doc fixes

### DIFF
--- a/cmd/dashboard/README.md
+++ b/cmd/dashboard/README.md
@@ -6,6 +6,9 @@ Table of contents:
 - [Function template](#function-template)
 - [Misc](#misc)
 
+## Notes
+1. `metadata.name` is mandatory in all bodies (required to identify the resource). If you omit `namespace`, the dashboard will use the default namespace, as configured in its command line arguments
+
 ## Function
 
 ### Listing all functions
@@ -124,7 +127,10 @@ To create a function, provide the following request and then periodically GET th
  {
     "metadata": {
         "name": "hello-world",
-        "namespace": "nuclio"
+        "namespace": "nuclio",
+        "labels": {
+            "nuclio.io/project-name": "function-project",
+        }
     },
     "spec": {
         "runtime": "golang",
@@ -182,7 +188,8 @@ Updating a function is similar to creating a function. The only differences are:
 
 ### Invoking a function
 #### Request
-* URL: `POST /api/function_invocations`
+The HTTP method you apply to this endpoint is the one with which dashboard will invoke the function. For example, if you `DELETE /api/function_invokations`, the HTTP method in the event as received by the function will be `DELETE`.
+* URL: `<Method> /api/function_invocations`
 * Headers:
   * `x-nuclio-function-name`: Function name (required)
   * `x-nuclio-function-namespace`: Namespace (required)
@@ -281,7 +288,7 @@ Creating a project is synchronous. By the time the response returns, the project
   * `Content-Type`: Must be set to `application/json`
 * Body:
 ```json
- {
+{
     "metadata": {
         "name": "my-project-1",
         "namespace": "nuclio"
@@ -316,7 +323,7 @@ Creating a project is synchronous. By the time the response returns, the project
 }
 ```
 #### Response
-* Status code: 200
+* Status code: 204
 
 ### Deleting a project
 Only projects with no functions can be deleted. Attempting to delete a project with functions will result in an error being returned.
@@ -443,7 +450,7 @@ The function event contains per-trigger attributes. The `triggerKind` specifies 
 ```
 
 ### Creating a function event
-Creating a function event is synchronous. By the time the response returns, the function event has been created. If `name` is omitted, a UUID is generated.
+Creating a function event is synchronous. By the time the response returns, the function event has been created. If `name` is omitted, a UUID is generated. Set the function name via the `nuclio.io/function-name` label in `metadata.labels`.
 
 #### Request
 * URL: `POST /api/function_events`
@@ -534,7 +541,7 @@ Creating a function event is synchronous. By the time the response returns, the 
 ```
 
 #### Response
-* Status code: 202
+* Status code: 204
 
 ### Deleting a function event
 

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -327,7 +327,7 @@ func (fr *functionResource) getFunctionInfoFromRequest(request *http.Request) (*
 	if functionInfoInstance.Meta == nil ||
 		functionInfoInstance.Meta.Name == "" ||
 		functionInfoInstance.Meta.Namespace == "" {
-		err := errors.New("Function name and namespace must be provided in metadata")
+		err := errors.New("Function name must be provided in metadata")
 
 		return nil, nuclio.WrapErrBadRequest(err)
 	}

--- a/pkg/dashboard/resource/functionevent.go
+++ b/pkg/dashboard/resource/functionevent.go
@@ -197,7 +197,7 @@ func (fer *functionEventResource) deleteFunctionEvent(request *http.Request) (*r
 
 func (fer *functionEventResource) updateFunctionEvent(request *http.Request) (*restful.CustomRouteFuncResponse, error) {
 
-	statusCode := http.StatusAccepted
+	statusCode := http.StatusNoContent
 
 	// get function event config and status from body
 	functionEventInfo, err := fer.getFunctionEventInfoFromRequest(request, true)
@@ -278,7 +278,7 @@ func (fer *functionEventResource) getFunctionEventInfoFromRequest(request *http.
 	if functionEventInfoInstance.Meta == nil ||
 		(nameRequired && functionEventInfoInstance.Meta.Name == "") ||
 		functionEventInfoInstance.Meta.Namespace == "" {
-		err := errors.New("Function event name and namespace must be provided in metadata")
+		err := errors.New("Function event name must be provided in metadata")
 
 		return nil, nuclio.WrapErrBadRequest(err)
 	}

--- a/pkg/dashboard/resource/invocation.go
+++ b/pkg/dashboard/resource/invocation.go
@@ -62,7 +62,7 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 
 	if functionName == "" || functionNamespace == "" {
 		responseWriter.WriteHeader(http.StatusBadRequest)
-		responseWriter.Write([]byte(`{"error": "Function name and namespace must be provided"}`)) // nolint: errcheck
+		responseWriter.Write([]byte(`{"error": "Function name must be provided"}`)) // nolint: errcheck
 		return
 	}
 

--- a/pkg/dashboard/resource/namespaces.go
+++ b/pkg/dashboard/resource/namespaces.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"net/http"
+
+	"github.com/nuclio/nuclio/pkg/dashboard"
+	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/restful"
+)
+
+type namespaceResource struct {
+	*resource
+}
+
+// GetAll returns all namespaces
+func (nr *namespaceResource) GetAll(request *http.Request) (map[string]restful.Attributes, error) {
+	namespaces, err := nr.getPlatform().GetNamespaces()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get external IP addresses")
+	}
+
+	response := map[string]restful.Attributes{
+		"namespaces": {
+			"names": namespaces,
+		},
+	}
+
+	return response, nil
+}
+
+// register the resource
+var namespaceResourceInstance = &namespaceResource{
+	resource: newResource("api/namespaces", []restful.ResourceMethod{
+		restful.ResourceMethodGetList,
+	}),
+}
+
+func init() {
+	namespaceResourceInstance.Resource = namespaceResourceInstance
+	namespaceResourceInstance.Register(dashboard.DashboardResourceRegistrySingleton)
+}

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -187,7 +187,7 @@ func (pr *projectResource) deleteProject(request *http.Request) (*restful.Custom
 
 func (pr *projectResource) updateProject(request *http.Request) (*restful.CustomRouteFuncResponse, error) {
 
-	statusCode := http.StatusAccepted
+	statusCode := http.StatusNoContent
 
 	// get project config and status from body
 	projectInfo, err := pr.getProjectInfoFromRequest(request, true)
@@ -264,7 +264,7 @@ func (pr *projectResource) getProjectInfoFromRequest(request *http.Request, name
 	if projectInfoInstance.Meta == nil ||
 		(nameRequired && projectInfoInstance.Meta.Name == "") ||
 		projectInfoInstance.Meta.Namespace == "" {
-		err := errors.New("Project name and namespace must be provided in metadata")
+		err := errors.New("Project name must be provided in metadata")
 
 		return nil, nuclio.WrapErrBadRequest(err)
 	}

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1055,7 +1055,7 @@ func (suite *projectTestSuite) TestUpdateSuccessful() {
 		Return(nil).
 		Once()
 
-	expectedStatusCode := http.StatusAccepted
+	expectedStatusCode := http.StatusNoContent
 	requestBody := `{
 	"metadata": {
 		"name": "p1",
@@ -1537,7 +1537,7 @@ func (suite *functionEventTestSuite) TestUpdateSuccessful() {
 		Return(nil).
 		Once()
 
-	expectedStatusCode := http.StatusAccepted
+	expectedStatusCode := http.StatusNoContent
 	requestBody := `{
 	"metadata": {
 		"name": "fe1",

--- a/pkg/platform/errors.go
+++ b/pkg/platform/errors.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platform
+
+import (
+	"github.com/nuclio/nuclio-sdk-go"
+)
+
+// A project contains functions, cannot be deleted
+var ErrProjectContainsFunctions = nuclio.NewErrConflict("Project contains functions")

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -320,7 +320,7 @@ func (p *Platform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOpt
 	}
 
 	if len(functions) != 0 {
-		return fmt.Errorf("Project has %d functions, can't delete", len(functions))
+		return platform.ErrProjectContainsFunctions
 	}
 
 	err = p.consumer.nuclioClientSet.NuclioV1beta1().

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -593,6 +593,22 @@ func (p *Platform) ResolveDefaultNamespace(defaultNamespace string) string {
 	return defaultNamespace
 }
 
+// GetNamespaces returns all the namespaces in the platform
+func (p *Platform) GetNamespaces() ([]string, error) {
+	namespaces, err := p.consumer.kubeClientSet.CoreV1().Namespaces().List(meta_v1.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to list namespaces")
+	}
+
+	var namespaceNames []string
+
+	for _, namespace := range namespaces.Items {
+		namespaceNames = append(namespaceNames, namespace.Name)
+	}
+
+	return namespaceNames, nil
+}
+
 func getKubeconfigFromHomeDir() string {
 	homeDir, err := homedir.Dir()
 	if err != nil {

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -37,6 +37,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/config"
 
 	"github.com/nuclio/logger"
+	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/nuclio/zap"
 )
 
@@ -222,6 +223,12 @@ func (p *Platform) DeleteFunction(deleteFunctionOptions *platform.DeleteFunction
 	// delete the function from the local store
 	err := p.localStore.deleteFunction(&deleteFunctionOptions.FunctionConfig.Meta)
 	if err != nil {
+
+		// propagate not found errors
+		if err == nuclio.ErrNotFound {
+			return err
+		}
+
 		p.Logger.WarnWith("Failed to delete function from local store", "err", err.Error())
 	}
 
@@ -358,11 +365,18 @@ func (p *Platform) GetExternalIPAddresses() ([]string, error) {
 
 // ResolveDefaultNamespace returns the proper default resource namespace, given the current default namespace
 func (p *Platform) ResolveDefaultNamespace(defaultNamespace string) string {
-	if defaultNamespace == "@nuclio.selfNamespace" {
+
+	// if no default namespace is chosen, use "nuclio"
+	if defaultNamespace == "@nuclio.selfNamespace" || defaultNamespace == "" {
 		return "nuclio"
 	}
 
 	return defaultNamespace
+}
+
+// GetNamespaces returns all the namespaces in the platform
+func (p *Platform) GetNamespaces() ([]string, error) {
+	return []string{"nuclio"}, nil
 }
 
 func (p *Platform) getFreeLocalPort() (int, error) {

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -296,7 +296,7 @@ func (p *Platform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOpt
 	}
 
 	if len(functions) != 0 {
-		return fmt.Errorf("Project has %d functions, can't delete", len(functions))
+		return platform.ErrProjectContainsFunctions
 	}
 
 	return p.localStore.deleteProject(&deleteProjectOptions.Meta)

--- a/pkg/platform/local/store.go
+++ b/pkg/platform/local/store.go
@@ -340,8 +340,14 @@ func (s *store) runCommand(env map[string]string, format string, args ...interfa
 func (s *store) deleteResource(resourceDir string, resourceNamespace string, resourceName string) error {
 	resourcePath := s.getResourcePath(resourceDir, resourceNamespace, resourceName)
 
+	// stat the file
+	_, _, err := s.runCommand(nil, "/bin/stat %s", resourcePath)
+	if err != nil {
+		return nuclio.ErrNotFound
+	}
+
 	// remove the file
-	_, _, err := s.runCommand(nil, "/bin/rm %s", resourcePath)
+	_, _, err = s.runCommand(nil, "/bin/rm %s", resourcePath)
 
 	// if there error indicates that there's no such file - that means nothing was created yet
 	cause := errors.Cause(err)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -98,6 +98,9 @@ type Platform interface {
 	// These addresses are either set through SetExternalIPAddresses or automatically discovered
 	GetExternalIPAddresses() ([]string, error)
 
+	// GetNamespaces returns all the namespaces in the platform
+	GetNamespaces() ([]string, error)
+
 	// GetHealthCheckMode returns the healthcheck mode the platform requires
 	GetHealthCheckMode() HealthCheckMode
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -142,7 +142,7 @@ func (b *Builder) Build(options *platform.CreateFunctionBuildOptions) (*platform
 	configurationRead := false
 	if common.IsFile(b.providedFunctionConfigFilePath()) {
 		b.logger.InfoWith("Reading user provided configuration", "path", b.providedFunctionConfigFilePath())
-		if _, err := b.readConfiguration(); err != nil {
+		if _, err = b.readConfiguration(); err != nil {
 			return nil, errors.Wrap(err, "Failed to read configuration")
 		}
 		configurationRead = true

--- a/pkg/processor/runtime/ruby/test/ruby_test.go
+++ b/pkg/processor/runtime/ruby/test/ruby_test.go
@@ -101,7 +101,7 @@ func (suite *TestSuite) TestOutputs() {
 					"Info message",
 					"Warn message",
 					"Error message",
-					"Response is",	// request debug log
+					"Response is", // request debug log
 				},
 			},
 			{

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -443,16 +443,16 @@ func (ar *AbstractResource) writeStatusCodeAndErrorReason(responseWriter http.Re
 	// get the status code from the error
 	statusCode := ar.getStatusCodeFromError(err, defaultStatusCode)
 
-	// set the status code at the end, seeing how you can't add headers to the response after you do this
-	defer responseWriter.WriteHeader(statusCode)
-
 	// if the status code is an actual error, write the error reason and return
 	if ar.statusCodeIsError(statusCode) {
 		responseWriter.Header().Set("Content-Type", "application/json")
+		responseWriter.WriteHeader(statusCode)
+
 		ar.writeErrorReason(responseWriter, err)
 
 		return true
 	}
 
+	responseWriter.WriteHeader(statusCode)
 	return false
 }

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -442,10 +442,13 @@ func (ar *AbstractResource) writeStatusCodeAndErrorReason(responseWriter http.Re
 
 	// get the status code from the error
 	statusCode := ar.getStatusCodeFromError(err, defaultStatusCode)
-	responseWriter.WriteHeader(statusCode)
+
+	// set the status code at the end, seeing how you can't add headers to the response after you do this
+	defer responseWriter.WriteHeader(statusCode)
 
 	// if the status code is an actual error, write the error reason and return
 	if ar.statusCodeIsError(statusCode) {
+		responseWriter.Header().Set("Content-Type", "application/json")
 		ar.writeErrorReason(responseWriter, err)
 
 		return true


### PR DESCRIPTION
1. Update function event / project returns 204 rather than 202
2. Error messages no longer indicate namespace is mandated
3. Dashboard supports /api/namespaces - returns a list of namespaces if dashboard is capable of retreiving this
4. Deleting project with functions returns 409 rather than 500
5. Performing actions that return error (e.g. updating a project without specifying name) sets content-type to application/json (rather than text/plain)
6. Deleting a non-existing resource (e.g. function / project) will return 404
