### PR TITLE
Populate image of function on disable/enable

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -132,6 +132,11 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 			return nil, errors.New("If image is passed, runtime must be specified")
 		}
 
+		// populate image if possible
+		if existingFunctionConfig != nil {
+			createFunctionOptions.FunctionConfig.Spec.Image = existingFunctionConfig.Spec.Image
+		}
+
 		// trigger the on after config update ourselves
 		if err = onAfterConfigUpdatedWrapper(&createFunctionOptions.FunctionConfig); err != nil {
 			return nil, errors.Wrap(err, "Failed to trigger on after config update")


### PR DESCRIPTION
This is to keep the image of the function when disabling a function

before removing image and runRegistry from spec returned from function resource handler, this was given by the client