### PR TITLE
UI: Triggers: RabbitMQ: Queue Name and Topics can't be both empty

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.4.16",
+    "iguazio.dashboard-controls": "^0.4.17",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
Plus, placeholders were added to these fields.

Depends on: https://github.com/iguazio/dashboard-controls/pull/426