### PR TITLE
Update dashboard-controls version to 0.1.6

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -33,7 +33,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.1.5",
+    "iguazio.dashboard-controls": "^0.1.6",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
**Enhancements**
- Remove "Num Container Workers" field from v3io-stream trigger
- Add "Num Workers" to v3io data binding
- Implement "Test" pane
- Change URL and page title from "trigger" to "triggers"

**Fixed issues**
- Broken screen on nav to non-existing project