### PR TITLE
Fix 502 error when exceeding logs header limit 

### DIFF
--- a/pkg/platform/kube/function.go
+++ b/pkg/platform/kube/function.go
@@ -233,13 +233,13 @@ func (f *function) getIngressInvokeURL() (string, int, string, error) {
 }
 
 func (f *function) getExternalIPInvokeURL() (string, int, string, error) {
-	host, port, err := f.GetExternalIPInvocationURL()
+	_, port, err := f.GetExternalIPInvocationURL()
 	if err != nil {
 		return "", 0, "", errors.Wrap(err, "Failed to get external IP invocation URL")
 	}
 
 	// return it and the port
-	return host, port, "", nil
+	return "127.0.0.1", port, "", nil
 }
 
 func (f *function) getDomainNameInvokeURL() (string, int, string, error) {

--- a/pkg/platform/kube/function.go
+++ b/pkg/platform/kube/function.go
@@ -233,13 +233,13 @@ func (f *function) getIngressInvokeURL() (string, int, string, error) {
 }
 
 func (f *function) getExternalIPInvokeURL() (string, int, string, error) {
-	_, port, err := f.GetExternalIPInvocationURL()
+	host, port, err := f.GetExternalIPInvocationURL()
 	if err != nil {
 		return "", 0, "", errors.Wrap(err, "Failed to get external IP invocation URL")
 	}
 
 	// return it and the port
-	return "127.0.0.1", port, "", nil
+	return host, port, "", nil
 }
 
 func (f *function) getDomainNameInvokeURL() (string, int, string, error) {

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -179,7 +179,12 @@ func (h *http) requestHandler(ctx *fasthttp.RequestCtx) {
 		// write open bracket for JSON
 		logContents = append(logContents, byte(']'))
 
-		ctx.Response.Header.SetBytesV("X-nuclio-logs", logContents)
+		// there's a limit on the amount of logs that can be passed in a header
+		if len(logContents) < 4096 {
+			ctx.Response.Header.SetBytesV("X-nuclio-logs", logContents)
+		} else {
+			h.Logger.Warn("Skipped setting logs in header cause of size limit")
+		}
 
 		// return the buffer logger to the pool
 		h.bufferLoggerPool.Release(bufferLogger)


### PR DESCRIPTION
On function invocation the logs are returned as part of the header, the size limit of default nginx config is 4096 bytes, so if the logs exceed the size don't set them in the header and skip