### PR TITLE
UI: Display proper error on function invocation error

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.4.1",
+    "iguazio.dashboard-controls": "^0.4.5",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",

--- a/pkg/dashboard/ui/src/app/shared/services/nuclio-event-data.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/nuclio-event-data.service.js
@@ -120,7 +120,12 @@
                 .then(parseResult, parseResult);
 
             function parseResult(result) {
-                return {
+                return lodash.isError(result) ? {
+                    status: -1,
+                    statusText: 'Invalid response',
+                    headers: { 'Content-Type': 'text/plain' },
+                    body: result.message
+                } : {
                     status: result.status,
                     statusText: result.statusText,
                     headers: result.headers(),


### PR DESCRIPTION
Also:
- Remove Pypy runtime entirely
- Fix: checkbox of project is not checked after failed deletion and actions panel is hidden
- Fix: on deleting an environment variable, always the last one on the list is actually removed