### PR TITLE
UI: Remove some defaults from function creation; Fix quotes bug

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.8.0",
+    "iguazio.dashboard-controls": "^0.8.1",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",

--- a/pkg/dashboard/ui/src/less/mixins.less
+++ b/pkg/dashboard/ui/src/less/mixins.less
@@ -242,6 +242,8 @@
 
     @number-input-disabled-bg-color: @white;
     @number-input-disabled-icon-hover-color: .duskThree(0.54)[@color];
+
+    @number-input-placeholder-color: .duskThree(0.44)[@color];
 }
 
 .pagination-color-set() {


### PR DESCRIPTION
- Create function from scratch: These fields no longer have default values in UI so they don't override their corresponding values from remote configuration (from archive or GitHub): Min replicas, Max Replicas, Target CPU.
- Bugfix: single-quotes were doubled in request body on deploy (e.g. `"commands": ["echo: ''hello''"]` instead of `"commands": ["echo: 'hello'"]`).
- Align tone of placeholder text color of number inputs with that of text inputs.
- Multi-line text input fields are now scrollable.
- Bugfix: scrollbar of Monaco code editor was flickering on Firefox web browser.

Depends on PR https://github.com/iguazio/dashboard-controls/pull/562