### PR TITLE
Support label selector for platform config deployment augmentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
 
 language: go
 go_import_path: github.com/nuclio/nuclio
-go: "1.10"
+go: "1.12"
 
 script:
   - go get github.com/v3io/v3io-go-http

--- a/pkg/common/url_test.go
+++ b/pkg/common/url_test.go
@@ -59,7 +59,7 @@ func (ts *IsURLTestSuite) TestIsLocalFileURL() {
 }
 
 func (ts *IsURLTestSuite) TestGetPathFromLocalFileURL() {
-	ts.Require().Equal("/path/to/file" ,GetPathFromLocalFileURL("file://path/to/file"))
+	ts.Require().Equal("/path/to/file", GetPathFromLocalFileURL("file://path/to/file"))
 }
 
 func (ts *DownloadFileTestSuite) TestDownloadFile() {

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -857,8 +857,8 @@ func (suite *functionTestSuite) sendRequestWithExistingName(method string) {
 
 	expectedStatusCode := http.StatusConflict
 
-	headers := map[string]string {
-		"x-nuclio-project-name": "proj",
+	headers := map[string]string{
+		"x-nuclio-project-name":       "proj",
 		"x-nuclio-function-namespace": "f1Namespace",
 	}
 
@@ -1322,7 +1322,7 @@ func (suite *projectTestSuite) sendRequestWithExistingDisplayName(method string)
 	}
 
 	// mock a different project (with a different name) but with the same display name
-	mockedProject, _ := platform.NewAbstractProject(suite.logger, nil, platform.ProjectConfig {
+	mockedProject, _ := platform.NewAbstractProject(suite.logger, nil, platform.ProjectConfig{
 		Meta: platform.ProjectMeta{Namespace: "p1Namespace", Name: "p2"},
 		Spec: platform.ProjectSpec{DisplayName: "p1DisplayName"},
 	})

--- a/pkg/functionconfig/reader_test.go
+++ b/pkg/functionconfig/reader_test.go
@@ -106,14 +106,14 @@ spec:
 
 	config := Config{
 		Meta: Meta{
-			Name: "my_name",
+			Name:      "my_name",
 			Namespace: "my_namespace",
-			Labels: map[string]string{}, // empty map
+			Labels:    map[string]string{}, // empty map
 		},
 		Spec: Spec{
 			Runtime: "python2.7",
 			Handler: "my_handler",
-			Env: []v1.EnvVar{{Name: "env_var", Value: "my_env_val"}},
+			Env:     []v1.EnvVar{{Name: "env_var", Value: "my_env_val"}},
 		},
 	}
 	reader, err := NewReader(suite.logger)

--- a/pkg/loggersink/loggersink.go
+++ b/pkg/loggersink/loggersink.go
@@ -83,6 +83,10 @@ func createLoggers(name string, loggerSinksWithLevel map[string]platformconfig.L
 		}
 
 	} else {
+		if len(loggers) == 0 {
+			return nil, errors.New("Must configure at least one logger")
+		}
+
 		loggerInstance = loggers[0]
 	}
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -31,7 +31,6 @@ type Config struct {
 	ScaleToZero              ScaleToZero              `json:"scaleToZero,omitempty"`
 	AutoScale                AutoScale                `json:"autoScale,omitempty"`
 	FunctionAugmentedConfigs []LabelSelectorAndConfig `json:"functionAugmentedConfigs,omitempty"`
-	Kubernetes               Kubernetes               `json:"kubernetes,omitempty"`
 }
 
 func (config *Config) GetSystemLoggerSinks() (map[string]LoggerSinkWithLevel, error) {

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -83,6 +83,7 @@ type Metrics struct {
 type LabelSelectorAndConfig struct {
 	LabelSelector  v1.LabelSelector      `json:"labelSelector,omitempty"`
 	FunctionConfig functionconfig.Config `json:"functionConfig,omitempty"`
+	Kubernetes     Kubernetes            `json:"kubernetes,omitempty"`
 }
 
 type Kubernetes struct {

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -534,7 +534,7 @@ func (b *Builder) resolveFunctionPath(functionPath string) (string, error) {
 
 		tempFile, err := ioutil.TempFile(tempDir, "nuclio-function-")
 		if err != nil {
-			return "", errors.Wrapf(err, "Failed to create temporary file: %s", tempFile)
+			return "", errors.Wrapf(err, "Failed to create temporary file: %s", tempDir)
 		}
 
 		userDefinedHeaders, found := b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["headers"]

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -249,7 +249,7 @@ func (b *Builder) Build(options *platform.CreateFunctionBuildOptions) (*platform
 	}
 
 	buildResult := &platform.CreateFunctionBuildResult{
-		Image: processorImage,
+		Image:                 processorImage,
 		UpdatedFunctionConfig: enrichedConfiguration,
 	}
 

--- a/pkg/processor/trigger/cron/cron_test.go
+++ b/pkg/processor/trigger/cron/cron_test.go
@@ -177,7 +177,7 @@ func (suite *TestSuite) TestNextScheduleDayDifference() {
 	suite.Assert().NoError(err, "Invalid interval string")
 
 	nextEventSubmitTime := suite.trigger.schedule.Next(lastRuntime)
-	suite.Assert().Equal(nextEventSubmitTime.Day(), lastRuntime.Day() + 1, "Event should be fired the next day")
+	suite.Assert().Equal(nextEventSubmitTime.Day(), lastRuntime.Day()+1, "Event should be fired the next day")
 }
 
 func (suite *TestSuite) getInterval(delay string) (cronlib.Schedule, error) {

--- a/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
+++ b/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
@@ -101,7 +101,7 @@ func (suite *testSuite) TestPreexistingResources() {
 			"queueName":    suite.brokerQueueName,
 
 			// no topics passed means to listen on topics binded pre function deploy
-			"topics":       []string{},
+			"topics": []string{},
 		},
 	}
 

--- a/pkg/processor/trigger/rabbitmq/trigger.go
+++ b/pkg/processor/trigger/rabbitmq/trigger.go
@@ -147,11 +147,11 @@ func (rmq *rabbitMq) createBrokerResources() error {
 
 		rmq.brokerQueue, err = rmq.brokerChannel.QueueDeclare(
 			rmq.configuration.QueueName, // queue name (account  + function name)
-			false, // durable  TBD: change to true if/when we bind to persistent storage
-			false, // delete when unused
-			false, // exclusive
-			false, // no-wait
-			nil,   // arguments
+			false,                       // durable  TBD: change to true if/when we bind to persistent storage
+			false,                       // delete when unused
+			false,                       // exclusive
+			false,                       // no-wait
+			nil,                         // arguments
 		)
 		if err != nil {
 			return errors.Wrap(err, "Failed to declare queue")
@@ -161,8 +161,8 @@ func (rmq *rabbitMq) createBrokerResources() error {
 
 		for _, topic := range rmq.configuration.Topics {
 			err = rmq.brokerChannel.QueueBind(
-				rmq.brokerQueue.Name, // queue name
-				topic,                // routing key
+				rmq.brokerQueue.Name,           // queue name
+				topic,                          // routing key
 				rmq.configuration.ExchangeName, // exchange
 				false,
 				nil)
@@ -179,12 +179,12 @@ func (rmq *rabbitMq) createBrokerResources() error {
 
 	rmq.brokerInputMessagesChannel, err = rmq.brokerChannel.Consume(
 		rmq.configuration.QueueName, // queue
-		"",    // consumer
-		false, // auto-ack
-		false, // exclusive
-		false, // no-local
-		true,  // no-wait
-		nil,   // args
+		"",                          // consumer
+		false,                       // auto-ack
+		false,                       // exclusive
+		false,                       // no-local
+		true,                        // no-wait
+		nil,                         // args
 	)
 	if err != nil {
 		return errors.Wrap(err, "Failed to start consuming messages")

--- a/vendor/github.com/imdario/mergo/.gitignore
+++ b/vendor/github.com/imdario/mergo/.gitignore
@@ -1,0 +1,33 @@
+#### joe made this: http://goel.io/joe
+
+#### go ####
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/
+
+#### vim ####
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags

--- a/vendor/github.com/imdario/mergo/.travis.yml
+++ b/vendor/github.com/imdario/mergo/.travis.yml
@@ -1,2 +1,9 @@
 language: go
-install: go get -t
+install:
+  - go get -t
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/mattn/goveralls
+script:
+  - go test -race -v ./...
+after_script:
+  - $HOME/gopath/bin/goveralls -service=travis-ci -repotoken $COVERALLS_TOKEN

--- a/vendor/github.com/imdario/mergo/CODE_OF_CONDUCT.md
+++ b/vendor/github.com/imdario/mergo/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at i@dario.im. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/vendor/github.com/imdario/mergo/README.md
+++ b/vendor/github.com/imdario/mergo/README.md
@@ -2,14 +2,73 @@
 
 A helper to merge structs and maps in Golang. Useful for configuration default values, avoiding messy if-statements.
 
-Also a lovely [comune](http://en.wikipedia.org/wiki/Mergo) (municipality) in the Province of Ancona in the Italian region Marche.
-
-![Mergo dall'alto](http://www.comune.mergo.an.it/Siti/Mergo/Immagini/Foto/mergo_dall_alto.jpg)
+Also a lovely [comune](http://en.wikipedia.org/wiki/Mergo) (municipality) in the Province of Ancona in the Italian region of Marche.
 
 ## Status
 
-It is ready for production use. It works fine although it may use more of testing. Here some projects in the wild using Mergo:
+It is ready for production use. [It is used in several projects by Docker, Google, The Linux Foundation, VMWare, Shopify, etc](https://github.com/imdario/mergo#mergo-in-the-wild).
 
+[![GoDoc][3]][4]
+[![GoCard][5]][6]
+[![Build Status][1]][2]
+[![Coverage Status][7]][8]
+[![Sourcegraph][9]][10]
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fimdario%2Fmergo.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fimdario%2Fmergo?ref=badge_shield)
+
+[1]: https://travis-ci.org/imdario/mergo.png
+[2]: https://travis-ci.org/imdario/mergo
+[3]: https://godoc.org/github.com/imdario/mergo?status.svg
+[4]: https://godoc.org/github.com/imdario/mergo
+[5]: https://goreportcard.com/badge/imdario/mergo
+[6]: https://goreportcard.com/report/github.com/imdario/mergo
+[7]: https://coveralls.io/repos/github/imdario/mergo/badge.svg?branch=master
+[8]: https://coveralls.io/github/imdario/mergo?branch=master
+[9]: https://sourcegraph.com/github.com/imdario/mergo/-/badge.svg
+[10]: https://sourcegraph.com/github.com/imdario/mergo?badge
+
+### Latest release
+
+[Release v0.3.7](https://github.com/imdario/mergo/releases/tag/v0.3.7).
+
+### Important note
+
+Please keep in mind that in [0.3.2](//github.com/imdario/mergo/releases/tag/0.3.2) Mergo changed `Merge()`and `Map()` signatures to support [transformers](#transformers). An optional/variadic argument has been added, so it won't break existing code.
+
+If you were using Mergo **before** April 6th 2015, please check your project works as intended after updating your local copy with ```go get -u github.com/imdario/mergo```. I apologize for any issue caused by its previous behavior and any future bug that Mergo could cause (I hope it won't!) in existing projects after the change (release 0.2.0).
+
+### Donations
+
+If Mergo is useful to you, consider buying me a coffee, a beer or making a monthly donation so I can keep building great free software. :heart_eyes:
+
+<a href='https://ko-fi.com/B0B58839' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://az743702.vo.msecnd.net/cdn/kofi1.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
+[![Beerpay](https://beerpay.io/imdario/mergo/badge.svg)](https://beerpay.io/imdario/mergo)
+[![Beerpay](https://beerpay.io/imdario/mergo/make-wish.svg)](https://beerpay.io/imdario/mergo)
+<a href="https://liberapay.com/dario/donate"><img alt="Donate using Liberapay" src="https://liberapay.com/assets/widgets/donate.svg"></a>
+
+### Mergo in the wild
+
+- [moby/moby](https://github.com/moby/moby)
+- [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
+- [vmware/dispatch](https://github.com/vmware/dispatch)
+- [Shopify/themekit](https://github.com/Shopify/themekit)
+- [imdario/zas](https://github.com/imdario/zas)
+- [matcornic/hermes](https://github.com/matcornic/hermes)
+- [OpenBazaar/openbazaar-go](https://github.com/OpenBazaar/openbazaar-go)
+- [kataras/iris](https://github.com/kataras/iris)
+- [michaelsauter/crane](https://github.com/michaelsauter/crane)
+- [go-task/task](https://github.com/go-task/task)
+- [sensu/uchiwa](https://github.com/sensu/uchiwa)
+- [ory/hydra](https://github.com/ory/hydra)
+- [sisatech/vcli](https://github.com/sisatech/vcli)
+- [dairycart/dairycart](https://github.com/dairycart/dairycart)
+- [projectcalico/felix](https://github.com/projectcalico/felix)
+- [resin-os/balena](https://github.com/resin-os/balena)
+- [go-kivik/kivik](https://github.com/go-kivik/kivik)
+- [Telefonica/govice](https://github.com/Telefonica/govice)
+- [supergiant/supergiant](supergiant/supergiant)
+- [SergeyTsalkov/brooce](https://github.com/SergeyTsalkov/brooce)
+- [soniah/dnsmadeeasy](https://github.com/soniah/dnsmadeeasy)
+- [ohsu-comp-bio/funnel](https://github.com/ohsu-comp-bio/funnel)
 - [EagerIO/Stout](https://github.com/EagerIO/Stout)
 - [lynndylanhurley/defsynth-api](https://github.com/lynndylanhurley/defsynth-api)
 - [russross/canvasassignments](https://github.com/russross/canvasassignments)
@@ -17,12 +76,17 @@ It is ready for production use. It works fine although it may use more of testin
 - [casualjim/exeggutor](https://github.com/casualjim/exeggutor)
 - [divshot/gitling](https://github.com/divshot/gitling)
 - [RWJMurphy/gorl](https://github.com/RWJMurphy/gorl)
-
-[![Build Status][1]][2]
-[![GoDoc](https://godoc.org/github.com/imdario/mergo?status.svg)](https://godoc.org/github.com/imdario/mergo)
-
-[1]: https://travis-ci.org/imdario/mergo.png
-[2]: https://travis-ci.org/imdario/mergo
+- [andrerocker/deploy42](https://github.com/andrerocker/deploy42)
+- [elwinar/rambler](https://github.com/elwinar/rambler)
+- [tmaiaroto/gopartman](https://github.com/tmaiaroto/gopartman)
+- [jfbus/impressionist](https://github.com/jfbus/impressionist)
+- [Jmeyering/zealot](https://github.com/Jmeyering/zealot)
+- [godep-migrator/rigger-host](https://github.com/godep-migrator/rigger-host)
+- [Dronevery/MultiwaySwitch-Go](https://github.com/Dronevery/MultiwaySwitch-Go)
+- [thoas/picfit](https://github.com/thoas/picfit)
+- [mantasmatelis/whooplist-server](https://github.com/mantasmatelis/whooplist-server)
+- [jnuthong/item_search](https://github.com/jnuthong/item_search)
+- [bukalapak/snowboard](https://github.com/bukalapak/snowboard)
 
 ## Installation
 
@@ -35,25 +99,116 @@ It is ready for production use. It works fine although it may use more of testin
 
 ## Usage
 
-You can only merge same-type structs with exported fields initialized as zero value of their type and same-types maps. Mergo won't merge unexported (private) fields but will do recursively any exported one. Also maps will be merged recursively except for structs inside maps (because they are not addressable using Go reflection).
+You can only merge same-type structs with exported fields initialized as zero value of their type and same-types maps. Mergo won't merge unexported (private) fields but will do recursively any exported one. It won't merge empty structs value as [they are not considered zero values](https://golang.org/ref/spec#The_zero_value) either. Also maps will be merged recursively except for structs inside maps (because they are not addressable using Go reflection).
 
-    if err := mergo.Merge(&dst, src); err != nil {
-        // ...
-    }
+```go
+if err := mergo.Merge(&dst, src); err != nil {
+    // ...
+}
+```
 
-Additionally, you can map a map[string]interface{} to a struct (and otherwise, from struct to map), following the same restrictions as in Merge(). Keys are capitalized to find each corresponding exported field.
+Also, you can merge overwriting values using the transformer `WithOverride`.
 
-    if err := mergo.Map(&dst, srcMap); err != nil {
-        // ...
-    }
+```go
+if err := mergo.Merge(&dst, src, mergo.WithOverride); err != nil {
+    // ...
+}
+```
 
-Warning: if you map a struct to map, it won't do it recursively. Don't expect Mergo to map struct members of your struct as map[string]interface{}. They will be just assigned as values.
+Additionally, you can map a `map[string]interface{}` to a struct (and otherwise, from struct to map), following the same restrictions as in `Merge()`. Keys are capitalized to find each corresponding exported field.
+
+```go
+if err := mergo.Map(&dst, srcMap); err != nil {
+    // ...
+}
+```
+
+Warning: if you map a struct to map, it won't do it recursively. Don't expect Mergo to map struct members of your struct as `map[string]interface{}`. They will be just assigned as values.
 
 More information and examples in [godoc documentation](http://godoc.org/github.com/imdario/mergo).
 
+### Nice example
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/imdario/mergo"
+)
+
+type Foo struct {
+	A string
+	B int64
+}
+
+func main() {
+	src := Foo{
+		A: "one",
+		B: 2,
+	}
+	dest := Foo{
+		A: "two",
+	}
+	mergo.Merge(&dest, src)
+	fmt.Println(dest)
+	// Will print
+	// {two 2}
+}
+```
+
 Note: if test are failing due missing package, please execute:
 
-    go get gopkg.in/yaml.v1
+    go get gopkg.in/yaml.v2
+
+### Transformers
+
+Transformers allow to merge specific types differently than in the default behavior. In other words, now you can customize how some types are merged. For example, `time.Time` is a struct; it doesn't have zero value but IsZero can return true because it has fields with zero value. How can we merge a non-zero `time.Time`?
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/imdario/mergo"
+        "reflect"
+        "time"
+)
+
+type timeTransfomer struct {
+}
+
+func (t timeTransfomer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	if typ == reflect.TypeOf(time.Time{}) {
+		return func(dst, src reflect.Value) error {
+			if dst.CanSet() {
+				isZero := dst.MethodByName("IsZero")
+				result := isZero.Call([]reflect.Value{})
+				if result[0].Bool() {
+					dst.Set(src)
+				}
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+type Snapshot struct {
+	Time time.Time
+	// ...
+}
+
+func main() {
+	src := Snapshot{time.Now()}
+	dest := Snapshot{}
+	mergo.Merge(&dest, src, mergo.WithTransformers(timeTransfomer{}))
+	fmt.Println(dest)
+	// Will print
+	// { 2018-01-12 01:15:00 +0000 UTC m=+0.000000001 }
+}
+```
+
 
 ## Contact me
 
@@ -63,6 +218,21 @@ If I can help you, you have an idea or you are using Mergo in your projects, don
 
 Written by [Dario Castañé](http://dario.im).
 
+## Top Contributors
+
+[![0](https://sourcerer.io/fame/imdario/imdario/mergo/images/0)](https://sourcerer.io/fame/imdario/imdario/mergo/links/0)
+[![1](https://sourcerer.io/fame/imdario/imdario/mergo/images/1)](https://sourcerer.io/fame/imdario/imdario/mergo/links/1)
+[![2](https://sourcerer.io/fame/imdario/imdario/mergo/images/2)](https://sourcerer.io/fame/imdario/imdario/mergo/links/2)
+[![3](https://sourcerer.io/fame/imdario/imdario/mergo/images/3)](https://sourcerer.io/fame/imdario/imdario/mergo/links/3)
+[![4](https://sourcerer.io/fame/imdario/imdario/mergo/images/4)](https://sourcerer.io/fame/imdario/imdario/mergo/links/4)
+[![5](https://sourcerer.io/fame/imdario/imdario/mergo/images/5)](https://sourcerer.io/fame/imdario/imdario/mergo/links/5)
+[![6](https://sourcerer.io/fame/imdario/imdario/mergo/images/6)](https://sourcerer.io/fame/imdario/imdario/mergo/links/6)
+[![7](https://sourcerer.io/fame/imdario/imdario/mergo/images/7)](https://sourcerer.io/fame/imdario/imdario/mergo/links/7)
+
+
 ## License
 
 [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause) license, as [Go language](http://golang.org/LICENSE).
+
+
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fimdario%2Fmergo.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fimdario%2Fmergo?ref=badge_large)

--- a/vendor/github.com/imdario/mergo/issue17_test.go
+++ b/vendor/github.com/imdario/mergo/issue17_test.go
@@ -1,0 +1,25 @@
+package mergo
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+var (
+	request    = `{"timestamp":null, "name": "foo"}`
+	maprequest = map[string]interface{}{
+		"timestamp": nil,
+		"name":      "foo",
+		"newStuff":  "foo",
+	}
+)
+
+func TestIssue17MergeWithOverwrite(t *testing.T) {
+	var something map[string]interface{}
+	if err := json.Unmarshal([]byte(request), &something); err != nil {
+		t.Errorf("Error while Unmarshalling maprequest: %s", err)
+	}
+	if err := MergeWithOverwrite(&something, maprequest); err != nil {
+		t.Errorf("Error while merging: %s", err)
+	}
+}

--- a/vendor/github.com/imdario/mergo/issue23_test.go
+++ b/vendor/github.com/imdario/mergo/issue23_test.go
@@ -1,0 +1,27 @@
+package mergo
+
+import (
+	"testing"
+	"time"
+)
+
+type document struct {
+	Created *time.Time
+}
+
+func TestIssue23MergeWithOverwrite(t *testing.T) {
+	now := time.Now()
+	dst := document{
+		&now,
+	}
+	expected := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	src := document{
+		&expected,
+	}
+	if err := MergeWithOverwrite(&dst, src); err != nil {
+		t.Errorf("Error while merging %s", err)
+	}
+	if !dst.Created.Equal(*src.Created) { //--> https://golang.org/pkg/time/#pkg-overview
+		t.Fatalf("Created not merged in properly: dst.Created(%v) != src.Created(%v)", dst.Created, src.Created)
+	}
+}

--- a/vendor/github.com/imdario/mergo/issue33_test.go
+++ b/vendor/github.com/imdario/mergo/issue33_test.go
@@ -1,0 +1,33 @@
+package mergo
+
+import (
+	"testing"
+)
+
+type Foo struct {
+	Str    string
+	Bslice []byte
+}
+
+func TestIssue33Merge(t *testing.T) {
+	dest := Foo{Str: "a"}
+	toMerge := Foo{
+		Str:    "b",
+		Bslice: []byte{1, 2},
+	}
+	if err := Merge(&dest, toMerge); err != nil {
+		t.Errorf("Error while merging: %s", err)
+	}
+	// Merge doesn't overwrite an attribute if in destination it doesn't have a zero value.
+	// In this case, Str isn't a zero value string.
+	if dest.Str != "a" {
+		t.Errorf("dest.Str should have not been override as it has a non-zero value: dest.Str(%v) != 'a'", dest.Str)
+	}
+	// If we want to override, we must use MergeWithOverwrite or Merge using WithOverride.
+	if err := Merge(&dest, toMerge, WithOverride); err != nil {
+		t.Errorf("Error while merging: %s", err)
+	}
+	if dest.Str != toMerge.Str {
+		t.Errorf("dest.Str should have been override: dest.Str(%v) != toMerge.Str(%v)", dest.Str, toMerge.Str)
+	}
+}

--- a/vendor/github.com/imdario/mergo/issue38_test.go
+++ b/vendor/github.com/imdario/mergo/issue38_test.go
@@ -1,0 +1,59 @@
+package mergo
+
+import (
+	"testing"
+	"time"
+)
+
+type structWithoutTimePointer struct {
+	Created time.Time
+}
+
+func TestIssue38Merge(t *testing.T) {
+	dst := structWithoutTimePointer{
+		time.Now(),
+	}
+
+	expected := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	src := structWithoutTimePointer{
+		expected,
+	}
+	if err := Merge(&dst, src); err != nil {
+		t.Errorf("Error while merging %s", err)
+	}
+	if dst.Created == src.Created {
+		t.Fatalf("Created merged unexpectedly: dst.Created(%v) == src.Created(%v)", dst.Created, src.Created)
+	}
+}
+
+func TestIssue38MergeEmptyStruct(t *testing.T) {
+	dst := structWithoutTimePointer{}
+
+	expected := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	src := structWithoutTimePointer{
+		expected,
+	}
+	if err := Merge(&dst, src); err != nil {
+		t.Errorf("Error while merging %s", err)
+	}
+	if dst.Created == src.Created {
+		t.Fatalf("Created merged unexpectedly: dst.Created(%v) == src.Created(%v)", dst.Created, src.Created)
+	}
+}
+
+func TestIssue38MergeWithOverwrite(t *testing.T) {
+	dst := structWithoutTimePointer{
+		time.Now(),
+	}
+
+	expected := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	src := structWithoutTimePointer{
+		expected,
+	}
+	if err := MergeWithOverwrite(&dst, src); err != nil {
+		t.Errorf("Error while merging %s", err)
+	}
+	if dst.Created != src.Created {
+		t.Fatalf("Created not merged in properly: dst.Created(%v) != src.Created(%v)", dst.Created, src.Created)
+	}
+}

--- a/vendor/github.com/imdario/mergo/issue50_test.go
+++ b/vendor/github.com/imdario/mergo/issue50_test.go
@@ -1,0 +1,18 @@
+package mergo
+
+import (
+	"testing"
+	"time"
+)
+
+type testStruct struct {
+	time.Duration
+}
+
+func TestIssue50Merge(t *testing.T) {
+	to := testStruct{}
+	from := testStruct{}
+	if err := Merge(&to, from); err != nil {
+		t.Fail()
+	}
+}

--- a/vendor/github.com/imdario/mergo/issue52_test.go
+++ b/vendor/github.com/imdario/mergo/issue52_test.go
@@ -1,0 +1,99 @@
+package mergo
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+type structWithTime struct {
+	Birth time.Time
+}
+
+type timeTransfomer struct {
+	overwrite bool
+}
+
+func (t timeTransfomer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	if typ == reflect.TypeOf(time.Time{}) {
+		return func(dst, src reflect.Value) error {
+			if dst.CanSet() {
+				if t.overwrite {
+					isZero := src.MethodByName("IsZero")
+					result := isZero.Call([]reflect.Value{})
+					if !result[0].Bool() {
+						dst.Set(src)
+					}
+				} else {
+					isZero := dst.MethodByName("IsZero")
+					result := isZero.Call([]reflect.Value{})
+					if result[0].Bool() {
+						dst.Set(src)
+					}
+				}
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+func TestOverwriteZeroSrcTime(t *testing.T) {
+	now := time.Now()
+	dst := structWithTime{now}
+	src := structWithTime{}
+	if err := MergeWithOverwrite(&dst, src); err != nil {
+		t.FailNow()
+	}
+	if !dst.Birth.IsZero() {
+		t.Fatalf("dst should have been overwritten: dst.Birth(%v) != now(%v)", dst.Birth, now)
+	}
+}
+
+func TestOverwriteZeroSrcTimeWithTransformer(t *testing.T) {
+	now := time.Now()
+	dst := structWithTime{now}
+	src := structWithTime{}
+	if err := MergeWithOverwrite(&dst, src, WithTransformers(timeTransfomer{true})); err != nil {
+		t.FailNow()
+	}
+	if dst.Birth.IsZero() {
+		t.Fatalf("dst should not have been overwritten: dst.Birth(%v) != now(%v)", dst.Birth, now)
+	}
+}
+
+func TestOverwriteZeroDstTime(t *testing.T) {
+	now := time.Now()
+	dst := structWithTime{}
+	src := structWithTime{now}
+	if err := MergeWithOverwrite(&dst, src); err != nil {
+		t.FailNow()
+	}
+	if dst.Birth.IsZero() {
+		t.Fatalf("dst should have been overwritten: dst.Birth(%v) != zero(%v)", dst.Birth, time.Time{})
+	}
+}
+
+func TestZeroDstTime(t *testing.T) {
+	now := time.Now()
+	dst := structWithTime{}
+	src := structWithTime{now}
+	if err := Merge(&dst, src); err != nil {
+		t.FailNow()
+	}
+	if !dst.Birth.IsZero() {
+		t.Fatalf("dst should not have been overwritten: dst.Birth(%v) != zero(%v)", dst.Birth, time.Time{})
+	}
+}
+
+func TestZeroDstTimeWithTransformer(t *testing.T) {
+	now := time.Now()
+	dst := structWithTime{}
+	src := structWithTime{now}
+	if err := Merge(&dst, src, WithTransformers(timeTransfomer{})); err != nil {
+		t.FailNow()
+	}
+	if dst.Birth.IsZero() {
+		t.Fatalf("dst should have been overwritten: dst.Birth(%v) != now(%v)", dst.Birth, now)
+	}
+}

--- a/vendor/github.com/imdario/mergo/issue61_test.go
+++ b/vendor/github.com/imdario/mergo/issue61_test.go
@@ -1,0 +1,20 @@
+package mergo
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestIssue61MergeNilMap(t *testing.T) {
+	type T struct {
+		I map[string][]string
+	}
+	t1 := T{}
+	t2 := T{I: map[string][]string{"hi": {"there"}}}
+	if err := Merge(&t1, t2); err != nil {
+		t.Fail()
+	}
+	if !reflect.DeepEqual(t2, T{I: map[string][]string{"hi": {"there"}}}) {
+		t.FailNow()
+	}
+}

--- a/vendor/github.com/imdario/mergo/issue64_test.go
+++ b/vendor/github.com/imdario/mergo/issue64_test.go
@@ -1,0 +1,38 @@
+package mergo
+
+import (
+	"testing"
+)
+
+type Student struct {
+	Name  string
+	Books []string
+}
+
+var testData = []struct {
+	S1            Student
+	S2            Student
+	ExpectedSlice []string
+}{
+	{Student{"Jack", []string{"a", "B"}}, Student{"Tom", []string{"1"}}, []string{"a", "B"}},
+	{Student{"Jack", []string{"a", "B"}}, Student{"Tom", []string{}}, []string{"a", "B"}},
+	{Student{"Jack", []string{}}, Student{"Tom", []string{"1"}}, []string{"1"}},
+	{Student{"Jack", []string{}}, Student{"Tom", []string{}}, []string{}},
+}
+
+func TestIssue64MergeSliceWithOverride(t *testing.T) {
+	for _, data := range testData {
+		err := Merge(&data.S2, data.S1, WithOverride)
+		if err != nil {
+			t.Errorf("Error while merging %s", err)
+		}
+		if len(data.S2.Books) != len(data.ExpectedSlice) {
+			t.Fatalf("Got %d elements in slice, but expected %d", len(data.S2.Books), len(data.ExpectedSlice))
+		}
+		for i, val := range data.S2.Books {
+			if val != data.ExpectedSlice[i] {
+				t.Fatalf("Expected %s, but got %s while merging slice with override", data.ExpectedSlice[i], val)
+			}
+		}
+	}
+}

--- a/vendor/github.com/imdario/mergo/issue66_test.go
+++ b/vendor/github.com/imdario/mergo/issue66_test.go
@@ -1,0 +1,48 @@
+package mergo
+
+import (
+	"testing"
+)
+
+type PrivateSliceTest66 struct {
+	PublicStrings  []string
+	privateStrings []string
+}
+
+func TestPrivateSlice(t *testing.T) {
+	p1 := PrivateSliceTest66{
+		PublicStrings:  []string{"one", "two", "three"},
+		privateStrings: []string{"four", "five"},
+	}
+	p2 := PrivateSliceTest66{
+		PublicStrings: []string{"six", "seven"},
+	}
+	if err := Merge(&p1, p2); err != nil {
+		t.Fatalf("Error during the merge: %v", err)
+	}
+	if len(p1.PublicStrings) != 3 {
+		t.Error("5 elements should be in 'PublicStrings' field")
+	}
+	if len(p1.privateStrings) != 2 {
+		t.Error("2 elements should be in 'privateStrings' field")
+	}
+}
+
+func TestPrivateSliceWithAppendSlice(t *testing.T) {
+	p1 := PrivateSliceTest66{
+		PublicStrings:  []string{"one", "two", "three"},
+		privateStrings: []string{"four", "five"},
+	}
+	p2 := PrivateSliceTest66{
+		PublicStrings: []string{"six", "seven"},
+	}
+	if err := Merge(&p1, p2, WithAppendSlice); err != nil {
+		t.Fatalf("Error during the merge: %v", err)
+	}
+	if len(p1.PublicStrings) != 5 {
+		t.Error("5 elements should be in 'PublicStrings' field")
+	}
+	if len(p1.privateStrings) != 2 {
+		t.Error("2 elements should be in 'privateStrings' field")
+	}
+}

--- a/vendor/github.com/imdario/mergo/issue84_test.go
+++ b/vendor/github.com/imdario/mergo/issue84_test.go
@@ -1,0 +1,82 @@
+package mergo
+
+import (
+	"testing"
+)
+
+type DstStructIssue84 struct {
+	A int
+	B int
+	C int
+}
+
+type DstNestedStructIssue84 struct {
+	A struct {
+		A int
+		B int
+		C int
+	}
+	B int
+	C int
+}
+
+func TestIssue84MergeMapWithNilValueToStructWithOverride(t *testing.T) {
+	p1 := DstStructIssue84{
+		A: 0, B: 1, C: 2,
+	}
+	p2 := map[string]interface{}{
+		"A": 3, "B": 4, "C": 0,
+	}
+	if err := Map(&p1, p2, WithOverride); err != nil {
+		t.Fatalf("Error during the merge: %v", err)
+	}
+	if p1.C != 0 {
+		t.Error("C field should become '0'")
+	}
+}
+
+func TestIssue84MergeMapWithoutKeyExistsToStructWithOverride(t *testing.T) {
+	p1 := DstStructIssue84{
+		A: 0, B: 1, C: 2,
+	}
+	p2 := map[string]interface{}{
+		"A": 3, "B": 4,
+	}
+	if err := Map(&p1, p2, WithOverride); err != nil {
+		t.Fatalf("Error during the merge: %v", err)
+	}
+	if p1.C != 2 {
+		t.Error("C field should be '2'")
+	}
+}
+
+func TestIssue84MergeNestedMapWithNilValueToStructWithOverride(t *testing.T) {
+	p1 := DstNestedStructIssue84{
+		A: struct {
+			A int
+			B int
+			C int
+		}{A: 1, B: 2, C: 0},
+		B: 0,
+		C: 2,
+	}
+	p2 := map[string]interface{}{
+		"A": map[string]interface{}{
+			"A": 0, "B": 0, "C": 5,
+		}, "B": 4, "C": 0,
+	}
+	if err := Map(&p1, p2, WithOverride); err != nil {
+		t.Fatalf("Error during the merge: %v", err)
+	}
+	if p1.B != 4 {
+		t.Error("A.C field should become '4'")
+	}
+
+	if p1.A.C != 5 {
+		t.Error("A.C field should become '5'")
+	}
+
+	if p1.A.B != 0 || p1.A.A != 0 {
+		t.Error("A.A and A.B field should become '0'")
+	}
+}

--- a/vendor/github.com/imdario/mergo/map.go
+++ b/vendor/github.com/imdario/mergo/map.go
@@ -31,7 +31,8 @@ func isExported(field reflect.StructField) bool {
 // Traverses recursively both values, assigning src's fields values to dst.
 // The map argument tracks comparisons that have already been seen, which allows
 // short circuiting on recursive types.
-func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (err error) {
+func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, config *Config) (err error) {
+	overwrite := config.Overwrite
 	if dst.CanAddr() {
 		addr := dst.UnsafeAddr()
 		h := 17 * addr
@@ -57,13 +58,21 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (err
 			}
 			fieldName := field.Name
 			fieldName = changeInitialCase(fieldName, unicode.ToLower)
-			if v, ok := dstMap[fieldName]; !ok || isEmptyValue(reflect.ValueOf(v)) {
+			if v, ok := dstMap[fieldName]; !ok || (isEmptyValue(reflect.ValueOf(v)) || overwrite) {
 				dstMap[fieldName] = src.Field(i).Interface()
 			}
 		}
+	case reflect.Ptr:
+		if dst.IsNil() {
+			v := reflect.New(dst.Type().Elem())
+			dst.Set(v)
+		}
+		dst = dst.Elem()
+		fallthrough
 	case reflect.Struct:
 		srcMap := src.Interface().(map[string]interface{})
 		for key := range srcMap {
+			config.overwriteWithEmptyValue = true
 			srcValue := srcMap[key]
 			fieldName := changeInitialCase(key, unicode.ToUpper)
 			dstElement := dst.FieldByName(fieldName)
@@ -85,21 +94,24 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (err
 					srcKind = reflect.Ptr
 				}
 			}
+
 			if !srcElement.IsValid() {
 				continue
 			}
 			if srcKind == dstKind {
-				if err = deepMerge(dstElement, srcElement, visited, depth+1); err != nil {
+				if err = deepMerge(dstElement, srcElement, visited, depth+1, config); err != nil {
+					return
+				}
+			} else if dstKind == reflect.Interface && dstElement.Kind() == reflect.Interface {
+				if err = deepMerge(dstElement, srcElement, visited, depth+1, config); err != nil {
+					return
+				}
+			} else if srcKind == reflect.Map {
+				if err = deepMap(dstElement, srcElement, visited, depth+1, config); err != nil {
 					return
 				}
 			} else {
-				if srcKind == reflect.Map {
-					if err = deepMap(dstElement, srcElement, visited, depth+1); err != nil {
-						return
-					}
-				} else {
-					return fmt.Errorf("type mismatch on %s field: found %v, expected %v", fieldName, srcKind, dstKind)
-				}
+				return fmt.Errorf("type mismatch on %s field: found %v, expected %v", fieldName, srcKind, dstKind)
 			}
 		}
 	}
@@ -117,18 +129,35 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (err
 // doesn't apply if dst is a map.
 // This is separated method from Merge because it is cleaner and it keeps sane
 // semantics: merging equal types, mapping different (restricted) types.
-func Map(dst, src interface{}) error {
+func Map(dst, src interface{}, opts ...func(*Config)) error {
+	return _map(dst, src, opts...)
+}
+
+// MapWithOverwrite will do the same as Map except that non-empty dst attributes will be overridden by
+// non-empty src attribute values.
+// Deprecated: Use Map(…) with WithOverride
+func MapWithOverwrite(dst, src interface{}, opts ...func(*Config)) error {
+	return _map(dst, src, append(opts, WithOverride)...)
+}
+
+func _map(dst, src interface{}, opts ...func(*Config)) error {
 	var (
 		vDst, vSrc reflect.Value
 		err        error
 	)
+	config := &Config{}
+
+	for _, opt := range opts {
+		opt(config)
+	}
+
 	if vDst, vSrc, err = resolveValues(dst, src); err != nil {
 		return err
 	}
 	// To be friction-less, we redirect equal-type arguments
 	// to deepMerge. Only because arguments can be anything.
 	if vSrc.Kind() == vDst.Kind() {
-		return deepMerge(vDst, vSrc, make(map[uintptr]*visit), 0)
+		return deepMerge(vDst, vSrc, make(map[uintptr]*visit), 0, config)
 	}
 	switch vSrc.Kind() {
 	case reflect.Struct:
@@ -142,5 +171,5 @@ func Map(dst, src interface{}) error {
 	default:
 		return ErrNotSupported
 	}
-	return deepMap(vDst, vSrc, make(map[uintptr]*visit), 0)
+	return deepMap(vDst, vSrc, make(map[uintptr]*visit), 0, config)
 }

--- a/vendor/github.com/imdario/mergo/merge.go
+++ b/vendor/github.com/imdario/mergo/merge.go
@@ -9,13 +9,43 @@
 package mergo
 
 import (
+	"fmt"
 	"reflect"
 )
+
+func hasExportedField(dst reflect.Value) (exported bool) {
+	for i, n := 0, dst.NumField(); i < n; i++ {
+		field := dst.Type().Field(i)
+		if field.Anonymous && dst.Field(i).Kind() == reflect.Struct {
+			exported = exported || hasExportedField(dst.Field(i))
+		} else {
+			exported = exported || len(field.PkgPath) == 0
+		}
+	}
+	return
+}
+
+type Config struct {
+	Overwrite               bool
+	AppendSlice             bool
+	TypeCheck               bool
+	Transformers            Transformers
+	overwriteWithEmptyValue bool
+}
+
+type Transformers interface {
+	Transformer(reflect.Type) func(dst, src reflect.Value) error
+}
 
 // Traverses recursively both values, assigning src's fields values to dst.
 // The map argument tracks comparisons that have already been seen, which allows
 // short circuiting on recursive types.
-func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (err error) {
+func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, config *Config) (err error) {
+	overwrite := config.Overwrite
+	typeCheck := config.TypeCheck
+	overwriteWithEmptySrc := config.overwriteWithEmptyValue
+	config.overwriteWithEmptyValue = false
+
 	if !src.IsValid() {
 		return
 	}
@@ -32,68 +62,214 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (e
 		// Remember, remember...
 		visited[h] = &visit{addr, typ, seen}
 	}
+
+	if config.Transformers != nil && !isEmptyValue(dst) {
+		if fn := config.Transformers.Transformer(dst.Type()); fn != nil {
+			err = fn(dst, src)
+			return
+		}
+	}
+
 	switch dst.Kind() {
 	case reflect.Struct:
-		for i, n := 0, dst.NumField(); i < n; i++ {
-			if err = deepMerge(dst.Field(i), src.Field(i), visited, depth+1); err != nil {
-				return
+		if hasExportedField(dst) {
+			for i, n := 0, dst.NumField(); i < n; i++ {
+				if err = deepMerge(dst.Field(i), src.Field(i), visited, depth+1, config); err != nil {
+					return
+				}
+			}
+		} else {
+			if dst.CanSet() && (!isEmptyValue(src) || overwriteWithEmptySrc) && (overwrite || isEmptyValue(dst)) {
+				dst.Set(src)
 			}
 		}
 	case reflect.Map:
+		if dst.IsNil() && !src.IsNil() {
+			dst.Set(reflect.MakeMap(dst.Type()))
+		}
 		for _, key := range src.MapKeys() {
 			srcElement := src.MapIndex(key)
 			if !srcElement.IsValid() {
 				continue
 			}
 			dstElement := dst.MapIndex(key)
-			switch reflect.TypeOf(srcElement.Interface()).Kind() {
-			case reflect.Struct:
+			switch srcElement.Kind() {
+			case reflect.Chan, reflect.Func, reflect.Map, reflect.Interface, reflect.Slice:
+				if srcElement.IsNil() {
+					continue
+				}
 				fallthrough
-			case reflect.Map:
-				if err = deepMerge(dstElement, srcElement, visited, depth+1); err != nil {
-					return
+			default:
+				if !srcElement.CanInterface() {
+					continue
+				}
+				switch reflect.TypeOf(srcElement.Interface()).Kind() {
+				case reflect.Struct:
+					fallthrough
+				case reflect.Ptr:
+					fallthrough
+				case reflect.Map:
+					srcMapElm := srcElement
+					dstMapElm := dstElement
+					if srcMapElm.CanInterface() {
+						srcMapElm = reflect.ValueOf(srcMapElm.Interface())
+						if dstMapElm.IsValid() {
+							dstMapElm = reflect.ValueOf(dstMapElm.Interface())
+						}
+					}
+					if err = deepMerge(dstMapElm, srcMapElm, visited, depth+1, config); err != nil {
+						return
+					}
+				case reflect.Slice:
+					srcSlice := reflect.ValueOf(srcElement.Interface())
+
+					var dstSlice reflect.Value
+					if !dstElement.IsValid() || dstElement.IsNil() {
+						dstSlice = reflect.MakeSlice(srcSlice.Type(), 0, srcSlice.Len())
+					} else {
+						dstSlice = reflect.ValueOf(dstElement.Interface())
+					}
+
+					if (!isEmptyValue(src) || overwriteWithEmptySrc) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
+						if typeCheck && srcSlice.Type() != dstSlice.Type() {
+							return fmt.Errorf("cannot override two slices with different type (%s, %s)", srcSlice.Type(), dstSlice.Type())
+						}
+						dstSlice = srcSlice
+					} else if config.AppendSlice {
+						if srcSlice.Type() != dstSlice.Type() {
+							return fmt.Errorf("cannot append two slices with different type (%s, %s)", srcSlice.Type(), dstSlice.Type())
+						}
+						dstSlice = reflect.AppendSlice(dstSlice, srcSlice)
+					}
+					dst.SetMapIndex(key, dstSlice)
 				}
 			}
-			if !dstElement.IsValid() {
+			if dstElement.IsValid() && !isEmptyValue(dstElement) && (reflect.TypeOf(srcElement.Interface()).Kind() == reflect.Map || reflect.TypeOf(srcElement.Interface()).Kind() == reflect.Slice) {
+				continue
+			}
+
+			if srcElement.IsValid() && (overwrite || (!dstElement.IsValid() || isEmptyValue(dstElement))) {
+				if dst.IsNil() {
+					dst.Set(reflect.MakeMap(dst.Type()))
+				}
 				dst.SetMapIndex(key, srcElement)
 			}
+		}
+	case reflect.Slice:
+		if !dst.CanSet() {
+			break
+		}
+		if (!isEmptyValue(src) || overwriteWithEmptySrc) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
+			dst.Set(src)
+		} else if config.AppendSlice {
+			if src.Type() != dst.Type() {
+				return fmt.Errorf("cannot append two slice with different type (%s, %s)", src.Type(), dst.Type())
+			}
+			dst.Set(reflect.AppendSlice(dst, src))
 		}
 	case reflect.Ptr:
 		fallthrough
 	case reflect.Interface:
 		if src.IsNil() {
 			break
-		} else if dst.IsNil() {
-			if dst.CanSet() && isEmptyValue(dst) {
+		}
+
+		if dst.Kind() != reflect.Ptr && src.Type().AssignableTo(dst.Type()) {
+			if dst.IsNil() || overwrite {
+				if dst.CanSet() && (overwrite || isEmptyValue(dst)) {
+					dst.Set(src)
+				}
+			}
+			break
+		}
+
+		if src.Kind() != reflect.Interface {
+			if dst.IsNil() || overwrite {
+				if dst.CanSet() && (overwrite || isEmptyValue(dst)) {
+					dst.Set(src)
+				}
+			} else if src.Kind() == reflect.Ptr {
+				if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1, config); err != nil {
+					return
+				}
+			} else if dst.Elem().Type() == src.Type() {
+				if err = deepMerge(dst.Elem(), src, visited, depth+1, config); err != nil {
+					return
+				}
+			} else {
+				return ErrDifferentArgumentsTypes
+			}
+			break
+		}
+		if dst.IsNil() || overwrite {
+			if dst.CanSet() && (overwrite || isEmptyValue(dst)) {
 				dst.Set(src)
 			}
-		} else if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1); err != nil {
+		} else if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1, config); err != nil {
 			return
 		}
 	default:
-		if dst.CanSet() && !isEmptyValue(src) {
+		if dst.CanSet() && (!isEmptyValue(src) || overwriteWithEmptySrc) && (overwrite || isEmptyValue(dst)) {
 			dst.Set(src)
 		}
 	}
 	return
 }
 
-// Merge sets fields' values in dst from src if they have a zero
-// value of their type.
-// dst and src must be valid same-type structs and dst must be
-// a pointer to struct.
-// It won't merge unexported (private) fields and will do recursively
-// any exported field.
-func Merge(dst, src interface{}) error {
+// Merge will fill any empty for value type attributes on the dst struct using corresponding
+// src attributes if they themselves are not empty. dst and src must be valid same-type structs
+// and dst must be a pointer to struct.
+// It won't merge unexported (private) fields and will do recursively any exported field.
+func Merge(dst, src interface{}, opts ...func(*Config)) error {
+	return merge(dst, src, opts...)
+}
+
+// MergeWithOverwrite will do the same as Merge except that non-empty dst attributes will be overriden by
+// non-empty src attribute values.
+// Deprecated: use Merge(…) with WithOverride
+func MergeWithOverwrite(dst, src interface{}, opts ...func(*Config)) error {
+	return merge(dst, src, append(opts, WithOverride)...)
+}
+
+// WithTransformers adds transformers to merge, allowing to customize the merging of some types.
+func WithTransformers(transformers Transformers) func(*Config) {
+	return func(config *Config) {
+		config.Transformers = transformers
+	}
+}
+
+// WithOverride will make merge override non-empty dst attributes with non-empty src attributes values.
+func WithOverride(config *Config) {
+	config.Overwrite = true
+}
+
+// WithAppendSlice will make merge append slices instead of overwriting it.
+func WithAppendSlice(config *Config) {
+	config.AppendSlice = true
+}
+
+// WithTypeCheck will make merge check types while overwriting it (must be used with WithOverride).
+func WithTypeCheck(config *Config) {
+	config.TypeCheck = true
+}
+
+func merge(dst, src interface{}, opts ...func(*Config)) error {
 	var (
 		vDst, vSrc reflect.Value
 		err        error
 	)
+
+	config := &Config{}
+
+	for _, opt := range opts {
+		opt(config)
+	}
+
 	if vDst, vSrc, err = resolveValues(dst, src); err != nil {
 		return err
 	}
 	if vDst.Type() != vSrc.Type() {
 		return ErrDifferentArgumentsTypes
 	}
-	return deepMerge(vDst, vSrc, make(map[uintptr]*visit), 0)
+	return deepMerge(vDst, vSrc, make(map[uintptr]*visit), 0, config)
 }

--- a/vendor/github.com/imdario/mergo/merge_appendslice_test.go
+++ b/vendor/github.com/imdario/mergo/merge_appendslice_test.go
@@ -1,0 +1,33 @@
+package mergo
+
+import (
+	"testing"
+)
+
+var testDataS = []struct {
+	S1            Student
+	S2            Student
+	ExpectedSlice []string
+}{
+	{Student{"Jack", []string{"a", "B"}}, Student{"Tom", []string{"1"}}, []string{"1", "a", "B"}},
+	{Student{"Jack", []string{"a", "B"}}, Student{"Tom", []string{}}, []string{"a", "B"}},
+	{Student{"Jack", []string{}}, Student{"Tom", []string{"1"}}, []string{"1"}},
+	{Student{"Jack", []string{}}, Student{"Tom", []string{}}, []string{}},
+}
+
+func TestMergeSliceWithOverrideWithAppendSlice(t *testing.T) {
+	for _, data := range testDataS {
+		err := Merge(&data.S2, data.S1, WithOverride, WithAppendSlice)
+		if err != nil {
+			t.Errorf("Error while merging %s", err)
+		}
+		if len(data.S2.Books) != len(data.ExpectedSlice) {
+			t.Fatalf("Got %d elements in slice, but expected %d", len(data.S2.Books), len(data.ExpectedSlice))
+		}
+		for i, val := range data.S2.Books {
+			if val != data.ExpectedSlice[i] {
+				t.Fatalf("Expected %s, but got %s while merging slice with override", data.ExpectedSlice[i], val)
+			}
+		}
+	}
+}

--- a/vendor/github.com/imdario/mergo/merge_interface_concrete_test.go
+++ b/vendor/github.com/imdario/mergo/merge_interface_concrete_test.go
@@ -1,0 +1,42 @@
+package mergo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type ifaceTypesTest struct {
+	N       int
+	Handler http.Handler
+}
+
+type ifaceTypesHandler int
+
+func (*ifaceTypesHandler) ServeHTTP(rw http.ResponseWriter, _ *http.Request) {
+	rw.Header().Set("Test", "ifaceTypesHandler")
+}
+
+func TestMergeInterfaceWithDifferentConcreteTypes(t *testing.T) {
+	dst := ifaceTypesTest{
+		Handler: new(ifaceTypesHandler),
+	}
+
+	src := ifaceTypesTest{
+		N: 42,
+		Handler: http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+			rw.Header().Set("Test", "handlerFunc")
+		}),
+	}
+
+	if err := Merge(&dst, src); err != nil {
+		t.Errorf("Error while merging %s", err)
+	}
+
+	rw := httptest.NewRecorder()
+	dst.Handler.ServeHTTP(rw, nil)
+
+	if got, want := rw.Header().Get("Test"), "ifaceTypesHandler"; got != want {
+		t.Errorf("Handler not merged in properly: got %q header value %q, want %q", "Test", got, want)
+	}
+}

--- a/vendor/github.com/imdario/mergo/merge_test.go
+++ b/vendor/github.com/imdario/mergo/merge_test.go
@@ -1,0 +1,50 @@
+package mergo
+
+import (
+	"reflect"
+	"testing"
+)
+
+type transformer struct {
+	m map[reflect.Type]func(dst, src reflect.Value) error
+}
+
+func (s *transformer) Transformer(t reflect.Type) func(dst, src reflect.Value) error {
+	if fn, ok := s.m[t]; ok {
+		return fn
+	}
+	return nil
+}
+
+type foo struct {
+	s   string
+	Bar *bar
+}
+
+type bar struct {
+	i int
+	s map[string]string
+}
+
+func TestMergeWithTransformerNilStruct(t *testing.T) {
+	a := foo{s: "foo"}
+	b := foo{Bar: &bar{i: 2, s: map[string]string{"foo": "bar"}}}
+	if err := Merge(&a, &b, WithOverride, WithTransformers(&transformer{
+		m: map[reflect.Type]func(dst, src reflect.Value) error{
+			reflect.TypeOf(&bar{}): func(dst, src reflect.Value) error {
+				// Do sthg with Elem
+				t.Log(dst.Elem().FieldByName("i"))
+				t.Log(src.Elem())
+				return nil
+			},
+		},
+	})); err != nil {
+		t.Fatal(err)
+	}
+	if a.s != "foo" {
+		t.Fatalf("b not merged in properly: a.s.Value(%s) != expected(%s)", a.s, "foo")
+	}
+	if a.Bar == nil {
+		t.Fatalf("b not merged in properly: a.Bar shouldn't be nil")
+	}
+}

--- a/vendor/github.com/imdario/mergo/mergo.go
+++ b/vendor/github.com/imdario/mergo/mergo.go
@@ -32,7 +32,7 @@ type visit struct {
 	next *visit
 }
 
-// From src/pkg/encoding/json.
+// From src/pkg/encoding/json/encode.go.
 func isEmptyValue(v reflect.Value) bool {
 	switch v.Kind() {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
@@ -46,7 +46,14 @@ func isEmptyValue(v reflect.Value) bool {
 	case reflect.Float32, reflect.Float64:
 		return v.Float() == 0
 	case reflect.Interface, reflect.Ptr:
+		if v.IsNil() {
+			return true
+		}
+		return isEmptyValue(v.Elem())
+	case reflect.Func:
 		return v.IsNil()
+	case reflect.Invalid:
+		return true
 	}
 	return false
 }

--- a/vendor/github.com/imdario/mergo/mergo_test.go
+++ b/vendor/github.com/imdario/mergo/mergo_test.go
@@ -6,10 +6,13 @@
 package mergo
 
 import (
-	"gopkg.in/yaml.v1"
 	"io/ioutil"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
+
+	"gopkg.in/yaml.v2"
 )
 
 type simpleTest struct {
@@ -19,7 +22,15 @@ type simpleTest struct {
 type complexTest struct {
 	St simpleTest
 	sz int
-	Id string
+	ID string
+}
+
+type mapTest struct {
+	M map[int]int
+}
+
+type ifcTest struct {
+	I interface{}
 }
 
 type moreComplextText struct {
@@ -34,6 +45,41 @@ type pointerTest struct {
 
 type sliceTest struct {
 	S []int
+}
+
+func TestKb(t *testing.T) {
+	type testStruct struct {
+		Name     string
+		KeyValue map[string]interface{}
+	}
+
+	akv := make(map[string]interface{})
+	akv["Key1"] = "not value 1"
+	akv["Key2"] = "value2"
+	a := testStruct{}
+	a.Name = "A"
+	a.KeyValue = akv
+
+	bkv := make(map[string]interface{})
+	bkv["Key1"] = "value1"
+	bkv["Key3"] = "value3"
+	b := testStruct{}
+	b.Name = "B"
+	b.KeyValue = bkv
+
+	ekv := make(map[string]interface{})
+	ekv["Key1"] = "value1"
+	ekv["Key2"] = "value2"
+	ekv["Key3"] = "value3"
+	expected := testStruct{}
+	expected.Name = "B"
+	expected.KeyValue = ekv
+
+	Merge(&b, a)
+
+	if !reflect.DeepEqual(b, expected) {
+		t.Errorf("Actual: %#v did not match \nExpected: %#v", b, expected)
+	}
 }
 
 func TestNil(t *testing.T) {
@@ -57,7 +103,7 @@ func TestSimpleStruct(t *testing.T) {
 		t.FailNow()
 	}
 	if a.Value != 42 {
-		t.Fatalf("b not merged in a properly: a.Value(%d) != b.Value(%d)", a.Value, b.Value)
+		t.Fatalf("b not merged in properly: a.Value(%d) != b.Value(%d)", a.Value, b.Value)
 	}
 	if !reflect.DeepEqual(a, b) {
 		t.FailNow()
@@ -66,19 +112,33 @@ func TestSimpleStruct(t *testing.T) {
 
 func TestComplexStruct(t *testing.T) {
 	a := complexTest{}
-	a.Id = "athing"
+	a.ID = "athing"
 	b := complexTest{simpleTest{42}, 1, "bthing"}
 	if err := Merge(&a, b); err != nil {
 		t.FailNow()
 	}
 	if a.St.Value != 42 {
-		t.Fatalf("b not merged in a properly: a.St.Value(%d) != b.St.Value(%d)", a.St.Value, b.St.Value)
+		t.Fatalf("b not merged in properly: a.St.Value(%d) != b.St.Value(%d)", a.St.Value, b.St.Value)
 	}
 	if a.sz == 1 {
 		t.Fatalf("a's private field sz not preserved from merge: a.sz(%d) == b.sz(%d)", a.sz, b.sz)
 	}
-	if a.Id != b.Id {
-		t.Fatalf("a's field Id not merged properly: a.Id(%s) != b.Id(%s)", a.Id, b.Id)
+	if a.ID == b.ID {
+		t.Fatalf("a's field ID merged unexpectedly: a.ID(%s) == b.ID(%s)", a.ID, b.ID)
+	}
+}
+
+func TestComplexStructWithOverwrite(t *testing.T) {
+	a := complexTest{simpleTest{1}, 1, "do-not-overwrite-with-empty-value"}
+	b := complexTest{simpleTest{42}, 2, ""}
+
+	expect := complexTest{simpleTest{42}, 1, "do-not-overwrite-with-empty-value"}
+	if err := MergeWithOverwrite(&a, b); err != nil {
+		t.FailNow()
+	}
+
+	if !reflect.DeepEqual(a, expect) {
+		t.Fatalf("Test failed:\ngot  :\n%#v\n\nwant :\n%#v\n\n", a, expect)
 	}
 }
 
@@ -91,7 +151,68 @@ func TestPointerStruct(t *testing.T) {
 		t.FailNow()
 	}
 	if a.C.Value != b.C.Value {
-		//t.Fatalf("b not merged in a properly: a.C.Value(%d) != b.C.Value(%d)", a.C.Value, b.C.Value)
+		t.Fatalf("b not merged in properly: a.C.Value(%d) != b.C.Value(%d)", a.C.Value, b.C.Value)
+	}
+}
+
+type embeddingStruct struct {
+	embeddedStruct
+}
+
+type embeddedStruct struct {
+	A string
+}
+
+func TestEmbeddedStruct(t *testing.T) {
+	tests := []struct {
+		src      embeddingStruct
+		dst      embeddingStruct
+		expected embeddingStruct
+	}{
+		{
+			src: embeddingStruct{
+				embeddedStruct{"foo"},
+			},
+			dst: embeddingStruct{
+				embeddedStruct{""},
+			},
+			expected: embeddingStruct{
+				embeddedStruct{"foo"},
+			},
+		},
+		{
+			src: embeddingStruct{
+				embeddedStruct{""},
+			},
+			dst: embeddingStruct{
+				embeddedStruct{"bar"},
+			},
+			expected: embeddingStruct{
+				embeddedStruct{"bar"},
+			},
+		},
+		{
+			src: embeddingStruct{
+				embeddedStruct{"foo"},
+			},
+			dst: embeddingStruct{
+				embeddedStruct{"bar"},
+			},
+			expected: embeddingStruct{
+				embeddedStruct{"bar"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		err := Merge(&test.dst, test.src)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			continue
+		}
+		if !reflect.DeepEqual(test.dst, test.expected) {
+			t.Errorf("unexpected output\nexpected:\n%+v\nsaw:\n%+v\n", test.expected, test.dst)
+		}
 	}
 }
 
@@ -106,47 +227,180 @@ func TestPointerStructNil(t *testing.T) {
 	}
 }
 
-func TestSliceStruct(t *testing.T) {
-	a := sliceTest{}
-	b := sliceTest{[]int{1, 2, 3}}
-	if err := Merge(&a, b); err != nil {
+func testSlice(t *testing.T, a []int, b []int, e []int, opts ...func(*Config)) {
+	t.Helper()
+	bc := b
+
+	sa := sliceTest{a}
+	sb := sliceTest{b}
+	if err := Merge(&sa, sb, opts...); err != nil {
 		t.FailNow()
 	}
-	if len(b.S) != 3 {
-		t.FailNow()
+	if !reflect.DeepEqual(sb.S, bc) {
+		t.Fatalf("Source slice was modified %d != %d", sb.S, bc)
 	}
-	if len(a.S) != len(b.S) {
-		t.Fatalf("b not merged in a properly %d != %d", len(a.S), len(b.S))
+	if !reflect.DeepEqual(sa.S, e) {
+		t.Fatalf("b not merged in a proper way %d != %d", sa.S, e)
 	}
 
-	a = sliceTest{[]int{1}}
-	b = sliceTest{[]int{1, 2, 3}}
+	ma := map[string][]int{"S": a}
+	mb := map[string][]int{"S": b}
+	if err := Merge(&ma, mb, opts...); err != nil {
+		t.FailNow()
+	}
+	if !reflect.DeepEqual(mb["S"], bc) {
+		t.Fatalf("map value: Source slice was modified %d != %d", mb["S"], bc)
+	}
+	if !reflect.DeepEqual(ma["S"], e) {
+		t.Fatalf("map value: b not merged in a proper way %d != %d", ma["S"], e)
+	}
+
+	if a == nil {
+		// test case with missing dst key
+		ma := map[string][]int{}
+		mb := map[string][]int{"S": b}
+		if err := Merge(&ma, mb); err != nil {
+			t.FailNow()
+		}
+		if !reflect.DeepEqual(mb["S"], bc) {
+			t.Fatalf("missing dst key: Source slice was modified %d != %d", mb["S"], bc)
+		}
+		if !reflect.DeepEqual(ma["S"], e) {
+			t.Fatalf("missing dst key: b not merged in a proper way %d != %d", ma["S"], e)
+		}
+	}
+
+	if b == nil {
+		// test case with missing src key
+		ma := map[string][]int{"S": a}
+		mb := map[string][]int{}
+		if err := Merge(&ma, mb); err != nil {
+			t.FailNow()
+		}
+		if !reflect.DeepEqual(mb["S"], bc) {
+			t.Fatalf("missing src key: Source slice was modified %d != %d", mb["S"], bc)
+		}
+		if !reflect.DeepEqual(ma["S"], e) {
+			t.Fatalf("missing src key: b not merged in a proper way %d != %d", ma["S"], e)
+		}
+	}
+}
+
+func TestSlice(t *testing.T) {
+	testSlice(t, nil, []int{1, 2, 3}, []int{1, 2, 3})
+	testSlice(t, []int{}, []int{1, 2, 3}, []int{1, 2, 3})
+	testSlice(t, []int{1}, []int{2, 3}, []int{1})
+	testSlice(t, []int{1}, []int{}, []int{1})
+	testSlice(t, []int{1}, nil, []int{1})
+	testSlice(t, nil, []int{1, 2, 3}, []int{1, 2, 3}, WithAppendSlice)
+	testSlice(t, []int{}, []int{1, 2, 3}, []int{1, 2, 3}, WithAppendSlice)
+	testSlice(t, []int{1}, []int{2, 3}, []int{1, 2, 3}, WithAppendSlice)
+	testSlice(t, []int{1}, []int{2, 3}, []int{1, 2, 3}, WithAppendSlice, WithOverride)
+	testSlice(t, []int{1}, []int{}, []int{1}, WithAppendSlice)
+	testSlice(t, []int{1}, nil, []int{1}, WithAppendSlice)
+}
+
+func TestEmptyMaps(t *testing.T) {
+	a := mapTest{}
+	b := mapTest{
+		map[int]int{},
+	}
 	if err := Merge(&a, b); err != nil {
+		t.Fail()
+	}
+	if !reflect.DeepEqual(a, b) {
 		t.FailNow()
 	}
-	if len(b.S) != 3 {
+}
+
+func TestEmptyToEmptyMaps(t *testing.T) {
+	a := mapTest{}
+	b := mapTest{}
+	if err := Merge(&a, b); err != nil {
+		t.Fail()
+	}
+	if !reflect.DeepEqual(a, b) {
 		t.FailNow()
 	}
-	if len(a.S) != len(b.S) {
-		t.Fatalf("b not merged in a properly %d != %d", len(a.S), len(b.S))
+}
+
+func TestEmptyToNotEmptyMaps(t *testing.T) {
+	a := mapTest{map[int]int{
+		1: 2,
+		3: 4,
+	}}
+	aa := mapTest{map[int]int{
+		1: 2,
+		3: 4,
+	}}
+	b := mapTest{
+		map[int]int{},
+	}
+	if err := Merge(&a, b); err != nil {
+		t.Fail()
+	}
+	if !reflect.DeepEqual(a, aa) {
+		t.FailNow()
+	}
+}
+
+func TestMapsWithOverwrite(t *testing.T) {
+	m := map[string]simpleTest{
+		"a": {},   // overwritten by 16
+		"b": {42}, // not overwritten by empty value
+		"c": {13}, // overwritten by 12
+		"d": {61},
+	}
+	n := map[string]simpleTest{
+		"a": {16},
+		"b": {},
+		"c": {12},
+		"e": {14},
+	}
+	expect := map[string]simpleTest{
+		"a": {16},
+		"b": {},
+		"c": {12},
+		"d": {61},
+		"e": {14},
+	}
+
+	if err := MergeWithOverwrite(&m, n); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if !reflect.DeepEqual(m, expect) {
+		t.Fatalf("Test failed:\ngot  :\n%#v\n\nwant :\n%#v\n\n", m, expect)
 	}
 }
 
 func TestMaps(t *testing.T) {
 	m := map[string]simpleTest{
-		"a": simpleTest{},
-		"b": simpleTest{42},
+		"a": {},
+		"b": {42},
+		"c": {13},
+		"d": {61},
 	}
 	n := map[string]simpleTest{
-		"a": simpleTest{16},
-		"b": simpleTest{},
-		"c": simpleTest{12},
+		"a": {16},
+		"b": {},
+		"c": {12},
+		"e": {14},
 	}
+	expect := map[string]simpleTest{
+		"a": {0},
+		"b": {42},
+		"c": {13},
+		"d": {61},
+		"e": {14},
+	}
+
 	if err := Merge(&m, n); err != nil {
 		t.Fatalf(err.Error())
 	}
-	if len(m) != 3 {
-		t.Fatalf(`n not merged in m properly, m must have 3 elements instead of %d`, len(m))
+
+	if !reflect.DeepEqual(m, expect) {
+		t.Fatalf("Test failed:\ngot  :\n%#v\n\nwant :\n%#v\n\n", m, expect)
 	}
 	if m["a"].Value != 0 {
 		t.Fatalf(`n merged in m because I solved non-addressable map values TODO: m["a"].Value(%d) != n["a"].Value(%d)`, m["a"].Value, n["a"].Value)
@@ -154,8 +408,32 @@ func TestMaps(t *testing.T) {
 	if m["b"].Value != 42 {
 		t.Fatalf(`n wrongly merged in m: m["b"].Value(%d) != n["b"].Value(%d)`, m["b"].Value, n["b"].Value)
 	}
-	if m["c"].Value != 12 {
-		t.Fatalf(`n not merged in m: m["c"].Value(%d) != n["c"].Value(%d)`, m["c"].Value, n["c"].Value)
+	if m["c"].Value != 13 {
+		t.Fatalf(`n overwritten in m: m["c"].Value(%d) != n["c"].Value(%d)`, m["c"].Value, n["c"].Value)
+	}
+}
+
+func TestMapsWithNilPointer(t *testing.T) {
+	m := map[string]*simpleTest{
+		"a": nil,
+		"b": nil,
+	}
+	n := map[string]*simpleTest{
+		"b": nil,
+		"c": nil,
+	}
+	expect := map[string]*simpleTest{
+		"a": nil,
+		"b": nil,
+		"c": nil,
+	}
+
+	if err := Merge(&m, n, WithOverride); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if !reflect.DeepEqual(m, expect) {
+		t.Fatalf("Test failed:\ngot   :\n%#v\n\nwant :\n%#v\n\n", m, expect)
 	}
 }
 
@@ -164,7 +442,8 @@ func TestYAMLMaps(t *testing.T) {
 	license := loadYAML("testdata/license.yml")
 	ft := thing["fields"].(map[interface{}]interface{})
 	fl := license["fields"].(map[interface{}]interface{})
-	expectedLength := len(ft) + len(fl)
+	// license has one extra field (site) and another already existing in thing (author) that Mergo won't override.
+	expectedLength := len(ft) + len(fl) - 1
 	if err := Merge(&license, thing); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -188,7 +467,7 @@ func TestTwoPointerValues(t *testing.T) {
 
 func TestMap(t *testing.T) {
 	a := complexTest{}
-	a.Id = "athing"
+	a.ID = "athing"
 	c := moreComplextText{a, simpleTest{}, simpleTest{}}
 	b := map[string]interface{}{
 		"ct": map[string]interface{}{
@@ -210,19 +489,19 @@ func TestMap(t *testing.T) {
 	o := b["st"].(*simpleTest)
 	p := b["nt"].(simpleTest)
 	if c.Ct.St.Value != 42 {
-		t.Fatalf("b not merged in a properly: c.Ct.St.Value(%d) != b.Ct.St.Value(%d)", c.Ct.St.Value, n["value"])
+		t.Fatalf("b not merged in properly: c.Ct.St.Value(%d) != b.Ct.St.Value(%d)", c.Ct.St.Value, n["value"])
 	}
 	if c.St.Value != 144 {
-		t.Fatalf("b not merged in a properly: c.St.Value(%d) != b.St.Value(%d)", c.St.Value, o.Value)
+		t.Fatalf("b not merged in properly: c.St.Value(%d) != b.St.Value(%d)", c.St.Value, o.Value)
 	}
 	if c.Nt.Value != 3 {
-		t.Fatalf("b not merged in a properly: c.Nt.Value(%d) != b.Nt.Value(%d)", c.St.Value, p.Value)
+		t.Fatalf("b not merged in properly: c.Nt.Value(%d) != b.Nt.Value(%d)", c.St.Value, p.Value)
 	}
 	if c.Ct.sz == 1 {
 		t.Fatalf("a's private field sz not preserved from merge: c.Ct.sz(%d) == b.Ct.sz(%d)", c.Ct.sz, m["sz"])
 	}
-	if c.Ct.Id != m["id"] {
-		t.Fatalf("a's field Id not merged properly: c.Ct.Id(%s) != b.Ct.Id(%s)", c.Ct.Id, m["id"])
+	if c.Ct.ID == m["id"] {
+		t.Fatalf("a's field ID merged unexpectedly: c.Ct.ID(%s) == b.Ct.ID(%s)", c.Ct.ID, m["id"])
 	}
 }
 
@@ -235,7 +514,46 @@ func TestSimpleMap(t *testing.T) {
 		t.FailNow()
 	}
 	if a.Value != 42 {
-		t.Fatalf("b not merged in a properly: a.Value(%d) != b.Value(%v)", a.Value, b["value"])
+		t.Fatalf("b not merged in properly: a.Value(%d) != b.Value(%v)", a.Value, b["value"])
+	}
+}
+
+func TestIfcMap(t *testing.T) {
+	a := ifcTest{}
+	b := ifcTest{42}
+	if err := Map(&a, b); err != nil {
+		t.FailNow()
+	}
+	if a.I != 42 {
+		t.Fatalf("b not merged in properly: a.I(%d) != b.I(%d)", a.I, b.I)
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.FailNow()
+	}
+}
+
+func TestIfcMapNoOverwrite(t *testing.T) {
+	a := ifcTest{13}
+	b := ifcTest{42}
+	if err := Map(&a, b); err != nil {
+		t.FailNow()
+	}
+	if a.I != 13 {
+		t.Fatalf("a not left alone: a.I(%d) == b.I(%d)", a.I, b.I)
+	}
+}
+
+func TestIfcMapWithOverwrite(t *testing.T) {
+	a := ifcTest{13}
+	b := ifcTest{42}
+	if err := MapWithOverwrite(&a, b); err != nil {
+		t.FailNow()
+	}
+	if a.I != 42 {
+		t.Fatalf("b not merged in properly: a.I(%d) != b.I(%d)", a.I, b.I)
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.FailNow()
 	}
 }
 
@@ -256,10 +574,10 @@ func TestBackAndForth(t *testing.T) {
 		ok bool
 	)
 	if v, ok = m["a"]; v.(int) != pt.A || !ok {
-		t.Fatalf("pt not merged properly: m[`a`](%d) != pt.A(%d)", v, pt.A)
+		t.Fatalf("pt not merged in properly: m[`a`](%d) != pt.A(%d)", v, pt.A)
 	}
 	if v, ok = m["b"]; !ok {
-		t.Fatalf("pt not merged properly: B is missing in m")
+		t.Fatalf("pt not merged in properly: B is missing in m")
 	}
 	var st *simpleTest
 	if st = v.(*simpleTest); st.Value != 66 {
@@ -270,13 +588,96 @@ func TestBackAndForth(t *testing.T) {
 		t.Fatal(err)
 	}
 	if bpt.A != pt.A {
-		t.Fatalf("pt not merged properly: bpt.A(%d) != pt.A(%d)", bpt.A, pt.A)
+		t.Fatalf("pt not merged in properly: bpt.A(%d) != pt.A(%d)", bpt.A, pt.A)
 	}
 	if bpt.hidden == pt.hidden {
 		t.Fatalf("pt unexpectedly merged: bpt.hidden(%d) == pt.hidden(%d)", bpt.hidden, pt.hidden)
 	}
 	if bpt.B.Value != pt.B.Value {
-		t.Fatalf("pt not merged properly: bpt.B.Value(%d) != pt.B.Value(%d)", bpt.B.Value, pt.B.Value)
+		t.Fatalf("pt not merged in properly: bpt.B.Value(%d) != pt.B.Value(%d)", bpt.B.Value, pt.B.Value)
+	}
+}
+
+func TestEmbeddedPointerUnpacking(t *testing.T) {
+	tests := []struct{ input pointerMapTest }{
+		{pointerMapTest{42, 1, nil}},
+		{pointerMapTest{42, 1, &simpleTest{66}}},
+	}
+	newValue := 77
+	m := map[string]interface{}{
+		"b": map[string]interface{}{
+			"value": newValue,
+		},
+	}
+	for _, test := range tests {
+		pt := test.input
+		if err := MapWithOverwrite(&pt, m); err != nil {
+			t.FailNow()
+		}
+		if pt.B.Value != newValue {
+			t.Fatalf("pt not mapped properly: pt.A.Value(%d) != m[`b`][`value`](%d)", pt.B.Value, newValue)
+		}
+
+	}
+}
+
+type structWithTimePointer struct {
+	Birth *time.Time
+}
+
+func TestTime(t *testing.T) {
+	now := time.Now()
+	dataStruct := structWithTimePointer{
+		Birth: &now,
+	}
+	dataMap := map[string]interface{}{
+		"Birth": &now,
+	}
+	b := structWithTimePointer{}
+	if err := Merge(&b, dataStruct); err != nil {
+		t.FailNow()
+	}
+	if b.Birth.IsZero() {
+		t.Fatalf("time.Time not merged in properly: b.Birth(%v) != dataStruct['Birth'](%v)", b.Birth, dataStruct.Birth)
+	}
+	if b.Birth != dataStruct.Birth {
+		t.Fatalf("time.Time not merged in properly: b.Birth(%v) != dataStruct['Birth'](%v)", b.Birth, dataStruct.Birth)
+	}
+	b = structWithTimePointer{}
+	if err := Map(&b, dataMap); err != nil {
+		t.FailNow()
+	}
+	if b.Birth.IsZero() {
+		t.Fatalf("time.Time not merged in properly: b.Birth(%v) != dataMap['Birth'](%v)", b.Birth, dataMap["Birth"])
+	}
+}
+
+type simpleNested struct {
+	A int
+}
+
+type structWithNestedPtrValueMap struct {
+	NestedPtrValue map[string]*simpleNested
+}
+
+func TestNestedPtrValueInMap(t *testing.T) {
+	src := &structWithNestedPtrValueMap{
+		NestedPtrValue: map[string]*simpleNested{
+			"x": {
+				A: 1,
+			},
+		},
+	}
+	dst := &structWithNestedPtrValueMap{
+		NestedPtrValue: map[string]*simpleNested{
+			"x": {},
+		},
+	}
+	if err := Map(dst, src); err != nil {
+		t.FailNow()
+	}
+	if dst.NestedPtrValue["x"].A == 0 {
+		t.Fatalf("Nested Ptr value not merged in properly: dst.NestedPtrValue[\"x\"].A(%v) != src.NestedPtrValue[\"x\"].A(%v)", dst.NestedPtrValue["x"].A, src.NestedPtrValue["x"].A)
 	}
 }
 
@@ -285,4 +686,92 @@ func loadYAML(path string) (m map[string]interface{}) {
 	raw, _ := ioutil.ReadFile(path)
 	_ = yaml.Unmarshal(raw, &m)
 	return
+}
+
+type structWithMap struct {
+	m map[string]structWithUnexportedProperty
+}
+
+type structWithUnexportedProperty struct {
+	s string
+}
+
+func TestUnexportedProperty(t *testing.T) {
+	a := structWithMap{map[string]structWithUnexportedProperty{
+		"key": {"hello"},
+	}}
+	b := structWithMap{map[string]structWithUnexportedProperty{
+		"key": {"hi"},
+	}}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Should not have panicked")
+		}
+	}()
+	Merge(&a, b)
+}
+
+type structWithBoolPointer struct {
+	C *bool
+}
+
+func TestBooleanPointer(t *testing.T) {
+	bt, bf := true, false
+	src := structWithBoolPointer{
+		&bt,
+	}
+	dst := structWithBoolPointer{
+		&bf,
+	}
+	if err := Merge(&dst, src); err != nil {
+		t.FailNow()
+	}
+	if dst.C == src.C {
+		t.Fatalf("dst.C should be a different pointer than src.C")
+	}
+	if *dst.C != *src.C {
+		t.Fatalf("dst.C should be true")
+	}
+}
+
+func TestMergeMapWithInnerSliceOfDifferentType(t *testing.T) {
+	testCases := []struct {
+		name    string
+		options []func(*Config)
+		err     string
+	}{
+		{
+			"With override and append slice",
+			[]func(*Config){WithOverride, WithAppendSlice},
+			"cannot append two slices with different type",
+		},
+		{
+			"With override and type check",
+			[]func(*Config){WithOverride, WithTypeCheck},
+			"cannot override two slices with different type",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := map[string]interface{}{
+				"foo": []string{"a", "b"},
+			}
+			dst := map[string]interface{}{
+				"foo": []int{1, 2},
+			}
+
+			if err := Merge(&src, &dst, tc.options...); err == nil || !strings.Contains(err.Error(), tc.err) {
+				t.Fatalf("expected %q, got %q", tc.err, err)
+			}
+		})
+	}
+}
+
+func TestMergeSlicesIsNotSupported(t *testing.T) {
+	src := []string{"a", "b"}
+	dst := []int{1, 2}
+
+	if err := Merge(&src, &dst, WithOverride, WithAppendSlice); err != ErrNotSupported {
+		t.Fatalf("expected %q, got %q", ErrNotSupported, err)
+	}
 }

--- a/vendor/github.com/imdario/mergo/pr80_test.go
+++ b/vendor/github.com/imdario/mergo/pr80_test.go
@@ -1,0 +1,18 @@
+package mergo
+
+import (
+	"testing"
+)
+
+type mapInterface map[string]interface{}
+
+func TestMergeMapsEmptyString(t *testing.T) {
+	a := mapInterface{"s": ""}
+	b := mapInterface{"s": "foo"}
+	if err := Merge(&a, b); err != nil {
+		t.Fatal(err)
+	}
+	if a["s"] != "foo" {
+		t.Fatalf("b not merged in properly: a.s.Value(%s) != expected(%s)", a["s"], "foo")
+	}
+}

--- a/vendor/github.com/imdario/mergo/pr81_test.go
+++ b/vendor/github.com/imdario/mergo/pr81_test.go
@@ -1,0 +1,42 @@
+package mergo
+
+import (
+	"testing"
+)
+
+func TestMapInterfaceWithMultipleLayer(t *testing.T) {
+	m1 := map[string]interface{}{
+		"k1": map[string]interface{}{
+			"k1.1": "v1",
+		},
+	}
+
+	m2 := map[string]interface{}{
+		"k1": map[string]interface{}{
+			"k1.1": "v2",
+			"k1.2": "v3",
+		},
+	}
+
+	if err := Map(&m1, m2, WithOverride); err != nil {
+		t.Fatalf("Error merging: %v", err)
+	}
+
+	// Check overwrite of sub map works
+	expected := "v2"
+	actual := m1["k1"].(map[string]interface{})["k1.1"].(string)
+	if actual != expected {
+		t.Fatalf("Expected %v but got %v",
+			expected,
+			actual)
+	}
+
+	// Check new key is merged
+	expected = "v3"
+	actual = m1["k1"].(map[string]interface{})["k1.2"].(string)
+	if actual != expected {
+		t.Fatalf("Expected %v but got %v",
+			expected,
+			actual)
+	}
+}

--- a/vendor/github.com/imdario/mergo/testdata/license.yml
+++ b/vendor/github.com/imdario/mergo/testdata/license.yml
@@ -1,3 +1,4 @@
 import: ../../../../fossene/db/schema/thing.yml
 fields:
     site: string
+    author: root

--- a/vendor/github.com/imdario/mergo/testdata/thing.yml
+++ b/vendor/github.com/imdario/mergo/testdata/thing.yml
@@ -3,3 +3,4 @@ fields:
     name: string
     parent: ref "datu:thing"
     status: enum(draft, public, private)
+    author: updater


### PR DESCRIPTION
Previous PR for #1201 did not leverage the label selection mechanism and all functions would have received the deployment augmentation. This leverages the label selector to choose which augmentations should be applied.