### PR TITLE
Fix update of projects and function events in k8s platform

### DIFF
--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -441,17 +441,17 @@ func (p *Platform) UpdateFunctionEvent(updateFunctionEventOptions *platform.Upda
 		Get(updateFunctionEventOptions.FunctionEventConfig.Meta.Name, meta_v1.GetOptions{})
 
 	if err != nil {
-		return errors.Wrap(err, "Failed to get function")
+		return errors.Wrap(err, "Failed to get function event")
 	}
 
 	// update it with spec if passed
 	if &updateFunctionEventOptions.FunctionEventConfig.Spec != nil {
-		functionEvent.Spec = updateFunctionEventOptions.FunctionEventConfig.Spec
+		functionEvent.Spec = updatedFunctionEvent.Spec
 	}
 
 	_, err = p.consumer.nuclioClientSet.NuclioV1beta1().
 		FunctionEvents(updateFunctionEventOptions.FunctionEventConfig.Meta.Namespace).
-		Update(functionEvent)
+		Update(&updatedFunctionEvent)
 
 	if err != nil {
 		return errors.Wrap(err, "Failed to update function event")

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -296,6 +296,9 @@ func (p *Platform) UpdateProject(updateProjectOptions *platform.UpdateProjectOpt
 	project, err := p.consumer.nuclioClientSet.NuclioV1beta1().
 		Projects(updateProjectOptions.ProjectConfig.Meta.Namespace).
 		Get(updateProjectOptions.ProjectConfig.Meta.Name, meta_v1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(err, "Failed to get projects")
+	}
 
 	updatedProject := nuclioio.Project{}
 	p.platformProjectToProject(&updateProjectOptions.ProjectConfig, &updatedProject)
@@ -435,7 +438,7 @@ func (p *Platform) UpdateFunctionEvent(updateFunctionEventOptions *platform.Upda
 
 	functionEvent, err := p.consumer.nuclioClientSet.NuclioV1beta1().
 		FunctionEvents(updateFunctionEventOptions.FunctionEventConfig.Meta.Namespace).
-			Get(updateFunctionEventOptions.FunctionEventConfig.Meta.Name, meta_v1.GetOptions{})
+		Get(updateFunctionEventOptions.FunctionEventConfig.Meta.Name, meta_v1.GetOptions{})
 
 	if err != nil {
 		return errors.Wrap(err, "Failed to get function")

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -451,7 +451,7 @@ func (p *Platform) UpdateFunctionEvent(updateFunctionEventOptions *platform.Upda
 
 	_, err = p.consumer.nuclioClientSet.NuclioV1beta1().
 		FunctionEvents(updateFunctionEventOptions.FunctionEventConfig.Meta.Namespace).
-		Update(&updatedFunctionEvent)
+		Update(&functionEvent)
 
 	if err != nil {
 		return errors.Wrap(err, "Failed to update function event")

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -293,12 +293,20 @@ func (p *Platform) CreateProject(createProjectOptions *platform.CreateProjectOpt
 
 // UpdateProject will update a previously existing project
 func (p *Platform) UpdateProject(updateProjectOptions *platform.UpdateProjectOptions) error {
+	project, err := p.consumer.nuclioClientSet.NuclioV1beta1().
+		Projects(updateProjectOptions.ProjectConfig.Meta.Namespace).
+		Get(updateProjectOptions.ProjectConfig.Meta.Name, meta_v1.GetOptions{})
+
 	updatedProject := nuclioio.Project{}
 	p.platformProjectToProject(&updateProjectOptions.ProjectConfig, &updatedProject)
 
-	_, err := p.consumer.nuclioClientSet.NuclioV1beta1().
+	if &updatedProject.Spec != nil {
+		project.Spec = updatedProject.Spec
+	}
+
+	_, err = p.consumer.nuclioClientSet.NuclioV1beta1().
 		Projects(updateProjectOptions.ProjectConfig.Meta.Namespace).
-		Update(&updatedProject)
+		Update(project)
 
 	if err != nil {
 		return errors.Wrap(err, "Failed to update project")
@@ -425,9 +433,22 @@ func (p *Platform) UpdateFunctionEvent(updateFunctionEventOptions *platform.Upda
 	updatedFunctionEvent := nuclioio.FunctionEvent{}
 	p.platformFunctionEventToFunctionEvent(&updateFunctionEventOptions.FunctionEventConfig, &updatedFunctionEvent)
 
-	_, err := p.consumer.nuclioClientSet.NuclioV1beta1().
+	functionEvent, err := p.consumer.nuclioClientSet.NuclioV1beta1().
 		FunctionEvents(updateFunctionEventOptions.FunctionEventConfig.Meta.Namespace).
-		Update(&updatedFunctionEvent)
+			Get(updateFunctionEventOptions.FunctionEventConfig.Meta.Name, meta_v1.GetOptions{})
+
+	if err != nil {
+		return errors.Wrap(err, "Failed to get function")
+	}
+
+	// update it with spec if passed
+	if &updateFunctionEventOptions.FunctionEventConfig.Spec != nil {
+		functionEvent.Spec = updateFunctionEventOptions.FunctionEventConfig.Spec
+	}
+
+	_, err = p.consumer.nuclioClientSet.NuclioV1beta1().
+		FunctionEvents(updateFunctionEventOptions.FunctionEventConfig.Meta.Namespace).
+		Update(functionEvent)
 
 	if err != nil {
 		return errors.Wrap(err, "Failed to update function event")

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -451,7 +451,7 @@ func (p *Platform) UpdateFunctionEvent(updateFunctionEventOptions *platform.Upda
 
 	_, err = p.consumer.nuclioClientSet.NuclioV1beta1().
 		FunctionEvents(updateFunctionEventOptions.FunctionEventConfig.Meta.Namespace).
-		Update(&functionEvent)
+		Update(functionEvent)
 
 	if err != nil {
 		return errors.Wrap(err, "Failed to update function event")


### PR DESCRIPTION
Update of projects and function events on k8s didn't worked since it expected a `metadata.resourceVersion` to be present.
Providing it the needed metadata by first doing Get on the requested function event or project