### PR TITLE
UI: Add ability to set password fields in template params

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -1,4 +1,5 @@
 {
+
   "name": "iguaz.io",
   "version": "0.0.2",
   "private": true,
@@ -47,7 +48,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.4.10",
+    "iguazio.dashboard-controls": "^0.4.12",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
You can now use: `"kind": "string", "password": true` to render a password input field where entered characters are obscured on screen.