### PR TITLE
Add error cause and increase creation state update timeout

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -177,7 +177,7 @@ func (fr *functionResource) GetCustomRoutes() ([]restful.CustomRoute, error) {
 
 func (fr *functionResource) storeAndDeployFunction(functionInfo *functionInfo, request *http.Request) error {
 
-	creationStateUpdatedTimeout := 15 * time.Second
+	creationStateUpdatedTimeout := 45 * time.Second
 
 	doneChan := make(chan bool, 1)
 	creationStateUpdatedChan := make(chan bool, 1)

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -409,11 +409,11 @@ func (ar *AbstractResource) writeErrorReason(responseWriter io.Writer, err error
 
 	// format to json manually
 	serializedError, _ := json.Marshal(struct {
-		Error      string `json:"error"`
-		ErrorCause string `json:"errorCause"`
+		Error           string `json:"error"`
+		ErrorStackTrace string `json:"errorStackTrace"`
 	}{
-		buffer.String(),
 		errorCause,
+		buffer.String(),
 	})
 
 	// write to the response

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -399,14 +399,21 @@ func (ar *AbstractResource) writeErrorReason(responseWriter io.Writer, err error
 		err = typedErr.GetError()
 	}
 
+	errorCause := ""
+	if errors.Cause(err) != nil {
+		errorCause = errors.Cause(err).Error()
+	}
+
 	// try to get the error stack
 	errors.PrintErrorStack(&buffer, err, 10)
 
 	// format to json manually
 	serializedError, _ := json.Marshal(struct {
-		Error string `json:"error"`
+		Error      string `json:"error"`
+		ErrorCause string `json:"errorCause"`
 	}{
 		buffer.String(),
+		errorCause,
 	})
 
 	// write to the response

--- a/pkg/restful/resource_test.go
+++ b/pkg/restful/resource_test.go
@@ -195,7 +195,7 @@ func (suite *resourceTestSuite) sendErrorRequests(method string, path string) {
 
 	// handler returns a *wrapped* ErrorWithStatusCode, and status code is above 400
 	code = http.StatusBadRequest
-	ecv = NewErrorContainsVerifier(suite.logger, []string{"ORIGINAL_ERROR", "BADREQUEST_WRAPPED"})
+	ecv = NewErrorContainsVerifier(suite.logger, []string{"ORIGINAL_ERROR"})
 	headers = map[string]string{"return": "error-with-status-400-wrapped"}
 	suite.sendRequest(method, path, headers, nil, &code, ecv.Verify)
 }


### PR DESCRIPTION
- Increasing creation state update timeout to 45 to prevent wrong function deployment timeout, that may be caused as a result of a longer download of function files from external code entry type for example
- adding errorCause to the error response payload to provide the UI with a human-readable information to show to the user when an error happens