### PR TITLE
Fix function labels as re-deploy fails

### DIFF
--- a/pkg/common/aws.go
+++ b/pkg/common/aws.go
@@ -43,6 +43,9 @@ func DownloadFileFromAWSS3(file *os.File, bucket, itemKey, region, accessKeyID, 
 			Bucket: aws.String(bucketAndPath),
 			Key:    aws.String(item),
 		})
+	if err != nil {
+		return errors.Wrap(err, "Failed to download file from s3")
+	}
 
-	return err
+	return nil
 }

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -46,6 +46,7 @@ func (fesr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restf
 		Single:     true,
 		StatusCode: http.StatusOK,
 		Resources:  frontendSpec,
+		Headers:    map[string]string{"Content-Type": "application/json"},
 	}, nil
 }
 

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -580,6 +580,7 @@ func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 		deployment.Spec.Replicas = &replicas
 		deployment.Spec.Template.Annotations = podAnnotations
 		deployment.Spec.Template.Labels = functionLabels
+		deployment.Spec.Selector.MatchLabels = functionLabels
 		lc.populateDeploymentContainer(functionLabels, function, &deployment.Spec.Template.Spec.Containers[0])
 		deployment.Spec.Template.Spec.Volumes = volumes
 		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = volumeMounts

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -116,7 +116,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	createFunctionOptions.Logger = logStream.GetLogger()
 
 	reportCreationError := func(creationError error) error {
-		createFunctionOptions.Logger.WarnWith("Create function failed failed, setting function status",
+		createFunctionOptions.Logger.WarnWith("Create function failed, setting function status",
 			"err", creationError)
 
 		errorStack := bytes.Buffer{}


### PR DESCRIPTION
The problem happened because the function `spec.selector.matchLabels` didn't update on function update to the new labels (the deployment's `spec.selector.matchLabels` must be a subset of `spec.template.labels`)

- added also some other small fixes