### PR TITLE
UI: Update dashboard-controls version to 0.1.8 + more

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -45,7 +45,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.1.7",
+    "iguazio.dashboard-controls": "^0.1.8",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",

--- a/pkg/dashboard/ui/src/app/shared/services/nuclio-event-data.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/nuclio-event-data.service.js
@@ -93,7 +93,8 @@
             var headers = lodash.assign({}, userDefinedHeaders, {
                 'x-nuclio-function-name': eventData.metadata.labels['nuclio.io/function-name'],
                 'x-nuclio-invoke-via': 'external-ip',
-                'x-nuclio-path': eventData.spec.attributes.path
+                'x-nuclio-path': eventData.spec.attributes.path,
+                'x-nuclio-log-level': 'debug'
             });
 
             var config = {


### PR DESCRIPTION
Depends on https://github.com/iguazio/dashboard-controls/pull/207

**Improvements**
- Send `x-nuclio-log-level` header on function invocation to get `x-nuclio-logs` header on response.
- Specific error message when attempting to delete a non-empty project.

**Issues fixed**
- Function deletion not working in functions list after one function is deleted.
- Can't create new functions.