### PR TITLE
Functions can override logger configuration

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -34,11 +34,11 @@ import (
 )
 
 func Run(kubeconfigPath string,
-	resolvedNamespace string,
+	namespace string,
 	imagePullSecrets string,
 	platformConfigurationPath string) error {
 
-	newController, err := createController(kubeconfigPath, resolvedNamespace, imagePullSecrets, platformConfigurationPath)
+	newController, err := createController(kubeconfigPath, namespace, imagePullSecrets, platformConfigurationPath)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create controller")
 	}
@@ -53,7 +53,7 @@ func Run(kubeconfigPath string,
 }
 
 func createController(kubeconfigPath string,
-	resolvedNamespace string,
+	namespace string,
 	imagePullSecrets string,
 	platformConfigurationPath string) (*controller.Controller, error) {
 
@@ -64,7 +64,7 @@ func createController(kubeconfigPath string,
 	}
 
 	// create a root logger
-	rootLogger, _, err := loggersink.CreateLoggers("controller", platformConfiguration)
+	rootLogger, err := loggersink.CreateSystemLogger("controller", platformConfiguration)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create logger")
 	}
@@ -91,7 +91,7 @@ func createController(kubeconfigPath string,
 	}
 
 	newController, err := controller.NewController(rootLogger,
-		resolvedNamespace,
+		namespace,
 		imagePullSecrets,
 		kubeClientSet,
 		nuclioClientSet,
@@ -114,7 +114,7 @@ func getClientConfig(kubeconfigPath string) (*rest.Config, error) {
 	return rest.InClusterConfig()
 }
 
-func readPlatformConfiguration(configurationPath string) (*platformconfig.Configuration, error) {
+func readPlatformConfiguration(configurationPath string) (*platformconfig.Config, error) {
 	platformConfigurationReader, err := platformconfig.NewReader()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create platform configuration reader")

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -42,7 +42,7 @@ func getNamespace(namespaceArgument string) string {
 }
 
 func main() {
-	kubeconfigPath := flag.String("kubeconfig-path", "", "Path of kubeconfig file")
+	kubeconfigPath := flag.String("kubeconfig-path", os.Getenv("KUBECONFIG"), "Path of kubeconfig file")
 	namespace := flag.String("namespace", "", "Namespace to listen on, or * for all")
 	imagePullSecrets := flag.String("image-pull-secrets", os.Getenv("NUCLIO_CONTROLLER_IMAGE_PULL_SECRETS"), "Optional secret name to use for pull")
 	platformConfigurationPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")

--- a/cmd/dashboard/app/dashboard.go
+++ b/cmd/dashboard/app/dashboard.go
@@ -57,7 +57,7 @@ func Run(listenAddress string,
 	}
 
 	// create a root logger
-	rootLogger, _, err := loggersink.CreateLoggers("controller", platformConfiguration)
+	rootLogger, err := loggersink.CreateSystemLogger("controller", platformConfiguration)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create logger")
 	}
@@ -192,7 +192,7 @@ func getDefaultCredRefreshInterval(logger logger.Logger, defaultCredRefreshInter
 	return &defaultCredRefreshInterval
 }
 
-func readPlatformConfiguration(configurationPath string) (*platformconfig.Configuration, error) {
+func readPlatformConfiguration(configurationPath string) (*platformconfig.Config, error) {
 	platformConfigurationReader, err := platformconfig.NewReader()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create platform configuration reader")

--- a/cmd/dlx/app/dlx.go
+++ b/cmd/dlx/app/dlx.go
@@ -2,19 +2,24 @@ package app
 
 import (
 	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/loggersink"
 	nuclioio_client "github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/versioned"
 	"github.com/nuclio/nuclio/pkg/platform/kube/dlx"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+	// load all sinks
+	_ "github.com/nuclio/nuclio/pkg/sinks"
 
-	"github.com/nuclio/logger"
-	"github.com/nuclio/zap"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func Run(kubeconfigPath string, listenURL string, resolvedNamespace string) error {
+func Run(kubeconfigPath string,
+	listenURL string,
+	namespace string,
+	platformConfigurationPath string) error {
 
-	newDLX, err := createDLX(kubeconfigPath, listenURL, resolvedNamespace)
+	newDLX, err := createDLX(kubeconfigPath, listenURL, namespace, platformConfigurationPath)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create dlx")
 	}
@@ -29,12 +34,19 @@ func Run(kubeconfigPath string, listenURL string, resolvedNamespace string) erro
 
 func createDLX(kubeconfigPath string,
 	listenURL string,
-	resolvedNamespace string) (*dlx.DLX, error) {
+	namespace string,
+	platformConfigurationPath string) (*dlx.DLX, error) {
+
+	// read platform configuration
+	platformConfiguration, err := readPlatformConfiguration(platformConfigurationPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to read platform configuration")
+	}
 
 	// create a root logger
-	rootLogger, err := createLogger()
+	rootLogger, err := loggersink.CreateSystemLogger("dlx", platformConfiguration)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create root logger")
+		return nil, errors.Wrap(err, "Failed to create logger")
 	}
 
 	restConfig, err := getClientConfig(kubeconfigPath)
@@ -56,7 +68,7 @@ func createDLX(kubeconfigPath string,
 		URL: listenURL,
 	}
 
-	newProxier, err := dlx.NewDLX(rootLogger, resolvedNamespace, kubeClientSet, nuclioClientSet, cfg)
+	newProxier, err := dlx.NewDLX(rootLogger, namespace, kubeClientSet, nuclioClientSet, cfg)
 	return newProxier, err
 }
 
@@ -68,6 +80,11 @@ func getClientConfig(kubeconfigPath string) (*rest.Config, error) {
 	return rest.InClusterConfig()
 }
 
-func createLogger() (logger.Logger, error) {
-	return nucliozap.NewNuclioZapCmd("dlx", nucliozap.DebugLevel)
+func readPlatformConfiguration(configurationPath string) (*platformconfig.Config, error) {
+	platformConfigurationReader, err := platformconfig.NewReader()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create platform configuration reader")
+	}
+
+	return platformConfigurationReader.ReadFileOrDefault(configurationPath)
 }

--- a/cmd/dlx/main.go
+++ b/cmd/dlx/main.go
@@ -27,8 +27,9 @@ func getNamespace(namespaceArgument string) string {
 
 func main() {
 	listenAddress := flag.String("listen-addr", ":8080", "IP/port on which dlx listens on")
-	kubeconfigPath := flag.String("kubeconfig-path", "", "Path of kubeconfig file")
+	kubeconfigPath := flag.String("kubeconfig-path", os.Getenv("KUBECONFIG"), "Path of kubeconfig file")
 	namespace := flag.String("namespace", "", "Namespace to listen on, or * for all")
+	platformConfigurationPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
 	flag.Parse()
 
 	// get the namespace from args -> env -> default (*)
@@ -43,7 +44,7 @@ func main() {
 		}
 	}
 
-	if err := app.Run(*kubeconfigPath, *listenAddress, resolvedNamespace); err != nil {
+	if err := app.Run(*kubeconfigPath, *listenAddress, resolvedNamespace, *platformConfigurationPath); err != nil {
 		errors.PrintErrorStack(os.Stderr, err, 5)
 
 		os.Exit(1)

--- a/cmd/scaler/app/scaler.go
+++ b/cmd/scaler/app/scaler.go
@@ -2,12 +2,13 @@ package app
 
 import (
 	"github.com/nuclio/nuclio/pkg/errors"
+	"github.com/nuclio/nuclio/pkg/loggersink"
 	nuclioio_client "github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/versioned"
 	"github.com/nuclio/nuclio/pkg/platform/kube/scaler"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
+	// load all sinks
+	_ "github.com/nuclio/nuclio/pkg/sinks"
 
-	"github.com/nuclio/logger"
-	"github.com/nuclio/zap"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -38,16 +39,16 @@ func createScaler(kubeconfigPath string,
 	resolvedNamespace string,
 	platformConfigurationPath string) (*scaler.Scaler, error) {
 
-	// create a root logger
-	rootLogger, err := createLogger()
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create root logger")
-	}
-
 	// read platform configuration
 	platformConfiguration, err := readPlatformConfiguration(platformConfigurationPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to read platform configuration")
+	}
+
+	// create a root logger
+	rootLogger, err := loggersink.CreateSystemLogger("scaler", platformConfiguration)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create logger")
 	}
 
 	restConfig, err := getClientConfig(kubeconfigPath)
@@ -98,15 +99,11 @@ func getClientConfig(kubeconfigPath string) (*rest.Config, error) {
 	return rest.InClusterConfig()
 }
 
-func readPlatformConfiguration(configurationPath string) (*platformconfig.Configuration, error) {
+func readPlatformConfiguration(configurationPath string) (*platformconfig.Config, error) {
 	platformConfigurationReader, err := platformconfig.NewReader()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create platform configuration reader")
 	}
 
 	return platformConfigurationReader.ReadFileOrDefault(configurationPath)
-}
-
-func createLogger() (logger.Logger, error) {
-	return nucliozap.NewNuclioZapCmd("scaler", nucliozap.DebugLevel)
 }

--- a/cmd/scaler/main.go
+++ b/cmd/scaler/main.go
@@ -26,7 +26,7 @@ func getNamespace(namespaceArgument string) string {
 }
 
 func main() {
-	kubeconfigPath := flag.String("kubeconfig-path", "", "Path of kubeconfig file")
+	kubeconfigPath := flag.String("kubeconfig-path", os.Getenv("KUBECONFIG"), "Path of kubeconfig file")
 	namespace := flag.String("namespace", "", "Namespace to listen on, or * for all")
 	platformConfigurationPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
 	flag.Parse()

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -49,7 +49,7 @@ type Server struct {
 	defaultNamespace      string
 	Offline               bool
 	Repository            *functiontemplates.Repository
-	platformConfiguration *platformconfig.Configuration
+	platformConfiguration *platformconfig.Config
 }
 
 func NewServer(parentLogger logger.Logger,
@@ -64,7 +64,7 @@ func NewServer(parentLogger logger.Logger,
 	defaultNamespace string,
 	offline bool,
 	repository *functiontemplates.Repository,
-	platformConfiguration *platformconfig.Configuration) (*Server, error) {
+	platformConfiguration *platformconfig.Config) (*Server, error) {
 
 	var err error
 
@@ -247,7 +247,7 @@ func (s *Server) loadDockerKeys(dockerKeyDir string) error {
 	return s.dockerCreds.LoadFromDir(dockerKeyDir)
 }
 
-func (s *Server) readPlatformConfiguration(configurationPath string) (*platformconfig.Configuration, error) {
+func (s *Server) readPlatformConfiguration(configurationPath string) (*platformconfig.Config, error) {
 	platformConfigurationReader, err := platformconfig.NewReader()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create platform configuration reader")

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -210,6 +210,7 @@ type Spec struct {
 	Build                   Build                   `json:"build,omitempty"`
 	RunRegistry             string                  `json:"runRegistry,omitempty"`
 	RuntimeAttributes       map[string]interface{}  `json:"runtimeAttributes,omitempty"`
+	LoggerLevel             string                  `json:"loggerLevel,omitempty"`
 	LoggerSinks             []LoggerSink            `json:"loggerSinks,omitempty"`
 	DealerURI               string                  `json:"dealerURI,omitempty"`
 	Platform                Platform                `json:"platform,omitempty"`

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -210,7 +210,6 @@ type Spec struct {
 	Build                   Build                   `json:"build,omitempty"`
 	RunRegistry             string                  `json:"runRegistry,omitempty"`
 	RuntimeAttributes       map[string]interface{}  `json:"runtimeAttributes,omitempty"`
-	LoggerLevel             string                  `json:"loggerLevel,omitempty"`
 	LoggerSinks             []LoggerSink            `json:"loggerSinks,omitempty"`
 	DealerURI               string                  `json:"dealerURI,omitempty"`
 	Platform                Platform                `json:"platform,omitempty"`

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -50,6 +50,7 @@ type deployCommandeer struct {
 	encodedBuildRuntimeAttributes   string
 	encodedBuildCodeEntryAttributes string
 	inputImageFile                  string
+	loggerLevel                     string
 }
 
 func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
@@ -151,6 +152,13 @@ func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
 				})
 			}
 
+			// check if logger level is set
+			if commandeer.loggerLevel != "" {
+				commandeer.functionConfig.Spec.LoggerSinks = []functionconfig.LoggerSink{
+					{Level: commandeer.loggerLevel},
+				}
+			}
+
 			// update function
 			commandeer.functionConfig.Meta.Namespace = rootCommandeer.namespace
 			commandeer.functionConfig.Spec.Build.Commands = commandeer.commands
@@ -198,6 +206,7 @@ func addDeployFlags(cmd *cobra.Command,
 	cmd.Flags().Var(&commandeer.volumes, "volume", "Volumes for the deployment function (src1=dest1[,src2=dest2,...])")
 	cmd.Flags().Var(&commandeer.resourceLimits, "resource-limit", "Limits resources in the format of resource-name=quantity (e.g. cpu=3)")
 	cmd.Flags().Var(&commandeer.resourceRequests, "resource-request", "Requests resources in the format of resource-name=quantity (e.g. cpu=3)")
+	cmd.Flags().StringVar(&commandeer.loggerLevel, "logger-level", "", "One of debug, info, warn, error. By default, uses platform configuration")
 }
 
 func parseResourceAllocations(values stringSliceFlag, resources *v1.ResourceList) error {

--- a/pkg/platform/kube/controller/controller.go
+++ b/pkg/platform/kube/controller/controller.go
@@ -41,7 +41,7 @@ type Controller struct {
 	functionOperator      *functionOperator
 	projectOperator       *projectOperator
 	functionEventOperator *functionEventOperator
-	platformConfiguration *platformconfig.Configuration
+	platformConfiguration *platformconfig.Config
 }
 
 func NewController(parentLogger logger.Logger,
@@ -51,7 +51,7 @@ func NewController(parentLogger logger.Logger,
 	nuclioClientSet nuclioio_client.Interface,
 	functionresClient functionres.Client,
 	resyncInterval time.Duration,
-	platformConfiguration *platformconfig.Configuration) (*Controller, error) {
+	platformConfiguration *platformconfig.Config) (*Controller, error) {
 	var err error
 
 	// replace "*" with "", which is actually "all" in kube-speak
@@ -132,6 +132,6 @@ func (c *Controller) Start() error {
 	return nil
 }
 
-func (c *Controller) GetPlatformConfiguration() *platformconfig.Configuration {
+func (c *Controller) GetPlatformConfiguration() *platformconfig.Config {
 	return c.platformConfiguration
 }

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -883,7 +883,7 @@ func (lc *lazyClient) populateServiceSpec(labels map[string]string,
 	spec.Ports = lc.ensureServicePortsExist(spec.Ports, platformServicePorts)
 }
 
-func (lc *lazyClient) getServicePortsFromPlatform(platformConfiguration *platformconfig.Configuration) []v1.ServicePort {
+func (lc *lazyClient) getServicePortsFromPlatform(platformConfiguration *platformconfig.Config) []v1.ServicePort {
 	var servicePorts []v1.ServicePort
 
 	if lc.functionsHaveMetricSink(platformConfiguration, "prometheusPull") {
@@ -896,7 +896,7 @@ func (lc *lazyClient) getServicePortsFromPlatform(platformConfiguration *platfor
 	return servicePorts
 }
 
-func (lc *lazyClient) functionsHaveMetricSink(platformConfiguration *platformconfig.Configuration, kind string) bool {
+func (lc *lazyClient) functionsHaveMetricSink(platformConfiguration *platformconfig.Config, kind string) bool {
 	metricSinks, err := platformConfiguration.GetFunctionMetricSinks()
 	if err != nil {
 		return false
@@ -911,7 +911,7 @@ func (lc *lazyClient) functionsHaveMetricSink(platformConfiguration *platformcon
 	return false
 }
 
-func (lc *lazyClient) functionsHaveAutoScaleMetrics(platformConfiguration *platformconfig.Configuration) bool {
+func (lc *lazyClient) functionsHaveAutoScaleMetrics(platformConfiguration *platformconfig.Config) bool {
 	autoScaleMetrics := platformConfiguration.AutoScale
 	if autoScaleMetrics.MetricName == "" || autoScaleMetrics.TargetValue == "" {
 		return false

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -181,11 +181,11 @@ func (suite *lazyTestSuite) TestTriggerDefinedMultipleIngresses() {
 func (suite *lazyTestSuite) TestPlatformServicePorts() {
 
 	// configuration with no ports
-	servicePorts := suite.client.getServicePortsFromPlatform(&platformconfig.Configuration{})
+	servicePorts := suite.client.getServicePortsFromPlatform(&platformconfig.Config{})
 	suite.Require().Len(servicePorts, 0)
 
 	// configuration with prometheus pull
-	servicePorts = suite.client.getServicePortsFromPlatform(&platformconfig.Configuration{
+	servicePorts = suite.client.getServicePortsFromPlatform(&platformconfig.Config{
 		Metrics: platformconfig.Metrics{
 			Sinks: map[string]platformconfig.MetricSink{
 				"pp": {

--- a/pkg/platform/kube/functionres/types.go
+++ b/pkg/platform/kube/functionres/types.go
@@ -15,7 +15,7 @@ import (
 type PlatformConfigurationProvider interface {
 
 	// GetPlatformConfiguration returns a platform configuration
-	GetPlatformConfiguration() *platformconfig.Configuration
+	GetPlatformConfiguration() *platformconfig.Config
 }
 
 type Client interface {

--- a/pkg/platform/kube/scaler/scaler.go
+++ b/pkg/platform/kube/scaler/scaler.go
@@ -42,7 +42,7 @@ func NewScaler(parentLogger logger.Logger,
 	metricsClientSet *metricsv1.Clientset,
 	nuclioClientSet *nuclioio_client.Clientset,
 	customMetricsClientSet custommetricsv1.CustomMetricsClient,
-	platformConfig *platformconfig.Configuration) (*Scaler, error) {
+	platformConfig *platformconfig.Config) (*Scaler, error) {
 
 	// replace "*" with "", which is actually "all" in kube-speak
 	if namespace == "*" {

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -77,7 +77,7 @@ metrics:
   - mypush
 `
 
-	var readConfiguration, expectedConfiguration Configuration
+	var readConfiguration, expectedConfiguration Config
 
 	// init expected
 	trueValue := true
@@ -161,7 +161,7 @@ logger:
     sink: stdout
 `
 
-	var readConfiguration Configuration
+	var readConfiguration Config
 
 	// read configuration
 	err := suite.reader.Read(bytes.NewBufferString(configurationContents), "yaml", &readConfiguration)
@@ -208,7 +208,7 @@ logger:
     sink: stdout
 `
 
-	var readConfiguration Configuration
+	var readConfiguration Config
 
 	// read configuration
 	err := suite.reader.Read(bytes.NewBufferString(configurationContents), "yaml", &readConfiguration)
@@ -235,7 +235,7 @@ logger:
     sink: stdout
 `
 
-	var readConfiguration Configuration
+	var readConfiguration Config
 
 	// read configuration
 	err := suite.reader.Read(bytes.NewBufferString(configurationContents), "yaml", &readConfiguration)
@@ -273,7 +273,7 @@ logger:
     sink: stdout
 `
 
-	var readConfiguration Configuration
+	var readConfiguration Config
 
 	// read configuration
 	err := suite.reader.Read(bytes.NewBufferString(configurationContents), "yaml", &readConfiguration)
@@ -330,7 +330,7 @@ logger:
     sink: blah
 `
 
-	var readConfiguration Configuration
+	var readConfiguration Config
 
 	// read configuration
 	err := suite.reader.Read(bytes.NewBufferString(configurationContents), "yaml", &readConfiguration)
@@ -357,7 +357,7 @@ metrics:
   - pullSink
 `
 
-	var readConfiguration Configuration
+	var readConfiguration Config
 
 	// read configuration
 	err := suite.reader.Read(bytes.NewBufferString(configurationContents), "yaml", &readConfiguration)
@@ -396,7 +396,7 @@ metrics:
   - pullSink
 `
 
-	var readConfiguration Configuration
+	var readConfiguration Config
 
 	// read configuration
 	err := suite.reader.Read(bytes.NewBufferString(configurationContents), "yaml", &readConfiguration)
@@ -423,7 +423,7 @@ metrics:
   - pullSink
 `
 
-	var readConfiguration Configuration
+	var readConfiguration Config
 
 	// read configuration
 	err := suite.reader.Read(bytes.NewBufferString(configurationContents), "yaml", &readConfiguration)

--- a/pkg/platformconfig/reader.go
+++ b/pkg/platformconfig/reader.go
@@ -32,7 +32,7 @@ func NewReader() (*Reader, error) {
 	return &Reader{}, nil
 }
 
-func (r *Reader) Read(reader io.Reader, configType string, config *Configuration) error {
+func (r *Reader) Read(reader io.Reader, configType string, config *Config) error {
 	configBytes, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return errors.Wrap(err, "Failed to read platform configuration")
@@ -41,8 +41,8 @@ func (r *Reader) Read(reader io.Reader, configType string, config *Configuration
 	return yaml.Unmarshal(configBytes, config)
 }
 
-func (r *Reader) ReadFileOrDefault(configurationPath string) (*Configuration, error) {
-	var platformConfiguration Configuration
+func (r *Reader) ReadFileOrDefault(configurationPath string) (*Config, error) {
+	var platformConfiguration Config
 
 	// if there's no configuration file, return a default configuration. otherwise try to parse it
 	platformConfigurationFile, err := os.Open(configurationPath)
@@ -57,10 +57,10 @@ func (r *Reader) ReadFileOrDefault(configurationPath string) (*Configuration, er
 	return &platformConfiguration, nil
 }
 
-func (r *Reader) GetDefaultConfiguration() *Configuration {
+func (r *Reader) GetDefaultConfiguration() *Config {
 	trueValue := true
 
-	return &Configuration{
+	return &Config{
 		WebAdmin: WebServer{
 			Enabled:       &trueValue,
 			ListenAddress: ":8081",

--- a/pkg/processor/types.go
+++ b/pkg/processor/types.go
@@ -23,5 +23,5 @@ import (
 
 type Configuration struct {
 	functionconfig.Config
-	PlatformConfig *platformconfig.Configuration
+	PlatformConfig *platformconfig.Config
 }


### PR DESCRIPTION
1. Populating `spec.loggerSinks` will override the logger sinks from platform configuration 
2. Populating a single logger sink in `spec.loggerSinks` with only the level set will override all platform configuration logger sinks' levels
3. Used platform configuration to create loggers for dlx and scaler