### PR TITLE
IG-2174 [Nuclio] Import multiple-projects YAML not working

### DIFF
--- a/pkg/dashboard/ui/src/app/shared/services/import.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/import.service.js
@@ -4,7 +4,7 @@
     angular.module('nuclio.app')
         .factory('ImportService', ImportService);
 
-    function ImportService($q, NuclioFunctionsDataService, NuclioProjectsDataService, lodash, YAML) {
+    function ImportService($q, DialogsService, NuclioFunctionsDataService, NuclioProjectsDataService, lodash, YAML) {
         return {
             importFile: importFile
         };
@@ -63,11 +63,13 @@
                     var projectID = lodash.get(currentProject, 'metadata.name');
 
                     lodash.forEach(functions, function (func) {
-                        NuclioFunctionsDataService.updateFunction(func, projectID);
+                        NuclioFunctionsDataService.createFunction(func, projectID);
                     });
 
                     promise.resolve();
                 });
+            }).catch(function () {
+                DialogsService.alert('Error occurred while creating a new project.');
             });
         }
     }


### PR DESCRIPTION
- Bugfix: YAML import/export of both projects and functions is corrupted when quote character (`'`) is used
- Projects screen:
   - Bugfix: import a YAML file with multiple projects is not working
- Function screen:
    - "Code" tab:
        - for "Archive" code-entry type: renamed "Session Key" to "Access key"
        - for "GitHub" code-entry type: added "Token" field which populates `Authorization: token <user_token>` request-HTTP header
    - "Configuration" tab:
        - "Resources": "Request" field  is removed from "GPU" since only "Limit" is relevant according to [docs](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/#v1-8-onwards)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/514