### PR TITLE
Expect archive file type only on external code entry types

### DIFF
--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -591,8 +591,9 @@ func (b *Builder) resolveFunctionPath(functionPath string) (string, error) {
 
 		functionPath = tempFile.Name()
 
-		if !b.isSupportedFunctionFileType(functionPath) {
-			return "", errors.New("Downloaded file type is not supported. (must be either archive or jar)")
+		if (codeEntryType == S3EntryType || codeEntryType == GithubEntryType || codeEntryType == ArchiveEntryType) &&
+			!util.IsCompressed(functionPath) {
+			return "", errors.New("Downloaded file type is not supported.(expected an archive)")
 		}
 	}
 
@@ -614,18 +615,6 @@ func (b *Builder) resolveFunctionPath(functionPath string) (string, error) {
 	}
 
 	return resolvedPath, nil
-}
-
-func (b *Builder) isSupportedFunctionFileType(functionPath string) bool {
-	if util.IsCompressed(functionPath) {
-		return true
-	}
-
-	if strings.ToLower(path.Ext(functionPath)) == ".jar" {
-		return true
-	}
-
-	return false
 }
 
 func (b *Builder) validateAndParseS3Attributes(attributes map[string]interface{}) (map[string]string, error) {

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -593,7 +593,7 @@ func (b *Builder) resolveFunctionPath(functionPath string) (string, error) {
 
 		if (codeEntryType == S3EntryType || codeEntryType == GithubEntryType || codeEntryType == ArchiveEntryType) &&
 			!util.IsCompressed(functionPath) {
-			return "", errors.New("Downloaded file type is not supported.(expected an archive)")
+			return "", errors.New("Downloaded file type is not supported. (expected an archive)")
 		}
 	}
 


### PR DESCRIPTION
Bug description:
When passing `path` to a function that is not of type archive - build fails with `Downloaded file type is not supported. (expected an archive)`
(for example when passing a path to `.go` file that describes only the source code of a function)

Solution:
Specified the restriction to add only archive files - only to the relevant code entry types - `archive`, `s3` and `github`