### PR TITLE
Fix: Include function metadata in the generated processor ConfigMap for k8s deployments

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -982,6 +982,12 @@ func (lc *lazyClient) populateConfigMap(labels map[string]string,
 
 	if err := configWriter.Write(&configMapContents, &processor.Configuration{
 		Config: functionconfig.Config{
+			Meta: functionconfig.Meta{
+				Name:        function.Name,
+				Namespace:   function.Namespace,
+				Labels:      labels,
+				Annotations: function.Annotations,
+			},
 			Spec: function.Spec,
 		},
 	}); err != nil {


### PR DESCRIPTION
Some triggers (e.g. RabbitMQ) use the runtime.Configuration metadata passed to the Start() method to generate unique names for things such as worker queues. Currently, this is not included in the ConfigMap used to provide the metadata to processors running on Kubernetes. This PR updates the ConfigMap generation code to include all relevant metadata.

Thanks to @pavius for basically all of this :-)
