### PR TITLE
Add an ingress for the dashboard in the Helm chart

### DIFF
--- a/hack/k8s/helm/nuclio/templates/ingress/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/ingress/dashboard.yaml
@@ -1,0 +1,53 @@
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.dashboard.enabled }}
+{{- if .Values.dashboard.ingress.enabled }}
+{{- $fullName := include "nuclio.dashboardName" . -}}
+{{- $ingressPath := .Values.dashboard.ingress.path }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    nuclio.io/app: dashboard
+    nuclio.io/name: {{ $fullName }}
+    nuclio.io/class: ingress
+{{- with .Values.dashboard.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.dashboard.ingress.tls }}
+  tls:
+  {{- range .Values.dashboard.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.dashboard.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: admin
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/hack/k8s/helm/nuclio/templates/ingress/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/ingress/dashboard.yaml
@@ -16,7 +16,7 @@
 {{- if .Values.dashboard.ingress.enabled }}
 {{- $fullName := include "nuclio.dashboardName" . -}}
 {{- $ingressPath := .Values.dashboard.ingress.path }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -27,6 +27,19 @@ dashboard:
   # Uncomment to configure node port
   # nodePort: 32050
 
+  ingress:
+    enabled: false
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    path: /
+    hosts:
+      - nuclio.local
+    tls: []
+    #  - secretName: nuclio-tls
+    #    hosts:
+    #      - nuclio.local
+
 autoscaler:
   enabled: false
   replicas: 1


### PR DESCRIPTION
A small PR to enable users to add an ingress for the dashboard.

I've used the "best practice" way for creating the ingress resource, that is the way the ingress is created when you do a `helm create mychart`.

I've also tried to copy the practices used in the nuclio helm chart for the labels and the directory structure.