### PR TITLE
fix local deployment timeout

### DIFF
--- a/cmd/dashboard/app/dashboard.go
+++ b/cmd/dashboard/app/dashboard.go
@@ -53,7 +53,10 @@ func Run(listenAddress string,
 	// set external ip addresses based if user passed overriding values or not
 	var splitExternalIPAddresses []string
 	if externalIPAddresses == "" {
-		splitExternalIPAddresses = platformInstance.GetDefaultInvokeIPAddresses()
+		splitExternalIPAddresses, err = platformInstance.GetDefaultInvokeIPAddresses()
+		if err != nil {
+			return errors.Wrap(err, "Failed to get default invoke ip addresses")
+		}
 	} else {
 
 		// "10.0.0.1,10.0.0.2" -> ["10.0.0.1", "10.0.0.2"]

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -201,9 +201,9 @@ func (mp *mockPlatform) GetNamespaces() ([]string, error) {
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (mp *mockPlatform) GetDefaultInvokeIPAddresses() []string {
+func (mp *mockPlatform) GetDefaultInvokeIPAddresses() ([]string, error) {
 	args := mp.Called()
-	return args.Get(0).([]string)
+	return args.Get(0).([]string), args.Error(1)
 }
 
 //

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -637,8 +637,8 @@ func (p *Platform) GetNamespaces() ([]string, error) {
 	return namespaceNames, nil
 }
 
-func (p *Platform) GetDefaultInvokeIPAddresses() []string {
-	return []string{}
+func (p *Platform) GetDefaultInvokeIPAddresses() ([]string, error) {
+	return []string{}, nil
 }
 
 func getKubeconfigFromHomeDir() string {

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -412,8 +412,8 @@ func (p *Platform) GetNamespaces() ([]string, error) {
 	return []string{"nuclio"}, nil
 }
 
-func (p *Platform) GetDefaultInvokeIPAddresses() []string {
-	return []string{"172.17.0.1"}
+func (p *Platform) GetDefaultInvokeIPAddresses() ([]string, error) {
+	return []string{"172.17.0.1"}, nil
 }
 
 func (p *Platform) getFreeLocalPort() (int, error) {
@@ -502,13 +502,14 @@ func (p *Platform) deployFunction(createFunctionOptions *platform.CreateFunction
 
 	p.Logger.InfoWith("Waiting for function to be ready", "timeout", createFunctionOptions.FunctionConfig.Spec.ReadinessTimeoutSeconds)
 
-	var readinessTimeout *time.Duration
+	var readinessTimeout time.Duration
 	if createFunctionOptions.FunctionConfig.Spec.ReadinessTimeoutSeconds != 0 {
-		duration := time.Duration(createFunctionOptions.FunctionConfig.Spec.ReadinessTimeoutSeconds) * time.Second
-		readinessTimeout = &duration
+		readinessTimeout = time.Duration(createFunctionOptions.FunctionConfig.Spec.ReadinessTimeoutSeconds) * time.Second
+	} else {
+		readinessTimeout = 30 * time.Second
 	}
 
-	if err = p.dockerClient.AwaitContainerHealth(containerID, readinessTimeout); err != nil {
+	if err = p.dockerClient.AwaitContainerHealth(containerID, &readinessTimeout); err != nil {
 		var errMessage string
 
 		// try to get error logs

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -54,7 +54,7 @@ type Platform interface {
 	GetFunctions(getFunctionsOptions *GetFunctionsOptions) ([]Function, error)
 
 	// GetDefaultInvokeIPAddresses will return a list of ip addresses to be used by the platform to inovke a function
-	GetDefaultInvokeIPAddresses() []string
+	GetDefaultInvokeIPAddresses() ([]string, error)
 
 	//
 	// Project

--- a/pkg/processor/test/readinesstimeout/suite_test.go
+++ b/pkg/processor/test/readinesstimeout/suite_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package readinessTimeout
+
+import (
+	"path"
+	"testing"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type readinessTimeoutTestSuite struct { // nolint
+	httpsuite.TestSuite
+}
+
+// Deploys a failing Python function. Expect the function to fail after 30 seconds
+func (suite *readinessTimeoutTestSuite) TestPythonNoReadinessTimeout() {
+
+	beforeTime := time.Now()
+	suite.deployFailingPythonFunction(0)
+
+	// the default timeout is 30 seconds - it must have timed out after that
+	suite.Require().True(time.Since(beforeTime) >= 30*time.Second)
+}
+
+// Deploys a failing Python function. Expect the function to fail after 10 seconds
+func (suite *readinessTimeoutTestSuite) TestPythonSpecifiedReadinessTimeout() {
+
+	beforeTime := time.Now()
+	suite.deployFailingPythonFunction(10)
+
+	// the default timeout is 30 seconds - it must have timed out after that
+	suite.Require().True(time.Since(beforeTime) <= 29*time.Second)
+}
+
+func (suite *readinessTimeoutTestSuite) deployFailingPythonFunction(readinessTimeoutSeconds int) {
+	createFunctionOptions := suite.GetDeployOptions("reverser",
+		path.Join(suite.GetTestFunctionsDir(), "common", "reverser", "python"))
+
+	// configure the function to connect to some invalid kafka - it will fail after coming up and never
+	// reach healthy
+	createFunctionOptions.FunctionConfig.Spec.ReadinessTimeoutSeconds = readinessTimeoutSeconds
+	createFunctionOptions.FunctionConfig.Spec.Runtime = "python:3.6"
+	createFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{
+		"badkafka": {
+			Kind: "kafka",
+			URL:  "127.0.0.1:9999",
+		},
+	}
+
+	// add some commonly used options to createFunctionOptions
+	suite.PopulateDeployOptions(createFunctionOptions)
+
+	// deploy the function - it's OK for it to time out
+	_, err := suite.Platform.CreateFunction(createFunctionOptions)
+	suite.Require().Error(err)
+
+	// delete the function when done
+	defer suite.Platform.DeleteFunction(&platform.DeleteFunctionOptions{ // nolint: errcheck
+		FunctionConfig: createFunctionOptions.FunctionConfig,
+	})
+}
+
+func TestOfflineSuite(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	suite.Run(t, new(readinessTimeoutTestSuite))
+}


### PR DESCRIPTION
A feature in 0.5.8 (per function readinessTimeout) broke the deploy timeout for local platforms - unless the timeout was specified, the deploy would never fail. 

This fixes that regression (defaulting to the usual 30 seconds) and adds two integration tests to enforce it.