### PR TITLE
Fix volume subpath structure when a wrong one is given

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1271,6 +1271,25 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(function *nuclioio.NuclioFuncti
 			continue
 		}
 
+		if configVolume.Volume.FlexVolume != nil && configVolume.Volume.FlexVolume.Driver == "v3io/fuse" {
+
+			// make sure the given sub path matches the needed structure. fix in case it doesn't
+			subPath, subPathExists := configVolume.Volume.FlexVolume.Options["subPath"]
+			if subPathExists && len(subPath) != 0 {
+
+				// insert slash in the beginning in case it wasn't given (example: "my/path" -> "/my/path")
+				if subPath[0] != '/' {
+					configVolume.Volume.FlexVolume.Options["subPath"] = "/" + subPath
+				}
+
+				// remove ending slash in case it was given (example: "/my/path/" -> "/my/path")
+				if subPath[len(subPath)-1] == '/' {
+					configVolume.Volume.FlexVolume.Options["subPath"] = subPath[:len(subPath)-1]
+
+				}
+			}
+		}
+
 		lc.logger.DebugWith("Adding volume",
 			"configVolume",
 			configVolume)

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1279,14 +1279,15 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(function *nuclioio.NuclioFuncti
 
 				// insert slash in the beginning in case it wasn't given (example: "my/path" -> "/my/path")
 				if subPath[0] != '/' {
-					configVolume.Volume.FlexVolume.Options["subPath"] = "/" + subPath
+					subPath = "/" + subPath
 				}
 
 				// remove ending slash in case it was given (example: "/my/path/" -> "/my/path")
 				if subPath[len(subPath)-1] == '/' {
-					configVolume.Volume.FlexVolume.Options["subPath"] = subPath[:len(subPath)-1]
-
+					subPath = subPath[:len(subPath)-1]
 				}
+
+				configVolume.Volume.FlexVolume.Options["subPath"] = subPath
 			}
 		}
 

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"text/template"
@@ -1278,13 +1279,15 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(function *nuclioio.NuclioFuncti
 			if subPathExists && len(subPath) != 0 {
 
 				// insert slash in the beginning in case it wasn't given (example: "my/path" -> "/my/path")
-				if subPath[0] != '/' {
+				if !filepath.IsAbs(subPath) {
 					subPath = "/" + subPath
 				}
 
-				// remove ending slash in case it was given (example: "/my/path/" -> "/my/path")
-				if subPath[len(subPath)-1] == '/' {
-					subPath = subPath[:len(subPath)-1]
+				if subPath == "/" {
+					subPath = ""
+
+				} else {
+					subPath = filepath.Clean(subPath)
 				}
 
 				configVolume.Volume.FlexVolume.Options["subPath"] = subPath

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1283,11 +1283,9 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(function *nuclioio.NuclioFuncti
 					subPath = "/" + subPath
 				}
 
+				subPath = filepath.Clean(subPath)
 				if subPath == "/" {
 					subPath = ""
-
-				} else {
-					subPath = filepath.Clean(subPath)
 				}
 
 				configVolume.Volume.FlexVolume.Options["subPath"] = subPath


### PR DESCRIPTION
Fixes 2 bugs that make deploy fail when subpath:
1. doesn't start with '/'
2. ends with '/' 