### PR TITLE
Change AuthConfig to use BearerToken rather than OIDC Auth Provider

### DIFF
--- a/pkg/dashboard/resource/resource.go
+++ b/pkg/dashboard/resource/resource.go
@@ -67,7 +67,7 @@ func (r *resource) getRequestAuthConfig(request *http.Request) (*platform.AuthCo
 
 		// create the configuration
 		return &platform.AuthConfig{
-			Token:  strings.TrimPrefix(authorizationHeaderFromRequest, "Bearer "),
+			Token: strings.TrimPrefix(authorizationHeaderFromRequest, "Bearer "),
 		}, nil
 	}
 

--- a/pkg/dashboard/resource/resource.go
+++ b/pkg/dashboard/resource/resource.go
@@ -18,6 +18,7 @@ package resource
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/nuclio/nuclio/pkg/dashboard"
 	"github.com/nuclio/nuclio/pkg/errors"
@@ -25,7 +26,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/restful"
 
 	"github.com/nuclio/nuclio-sdk-go"
-	"github.com/rs/xid"
 )
 
 type resource struct {
@@ -61,18 +61,13 @@ func (r *resource) getRequestAuthConfig(request *http.Request) (*platform.AuthCo
 
 		// make sure the Authorization header exists
 		authorizationHeaderFromRequest := request.Header.Get("Authorization")
-		if authorizationHeaderFromRequest == "" {
+		if authorizationHeaderFromRequest == "" || !strings.HasPrefix(authorizationHeaderFromRequest, "Bearer ") {
 			return nil, nuclio.WrapErrForbidden(errors.New("Missing Authorization header"))
 		}
 
 		// create the configuration
 		return &platform.AuthConfig{
-			Name: "oidc",
-			Config: map[string]string{
-				"id-token":       authorizationHeaderFromRequest,
-				"idp-issuer-url": "http://127.0.0.1/" + xid.New().String(),
-				"client-id":      "nuclio",
-			},
+			Token:  strings.TrimPrefix(authorizationHeaderFromRequest, "Bearer "),
 		}, nil
 	}
 

--- a/pkg/platform/kube/consumer.go
+++ b/pkg/platform/kube/consumer.go
@@ -26,7 +26,6 @@ import (
 	// enable OIDC plugin
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 type consumer struct {
@@ -81,10 +80,7 @@ func (c *consumer) getNuclioClientSet(authConfig *platform.AuthConfig) (nuclioio
 	}
 
 	// set the auth provider config
-	restConfig.AuthProvider = &clientcmdapi.AuthProviderConfig{
-		Name:   authConfig.Name,
-		Config: authConfig.Config,
-	}
+	restConfig.BearerToken = authConfig.Token
 
 	return nuclioio_client.NewForConfig(restConfig)
 }

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -30,7 +30,7 @@ import (
 //
 
 type AuthConfig struct {
-	Token   string
+	Token string
 }
 
 //

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -30,8 +30,7 @@ import (
 //
 
 type AuthConfig struct {
-	Name   string
-	Config map[string]string
+	Token   string
 }
 
 //


### PR DESCRIPTION
Fixes #1205

Uses Header Authorization to authenticate against kubernetes apiserver
```
Authorization: Bearer [TOKEN_VALUE]
```