### PR TITLE
GitHub entry type support

### DIFF
--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -150,25 +150,26 @@ type Directive struct {
 
 // Build holds all configuration parameters related to building a function
 type Build struct {
-	Path               string                 `json:"path,omitempty"`
-	FunctionSourceCode string                 `json:"functionSourceCode,omitempty"`
-	FunctionConfigPath string                 `json:"functionConfigPath,omitempty"`
-	TempDir            string                 `json:"tempDir,omitempty"`
-	Registry           string                 `json:"registry,omitempty"`
-	Image              string                 `json:"image,omitempty"`
-	NoBaseImagesPull   bool                   `json:"noBaseImagesPull,omitempty"`
-	NoCache            bool                   `json:"noCache,omitempty"`
-	NoCleanup          bool                   `json:"noCleanup,omitempty"`
-	BaseImage          string                 `json:"baseImage,omitempty"`
-	Commands           []string               `json:"commands,omitempty"`
-	Directives         map[string][]Directive `json:"directives,omitempty"`
-	ScriptPaths        []string               `json:"scriptPaths,omitempty"`
-	AddedObjectPaths   map[string]string      `json:"addedPaths,omitempty"`
-	Dependencies       []string               `json:"dependencies,omitempty"`
-	OnbuildImage       string                 `json:"onbuildImage,omitempty"`
-	Offline            bool                   `json:"offline,omitempty"`
-	RuntimeAttributes  map[string]interface{} `json:"runtimeAttributes,omitempty"`
-	CodeEntryType      string                 `json:"codeEntryType,omitempty"`
+	Path                string                 `json:"path,omitempty"`
+	FunctionSourceCode  string                 `json:"functionSourceCode,omitempty"`
+	FunctionConfigPath  string                 `json:"functionConfigPath,omitempty"`
+	TempDir             string                 `json:"tempDir,omitempty"`
+	Registry            string                 `json:"registry,omitempty"`
+	Image               string                 `json:"image,omitempty"`
+	NoBaseImagesPull    bool                   `json:"noBaseImagesPull,omitempty"`
+	NoCache             bool                   `json:"noCache,omitempty"`
+	NoCleanup           bool                   `json:"noCleanup,omitempty"`
+	BaseImage           string                 `json:"baseImage,omitempty"`
+	Commands            []string               `json:"commands,omitempty"`
+	Directives          map[string][]Directive `json:"directives,omitempty"`
+	ScriptPaths         []string               `json:"scriptPaths,omitempty"`
+	AddedObjectPaths    map[string]string      `json:"addedPaths,omitempty"`
+	Dependencies        []string               `json:"dependencies,omitempty"`
+	OnbuildImage        string                 `json:"onbuildImage,omitempty"`
+	Offline             bool                   `json:"offline,omitempty"`
+	RuntimeAttributes   map[string]interface{} `json:"runtimeAttributes,omitempty"`
+	CodeEntryType       string                 `json:"codeEntryType,omitempty"`
+	CodeEntryAttributes map[string]interface{} `json:"codeEntryAttributes,omitempty"`
 }
 
 // Spec holds all parameters related to a function's configuration

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -33,21 +33,22 @@ import (
 )
 
 type deployCommandeer struct {
-	cmd                           *cobra.Command
-	rootCommandeer                *RootCommandeer
-	functionConfig                functionconfig.Config
-	volumes                       stringSliceFlag
-	commands                      stringSliceFlag
-	encodedDataBindings           string
-	encodedTriggers               string
-	encodedLabels                 string
-	encodedRuntimeAttributes      string
-	projectName                   string
-	resourceLimits                stringSliceFlag
-	resourceRequests              stringSliceFlag
-	encodedEnv                    stringSliceFlag
-	encodedFunctionPlatformConfig string
-	encodedBuildRuntimeAttributes string
+	cmd                             *cobra.Command
+	rootCommandeer                  *RootCommandeer
+	functionConfig                  functionconfig.Config
+	volumes                         stringSliceFlag
+	commands                        stringSliceFlag
+	encodedDataBindings             string
+	encodedTriggers                 string
+	encodedLabels                   string
+	encodedRuntimeAttributes        string
+	projectName                     string
+	resourceLimits                  stringSliceFlag
+	resourceRequests                stringSliceFlag
+	encodedEnv                      stringSliceFlag
+	encodedFunctionPlatformConfig   string
+	encodedBuildRuntimeAttributes   string
+	encodedBuildCodeEntryAttributes string
 }
 
 func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
@@ -113,6 +114,12 @@ func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
 				return errors.Wrap(err, "Failed to decode build runtime attributes")
 			}
 
+			// decode the JSON build code entry attributes
+			if err := json.Unmarshal([]byte(commandeer.encodedBuildCodeEntryAttributes),
+				&commandeer.functionConfig.Spec.Build.CodeEntryAttributes); err != nil {
+				return errors.Wrap(err, "Failed to decode code entry attributes")
+			}
+
 			// initialize root
 			if err := rootCommandeer.initialize(); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
@@ -163,7 +170,7 @@ func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
 func addDeployFlags(cmd *cobra.Command,
 	functionConfig *functionconfig.Config,
 	commandeer *deployCommandeer) {
-	addBuildFlags(cmd, functionConfig, &commandeer.commands, &commandeer.encodedBuildRuntimeAttributes)
+	addBuildFlags(cmd, functionConfig, &commandeer.commands, &commandeer.encodedBuildRuntimeAttributes, &commandeer.encodedBuildCodeEntryAttributes)
 
 	cmd.Flags().StringVar(&functionConfig.Spec.Description, "desc", "", "Function description")
 	cmd.Flags().StringVarP(&commandeer.encodedLabels, "labels", "l", "", "Additional function labels (lbl1=val1[,lbl2=val2,...])")

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -55,6 +55,8 @@ import (
 const (
 	functionConfigFileName = "function.yaml"
 	uhttpcImage            = "nuclio/uhttpc:0.0.1-amd64"
+	githubEntryType        = "github"
+	archiveEntryType       = "archive"
 )
 
 // holds parameters for things that are required before a runtime can be initialized
@@ -472,6 +474,7 @@ func (b *Builder) writeFunctionSourceCodeToTempFile(functionSourceCode string) (
 }
 
 func (b *Builder) resolveFunctionPath(functionPath string) (string, error) {
+	var err error
 
 	if b.options.FunctionConfig.Spec.Build.FunctionSourceCode != "" {
 
@@ -499,8 +502,23 @@ func (b *Builder) resolveFunctionPath(functionPath string) (string, error) {
 		}
 	}
 
-	// if the function path is a URL - first download the file
+	// if the function path is a URL or type is Github - first download the file
+	codeEntryType := b.options.FunctionConfig.Spec.Build.CodeEntryType
+
+	// user has to provide valid url when code entry type is github
+	if !common.IsURL(functionPath) && codeEntryType == githubEntryType {
+		return "", errors.New("Must provide valid URL when code entry type is github or archive")
+	}
+
+	// for backwards compatibility, don't check for entry type url specifically
 	if common.IsURL(functionPath) {
+		if codeEntryType == githubEntryType {
+			functionPath, err = b.getFunctionPathFromGithubURL(functionPath)
+			if err != nil {
+				return "", errors.Wrapf(err, "Failed to infer function path of github entry type")
+			}
+		}
+
 		tempDir, err := b.mkDirUnderTemp("download")
 		if err != nil {
 			return "", errors.Wrapf(err, "Failed to create temporary dir for download: %s", tempDir)
@@ -539,6 +557,17 @@ func (b *Builder) resolveFunctionPath(functionPath string) (string, error) {
 	return resolvedPath, nil
 }
 
+func (b *Builder) getFunctionPathFromGithubURL(functionPath string) (string, error) {
+	if branch, ok := b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["branch"]; ok {
+		functionPath = fmt.Sprintf("%s/archive/%s.zip",
+			strings.TrimRight(functionPath, "/"),
+			branch)
+	} else {
+		return "", errors.New("If code entry type is github, branch must be provided")
+	}
+	return functionPath, nil
+}
+
 func (b *Builder) decompressFunctionArchive(functionPath string) (string, error) {
 
 	// create a staging directory
@@ -555,6 +584,48 @@ func (b *Builder) decompressFunctionArchive(functionPath string) (string, error)
 	err = decompressor.Decompress(functionPath, decompressDir)
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed to decompress file %s", functionPath)
+	}
+
+	codeEntryType := b.options.FunctionConfig.Spec.Build.CodeEntryType
+	if codeEntryType == githubEntryType {
+		decompressDir, err = b.resolveGithubArchiveWorkDir(decompressDir)
+		if err != nil {
+			return "", errors.Wrap(err, "Failed to get decompressed directory of entry type github")
+		}
+	}
+
+	return b.resolveUserSpecifiedArchiveWorkdir(decompressDir)
+}
+
+func (b *Builder) resolveGithubArchiveWorkDir(decompressDir string) (string, error) {
+	directories, err := ioutil.ReadDir(decompressDir)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to list decompressed directory tree")
+	}
+
+	// when code entry type is github assume only one directory under root
+	directory := directories[0]
+
+	if directory.IsDir() {
+		decompressDir = filepath.Join(decompressDir, directory.Name())
+	} else {
+		return "", errors.New("Unexpected non directory found with entry code type github")
+	}
+
+	return decompressDir, nil
+}
+
+func (b *Builder) resolveUserSpecifiedArchiveWorkdir(decompressDir string) (string, error) {
+	codeEntryType := b.options.FunctionConfig.Spec.Build.CodeEntryType
+	userSpecifiedWorkDirectoryInterface, found := b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["workDir"]
+
+	if (codeEntryType == archiveEntryType || codeEntryType == githubEntryType) && found {
+		userSpecifiedWorkDirectory, ok := userSpecifiedWorkDirectoryInterface.(string)
+		if !ok {
+			return "", errors.New("If code entry type is (archive or github) and workDir is provided, " +
+				"workDir expected to be string")
+		}
+		decompressDir = filepath.Join(decompressDir, userSpecifiedWorkDirectory)
 	}
 	return decompressDir, nil
 }

--- a/pkg/processor/build/runtime/dotnetcore/test/dotnetcore_test.go
+++ b/pkg/processor/build/runtime/dotnetcore/test/dotnetcore_test.go
@@ -32,6 +32,7 @@ func (suite *TestSuite) SetupSuite() {
 	suite.TestSuite.SetupSuite()
 
 	suite.TestSuite.RuntimeSuite = suite
+	suite.TestSuite.ArchivePattern = "dotnetcore"
 }
 
 func (suite *TestSuite) GetFunctionInfo(functionName string) buildsuite.FunctionInfo {

--- a/pkg/processor/build/runtime/golang/test/golang_test.go
+++ b/pkg/processor/build/runtime/golang/test/golang_test.go
@@ -36,6 +36,7 @@ func (suite *testSuite) SetupSuite() {
 	suite.TestSuite.SetupSuite()
 
 	suite.TestSuite.RuntimeSuite = suite
+	suite.TestSuite.ArchivePattern = "golang"
 }
 
 func (suite *testSuite) TestBuildWithCompilationError() {

--- a/pkg/processor/build/runtime/java/test/java_test.go
+++ b/pkg/processor/build/runtime/java/test/java_test.go
@@ -35,6 +35,7 @@ func (suite *TestSuite) SetupSuite() {
 	suite.TestSuite.SetupSuite()
 
 	suite.TestSuite.RuntimeSuite = suite
+	suite.TestSuite.ArchivePattern = "java"
 }
 
 func (suite *TestSuite) GetFunctionInfo(functionName string) buildsuite.FunctionInfo {

--- a/pkg/processor/build/runtime/nodejs/test/nodejs_test.go
+++ b/pkg/processor/build/runtime/nodejs/test/nodejs_test.go
@@ -32,6 +32,7 @@ func (suite *TestSuite) SetupSuite() {
 	suite.TestSuite.SetupSuite()
 
 	suite.TestSuite.RuntimeSuite = suite
+	suite.TestSuite.ArchivePattern = "nodejs"
 }
 
 func (suite *TestSuite) GetFunctionInfo(functionName string) buildsuite.FunctionInfo {

--- a/pkg/processor/build/runtime/pypy/_test/pypy_test.go
+++ b/pkg/processor/build/runtime/pypy/_test/pypy_test.go
@@ -32,6 +32,7 @@ func (suite *TestSuite) SetupSuite() {
 	suite.TestSuite.SetupSuite()
 
 	suite.TestSuite.RuntimeSuite = suite
+	suite.TestSuite.ArchivePattern = "pypy"
 }
 
 func (suite *TestSuite) GetFunctionInfo(functionName string) buildsuite.FunctionInfo {

--- a/pkg/processor/build/runtime/python/test/python_test.go
+++ b/pkg/processor/build/runtime/python/test/python_test.go
@@ -40,6 +40,7 @@ func (suite *testSuite) SetupSuite() {
 	suite.TestSuite.SetupSuite()
 
 	suite.TestSuite.RuntimeSuite = suite
+	suite.TestSuite.ArchivePattern = "python"
 }
 
 func (suite *testSuite) TestBuildPy2() {

--- a/pkg/processor/build/runtime/ruby/test/ruby_test.go
+++ b/pkg/processor/build/runtime/ruby/test/ruby_test.go
@@ -32,6 +32,7 @@ func (suite *TestSuite) SetupSuite() {
 	suite.TestSuite.SetupSuite()
 
 	suite.TestSuite.RuntimeSuite = suite
+	suite.TestSuite.ArchivePattern = "ruby"
 }
 
 func (suite *TestSuite) GetFunctionInfo(functionName string) buildsuite.FunctionInfo {

--- a/pkg/processor/build/runtime/shell/test/shell_test.go
+++ b/pkg/processor/build/runtime/shell/test/shell_test.go
@@ -33,6 +33,7 @@ func (suite *TestSuite) SetupSuite() {
 	suite.TestSuite.SetupSuite()
 
 	suite.TestSuite.RuntimeSuite = suite
+	suite.TestSuite.ArchivePattern = "shell"
 }
 
 func (suite *TestSuite) TestBuildBinaryWithStdin() {

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -51,8 +51,9 @@ type archiveInfo struct {
 
 type TestSuite struct {
 	httpsuite.TestSuite
-	RuntimeSuite RuntimeSuite
-	archiveInfos []archiveInfo
+	RuntimeSuite     RuntimeSuite
+	ArchivePattern   string
+	archiveInfos     []archiveInfo
 }
 
 func (suite *TestSuite) SetupSuite() {
@@ -144,13 +145,17 @@ func (suite *TestSuite) TestBuildArchive() {
 
 func (suite *TestSuite) TestBuildArchiveFromURL() {
 	for _, archiveInfo := range suite.archiveInfos {
-		suite.compressAndDeployFunctionFromURL(archiveInfo.extension, archiveInfo.compressor)
+		suite.compressAndDeployFunctionFromURL(archiveInfo.extension,
+			archiveInfo.compressor,
+			suite.ArchivePattern)
 	}
 }
 
 func (suite *TestSuite) TestBuildArchiveFromURLWithCustomDir() {
 	for _, archiveInfo := range suite.archiveInfos {
-		suite.compressAndDeployFunctionFromURLWithCustomDir(archiveInfo.extension, archiveInfo.compressor)
+		suite.compressAndDeployFunctionFromURLWithCustomDir(archiveInfo.extension,
+			archiveInfo.compressor,
+			suite.ArchivePattern)
 	}
 }
 
@@ -159,7 +164,7 @@ func (suite *TestSuite) TestBuildArchiveFromGithub() {
 
 	extension := suite.archiveInfos[0].extension
 	compressor := suite.archiveInfos[0].compressor
-	suite.compressAndDeployFunctionFromGithub(extension, compressor)
+	suite.compressAndDeployFunctionFromGithub(extension, compressor, suite.ArchivePattern)
 }
 
 func (suite *TestSuite) TestBuildFuncFromFunctionSourceCode() {
@@ -309,7 +314,8 @@ func (suite *TestSuite) DeployFunctionFromURL(createFunctionOptions *platform.Cr
 }
 
 func (suite *TestSuite) compressAndDeployFunctionFromURL(archiveExtension string,
-	compressor func(string, []string) error) {
+	compressor func(string, []string) error,
+	archivePattern string) {
 
 	createFunctionOptions := suite.getDeployOptionsDir("reverser")
 
@@ -322,24 +328,26 @@ func (suite *TestSuite) compressAndDeployFunctionFromURL(archiveExtension string
 }
 
 func (suite *TestSuite) compressAndDeployFunctionFromURLWithCustomDir(archiveExtension string,
-	compressor func(string, []string) error) {
+	compressor func(string, []string) error,
+	archivePattern string) {
 
 	createFunctionOptions := suite.getDeployOptionsDir("reverser")
 	createFunctionOptions.FunctionConfig.Spec.Build.CodeEntryAttributes = map[string]interface{}{
-		"workDir": createFunctionOptions.FunctionConfig.Spec.Runtime,
+		"workDir": archivePattern,
 	}
 
 	parentPath := filepath.Dir(createFunctionOptions.FunctionConfig.Spec.Build.Path)
 	archivePath := suite.createFunctionArchive(parentPath,
 		archiveExtension,
-		createFunctionOptions.FunctionConfig.Spec.Runtime,
+		archivePattern,
 		compressor)
 
 	suite.compressAndDeployFunctionWithCodeEntryOptions(archivePath, createFunctionOptions)
 }
 
 func (suite *TestSuite) compressAndDeployFunctionFromGithub(archiveExtension string,
-	compressor func(string, []string) error) {
+	compressor func(string, []string) error,
+	archivePattern string) {
 
 	branch := "master"
 	createFunctionOptions := suite.getDeployOptionsDir("reverser")
@@ -348,7 +356,7 @@ func (suite *TestSuite) compressAndDeployFunctionFromGithub(archiveExtension str
 	parentPath := filepath.Dir(createFunctionOptions.FunctionConfig.Spec.Build.Path)
 	archivePath := suite.createFunctionArchive(parentPath,
 		archiveExtension,
-		createFunctionOptions.FunctionConfig.Spec.Runtime,
+		archivePattern,
 		compressor)
 
 	// create a path like it would have been created by github

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -51,9 +51,9 @@ type archiveInfo struct {
 
 type TestSuite struct {
 	httpsuite.TestSuite
-	RuntimeSuite     RuntimeSuite
-	ArchivePattern   string
-	archiveInfos     []archiveInfo
+	RuntimeSuite   RuntimeSuite
+	ArchivePattern string
+	archiveInfos   []archiveInfo
 }
 
 func (suite *TestSuite) SetupSuite() {

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -325,10 +325,15 @@ func (suite *TestSuite) compressAndDeployFunctionFromURLWithCustomDir(archiveExt
 	compressor func(string, []string) error) {
 
 	createFunctionOptions := suite.getDeployOptionsDir("reverser")
-	createFunctionOptions.FunctionConfig.Spec.Build.CodeEntryAttributes = map[string]interface{}{"workDir": "golang"}
+	createFunctionOptions.FunctionConfig.Spec.Build.CodeEntryAttributes = map[string]interface{}{
+		"workDir": createFunctionOptions.FunctionConfig.Spec.Runtime,
+	}
 
 	parentPath := filepath.Dir(createFunctionOptions.FunctionConfig.Spec.Build.Path)
-	archivePath := suite.createFunctionArchive(parentPath, archiveExtension, "golang", compressor)
+	archivePath := suite.createFunctionArchive(parentPath,
+		archiveExtension,
+		createFunctionOptions.FunctionConfig.Spec.Runtime,
+		compressor)
 
 	suite.compressAndDeployFunctionWithCodeEntryOptions(archivePath, createFunctionOptions)
 }
@@ -341,7 +346,10 @@ func (suite *TestSuite) compressAndDeployFunctionFromGithub(archiveExtension str
 
 	// get the parent directory, and archive it just like github does
 	parentPath := filepath.Dir(createFunctionOptions.FunctionConfig.Spec.Build.Path)
-	archivePath := suite.createFunctionArchive(parentPath, archiveExtension, "golang", compressor)
+	archivePath := suite.createFunctionArchive(parentPath,
+		archiveExtension,
+		createFunctionOptions.FunctionConfig.Spec.Runtime,
+		compressor)
 
 	// create a path like it would have been created by github
 	pathToFunction := "/some/repo"


### PR DESCRIPTION
Allows specifying github as a code entry type and introducing code entry attributes for both github code entry type and archive code entry type

Archive handling is left as is, adding optional workDir attribute

When specifying github code entry type, path should be the github repo url (e.g. https://github.com/nuclio/nuclio) and a branch is required to be set

- Github code entry attributes
  - branch (specifying from what branch to download the archive)
  - workDir (specifying the working directory where handler files located)
- Archive code entry attributes
  - workDir (specifying the working directory where handler files located)