### PR TITLE
Experimental: Shared workers

### DIFF
--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -62,6 +62,7 @@ type Trigger struct {
 	Partitions                            []Partition       `json:"partitions,omitempty"`
 	Annotations                           map[string]string `json:"annotations,omitempty"`
 	WorkerAvailabilityTimeoutMilliseconds int               `json:"workerAvailabilityTimeoutMilliseconds,omitempty"`
+	WorkerAllocatorName                   string            `json:"workerAllocatorName,omitempty"`
 
 	// Dealer Information
 	TotalTasks        int `json:"total_tasks,omitempty"`

--- a/pkg/processor/runtime/runtime.go
+++ b/pkg/processor/runtime/runtime.go
@@ -74,7 +74,7 @@ func NewAbstractRuntime(logger logger.Logger, configuration *Configuration) (*Ab
 	}
 
 	// set some environment variables
-	if err := os.Setenv("NUCLIO_HANDLER", configuration.Spec.Handler); err != nil {
+	if err = os.Setenv("NUCLIO_HANDLER", configuration.Spec.Handler); err != nil {
 		return nil, errors.Wrap(err, "Failed to set handler env")
 	}
 

--- a/pkg/processor/trigger/factory.go
+++ b/pkg/processor/trigger/factory.go
@@ -1,0 +1,36 @@
+package trigger
+
+import (
+	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/processor/worker"
+)
+
+type Factory struct{}
+
+func (f *Factory) GetWorkerAllocator(workerAllocatorName string,
+	namedWorkerAllocators map[string]worker.Allocator,
+	workerAllocatorCreator func() (worker.Allocator, error)) (worker.Allocator, error) {
+
+	// if our allocator is unnamed, just create a worker allocator
+	if workerAllocatorName == "" {
+		return workerAllocatorCreator()
+	}
+
+	// try to find worker allocator
+	workerAllocator, workerAllocatorExists := namedWorkerAllocators[workerAllocatorName]
+
+	// if it already exists, just use it
+	if workerAllocatorExists {
+		return workerAllocator, nil
+	}
+
+	// if it doesn't exist - create it
+	workerAllocator, err := workerAllocatorCreator()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create worker allocator")
+	}
+
+	namedWorkerAllocators[workerAllocatorName] = workerAllocator
+
+	return workerAllocator, nil
+}

--- a/pkg/processor/trigger/kinesis/factory.go
+++ b/pkg/processor/trigger/kinesis/factory.go
@@ -31,7 +31,8 @@ type factory struct{}
 func (f *factory) Create(parentLogger logger.Logger,
 	ID string,
 	triggerConfiguration *functionconfig.Trigger,
-	runtimeConfiguration *runtime.Configuration) (trigger.Trigger, error) {
+	runtimeConfiguration *runtime.Configuration,
+	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
 
 	// create logger parent
 	kinesisLogger := parentLogger.GetChild("kinesis")

--- a/pkg/processor/trigger/nats/factory.go
+++ b/pkg/processor/trigger/nats/factory.go
@@ -31,7 +31,8 @@ type factory struct{}
 func (f *factory) Create(parentLogger logger.Logger,
 	ID string,
 	triggerConfiguration *functionconfig.Trigger,
-	runtimeConfiguration *runtime.Configuration) (trigger.Trigger, error) {
+	runtimeConfiguration *runtime.Configuration,
+	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
 
 	// create logger parent
 	natsLogger := parentLogger.GetChild("nats")

--- a/pkg/processor/trigger/partitioned/eventhub/factory.go
+++ b/pkg/processor/trigger/partitioned/eventhub/factory.go
@@ -31,7 +31,8 @@ type factory struct{}
 func (f *factory) Create(parentLogger logger.Logger,
 	ID string,
 	triggerConfiguration *functionconfig.Trigger,
-	runtimeConfiguration *runtime.Configuration) (trigger.Trigger, error) {
+	runtimeConfiguration *runtime.Configuration,
+	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
 	var triggerInstance trigger.Trigger
 
 	// create logger parent

--- a/pkg/processor/trigger/partitioned/kafka/factory.go
+++ b/pkg/processor/trigger/partitioned/kafka/factory.go
@@ -31,7 +31,8 @@ type factory struct{}
 func (f *factory) Create(parentLogger logger.Logger,
 	ID string,
 	triggerConfiguration *functionconfig.Trigger,
-	runtimeConfiguration *runtime.Configuration) (trigger.Trigger, error) {
+	runtimeConfiguration *runtime.Configuration,
+	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
 	var triggerInstance trigger.Trigger
 
 	// create logger parent

--- a/pkg/processor/trigger/partitioned/v3io/factory.go
+++ b/pkg/processor/trigger/partitioned/v3io/factory.go
@@ -31,7 +31,8 @@ type factory struct{}
 func (f *factory) Create(parentLogger logger.Logger,
 	ID string,
 	triggerConfiguration *functionconfig.Trigger,
-	runtimeConfiguration *runtime.Configuration) (trigger.Trigger, error) {
+	runtimeConfiguration *runtime.Configuration,
+	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
 	var triggerInstance trigger.Trigger
 
 	// create logger parent

--- a/pkg/processor/trigger/poller/v3ioitempoller/factory.go
+++ b/pkg/processor/trigger/poller/v3ioitempoller/factory.go
@@ -31,7 +31,8 @@ type factory struct{}
 func (f *factory) Create(parentLogger logger.Logger,
 	ID string,
 	triggerConfiguration *functionconfig.Trigger,
-	runtimeConfiguration *runtime.Configuration) (trigger.Trigger, error) {
+	runtimeConfiguration *runtime.Configuration,
+	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
 
 	// create logger parent
 	v3ioItemPollerLogger := parentLogger.GetChild("v3io_item_poller")

--- a/pkg/processor/trigger/rabbitmq/factory.go
+++ b/pkg/processor/trigger/rabbitmq/factory.go
@@ -31,7 +31,8 @@ type factory struct{}
 func (f *factory) Create(parentLogger logger.Logger,
 	ID string,
 	triggerConfiguration *functionconfig.Trigger,
-	runtimeConfiguration *runtime.Configuration) (trigger.Trigger, error) {
+	runtimeConfiguration *runtime.Configuration,
+	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
 
 	// create logger parent
 	rabbitMqLogger := parentLogger.GetChild("rabbit_mq")

--- a/pkg/processor/trigger/registry.go
+++ b/pkg/processor/trigger/registry.go
@@ -19,6 +19,7 @@ package trigger
 import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/worker"
 	"github.com/nuclio/nuclio/pkg/registry"
 
 	"github.com/nuclio/logger"
@@ -28,7 +29,7 @@ import (
 type Creator interface {
 
 	// Create creates a trigger instance
-	Create(logger.Logger, string, *functionconfig.Trigger, *runtime.Configuration) (Trigger, error)
+	Create(logger.Logger, string, *functionconfig.Trigger, *runtime.Configuration, map[string]worker.Allocator) (Trigger, error)
 }
 
 type Registry struct {
@@ -44,7 +45,8 @@ func (r *Registry) NewTrigger(logger logger.Logger,
 	kind string,
 	name string,
 	triggerConfiguration *functionconfig.Trigger,
-	runtimeConfiguration *runtime.Configuration) (Trigger, error) {
+	runtimeConfiguration *runtime.Configuration,
+	namedWorkerAllocators map[string]worker.Allocator) (Trigger, error) {
 
 	registree, err := r.Get(kind)
 	if err != nil {
@@ -54,5 +56,6 @@ func (r *Registry) NewTrigger(logger logger.Logger,
 	return registree.(Creator).Create(logger,
 		name,
 		triggerConfiguration,
-		runtimeConfiguration)
+		runtimeConfiguration,
+		namedWorkerAllocators)
 }


### PR DESCRIPTION
Allows different triggers to share their worker pool. This allows re-using context state across different triggers (e.g. cron and http calling the same stateful function) and reducing the number of workers (e.g. two HTTP triggers for two different ports)

Currently only for cron and HTTP.