### PR TITLE
UI: Add S3 code entry type

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.8.12",
+    "iguazio.dashboard-controls": "^0.8.14",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- Function:
    - Code:
        - Added "S3" code entry type
    - Configuration:
        - Added "more info" icons with explanatory tooltips on click
        - Build: Removed default value of "Readiness Timeout (seconds)"
    - Triggers:
        - bugfix: trigger got collapsed on clicking/dragging the scrollbar thumb
        - bugfix: some console errors when deploying HTTP trigger with ingresses

Depends on PR https://github.com/iguazio/dashboard-controls/pull/609
Corresponds to PR https://github.com/nuclio/nuclio/pull/1242