### PR TITLE
Fix JSON in docs

### DIFF
--- a/cmd/dashboard/README.md
+++ b/cmd/dashboard/README.md
@@ -129,7 +129,7 @@ To create a function, provide the following request and then periodically GET th
         "name": "hello-world",
         "namespace": "nuclio",
         "labels": {
-            "nuclio.io/project-name": "function-project",
+            "nuclio.io/project-name": "function-project"
         }
     },
     "spec": {


### PR DESCRIPTION
Small typo in JSON example.

Use the following script to check, maybe it should be integrated in the tests/build cycle.

```python
import json
from glob import glob


def check_json(fname):
    ok = True
    in_json = False
    json_lines = []
    with open(fname) as fp:
        for lnum, line in enumerate(fp, 1):
            if '```json' in line:
                in_json = True
                continue

            if '```' in line and '```json' not in line:
                data = ''.join(json_lines)
                if data:
                    try:
                        json.loads(data)
                    except ValueError as err:
                        ok = False
                        print(f'{fname}:{lnum}: json error: {err}')
                json_lines = []
                in_json = False
                continue

            if in_json:
                json_lines.append(line)
    return ok


for fname in glob('./**/README.md', recursive=True):
    if 'vendor' in fname:
        continue
    ok = check_json(fname)
    print(f'{fname}: {"OK" if ok else "ERROR"}')
```