### PR TITLE
Adding github as code entry type

### DIFF
--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -82,7 +82,6 @@ The `spec` section contains the requirements and attributes and has the followin
 | runtimeAttributes | See reference | Runtime specific attributes, see runtime documentation for specifics |
 | resources | See [reference](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) | Limit resources allocated to deployed function |
 | readinessTimeoutSeconds | int | Number of seconds that the controller will wait for the function to become ready before declaring failure (default: 30) |
-| build.codeEntryAttributes | map | Code entry specific attributes for archive and github code entry types, see |
 
 ### Example
 

--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -82,6 +82,7 @@ The `spec` section contains the requirements and attributes and has the followin
 | runtimeAttributes | See reference | Runtime specific attributes, see runtime documentation for specifics |
 | resources | See [reference](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) | Limit resources allocated to deployed function |
 | readinessTimeoutSeconds | int | Number of seconds that the controller will wait for the function to become ready before declaring failure (default: 30) |
+| build.codeEntryAttributes | map | Code entry specific attributes for archive and github code entry types, see |
 
 ### Example
 

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -150,25 +150,26 @@ type Directive struct {
 
 // Build holds all configuration parameters related to building a function
 type Build struct {
-	Path               string                 `json:"path,omitempty"`
-	FunctionSourceCode string                 `json:"functionSourceCode,omitempty"`
-	FunctionConfigPath string                 `json:"functionConfigPath,omitempty"`
-	TempDir            string                 `json:"tempDir,omitempty"`
-	Registry           string                 `json:"registry,omitempty"`
-	Image              string                 `json:"image,omitempty"`
-	NoBaseImagesPull   bool                   `json:"noBaseImagesPull,omitempty"`
-	NoCache            bool                   `json:"noCache,omitempty"`
-	NoCleanup          bool                   `json:"noCleanup,omitempty"`
-	BaseImage          string                 `json:"baseImage,omitempty"`
-	Commands           []string               `json:"commands,omitempty"`
-	Directives         map[string][]Directive `json:"directives,omitempty"`
-	ScriptPaths        []string               `json:"scriptPaths,omitempty"`
-	AddedObjectPaths   map[string]string      `json:"addedPaths,omitempty"`
-	Dependencies       []string               `json:"dependencies,omitempty"`
-	OnbuildImage       string                 `json:"onbuildImage,omitempty"`
-	Offline            bool                   `json:"offline,omitempty"`
-	RuntimeAttributes  map[string]interface{} `json:"runtimeAttributes,omitempty"`
-	CodeEntryType      string                 `json:"codeEntryType,omitempty"`
+	Path                string                 `json:"path,omitempty"`
+	FunctionSourceCode  string                 `json:"functionSourceCode,omitempty"`
+	FunctionConfigPath  string                 `json:"functionConfigPath,omitempty"`
+	TempDir             string                 `json:"tempDir,omitempty"`
+	Registry            string                 `json:"registry,omitempty"`
+	Image               string                 `json:"image,omitempty"`
+	NoBaseImagesPull    bool                   `json:"noBaseImagesPull,omitempty"`
+	NoCache             bool                   `json:"noCache,omitempty"`
+	NoCleanup           bool                   `json:"noCleanup,omitempty"`
+	BaseImage           string                 `json:"baseImage,omitempty"`
+	Commands            []string               `json:"commands,omitempty"`
+	Directives          map[string][]Directive `json:"directives,omitempty"`
+	ScriptPaths         []string               `json:"scriptPaths,omitempty"`
+	AddedObjectPaths    map[string]string      `json:"addedPaths,omitempty"`
+	Dependencies        []string               `json:"dependencies,omitempty"`
+	OnbuildImage        string                 `json:"onbuildImage,omitempty"`
+	Offline             bool                   `json:"offline,omitempty"`
+	RuntimeAttributes   map[string]interface{} `json:"runtimeAttributes,omitempty"`
+	CodeEntryType       string                 `json:"codeEntryType,omitempty"`
+	CodeEntryAttributes map[string]interface{} `json:"codeEntryAttributes,omitempty"`
 }
 
 // Spec holds all parameters related to a function's configuration

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -105,4 +105,5 @@ func addBuildFlags(cmd *cobra.Command, config *functionconfig.Config, commands *
 	cmd.Flags().BoolVarP(&config.Spec.Build.Offline, "offline", "", false, "Don't assume internet connectivity exists")
 	cmd.Flags().StringVar(encodedRuntimeAttributes, "build-runtime-attrs", "{}", "JSON-encoded build runtime attributes for the function")
 	cmd.Flags().StringVar(encodedCodeEntryAttributes, "build-code-entry-attrs", "{}", "JSON-encoded build code entry attributes for the function")
+	cmd.Flags().StringVar(&config.Spec.Build.CodeEntryType, "code-entry-type", "", "Type of code entry (for example, \"url\", \"github\", \"image\")")
 }

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -28,11 +28,12 @@ import (
 )
 
 type buildCommandeer struct {
-	cmd                      *cobra.Command
-	rootCommandeer           *RootCommandeer
-	commands                 stringSliceFlag
-	functionConfig           functionconfig.Config
-	encodedRuntimeAttributes string
+	cmd                        *cobra.Command
+	rootCommandeer             *RootCommandeer
+	commands                   stringSliceFlag
+	functionConfig             functionconfig.Config
+	encodedRuntimeAttributes   string
+	encodedCodeEntryAttributes string
 }
 
 func newBuildCommandeer(rootCommandeer *RootCommandeer) *buildCommandeer {
@@ -66,6 +67,12 @@ func newBuildCommandeer(rootCommandeer *RootCommandeer) *buildCommandeer {
 				return errors.Wrap(err, "Failed to decode build runtime attributes")
 			}
 
+			// decode the JSON build code entry attributes
+			if err := json.Unmarshal([]byte(commandeer.encodedCodeEntryAttributes),
+				&commandeer.functionConfig.Spec.Build.CodeEntryAttributes); err != nil {
+				return errors.Wrap(err, "Failed to decode code entry attributes")
+			}
+
 			_, err := rootCommandeer.platform.CreateFunctionBuild(&platform.CreateFunctionBuildOptions{
 				Logger:         rootCommandeer.loggerInstance,
 				FunctionConfig: commandeer.functionConfig,
@@ -75,14 +82,14 @@ func newBuildCommandeer(rootCommandeer *RootCommandeer) *buildCommandeer {
 		},
 	}
 
-	addBuildFlags(cmd, &commandeer.functionConfig, &commandeer.commands, &commandeer.encodedRuntimeAttributes)
+	addBuildFlags(cmd, &commandeer.functionConfig, &commandeer.commands, &commandeer.encodedRuntimeAttributes, &commandeer.encodedCodeEntryAttributes)
 
 	commandeer.cmd = cmd
 
 	return commandeer
 }
 
-func addBuildFlags(cmd *cobra.Command, config *functionconfig.Config, commands *stringSliceFlag, encodedRuntimeAttributes *string) { // nolint
+func addBuildFlags(cmd *cobra.Command, config *functionconfig.Config, commands *stringSliceFlag, encodedRuntimeAttributes *string, encodedCodeEntryAttributes *string) { // nolint
 	cmd.Flags().StringVarP(&config.Spec.Build.Path, "path", "p", "", "Path to the function's source code")
 	cmd.Flags().StringVarP(&config.Spec.Build.FunctionSourceCode, "source", "", "", "The function's source code (overrides \"path\")")
 	cmd.Flags().StringVarP(&config.Spec.Build.FunctionConfigPath, "file", "f", "", "Path to a function-configuration file")
@@ -97,4 +104,5 @@ func addBuildFlags(cmd *cobra.Command, config *functionconfig.Config, commands *
 	cmd.Flags().StringVarP(&config.Spec.Build.OnbuildImage, "onbuild-image", "", "", "The runtime onbuild image used to build the processor image")
 	cmd.Flags().BoolVarP(&config.Spec.Build.Offline, "offline", "", false, "Don't assume internet connectivity exists")
 	cmd.Flags().StringVar(encodedRuntimeAttributes, "build-runtime-attrs", "{}", "JSON-encoded build runtime attributes for the function")
+	cmd.Flags().StringVar(encodedCodeEntryAttributes, "build-code-entry-attrs", "{}", "JSON-encoded build code entry attributes for the function")
 }

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -33,21 +33,22 @@ import (
 )
 
 type deployCommandeer struct {
-	cmd                           *cobra.Command
-	rootCommandeer                *RootCommandeer
-	functionConfig                functionconfig.Config
-	volumes                       stringSliceFlag
-	commands                      stringSliceFlag
-	encodedDataBindings           string
-	encodedTriggers               string
-	encodedLabels                 string
-	encodedRuntimeAttributes      string
-	projectName                   string
-	resourceLimits                stringSliceFlag
-	resourceRequests              stringSliceFlag
-	encodedEnv                    stringSliceFlag
-	encodedFunctionPlatformConfig string
-	encodedBuildRuntimeAttributes string
+	cmd                             *cobra.Command
+	rootCommandeer                  *RootCommandeer
+	functionConfig                  functionconfig.Config
+	volumes                         stringSliceFlag
+	commands                        stringSliceFlag
+	encodedDataBindings             string
+	encodedTriggers                 string
+	encodedLabels                   string
+	encodedRuntimeAttributes        string
+	projectName                     string
+	resourceLimits                  stringSliceFlag
+	resourceRequests                stringSliceFlag
+	encodedEnv                      stringSliceFlag
+	encodedFunctionPlatformConfig   string
+	encodedBuildRuntimeAttributes   string
+	encodedBuildCodeEntryAttributes string
 }
 
 func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
@@ -113,6 +114,12 @@ func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
 				return errors.Wrap(err, "Failed to decode build runtime attributes")
 			}
 
+			// decode the JSON build code entry attributes
+			if err := json.Unmarshal([]byte(commandeer.encodedBuildCodeEntryAttributes),
+				&commandeer.functionConfig.Spec.Build.CodeEntryAttributes); err != nil {
+				return errors.Wrap(err, "Failed to decode code entry attributes")
+			}
+
 			// initialize root
 			if err := rootCommandeer.initialize(); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
@@ -163,7 +170,7 @@ func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
 func addDeployFlags(cmd *cobra.Command,
 	functionConfig *functionconfig.Config,
 	commandeer *deployCommandeer) {
-	addBuildFlags(cmd, functionConfig, &commandeer.commands, &commandeer.encodedBuildRuntimeAttributes)
+	addBuildFlags(cmd, functionConfig, &commandeer.commands, &commandeer.encodedBuildRuntimeAttributes, &commandeer.encodedBuildCodeEntryAttributes)
 
 	cmd.Flags().StringVar(&functionConfig.Spec.Description, "desc", "", "Function description")
 	cmd.Flags().StringVarP(&commandeer.encodedLabels, "labels", "l", "", "Additional function labels (lbl1=val1[,lbl2=val2,...])")

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -592,12 +592,12 @@ func (b *Builder) decompressFunctionArchive(functionPath string) (string, error)
 
 	}
 
-	userSpecifiedRootDirectoryInterface, found := b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["rootDir"]
+	userSpecifiedWorkDirectoryInterface, found := b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["workDir"]
 
-	if b.options.FunctionConfig.Spec.Build.CodeEntryType == "url" && found {
-		userSpecifiedRootDirectory, ok := userSpecifiedRootDirectoryInterface.(string)
+	if b.options.FunctionConfig.Spec.Build.CodeEntryType == "archive" && found {
+		userSpecifiedRootDirectory, ok := userSpecifiedWorkDirectoryInterface.(string)
 		if !ok {
-			return "", errors.New("If code entry type is URL and rootDir is provided, rootDir expected to be string")
+			return "", errors.New("If code entry type is URL and workDir is provided, workDir expected to be string")
 		}
 		decompressDir = filepath.Join(decompressDir, userSpecifiedRootDirectory)
 	}

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -501,13 +501,14 @@ func (b *Builder) resolveFunctionPath(functionPath string) (string, error) {
 
 	// if the function path is a URL or type is Github - first download the file
 	codeEntryType := b.options.FunctionConfig.Spec.Build.CodeEntryType
-	if codeEntryType == "url" || codeEntryType == "github" {
 
-		// user has to provide url even if it's github repo
-		if !common.IsURL(functionPath) {
-			return "", errors.New( "Must provide valid URL when code entry type is github or url")
-		}
+	// user has to provide valid url when code entry type is github
+	if !common.IsURL(functionPath) && codeEntryType == "github" {
+		return "", errors.New( "Must provide valid URL when code entry type is github or url")
+	}
 
+	// for backwards compatibility, don't check for entry type url specifically
+	if common.IsURL(functionPath) {
 		if codeEntryType == "github" {
 			if branch, ok := b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["branch"]; ok {
 				functionPath = fmt.Sprintf("%s/archive/%s.zip",

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -504,7 +504,7 @@ func (b *Builder) resolveFunctionPath(functionPath string) (string, error) {
 
 	// user has to provide valid url when code entry type is github
 	if !common.IsURL(functionPath) && codeEntryType == "github" {
-		return "", errors.New( "Must provide valid URL when code entry type is github or url")
+		return "", errors.New("Must provide valid URL when code entry type is github or url")
 	}
 
 	// for backwards compatibility, don't check for entry type url specifically
@@ -515,7 +515,7 @@ func (b *Builder) resolveFunctionPath(functionPath string) (string, error) {
 					strings.TrimRight(functionPath, "/"),
 					branch)
 			} else {
-				return "", errors.New( "If code entry type is github, branch must be provided")
+				return "", errors.New("If code entry type is github, branch must be provided")
 			}
 		}
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -55,6 +55,8 @@ import (
 const (
 	functionConfigFileName = "function.yaml"
 	uhttpcImage            = "nuclio/uhttpc:0.0.1-amd64"
+	githubEntryType        = "github"
+	archiveEntryType       = "archive"
 )
 
 // holds parameters for things that are required before a runtime can be initialized
@@ -503,13 +505,13 @@ func (b *Builder) resolveFunctionPath(functionPath string) (string, error) {
 	codeEntryType := b.options.FunctionConfig.Spec.Build.CodeEntryType
 
 	// user has to provide valid url when code entry type is github
-	if !common.IsURL(functionPath) && codeEntryType == "github" {
+	if !common.IsURL(functionPath) && codeEntryType == githubEntryType{
 		return "", errors.New("Must provide valid URL when code entry type is github or archive")
 	}
 
 	// for backwards compatibility, don't check for entry type url specifically
 	if common.IsURL(functionPath) {
-		if codeEntryType == "github" {
+		if codeEntryType == githubEntryType {
 			if branch, ok := b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["branch"]; ok {
 				functionPath = fmt.Sprintf("%s/archive/%s.zip",
 					strings.TrimRight(functionPath, "/"),
@@ -576,7 +578,7 @@ func (b *Builder) decompressFunctionArchive(functionPath string) (string, error)
 	}
 
 	codeEntryType := b.options.FunctionConfig.Spec.Build.CodeEntryType
-	if codeEntryType == "github" {
+	if codeEntryType == githubEntryType {
 		directories, err := ioutil.ReadDir(decompressDir)
 		if err != nil {
 			return "", errors.Wrap(err, "Failed to list decompressed directory tree")
@@ -595,7 +597,7 @@ func (b *Builder) decompressFunctionArchive(functionPath string) (string, error)
 
 	userSpecifiedWorkDirectoryInterface, found := b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["workDir"]
 
-	if (codeEntryType == "archive" || codeEntryType == "github") && found {
+	if (codeEntryType == archiveEntryType || codeEntryType == githubEntryType) && found {
 		userSpecifiedWorkDirectory, ok := userSpecifiedWorkDirectoryInterface.(string)
 		if !ok {
 			return "", errors.New("If code entry type is (archive or github) and workDir is provided, "+

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -505,7 +505,7 @@ func (b *Builder) resolveFunctionPath(functionPath string) (string, error) {
 	codeEntryType := b.options.FunctionConfig.Spec.Build.CodeEntryType
 
 	// user has to provide valid url when code entry type is github
-	if !common.IsURL(functionPath) && codeEntryType == githubEntryType{
+	if !common.IsURL(functionPath) && codeEntryType == githubEntryType {
 		return "", errors.New("Must provide valid URL when code entry type is github or archive")
 	}
 
@@ -600,7 +600,7 @@ func (b *Builder) decompressFunctionArchive(functionPath string) (string, error)
 	if (codeEntryType == archiveEntryType || codeEntryType == githubEntryType) && found {
 		userSpecifiedWorkDirectory, ok := userSpecifiedWorkDirectoryInterface.(string)
 		if !ok {
-			return "", errors.New("If code entry type is (archive or github) and workDir is provided, "+
+			return "", errors.New("If code entry type is (archive or github) and workDir is provided, " +
 				"workDir expected to be string")
 		}
 		decompressDir = filepath.Join(decompressDir, userSpecifiedWorkDirectory)

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -155,9 +155,11 @@ func (suite *TestSuite) TestBuildArchiveFromURLWithCustomDir() {
 }
 
 func (suite *TestSuite) TestBuildArchiveFromGithub() {
-	for _, archiveInfo := range suite.archiveInfos {
-		suite.compressAndDeployFunctionFromGithub(archiveInfo.extension, archiveInfo.compressor)
-	}
+	// test only zip
+
+	extension := suite.archiveInfos[0].extension
+	compressor := suite.archiveInfos[0].compressor
+	suite.compressAndDeployFunctionFromGithub(extension, compressor)
 }
 
 func (suite *TestSuite) TestBuildFuncFromFunctionSourceCode() {
@@ -311,8 +313,7 @@ func (suite *TestSuite) compressAndDeployFunctionFromURL(archiveExtension string
 
 	createFunctionOptions := suite.getDeployOptionsDir("reverser")
 
-	parentPath := filepath.Dir(createFunctionOptions.FunctionConfig.Spec.Build.Path)
-	archivePath := suite.createFunctionArchive(parentPath,
+	archivePath := suite.createFunctionArchive(createFunctionOptions.FunctionConfig.Spec.Build.Path,
 		archiveExtension,
 		".*",
 		compressor)
@@ -326,10 +327,8 @@ func (suite *TestSuite) compressAndDeployFunctionFromURLWithCustomDir(archiveExt
 	createFunctionOptions := suite.getDeployOptionsDir("reverser")
 	createFunctionOptions.FunctionConfig.Spec.Build.CodeEntryAttributes = map[string]interface{}{"workDir": "golang"}
 
-	archivePath := suite.createFunctionArchive(createFunctionOptions.FunctionConfig.Spec.Build.Path,
-		archiveExtension,
-		"golang",
-		compressor)
+	parentPath := filepath.Dir(createFunctionOptions.FunctionConfig.Spec.Build.Path)
+	archivePath := suite.createFunctionArchive(parentPath, archiveExtension, "golang", compressor)
 
 	suite.compressAndDeployFunctionWithCodeEntryOptions(archivePath, createFunctionOptions)
 }

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -19,16 +19,16 @@ package buildsuite
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
-	"path"
-
+	"github.com/mholt/archiver"
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
 	"github.com/nuclio/nuclio/test/httpsrv"
-
-	"github.com/mholt/archiver"
+	"io/ioutil"
+	"path"
+	"path/filepath"
+	"regexp"
 )
 
 type FunctionInfo struct {
@@ -143,6 +143,18 @@ func (suite *TestSuite) TestBuildArchive() {
 func (suite *TestSuite) TestBuildArchiveFromURL() {
 	for _, archiveInfo := range suite.archiveInfos {
 		suite.compressAndDeployFunctionFromURL(archiveInfo.extension, archiveInfo.compressor)
+	}
+}
+
+func (suite *TestSuite) TestBuildArchiveFromURLWithCustomDir() {
+	for _, archiveInfo := range suite.archiveInfos {
+		suite.compressAndDeployFunctionFromURLWithCustomDir(archiveInfo.extension, archiveInfo.compressor)
+	}
+}
+
+func (suite *TestSuite) TestBuildArchiveFromGithub() {
+	for _, archiveInfo := range suite.archiveInfos {
+		suite.compressAndDeployFunctionFromGithub(archiveInfo.extension, archiveInfo.compressor)
 	}
 }
 
@@ -297,10 +309,70 @@ func (suite *TestSuite) compressAndDeployFunctionFromURL(archiveExtension string
 
 	createFunctionOptions := suite.getDeployOptionsDir("reverser")
 
-	archivePath := suite.createFunctionArchive(createFunctionOptions.FunctionConfig.Spec.Build.Path,
+	parentPath := filepath.Dir(createFunctionOptions.FunctionConfig.Spec.Build.Path)
+	archivePath := suite.createFunctionArchive(parentPath,
 		archiveExtension,
+		".*",
 		compressor)
 
+	suite.compressAndDeployFunctionWithCodeEntryOptions(archivePath, createFunctionOptions)
+}
+
+func (suite *TestSuite) compressAndDeployFunctionFromURLWithCustomDir(archiveExtension string,
+	compressor func(string, []string) error) {
+
+	createFunctionOptions := suite.getDeployOptionsDir("reverser")
+	createFunctionOptions.FunctionConfig.Spec.Build.CodeEntryAttributes = map[string]interface{}{"rootDir": "golang"}
+
+	archivePath := suite.createFunctionArchive(createFunctionOptions.FunctionConfig.Spec.Build.Path,
+		archiveExtension,
+		"golang",
+		compressor)
+
+	suite.compressAndDeployFunctionWithCodeEntryOptions(archivePath, createFunctionOptions)
+}
+
+func (suite *TestSuite) compressAndDeployFunctionFromGithub(archiveExtension string,
+	compressor func(string, []string) error) {
+
+	branch := "master"
+	createFunctionOptions := suite.getDeployOptionsDir("reverser")
+
+	// get the parent directory, and archive it just like github does
+	parentPath := filepath.Dir(createFunctionOptions.FunctionConfig.Spec.Build.Path)
+	archivePath := suite.createFunctionArchive(parentPath, archiveExtension, "golang", compressor)
+
+	// create a path like it would have been created by github
+	pathToFunction :="/some/repo"
+
+	// start an HTTP server to serve the reverser py
+	httpServer, err := httpsrv.NewServer("", []httpsrv.ServedFile{
+		{
+			LocalPath: archivePath,
+			Pattern:   fmt.Sprintf("%s/archive/%s.zip", pathToFunction, branch),
+		},
+	}, nil)
+
+	suite.Require().NoError(err)
+	defer httpServer.Stop() // nolint: errcheck
+
+	createFunctionOptions.FunctionConfig.Spec.Build.Path = fmt.Sprintf("http://%s%s",
+		httpServer.Addr,
+		pathToFunction)
+
+	createFunctionOptions.FunctionConfig.Spec.Build.CodeEntryType = "github"
+	createFunctionOptions.FunctionConfig.Spec.Build.CodeEntryAttributes = map[string]interface{}{"branch": branch}
+
+	suite.DeployFunctionAndRequest(createFunctionOptions,
+		&httpsuite.Request{
+			RequestMethod:        "POST",
+			RequestBody:          "abcdef",
+			ExpectedResponseBody: "fedcba",
+		})
+}
+
+func (suite *TestSuite) compressAndDeployFunctionWithCodeEntryOptions(archivePath string,
+	createFunctionOptions *platform.CreateFunctionOptions) {
 	pathToFunction := "/some/path/to/function/" + path.Base(archivePath)
 
 	// start an HTTP server to serve the reverser py
@@ -317,6 +389,8 @@ func (suite *TestSuite) compressAndDeployFunctionFromURL(archiveExtension string
 	createFunctionOptions.FunctionConfig.Spec.Build.Path = fmt.Sprintf("http://%s%s",
 		httpServer.Addr,
 		pathToFunction)
+
+	createFunctionOptions.FunctionConfig.Spec.Build.CodeEntryType = "url"
 
 	suite.DeployFunctionAndRequest(createFunctionOptions,
 		&httpsuite.Request{
@@ -339,6 +413,7 @@ func (suite *TestSuite) compressAndDeployFunction(archiveExtension string, compr
 
 	archivePath := suite.createFunctionArchive(createFunctionOptions.FunctionConfig.Spec.Build.Path,
 		archiveExtension,
+		".*",
 		compressor)
 
 	// set the path to the zip
@@ -354,6 +429,7 @@ func (suite *TestSuite) compressAndDeployFunction(archiveExtension string, compr
 
 func (suite *TestSuite) createFunctionArchive(functionDir string,
 	archiveExtension string,
+	archivePattern string,
 	compressor func(string, []string) error) string {
 
 	// create a temp directory that will hold the archive
@@ -368,8 +444,12 @@ func (suite *TestSuite) createFunctionArchive(functionDir string,
 
 	var functionFileNames []string
 	for _, functionFileInfo := range functionFileInfos {
-		functionFileNames = append(functionFileNames,
-			path.Join(functionDir, functionFileInfo.Name()))
+		matched, err := regexp.MatchString(archivePattern, functionFileInfo.Name())
+		suite.Require().NoError(err)
+
+		if matched {
+			functionFileNames = append(functionFileNames, path.Join(functionDir, functionFileInfo.Name()))
+		}
 	}
 
 	// create the archive

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -345,7 +345,7 @@ func (suite *TestSuite) compressAndDeployFunctionFromGithub(archiveExtension str
 	archivePath := suite.createFunctionArchive(parentPath, archiveExtension, "golang", compressor)
 
 	// create a path like it would have been created by github
-	pathToFunction :="/some/repo"
+	pathToFunction := "/some/repo"
 
 	// start an HTTP server to serve the reverser py
 	httpServer, err := httpsrv.NewServer("", []httpsrv.ServedFile{

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -19,16 +19,18 @@ package buildsuite
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/mholt/archiver"
+	"io/ioutil"
+	"path"
+	"path/filepath"
+	"regexp"
+
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
 	"github.com/nuclio/nuclio/test/httpsrv"
-	"io/ioutil"
-	"path"
-	"path/filepath"
-	"regexp"
+
+	"github.com/mholt/archiver"
 )
 
 type FunctionInfo struct {

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -324,7 +324,7 @@ func (suite *TestSuite) compressAndDeployFunctionFromURLWithCustomDir(archiveExt
 	compressor func(string, []string) error) {
 
 	createFunctionOptions := suite.getDeployOptionsDir("reverser")
-	createFunctionOptions.FunctionConfig.Spec.Build.CodeEntryAttributes = map[string]interface{}{"rootDir": "golang"}
+	createFunctionOptions.FunctionConfig.Spec.Build.CodeEntryAttributes = map[string]interface{}{"workDir": "golang"}
 
 	archivePath := suite.createFunctionArchive(createFunctionOptions.FunctionConfig.Spec.Build.Path,
 		archiveExtension,
@@ -392,7 +392,7 @@ func (suite *TestSuite) compressAndDeployFunctionWithCodeEntryOptions(archivePat
 		httpServer.Addr,
 		pathToFunction)
 
-	createFunctionOptions.FunctionConfig.Spec.Build.CodeEntryType = "url"
+	createFunctionOptions.FunctionConfig.Spec.Build.CodeEntryType = "archive"
 
 	suite.DeployFunctionAndRequest(createFunctionOptions,
 		&httpsuite.Request{


### PR DESCRIPTION
Allows specifying github as a code entry type and introducing code entry attributes for both github code entry type and archive code entry type

Archive handling is left as is, adding optional workDir attribute

When specifying github code entry type, path should be the github repo url (e.g. https://github.com/nuclio/nuclio) and a branch is required to be set

- Github code entry attributes
  - branch (specifying from what branch to download the archive)
  - workDir (specifying the working directory where handler files located)
- Archive code entry attributes
  - workDir (specifying the working directory where handler files located)