### PR TITLE
Disable golang/x/net/trace init

### DIFF
--- a/vendor/golang.org/x/net/trace/trace.go
+++ b/vendor/golang.org/x/net/trace/trace.go
@@ -112,8 +112,8 @@ var AuthRequest = func(req *http.Request) (any, sensitive bool) {
 func init() {
 	// TODO(jbd): Serve Traces from /debug/traces in the future?
 	// There is no requirement for a request to be present to have traces.
-	http.HandleFunc("/debug/requests", Traces)
-	http.HandleFunc("/debug/events", Events)
+	// http.HandleFunc("/debug/requests", Traces)
+	// http.HandleFunc("/debug/events", Events)
 }
 
 // Traces responds with traces from the program.


### PR DESCRIPTION
Golang functions that vendor golang/x/net/trace explode on double init (for no good reason). This prevents this by not initializing trace in Nuclio processor