### PR TITLE
UI: Cron schedule syntax issue fixed + minor UX improvement

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.5.10",
+    "iguazio.dashboard-controls": "^0.5.11",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- Function:
    - Configuration & Triggers:
      - When a collapsible row is expanded and the "Create new" button is clicked, it will both collapse the expanded rows on that list and create a new row with a single click.
  - Triggers:
      - For `cron` only:
        - Schedule: fix issue with different formats (`sec min hrs day mon yrs` vs `min hrs day mon yrs`, see https://github.com/nuclio/nuclio/issues/1146)

Closes https://github.com/nuclio/nuclio/issues/1146