### PR TITLE
Better test failure message.

### DIFF
--- a/pkg/processor/trigger/test/eventrecorder.go
+++ b/pkg/processor/trigger/test/eventrecorder.go
@@ -21,11 +21,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/processor/test/suite"
-	"github.com/nuclio/nuclio/test/compare"
 )
 
 type Event struct {
@@ -110,8 +110,11 @@ func InvokeEventRecorder(suite *processorsuite.TestSuite,
 			}
 		}
 
+		sort.Strings(sentBodies)
+		sort.Strings(receivedBodies)
+
 		// compare bodies
-		suite.Require().True(compare.CompareNoOrder(sentBodies, receivedBodies))
+		suite.Require().Equal(sentBodies, receivedBodies)
 
 		return true
 	})


### PR DESCRIPTION
Before:
```
 	Error:      	Should be true
FAIL
```
After:
```
	Error:      	Not equal: 
	            	expected: []string{"myTopic-0", "myTopic-1", "myTopic-2"}
	            	actual: []string{"myTopic-0", "myTopic-1", "myTopic-2", "this-shouldn't-be-here"}
	            	
	            	Diff:
	            	--- Expected
	            	+++ Actual
	            	@@ -1,5 +1,6 @@
	            	-([]string) (len=3) {
	            	+([]string) (len=4) {
	            	  (string) (len=9) "myTopic-0",
	            	  (string) (len=9) "myTopic-1",
	            	- (string) (len=9) "myTopic-2"
	            	+ (string) (len=9) "myTopic-2",
	            	+ (string) (len=22) "this-shouldn't-be-here"
	            	 }
FAIL
```