### PR TITLE
UI: Triggers>RabbitMQ>Topics: wrong value when empty

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.4.17",
+    "iguazio.dashboard-controls": "^0.4.18",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
When the field is empty the model value should be an empty array: `[]`.
Instead, if was an array with a single item, an empty string: `['']`.

Depends on: https://github.com/iguazio/dashboard-controls/pull/428