### PR TITLE
UI: Fix bug where trigger info is not displayed after creation

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.8.20",
+    "iguazio.dashboard-controls": "^0.8.21",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- Function » Triggers: [bugfix] When creating a new trigger and collapsing it, its info is not displayed on the trigger's row.

Depends on PR https://github.com/iguazio/dashboard-controls/pull/637