### PR TITLE
UI: Cron trigger: use 0 instead of * for seconds in schedule

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.6.13",
+    "iguazio.dashboard-controls": "^0.6.14",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- Function » Triggers » for Cron only » Schedule:
  - Display entire 6-part value in collapsed row.
  - Instead of prepending value with `*` for seconds, use `0` instead.
- Number input: bugfix – arrows mispositioned on Firefox browser.

Depends on PR https://github.com/iguazio/dashboard-controls/pull/533