### PR TITLE
V3IO streams trigger - only sleep on empty response

### DIFF
--- a/pkg/processor/trigger/partitioned/v3io/partition.go
+++ b/pkg/processor/trigger/partitioned/v3io/partition.go
@@ -86,8 +86,6 @@ func (p *partition) Read() error {
 	pollingInterval := time.Duration(p.v3ioTrigger.configuration.PollingIntervalMs) * time.Millisecond
 
 	for {
-		time.Sleep(pollingInterval)
-
 		// get records
 		response, err = p.v3ioTrigger.container.Sync.GetRecords(&v3iohttp.GetRecordsInput{
 			Path:     partitionPath,
@@ -112,7 +110,11 @@ func (p *partition) Read() error {
 			p.event.record = &record
 
 			// submit to worker
-			p.Stream.SubmitEventToWorker(nil, p.Worker, &p.event) // nolint: errcheck
+			_, _ = p.Stream.SubmitEventToWorker(nil, p.Worker, &p.event)
+		}
+
+		if len(getRecordsOutput.Records) == 0 {
+			time.Sleep(pollingInterval)
 		}
 	}
 }

--- a/pkg/processor/trigger/partitioned/v3io/types.go
+++ b/pkg/processor/trigger/partitioned/v3io/types.go
@@ -64,10 +64,6 @@ func NewConfiguration(ID string,
 		newConfiguration.ReadBatchSize = 64
 	}
 
-	if newConfiguration.PollingIntervalMs == 0 {
-		newConfiguration.PollingIntervalMs = 500
-	}
-
 	if newConfiguration.SeekTo == "" {
 		newConfiguration.SeekTo = string(seekToTypeLatest)
 	}


### PR DESCRIPTION
* Only sleep when getRecords returns zero records.
* Allow zero polling interval.
* Minor style improvement for ignoring an error.