### PR TITLE
UI: Fix Test pane visual bugs; Status Invocation URL is N/A

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.3.12",
+    "iguazio.dashboard-controls": "^0.3.13",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- "Code" tab:
  - "Test" pane:
    - When reducing Test pane's width, the Headers, Body type drop-down and Log Level drop-down wrap around and move to the next line, instead of staying on the same lime.
    - The contents of code editor in response part sometimes overflows to the right of the screen.
- "Status" tab:
  - Invocation URL shows "N/A" even though the function is deployed and has a defined port number.