### PR TITLE
IG-8839: Don't allow to create two functions with same name

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -151,7 +151,6 @@ func (fr *functionResource) updateFunction(request *http.Request) (*restful.Cust
 		return nil, responseErr
 	}
 
-	fr.Logger.DebugWith("done2", "responseERr", responseErr)
 	return &restful.CustomRouteFuncResponse{
 		ResourceType: "function",
 		Single:       true,


### PR DESCRIPTION
http://jira.iguazeng.com:8080/browse/IG-8839
Description: Nuclio function with duplicated name overrides existing function

Changes:
- Added 'PUT' endpoint to '/functions'.
- Whenever triggering '/functions' endpoint with 'POST' there'll be a validation that no other function inside the same project and namespace has the same name