### PR TITLE
Added missing dependency in how-to-contribute guide

### DIFF
--- a/docs/devel/contributing.md
+++ b/docs/devel/contributing.md
@@ -27,7 +27,7 @@ cd $GOPATH/src/github.com/nuclio/nuclio && git checkout development
 Now `go get` some dependencies that are injected into functions and cannot be vendored:
 
 ```sh
-go get github.com/v3io/v3io-go-http/... && go get github.com/nuclio/logger/... && go get github.com/nuclio/nuclio-sdk-go/... && go get github.com/nuclio/amqp/...
+go get github.com/v3io/v3io-go-http/... && go get github.com/nuclio/logger/... && go get github.com/nuclio/nuclio-sdk-go/... && go get github.com/nuclio/amqp/... && go get github.com/v3io/scaler-types/...
 ```
 
 Build Nuclio artifacts (`nuctl`, Docker images):


### PR DESCRIPTION
... otherwise `make lint` will fail. 