### PR TITLE
Enrich deployments with platformConfig default values

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -497,6 +497,7 @@ func (lc *lazyClient) createOrUpdateService(functionLabels labels.Set,
 func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 	imagePullSecrets string,
 	function *nuclioio.NuclioFunction) (*apps_v1beta1.Deployment, error) {
+	lc.logger.Debug("New log - Creating or updating deployment")
 
 	// to make sure the pod re-pulls the image, we need to specify a unique string here
 	podAnnotations, err := lc.getPodAnnotations(function)
@@ -505,7 +506,7 @@ func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 	}
 
 	replicas := int32(lc.getFunctionReplicas(function))
-	lc.logger.DebugWith("Got replicass", "replicas", replicas)
+	lc.logger.DebugWith("Got replicas", "replicas", replicas)
 	deploymentAnnotations, err := lc.getDeploymentAnnotations(function)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get function annotations")
@@ -549,10 +550,13 @@ func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 			},
 		}
 
+
 		// enrich deployment spec with default fields that were passed inside the platform configuration
-		platformConfigDeploymentSpec := lc.platformConfigurationProvider.GetPlatformConfiguration().Kubernetes.Deployment.Spec
-		if err := enrichDeploymentSpec(&deploymentSpec, platformConfigDeploymentSpec); err != nil {
-			return nil, err
+		platformConfigDeployment := lc.platformConfigurationProvider.GetPlatformConfiguration().Kubernetes.Deployment
+		if platformConfigDeployment != nil {
+			if err := enrichDeploymentSpec(&deploymentSpec, platformConfigDeployment.Spec); err != nil {
+				return nil, err
+			}
 		}
 
 		deployment := apps_v1beta1.Deployment{

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -557,7 +557,7 @@ func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 			}
 		}
 
-		deployment := apps_v1beta1.Deployment{
+		return lc.kubeClientSet.AppsV1beta1().Deployments(function.Namespace).Create(&apps_v1beta1.Deployment{
 
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:        function.Name,
@@ -566,9 +566,7 @@ func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 				Annotations: deploymentAnnotations,
 			},
 			Spec: deploymentSpec,
-		}
-
-		return lc.kubeClientSet.AppsV1beta1().Deployments(function.Namespace).Create(&deployment)
+		})
 	}
 
 	updateDeployment := func(resource interface{}) (interface{}, error) {

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -31,6 +31,7 @@ type Config struct {
 	ScaleToZero              ScaleToZero              `json:"scaleToZero,omitempty"`
 	AutoScale                AutoScale                `json:"autoScale,omitempty"`
 	FunctionAugmentedConfigs []LabelSelectorAndConfig `json:"functionAugmentedConfigs,omitempty"`
+	Kubernetes               Kubernetes               `json:"kubernetes,omitempty"`
 }
 
 func (config *Config) GetSystemLoggerSinks() (map[string]LoggerSinkWithLevel, error) {

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -19,6 +19,7 @@ package platformconfig
 import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 
+	"k8s.io/api/apps/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -82,4 +83,8 @@ type Metrics struct {
 type LabelSelectorAndConfig struct {
 	LabelSelector  v1.LabelSelector      `json:"labelSelector,omitempty"`
 	FunctionConfig functionconfig.Config `json:"functionConfig,omitempty"`
+}
+
+type Kubernetes struct {
+	Deployment *v1beta1.Deployment `json:"deployment,omitempty"`
 }


### PR DESCRIPTION
Following #1201 

Enriches every function deployment with default values set inside platform config.
(platform config values will not override deployment's values)

structure example: (platform.yaml)
```
logger:
  functions:
  - level: debug
    sink: myStdoutLoggerSink
  sinks:
    myStdoutLoggerSink:
      attributes:
        encoding: json
        timeFieldEncoding: iso8601
        timeFieldName: time
        varGroupName: more
      kind: stdout
  system:
  - level: debug
    sink: myStdoutLoggerSink
kubernetes:
  deployment: # a *v1beta1.Deployment struct
    spec:
      minReadySeconds: 2
```