### PR TITLE
Panics during dashboard deploy are now logged

### DIFF
--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -434,9 +434,9 @@ func (suite *functionDeployTestSuite) TestBuildWithSaveDeployWithLoad() {
 
 	err := suite.ExecuteNutcl([]string{"build", functionName, "--verbose", "--no-pull"},
 		map[string]string{
-			"path":    path.Join(suite.GetFunctionsDir(), "common", "reverser", "golang"),
-			"image":   imageName,
-			"runtime": "golang",
+			"path":              path.Join(suite.GetFunctionsDir(), "common", "reverser", "golang"),
+			"image":             imageName,
+			"runtime":           "golang",
 			"output-image-file": tarName,
 		})
 
@@ -450,9 +450,9 @@ func (suite *functionDeployTestSuite) TestBuildWithSaveDeployWithLoad() {
 	// use deploy with the image we just created
 	err = suite.ExecuteNutcl([]string{"deploy", functionName, "--verbose"},
 		map[string]string{
-			"run-image": imageName,
-			"runtime":   "golang",
-			"handler":   "main:Reverse",
+			"run-image":        imageName,
+			"runtime":          "golang",
+			"handler":          "main:Reverse",
 			"input-image-file": tarName,
 		})
 

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -487,7 +487,11 @@ func (p *Platform) deployFunction(createFunctionOptions *platform.CreateFunction
 	}
 
 	for _, volume := range createFunctionOptions.FunctionConfig.Spec.Volumes {
-		volumesMap[volume.Volume.HostPath.Path] = volume.VolumeMount.MountPath
+
+		// only add hostpath volumes
+		if volume.Volume.HostPath != nil {
+			volumesMap[volume.Volume.HostPath.Path] = volume.VolumeMount.MountPath
+		}
 	}
 
 	envMap := map[string]string{}


### PR DESCRIPTION
1. If a panic occurs during dashboard deploy, it is logged
2. Removed unused code for update function
3. Local platform will ignore non hostPath volumes (caused panic)