### PR TITLE
[DOC] Edit CallFunction example description & log messages; unify capitalization in the examples README

### DIFF
--- a/hack/examples/README.md
+++ b/hack/examples/README.md
@@ -7,10 +7,15 @@ To help you make the most of Nuclio, the following function examples are provide
 - [Hello World](golang/helloworld) (`helloworld`): A simple function that showcases unstructured logging and a structured response.
 - [Compliance Checker](golang/regexscan) (`regexscan`): A function that uses regular expressions to find patterns of social-security numbers (SSN), credit-card numbers, etc., using text input.
 - [Image Resize and Convert](golang/image) (`image`): A function that demonstrates how to pass a binary-large object (blob) in an HTTP request body and response. The function defines an HTTP request that accepts a binary image or URL as input, converts the input to the target format and size, and returns the converted image in the HTTP response.
-- [HTTP ingress](golang/ingress) (`ingress`): A simple function with an HTTP ingress configuration (using embedded YAML code) that routes specific URL paths to the function.
+- [HTTP Ingress](golang/ingress) (`ingress`): A simple function with an HTTP ingress configuration (using embedded YAML code) that routes specific URL paths to the function.
 - [RabbitMQ](golang/rabbitmq) (`rabbitmq`): A multi-trigger function with a configuration that connects to RabbitMQ to read messages and write them to local ephemeral storage. If triggered with an HTTP `GET` request, the function returns the messages that it read from RabbitMQ.
 - [Azure Event Hub](golang/eventhub) (`eventhub`): An Azure Event Hub triggered function with a configuration that connects to an Azure Event Hub. The function reads messages from two partitions, process the messages, invokes another function, and sends the processed payload to another Azure Event Hub. You can find a full demo scenario [here](https://github.com/nuclio/demos/tree/master/fleet-alarm-detection-azure).
-- [Call function](golang/callfunction) (`callfunction`): A set of two functions: **fibonacci** - getting `n` and return `fib(n)`, **fibonaccisum** - returns `fib(2)+fib(10)+fib(17)` using first function. It's demonstration of CallFunction feature. To try: deploy **fibonacci** function and name it **fibonacci**, deploy **fibonaccisum** with any name to the same namespace and call it.
+- [Call Function](golang/callfunction) (`callfunction`): A set of two functions that demonstrates the `CallFunction` feature:
+
+    - [`fibonacci`](golang/callfunction/fibonacci/fibonacci.go) - For input parameter `n`, returns the `n`-th number in the Fibonacci series (`fib(n)`).
+    - [`fibonaccisum`](golang/callfunction/fibonacci/fibonaccisum.go) - Uses `CallFunction` to call the `fibonacci` function for input numbers 2, 10, and 17, and returns the sum of the three returned Fibonacci numbers (`fib(2)+fib(10)+fib(17)`).
+
+    To try the example, deploy the `fibonacci` function and name it `fibonacci`; then, deploy the `fibonaccisum` function to the same namespace, using your preferred function name, and call it.
 
 ## Python examples
 
@@ -22,7 +27,7 @@ To help you make the most of Nuclio, the following function examples are provide
 
 ## Shell examples
 
-- [Image convert](shell/img-convert) (`img-convert`): A wrapper script around ImageMagick's **convert** executable, which is capable of generating thumbnails from received images (among other things). 
+- [Image Convert](shell/img-convert) (`img-convert`): A wrapper script around ImageMagick's **convert** executable, which is capable of generating thumbnails from received images (among other things). 
 
 ## NodeJS examples
 

--- a/hack/examples/golang/callfunction/fibonacci/fibonacci.go
+++ b/hack/examples/golang/callfunction/fibonacci/fibonacci.go
@@ -28,7 +28,7 @@ func Handler(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
 		return nil, err
 	}
 
-	context.Logger.InfoWith("Calculating fibonacci number", "n", n)
+	context.Logger.InfoWith("Calculating Fibonacci number", "n", n)
 
 	result, err := fib(n)
 	if err != nil {
@@ -52,7 +52,7 @@ func fib(n uint64) (uint64, error) {
 		if a < math.MaxUint64-b {
 			a, b = b, a+b
 		} else {
-			return 0, errors.New("Overflow. Too big request")
+			return 0, errors.New("Overflow. The request size exceeds the maximum")
 		}
 	}
 


### PR DESCRIPTION
- Doc review for the Go `callfunction` example added in PR #1174, commit 34c879a.
- Unify capitalization of the example names in **hack/examples/README.md**; as most of the names used title-case capitalization, I changed the few names that used sentence-case capitalization to title case.