### PR TITLE
Dashboard accepts "build.offline" parameter as environment variable

### DIFF
--- a/cmd/dashboard/app/dashboard.go
+++ b/cmd/dashboard/app/dashboard.go
@@ -37,7 +37,8 @@ func Run(listenAddress string,
 	noPullBaseImages bool,
 	defaultCredRefreshIntervalString string,
 	externalIPAddresses string,
-	defaultNamespace string) error {
+	defaultNamespace string,
+	offline bool) error {
 
 	logger, err := nucliozap.NewNuclioZapCmd("dashboard", nucliozap.DebugLevel)
 	if err != nil {
@@ -71,6 +72,7 @@ func Run(listenAddress string,
 	logger.InfoWith("Starting",
 		"name", platformInstance.GetName(),
 		"noPull", noPullBaseImages,
+		"offline", offline,
 		"defaultCredRefreshInterval", defaultCredRefreshIntervalString,
 		"defaultNamespace", defaultNamespace)
 
@@ -96,7 +98,8 @@ func Run(listenAddress string,
 		webServerConfiguration,
 		getDefaultCredRefreshInterval(logger, defaultCredRefreshIntervalString),
 		splitExternalIPAddresses,
-		defaultNamespace)
+		defaultNamespace,
+		offline)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create server")
 	}

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -43,6 +43,7 @@ func getNamespace(namespaceArgument string) string {
 
 func main() {
 	defaultNoPullBaseImages := os.Getenv("NUCLIO_DASHBOARD_NO_PULL_BASE_IMAGES") == "true"
+	defaultOffline := os.Getenv("NUCLIO_DASHBOARD_OFFLINE") == "true"
 
 	externalIPAddressesDefault := os.Getenv("NUCLIO_DASHBOARD_EXTERNAL_IP_ADDRESSES")
 
@@ -55,6 +56,7 @@ func main() {
 	credsRefreshInterval := flag.String("creds-refresh-interval", os.Getenv("NUCLIO_DASHBOARD_CREDS_REFRESH_INTERVAL"), "Default credential refresh interval, or 'none' (12h by default)")
 	externalIPAddresses := flag.String("external-ip-addresses", externalIPAddressesDefault, "Comma delimited list of external IP addresses")
 	namespace := flag.String("namespace", "", "Namespace in which all actions apply to, if not passed in request")
+	offline := flag.Bool("offline", defaultOffline, "If true, assumes no internet connectivity")
 
 	// get the namespace from args -> env -> default
 	*namespace = getNamespace(*namespace)
@@ -69,7 +71,8 @@ func main() {
 		*noPullBaseImages,
 		*credsRefreshInterval,
 		*externalIPAddresses,
-		*namespace); err != nil {
+		*namespace,
+		*offline); err != nil {
 
 		errors.PrintErrorStack(os.Stderr, err, 5)
 

--- a/hack/aks/resources/nuclio.yaml
+++ b/hack/aks/resources/nuclio.yaml
@@ -91,11 +91,11 @@ spec:
         nuclio.io/app: controller
         nuclio.io/class: service
       annotations:
-        nuclio.io/version: 0.5.9
+        nuclio.io/version: 0.5.10
     spec:
       containers:
       - name: nuclio-controller
-        image: nuclio/controller:0.5.9-amd64
+        image: nuclio/controller:0.5.10-amd64
         env:
         - name: NUCLIO_CONTROLLER_IMAGE_PULL_SECRETS
           value: registry-credentials
@@ -118,11 +118,11 @@ spec:
         nuclio.io/app: dashboard
         nuclio.io/class: service
       annotations:
-        nuclio.io/version: 0.5.9
+        nuclio.io/version: 0.5.10
     spec:
       containers:
       - name: nuclio-dashboard
-        image: nuclio/dashboard:0.5.9-amd64
+        image: nuclio/dashboard:0.5.10-amd64
         ports:
         - containerPort: 8070
         volumeMounts:

--- a/hack/gke/resources/nuclio.yaml
+++ b/hack/gke/resources/nuclio.yaml
@@ -91,11 +91,11 @@ spec:
         nuclio.io/app: controller
         nuclio.io/class: service
       annotations:
-        nuclio.io/version: 0.5.9
+        nuclio.io/version: 0.5.10
     spec:
       containers:
       - name: nuclio-controller
-        image: nuclio/controller:0.5.9-amd64
+        image: nuclio/controller:0.5.10-amd64
         env:
         - name: NUCLIO_CONTROLLER_IMAGE_PULL_SECRETS
           value: registry-credentials
@@ -118,11 +118,11 @@ spec:
         nuclio.io/app: dashboard
         nuclio.io/class: service
       annotations:
-        nuclio.io/version: 0.5.9
+        nuclio.io/version: 0.5.10
     spec:
       containers:
       - name: nuclio-dashboard
-        image: nuclio/dashboard:0.5.9-amd64
+        image: nuclio/dashboard:0.5.10-amd64
         ports:
         - containerPort: 8070
         volumeMounts:

--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.1.17
-appVersion: 0.5.9
+version: 0.1.18
+appVersion: 0.5.10
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io
 sources:

--- a/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
@@ -36,8 +36,4 @@ spec:
         env:
         - name: NUCLIO_CONTROLLER_IMAGE_PULL_SECRETS
           value: {{ template "nuclio.registryCredentialsName" . }}
-        {{- if eq .Values.controller.baseImagePullPolicy "Never" }}
-        - name: NUCLIO_CONTROLLER_NO_PULL_BASE_IMAGES
-          value: "true"
-        {{- end }}
 {{- end }}

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -52,6 +52,10 @@ spec:
         - name: NUCLIO_DASHBOARD_NO_PULL_BASE_IMAGES
           value: "true"
         {{- end }}
+        {{- if .Values.offline }}
+        - name: NUCLIO_DASHBOARD_OFFLINE
+          value: "true"
+        {{- end }}
         - name: NUCLIO_DASHBOARD_EXTERNAL_IP_ADDRESSES
           value: {{ .Values.dashboard.externalIPAddresses | join "," | quote }}
       volumes:

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -1,3 +1,6 @@
+# if true, all components assume no internet connectivity
+offline: false
+
 # Controller settings
 controller:
   enabled: true

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -3,7 +3,7 @@ controller:
   enabled: true
   image:
     repository: nuclio/controller
-    tag: 0.5.9-amd64
+    tag: 0.5.10-amd64
     pullPolicy: IfNotPresent
   baseImagePullPolicy: IfNotPresent
 
@@ -13,7 +13,7 @@ dashboard:
   replicas: 1
   image:
     repository: nuclio/dashboard
-    tag: 0.5.9-amd64
+    tag: 0.5.10-amd64
     pullPolicy: IfNotPresent
   baseImagePullPolicy: IfNotPresent
   externalIPAddresses: []

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -8,7 +8,6 @@ controller:
     repository: nuclio/controller
     tag: 0.5.10-amd64
     pullPolicy: IfNotPresent
-  baseImagePullPolicy: IfNotPresent
 
 # Dashboard settings
 dashboard:

--- a/hack/k8s/resources/nuclio.yaml
+++ b/hack/k8s/resources/nuclio.yaml
@@ -91,11 +91,11 @@ spec:
         nuclio.io/app: controller
         nuclio.io/class: service
       annotations:
-        nuclio.io/version: 0.5.9
+        nuclio.io/version: 0.5.10
     spec:
       containers:
       - name: nuclio-controller
-        image: nuclio/controller:0.5.9-amd64
+        image: nuclio/controller:0.5.10-amd64
         env:
         - name: NUCLIO_CONTROLLER_IMAGE_PULL_SECRETS
           value: registry-credentials
@@ -118,11 +118,11 @@ spec:
         nuclio.io/app: dashboard
         nuclio.io/class: service
       annotations:
-        nuclio.io/version: 0.5.9
+        nuclio.io/version: 0.5.10
     spec:
       containers:
       - name: nuclio-dashboard
-        image: nuclio/dashboard:0.5.9-amd64
+        image: nuclio/dashboard:0.5.10-amd64
         ports:
         - containerPort: 8070
         volumeMounts:

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -130,6 +130,7 @@ func (fr *functionResource) Create(request *http.Request) (id string, attributes
 		}
 
 		functionInfo.Spec.Build.NoBaseImagesPull = dashboardServer.NoPullBaseImages
+		functionInfo.Spec.Build.Offline = dashboardServer.Offline
 
 		// just deploy. the status is async through polling
 		_, err := fr.getPlatform().CreateFunction(&platform.CreateFunctionOptions{

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -46,6 +46,7 @@ type Server struct {
 	NoPullBaseImages      bool
 	externalIPAddresses   []string
 	defaultNamespace      string
+	Offline               bool
 }
 
 func NewServer(parentLogger logger.Logger,
@@ -57,7 +58,8 @@ func NewServer(parentLogger logger.Logger,
 	configuration *platformconfig.WebServer,
 	defaultCredRefreshInterval *time.Duration,
 	externalIPAddresses []string,
-	defaultNamespace string) (*Server, error) {
+	defaultNamespace string,
+	offline bool) (*Server, error) {
 
 	var err error
 
@@ -71,6 +73,11 @@ func NewServer(parentLogger logger.Logger,
 		return nil, errors.Wrap(err, "Failed to create docker loginner")
 	}
 
+	// if we're set to build offline, make sure not to pull base images
+	if offline {
+		noPullBaseImages = true
+	}
+
 	newServer := &Server{
 		dockerKeyDir:          dockerKeyDir,
 		defaultRegistryURL:    defaultRegistryURL,
@@ -81,6 +88,7 @@ func NewServer(parentLogger logger.Logger,
 		NoPullBaseImages:      noPullBaseImages,
 		externalIPAddresses:   externalIPAddresses,
 		defaultNamespace:      defaultNamespace,
+		Offline:               offline,
 	}
 
 	// create server

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -235,7 +235,8 @@ func (suite *dashboardTestSuite) SetupTest() {
 		&platformconfig.WebServer{Enabled: &trueValue},
 		nil,
 		nil,
-		"")
+		"",
+		true)
 
 	if err != nil {
 		panic("Failed to create server")


### PR DESCRIPTION
1. If dashboard is run with `NUCLIO_DASHBOARD_OFFLINE` set to true, it will set the `Spec.Build.Offline` and `Spec.Build.NoPullBaseImages` for all builds it receives
2. `offline` stanza added to helm chart