### PR TITLE
Support scale from zero to one in function invocation

### DIFF
--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -207,6 +207,11 @@ func (mp *mockPlatform) GetDefaultInvokeIPAddresses() ([]string, error) {
 	return args.Get(0).([]string), args.Error(1)
 }
 
+func (mp *mockPlatform) GetDLXServiceNameAndPort(namespace string) (string, int, error) {
+	args := mp.Called()
+	return args.Get(0).(string), args.Get(1).(int), args.Error(2)
+}
+
 //
 // Test suite
 //

--- a/pkg/platform/abstract/invoker.go
+++ b/pkg/platform/abstract/invoker.go
@@ -22,8 +22,10 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 
 	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 
 	"github.com/nuclio/logger"
@@ -45,6 +47,8 @@ func newInvoker(parentLogger logger.Logger, platform platform.Platform) (*invoke
 }
 
 func (i *invoker) invoke(createFunctionInvocationOptions *platform.CreateFunctionInvocationOptions) (*platform.CreateFunctionInvocationResult, error) {
+	var invokeURL string
+	var invokePort int
 
 	// save options
 	i.createFunctionInvocationOptions = createFunctionInvocationOptions
@@ -68,18 +72,33 @@ func (i *invoker) invoke(createFunctionInvocationOptions *platform.CreateFunctio
 	// use the first function found (should always be one, but if there's more just use first)
 	function := functions[0]
 
-	// make sure to initialize the function (some underlying functions are lazy load)
-	if err = function.Initialize(nil); err != nil {
-		return nil, errors.Wrap(err, "Failed to initialize function")
-	}
+	// two paths here, either the function is scaled to zero state and we need dlx service or other and we need the
+	// function invoke url
+	if function.GetStatus().State == functionconfig.FunctionStateScaledToZero {
+		i.logger.DebugWith("Function is scaled to zero, invoking dlx service instead",
+			"function", function.GetConfig().Meta.Name)
+		invokeURL, invokePort, err = i.platform.GetDLXServiceNameAndPort(function.GetConfig().Meta.Namespace)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to get invoke URL of DLX service")
+		}
+	} else {
+		// make sure to initialize the function (some underlying functions are lazy load)
+		if err = function.Initialize(nil); err != nil {
+			return nil, errors.Wrap(err, "Failed to initialize function")
+		}
 
-	// get where the function resides
-	invokeURL, err := function.GetInvokeURL(createFunctionInvocationOptions.Via)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get invoke URL")
+		// get where the function resides
+		invokeURL, err = function.GetInvokeURL(createFunctionInvocationOptions.Via)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to get invoke URL")
+		}
 	}
 
 	fullpath := "http://" + invokeURL
+	if invokePort != 0 {
+		fullpath += ":" + strconv.Itoa(invokePort)
+	}
+
 	if createFunctionInvocationOptions.Path != "" {
 		fullpath += "/" + createFunctionInvocationOptions.Path
 	}
@@ -107,6 +126,10 @@ func (i *invoker) invoke(createFunctionInvocationOptions *platform.CreateFunctio
 
 	// set headers
 	req.Header = createFunctionInvocationOptions.Headers
+
+	if function.GetStatus().State == functionconfig.FunctionStateScaledToZero {
+		req.Header.Set("x-nuclio-target", function.GetConfig().Meta.Name)
+	}
 
 	// request logs from a given verbosity unless we're specified no logs should be returned
 	if createFunctionInvocationOptions.LogLevelName != "none" && req.Header.Get("x-nuclio-log-level") == "" {

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -232,6 +232,11 @@ func (ap *Platform) ResolveDefaultNamespace(defaultNamespace string) string {
 	return ""
 }
 
+// GetDLXServiceName returns the name and port of dlx service in namespace (k8s only)
+func (ap *Platform) GetDLXServiceNameAndPort(defaultNamespace string) (string, int, error) {
+	return "", 0, nil
+}
+
 func (ap *Platform) functionBuildRequired(createFunctionOptions *platform.CreateFunctionOptions) (bool, error) {
 
 	// if neverBuild was passed explicitly don't build

--- a/pkg/platform/kube/dlx/handler.go
+++ b/pkg/platform/kube/dlx/handler.go
@@ -45,13 +45,14 @@ func (h *Handler) handleRequest(res http.ResponseWriter, req *http.Request) {
 			return
 		}
 	} else {
-		functionName := req.Header.Get("X-nuclio-target")
+		functionName = req.Header.Get("X-Nuclio-Target")
+		path := req.Header.Get("X-Nuclio-Function-Path")
 		if functionName == "" {
 			h.logger.Warn("When ingress not set, must pass X-nuclio-target header value")
 			res.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		targetURL, err = url.Parse(fmt.Sprintf("http://%s:8080", functionName))
+		targetURL, err = url.Parse(fmt.Sprintf("http://%s:8080/%s", functionName, path))
 		if err != nil {
 			res.WriteHeader(h.URLBadParse(functionName, err))
 			return

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -963,7 +963,6 @@ func (lc *lazyClient) populateIngressConfig(labels map[string]string,
 	}
 
 	if function.Status.State == functionconfig.FunctionStateScaledToZero {
-
 		dlxServiceName, err := lc.getDLXServiceName(function.Namespace)
 		if err != nil {
 			return errors.Wrap(err, "Failed to get DLX service name")

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -654,6 +654,24 @@ func (p *Platform) GetDefaultInvokeIPAddresses() ([]string, error) {
 	return []string{}, nil
 }
 
+func (p *Platform) GetDLXServiceNameAndPort(namespace string) (string, int, error) {
+	dlxServices, err := p.consumer.kubeClientSet.CoreV1().Services(namespace).List(meta_v1.ListOptions{
+		LabelSelector: "nuclio.io/app=dlx",
+	})
+	if err != nil {
+		return "", 0, errors.Wrap(err, "Failed to get DLX services")
+	}
+
+	if len(dlxServices.Items) == 0 {
+		return "", 0, errors.New("Failed to find DLX service")
+	}
+
+	dlxService := dlxServices.Items[0]
+	dlxServiceName := dlxService.Name
+	dlxServicePort := dlxService.Spec.Ports[0].Port
+	return dlxServiceName, int(dlxServicePort), nil
+}
+
 func getKubeconfigFromHomeDir() string {
 	homeDir, err := homedir.Dir()
 	if err != nil {

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -448,6 +448,10 @@ func (p *Platform) GetDefaultInvokeIPAddresses() ([]string, error) {
 	return []string{"172.17.0.1"}, nil
 }
 
+func (p *Platform) GetDLXServiceNameAndPort(namespace string) (string, int, error) {
+	return "", 0, nil
+}
+
 func (p *Platform) getFreeLocalPort() (int, error) {
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -56,6 +56,8 @@ type Platform interface {
 	// GetDefaultInvokeIPAddresses will return a list of ip addresses to be used by the platform to inovke a function
 	GetDefaultInvokeIPAddresses() ([]string, error)
 
+	GetDLXServiceNameAndPort(string) (string, int, error)
+
 	//
 	// Project
 	//


### PR DESCRIPTION
When triggering function invocation set the proper headers and send the request to DLX service