### PR TITLE
UI: Refactor V3IO volumes & move Worker Allocator Name to be last

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.6.10",
+    "iguazio.dashboard-controls": "^0.6.11",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- Function screen:
  - Configuration tab: Volumes: Refactor V3IO type model & change field order
  - Triggers tab: Move "Worker Allocator Name" to be last of the fields

Depends on PR https://github.com/iguazio/dashboard-controls/pull/519