### PR TITLE
IG-2131 fixed placement of 'external link' icon

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.5.9",
+    "iguazio.dashboard-controls": "^0.5.10",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",

--- a/pkg/dashboard/ui/src/less/mixins.less
+++ b/pkg/dashboard/ui/src/less/mixins.less
@@ -470,7 +470,7 @@
 
     @link-color: @dark-sky-blue;
     @link-hover-active-focus-color: @bluish;
-    @link-before-color: @cool-grey;
+    @external-link-icon-after-color: @cool-grey;
 }
 
 .icons-color-set() {


### PR DESCRIPTION
- Bugfix: function "Code" tab is visually distorted on Safari web browser (https://github.com/nuclio/nuclio/issues/1140)
- General: do not hide placeholder on focus.
- Function screen:
    - Triggers:
        - Do not crop the trigger list after 500 pixels

Depends on PR https://github.com/iguazio/dashboard-controls/pull/469