### PR TITLE
dotnet-runtime: Fixed handling of large function-input

### DIFF
--- a/pkg/processor/runtime/dotnetcore/UnixSocketHandler.cs
+++ b/pkg/processor/runtime/dotnetcore/UnixSocketHandler.cs
@@ -56,13 +56,20 @@ namespace processor
                     await _socket.ConnectAsync(ep);
                     var clientReceives = Task.Run(async () =>
                     {
+                        var message = "";
                         while (true)
                         {
                             var buffer = new byte[1024];
                             await _socket.ReceiveAsync(new ArraySegment<byte>(buffer), SocketFlags.None);
-                            var message = Encoding.UTF8.GetString(buffer);
-                            message = message.Substring(0, message.IndexOf('\n'));
-                            OnMessageReceived(new MessageEventArgs() { Message = message });
+                            var messagePart = Encoding.UTF8.GetString(buffer);
+                            var linebreakIndex = messagePart.IndexOf('\n');
+                            if (linebreakIndex == -1) {
+                                message += messagePart;
+                            } else {
+                                message += messagePart.Substring(0, linebreakIndex);
+                                OnMessageReceived(new MessageEventArgs() { Message = message });
+                                message = "";
+                            }
                         }
                     });
 

--- a/pkg/processor/runtime/dotnetcore/test/_outputter/outputter.cs
+++ b/pkg/processor/runtime/dotnetcore/test/_outputter/outputter.cs
@@ -25,12 +25,15 @@ public class nuclio
             return eventBase.Method;
 
         var body = eventBase.GetBody();
+
+        if body.StartsWith("long body") {
+            return body;
+        }
+
         switch (body)
         {
             case "return_string":
                 return "a string";
-            case "long_bdoy":
-                return body;
             case "log":
                 context.Logger.Debug("Debug message");
                 context.Logger.Info("Info message");

--- a/pkg/processor/runtime/dotnetcore/test/_outputter/outputter.cs
+++ b/pkg/processor/runtime/dotnetcore/test/_outputter/outputter.cs
@@ -29,6 +29,8 @@ public class nuclio
         {
             case "return_string":
                 return "a string";
+            case "long_bdoy":
+                return body;
             case "log":
                 context.Logger.Debug("Debug message");
                 context.Logger.Info("Info message");

--- a/pkg/processor/runtime/dotnetcore/test/_outputter/outputter.cs
+++ b/pkg/processor/runtime/dotnetcore/test/_outputter/outputter.cs
@@ -25,11 +25,6 @@ public class nuclio
             return eventBase.Method;
 
         var body = eventBase.GetBody();
-
-        if body.StartsWith("long body") {
-            return body;
-        }
-
         switch (body)
         {
             case "return_string":
@@ -66,6 +61,11 @@ public class nuclio
             case "return_path":
                 return eventBase.Path;
         }
+
+        if (body.StartsWith("long body")) {
+            return body;
+        }
+
         throw new Exception(string.Empty);
 
     }

--- a/pkg/processor/runtime/dotnetcore/test/dotnetcore_test.go
+++ b/pkg/processor/runtime/dotnetcore/test/dotnetcore_test.go
@@ -48,7 +48,7 @@ func (suite *TestSuite) TestOutputs() {
 	logLevelDebug := "debug"
 	logLevelWarn := "warn"
 	testPath := "/path/to/nowhere"
-	longTestBody := `Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. 
+	longTestBody := `long body: Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. 
 	Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, 
 	pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, 
 	vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.`

--- a/pkg/processor/runtime/dotnetcore/test/dotnetcore_test.go
+++ b/pkg/processor/runtime/dotnetcore/test/dotnetcore_test.go
@@ -48,6 +48,10 @@ func (suite *TestSuite) TestOutputs() {
 	logLevelDebug := "debug"
 	logLevelWarn := "warn"
 	testPath := "/path/to/nowhere"
+	longTestBody := `Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. 
+	Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, 
+	pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, 
+	vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.`
 
 	headersContentTypeTextPlain := map[string]string{"content-type": "text/plain"}
 
@@ -64,6 +68,13 @@ func (suite *TestSuite) TestOutputs() {
 				RequestBody:                "return_string",
 				ExpectedResponseHeaders:    headersContentTypeTextPlain,
 				ExpectedResponseBody:       "a string",
+				ExpectedResponseStatusCode: &statusOK,
+			},
+			{
+				Name:                       "long body",
+				RequestBody:                longTestBody,
+				ExpectedResponseHeaders:    headersContentTypeTextPlain,
+				ExpectedResponseBody:       longTestBody,
 				ExpectedResponseStatusCode: &statusOK,
 			},
 			{


### PR DESCRIPTION
If you're passing a message body with more than ~370 Characters you get the errors described in #1001.

Problems in current code:
Searching for '\n' only works, if the whole message (including linebreak) fits into the buffer. If you need to read the buffer a second time, there won't be a linebreak in the first part of the buffer. 
Then, IndexOf returns -1 and substring will fail with the exception (which is also in #1001):
```
Socket Error: Length cannot be less than zero.,
Parameter name: length,
```
The exception breaks the while loop and every next request will be answered with 500.

I fixed it by reading the input message until the linebreak is recognized.

