### PR TITLE
UI: Re-organize Configuration panes; Readiness timeout min val 1

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.7.0",
+    "iguazio.dashboard-controls": "^0.7.1",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- Function screen » "Configuration" tab:
  - Re-organization:
    - Switched places of "Data Bindings" and "Volumes" panes
    - Moved "Logger level" from "Logging" pane to "Basic Settings" pane
    - Removed "Logging" pane
  - Build » Timeout Readiness (seconds): changed minimum valid value from 0 to 1