### PR TITLE
Replace default-backend for dlx with service selector

### DIFF
--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -207,11 +207,6 @@ func (mp *mockPlatform) GetDefaultInvokeIPAddresses() ([]string, error) {
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (mp *mockPlatform) GetDLXServiceNameAndPort(namespace string) (string, int, error) {
-	args := mp.Called()
-	return args.Get(0).(string), args.Get(1).(int), args.Error(2)
-}
-
 //
 // Test suite
 //

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -232,11 +232,6 @@ func (ap *Platform) ResolveDefaultNamespace(defaultNamespace string) string {
 	return ""
 }
 
-// GetDLXServiceName returns the name and port of dlx service in namespace (k8s only)
-func (ap *Platform) GetDLXServiceNameAndPort(defaultNamespace string) (string, int, error) {
-	return "", 0, nil
-}
-
 func (ap *Platform) functionBuildRequired(createFunctionOptions *platform.CreateFunctionOptions) (bool, error) {
 
 	// if neverBuild was passed explicitly don't build

--- a/pkg/platform/kube/dlx/handler.go
+++ b/pkg/platform/kube/dlx/handler.go
@@ -48,7 +48,7 @@ func (h *Handler) handleRequest(res http.ResponseWriter, req *http.Request) {
 		functionName = req.Header.Get("X-Nuclio-Target")
 		path := req.Header.Get("X-Nuclio-Function-Path")
 		if functionName == "" {
-			h.logger.Warn("When ingress not set, must pass X-nuclio-target header value")
+			h.logger.Warn("When ingress not set, must pass X-Nuclio-Target header value")
 			res.WriteHeader(http.StatusBadRequest)
 			return
 		}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -857,7 +857,14 @@ func (lc *lazyClient) serializeFunctionJSON(function *nuclioio.Function) (string
 func (lc *lazyClient) populateServiceSpec(labels map[string]string,
 	function *nuclioio.Function,
 	spec *v1.ServiceSpec) {
-	spec.Selector = labels
+
+	if function.Status.State == functionconfig.FunctionStateScaledToZero {
+
+		// pass all further requests to DLX service
+		spec.Selector = map[string]string{"nuclio.io/app": "dlx"}
+	} else {
+		spec.Selector = labels
+	}
 
 	spec.Type = v1.ServiceTypeNodePort
 
@@ -962,13 +969,9 @@ func (lc *lazyClient) populateIngressConfig(labels map[string]string,
 		break
 	}
 
-	if function.Status.State == functionconfig.FunctionStateScaledToZero {
-		dlxServiceName, err := lc.getDLXServiceName(function.Namespace)
-		if err != nil {
-			return errors.Wrap(err, "Failed to get DLX service name")
-		}
-		meta.Annotations["nginx.ingress.kubernetes.io/default-backend"] = dlxServiceName
-	}
+	// set nuclio target header on ingress
+	meta.Annotations["nginx.ingress.kubernetes.io/configuration-snippet"] = fmt.Sprintf(
+		`proxy_set_header X-Nuclio-Target "%s";`, function.Name)
 
 	// clear out existing so that we don't keep adding rules
 	spec.Rules = []ext_v1beta1.IngressRule{}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1309,21 +1309,6 @@ func (lc *lazyClient) getMetricResourceByName(resourceName string) v1.ResourceNa
 	}
 }
 
-func (lc *lazyClient) getDLXServiceName(namespace string) (string, error) {
-	dlxServices, err := lc.kubeClientSet.CoreV1().Services(namespace).List(meta_v1.ListOptions{
-		LabelSelector: "nuclio.io/app=dlx",
-	})
-	if err != nil {
-		return "", errors.Wrap(err, "Failed to locate DLX service")
-	}
-
-	if len(dlxServices.Items) == 0 {
-		return "", errors.New("No DLX services found")
-	}
-
-	return dlxServices.Items[0].Name, nil
-}
-
 //
 // Resources
 //

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -654,24 +654,6 @@ func (p *Platform) GetDefaultInvokeIPAddresses() ([]string, error) {
 	return []string{}, nil
 }
 
-func (p *Platform) GetDLXServiceNameAndPort(namespace string) (string, int, error) {
-	dlxServices, err := p.consumer.kubeClientSet.CoreV1().Services(namespace).List(meta_v1.ListOptions{
-		LabelSelector: "nuclio.io/app=dlx",
-	})
-	if err != nil {
-		return "", 0, errors.Wrap(err, "Failed to get DLX services")
-	}
-
-	if len(dlxServices.Items) == 0 {
-		return "", 0, errors.New("Failed to find DLX service")
-	}
-
-	dlxService := dlxServices.Items[0]
-	dlxServiceName := dlxService.Name
-	dlxServicePort := dlxService.Spec.Ports[0].Port
-	return dlxServiceName, int(dlxServicePort), nil
-}
-
 func getKubeconfigFromHomeDir() string {
 	homeDir, err := homedir.Dir()
 	if err != nil {

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -448,10 +448,6 @@ func (p *Platform) GetDefaultInvokeIPAddresses() ([]string, error) {
 	return []string{"172.17.0.1"}, nil
 }
 
-func (p *Platform) GetDLXServiceNameAndPort(namespace string) (string, int, error) {
-	return "", 0, nil
-}
-
 func (p *Platform) getFreeLocalPort() (int, error) {
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -56,8 +56,6 @@ type Platform interface {
 	// GetDefaultInvokeIPAddresses will return a list of ip addresses to be used by the platform to inovke a function
 	GetDefaultInvokeIPAddresses() ([]string, error)
 
-	GetDLXServiceNameAndPort(string) (string, int, error)
-
 	//
 	// Project
 	//

--- a/pkg/processor/trigger/partitioned/v3io/test/v3io_test.go
+++ b/pkg/processor/trigger/partitioned/v3io/test/v3io_test.go
@@ -128,7 +128,10 @@ func (suite *testSuite) publishMessageToTopic(topic string, body string) error {
 	_, err = suite.container.Sync.PutRecords(&v3iohttp.PutRecordsInput{
 		Path: suite.streamPath + "/",
 		Records: []*v3iohttp.StreamRecord{
-			{&partitionID, []byte(body)},
+			{
+				ShardID: &partitionID,
+				Data:    []byte(body),
+			},
 		},
 	})
 


### PR DESCRIPTION
A selector for service is changed when a function is scaled to zero and on cold start, this allows cold start on inter-function communication.