### PR TITLE
dotnet: Fix loading of handler in Wrapper to allow custom nuget packages

### DIFF
--- a/docs/reference/runtimes/dotnetcore/dotnetcore-reference.md
+++ b/docs/reference/runtimes/dotnetcore/dotnetcore-reference.md
@@ -27,7 +27,36 @@ public class nuclio
 }
 ```
 
-The `handler` field is of the form `<class>:<entrypoint>`. In the example above, the handler is `nuclio:empty`. 
+The `handler` field is of the form `<class>:<entrypoint>`. In the example above, the handler is `nuclio:empty`.
+
+## Project file
+
+In order to use/import external dependencies, create a `handler.csproj` file, alongside your function handler file
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>7.2</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+  </ItemGroup>
+</Project>
+``` 
+
+Using the above, you would be able to use `Newtonsoft.Json` package as follow:
+
+```cs
+using Newtonsoft.Json;
+...
+JsonConvert.SerializeObject(...);
+```
+
+Adding more dependencies is made easy using `dotnet add package <package name>`
+
+More details about `dotnet` can be found [here](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-add-package)
 
 ## Dockerfile
 

--- a/pkg/processor/build/runtime/dotnetcore/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/dotnetcore/docker/onbuild/Dockerfile
@@ -33,7 +33,9 @@ RUN curl -L https://github.com/nuclio/nuclio-sdk-dotnetcore/archive/master.tar.g
 COPY pkg/processor/runtime/dotnetcore /home/nuclio/src/wrapper
 RUN dotnet add /home/nuclio/src/wrapper package Microsoft.CSharp && \
     dotnet add /home/nuclio/src/wrapper package System.Dynamic.Runtime && \
-    dotnet add /home/nuclio/src/wrapper package Newtonsoft.Json -v 11.0.1 && \
+    dotnet add /home/nuclio/src/wrapper package System.Runtime.Loader && \
+    dotnet add /home/nuclio/src/wrapper package Microsoft.Extensions.DependencyModel && \
+    dotnet add /home/nuclio/src/wrapper package Newtonsoft.Json && \
     dotnet add /home/nuclio/src/wrapper reference /home/nuclio/src/nuclio-sdk-dotnetcore/nuclio-sdk-dotnetcore.csproj
 
 # Build the wrapper
@@ -52,8 +54,8 @@ ONBUILD COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} /home/nuclio/src/handler
 
 ONBUILD RUN dotnet add /home/nuclio/src/handler package Microsoft.CSharp && \
             dotnet add /home/nuclio/src/handler package System.Dynamic.Runtime && \
-            dotnet add /home/nuclio/src/handler package Newtonsoft.Json -v 11.0.1 && \
-            dotnet add /home/nuclio/src/handler package Microsoft.Azure.EventHubs -v 2.0.0-preview && \
+            dotnet add /home/nuclio/src/handler package Newtonsoft.Json && \
+            dotnet add /home/nuclio/src/handler package Microsoft.Azure.EventHubs -v 2.2.1 && \
             dotnet add /home/nuclio/src/handler reference /home/nuclio/src/nuclio-sdk-dotnetcore/nuclio-sdk-dotnetcore.csproj
 
 ONBUILD RUN cd /home/nuclio/src/handler \

--- a/pkg/processor/runtime/dotnetcore/AssemblyLoader.cs
+++ b/pkg/processor/runtime/dotnetcore/AssemblyLoader.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.Extensions.DependencyModel;
+
+// Taken from https://github.com/dotnet/corefx/issues/11639#issuecomment-363441773
+public static class AssemblyLoader
+{
+    public static Assembly LoadFromAssemblyPath(string assemblyFullPath)
+    {
+        var fileNameWithOutExtension = Path.GetFileNameWithoutExtension(assemblyFullPath);
+        var fileName = Path.GetFileName(assemblyFullPath);
+        var directory = Path.GetDirectoryName(assemblyFullPath);
+
+        var inCompileLibraries = DependencyContext.Default.CompileLibraries.Any(l => l.Name.Equals(fileNameWithOutExtension, StringComparison.OrdinalIgnoreCase));
+        var inRuntimeLibraries = DependencyContext.Default.RuntimeLibraries.Any(l => l.Name.Equals(fileNameWithOutExtension, StringComparison.OrdinalIgnoreCase));
+
+        var assembly = (inCompileLibraries || inRuntimeLibraries)
+            ? Assembly.Load(new AssemblyName(fileNameWithOutExtension))
+            : AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyFullPath);
+
+        if (assembly != null)
+            LoadReferencedAssemblies(assembly, fileName, directory);
+
+        return assembly;
+    }
+
+    private static void LoadReferencedAssemblies(Assembly assembly, string fileName, string directory)
+    {
+        var filesInDirectory = Directory.GetFiles(directory).Where(x => x != fileName).Select(x => Path.GetFileNameWithoutExtension(x)).ToList();
+        var references = assembly.GetReferencedAssemblies();
+
+        foreach (var reference in references)
+        {
+            if (filesInDirectory.Contains(reference.Name))
+            {
+                var loadFileName = reference.Name + ".dll";
+                var path = Path.Combine(directory, loadFileName);
+                var loadedAssembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
+                if (loadedAssembly != null)
+                {
+                    LoadReferencedAssemblies(loadedAssembly, loadFileName, directory);
+                }
+            }
+        }
+    }
+}

--- a/pkg/processor/runtime/dotnetcore/Wrapper.cs
+++ b/pkg/processor/runtime/dotnetcore/Wrapper.cs
@@ -13,8 +13,6 @@
 //  limitations under the License.
 
 using System;
-using System.Reflection;
-using System.Runtime.Loader;
 using System.Collections.Generic;
 using System.Text;
 using Nuclio.Sdk;
@@ -45,7 +43,8 @@ namespace processor
         {
             try
             {
-                var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(dllPath);
+                // AssemblyLoadContext.Default.LoadFromAssemblyPath does not load dependency-dlls, so use custom Loader
+                var assembly = AssemblyLoader.LoadFromAssemblyPath(dllPath);
                 // Get the type to use.
                 var methodType = assembly.GetType(typeName); // Namespace and class
                 // Get the method to call.

--- a/pkg/processor/runtime/dotnetcore/test/_outputter/handler.csproj
+++ b/pkg/processor/runtime/dotnetcore/test/_outputter/handler.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>7.2</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+  </ItemGroup>
+</Project>

--- a/pkg/processor/runtime/dotnetcore/test/_outputter/outputter.cs
+++ b/pkg/processor/runtime/dotnetcore/test/_outputter/outputter.cs
@@ -16,6 +16,15 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Nuclio.Sdk;
+using Newtonsoft.Json;
+
+
+public class Account
+{
+    public string Name { get; set; }
+    public string Email { get; set; }
+}
+
 
 public class nuclio
 {
@@ -60,6 +69,14 @@ public class nuclio
                 return String.Join(",", listOfFields.Select(x => x.ToString()).ToArray());
             case "return_path":
                 return eventBase.Path;
+            case "json_convert":
+                Account account = new Account
+                {
+                    Name = "John Doe",
+                    Email = "john@iguazio.com"
+                };
+                string json = JsonConvert.SerializeObject(account, Formatting.Indented);
+                return json;
         }
 
         if (body.StartsWith("long body")) {

--- a/pkg/processor/runtime/dotnetcore/test/dotnetcore_test.go
+++ b/pkg/processor/runtime/dotnetcore/test/dotnetcore_test.go
@@ -39,9 +39,6 @@ func (suite *TestSuite) SetupTest() {
 }
 
 func (suite *TestSuite) TestOutputs() {
-	// TODO: Have common tests and use here and in Python
-	// see https://github.com/nuclio/nuclio/issues/227
-
 	statusOK := http.StatusOK
 	statusCreated := http.StatusCreated
 	statusInternalError := http.StatusInternalServerError
@@ -68,6 +65,13 @@ func (suite *TestSuite) TestOutputs() {
 				RequestBody:                "return_string",
 				ExpectedResponseHeaders:    headersContentTypeTextPlain,
 				ExpectedResponseBody:       "a string",
+				ExpectedResponseStatusCode: &statusOK,
+			},
+			{
+				Name:                       "json_convert",
+				RequestBody:                "json_convert",
+				ExpectedResponseHeaders:    headersContentTypeTextPlain,
+				ExpectedResponseBody:       "{\n  \"Name\": \"John Doe\",\n  \"Email\": \"john@iguazio.com\"\n}",
 				ExpectedResponseStatusCode: &statusOK,
 			},
 			{


### PR DESCRIPTION
Currently the wrapper loads the handler.dll, but without the dependency-dlls of handler. 

I used a custom AssemblyLoader taken from a dotnet-core github issue (referenced in code).
With this AssemblyLoader all necessary dependencies will be loaded.

You can now use your own nuget-packages by creating a handler.csproj (Use the [handler.csproj from nuclio repo](https://github.com/nuclio/nuclio/blob/master/pkg/processor/build/runtime/dotnetcore/docker/onbuild/handler.csproj) as base and extend it with your own packages) file in your project, which will be copied by the Dockerfile in ONBUILD RUN section and its packages will be restored. 

This should fix #1281 and #1078. Until this is merged and shipped I will write a short how-to in #1078 how to build the function with a custom dockerfile. 