### PR TITLE
Fix prometheus pull + platform support in helm

### DIFF
--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -141,7 +141,7 @@ func NewProcessor(configurationPath string, platformConfigurationPath string) (*
 	}
 
 	// create metric pusher
-	newProcessor.metricSinks, err = newProcessor.createMetricSinks(platformConfiguration)
+	newProcessor.metricSinks, err = newProcessor.createMetricSinks(processorConfiguration, platformConfiguration)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create metric sinks")
 	}
@@ -435,7 +435,8 @@ func (p *Processor) createAndStartHealthCheckServer(platformConfiguration *platf
 	return server, nil
 }
 
-func (p *Processor) createMetricSinks(platformConfiguration *platformconfig.Configuration) ([]metricsink.MetricSink, error) {
+func (p *Processor) createMetricSinks(processorConfiguration *processor.Configuration,
+	platformConfiguration *platformconfig.Configuration) ([]metricsink.MetricSink, error) {
 	metricSinksConfiguration, err := platformConfiguration.GetFunctionMetricSinks()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get function metric sinks configuration")
@@ -445,6 +446,7 @@ func (p *Processor) createMetricSinks(platformConfiguration *platformconfig.Conf
 
 	for metricSinkName, metricSinkConfiguration := range metricSinksConfiguration {
 		newMetricSinkInstance, err := metricsink.RegistrySingleton.NewMetricSink(p.logger,
+			processorConfiguration,
 			metricSinkConfiguration.Kind,
 			metricSinkName,
 			&metricSinkConfiguration,

--- a/hack/k8s/helm/nuclio/templates/_helpers.tpl
+++ b/hack/k8s/helm/nuclio/templates/_helpers.tpl
@@ -39,3 +39,7 @@
 {{- define "nuclio.crdAdminName" -}}
 {{- printf "%s-crd-admin" .Release.Name -}}
 {{- end -}}
+
+{{- define "nuclio.platformName" -}}
+{{- printf "platform-config" -}}
+{{- end -}}

--- a/hack/k8s/helm/nuclio/templates/configmap/platform.yaml
+++ b/hack/k8s/helm/nuclio/templates/configmap/platform.yaml
@@ -18,10 +18,6 @@ kind: ConfigMap
 metadata:
   name: {{ template "nuclio.platformName" . }}
 data:
-  logger:
-    sinks:
-{{ toYaml .Values.platform.logger.sinks | indent 6 }}
-  metric:
-    sinks:
-{{ toYaml .Values.platform.metric.sinks | indent 6 }}
+  platform.yaml: |
+{{ toYaml .Values.platform | indent 4 }}
 {{- end }}

--- a/hack/k8s/helm/nuclio/templates/configmap/platform.yaml
+++ b/hack/k8s/helm/nuclio/templates/configmap/platform.yaml
@@ -1,0 +1,27 @@
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.platform }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nuclio.platformName" . }}
+data:
+  logger:
+    sinks:
+{{ toYaml .Values.platform.logger.sinks | indent 6 }}
+  metric:
+    sinks:
+{{ toYaml .Values.platform.metric.sinks | indent 6 }}
+{{- end }}

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -70,3 +70,12 @@ crd:
   
   # If true, creates cluster wide custom resources defenitions for nuclio's resources
   create: true
+
+platform:
+  logger:
+    sinks:
+      humanReadableStdout:
+        kind: stdout
+        format: humanReadable
+  metric:
+    sinks: {}

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -71,23 +71,23 @@ crd:
   # If true, creates cluster wide custom resources defenitions for nuclio's resources
   create: true
 
-platform:
-  logger:
-    sinks:
-      myHumanReadableStdout:
-        kind: stdout
-        format: humanReadable
-    system:
-    - level: debug
-      sink: myHumanReadableStdout
-    functions:
-    - level: debug
-      sink: myHumanReadableStdout
-  metrics:
-    sinks:
-      myPrometheusPull:
-        kind: prometheusPull
-    system:
-    - myPrometheusPull
-    functions:
-    - myPrometheusPull
+platform: {}
+#  logger:
+#    sinks:
+#      myHumanReadableStdout:
+#        kind: stdout
+#        format: humanReadable
+#    system:
+#    - level: debug
+#      sink: myHumanReadableStdout
+#    functions:
+#    - level: debug
+#      sink: myHumanReadableStdout
+#  metrics:
+#    sinks:
+#      myPrometheusPull:
+#        kind: prometheusPull
+#    system:
+#    - myPrometheusPull
+#    functions:
+#    - myPrometheusPull

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -74,8 +74,20 @@ crd:
 platform:
   logger:
     sinks:
-      humanReadableStdout:
+      myHumanReadableStdout:
         kind: stdout
         format: humanReadable
-  metric:
-    sinks: {}
+    system:
+    - level: debug
+      sink: myHumanReadableStdout
+    functions:
+    - level: debug
+      sink: myHumanReadableStdout
+  metrics:
+    sinks:
+      myPrometheusPull:
+        kind: prometheusPull
+    system:
+    - myPrometheusPull
+    functions:
+    - myPrometheusPull

--- a/pkg/processor/metricsink/appinsights/factory.go
+++ b/pkg/processor/metricsink/appinsights/factory.go
@@ -19,6 +19,7 @@ package appinsights
 import (
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
+	"github.com/nuclio/nuclio/pkg/processor"
 	"github.com/nuclio/nuclio/pkg/processor/metricsink"
 
 	"github.com/nuclio/logger"
@@ -27,6 +28,7 @@ import (
 type factory struct{}
 
 func (f *factory) Create(parentLogger logger.Logger,
+	processorConfiguration *processor.Configuration,
 	name string,
 	metricSinkConfiguration *platformconfig.MetricSink,
 	metricProvider metricsink.MetricProvider) (metricsink.MetricSink, error) {
@@ -40,7 +42,10 @@ func (f *factory) Create(parentLogger logger.Logger,
 	}
 
 	// create the metric sink
-	appinsightsMetricSink, err := newMetricSink(appinsightsLogger, configuration, metricProvider)
+	appinsightsMetricSink, err := newMetricSink(appinsightsLogger,
+		processorConfiguration,
+		configuration,
+		metricProvider)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create prometheus pull metric sink")
 	}

--- a/pkg/processor/metricsink/appinsights/metricsink.go
+++ b/pkg/processor/metricsink/appinsights/metricsink.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/processor"
 	"github.com/nuclio/nuclio/pkg/processor/metricsink"
 	"github.com/nuclio/nuclio/pkg/processor/metricsink/prometheus"
 
@@ -35,6 +36,7 @@ type MetricSink struct {
 }
 
 func newMetricSink(parentLogger logger.Logger,
+	processorConfiguration *processor.Configuration,
 	configuration *Configuration,
 	metricProvider metricsink.MetricProvider) (*MetricSink, error) {
 	loggerInstance := parentLogger.GetChild(configuration.Name)

--- a/pkg/processor/metricsink/prometheus/pull/factory.go
+++ b/pkg/processor/metricsink/prometheus/pull/factory.go
@@ -19,6 +19,7 @@ package prometheuspull
 import (
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
+	"github.com/nuclio/nuclio/pkg/processor"
 	"github.com/nuclio/nuclio/pkg/processor/metricsink"
 
 	"github.com/nuclio/logger"
@@ -27,6 +28,7 @@ import (
 type factory struct{}
 
 func (f *factory) Create(parentLogger logger.Logger,
+	processorConfiguration *processor.Configuration,
 	name string,
 	metricSinkConfiguration *platformconfig.MetricSink,
 	metricProvider metricsink.MetricProvider) (metricsink.MetricSink, error) {
@@ -40,7 +42,10 @@ func (f *factory) Create(parentLogger logger.Logger,
 	}
 
 	// create the metric sink
-	prometheusPullMetricSink, err := newMetricSink(prometheusPullLogger, configuration, metricProvider)
+	prometheusPullMetricSink, err := newMetricSink(prometheusPullLogger,
+		processorConfiguration,
+		configuration,
+		metricProvider)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create prometheus pull metric sink")
 	}

--- a/pkg/processor/metricsink/prometheus/pull/types.go
+++ b/pkg/processor/metricsink/prometheus/pull/types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package prometheuspull
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/errors"
@@ -29,7 +28,6 @@ import (
 
 type Configuration struct {
 	metricsink.Configuration
-	JobName        string
 	InstanceName   string
 	parsedInterval time.Duration
 }
@@ -45,14 +43,12 @@ func NewConfiguration(name string, metricSinkConfiguration *platformconfig.Metri
 		return nil, errors.Wrap(err, "Failed to decode attributes")
 	}
 
-	// verify job name passed
-	if newConfiguration.JobName == "" {
-		return nil, fmt.Errorf("Job name is required for metric sink %s", name)
+	if newConfiguration.URL == "" {
+		newConfiguration.URL = ":8090"
 	}
 
-	// verify instance name passed
 	if newConfiguration.InstanceName == "" {
-		return nil, fmt.Errorf("Instance name is required for metric sink %s", name)
+		newConfiguration.InstanceName = "{{ .Namespace }}-{{ .Name }}"
 	}
 
 	return &newConfiguration, nil

--- a/pkg/processor/metricsink/prometheus/push/factory.go
+++ b/pkg/processor/metricsink/prometheus/push/factory.go
@@ -19,6 +19,7 @@ package prometheuspush
 import (
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
+	"github.com/nuclio/nuclio/pkg/processor"
 	"github.com/nuclio/nuclio/pkg/processor/metricsink"
 
 	"github.com/nuclio/logger"
@@ -27,6 +28,7 @@ import (
 type factory struct{}
 
 func (f *factory) Create(parentLogger logger.Logger,
+	processorConfiguration *processor.Configuration,
 	name string,
 	metricSinkConfiguration *platformconfig.MetricSink,
 	metricProvider metricsink.MetricProvider) (metricsink.MetricSink, error) {
@@ -40,7 +42,10 @@ func (f *factory) Create(parentLogger logger.Logger,
 	}
 
 	// create the metric sink
-	prometheusPushMetricSink, err := newMetricSink(prometheusPushLogger, configuration, metricProvider)
+	prometheusPushMetricSink, err := newMetricSink(prometheusPushLogger,
+		processorConfiguration,
+		configuration,
+		metricProvider)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create prometheus push metric sink")
 	}

--- a/pkg/processor/metricsink/prometheus/push/metricsink.go
+++ b/pkg/processor/metricsink/prometheus/push/metricsink.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/processor"
 	"github.com/nuclio/nuclio/pkg/processor/metricsink"
 	"github.com/nuclio/nuclio/pkg/processor/metricsink/prometheus"
 
@@ -36,6 +37,7 @@ type MetricSink struct {
 }
 
 func newMetricSink(parentLogger logger.Logger,
+	processorConfiguration *processor.Configuration,
 	configuration *Configuration,
 	metricProvider metricsink.MetricProvider) (*MetricSink, error) {
 	loggerInstance := parentLogger.GetChild(configuration.Name)

--- a/pkg/processor/metricsink/prometheus/trigger.go
+++ b/pkg/processor/metricsink/prometheus/trigger.go
@@ -39,10 +39,9 @@ func NewTriggerGatherer(instanceName string,
 
 	// base labels for handle events
 	labels := prometheus.Labels{
-		"instance":      instanceName,
-		"trigger_class": trigger.GetClass(),
-		"trigger_kind":  trigger.GetKind(),
-		"trigger_id":    trigger.GetID(),
+		"instance":     instanceName,
+		"trigger_kind": trigger.GetKind(),
+		"trigger_id":   trigger.GetID(),
 	}
 
 	newTriggerGatherer.handledEventsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/pkg/processor/metricsink/prometheus/worker.go
+++ b/pkg/processor/metricsink/prometheus/worker.go
@@ -45,11 +45,10 @@ func NewWorkerGatherer(instanceName string,
 
 	// base labels for handle events
 	labels := prometheus.Labels{
-		"instance":      instanceName,
-		"trigger_class": trigger.GetClass(),
-		"trigger_kind":  trigger.GetKind(),
-		"trigger_id":    trigger.GetID(),
-		"worker_index":  strconv.Itoa(worker.GetIndex()),
+		"instance":     instanceName,
+		"trigger_kind": trigger.GetKind(),
+		"trigger_id":   trigger.GetID(),
+		"worker_index": strconv.Itoa(worker.GetIndex()),
 	}
 
 	newWorkerGatherer.handledEventsDurationMillisecondsSum = prometheus.NewCounter(prometheus.CounterOpts{

--- a/pkg/processor/metricsink/registry.go
+++ b/pkg/processor/metricsink/registry.go
@@ -18,6 +18,7 @@ package metricsink
 
 import (
 	"github.com/nuclio/nuclio/pkg/platformconfig"
+	"github.com/nuclio/nuclio/pkg/processor"
 	"github.com/nuclio/nuclio/pkg/registry"
 
 	"github.com/nuclio/logger"
@@ -27,7 +28,7 @@ import (
 type Creator interface {
 
 	// Create creates a metric sink instance
-	Create(logger.Logger, string, *platformconfig.MetricSink, MetricProvider) (MetricSink, error)
+	Create(logger.Logger, *processor.Configuration, string, *platformconfig.MetricSink, MetricProvider) (MetricSink, error)
 }
 
 type Registry struct {
@@ -41,6 +42,7 @@ var RegistrySingleton = Registry{
 
 // NewMetricSink creates a new metric sink
 func (r *Registry) NewMetricSink(logger logger.Logger,
+	processorConfiguration *processor.Configuration,
 	kind string,
 	name string,
 	metricSinkConfiguration *platformconfig.MetricSink,
@@ -52,6 +54,7 @@ func (r *Registry) NewMetricSink(logger logger.Logger,
 	}
 
 	return registree.(Creator).Create(logger,
+		processorConfiguration,
 		name,
 		metricSinkConfiguration,
 		metricProvider)


### PR DESCRIPTION
1. Prometheus pull expected job name and instance name which should not be a part of the configuration
2. Helm can receive platform configuration