### PR TITLE
Bumping dashboard controls and freezing to 0.8.22

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -47,7 +47,7 @@
     "gulp-rev-collector": "^1.0.2",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
-    "iguazio.dashboard-controls": "^0.8.18",
+    "iguazio.dashboard-controls": "0.8.22",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
This is to address a UI regression in roundtrip re-deployment where the default max-replicas=0 would prevent a redeployment if auto-filled by previous deployment

Depends on PR https://github.com/iguazio/dashboard-controls/pull/644