### PR TITLE
Change source hash to build mode

### DIFF
--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -148,6 +148,13 @@ type Directive struct {
 	Value string `json:"value,omitempty"`
 }
 
+type BuildMode string
+
+const (
+	NeverBuild  BuildMode = "neverBuild"
+	AlwaysBuild BuildMode = "alwaysBuild"
+)
+
 // Build holds all configuration parameters related to building a function
 type Build struct {
 	Path                string                 `json:"path,omitempty"`
@@ -171,6 +178,7 @@ type Build struct {
 	CodeEntryType       string                 `json:"codeEntryType,omitempty"`
 	CodeEntryAttributes map[string]interface{} `json:"codeEntryAttributes,omitempty"`
 	Timestamp           int64                  `json:"timestamp,omitempty"`
+	Mode                BuildMode              `json:"mode,omitempty"`
 }
 
 // Spec holds all parameters related to a function's configuration
@@ -200,7 +208,6 @@ type Spec struct {
 	DealerURI               string                  `json:"dealerURI,omitempty"`
 	Platform                Platform                `json:"platform,omitempty"`
 	ReadinessTimeoutSeconds int                     `json:"readinessTimeoutSeconds,omitempty"`
-	SourceHash              string                  `json:"sourceHash,omitempty"`
 }
 
 // to appease k8s

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -25,7 +25,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/build"
 
 	"github.com/nuclio/logger"
-	"github.com/rs/xid"
 )
 
 //
@@ -113,16 +112,10 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 				createFunctionOptions.FunctionConfig.Spec.RunRegistry = createFunctionOptions.FunctionConfig.Spec.Build.Registry
 			}
 
-			// on successful build set the source hash and timestamp of build
-			createFunctionOptions.FunctionConfig.Spec.SourceHash = xid.New().String()
+			// on successful build set the timestamp of build
 			createFunctionOptions.FunctionConfig.Spec.Build.Timestamp = time.Now().Unix()
 		}
 	} else {
-
-		// no function build required and no image passed, means to use latest known image
-		if existingFunctionConfig != nil && createFunctionOptions.FunctionConfig.Spec.Image == "" {
-			createFunctionOptions.FunctionConfig.Spec.Image = existingFunctionConfig.Spec.Image
-		}
 
 		// verify user passed runtime
 		if createFunctionOptions.FunctionConfig.Spec.Runtime == "" {
@@ -133,6 +126,12 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 		if err = onAfterConfigUpdatedWrapper(&createFunctionOptions.FunctionConfig); err != nil {
 			return nil, errors.Wrap(err, "Failed to trigger on after config update")
 		}
+	}
+
+	// bail early, no deploy needed
+	if existingFunctionConfig == nil &&
+		createFunctionOptions.FunctionConfig.Spec.Build.Mode == functionconfig.NeverBuild {
+		return nil, nil
 	}
 
 	// wrap the deployer's deploy with the base HandleDeployFunction
@@ -232,38 +231,26 @@ func (ap *Platform) ResolveDefaultNamespace(defaultNamespace string) string {
 func (ap *Platform) functionBuildRequired(existingFunctionConfig *functionconfig.ConfigWithStatus,
 	createFunctionOptions *platform.CreateFunctionOptions) (bool, error) {
 
-	// check if we have something to compare to, if so, check if anything changed
-	if existingFunctionConfig == nil ||
-		existingFunctionConfig.Status.State == functionconfig.FunctionStateError ||
-		!ap.equalFunctionConfigs(&existingFunctionConfig.Config, &createFunctionOptions.FunctionConfig) {
-
-		// if the function contains source code, an image name or a path somewhere - we need to rebuild. the shell
-		// runtime supports a case where user just tells image name and we build around the handler without a need
-		// for a path
-		if createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode != "" ||
-			createFunctionOptions.FunctionConfig.Spec.Build.Path != "" ||
-			createFunctionOptions.FunctionConfig.Spec.Build.Image != "" {
-			return true, nil
-		}
-
-		// if user didn't give any of the above but _did_ specify an image to run from, just dont build
-		if createFunctionOptions.FunctionConfig.Spec.Image != "" {
-			return false, nil
-		}
-
-		// should not get here - we should either be able to build an image or have one specified for us
-		return false, errors.New("Function must have either spec.build.path," +
-			"spec.build.functionSourceCode, spec.build.image or spec.image set in order to create")
+	// if neverBuild was passed explicitly don't build
+	if createFunctionOptions.FunctionConfig.Spec.Build.Mode == functionconfig.NeverBuild {
+		return false, nil
 	}
 
-	return false, nil
-}
+	// if the function contains source code, an image name or a path somewhere - we need to rebuild. the shell
+	// runtime supports a case where user just tells image name and we build around the handler without a need
+	// for a path
+	if createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode != "" ||
+		createFunctionOptions.FunctionConfig.Spec.Build.Path != "" ||
+		createFunctionOptions.FunctionConfig.Spec.Build.Image != "" {
+		return true, nil
+	}
 
-func (ap *Platform) equalFunctionConfigs(existingFunctionConfig *functionconfig.Config,
-	createFunctionConfig *functionconfig.Config) bool {
+	// if user didn't give any of the above but _did_ specify an image to run from, just dont build
+	if createFunctionOptions.FunctionConfig.Spec.Image != "" {
+		return false, nil
+	}
 
-	existingSpec := existingFunctionConfig.Spec
-	createSpec := createFunctionConfig.Spec
-
-	return existingSpec.SourceHash == createSpec.SourceHash
+	// should not get here - we should either be able to build an image or have one specified for us
+	return false, errors.New("Function must have either spec.build.path," +
+		"spec.build.functionSourceCode, spec.build.image or spec.image set in order to create")
 }

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -96,7 +96,7 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 
 	if existingFunctionConfig == nil &&
 		createFunctionOptions.FunctionConfig.Spec.Build.Mode == functionconfig.NeverBuild {
-			deployNeeded = false
+		deployNeeded = false
 	}
 
 	// clear build mode

--- a/pkg/processor/build/test/build_test.go
+++ b/pkg/processor/build/test/build_test.go
@@ -115,7 +115,48 @@ func (suite *testSuite) TestBuildFunctionFromSourceCodeMaintainsSource() {
 	})
 }
 
-func (suite *testSuite) TestBuildFunctionFromSourceCodeMaintainsSourceHash() {
+func (suite *testSuite) TestBuildFunctionFromSourceCodeDeployOnceNeverBuild() {
+	createFunctionOptions := &platform.CreateFunctionOptions{
+		Logger: suite.Logger,
+	}
+
+	functionSourceCode := base64.StdEncoding.EncodeToString([]byte(`def handler(context, event):
+	pass
+`))
+
+	createFunctionOptions.FunctionConfig.Meta.Name = "neverbuild-test"
+	createFunctionOptions.FunctionConfig.Meta.Namespace = "test"
+	createFunctionOptions.FunctionConfig.Spec.Handler = "main:handler"
+	createFunctionOptions.FunctionConfig.Spec.Runtime = "python:3.6"
+	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = functionSourceCode
+
+	// check that function was saved, "deploy" went without errors
+	createFunctionOptions.FunctionConfig.Spec.Build.Mode = functionconfig.NeverBuild
+
+	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+
+		// get the function
+		functions, err := suite.Platform.GetFunctions(&platform.GetFunctionsOptions{
+			Name:      createFunctionOptions.FunctionConfig.Meta.Name,
+			Namespace: createFunctionOptions.FunctionConfig.Meta.Namespace,
+		})
+
+		suite.Require().NoError(err)
+
+		// verify function was saved
+		suite.Require().Len(functions, 1)
+
+		suite.Require().Equal(functionSourceCode,
+			functions[0].GetConfig().Spec.Build.FunctionSourceCode)
+
+		// expect no deploy result
+		suite.Require().Nil(deployResult)
+
+		return true
+	})
+}
+
+func (suite *testSuite) TestBuildFunctionFromSourceCodeNeverBuildRedeploy() {
 	var resultFunctionConfigSpec functionconfig.Spec
 	var lastBuildTimestamp int64
 
@@ -127,7 +168,7 @@ func (suite *testSuite) TestBuildFunctionFromSourceCodeMaintainsSourceHash() {
     pass
 `))
 
-	createFunctionOptions.FunctionConfig.Meta.Name = "sourcehash-func"
+	createFunctionOptions.FunctionConfig.Meta.Name = "neverbuild-redeploy-func"
 	createFunctionOptions.FunctionConfig.Meta.Namespace = "test"
 	createFunctionOptions.FunctionConfig.Spec.Handler = "main:handler"
 	createFunctionOptions.FunctionConfig.Spec.Runtime = "python:3.6"
@@ -143,7 +184,7 @@ func (suite *testSuite) TestBuildFunctionFromSourceCodeMaintainsSourceHash() {
 
 		suite.Require().NoError(err)
 		resultFunctionConfigSpec = functions[0].GetConfig().Spec
-		createFunctionOptions.FunctionConfig.Spec.SourceHash = resultFunctionConfigSpec.SourceHash
+		createFunctionOptions.FunctionConfig.Spec.Build.Mode = functionconfig.NeverBuild
 		lastBuildTimestamp = resultFunctionConfigSpec.Build.Timestamp
 
 		return true

--- a/pkg/processor/build/test/build_test.go
+++ b/pkg/processor/build/test/build_test.go
@@ -149,6 +149,9 @@ func (suite *testSuite) TestBuildFunctionFromSourceCodeDeployOnceNeverBuild() {
 		suite.Require().Equal(functionSourceCode,
 			functions[0].GetConfig().Spec.Build.FunctionSourceCode)
 
+		// verify build mode is cleared
+		suite.Require().Equal("", functions[0].GetConfig().Spec.Build.Mode)
+
 		// expect no deploy result
 		suite.Require().Nil(deployResult)
 
@@ -201,6 +204,9 @@ func (suite *testSuite) TestBuildFunctionFromSourceCodeNeverBuildRedeploy() {
 		suite.Require().NoError(err)
 		resultFunctionConfigSpec = functions[0].GetConfig().Spec
 		suite.Equal(lastBuildTimestamp, resultFunctionConfigSpec.Build.Timestamp)
+
+		// verify build mode is cleared
+		suite.Require().Equal("", functions[0].GetConfig().Spec.Build.Mode)
 
 		return true
 	}


### PR DESCRIPTION
Source hash causes issues with backwards compatibility, simplify the logic for the client to decide when to build