### PR TITLE
Fix content type on invocation response

### DIFF
--- a/pkg/dashboard/resource/invocation.go
+++ b/pkg/dashboard/resource/invocation.go
@@ -61,14 +61,14 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 	path = strings.TrimLeft(path, "/")
 
 	if functionName == "" || functionNamespace == "" {
-		responseWriter.WriteHeader(http.StatusBadRequest)
+		tr.writeErrorHeader(responseWriter, http.StatusBadRequest)
 		responseWriter.Write([]byte(`{"error": "Function name must be provided"}`)) // nolint: errcheck
 		return
 	}
 
 	requestBody, err := ioutil.ReadAll(request.Body)
 	if err != nil {
-		responseWriter.WriteHeader(http.StatusInternalServerError)
+		tr.writeErrorHeader(responseWriter, http.StatusInternalServerError)
 		responseWriter.Write([]byte(`{"error": "Failed to read request body"}`)) // nolint: errcheck
 		return
 	}
@@ -84,13 +84,10 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 		Via:       invokeVia,
 	})
 
-	// defaults to json
-	responseWriter.Header().Set("Content-Type", "application/json")
-
 	if err != nil {
 		tr.Logger.WarnWith("Failed to invoke function", "err", err)
 
-		responseWriter.WriteHeader(http.StatusInternalServerError)
+		tr.writeErrorHeader(responseWriter, http.StatusInternalServerError)
 		responseWriter.Write([]byte(`{"error": "Failed to invoke function"}`)) // nolint: errcheck
 		return
 	}
@@ -121,6 +118,11 @@ func (tr *invocationResource) getInvokeVia(invokeViaName string) platform.Invoke
 	default:
 		return platform.InvokeViaAny
 	}
+}
+
+func (tr *invocationResource) writeErrorHeader(responseWriter http.ResponseWriter, statusCode int) {
+	responseWriter.Header().Set("Content-Type", "application/json")
+	responseWriter.WriteHeader(statusCode)
 }
 
 // register the resource

--- a/pkg/dashboard/resource/invocation.go
+++ b/pkg/dashboard/resource/invocation.go
@@ -84,6 +84,9 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 		Via:       invokeVia,
 	})
 
+	// defaults to json
+	responseWriter.Header().Set("Content-Type", "application/json")
+
 	if err != nil {
 		tr.Logger.WarnWith("Failed to invoke function", "err", err)
 
@@ -91,6 +94,7 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 		responseWriter.Write([]byte(`{"error": "Failed to invoke function"}`)) // nolint: errcheck
 		return
 	}
+
 
 	// set headers
 	for headerName, headerValue := range invocationResult.Headers {
@@ -101,7 +105,6 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 		}
 	}
 
-	responseWriter.Header().Set("Content-Type", "application/json")
 	responseWriter.WriteHeader(invocationResult.StatusCode)
 	responseWriter.Write(invocationResult.Body) // nolint: errcheck
 }

--- a/pkg/dashboard/resource/invocation.go
+++ b/pkg/dashboard/resource/invocation.go
@@ -95,7 +95,6 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 		return
 	}
 
-
 	// set headers
 	for headerName, headerValue := range invocationResult.Headers {
 


### PR DESCRIPTION
errors are returned properly now with `application/json` content type, any other message is for the caller to decide