### PR TITLE
Allow Nuclio build on EKS

### DIFF
--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -93,19 +93,19 @@ func (c *ShellClient) Build(buildOptions *BuildOptions) error {
 		CaptureOutputMode: cmdrunner.CaptureOutputModeStdout,
 		WorkingDir:        &buildOptions.ContextDir,
 	}
-	
+
 	hostNetString := ""
 	if len(os.Getenv("BUILD_USE_HOST_NET")) != 0 {
 		useHostNet, err := strconv.ParseBool(os.Getenv("BUILD_USE_HOST_NET"))
 		if err == nil {
 			if useHostNet {
 				hostNetString = "--network host"
-			}else {
+			} else {
 				hostNetString = "--network default"
 			}
 		}
 	}
-	
+
 	_, err := c.runCommand(runOptions,
 		"docker build %s --force-rm -t %s -f %s %s %s .",
 		hostNetString,

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -98,7 +98,7 @@ func (c *ShellClient) Build(buildOptions *BuildOptions) error {
 	if len(os.Getenv("BUILD_USE_HOST_NET")) != 0 {
 		useHostNet, err := strconv.ParseBool(os.Getenv("BUILD_USE_HOST_NET"))
 		if err == nil {
-			if useHostNet == true {
+			if useHostNet {
 				hostNetString = "--network host"
 			}else {
 				hostNetString = "--network default"

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -21,6 +21,8 @@ import (
 	"path"
 	"strings"
 	"time"
+	"os"
+	"strconv"
 
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
 	"github.com/nuclio/nuclio/pkg/common"
@@ -91,9 +93,22 @@ func (c *ShellClient) Build(buildOptions *BuildOptions) error {
 		CaptureOutputMode: cmdrunner.CaptureOutputModeStdout,
 		WorkingDir:        &buildOptions.ContextDir,
 	}
-
+	
+	hostNetString := ""
+	if len(os.Getenv("BUILD_USE_HOST_NET")) != 0 {
+		useHostNet, err := strconv.ParseBool(os.Getenv("BUILD_USE_HOST_NET"))
+		if err == nil {
+			if useHostNet == true {
+				hostNetString = "--network host"
+			}else {
+				hostNetString = "--network default"
+			}
+		}
+	}
+	
 	_, err := c.runCommand(runOptions,
-		"docker build --force-rm -t %s -f %s %s %s .",
+		"docker build %s --force-rm -t %s -f %s %s %s .",
+		hostNetString,
 		buildOptions.Image,
 		buildOptions.DockerfilePath,
 		cacheOption,

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -18,11 +18,11 @@ package dockerclient
 
 import (
 	"fmt"
+	"os"
 	"path"
+	"strconv"
 	"strings"
 	"time"
-	"os"
-	"strconv"
 
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
 	"github.com/nuclio/nuclio/pkg/common"


### PR DESCRIPTION
When running builds on Amazon EKS, containers do not have access to the network/routing so have no access to the internet, this is an issue when building dependencies with pip for example. This fixes the issue by exposing and env variable that can be applied to the deployment of the nuclio dashboard.

```
env:
    - name: BUILD_USE_HOST_NET
      value: "true"
```

This will add the `--network host` argument to the build command.
If the variable is set to false, or not specified, it will default to `--network default`.