### PR TITLE
HPA defaults change

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -563,7 +563,7 @@ func (lc *lazyClient) createOrUpdateHorizontalPodAutoscaler(labels map[string]st
 
 	maxReplicas := int32(function.Spec.MaxReplicas)
 	if maxReplicas == 0 {
-		maxReplicas = 4
+		maxReplicas = 10
 	}
 
 	minReplicas := int32(function.Spec.MinReplicas)
@@ -586,7 +586,7 @@ func (lc *lazyClient) createOrUpdateHorizontalPodAutoscaler(labels map[string]st
 	}
 
 	createHorizontalPodAutoscaler := func() (interface{}, error) {
-		if function.Spec.MinReplicas == function.Spec.MaxReplicas {
+		if minReplicas == maxReplicas {
 			return nil, nil
 		}
 


### PR DESCRIPTION
Before this commit the behaviour was that if a user has not passed min and max replicas, it would have defaulted to zero and no pods were to be created.

This changes the behaviour to be at least 1 pod available and at max 10 as default for k8s based systems.