### PR TITLE
Inferring default external ip based on platform type

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -45,9 +45,6 @@ func main() {
 	defaultNoPullBaseImages := os.Getenv("NUCLIO_DASHBOARD_NO_PULL_BASE_IMAGES") == "true"
 
 	externalIPAddressesDefault := os.Getenv("NUCLIO_DASHBOARD_EXTERNAL_IP_ADDRESSES")
-	if externalIPAddressesDefault == "" {
-		externalIPAddressesDefault = "172.17.0.1"
-	}
 
 	listenAddress := flag.String("listen-addr", ":8070", "IP/port on which the playground listens")
 	dockerKeyDir := flag.String("docker-key-dir", "", "Directory to look for docker keys for secure registries")

--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.1.15
+version: 0.1.16
 appVersion: 0.5.8
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -16,7 +16,7 @@ dashboard:
     tag: 0.5.8-amd64
     pullPolicy: IfNotPresent
   baseImagePullPolicy: IfNotPresent
-  externalIPAddresses: {}
+  externalIPAddresses: []
 
   # Uncomment to configure node port
   # nodePort: 32050


### PR DESCRIPTION
Before this commit, if a user did not pass any external ip address, the docker daemon ip address is used as default on all type of platforms.

This change includes that:
- on kubernetes based systems, default external ip address should not be the docker daemon but an empty array of string, this will have the handler `/api/external_ip_addresses` return the internal or external ip addresses of the cluster nodes
- on docker based systems, the default stays as docker daemon ip address
- fix on helm, passing empty list and not empty map on default
- user can still pass custom external ips as before