### PR TITLE
Allow triggers to wait for an available worker rather than return error immediately

### DIFF
--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -67,6 +67,8 @@ The `spec` section contains the requirements and attributes and has the followin
 | triggers.(name).maxWorkers | int | The max number of concurrent requests this trigger can process |
 | triggers.(name).kind | string | The kind of trigger. One of `http`, `kafka`, `kinesis`, `eventhub`, `cron`, `nats`, `rabbitmq` |
 | triggers.(name).url | string | The trigger specific URL (not used by all triggers) |
+| triggers.(name).annotations | list of string | Annotations to be assigned to the trigger, if applicable |
+| triggers.(name).workerAvailabilityTimeoutMilliseconds | int | The number of milliseconds to wait for a worker if one is not available. 0 = never wait |
 | triggers.(name).attributes | See [reference](/docs/reference/triggers) | The per-trigger attributes |
 | build.path | string | A local directory or URL to a file/archive containing source and configuration |
 | build.functionSourceCode | string | The source code of the function, encoded in Base64. Mutually exclusive with build.path |

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -61,7 +61,7 @@ type Trigger struct {
 	Secret                                string            `json:"secret,omitempty"`
 	Partitions                            []Partition       `json:"partitions,omitempty"`
 	Annotations                           map[string]string `json:"annotations,omitempty"`
-	WorkerAvailabilityTimeoutMilliseconds int               `json:"workerAvailableTimeout,omitempty"`
+	WorkerAvailabilityTimeoutMilliseconds int               `json:"workerAvailabilityTimeoutMilliseconds,omitempty"`
 
 	// Dealer Information
 	TotalTasks        int `json:"total_tasks,omitempty"`

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -51,16 +51,17 @@ type Volume struct {
 
 // Trigger holds configuration for a trigger
 type Trigger struct {
-	Class       string            `json:"class"`
-	Kind        string            `json:"kind"`
-	Disabled    bool              `json:"disabled,omitempty"`
-	MaxWorkers  int               `json:"maxWorkers,omitempty"`
-	URL         string            `json:"url,omitempty"`
-	Paths       []string          `json:"paths,omitempty"`
-	User        string            `json:"user,omitempty"`
-	Secret      string            `json:"secret,omitempty"`
-	Partitions  []Partition       `json:"partitions,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
+	Class                                 string            `json:"class"`
+	Kind                                  string            `json:"kind"`
+	Disabled                              bool              `json:"disabled,omitempty"`
+	MaxWorkers                            int               `json:"maxWorkers,omitempty"`
+	URL                                   string            `json:"url,omitempty"`
+	Paths                                 []string          `json:"paths,omitempty"`
+	User                                  string            `json:"user,omitempty"`
+	Secret                                string            `json:"secret,omitempty"`
+	Partitions                            []Partition       `json:"partitions,omitempty"`
+	Annotations                           map[string]string `json:"annotations,omitempty"`
+	WorkerAvailabilityTimeoutMilliseconds int               `json:"workerAvailableTimeout,omitempty"`
 
 	// Dealer Information
 	TotalTasks        int `json:"total_tasks,omitempty"`

--- a/pkg/processor/test/workerwait/suite_test.go
+++ b/pkg/processor/test/workerwait/suite_test.go
@@ -49,8 +49,8 @@ func (suite *workerWaitTestSuite) deploySleeperWithTimeout(workerAvailabilityTim
 	createFunctionOptions.FunctionConfig.Spec.Runtime = "golang"
 	createFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{
 		"http": {
-			Kind:         "http",
-			MaxWorkers:   1,
+			Kind:                                  "http",
+			MaxWorkers:                            1,
 			WorkerAvailabilityTimeoutMilliseconds: workerAvailabilityTimeoutMilliseconds,
 		},
 	}
@@ -69,8 +69,10 @@ func (suite *workerWaitTestSuite) deploySleeperWithTimeout(workerAvailabilityTim
 					ExpectedResponseBody: func(body []byte, statusCode int) {
 						switch statusCode {
 						case 200:
+							suite.Logger.DebugWith("Got 200")
 							atomic.AddUint64(&successes, 1)
 						case 503:
+							suite.Logger.DebugWith("Got 503")
 							atomic.AddUint64(&errors, 1)
 						default:
 							suite.FailNow("Unexpected response")
@@ -79,6 +81,7 @@ func (suite *workerWaitTestSuite) deploySleeperWithTimeout(workerAvailabilityTim
 				}
 
 				suite.SendRequestVerifyResponse(&testRequest)
+
 				waitGroup.Done()
 			}()
 		}

--- a/pkg/processor/test/workerwait/suite_test.go
+++ b/pkg/processor/test/workerwait/suite_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workerwait
+
+import (
+	"path"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type workerWaitTestSuite struct { // nolint
+	httpsuite.TestSuite
+}
+
+func (suite *workerWaitTestSuite) TestGolang() {
+	suite.deploySleeperWithTimeout(0, 5, 1, 4)
+	suite.deploySleeperWithTimeout(10000, 5, 5, 0)
+}
+
+func (suite *workerWaitTestSuite) deploySleeperWithTimeout(workerAvailabilityTimeoutMilliseconds int,
+	numConcurrentRequests int,
+	expectedSuccesses int,
+	expectedErrors int) {
+
+	createFunctionOptions := suite.GetDeployOptions("sleeper",
+		path.Join(suite.GetTestFunctionsDir(), "common", "sleeper", "golang"))
+
+	createFunctionOptions.FunctionConfig.Spec.Runtime = "golang"
+	createFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{
+		"http": {
+			Kind:         "http",
+			MaxWorkers:   1,
+			WorkerAvailabilityTimeoutMilliseconds: workerAvailabilityTimeoutMilliseconds,
+		},
+	}
+
+	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+		var successes, errors uint64
+
+		waitGroup := sync.WaitGroup{}
+		waitGroup.Add(numConcurrentRequests)
+
+		for idx := 0; idx < numConcurrentRequests; idx++ {
+			go func() {
+				testRequest := httpsuite.Request{
+					RequestMethod: "POST",
+					RequestPort:   deployResult.Port,
+					ExpectedResponseBody: func(body []byte, statusCode int) {
+						switch statusCode {
+						case 200:
+							atomic.AddUint64(&successes, 1)
+						case 503:
+							atomic.AddUint64(&errors, 1)
+						default:
+							suite.FailNow("Unexpected response")
+						}
+					},
+				}
+
+				suite.SendRequestVerifyResponse(&testRequest)
+				waitGroup.Done()
+			}()
+		}
+
+		// wait until all 4 requests are done
+		waitGroup.Wait()
+
+		suite.Require().Equal(int(successes), expectedSuccesses)
+		suite.Require().Equal(int(errors), expectedErrors)
+
+		return true
+	})
+}
+
+func TestWorkerWaitSuite(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	suite.Run(t, new(workerWaitTestSuite))
+}

--- a/pkg/processor/trigger/http/test/suite/suite.go
+++ b/pkg/processor/trigger/http/test/suite/suite.go
@@ -217,6 +217,8 @@ func (suite *TestSuite) SendRequestVerifyResponse(request *Request) bool {
 		suite.Require().Regexp(typedExpectedResponseBody, string(body))
 	case func([]byte):
 		typedExpectedResponseBody(body)
+	case func([]byte, int):
+		typedExpectedResponseBody(body, httpResponse.StatusCode)
 	}
 
 	// if there are logs expected, verify them

--- a/pkg/processor/trigger/http/test/suite/suite.go
+++ b/pkg/processor/trigger/http/test/suite/suite.go
@@ -81,7 +81,7 @@ func (suite *TestSuite) SetupTest() {
 	suite.TestSuite.SetupTest()
 
 	suite.httpClient = &http.Client{
-		Timeout: 5 * time.Second,
+		Timeout: 10 * time.Second,
 	}
 }
 

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -122,7 +122,9 @@ func (h *http) requestHandler(ctx *fasthttp.RequestCtx) {
 		functionLogger, _ = nucliozap.NewMuxLogger(bufferLogger.Logger, h.Logger)
 	}
 
-	response, submitError, processError := h.AllocateWorkerAndSubmitEvent(ctx, functionLogger, 10*time.Second)
+	response, submitError, processError := h.AllocateWorkerAndSubmitEvent(ctx,
+		functionLogger,
+		time.Duration(h.configuration.WorkerAvailabilityTimeoutMilliseconds)*time.Millisecond)
 
 	if responseLogLevel != nil {
 

--- a/test/_functions/common/sleeper/golang/sleeper.go
+++ b/test/_functions/common/sleeper/golang/sleeper.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"time"
+
+	"github.com/nuclio/nuclio-sdk-go"
+)
+
+func Sleeper(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
+	time.Sleep(1 * time.Second)
+
+	return nil, nil
+}

--- a/test/_functions/common/sleeper/golang/sleeper.go
+++ b/test/_functions/common/sleeper/golang/sleeper.go
@@ -23,6 +23,8 @@ import (
 )
 
 func Sleeper(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
+	context.Logger.InfoWith("Got event, sleeping")
+
 	time.Sleep(1 * time.Second)
 
 	return nil, nil


### PR DESCRIPTION
Before this PR, if an event arrived at a trigger and no worker was available to handle it - the trigger would receive and return an error (e.g. 503 in HTTP). This PR introduces a new trigger configuration with a snappy name: `workerAvailabilityTimeoutMilliseconds` that allows specifying a timeout.

If this value is left unset or set to 0 - the behavior of the trigger is unchanged (including no performance hit). If this value is set, the trigger will wait for a worker to become available for this duration of time (with a certain amount of performance hit - to be determined by benchmarking). 