### PR TITLE
[Bug fix] targetCPU gets overridden by code entry configuration

### DIFF
--- a/pkg/functionconfig/reader.go
+++ b/pkg/functionconfig/reader.go
@@ -66,7 +66,13 @@ func (r *Reader) Read(reader io.Reader, configType string, config *Config) error
 		}
 	}
 
-	if err = yaml.Unmarshal(bodyBytes, &codeEntryConfigAsMap); err != nil {
+	// normalizing the received config to the JSON values of the function config Go struct
+	codeEntryConfigAsJSON, err := json.Marshal(codeEntryConfig)
+	if err != nil {
+		return errors.Wrap(err, "Failed to parse received config to JSON")
+	}
+
+	if err = yaml.Unmarshal(codeEntryConfigAsJSON, &codeEntryConfigAsMap); err != nil {
 		return errors.Wrap(err, "Failed to parse received config")
 	}
 

--- a/pkg/functionconfig/reader_test.go
+++ b/pkg/functionconfig/reader_test.go
@@ -94,6 +94,7 @@ metadata:
 spec:
   runtime: python3.6
   handler: code_entry_handler
+  targetCpu: 13
   build:
     commands:
     - pip install code_entry_package
@@ -114,6 +115,7 @@ spec:
 			Runtime: "python2.7",
 			Handler: "my_handler",
 			Env:     []v1.EnvVar{{Name: "env_var", Value: "my_env_val"}},
+			TargetCPU: 51,
 		},
 	}
 	reader, err := NewReader(suite.logger)
@@ -134,6 +136,7 @@ spec:
 	suite.Require().Equal("python2.7", config.Spec.Runtime, "Bad runtime")
 	suite.Require().Equal([]string{"pip install code_entry_package"}, config.Spec.Build.Commands, "Bad commands")
 	suite.Require().Equal(map[string]string{"label_key": "label_val"}, config.Meta.Labels, "Bad labels")
+	suite.Require().Equal(51, config.Spec.TargetCPU, "Bad target cpu")
 }
 
 func (suite *ReaderTestSuite) TestToDeployOptions() {

--- a/pkg/functionconfig/reader_test.go
+++ b/pkg/functionconfig/reader_test.go
@@ -84,6 +84,35 @@ spec:
 	}
 }
 
+func (suite *ReaderTestSuite) TestCodeEntryConfigCaseInsensitivity() {
+	configData := `
+metadata:
+  name: code_entry_name
+  namespace: code_entry_namespace
+spec:
+  runtime: python3.6
+  handler: code_entry_handler
+  targetCpu: 13  # instead of targetCPU to test case insensitivity
+`
+
+	config := Config{
+		Meta: Meta{
+			Name:      "my_name",
+			Namespace: "my_namespace",
+		},
+		Spec: Spec{
+			Runtime: "python2.7",
+			Handler: "my_handler",
+		},
+	}
+	reader, err := NewReader(suite.logger)
+	suite.Require().NoError(err, "Can't create reader")
+	err = reader.Read(strings.NewReader(configData), "processor", &config)
+	suite.Require().NoError(err, "Can't reader configuration")
+
+	suite.Require().Equal(13, config.Spec.TargetCPU, "Bad target cpu")
+}
+
 func (suite *ReaderTestSuite) TestCodeEntryConfigDontOverrideConfigValues() {
 	configData := `
 metadata:

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -218,7 +218,7 @@ type Spec struct {
 	Replicas                int                     `json:"replicas,omitempty"`
 	MinReplicas             int                     `json:"minReplicas,omitempty"`
 	MaxReplicas             int                     `json:"maxReplicas,omitempty"`
-	TargetCPU               int                     `json:"targetCpu,omitempty"`
+	TargetCPU               int                     `json:"targetCPU,omitempty"`
 	DataBindings            map[string]DataBinding  `json:"dataBindings,omitempty"`
 	Triggers                map[string]Trigger      `json:"triggers,omitempty"`
 	Volumes                 []Volume                `json:"volumes,omitempty"`
@@ -228,7 +228,7 @@ type Spec struct {
 	RunRegistry             string                  `json:"runRegistry,omitempty"`
 	RuntimeAttributes       map[string]interface{}  `json:"runtimeAttributes,omitempty"`
 	LoggerSinks             []LoggerSink            `json:"loggerSinks,omitempty"`
-	DealerURI               string                  `json:"dealerUri,omitempty"`
+	DealerURI               string                  `json:"dealerURI,omitempty"`
 	Platform                Platform                `json:"platform,omitempty"`
 	ReadinessTimeoutSeconds int                     `json:"readinessTimeoutSeconds,omitempty"`
 	Avatar                  string                  `json:"avatar,omitempty"`

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -218,7 +218,7 @@ type Spec struct {
 	Replicas                int                     `json:"replicas,omitempty"`
 	MinReplicas             int                     `json:"minReplicas,omitempty"`
 	MaxReplicas             int                     `json:"maxReplicas,omitempty"`
-	TargetCPU               int                     `json:"targetCPU,omitempty"`
+	TargetCPU               int                     `json:"targetCpu,omitempty"`
 	DataBindings            map[string]DataBinding  `json:"dataBindings,omitempty"`
 	Triggers                map[string]Trigger      `json:"triggers,omitempty"`
 	Volumes                 []Volume                `json:"volumes,omitempty"`
@@ -228,7 +228,7 @@ type Spec struct {
 	RunRegistry             string                  `json:"runRegistry,omitempty"`
 	RuntimeAttributes       map[string]interface{}  `json:"runtimeAttributes,omitempty"`
 	LoggerSinks             []LoggerSink            `json:"loggerSinks,omitempty"`
-	DealerURI               string                  `json:"dealerURI,omitempty"`
+	DealerURI               string                  `json:"dealerUri,omitempty"`
 	Platform                Platform                `json:"platform,omitempty"`
 	ReadinessTimeoutSeconds int                     `json:"readinessTimeoutSeconds,omitempty"`
 	Avatar                  string                  `json:"avatar,omitempty"`


### PR DESCRIPTION
Bug Description:
When setting code entry type to be `archive` for example, with `targetCpu: <some-value>` 
and passing from the UI another targetCpu - then the targetCPU is taken from the codeEntry instead from the UI as expected.

Cause and Solution:
This happened because the targetCpu was passed in the codeEntry configuration as `targetCpu` while in the backend it is saved as `targetCPU`, a thing that makes the `targetCpu` value get priority after the merge of the configurations.
solution - Normalize the given code entry configuration values to the matching JSON name declared in the FunctionConfiguration Go struct