### PR TITLE
[Fix] Set appropriate content type on function invocation response

### DIFF
--- a/pkg/dashboard/resource/invocation.go
+++ b/pkg/dashboard/resource/invocation.go
@@ -84,6 +84,9 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 		Via:       invokeVia,
 	})
 
+	// defaults to json
+	responseWriter.Header().Set("Content-Type", "application/json")
+
 	if err != nil {
 		tr.Logger.WarnWith("Failed to invoke function", "err", err)
 
@@ -91,6 +94,7 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 		responseWriter.Write([]byte(`{"error": "Failed to invoke function"}`)) // nolint: errcheck
 		return
 	}
+
 
 	// set headers
 	for headerName, headerValue := range invocationResult.Headers {
@@ -101,7 +105,6 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 		}
 	}
 
-	responseWriter.Header().Set("Content-Type", "application/json")
 	responseWriter.WriteHeader(invocationResult.StatusCode)
 	responseWriter.Write(invocationResult.Body) // nolint: errcheck
 }

--- a/pkg/dashboard/resource/invocation.go
+++ b/pkg/dashboard/resource/invocation.go
@@ -95,7 +95,6 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 		return
 	}
 
-
 	// set headers
 	for headerName, headerValue := range invocationResult.Headers {
 


### PR DESCRIPTION
Before sending an error or any other response, set content type as json, if the function have a different content type to return, it will be overridden down the road