### PR TITLE
Allow for multiple golang functions in a single image

### DIFF
--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
@@ -58,11 +58,14 @@ COPY pkg/processor/build/runtime/golang/docker/onbuild/build-handler.sh /
 # Specify the directory where the handler is kept. By default it is the context dir, but it is overridable
 ONBUILD ARG NUCLIO_BUILD_LOCAL_HANDLER_DIR=.
 
+# Specify the directory where the handler is written to
+ONBUILD ARG NUCLIO_BUILD_IMAGE_HANDLER_DIR=github.com/nuclio/handler
+
 # Copy handler sources to container, build-handler will move it to the right place
-ONBUILD COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} /go/src/github.com/nuclio/handler
+ONBUILD COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} /go/src/${NUCLIO_BUILD_IMAGE_HANDLER_DIR}
 
 # Specify an onbuild arg to specify offline
 ONBUILD ARG NUCLIO_BUILD_OFFLINE
 
 # Run build
-ONBUILD RUN /build-handler.sh
+ONBUILD RUN /build-handler.sh ${NUCLIO_BUILD_IMAGE_HANDLER_DIR}

--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile.alpine
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile.alpine
@@ -68,11 +68,14 @@ COPY pkg/processor/build/runtime/golang/docker/onbuild/build-handler.sh /
 # Specify the directory where the handler is kept. By default it is the context dir, but it is overridable
 ONBUILD ARG NUCLIO_BUILD_LOCAL_HANDLER_DIR=.
 
+# Specify the directory where the handler is written to
+ONBUILD ARG NUCLIO_BUILD_IMAGE_HANDLER_DIR=github.com/nuclio/handler
+
 # Copy handler sources to container, build-handler will move it to the right place
-ONBUILD COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} /go/src/github.com/nuclio/handler
+ONBUILD COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} /go/src/${NUCLIO_BUILD_IMAGE_HANDLER_DIR}
 
 # Specify an onbuild arg to specify offline
 ONBUILD ARG NUCLIO_BUILD_OFFLINE
 
 # Run build
-ONBUILD RUN /build-handler.sh
+ONBUILD RUN /build-handler.sh ${NUCLIO_BUILD_IMAGE_HANDLER_DIR}

--- a/pkg/processor/build/runtime/golang/docker/onbuild/build-handler.sh
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/build-handler.sh
@@ -21,7 +21,7 @@
 
 set -e
 
-cd /go/src/github.com/nuclio/handler
+cd /go/src/$1
 
 # if specified to build offline, skip go get
 if [ "${NUCLIO_BUILD_OFFLINE}" != "true" ]; then

--- a/pkg/processor/runtime/runtime.go
+++ b/pkg/processor/runtime/runtime.go
@@ -74,8 +74,9 @@ func NewAbstractRuntime(logger logger.Logger, configuration *Configuration) (*Ab
 	}
 
 	// set some environment variables
-	os.Setenv("NUCLIO_HANDLER", configuration.Spec.Handler)
-	os.Setenv("NUCLIO_RUNTIME", configuration.Spec.Runtime)
+	if err := os.Setenv("NUCLIO_HANDLER", configuration.Spec.Handler); err != nil {
+		return nil, errors.Wrap(err, "Failed to set handler env")
+	}
 
 	// create data bindings and start them (connecting to the actual data sources)
 	newAbstractRuntime.databindings, err = newAbstractRuntime.createAndStartDataBindings(logger, configuration)

--- a/pkg/processor/runtime/runtime.go
+++ b/pkg/processor/runtime/runtime.go
@@ -17,6 +17,8 @@ limitations under the License.
 package runtime
 
 import (
+	"os"
+
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/processor/databinding"
 	"github.com/nuclio/nuclio/pkg/processor/status"
@@ -70,6 +72,10 @@ func NewAbstractRuntime(logger logger.Logger, configuration *Configuration) (*Ab
 		FunctionLogger: configuration.FunctionLogger,
 		configuration:  configuration,
 	}
+
+	// set some environment variables
+	os.Setenv("NUCLIO_HANDLER", configuration.Spec.Handler)
+	os.Setenv("NUCLIO_RUNTIME", configuration.Spec.Runtime)
 
 	// create data bindings and start them (connecting to the actual data sources)
 	newAbstractRuntime.databindings, err = newAbstractRuntime.createAndStartDataBindings(logger, configuration)


### PR DESCRIPTION
1. User should be able to configure what was previously "github.com/nuclio/handler" - otherwise local imports won't work
2. User should be able to know how the handler during runtime to route `InitContext` to the proper function