### PR TITLE
Support Docker 1.12

### DIFF
--- a/hack/k8s/resources/nuclio.yaml
+++ b/hack/k8s/resources/nuclio.yaml
@@ -95,7 +95,7 @@ spec:
     spec:
       containers:
       - name: nuclio-controller
-        image: nuclio/controller:0.7.4-amd64
+        image: quay.io/nuclio/controller:0.7.4-amd64
         env:
         - name: NUCLIO_CONTROLLER_IMAGE_PULL_SECRETS
           value: registry-credentials
@@ -122,7 +122,7 @@ spec:
     spec:
       containers:
       - name: nuclio-dashboard
-        image: nuclio/dashboard:0.7.4-amd64
+        image: quay.io/nuclio/dashboard:0.7.4-amd64
         ports:
         - containerPort: 8070
         volumeMounts:

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1132,7 +1132,7 @@ func (b *Builder) generateSingleStageDockerfileContents(artifactDirNameInStaging
 
 	// now that all artifacts are in the artifacts directory, we can craft a single stage Dockerfile
 	dockerfileTemplateContents := `# From the base image
-FROM {{ .BaseImage -}}
+FROM {{ .BaseImage }}
 
 # Old(er) Docker support - must use all build args
 ARG NUCLIO_LABEL

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1134,6 +1134,11 @@ func (b *Builder) generateSingleStageDockerfileContents(artifactDirNameInStaging
 	dockerfileTemplateContents := `# From the base image
 FROM {{ .BaseImage -}}
 
+# Old(er) Docker support - must use all build args
+ARG NUCLIO_LABEL
+ARG NUCLIO_ARCH
+ARG NUCLIO_BUILD_LOCAL_HANDLER_DIR
+
 {{ if .PreCopyDirectives }}
 # Run the pre-copy directives
 {{ range $directive := .PreCopyDirectives }}
@@ -1296,11 +1301,19 @@ func (b *Builder) buildFromAndCopyObjectsFromContainer(onbuildImage string,
 
 	dockerfilePath := path.Join(b.stagingDir, "Dockerfile.onbuild")
 
+	onbuildDockerfileContents := fmt.Sprintf(`FROM %s
+ARG NUCLIO_LABEL
+ARG NUCLIO_ARCH
+`, onbuildImage)
+
 	// generate a simple Dockerfile from the onbuild image
-	err := ioutil.WriteFile(dockerfilePath, []byte(fmt.Sprintf("FROM %s", onbuildImage)), 0644)
+	err := ioutil.WriteFile(dockerfilePath, []byte(onbuildDockerfileContents), 0644)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to write onbuild Dockerfile to %s", dockerfilePath)
 	}
+
+	// log
+	b.logger.DebugWith("Generated onbuild Dockerfile", "contents", onbuildDockerfileContents)
 
 	// generate an image name
 	onbuildImageName := fmt.Sprintf("nuclio-onbuild-%s", xid.New().String())


### PR DESCRIPTION
Older Docker versions will return an error if build args are not used:
https://github.com/moby/moby/issues/26249

This declares the build args in the Dockerfiles so that builds will work for Docker 1.12.