### PR TITLE
Remove HostPath from function resource (and default readiness timeout update)

### DIFF
--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -201,7 +201,7 @@ func addDeployFlags(cmd *cobra.Command,
 	cmd.Flags().StringVar(&functionConfig.Spec.Image, "run-image", "", "Name of an existing image to deploy (default - build a new image to deploy)")
 	cmd.Flags().StringVar(&functionConfig.Spec.RunRegistry, "run-registry", os.Getenv("NUCTL_RUN_REGISTRY"), "URL of a registry for pulling the image, if differs from -r/--registry (env: NUCTL_RUN_REGISTRY)")
 	cmd.Flags().StringVar(&commandeer.encodedRuntimeAttributes, "runtime-attrs", "{}", "JSON-encoded runtime attributes for the function")
-	cmd.Flags().IntVar(&functionConfig.Spec.ReadinessTimeoutSeconds, "readiness-timeout", 30, "maximum wait time for the function to be ready")
+	cmd.Flags().IntVar(&functionConfig.Spec.ReadinessTimeoutSeconds, "readiness-timeout", 60, "maximum wait time for the function to be ready")
 	cmd.Flags().StringVar(&commandeer.projectName, "project-name", "", "name of project to which this function belongs to")
 	cmd.Flags().Var(&commandeer.volumes, "volume", "Volumes for the deployment function (src1=dest1[,src2=dest2,...])")
 	cmd.Flags().Var(&commandeer.resourceLimits, "resource-limit", "Limits resources in the format of resource-name=quantity (e.g. cpu=3)")

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -108,10 +108,10 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 			"Failed to create/update function"))
 	}
 
-	// wait for up to 30 seconds or whatever was set in the spec
+	// wait for up to 60 seconds or whatever was set in the spec
 	readinessTimeout := function.Spec.ReadinessTimeoutSeconds
 	if readinessTimeout == 0 {
-		readinessTimeout = 30
+		readinessTimeout = 60
 	}
 
 	waitContext, cancel := context.WithDeadline(ctx, time.Now().Add(time.Duration(readinessTimeout)*time.Second))

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -549,7 +549,7 @@ func (p *Platform) deployFunction(createFunctionOptions *platform.CreateFunction
 	if createFunctionOptions.FunctionConfig.Spec.ReadinessTimeoutSeconds != 0 {
 		readinessTimeout = time.Duration(createFunctionOptions.FunctionConfig.Spec.ReadinessTimeoutSeconds) * time.Second
 	} else {
-		readinessTimeout = 30 * time.Second
+		readinessTimeout = 60 * time.Second
 	}
 
 	if err = p.dockerClient.AwaitContainerHealth(containerID, &readinessTimeout); err != nil {


### PR DESCRIPTION
Instead of only ignoring HostPath volumes - remove them from the functionConfig so it won't be kept inside the nucliofunction resource

* Also updated function default readiness timeout to 60