### PR TITLE
[Fix] RabbitMQ, allow to only consume queues

### DIFF
--- a/pkg/processor/trigger/rabbitmq/rabbitmq_test.go
+++ b/pkg/processor/trigger/rabbitmq/rabbitmq_test.go
@@ -82,7 +82,7 @@ func (suite *TestSuite) TestSetEmptyParametersMakesNoChange() {
 
 	suite.trigger.setEmptyParameters()
 
-	suite.EqualValues(suite.trigger.configuration.Topics, []string{"*"})
+	suite.EqualValues(suite.trigger.configuration.Topics, []string{})
 }
 
 func TestRabbitMQSuite(t *testing.T) {

--- a/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
+++ b/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
@@ -92,10 +92,23 @@ func (suite *testSuite) WaitForBroker() error {
 func (suite *testSuite) TestPreexistingResources() {
 
 	// Create a queue and bind it to all topics
-	triggerConfig := suite.createBrokerResources(suite.brokerURL,
+	// create a trigger configuration where the queue name is specified
+	triggerConfig := functionconfig.Trigger{
+		Kind: "rabbit-mq",
+		URL:  fmt.Sprintf("amqp://guest:guest@172.17.0.1:%d", suite.brokerPort),
+		Attributes: map[string]interface{}{
+			"exchangeName": suite.brokerExchangeName,
+			"queueName":    suite.brokerQueueName,
+
+			// no topics passed means to listen on topics binded pre function deploy
+			"topics":       []string{},
+		},
+	}
+
+	suite.createBrokerResources(suite.brokerURL,
 		suite.brokerExchangeName,
 		suite.brokerQueueName,
-		[]string{"*"})
+		[]string{"t1", "t2", "t3"})
 
 	// invoke the event recorder
 	triggertest.InvokeEventRecorder(&suite.AbstractBrokerSuite.TestSuite,
@@ -113,10 +126,15 @@ func (suite *testSuite) TestPreexistingResources() {
 func (suite *testSuite) TestResourcesCreatedByFunction() {
 
 	// Declare an exchange, but don't create a queue
-	triggerConfig := suite.createBrokerResources(suite.brokerURL,
-		suite.brokerExchangeName,
-		"",
-		[]string{"t1", "t2", "t3"})
+	triggerConfig := functionconfig.Trigger{
+		Kind: "rabbit-mq",
+		URL:  fmt.Sprintf("amqp://guest:guest@172.17.0.1:%d", suite.brokerPort),
+		Attributes: map[string]interface{}{
+			"exchangeName": suite.brokerExchangeName,
+			"queueName":    suite.brokerQueueName,
+			"topics":       []string{"t1", "t2", "t3", "t4", "t5"},
+		},
+	}
 
 	// invoke the event recorder
 	triggertest.InvokeEventRecorder(&suite.AbstractBrokerSuite.TestSuite,
@@ -149,7 +167,7 @@ func (suite *testSuite) getCreateFunctionOptionsWithRmqTrigger(triggerConfig fun
 func (suite *testSuite) createBrokerResources(brokerURL string,
 	brokerExchangeName string,
 	queueName string,
-	topics []string) functionconfig.Trigger {
+	topics []string) {
 
 	var err error
 
@@ -195,19 +213,6 @@ func (suite *testSuite) createBrokerResources(brokerURL string,
 			suite.Require().NoError(err, "Failed to bind queue")
 		}
 	}
-
-	// create a trigger configuration where the queue name is specified
-	triggerConfig := functionconfig.Trigger{
-		Kind: "rabbit-mq",
-		URL:  fmt.Sprintf("amqp://guest:guest@172.17.0.1:%d", suite.brokerPort),
-		Attributes: map[string]interface{}{
-			"exchangeName": suite.brokerExchangeName,
-			"queueName":    queueName,
-			"topics":       topics,
-		},
-	}
-
-	return triggerConfig
 }
 
 func (suite *testSuite) deleteBrokerResources(brokerURL string, brokerExchangeName string, queueName string) {

--- a/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
+++ b/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
@@ -132,7 +132,7 @@ func (suite *testSuite) TestResourcesCreatedByFunction() {
 		Attributes: map[string]interface{}{
 			"exchangeName": suite.brokerExchangeName,
 			"queueName":    suite.brokerQueueName,
-			"topics":       []string{"t1", "t2", "t3", "t4", "t5"},
+			"topics":       []string{"t1", "t2", "t3"},
 		},
 	}
 

--- a/pkg/processor/trigger/rabbitmq/trigger.go
+++ b/pkg/processor/trigger/rabbitmq/trigger.go
@@ -179,12 +179,12 @@ func (rmq *rabbitMq) createBrokerResources() error {
 
 	rmq.brokerInputMessagesChannel, err = rmq.brokerChannel.Consume(
 		rmq.configuration.QueueName, // queue
-		"",                   // consumer
-		false,                // auto-ack
-		false,                // exclusive
-		false,                // no-local
-		true,                 // no-wait
-		nil,                  // args
+		"",    // consumer
+		false, // auto-ack
+		false, // exclusive
+		false, // no-local
+		true,  // no-wait
+		nil,   // args
 	)
 	if err != nil {
 		return errors.Wrap(err, "Failed to start consuming messages")


### PR DESCRIPTION
Don't force declaring of exchange or queue if no topics passed.

topics passed -> function should declare the exchange and queue, and bind the topics, then consume

topics not passed -> function only consumes, expects preconfigured queues and exchange