### PR TITLE
UI: Deploy not disabled on invalid key/name when editing

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.8.18",
+    "iguazio.dashboard-controls": "^0.8.19",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
Function » Configuration » Annotations, Labels & Environment Variables: [Bugfix] "Deploy" button does not turn disabled on entering an invalid value to "Name"/"Key" field of an existing item.
