### PR TITLE
UI: Remove unnecessary `$$hashKey` properties from YAML

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.6.12",
+    "iguazio.dashboard-controls": "^0.6.13",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- Bugfix: when viewing/exporting function to YAML some unrelated `$$hashKey` properties were there. They are omitted now.
-  Bugfix: when selecting "Duplicate function" action from function list and clicking on "Cancel" in the dialog, the list of functions used to be unnecessarily reloaded. Now it does not get reloaded in this case.

Depends on PR https://github.com/iguazio/dashboard-controls/pull/525