### PR TITLE
UI: Remove default value from "Readiness Timeout (seconds)"

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.8.19",
+    "iguazio.dashboard-controls": "^0.8.20",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- Projects: [bugfix] Some error appearing in browser console in welcome screen.
- Function » Configuration » Build: Remove default value from "Readiness Timeout (seconds)" field

Depends on PR https://github.com/iguazio/dashboard-controls/pull/635