### PR TITLE
Function templates load from local archive

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -45,7 +45,7 @@ func getEnvOrDefaultString(key string, defaultValue string) string {
 	value := os.Getenv(key)
 	if value == "" {
 		return defaultValue
-	} else if value == "nil" {
+	} else if value == "nil" || value == "none" {
 		return ""
 	}
 

--- a/pkg/common/url.go
+++ b/pkg/common/url.go
@@ -76,7 +76,7 @@ func IsLocalFileURL(s string) bool {
 // example: "file://path/to/file" -> "/path/to/file"
 func GetPathFromLocalFileURL(s string) string {
 	if IsLocalFileURL(s) {
-		return s[6:]
+		return strings.TrimPrefix(s, "file:/")
 	}
 	return ""
 }

--- a/pkg/common/url.go
+++ b/pkg/common/url.go
@@ -25,9 +25,9 @@ import (
 )
 
 const (
-	HTTPPrefix  = "http://"
-	HTTPSPrefix  = "https://"
-	LocalFilePrefix  = "file://"
+	HTTPPrefix      = "http://"
+	HTTPSPrefix     = "https://"
+	LocalFilePrefix = "file://"
 )
 
 func DownloadFile(URL, destFile string, headers http.Header) error {

--- a/pkg/common/url.go
+++ b/pkg/common/url.go
@@ -24,6 +24,12 @@ import (
 	"strings"
 )
 
+const (
+	HTTPPrefix  = "http://"
+	HTTPSPrefix  = "https://"
+	LocalFilePrefix  = "file://"
+)
+
 func DownloadFile(URL, destFile string, headers http.Header) error {
 	out, err := os.Create(destFile)
 	if err != nil {
@@ -65,18 +71,18 @@ func DownloadFile(URL, destFile string, headers http.Header) error {
 }
 
 func IsURL(s string) bool {
-	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+	return strings.HasPrefix(s, HTTPPrefix) || strings.HasPrefix(s, HTTPSPrefix)
 }
 
 func IsLocalFileURL(s string) bool {
-	return strings.HasPrefix(s, "file://")
+	return strings.HasPrefix(s, LocalFilePrefix)
 }
 
 // extracts absolute path to file from local file URL
 // example: "file://path/to/file" -> "/path/to/file"
 func GetPathFromLocalFileURL(s string) string {
 	if IsLocalFileURL(s) {
-		return strings.TrimPrefix(s, "file:/")
+		return "/" + strings.TrimPrefix(s, LocalFilePrefix)
 	}
 	return ""
 }

--- a/pkg/common/url.go
+++ b/pkg/common/url.go
@@ -67,3 +67,16 @@ func DownloadFile(URL, destFile string, headers http.Header) error {
 func IsURL(s string) bool {
 	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
 }
+
+func IsLocalFileURL(s string) bool {
+	return strings.HasPrefix(s, "file://")
+}
+
+// extracts absolute path to file from local file URL
+// example: "file://path/to/file" -> "/path/to/file"
+func GetPathFromLocalFileURL(s string) string {
+	if IsLocalFileURL(s) {
+		return s[6:]
+	}
+	return ""
+}

--- a/pkg/common/url_test.go
+++ b/pkg/common/url_test.go
@@ -50,6 +50,18 @@ func (ts *IsURLTestSuite) TestIsURLWithHTTPS() {
 	ts.Require().True(IsURL("https://www.example.com"))
 }
 
+func (ts *IsURLTestSuite) TestIsLocalFileURLWithHTTP() {
+	ts.Require().False(IsLocalFileURL("http://www.example.com"))
+}
+
+func (ts *IsURLTestSuite) TestIsLocalFileURL() {
+	ts.Require().True(IsLocalFileURL("file://path/to/file"))
+}
+
+func (ts *IsURLTestSuite) TestGetPathFromLocalFileURL() {
+	ts.Require().Equal("/path/to/file" ,GetPathFromLocalFileURL("file://path/to/file"))
+}
+
 func (ts *DownloadFileTestSuite) TestDownloadFile() {
 	content := "content"
 	errResult := ts.testDownloadFile(func(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
Corresponding to #1204 

Changes:
- can read from local file when archive URL starts with "file://"
- added the option to pass "none"  in addition to "nil" when passing git repo and ref