### PR TITLE
Allow to disable node port for functions

### DIFF
--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -215,6 +215,7 @@ type Spec struct {
 	Platform                Platform                `json:"platform,omitempty"`
 	ReadinessTimeoutSeconds int                     `json:"readinessTimeoutSeconds,omitempty"`
 	Avatar                  string                  `json:"avatar,omitempty"`
+	ServiceType             v1.ServiceType          `json:"serviceType,omitempty"`
 }
 
 // to appease k8s

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -23,13 +23,14 @@ import (
 )
 
 type Config struct {
-	Kind        string      `json:"kind,omitempty"`
-	WebAdmin    WebServer   `json:"webAdmin,omitempty"`
-	HealthCheck WebServer   `json:"healthCheck,omitempty"`
-	Logger      Logger      `json:"logger,omitempty"`
-	Metrics     Metrics     `json:"metrics,omitempty"`
-	ScaleToZero ScaleToZero `json:"scaleToZero,omitempty"`
-	AutoScale   AutoScale   `json:"autoScale,omitempty"`
+	Kind                     string           `json:"kind,omitempty"`
+	WebAdmin                 WebServer        `json:"webAdmin,omitempty"`
+	HealthCheck              WebServer        `json:"healthCheck,omitempty"`
+	Logger                   Logger           `json:"logger,omitempty"`
+	Metrics                  Metrics          `json:"metrics,omitempty"`
+	ScaleToZero              ScaleToZero      `json:"scaleToZero,omitempty"`
+	AutoScale                AutoScale        `json:"autoScale,omitempty"`
+	FunctionAugmentedConfigs []LabelAndConfig `json:"functionAugmentedConfigs,omitempty"`
 }
 
 func (config *Config) GetSystemLoggerSinks() (map[string]LoggerSinkWithLevel, error) {

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -23,14 +23,14 @@ import (
 )
 
 type Config struct {
-	Kind                     string           `json:"kind,omitempty"`
-	WebAdmin                 WebServer        `json:"webAdmin,omitempty"`
-	HealthCheck              WebServer        `json:"healthCheck,omitempty"`
-	Logger                   Logger           `json:"logger,omitempty"`
-	Metrics                  Metrics          `json:"metrics,omitempty"`
-	ScaleToZero              ScaleToZero      `json:"scaleToZero,omitempty"`
-	AutoScale                AutoScale        `json:"autoScale,omitempty"`
-	FunctionAugmentedConfigs []LabelAndConfig `json:"functionAugmentedConfigs,omitempty"`
+	Kind                     string                   `json:"kind,omitempty"`
+	WebAdmin                 WebServer                `json:"webAdmin,omitempty"`
+	HealthCheck              WebServer                `json:"healthCheck,omitempty"`
+	Logger                   Logger                   `json:"logger,omitempty"`
+	Metrics                  Metrics                  `json:"metrics,omitempty"`
+	ScaleToZero              ScaleToZero              `json:"scaleToZero,omitempty"`
+	AutoScale                AutoScale                `json:"autoScale,omitempty"`
+	FunctionAugmentedConfigs []LabelSelectorAndConfig `json:"functionAugmentedConfigs,omitempty"`
 }
 
 func (config *Config) GetSystemLoggerSinks() (map[string]LoggerSinkWithLevel, error) {

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package platformconfig
 
+import "github.com/nuclio/nuclio/pkg/functionconfig"
+
 type LoggerSink struct {
 	Kind       string                 `json:"kind,omitempty"`
 	URL        string                 `json:"url,omitempty"`
@@ -71,4 +73,9 @@ type Metrics struct {
 	Sinks     map[string]MetricSink `json:"sinks,omitempty"`
 	System    []string              `json:"system,omitempty"`
 	Functions []string              `json:"functions,omitempty"`
+}
+
+type LabelAndConfig struct {
+	Label          string                `json:"label,omitempty"`
+	FunctionConfig functionconfig.Config `json:"functionConfig,omitempty"`
 }

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package platformconfig
 
-import "github.com/nuclio/nuclio/pkg/functionconfig"
+import (
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 type LoggerSink struct {
 	Kind       string                 `json:"kind,omitempty"`
@@ -75,7 +79,7 @@ type Metrics struct {
 	Functions []string              `json:"functions,omitempty"`
 }
 
-type LabelAndConfig struct {
-	Label          string                `json:"label,omitempty"`
+type LabelSelectorAndConfig struct {
+	LabelSelector  v1.LabelSelector      `json:"labelSelector,omitempty"`
 	FunctionConfig functionconfig.Config `json:"functionConfig,omitempty"`
 }


### PR DESCRIPTION
Allow either globally using function config's augmented function config or per function to choose the k8s service type for that function.
if node port chosen (default) then any logic remains as is
else, no auto assigning of ports is done and k8s service type is set to the type passed (e.g. clusterIP or LoadBalancer)