### PR TITLE
UI: Resource memory units: change 'K' to 'k'

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.8.9",
+    "iguazio.dashboard-controls": "^0.8.10",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
Function » Configuration » Resources » Memory: change value of unit option "K" from `'K'` to `'k'` (according to https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/suffix.go#L127)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/593