### PR TITLE
UI: Move "V3IO" text from Archive option to Access Key field

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.6.9",
+    "iguazio.dashboard-controls": "^0.6.10",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- Function » Code » Code-Entry Type: for "Archive in V3IO" only:
  - Rename "Archive in V3IO" label to "Archive"
  - Rename "Access key" label of field to "Access key (V3IO only)"

#### Before
![image](https://user-images.githubusercontent.com/13918850/54683211-b980c380-4b19-11e9-8285-35cff8280b66.png)

#### After
![image](https://user-images.githubusercontent.com/13918850/54683238-ce5d5700-4b19-11e9-871b-cd80f25d8baf.png)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/516