### PR TITLE
Don't populate create function image if run image is specified

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -135,7 +135,7 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 		}
 
 		// populate image if possible
-		if existingFunctionConfig != nil {
+		if existingFunctionConfig != nil && createFunctionOptions.FunctionConfig.Spec.Image == "" {
 			createFunctionOptions.FunctionConfig.Spec.Image = existingFunctionConfig.Spec.Image
 		}
 


### PR DESCRIPTION
Fixes #1283

Skips populating existing function image to the requested function image
in case of codetype image or when the user specified the image to run with.