### PR TITLE
UI: Text boxes: reduce debounce for typing from 1s to 200ms

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.7.1",
+    "iguazio.dashboard-controls": "^0.7.2",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
Text boxes debounce for typing was reduced from 1 second to 200 milli-seconds.

Depends on PR https://github.com/iguazio/dashboard-controls/pull/554