### PR TITLE
Deprecate project display name

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -177,7 +177,7 @@ func (fr *functionResource) GetCustomRoutes() ([]restful.CustomRoute, error) {
 
 func (fr *functionResource) storeAndDeployFunction(functionInfo *functionInfo, request *http.Request) error {
 
-	creationStateUpdatedTimeout := 15 * time.Second
+	creationStateUpdatedTimeout := 45 * time.Second
 
 	doneChan := make(chan bool, 1)
 	creationStateUpdatedChan := make(chan bool, 1)

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -933,6 +933,7 @@ func (suite *projectTestSuite) TestGetDetailSuccessful() {
 	returnedProject := platform.AbstractProject{}
 	returnedProject.ProjectConfig.Meta.Name = "p1"
 	returnedProject.ProjectConfig.Meta.Namespace = "p1Namespace"
+	returnedProject.ProjectConfig.Spec.DisplayName = "p1DisplayName"
 	returnedProject.ProjectConfig.Spec.Description = "p1Desc"
 
 	// verify
@@ -959,6 +960,7 @@ func (suite *projectTestSuite) TestGetDetailSuccessful() {
 		"namespace": "p1Namespace"
 	},
 	"spec": {
+		"displayName": "p1DisplayName",
 		"description": "p1Desc"
 	}
 }`

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -933,7 +933,6 @@ func (suite *projectTestSuite) TestGetDetailSuccessful() {
 	returnedProject := platform.AbstractProject{}
 	returnedProject.ProjectConfig.Meta.Name = "p1"
 	returnedProject.ProjectConfig.Meta.Namespace = "p1Namespace"
-	returnedProject.ProjectConfig.Spec.DisplayName = "p1DisplayName"
 	returnedProject.ProjectConfig.Spec.Description = "p1Desc"
 
 	// verify
@@ -960,7 +959,6 @@ func (suite *projectTestSuite) TestGetDetailSuccessful() {
 		"namespace": "p1Namespace"
 	},
 	"spec": {
-		"displayName": "p1DisplayName",
 		"description": "p1Desc"
 	}
 }`
@@ -992,13 +990,11 @@ func (suite *projectTestSuite) TestGetListSuccessful() {
 	returnedProject1 := platform.AbstractProject{}
 	returnedProject1.ProjectConfig.Meta.Name = "p1"
 	returnedProject1.ProjectConfig.Meta.Namespace = "pNamespace"
-	returnedProject1.ProjectConfig.Spec.DisplayName = "p1DisplayName"
 	returnedProject1.ProjectConfig.Spec.Description = "p1Desc"
 
 	returnedProject2 := platform.AbstractProject{}
 	returnedProject2.ProjectConfig.Meta.Name = "p2"
 	returnedProject2.ProjectConfig.Meta.Namespace = "pNamespace"
-	returnedProject2.ProjectConfig.Spec.DisplayName = "p2DisplayName"
 	returnedProject2.ProjectConfig.Spec.Description = "p2Desc"
 
 	// verify
@@ -1026,7 +1022,6 @@ func (suite *projectTestSuite) TestGetListSuccessful() {
 			"namespace": "pNamespace"
 		},
 		"spec": {
-			"displayName": "p1DisplayName",
 			"description": "p1Desc"
 		}
 	},
@@ -1036,7 +1031,6 @@ func (suite *projectTestSuite) TestGetListSuccessful() {
 			"namespace": "pNamespace"
 		},
 		"spec": {
-			"displayName": "p2DisplayName",
 			"description": "p2Desc"
 		}
 	}
@@ -1071,7 +1065,6 @@ func (suite *projectTestSuite) TestCreateSuccessful() {
 	verifyCreateProject := func(createProjectOptions *platform.CreateProjectOptions) bool {
 		suite.Require().Equal("p1", createProjectOptions.ProjectConfig.Meta.Name)
 		suite.Require().Equal("p1Namespace", createProjectOptions.ProjectConfig.Meta.Namespace)
-		suite.Require().Equal("p1DisplayName", createProjectOptions.ProjectConfig.Spec.DisplayName)
 		suite.Require().Equal("p1Description", createProjectOptions.ProjectConfig.Spec.Description)
 
 		return true
@@ -1100,7 +1093,6 @@ func (suite *projectTestSuite) TestCreateSuccessful() {
 		"namespace": "p1Namespace"
 	},
 	"spec": {
-		"displayName": "p1DisplayName",
 		"description": "p1Description"
 	}
 }`
@@ -1136,7 +1128,6 @@ func (suite *projectTestSuite) TestCreateNoName() {
 		"namespace": "p1Namespace"
 	},
 	"spec": {
-		"displayName": "p1DisplayName",
 		"description": "p1Description"
 	}
 }`
@@ -1171,17 +1162,12 @@ func (suite *projectTestSuite) TestCreateNoNamespace() {
 	suite.sendRequestNoNamespace("POST")
 }
 
-func (suite *projectTestSuite) TestCreateProjectWithExistingDisplayName() {
-	suite.sendRequestWithExistingDisplayName("POST")
-}
-
 func (suite *projectTestSuite) TestUpdateSuccessful() {
 
 	// verify
 	verifyUpdateProject := func(updateProjectOptions *platform.UpdateProjectOptions) bool {
 		suite.Require().Equal("p1", updateProjectOptions.ProjectConfig.Meta.Name)
 		suite.Require().Equal("p1Namespace", updateProjectOptions.ProjectConfig.Meta.Namespace)
-		suite.Require().Equal("p1DisplayName", updateProjectOptions.ProjectConfig.Spec.DisplayName)
 		suite.Require().Equal("p1Description", updateProjectOptions.ProjectConfig.Spec.Description)
 
 		return true
@@ -1210,7 +1196,6 @@ func (suite *projectTestSuite) TestUpdateSuccessful() {
 		"namespace": "p1Namespace"
 	},
 	"spec": {
-		"displayName": "p1DisplayName",
 		"description": "p1Description"
 	}
 }`
@@ -1235,10 +1220,6 @@ func (suite *projectTestSuite) TestUpdateNoName() {
 
 func (suite *projectTestSuite) TestUpdateNoNamespace() {
 	suite.sendRequestNoNamespace("PUT")
-}
-
-func (suite *projectTestSuite) TestUpdateProjectWithExistingDisplayName() {
-	suite.sendRequestWithExistingDisplayName("PUT")
 }
 
 func (suite *projectTestSuite) TestDeleteSuccessful() {
@@ -1313,48 +1294,9 @@ func (suite *projectTestSuite) TestDeleteNoNamespace() {
 func (suite *projectTestSuite) sendRequestNoMetadata(method string) {
 	suite.sendRequestWithInvalidBody(method, `{
 	"spec": {
-		"displayName": "dn",
 		"description": "d"
 	}
 }`)
-}
-
-func (suite *projectTestSuite) sendRequestWithExistingDisplayName(method string) {
-	verifyGetProjects := func(getProjectsOptions *platform.GetProjectsOptions) bool {
-		suite.Require().Equal("p1Namespace", getProjectsOptions.Meta.Namespace)
-
-		return true
-	}
-
-	// mock a different project (with a different name) but with the same display name
-	mockedProject, _ := platform.NewAbstractProject(suite.logger, nil, platform.ProjectConfig{
-		Meta: platform.ProjectMeta{Namespace: "p1Namespace", Name: "p2"},
-		Spec: platform.ProjectSpec{DisplayName: "p1DisplayName"},
-	})
-
-	suite.mockPlatform.
-		On("GetProjects", mock.MatchedBy(verifyGetProjects)).
-		Return([]platform.Project{mockedProject}, nil).
-		Once()
-
-	expectedStatusCode := http.StatusConflict
-	requestBody := `{
-	"metadata": {
-		"name": "p1",
-		"namespace": "p1Namespace"
-	},
-	"spec": {
-		"displayName": "p1DisplayName",
-		"description": "p1Description"
-	}
-}`
-
-	suite.sendRequest(method,
-		"/api/projects",
-		nil,
-		bytes.NewBufferString(requestBody),
-		&expectedStatusCode,
-		nil)
 }
 
 func (suite *projectTestSuite) sendRequestNoNamespace(method string) {
@@ -1363,7 +1305,6 @@ func (suite *projectTestSuite) sendRequestNoNamespace(method string) {
 		"name": "name"
 	},
 	"spec": {
-		"displayName": "dn",
 		"description": "d"
 	}
 }`)
@@ -1375,7 +1316,6 @@ func (suite *projectTestSuite) sendRequestNoName(method string) {
 		"namespace": "namespace"
 	},
 	"spec": {
-		"displayName": "dn",
 		"description": "d"
 	}
 }`)
@@ -1447,7 +1387,6 @@ func (suite *functionEventTestSuite) TestGetDetailSuccessful() {
 		}
 	},
 	"spec": {
-		"displayName": "fe1DisplayName",
 		"triggerName": "fe1TriggerName",
 		"triggerKind": "fe1TriggerKind",
 		"body": "fe1Body",

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1075,17 +1075,6 @@ func (suite *projectTestSuite) TestCreateSuccessful() {
 		Return(nil).
 		Once()
 
-	verifyGetProjects := func(getProjectsOptions *platform.GetProjectsOptions) bool {
-		suite.Require().Equal("p1Namespace", getProjectsOptions.Meta.Namespace)
-
-		return true
-	}
-
-	suite.mockPlatform.
-		On("GetProjects", mock.MatchedBy(verifyGetProjects)).
-		Return([]platform.Project{}, nil).
-		Once()
-
 	expectedStatusCode := http.StatusCreated
 	requestBody := `{
 	"metadata": {
@@ -1117,14 +1106,10 @@ func (suite *projectTestSuite) TestCreateNoName() {
 		Return(nil).
 		Once()
 
-	suite.mockPlatform.
-		On("GetProjects", mock.Anything).
-		Return([]platform.Project{}, nil).
-		Once()
-
 	expectedStatusCode := http.StatusCreated
 	requestBody := `{
 	"metadata": {
+		"name": "p1name",
 		"namespace": "p1Namespace"
 	},
 	"spec": {
@@ -1139,11 +1124,7 @@ func (suite *projectTestSuite) TestCreateNoName() {
 
 		// get name
 		name := metadata["name"].(string)
-
-		// make sure that name was populated with a UUID
-		_, err := uuid.FromString(name)
-
-		suite.Require().NoError(err, "Name must contain UUID: %s", name)
+		suite.NotEqual("", name)
 
 		return true
 	}
@@ -1173,20 +1154,9 @@ func (suite *projectTestSuite) TestUpdateSuccessful() {
 		return true
 	}
 
-	verifyGetProjects := func(getProjectsOptions *platform.GetProjectsOptions) bool {
-		suite.Require().Equal("p1Namespace", getProjectsOptions.Meta.Namespace)
-
-		return true
-	}
-
 	suite.mockPlatform.
 		On("UpdateProject", mock.MatchedBy(verifyUpdateProject)).
 		Return(nil).
-		Once()
-
-	suite.mockPlatform.
-		On("GetProjects", mock.MatchedBy(verifyGetProjects)).
-		Return([]platform.Project{}, nil).
 		Once()
 
 	expectedStatusCode := http.StatusNoContent
@@ -1387,6 +1357,7 @@ func (suite *functionEventTestSuite) TestGetDetailSuccessful() {
 		}
 	},
 	"spec": {
+		"displayName": "fe1DisplayName",
 		"triggerName": "fe1TriggerName",
 		"triggerKind": "fe1TriggerKind",
 		"body": "fe1Body",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -53,7 +53,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.9.8",
+    "iguazio.dashboard-controls": "^0.9.13",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",

--- a/pkg/nuctl/command/create.go
+++ b/pkg/nuctl/command/create.go
@@ -85,7 +85,7 @@ func newCreateProjectCommandeer(createCommandeer *createCommandeer) *createProje
 
 			// if display name is set log a deprecation message
 			if commandeer.projectConfig.Spec.DisplayName != "" {
-				cmd.Printf("Display name is deprecated and will be removed on the next major version release")
+				cmd.Println("Warning: Display name is deprecated and will be removed on the next major version release")
 			}
 
 			return createCommandeer.rootCommandeer.platform.CreateProject(&platform.CreateProjectOptions{

--- a/pkg/nuctl/command/create.go
+++ b/pkg/nuctl/command/create.go
@@ -83,11 +83,6 @@ func newCreateProjectCommandeer(createCommandeer *createCommandeer) *createProje
 			commandeer.projectConfig.Meta.Name = args[0]
 			commandeer.projectConfig.Meta.Namespace = createCommandeer.rootCommandeer.namespace
 
-			// if display name is set log a deprecation message
-			if commandeer.projectConfig.Spec.DisplayName != "" {
-				cmd.Println("Warning: Display name is deprecated and will be removed on the next major version release")
-			}
-
 			return createCommandeer.rootCommandeer.platform.CreateProject(&platform.CreateProjectOptions{
 				ProjectConfig: commandeer.projectConfig,
 			})
@@ -95,6 +90,7 @@ func newCreateProjectCommandeer(createCommandeer *createCommandeer) *createProje
 	}
 
 	cmd.Flags().StringVar(&commandeer.projectConfig.Spec.DisplayName, "display-name", "", "Project display name, if different than name")
+	cmd.Flags().MarkDeprecated("display-name", "Display name is deprecated and will be removed on the next major version release")
 	cmd.Flags().StringVar(&commandeer.projectConfig.Spec.Description, "description", "", "Project description")
 
 	commandeer.cmd = cmd

--- a/pkg/nuctl/command/create.go
+++ b/pkg/nuctl/command/create.go
@@ -83,12 +83,18 @@ func newCreateProjectCommandeer(createCommandeer *createCommandeer) *createProje
 			commandeer.projectConfig.Meta.Name = args[0]
 			commandeer.projectConfig.Meta.Namespace = createCommandeer.rootCommandeer.namespace
 
+			// if display name is set log a deprecation message
+			if commandeer.projectConfig.Spec.DisplayName != "" {
+				cmd.Printf("Display name is deprecated and will be removed on the next major version release")
+			}
+
 			return createCommandeer.rootCommandeer.platform.CreateProject(&platform.CreateProjectOptions{
 				ProjectConfig: commandeer.projectConfig,
 			})
 		},
 	}
 
+	cmd.Flags().StringVar(&commandeer.projectConfig.Spec.DisplayName, "display-name", "", "Project display name, if different than name")
 	cmd.Flags().StringVar(&commandeer.projectConfig.Spec.Description, "description", "", "Project description")
 
 	commandeer.cmd = cmd

--- a/pkg/nuctl/command/create.go
+++ b/pkg/nuctl/command/create.go
@@ -90,7 +90,7 @@ func newCreateProjectCommandeer(createCommandeer *createCommandeer) *createProje
 	}
 
 	cmd.Flags().StringVar(&commandeer.projectConfig.Spec.DisplayName, "display-name", "", "Project display name, if different than name")
-	cmd.Flags().MarkDeprecated("display-name", "Display name is deprecated and will be removed on the next major version release")
+	cmd.Flags().MarkDeprecated("display-name", "will be removed on the next major version release") // nolint: errcheck
 	cmd.Flags().StringVar(&commandeer.projectConfig.Spec.Description, "description", "", "Project description")
 
 	commandeer.cmd = cmd

--- a/pkg/nuctl/command/create.go
+++ b/pkg/nuctl/command/create.go
@@ -83,18 +83,12 @@ func newCreateProjectCommandeer(createCommandeer *createCommandeer) *createProje
 			commandeer.projectConfig.Meta.Name = args[0]
 			commandeer.projectConfig.Meta.Namespace = createCommandeer.rootCommandeer.namespace
 
-			// if display name is not set, use name
-			if commandeer.projectConfig.Spec.DisplayName == "" {
-				commandeer.projectConfig.Spec.DisplayName = commandeer.projectConfig.Meta.Name
-			}
-
 			return createCommandeer.rootCommandeer.platform.CreateProject(&platform.CreateProjectOptions{
 				ProjectConfig: commandeer.projectConfig,
 			})
 		},
 	}
 
-	cmd.Flags().StringVar(&commandeer.projectConfig.Spec.DisplayName, "display-name", "", "Project display name, if different than name")
 	cmd.Flags().StringVar(&commandeer.projectConfig.Spec.Description, "description", "", "Project description")
 
 	commandeer.cmd = cmd

--- a/pkg/nuctl/command/get.go
+++ b/pkg/nuctl/command/get.go
@@ -275,7 +275,7 @@ func (g *getProjectCommandeer) renderProjects(projects []platform.Project, forma
 
 	switch format {
 	case outputFormatText, outputFormatWide:
-		header := []string{"Namespace", "Name"}
+		header := []string{"Namespace", "Name", "Display Name"}
 		if format == outputFormatWide {
 			header = append(header, []string{
 				"Description",
@@ -291,6 +291,7 @@ func (g *getProjectCommandeer) renderProjects(projects []platform.Project, forma
 			projectFields := []string{
 				project.GetConfig().Meta.Namespace,
 				project.GetConfig().Meta.Name,
+				project.GetConfig().Spec.DisplayName,
 			}
 
 			// add fields for wide view

--- a/pkg/nuctl/command/get.go
+++ b/pkg/nuctl/command/get.go
@@ -275,7 +275,7 @@ func (g *getProjectCommandeer) renderProjects(projects []platform.Project, forma
 
 	switch format {
 	case outputFormatText, outputFormatWide:
-		header := []string{"Namespace", "Name", "Display Name"}
+		header := []string{"Namespace", "Name"}
 		if format == outputFormatWide {
 			header = append(header, []string{
 				"Description",
@@ -291,7 +291,6 @@ func (g *getProjectCommandeer) renderProjects(projects []platform.Project, forma
 			projectFields := []string{
 				project.GetConfig().Meta.Namespace,
 				project.GetConfig().Meta.Name,
-				project.GetConfig().Spec.DisplayName,
 			}
 
 			// add fields for wide view

--- a/pkg/nuctl/test/project_test.go
+++ b/pkg/nuctl/test/project_test.go
@@ -46,7 +46,6 @@ func (suite *projectGetTestSuite) TestGet() {
 		projectNames = append(projectNames, projectName)
 
 		namedArgs := map[string]string{
-			"display-name": fmt.Sprintf("display-name-%d", projectIdx),
 			"description":  fmt.Sprintf("description-%d", projectIdx),
 		}
 

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -145,7 +145,7 @@ type ProjectMeta struct {
 }
 
 type ProjectSpec struct {
-	DisplayName string `json:"displayName,omitempty"`  // Deprecated. Will be removed in the next major version release
+	DisplayName string `json:"displayName,omitempty"` // Deprecated. Will be removed in the next major version release
 	Description string `json:"description,omitempty"`
 }
 

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -145,7 +145,6 @@ type ProjectMeta struct {
 }
 
 type ProjectSpec struct {
-	DisplayName string `json:"displayName,omitempty"`
 	Description string `json:"description,omitempty"`
 }
 

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -145,6 +145,7 @@ type ProjectMeta struct {
 }
 
 type ProjectSpec struct {
+	DisplayName string `json:"displayName,omitempty"`  // Deprecated. Will be removed in the next major version release
 	Description string `json:"description,omitempty"`
 }
 


### PR DESCRIPTION
Project ID (name) will be the one that is displayed. (instead of receiving `displayName` and generating uuid as project ID).
This change is made to make project identification easier.
This also means that project name cannot be updated anymore.

- Also increased `creationStateUpdatedTimeout` to 45 to prevent early timeout that may happen for example when the download of the function's code/configuration files takes longer than expected

**Note: this PR needs to be merged alongside matching UI branch**