### PR TITLE
UI: Remove "Host Path" volume type; Add some tooltips

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.6.15",
+    "iguazio.dashboard-controls": "^0.6.16",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- Function screen » Configuration:
    - Build:
        - Add tooltips to "Disabled cache" and "No internet" checkboxes
    - Resources:
        - GPU: Add tooltip "per replica"
    - Volumes:
        - Remove "Host Path" volume type

Complements PR https://github.com/nuclio/nuclio/pull/1186
Depends on PR https://github.com/iguazio/dashboard-controls/pull/541