### PR TITLE
UI: Duplicate function redirects to new function before deploy

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -52,7 +52,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.9.0",
+    "iguazio.dashboard-controls": "^0.9.1",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- Projects » Functions list » Actions:
  - Duplicate function redirects to function screen of the new duplicated function, and does not automatically initiates its deployment
- Function:
  - Actions: Duplicate function redirects to function screen of the new duplicated function, and does not automatically initiates its deployment
  - "Code" tab » "Test" pane » "Test" button:
    - For a function that is not in "Running" status, the "Test" button is disabled with a tooltip “Only running functions can be tested”
  - "Configuration" tab:
    - Several text additions and changes in description tooltips
    - Build » "Readiness Timeout (seconds)" field: Removed default value
- General:
  - More-info tooltip: for those tooltips which are opened on a click event rather than on hover, they are now closing when clicking anywhere in the document outside of the tooltip