### PR TITLE
Code entry values don't override base config values

### DIFF
--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -1,0 +1,12 @@
+package common
+
+import "k8s.io/api/core/v1"
+
+func EnvInSlice(env v1.EnvVar, slice []v1.EnvVar) bool {
+	for _, envVar := range slice {
+		if envVar.Name == env.Name {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/functionconfig/reader.go
+++ b/pkg/functionconfig/reader.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2017 The Nuclio Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/functionconfig/reader.go
+++ b/pkg/functionconfig/reader.go
@@ -21,11 +21,11 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio/pkg/errors"
 
 	"github.com/ghodss/yaml"
 	"github.com/imdario/mergo"
+	"github.com/nuclio/logger"
 )
 
 type Reader struct {

--- a/pkg/functionconfig/reader.go
+++ b/pkg/functionconfig/reader.go
@@ -38,7 +38,6 @@ func NewReader(parentLogger logger.Logger) (*Reader, error) {
 	}, nil
 }
 
-
 // Merges codeEntry config with base function config.
 // Base config populated values won't get override by codeEntry values.
 // The only exception is that there will be a union of the environment variables, with precedence to base config.

--- a/pkg/functionconfig/reader.go
+++ b/pkg/functionconfig/reader.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/errors"
 
 	"github.com/ghodss/yaml"
@@ -38,11 +39,11 @@ func NewReader(parentLogger logger.Logger) (*Reader, error) {
 	}, nil
 }
 
-// Merges codeEntry config with base function config.
-// Base config populated values won't get override by codeEntry values.
-// The only exception is that there will be a union of the environment variables, with precedence to base config.
+// Merges codeEntry config with the function config.
+// Config populated values won't get override by codeEntry values.
+// Enriches config with env vars existing only in codeEntry config
 func (r *Reader) Read(reader io.Reader, configType string, config *Config) error {
-	var codeEntryConfigAsMap, baseConfigAsMap map[string]interface{}
+	var codeEntryConfigMap, configMap map[string]interface{}
 	var codeEntryConfig Config
 
 	bodyBytes, err := ioutil.ReadAll(reader)
@@ -51,55 +52,48 @@ func (r *Reader) Read(reader io.Reader, configType string, config *Config) error
 		return errors.Wrap(err, "Failed to read configuration file")
 	}
 
-	// load codeEntry configuration into a Config struct
+	// load codeEntry config into a Config struct
 	if err := yaml.Unmarshal(bodyBytes, &codeEntryConfig); err != nil {
 		return errors.Wrap(err, "Failed to write configuration")
 	}
 
-	// merge env vars, with precedence to base config env vars
+	// enrich config with env vars existing only in codeEntry config
 	if codeEntryConfig.Spec.Env != nil && config.Spec.Env != nil {
 		for _, codeEntryEnvVar := range codeEntryConfig.Spec.Env {
-			existsInBaseEnv := false
-			for _, baseEnvVar := range config.Spec.Env {
-				if baseEnvVar.Name == codeEntryEnvVar.Name {
-					existsInBaseEnv = true
-					break
-				}
-			}
-			if !existsInBaseEnv {
+			if !common.EnvInSlice(codeEntryEnvVar, config.Spec.Env) {
 				config.Spec.Env = append(config.Spec.Env, codeEntryEnvVar)
 			}
 		}
 	}
 
-	if err = yaml.Unmarshal(bodyBytes, &codeEntryConfigAsMap); err != nil {
+	if err = yaml.Unmarshal(bodyBytes, &codeEntryConfigMap); err != nil {
 		return errors.Wrap(err, "Failed to parse received config")
 	}
 
-	// parse base config to JSON - in order to parse it afterwards into a map
-	baseConfigAsJSON, err := json.Marshal(config)
+	// parse config to JSON - in order to parse it afterwards into a map
+	configJSON, err := json.Marshal(config)
 	if err != nil {
-		return errors.Wrap(err, "Failed to parse base config to JSON")
+		return errors.Wrap(err, "Failed to parse config to JSON")
 	}
 
-	// create a map from the JSON of the base map. we need it as a map so we will be able to use mergo.Merge()
-	if err = json.Unmarshal(baseConfigAsJSON, &baseConfigAsMap); err != nil {
-		return errors.Wrap(err, "Failed to parse base config as JSON to map")
+	// create a map from the JSON of the config. we need it as a map so we will be able to use mergo.Merge()
+	if err = json.Unmarshal(configJSON, &configMap); err != nil {
+		return errors.Wrap(err, "Failed to parse config as JSON to map")
 	}
 
-	// merge base config with received config - and make base config values override codeEntry config values
-	if err = mergo.Merge(&baseConfigAsMap, &codeEntryConfigAsMap); err != nil {
-		return errors.Wrap(err, "Failed to merge base config and received config")
+	// merge config with codeEntry config - config populated values won't get overridden by codeEntry config values
+	if err = mergo.Merge(&configMap, &codeEntryConfigMap); err != nil {
+		return errors.Wrap(err, "Failed to merge config and codeEntry config")
 	}
 
-	// parse the modified base config map to be as JSON, so it can be easily unmarshalled into the config struct
-	mergedConfigAsJSON, err := json.Marshal(baseConfigAsMap)
+	// parse the modified config map to be as JSON, so it can be easily unmarshalled into the config struct
+	mergedConfigJSON, err := json.Marshal(configMap)
 	if err != nil {
 		return errors.Wrap(err, "Failed to parse new config from from map to JSON")
 	}
 
 	// load merged config into the function config
-	if err = json.Unmarshal(mergedConfigAsJSON, &config); err != nil {
+	if err = json.Unmarshal(mergedConfigJSON, &config); err != nil {
 		return errors.Wrap(err, "Failed to parse new config from JSON to *Config struct")
 	}
 

--- a/pkg/functionconfig/reader.go
+++ b/pkg/functionconfig/reader.go
@@ -1,12 +1,9 @@
 /*
 Copyright 2017 The Nuclio Authors.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,13 +14,15 @@ limitations under the License.
 package functionconfig
 
 import (
+	"encoding/json"
 	"io"
 	"io/ioutil"
 
+	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio/pkg/errors"
 
 	"github.com/ghodss/yaml"
-	"github.com/nuclio/logger"
+	"github.com/imdario/mergo"
 )
 
 type Reader struct {
@@ -36,15 +35,70 @@ func NewReader(parentLogger logger.Logger) (*Reader, error) {
 	}, nil
 }
 
+
+// Merges codeEntry config with base function config.
+// Base config populated values won't get override by codeEntry values.
+// The only exception is that there will be a union of the environment variables, with precedence to base config.
 func (r *Reader) Read(reader io.Reader, configType string, config *Config) error {
+	var codeEntryConfigAsMap, baseConfigAsMap map[string]interface{}
+	var codeEntryConfig Config
+
 	bodyBytes, err := ioutil.ReadAll(reader)
 
 	if err != nil {
 		return errors.Wrap(err, "Failed to read configuration file")
 	}
 
-	if err := yaml.Unmarshal(bodyBytes, config); err != nil {
+	// load codeEntry configuration into a Config struct
+	if err := yaml.Unmarshal(bodyBytes, &codeEntryConfig); err != nil {
 		return errors.Wrap(err, "Failed to write configuration")
+	}
+
+	// merge env vars, with precedence to base config env vars
+	if codeEntryConfig.Spec.Env != nil && config.Spec.Env != nil {
+		for _, codeEntryEnvVar := range codeEntryConfig.Spec.Env {
+			existsInBaseEnv := false
+			for _, baseEnvVar := range config.Spec.Env {
+				if baseEnvVar.Name == codeEntryEnvVar.Name {
+					existsInBaseEnv = true
+					break
+				}
+			}
+			if !existsInBaseEnv {
+				config.Spec.Env = append(config.Spec.Env, codeEntryEnvVar)
+			}
+		}
+	}
+
+	if err = yaml.Unmarshal(bodyBytes, &codeEntryConfigAsMap); err != nil {
+		return errors.Wrap(err, "Failed to parse received config")
+	}
+
+	// parse base config to JSON - in order to parse it afterwards into a map
+	baseConfigAsJSON, err := json.Marshal(config)
+	if err != nil {
+		return errors.Wrap(err, "Failed to parse base config to JSON")
+	}
+
+	// create a map from the JSON of the base map. we need it as a map so we will be able to use mergo.Merge()
+	if err = json.Unmarshal(baseConfigAsJSON, &baseConfigAsMap); err != nil {
+		return errors.Wrap(err, "Failed to parse base config as JSON to map")
+	}
+
+	// merge base config with received config - and make base config values override codeEntry config values
+	if err = mergo.Merge(&baseConfigAsMap, &codeEntryConfigAsMap); err != nil {
+		return errors.Wrap(err, "Failed to merge base config and received config")
+	}
+
+	// parse the modified base config map to be as JSON, so it can be easily unmarshalled into the config struct
+	mergedConfigAsJSON, err := json.Marshal(baseConfigAsMap)
+	if err != nil {
+		return errors.Wrap(err, "Failed to parse new config from from map to JSON")
+	}
+
+	// load merged config into the function config
+	if err = json.Unmarshal(mergedConfigAsJSON, &config); err != nil {
+		return errors.Wrap(err, "Failed to parse new config from JSON to *Config struct")
 	}
 
 	return nil

--- a/pkg/functionconfig/reader.go
+++ b/pkg/functionconfig/reader.go
@@ -40,10 +40,10 @@ func NewReader(parentLogger logger.Logger) (*Reader, error) {
 }
 
 // Merges codeEntry config with the function config.
-// Config populated values won't get override by codeEntry values.
+// CodeEntry config will get overridden by config values.
 // Enriches config with env vars existing only in codeEntry config
 func (r *Reader) Read(reader io.Reader, configType string, config *Config) error {
-	var codeEntryConfigMap, configMap map[string]interface{}
+	var codeEntryConfigAsMap, configAsMap map[string]interface{}
 	var codeEntryConfig Config
 
 	bodyBytes, err := ioutil.ReadAll(reader)
@@ -66,34 +66,34 @@ func (r *Reader) Read(reader io.Reader, configType string, config *Config) error
 		}
 	}
 
-	if err = yaml.Unmarshal(bodyBytes, &codeEntryConfigMap); err != nil {
+	if err = yaml.Unmarshal(bodyBytes, &codeEntryConfigAsMap); err != nil {
 		return errors.Wrap(err, "Failed to parse received config")
 	}
 
 	// parse config to JSON - in order to parse it afterwards into a map
-	configJSON, err := json.Marshal(config)
+	configAsJSON, err := json.Marshal(config)
 	if err != nil {
 		return errors.Wrap(err, "Failed to parse config to JSON")
 	}
 
 	// create a map from the JSON of the config. we need it as a map so we will be able to use mergo.Merge()
-	if err = json.Unmarshal(configJSON, &configMap); err != nil {
+	if err = json.Unmarshal(configAsJSON, &configAsMap); err != nil {
 		return errors.Wrap(err, "Failed to parse config as JSON to map")
 	}
 
-	// merge config with codeEntry config - config populated values won't get overridden by codeEntry config values
-	if err = mergo.Merge(&configMap, &codeEntryConfigMap); err != nil {
+	// merge config with codeEntry config - config populated values will take precedence
+	if err = mergo.Merge(&configAsMap, &codeEntryConfigAsMap); err != nil {
 		return errors.Wrap(err, "Failed to merge config and codeEntry config")
 	}
 
-	// parse the modified config map to be as JSON, so it can be easily unmarshalled into the config struct
-	mergedConfigJSON, err := json.Marshal(configMap)
+	// parse the modified configAsMap to be as JSON, so it can be easily unmarshalled into the config struct
+	mergedConfigAsJSON, err := json.Marshal(configAsMap)
 	if err != nil {
 		return errors.Wrap(err, "Failed to parse new config from from map to JSON")
 	}
 
 	// load merged config into the function config
-	if err = json.Unmarshal(mergedConfigJSON, &config); err != nil {
+	if err = json.Unmarshal(mergedConfigAsJSON, &config); err != nil {
 		return errors.Wrap(err, "Failed to parse new config from JSON to *Config struct")
 	}
 

--- a/pkg/functionconfig/reader_test.go
+++ b/pkg/functionconfig/reader_test.go
@@ -84,56 +84,56 @@ spec:
 	}
 }
 
-func (suite *ReaderTestSuite) TestReceivedConfigDontOverrideBaseConfig() {
+func (suite *ReaderTestSuite) TestCodeEntryConfigDontOverrideConfigValues() {
 	configData := `
 metadata:
-  name: new_name
-  namespace: new_namespace
+  name: code_entry_name
+  namespace: code_entry_namespace
   labels:
     label_key: label_val
 spec:
   runtime: python3.6
-  handler: new_handler
+  handler: code_entry_handler
   build:
     commands:
-    - pip install new
+    - pip install code_entry_package
   env:
     - name: env_var
-      value: new_env_val
-    - name: new_env_var
-      value: new_env_val_2
+      value: code_entry_env_val
+    - name: code_entry_env_var
+      value: code_entry_env_val_2
 `
 
-	baseConfig := Config{
+	config := Config{
 		Meta: Meta{
-			Name: "base_name",
-			Namespace: "base_namespace",
+			Name: "my_name",
+			Namespace: "my_namespace",
 			Labels: map[string]string{}, // empty map
 		},
 		Spec: Spec{
 			Runtime: "python2.7",
-			Handler: "base_handler",
-			Env: []v1.EnvVar{{Name: "env_var", Value: "base_env_val"}},
+			Handler: "my_handler",
+			Env: []v1.EnvVar{{Name: "env_var", Value: "my_env_val"}},
 		},
 	}
 	reader, err := NewReader(suite.logger)
 	suite.Require().NoError(err, "Can't create reader")
-	err = reader.Read(strings.NewReader(configData), "processor", &baseConfig)
+	err = reader.Read(strings.NewReader(configData), "processor", &config)
 	suite.Require().NoError(err, "Can't reader configuration")
 
-	suite.Require().Equal("base_name", baseConfig.Meta.Name, "Bad name")
-	suite.Require().Equal("base_namespace", baseConfig.Meta.Namespace, "Bad namespace")
+	suite.Require().Equal("my_name", config.Meta.Name, "Bad name")
+	suite.Require().Equal("my_namespace", config.Meta.Namespace, "Bad namespace")
 
 	expectedEnvVariables := []v1.EnvVar{
-		{Name: "env_var", Value: "base_env_val"},
-		{Name: "new_env_var", Value: "new_env_val_2"},
+		{Name: "env_var", Value: "my_env_val"},
+		{Name: "code_entry_env_var", Value: "code_entry_env_val_2"},
 	}
-	suite.Require().Equal(expectedEnvVariables, baseConfig.Spec.Env, "Bad env vars")
+	suite.Require().Equal(expectedEnvVariables, config.Spec.Env, "Bad env vars")
 
-	suite.Require().Equal("base_handler", baseConfig.Spec.Handler, "Bad handler")
-	suite.Require().Equal("python2.7", baseConfig.Spec.Runtime, "Bad runtime")
-	suite.Require().Equal([]string{"pip install new"}, baseConfig.Spec.Build.Commands, "Bad commands")
-	suite.Require().Equal(map[string]string{"label_key": "label_val"}, baseConfig.Meta.Labels, "Bad labels")
+	suite.Require().Equal("my_handler", config.Spec.Handler, "Bad handler")
+	suite.Require().Equal("python2.7", config.Spec.Runtime, "Bad runtime")
+	suite.Require().Equal([]string{"pip install code_entry_package"}, config.Spec.Build.Commands, "Bad commands")
+	suite.Require().Equal(map[string]string{"label_key": "label_val"}, config.Meta.Labels, "Bad labels")
 }
 
 func (suite *ReaderTestSuite) TestToDeployOptions() {

--- a/pkg/functionconfig/reader_test.go
+++ b/pkg/functionconfig/reader_test.go
@@ -54,9 +54,9 @@ spec:
       total_tasks: 2
       max_task_allocation: 3
       partitions:
-      - id: 0
-        checkpoint: 7
-      - id: 1
+      - id: "0"
+        checkpoint: "7"
+      - id: "1"
       attributes:
         topic: trial
 `

--- a/pkg/functionconfig/reader_test.go
+++ b/pkg/functionconfig/reader_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/nuclio/logger"
 	"github.com/nuclio/zap"
-
 	"github.com/stretchr/testify/suite"
 	"k8s.io/api/core/v1"
 )


### PR DESCRIPTION
As requested, Loading configuration from code entry (Archive, Github) will *not* override UI specified fields

The only exception is that env vars will be merged - with priority to UI when there's conflict