### PR TITLE
Change the way invoke happens in dashboard (k8s)

### DIFF
--- a/hack/k8s/helm/nuclio/README.md
+++ b/hack/k8s/helm/nuclio/README.md
@@ -68,10 +68,14 @@ helm install \
 	nuclio/nuclio
 ```
 
-### Advanced: Install on Minikube as a core Nuclio developer
-If you plan to develop the Nuclio core (see /docs/devel/minikube/developing-on-minikube.md), run the command thusly:
+### Advanced: Run on Docker for Mac as a core Nuclio developer
+:
 
+```sh
+kubectl port-forward $(kubectl get pod -l nuclio.io/app=dashboard -o jsonpath='{.items[0].metadata.name}') 8070:8070
 ```
+
+```sh
 helm install \
 	--set registry.secretName= \
 	--set controller.image.tag=latest-amd64 \
@@ -79,6 +83,11 @@ helm install \
 	--set controller.baseImagePullPolicy=Never \
 	--set dashboard.baseImagePullPolicy=Never \
 	.
+```
+
+You will need to run a local Docker registry. Run the following command on the host if you're working with Docker for Mac or on the Minikube VM:
+```sh
+docker run -d -p 5000:5000 registry:2
 ```
 
 ## Configuration

--- a/pkg/dashboard/resource/invocation.go
+++ b/pkg/dashboard/resource/invocation.go
@@ -107,8 +107,10 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 
 func (tr *invocationResource) getInvokeVia(invokeViaName string) platform.InvokeViaType {
 	switch invokeViaName {
-	case "external-ip":
-		return platform.InvokeViaExternalIP
+	// erd: For now, if the UI asked for external IP, force using "via any". "Any" should try external IP
+	// and then domain name, which is better
+	// case "external-ip":
+	// 	 return platform.InvokeViaExternalIP
 	case "loadbalancer":
 		return platform.InvokeViaLoadBalancer
 	case "domain-name":

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -672,7 +672,7 @@ func (suite *functionTestSuite) TestInvokeSuccessful() {
 		suite.Require().Equal(functionNamespace, createFunctionInvocationOptions.Namespace)
 		suite.Require().Equal(requestBody, createFunctionInvocationOptions.Body)
 		suite.Require().Equal(requestMethod, createFunctionInvocationOptions.Method)
-		suite.Require().Equal(platform.InvokeViaExternalIP, createFunctionInvocationOptions.Via)
+		suite.Require().Equal(platform.InvokeViaAny, createFunctionInvocationOptions.Via)
 
 		// dashboard will trim the first "/"
 		suite.Require().Equal(requestPath[1:], createFunctionInvocationOptions.Path)

--- a/pkg/platform/abstract/invoker.go
+++ b/pkg/platform/abstract/invoker.go
@@ -60,7 +60,9 @@ func (i *invoker) invoke(createFunctionInvocationOptions *platform.CreateFunctio
 	}
 
 	if len(functions) == 0 {
-		return nil, fmt.Errorf("Function not found: %s @ %s", createFunctionInvocationOptions.Name, createFunctionInvocationOptions.Namespace)
+		return nil, fmt.Errorf("Function not found: %s @ %s",
+			createFunctionInvocationOptions.Name,
+			createFunctionInvocationOptions.Namespace)
 	}
 
 	// use the first function found (should always be one, but if there's more just use first)

--- a/pkg/platform/kube/function.go
+++ b/pkg/platform/kube/function.go
@@ -162,6 +162,7 @@ func (f *function) GetConfig() *functionconfig.Config {
 func (f *function) getInvokeURLFields(invokeViaType platform.InvokeViaType) (string, int, string, error) {
 	var host, path string
 	var port int
+	var err error
 
 	// user wants a specific invoke via type
 	if invokeViaType != platform.InvokeViaAny {
@@ -169,11 +170,11 @@ func (f *function) getInvokeURLFields(invokeViaType platform.InvokeViaType) (str
 		// if there's an ingress address, use that. otherwise use
 		switch invokeViaType {
 		case platform.InvokeViaLoadBalancer:
-			host, port, path = f.getIngressInvokeURL()
+			host, port, path, err = f.getIngressInvokeURL()
 		case platform.InvokeViaExternalIP:
-			host, port, path = f.getExternalIPInvokeURL()
+			host, port, path, err = f.getExternalIPInvokeURL()
 		case platform.InvokeViaDomainName:
-			host, port, path = f.getDomainNameInvokeURL()
+			host, port, path, err = f.getDomainNameInvokeURL()
 		}
 
 		// if host is empty and we were configured to a specific via type, return an error
@@ -185,52 +186,68 @@ func (f *function) getInvokeURLFields(invokeViaType platform.InvokeViaType) (str
 	}
 
 	// try to get host, port, and path in through ingress and then via external ip
-	for _, urlGetter := range []func() (string, int, string){
-		f.getIngressInvokeURL,
+	for urlGetterIndex, urlGetter := range []func() (string, int, string, error) {
 		f.getExternalIPInvokeURL,
+		f.getDomainNameInvokeURL,
 	} {
 
 		// get the info
-		host, port, path = urlGetter()
+		host, port, path, err = urlGetter()
+
+		if err != nil {
+			f.Logger.DebugWith("Could not get invoke URL with method",
+				"index", urlGetterIndex,
+				"err", err)
+		}
 
 		// if we found something, return it
 		if host != "" {
+			f.Logger.DebugWith("Resolved invoke URL with method",
+				"index", urlGetterIndex,
+				"host", host,
+				"port", port,
+				"path", path)
+
 			return host, port, path, nil
 		}
 	}
 
-	return "", 0, "", errors.New("Could not find address")
+	return "", 0, "", errors.New("Could not resolve invoke URL")
 }
 
-func (f *function) getIngressInvokeURL() (string, int, string) {
+func (f *function) getIngressInvokeURL() (string, int, string, error) {
 	if f.ingressAddress != "" {
 
 		// 80 seems to be hardcoded in kubectl as well
 		return f.ingressAddress,
 			80,
-			fmt.Sprintf("/%s/%s", f.Config.Meta.Name, f.GetVersion())
+			fmt.Sprintf("/%s/%s", f.Config.Meta.Name, f.GetVersion()),
+			nil
 	}
 
-	return "", 0, ""
+	return "", 0, "", nil
 }
 
-func (f *function) getExternalIPInvokeURL() (string, int, string) {
+func (f *function) getExternalIPInvokeURL() (string, int, string, error) {
 	host, port, err := f.GetExternalIPInvocationURL()
 	if err != nil {
-		return "", 0, ""
+		return "", 0, "", errors.Wrap(err, "Failed to get external IP invocation URL")
 	}
 
 	// return it and the port
-	return host, port, ""
+	return host, port, "", nil
 }
 
-func (f *function) getDomainNameInvokeURL() (string, int, string) {
-	namespace := f.function.ObjectMeta.Namespace
-	if namespace == "" {
-		namespace = "nuclio"
+func (f *function) getDomainNameInvokeURL() (string, int, string, error) {
+	var domainName string
+
+	if f.function.ObjectMeta.Namespace == "" {
+		domainName = f.function.ObjectMeta.Name
+	} else {
+		domainName = fmt.Sprintf("%s.%s.svc.cluster.local",
+			f.function.ObjectMeta.Name,
+			f.function.ObjectMeta.Namespace)
 	}
 
-	domainName := fmt.Sprintf("%s.%s.svc.cluster.local", f.function.ObjectMeta.Name, namespace)
-
-	return domainName, 8080, ""
+	return domainName, 8080, "", nil
 }

--- a/pkg/platform/kube/function.go
+++ b/pkg/platform/kube/function.go
@@ -177,6 +177,10 @@ func (f *function) getInvokeURLFields(invokeViaType platform.InvokeViaType) (str
 			host, port, path, err = f.getDomainNameInvokeURL()
 		}
 
+		if err != nil {
+			return "", 0, "", errors.Wrap(err, "Failed to get invoke URL")
+		}
+
 		// if host is empty and we were configured to a specific via type, return an error
 		if host == "" {
 			return "", 0, "", errors.New("Couldn't find address for invoke via type")
@@ -186,7 +190,7 @@ func (f *function) getInvokeURLFields(invokeViaType platform.InvokeViaType) (str
 	}
 
 	// try to get host, port, and path in through ingress and then via external ip
-	for urlGetterIndex, urlGetter := range []func() (string, int, string, error) {
+	for urlGetterIndex, urlGetter := range []func() (string, int, string, error){
 		f.getExternalIPInvokeURL,
 		f.getDomainNameInvokeURL,
 	} {


### PR DESCRIPTION
Prior to this change, when a function invocation request was received at the dashboard it would resolve the function URL first through a configured external IP address and then through the node internal / external IP (queries k8s nodes).

This PR adds an additional step where if none of the above are configured, it will try to use the internal k8s DNS. 

In addition to the above, if there are errors in the process they will be logged.

