### PR TITLE
resource names for limits and requests - add special cases

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1354,8 +1354,12 @@ func (lc *lazyClient) getMetricResourceByName(resourceName string) v1.ResourceNa
 	switch resourceName {
 	case "memory":
 		return v1.ResourceMemory
+	case "nvidiaGpu":
+		return v1.ResourceNvidiaGPU
 	case "alpha.kubernetes.io/nvidia-gpu":
 		return v1.ResourceNvidiaGPU
+	case "ephemeralStorage":
+		return v1.ResourceEphemeralStorage
 	case "ephemeral-storage":
 		return v1.ResourceEphemeralStorage
 	case "storage":


### PR DESCRIPTION
Iguazio backend doesn't allow dashes and slashes as key name, allow camelCase variation as well