### PR TITLE
Doc: Update extra-config parameter to minikube start

### DIFF
--- a/docs/setup/minikube/getting-started-minikube.md
+++ b/docs/setup/minikube/getting-started-minikube.md
@@ -27,11 +27,11 @@ We recommend using drivers:
 
 **Mac OS**:
 ```sh
-minikube start --vm-driver=xhyve --extra-config=apiserver.Authorization.Mode=RBAC
+minikube start --vm-driver=xhyve --extra-config=apiserver.authorization-mode=RBAC
 ```
 **Linux**:
 ```sh
-minikube start --vm-driver=virtualbox --extra-config=apiserver.Authorization.Mode=RBAC
+minikube start --vm-driver=virtualbox --extra-config=apiserver.authorization-mode=RBAC
 ```
 
 **Set admin permissions:** bypass Minikube configuration issues by giving cluster-admin permissions to the Kubernetes services, so that services such as `kube-dns` can work in Minikube:


### PR DESCRIPTION
This PR updates the documentation for starting minikube with RBAC based on the updated example from [kubernetes/minikube](https://github.com/kubernetes/minikube/commit/508dda2692f83bfdc4d76b59d9b88dc114a58149).