### PR TITLE
UI: Configuration: Build: Disable pane for non-edit-online

### DIFF
--- a/pkg/dashboard/ui/gulpfile.js
+++ b/pkg/dashboard/ui/gulpfile.js
@@ -59,7 +59,7 @@ if (state.isDevMode) {
 /**
  * Make sure resources are built before app
  */
-iRequire.setup(require('sync-exec'), gutil);
+iRequire.setup(gutil);
 var previewServer = iRequire(config.resources.previewServer);
 var errHandler = iRequire(config.resources.errHandler);
 

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.8.1",
+    "iguazio.dashboard-controls": "^0.8.2",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",

--- a/pkg/dashboard/ui/resources/installRequire/app.js
+++ b/pkg/dashboard/ui/resources/installRequire/app.js
@@ -59,12 +59,9 @@ module.exports = function installRequire(src) {
 
 /**
  * Sets up and configs the modules used.
- * @param [execSyncModule]  sync-exec module {@link http://npmjs.com/package/sync-exec}
- *                          can be null if using nodejs v0.12.x
  * @param [gutilModule]     gutil module {@link http://npmjs.com/package/gutil}
  *                          if null, will use console instead
  */
-module.exports.setup = function setup(execSyncModule, gutilModule) {
-    execSync = childProcess.execSync || execSyncModule;
+module.exports.setup = function setup(gutilModule) {
     gutil = gutilModule || console;
 };


### PR DESCRIPTION
- Function configuration: Build: Disable entire pane when the selected code entry type in "Code" tab is not "Edit Online".
- Make placeholders more consistent:
  - "Enter" instead of "Type"
  - Removed "a" or "an" articles
  - Always end with "..." (and no space before it)
- Remove "sync-exec" dependency (due to vulnerability and it was no longer necessary)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/565