### PR TITLE
Platform configuration added to controller / dashboard

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -34,9 +34,9 @@ import (
 func Run(kubeconfigPath string,
 	resolvedNamespace string,
 	imagePullSecrets string,
-	platformConfigPath string) error {
+	platformConfigurationPath string) error {
 
-	newController, err := createController(kubeconfigPath, resolvedNamespace, imagePullSecrets, platformConfigPath)
+	newController, err := createController(kubeconfigPath, resolvedNamespace, imagePullSecrets, platformConfigurationPath)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create controller")
 	}
@@ -53,7 +53,7 @@ func Run(kubeconfigPath string,
 func createController(kubeconfigPath string,
 	resolvedNamespace string,
 	imagePullSecrets string,
-	platformConfigPath string) (*controller.Controller, error) {
+	platformConfigurationPath string) (*controller.Controller, error) {
 
 	// create a root logger
 	rootLogger, err := createLogger()
@@ -89,7 +89,7 @@ func createController(kubeconfigPath string,
 		nuclioClientSet,
 		functionresClient,
 		5*time.Minute,
-		platformConfigPath)
+		platformConfigurationPath)
 
 	if err != nil {
 		return nil, err

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -33,9 +33,10 @@ import (
 
 func Run(kubeconfigPath string,
 	resolvedNamespace string,
-	imagePullSecrets string) error {
+	imagePullSecrets string,
+	platformConfigPath string) error {
 
-	newController, err := createController(kubeconfigPath, resolvedNamespace, imagePullSecrets)
+	newController, err := createController(kubeconfigPath, resolvedNamespace, imagePullSecrets, platformConfigPath)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create controller")
 	}
@@ -51,7 +52,8 @@ func Run(kubeconfigPath string,
 
 func createController(kubeconfigPath string,
 	resolvedNamespace string,
-	imagePullSecrets string) (*controller.Controller, error) {
+	imagePullSecrets string,
+	platformConfigPath string) (*controller.Controller, error) {
 
 	// create a root logger
 	rootLogger, err := createLogger()
@@ -86,7 +88,8 @@ func createController(kubeconfigPath string,
 		kubeClientSet,
 		nuclioClientSet,
 		functionresClient,
-		5*time.Minute)
+		5*time.Minute,
+		platformConfigPath)
 
 	if err != nil {
 		return nil, err

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -45,7 +45,7 @@ func main() {
 	kubeconfigPath := flag.String("kubeconfig-path", "", "Path of kubeconfig file")
 	namespace := flag.String("namespace", "", "Namespace to listen on, or * for all")
 	imagePullSecrets := flag.String("image-pull-secrets", os.Getenv("NUCLIO_CONTROLLER_IMAGE_PULL_SECRETS"), "Optional secret name to use for pull")
-	platformConfigPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
+	platformConfigurationPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
 	flag.Parse()
 
 	// get the namespace from args -> env -> default (*)
@@ -60,7 +60,7 @@ func main() {
 		}
 	}
 
-	if err := app.Run(*kubeconfigPath, resolvedNamespace, *imagePullSecrets, *platformConfigPath); err != nil {
+	if err := app.Run(*kubeconfigPath, resolvedNamespace, *imagePullSecrets, *platformConfigurationPath); err != nil {
 		errors.PrintErrorStack(os.Stderr, err, 5)
 
 		os.Exit(1)

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -45,6 +45,7 @@ func main() {
 	kubeconfigPath := flag.String("kubeconfig-path", "", "Path of kubeconfig file")
 	namespace := flag.String("namespace", "", "Namespace to listen on, or * for all")
 	imagePullSecrets := flag.String("image-pull-secrets", os.Getenv("NUCLIO_CONTROLLER_IMAGE_PULL_SECRETS"), "Optional secret name to use for pull")
+	platformConfigPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
 	flag.Parse()
 
 	// get the namespace from args -> env -> default (*)
@@ -59,7 +60,7 @@ func main() {
 		}
 	}
 
-	if err := app.Run(*kubeconfigPath, resolvedNamespace, *imagePullSecrets); err != nil {
+	if err := app.Run(*kubeconfigPath, resolvedNamespace, *imagePullSecrets, *platformConfigPath); err != nil {
 		errors.PrintErrorStack(os.Stderr, err, 5)
 
 		os.Exit(1)

--- a/cmd/dashboard/app/dashboard.go
+++ b/cmd/dashboard/app/dashboard.go
@@ -38,7 +38,8 @@ func Run(listenAddress string,
 	defaultCredRefreshIntervalString string,
 	externalIPAddresses string,
 	defaultNamespace string,
-	offline bool) error {
+	offline bool,
+	platformConfigurationPath string) error {
 
 	logger, err := nucliozap.NewNuclioZapCmd("dashboard", nucliozap.DebugLevel)
 	if err != nil {
@@ -74,7 +75,8 @@ func Run(listenAddress string,
 		"noPull", noPullBaseImages,
 		"offline", offline,
 		"defaultCredRefreshInterval", defaultCredRefreshIntervalString,
-		"defaultNamespace", defaultNamespace)
+		"defaultNamespace", defaultNamespace,
+		"platformConfigurationPath", platformConfigurationPath)
 
 	// see if the platform has anything to say about the namespace
 	defaultNamespace = platformInstance.ResolveDefaultNamespace(defaultNamespace)
@@ -99,7 +101,8 @@ func Run(listenAddress string,
 		getDefaultCredRefreshInterval(logger, defaultCredRefreshIntervalString),
 		splitExternalIPAddresses,
 		defaultNamespace,
-		offline)
+		offline,
+		platformConfigurationPath)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create server")
 	}

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -57,6 +57,7 @@ func main() {
 	externalIPAddresses := flag.String("external-ip-addresses", externalIPAddressesDefault, "Comma delimited list of external IP addresses")
 	namespace := flag.String("namespace", "", "Namespace in which all actions apply to, if not passed in request")
 	offline := flag.Bool("offline", defaultOffline, "If true, assumes no internet connectivity")
+	platformConfigurationPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
 
 	// get the namespace from args -> env -> default
 	*namespace = getNamespace(*namespace)
@@ -72,7 +73,8 @@ func main() {
 		*credsRefreshInterval,
 		*externalIPAddresses,
 		*namespace,
-		*offline); err != nil {
+		*offline,
+		*platformConfigurationPath); err != nil {
 
 		errors.PrintErrorStack(os.Stderr, err, 5)
 

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -110,7 +110,9 @@ func NewProcessor(configurationPath string, platformConfigurationPath string) (*
 		return nil, err
 	}
 
-	newProcessor.logger.DebugWith("Read processor configuration", "config", processorConfiguration)
+	newProcessor.logger.DebugWith("Read configuration",
+		"config", processorConfiguration,
+		"platformConfig", platformConfiguration)
 
 	// save platform configuration in process configuration
 	processorConfiguration.PlatformConfig = platformConfiguration
@@ -236,7 +238,7 @@ func (p *Processor) readConfiguration(configurationPath string) (*processor.Conf
 }
 
 func (p *Processor) readPlatformConfiguration(configurationPath string) (*platformconfig.Configuration, error) {
-	platformConfigurationReader, err := platformconfig.NewReader(p.logger)
+	platformConfigurationReader, err := platformconfig.NewReader()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create platform configuration reader")
 	}

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -29,8 +29,8 @@ import (
 )
 
 func run() error {
-	configPath := flag.String("config", "", "Path of configuration file")
-	platformConfigPath := flag.String("platform-config", "", "Path of platform configuration file")
+	configPath := flag.String("config", "/etc/nuclio/config/processor/processor.yaml", "Path of configuration file")
+	platformConfigPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
 	listRuntimes := flag.Bool("list-runtimes", false, "Show runtimes and exit")
 	flag.Parse()
 

--- a/docs/reference/runtimes/dotnetcore/dotnetcore-reference.md
+++ b/docs/reference/runtimes/dotnetcore/dotnetcore-reference.md
@@ -59,6 +59,6 @@ COPY --from=uhttpc /home/nuclio/bin/uhttpc /usr/local/bin/uhttpc
 HEALTHCHECK --interval=1s --timeout=3s CMD /usr/local/bin/uhttpc --url http://127.0.0.1:8082/ready || exit 1
 
 # Run processor with configuration and platform configuration
-CMD [ "processor", "--config", "/etc/nuclio/config/processor/processor.yaml", "--platform-config", "/etc/nuclio/config/platform/platform.yaml" ]
+CMD [ "processor" ]
 ```
 

--- a/docs/reference/runtimes/golang/golang-reference.md
+++ b/docs/reference/runtimes/golang/golang-reference.md
@@ -51,6 +51,6 @@ COPY --from=uhttpc /home/nuclio/bin/uhttpc /usr/local/bin/uhttpc
 HEALTHCHECK --interval=1s --timeout=3s CMD /usr/local/bin/uhttpc --url http://127.0.0.1:8082/ready || exit 1
 
 # Run processor with configuration and platform configuration
-CMD [ "processor", "--config", "/etc/nuclio/config/processor/processor.yaml", "--platform-config", "/etc/nuclio/config/platform/platform.yaml" ]
+CMD [ "processor" ]
 ```
 

--- a/docs/reference/runtimes/java/java-reference.md
+++ b/docs/reference/runtimes/java/java-reference.md
@@ -131,6 +131,6 @@ COPY --from=uhttpc /home/nuclio/bin/uhttpc /usr/local/bin/uhttpc
 HEALTHCHECK --interval=1s --timeout=3s CMD /usr/local/bin/uhttpc --url http://127.0.0.1:8082/ready || exit 1
 
 # Run processor with configuration and platform configuration
-CMD [ "processor", "--config", "/etc/nuclio/config/processor/processor.yaml", "--platform-config", "/etc/nuclio/config/platform/platform.yaml" ]
+CMD [ "processor" ]
 ```
 

--- a/docs/reference/runtimes/nodejs/nodejs-reference.md
+++ b/docs/reference/runtimes/nodejs/nodejs-reference.md
@@ -52,6 +52,6 @@ HEALTHCHECK --interval=1s --timeout=3s CMD /usr/local/bin/uhttpc --url http://12
 ENV NODE_PATH=/usr/local/lib/node_modules
 
 # Run processor with configuration and platform configuration
-CMD [ "processor", "--config", "/etc/nuclio/config/processor/processor.yaml", "--platform-config", "/etc/nuclio/config/platform/platform.yaml" ]
+CMD [ "processor" ]
 ```
 

--- a/docs/reference/runtimes/python/python-reference.md
+++ b/docs/reference/runtimes/python/python-reference.md
@@ -47,6 +47,6 @@ COPY . /opt/nuclio
 HEALTHCHECK --interval=1s --timeout=3s CMD /usr/local/bin/uhttpc --url http://127.0.0.1:8082/ready || exit 1
 
 # Run processor with configuration and platform configuration
-CMD [ "processor", "--config", "/etc/nuclio/config/processor/processor.yaml", "--platform-config", "/etc/nuclio/config/platform/platform.yaml" ]
+CMD [ "processor" ]
 ```
 

--- a/docs/tasks/deploy-functions-from-dockerfile.md
+++ b/docs/tasks/deploy-functions-from-dockerfile.md
@@ -60,7 +60,7 @@ COPY --from=uhttpc /home/nuclio/bin/uhttpc /usr/local/bin/uhttpc
 HEALTHCHECK --interval=1s --timeout=3s CMD /usr/local/bin/uhttpc --url http://127.0.0.1:8082/ready || exit 1
 
 # Run processor with configuration and platform configuration
-CMD [ "processor", "--config", "/etc/nuclio/config/processor/processor.yaml", "--platform-config", "/etc/nuclio/config/platform/platform.yaml" ]
+CMD [ "processor" ]
 ```
 
 This multi-stage Dockerfile uses three `FROM` directives:

--- a/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
@@ -40,4 +40,15 @@ spec:
         - name: NUCLIO_CONTROLLER_NAMESPACE
           value: {{ .Values.controller.namespace | quote }}
         {{- end }}
+        {{- if .Values.platform }}
+        volumeMounts:
+        - name: platform-config
+          mountPath: /etc/nuclio/config/platform
+        {{- end }}
+      {{- if .Values.platform }}
+      volumes:
+      - name: platform-config
+        configMap:
+          name: {{ template "nuclio.platformName" . }}
+      {{- end }}
 {{- end }}

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -41,6 +41,10 @@ spec:
         - name: registry-credentials
           mountPath: "/etc/nuclio/dashboard/registry-credentials"
           readOnly: true
+        {{- if .Values.platform }}
+        - name: platform-config
+          mountPath: /etc/nuclio/config/platform
+        {{- end }}
         env:
         - name: NUCLIO_DASHBOARD_REGISTRY_URL
           valueFrom:
@@ -66,4 +70,9 @@ spec:
         secret:
           secretName: {{ template "nuclio.registryCredentialsName" . }}
           optional: true
+      {{- if .Values.platform }}
+      - name: platform-config
+        configMap:
+          name: {{ template "nuclio.platformName" . }}
+      {{- end }}
 {{- end }}

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -71,23 +71,23 @@ crd:
   # If true, creates cluster wide custom resources defenitions for nuclio's resources
   create: true
 
-platform:
-  logger:
-    sinks:
-      myHumanReadableStdout:
-        kind: stdout
-        format: humanReadable
-    system:
-    - level: debug
-      sink: myHumanReadableStdout
-    functions:
-    - level: debug
-      sink: myHumanReadableStdout
-  metrics:
-    sinks:
-      myPrometheusPull:
-        kind: prometheusPull
-    system:
-    - myPrometheusPull
-    functions:
-    - myPrometheusPull
+platform: {}
+#   logger:
+#     sinks:
+#       myHumanReadableStdout:
+#         kind: stdout
+#         format: humanReadable
+#     system:
+#     - level: debug
+#       sink: myHumanReadableStdout
+#     functions:
+#     - level: debug
+#       sink: myHumanReadableStdout
+#   metrics:
+#     sinks:
+#       myPrometheusPull:
+#         kind: prometheusPull
+#     system:
+#     - myPrometheusPull
+#     functions:
+#     - myPrometheusPull

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -71,23 +71,23 @@ crd:
   # If true, creates cluster wide custom resources defenitions for nuclio's resources
   create: true
 
-platform: {}
-#  logger:
-#    sinks:
-#      myHumanReadableStdout:
-#        kind: stdout
-#        format: humanReadable
-#    system:
-#    - level: debug
-#      sink: myHumanReadableStdout
-#    functions:
-#    - level: debug
-#      sink: myHumanReadableStdout
-#  metrics:
-#    sinks:
-#      myPrometheusPull:
-#        kind: prometheusPull
-#    system:
-#    - myPrometheusPull
-#    functions:
-#    - myPrometheusPull
+platform:
+  logger:
+    sinks:
+      myHumanReadableStdout:
+        kind: stdout
+        format: humanReadable
+    system:
+    - level: debug
+      sink: myHumanReadableStdout
+    functions:
+    - level: debug
+      sink: myHumanReadableStdout
+  metrics:
+    sinks:
+      myPrometheusPull:
+        kind: prometheusPull
+    system:
+    - myPrometheusPull
+    functions:
+    - myPrometheusPull

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -47,6 +47,7 @@ type Server struct {
 	externalIPAddresses   []string
 	defaultNamespace      string
 	Offline               bool
+	platformConfiguration *platformconfig.Configuration
 }
 
 func NewServer(parentLogger logger.Logger,
@@ -59,7 +60,8 @@ func NewServer(parentLogger logger.Logger,
 	defaultCredRefreshInterval *time.Duration,
 	externalIPAddresses []string,
 	defaultNamespace string,
-	offline bool) (*Server, error) {
+	offline bool,
+	platformConfigurationPath string) (*Server, error) {
 
 	var err error
 
@@ -100,6 +102,15 @@ func NewServer(parentLogger logger.Logger,
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create restful server")
 	}
+
+	// read platform configuration
+	newServer.platformConfiguration, err = newServer.readPlatformConfiguration(platformConfigurationPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to read platform configuration")
+	}
+
+	parentLogger.DebugWith("Read configuration",
+		"platformConfig", newServer.platformConfiguration)
 
 	// try to load docker keys, ignoring errors
 	if err := newServer.loadDockerKeys(newServer.dockerKeyDir); err != nil {
@@ -238,4 +249,13 @@ func (s *Server) loadDockerKeys(dockerKeyDir string) error {
 	}
 
 	return s.dockerCreds.LoadFromDir(dockerKeyDir)
+}
+
+func (s *Server) readPlatformConfiguration(configurationPath string) (*platformconfig.Configuration, error) {
+	platformConfigurationReader, err := platformconfig.NewReader()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create platform configuration reader")
+	}
+
+	return platformConfigurationReader.ReadFileOrDefault(configurationPath)
 }

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -236,7 +236,8 @@ func (suite *dashboardTestSuite) SetupTest() {
 		nil,
 		nil,
 		"",
-		true)
+		true,
+		"")
 
 	if err != nil {
 		panic("Failed to create server")

--- a/pkg/platform/kube/controller/controller.go
+++ b/pkg/platform/kube/controller/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/errors"
 	nuclioio_client "github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/versioned"
 	"github.com/nuclio/nuclio/pkg/platform/kube/functionres"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/version"
 
 	"github.com/nuclio/logger"
@@ -40,6 +41,7 @@ type Controller struct {
 	functionOperator      *functionOperator
 	projectOperator       *projectOperator
 	functionEventOperator *functionEventOperator
+	platformConfiguration *platformconfig.Configuration
 }
 
 func NewController(parentLogger logger.Logger,
@@ -48,7 +50,8 @@ func NewController(parentLogger logger.Logger,
 	kubeClientSet kubernetes.Interface,
 	nuclioClientSet nuclioio_client.Interface,
 	functionresClient functionres.Client,
-	resyncInterval time.Duration) (*Controller, error) {
+	resyncInterval time.Duration,
+	platformConfigurationPath string) (*Controller, error) {
 	var err error
 
 	// replace "*" with "", which is actually "all" in kube-speak
@@ -67,6 +70,16 @@ func NewController(parentLogger logger.Logger,
 
 	// log version info
 	version.Log(newController.logger)
+
+	// read platform configuration
+	newController.platformConfiguration, err = newController.readPlatformConfiguration(platformConfigurationPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to read platform configuration")
+	}
+
+	// set ourselves as the platform configuration provider of the function resource client (it needs it to do
+	// stuff when creating stuff)
+	functionresClient.SetPlatformConfigurationProvider(newController)
 
 	// create a function operator
 	newController.functionOperator, err = newFunctionOperator(parentLogger,
@@ -119,4 +132,17 @@ func (c *Controller) Start() error {
 	}
 
 	return nil
+}
+
+func (c *Controller) GetPlatformConfiguration() *platformconfig.Configuration {
+	return c.platformConfiguration
+}
+
+func (c *Controller) readPlatformConfiguration(configurationPath string) (*platformconfig.Configuration, error) {
+	platformConfigurationReader, err := platformconfig.NewReader(c.logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create platform configuration reader")
+	}
+
+	return platformConfigurationReader.ReadFileOrDefault(configurationPath)
 }

--- a/pkg/platform/kube/controller/controller.go
+++ b/pkg/platform/kube/controller/controller.go
@@ -77,6 +77,9 @@ func NewController(parentLogger logger.Logger,
 		return nil, errors.Wrap(err, "Failed to read platform configuration")
 	}
 
+	newController.logger.DebugWith("Read configuration",
+		"platformConfig", newController.platformConfiguration)
+
 	// set ourselves as the platform configuration provider of the function resource client (it needs it to do
 	// stuff when creating stuff)
 	functionresClient.SetPlatformConfigurationProvider(newController)
@@ -139,7 +142,7 @@ func (c *Controller) GetPlatformConfiguration() *platformconfig.Configuration {
 }
 
 func (c *Controller) readPlatformConfiguration(configurationPath string) (*platformconfig.Configuration, error) {
-	platformConfigurationReader, err := platformconfig.NewReader(c.logger)
+	platformConfigurationReader, err := platformconfig.NewReader()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create platform configuration reader")
 	}

--- a/pkg/platform/kube/controller/function.go
+++ b/pkg/platform/kube/controller/function.go
@@ -39,6 +39,7 @@ type functionOperator struct {
 	operator          operator.Operator
 	imagePullSecrets  string
 	functionresClient functionres.Client
+
 }
 
 func newFunctionOperator(parentLogger logger.Logger,

--- a/pkg/platform/kube/controller/function.go
+++ b/pkg/platform/kube/controller/function.go
@@ -39,7 +39,6 @@ type functionOperator struct {
 	operator          operator.Operator
 	imagePullSecrets  string
 	functionresClient functionres.Client
-
 }
 
 func newFunctionOperator(parentLogger logger.Logger,
@@ -122,7 +121,12 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 	}
 
 	if service != nil && len(service.Spec.Ports) != 0 {
-		httpPort = int(service.Spec.Ports[0].NodePort)
+		for _, port := range service.Spec.Ports {
+			if port.Name == "http" {
+				httpPort = int(port.NodePort)
+				break
+			}
+		}
 	}
 
 	// if the function state was ready, don't re-write the function state

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -54,6 +54,7 @@ type lazyClient struct {
 	kubeClientSet   kubernetes.Interface
 	nuclioClientSet nuclioio_client.Interface
 	classLabels     map[string]string
+	platformConfigurationProvider PlatformConfigurationProvider
 }
 
 func NewLazyClient(parentLogger logger.Logger,
@@ -289,6 +290,11 @@ func (lc *lazyClient) Delete(ctx context.Context, namespace string, name string)
 	lc.logger.DebugWith("Deleted deployed function", "namespace", namespace, "name", name)
 
 	return nil
+}
+
+// SetPlatformConfigurationProvider sets the provider of the platform configuration for any future access
+func (lc *lazyClient) SetPlatformConfigurationProvider(platformConfigurationProvider PlatformConfigurationProvider) {
+	lc.platformConfigurationProvider = platformConfigurationProvider
 }
 
 // as a closure so resourceExists can update

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -843,8 +843,8 @@ func (lc *lazyClient) populateServiceSpec(labels map[string]string,
 	if len(spec.Ports) == 0 || !(spec.Ports[0].NodePort != 0 && function.Spec.GetHTTPPort() == 0) {
 		spec.Ports = []v1.ServicePort{
 			{
-				Name: containerHTTPPortName,
-				Port: int32(containerHTTPPort),
+				Name:     containerHTTPPortName,
+				Port:     int32(containerHTTPPort),
 				NodePort: int32(function.Spec.GetHTTPPort()),
 			},
 		}

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -192,6 +192,7 @@ func (suite *lazyTestSuite) TestPlatformServicePorts() {
 					Kind: "prometheusPull",
 				},
 			},
+			Functions: []string{"pp"},
 		},
 	})
 	suite.Require().Len(servicePorts, 1)

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -22,11 +22,11 @@ import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
-	"k8s.io/api/core/v1"
 
 	"github.com/nuclio/logger"
 	"github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
+	"k8s.io/api/core/v1"
 	ext_v1beta1 "k8s.io/api/extensions/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -207,8 +207,8 @@ func (suite *lazyTestSuite) TestPlatformServicePorts() {
 		},
 	}, []v1.ServicePort{
 		{
-			Name:     containerMetricPortName,
-			Port:     int32(containerMetricPort),
+			Name: containerMetricPortName,
+			Port: int32(containerMetricPort),
 		},
 	})
 
@@ -223,8 +223,8 @@ func (suite *lazyTestSuite) TestPlatformServicePorts() {
 		},
 	}, []v1.ServicePort{
 		{
-			Name:     containerMetricPortName,
-			Port:     int32(containerMetricPort),
+			Name: containerMetricPortName,
+			Port: int32(containerMetricPort),
 		},
 	})
 

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+	"k8s.io/api/core/v1"
 
 	"github.com/nuclio/logger"
 	"github.com/nuclio/zap"
@@ -174,6 +176,60 @@ func (suite *lazyTestSuite) TestTriggerDefinedMultipleIngresses() {
 	rule = suite.getIngressRuleByHost(ingressSpec.Rules, "host4")
 	suite.Require().Equal("/constant-value-3", rule.HTTP.Paths[0].Path)
 	suite.Require().Equal("/constant-value-4", rule.HTTP.Paths[1].Path)
+}
+
+func (suite *lazyTestSuite) TestPlatformServicePorts() {
+
+	// configuration with no ports
+	servicePorts := suite.client.getServicePortsFromPlatform(&platformconfig.Configuration{})
+	suite.Require().Len(servicePorts, 0)
+
+	// configuration with prometheus pull
+	servicePorts = suite.client.getServicePortsFromPlatform(&platformconfig.Configuration{
+		Metrics: platformconfig.Metrics{
+			Sinks: map[string]platformconfig.MetricSink{
+				"pp": {
+					Kind: "prometheusPull",
+				},
+			},
+		},
+	})
+	suite.Require().Len(servicePorts, 1)
+	suite.Require().Equal(servicePorts[0].Name, containerMetricPortName)
+	suite.Require().Equal(servicePorts[0].Port, int32(containerMetricPort))
+
+	// ensure metric port
+	toServicePorts := suite.client.ensureServicePortsExist([]v1.ServicePort{
+		{
+			Name:     containerHTTPPortName,
+			Port:     int32(containerHTTPPort),
+			NodePort: 12345,
+		},
+	}, []v1.ServicePort{
+		{
+			Name:     containerMetricPortName,
+			Port:     int32(containerMetricPort),
+		},
+	})
+
+	// should be added
+	suite.Require().Len(toServicePorts, 2)
+
+	toServicePorts = suite.client.ensureServicePortsExist([]v1.ServicePort{
+		{
+			Name:     containerHTTPPortName,
+			Port:     int32(containerHTTPPort),
+			NodePort: 12345,
+		},
+	}, []v1.ServicePort{
+		{
+			Name:     containerMetricPortName,
+			Port:     int32(containerMetricPort),
+		},
+	})
+
+	// should not be added
+	suite.Require().Len(toServicePorts, 2)
 }
 
 func (suite *lazyTestSuite) getIngressRuleByHost(rules []ext_v1beta1.IngressRule, host string) *ext_v1beta1.IngressRule {

--- a/pkg/platform/kube/functionres/types.go
+++ b/pkg/platform/kube/functionres/types.go
@@ -12,12 +12,6 @@ import (
 	ext_v1beta1 "k8s.io/api/extensions/v1beta1"
 )
 
-const (
-	containerHTTPPort     = 8080
-	healthCheckHTTPPort   = 8082
-	containerHTTPPortName = "http"
-)
-
 type PlatformConfigurationProvider interface {
 
 	// GetPlatformConfiguration returns a platform configuration

--- a/pkg/platform/kube/functionres/types.go
+++ b/pkg/platform/kube/functionres/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
 
 	apps_v1beta1 "k8s.io/api/apps/v1beta1"
 	autos_v1 "k8s.io/api/autoscaling/v1"
@@ -16,6 +17,12 @@ const (
 	healthCheckHTTPPort   = 8082
 	containerHTTPPortName = "http"
 )
+
+type PlatformConfigurationProvider interface {
+
+	// GetPlatformConfiguration returns a platform configuration
+	GetPlatformConfiguration() *platformconfig.Configuration
+}
 
 type Client interface {
 
@@ -33,6 +40,9 @@ type Client interface {
 
 	// Delete deletes resources
 	Delete(context.Context, string, string) error
+
+	// SetPlatformConfigurationProvider sets the provider of the platform configuration for any future access
+	SetPlatformConfigurationProvider(PlatformConfigurationProvider)
 }
 
 // Resources holds the resources a functionres holds

--- a/pkg/platform/kube/updater.go
+++ b/pkg/platform/kube/updater.go
@@ -74,7 +74,7 @@ func (u *updater) update(updateFunctionOptions *platform.UpdateFunctionOptions) 
 	}
 
 	// wait for the function to be ready
-	err = waitForFunctionReadiness(u.logger,
+	_, err = waitForFunctionReadiness(u.logger,
 		u.consumer,
 		updatedFunction.Namespace,
 		updatedFunction.Name)

--- a/pkg/platformconfig/reader.go
+++ b/pkg/platformconfig/reader.go
@@ -21,20 +21,15 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio/pkg/errors"
 
 	"github.com/ghodss/yaml"
 )
 
-type Reader struct {
-	logger logger.Logger
-}
+type Reader struct{}
 
-func NewReader(parentLogger logger.Logger) (*Reader, error) {
-	return &Reader{
-		logger: parentLogger.GetChild("platformConfig"),
-	}, nil
+func NewReader() (*Reader, error) {
+	return &Reader{}, nil
 }
 
 func (r *Reader) Read(reader io.Reader, configType string, config *Configuration) error {
@@ -52,10 +47,6 @@ func (r *Reader) ReadFileOrDefault(configurationPath string) (*Configuration, er
 	// if there's no configuration file, return a default configuration. otherwise try to parse it
 	platformConfigurationFile, err := os.Open(configurationPath)
 	if err != nil {
-
-		// log whether we're running a default configuration
-		r.logger.WarnWith("Platform configuration not found, using defaults", "path", configurationPath)
-
 		return r.GetDefaultConfiguration(), nil
 	}
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1085,7 +1085,7 @@ COPY {{ $localArtifactPath }} {{ $imageArtifactPath }}
 {{ end }}
 
 # Run processor with configuration and platform configuration
-CMD [ "processor", "--config", "/etc/nuclio/config/processor/processor.yaml", "--platform-config", "/etc/nuclio/config/platform/platform.yaml" ]
+CMD [ "processor" ]
 `
 
 	// maps between a _relative_ path in staging to the path in the image

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -227,7 +227,7 @@ COPY imageLocal2 imageImage2
 postCopyKind1 postCopyValue1
 postCopyKind2 postCopyValue2
 # Run processor with configuration and platform configuration
-CMD [ "processor", "--config", "/etc/nuclio/config/processor/processor.yaml", "--platform-config", "/etc/nuclio/config/platform/platform.yaml" ]`)
+CMD [ "processor" ]`)
 
 	// all elements, health check not required
 	suite.generateDockerfileAndVerify(false, &runtime.ProcessorDockerfileInfo{
@@ -265,7 +265,7 @@ COPY imageLocal2 imageImage2
 postCopyKind1 postCopyValue1
 postCopyKind2 postCopyValue2
 # Run processor with configuration and platform configuration
-CMD [ "processor", "--config", "/etc/nuclio/config/processor/processor.yaml", "--platform-config", "/etc/nuclio/config/platform/platform.yaml" ]`)
+CMD [ "processor" ]`)
 }
 
 func (suite *testSuite) TestMergeDirectives() {


### PR DESCRIPTION
1. Dashboard / controller now receive platform configuration
2. Processor defaults `--config` and `--platform-config` - removed from all Dockerfiles and such
3. Kubernetes deployer will look at function's status for HTTP port rather than looking for the service information
4. Controller will create metric port (in deployment / service) if `prometheusPull` is configured as a metric sink