### PR TITLE
dotnet: Fixed byte length for buffer in Wrapper to avoid Base-64 errors

### DIFF
--- a/pkg/processor/runtime/dotnetcore/UnixSocketHandler.cs
+++ b/pkg/processor/runtime/dotnetcore/UnixSocketHandler.cs
@@ -60,8 +60,8 @@ namespace processor
                         while (true)
                         {
                             var buffer = new byte[1024];
-                            await _socket.ReceiveAsync(new ArraySegment<byte>(buffer), SocketFlags.None);
-                            var messagePart = Encoding.UTF8.GetString(buffer);
+                            int bytesReceived = await _socket.ReceiveAsync(new ArraySegment<byte>(buffer), SocketFlags.None);
+                            var messagePart = Encoding.UTF8.GetString(buffer, 0, bytesReceived);
                             var linebreakIndex = messagePart.IndexOf('\n');
                             if (linebreakIndex == -1) {
                                 message += messagePart;


### PR DESCRIPTION
This is a fix on top of #1288 .

I did a few tests under higher load and encountered not reproducible problems that a Function throws InternalServerError with a large JSON-input. After calling the function again with the same input it usually worked. 
 
In the logs I saw 
> The input is not a valid Base-64 string as it contains a non-base 64 character, more than two padding characters, or an illegal character among the padding.

which seems to be an error message of `Encoding.UTF8.GetString(buffer);`

I had a look at a few examples of c#-sockets and considered to include the number of received bytes.
With this fix, the problem did not appear again.

