### PR TITLE
[PR #3111 completion] Code-entry types function configuration: fix list-item indentation

### DIFF
--- a/docs/reference/function-configuration/code-entry-types.md
+++ b/docs/reference/function-configuration/code-entry-types.md
@@ -156,9 +156,9 @@ Set the [`spec.build.codeEntryType`](/docs/reference/function-configuration.md#s
 - `spec.build` &mdash;
   - `path` (dashboard: **URL**) (Required) &mdash; the URL of the GitHub repository that contains the function code.
   - `codeEntryAttributes` &mdash;
-    -  `branch` (dashboard: **Branch**) (Required) &mdash; the GitHub repository branch from which to download the function code.
-    - `headers.Authorization` (dashboard: **Token**) (Optional) &mdash; a GitHub access token for download authentication.
-    - `workDir` (dashboard: **Work directory**) (Optional) &mdash; the relative path to the function-code directory within the configured repository branch.
+      -  `branch` (dashboard: **Branch**) (Required) &mdash; the GitHub repository branch from which to download the function code.
+      - `headers.Authorization` (dashboard: **Token**) (Optional) &mdash; a GitHub access token for download authentication.
+      - `workDir` (dashboard: **Work directory**) (Optional) &mdash; the relative path to the function-code directory within the configured repository branch.
       The default work directory is the root directory of the GitHub repository (`"/"`).
 
 <a id="code-entry-type-github-example"></a>
@@ -193,9 +193,9 @@ The following configuration fields provide additional information for performing
   - `path` (dashboard: **URL**) (Required) &mdash; a URL for downloading the archive file.<br/>
     To download an archive file from an Iguazio Data Science Platform data container, the URL should be set to `<API URL of the platform's web-APIs service>/<container name>/<path to archive file>`, and a respective data-access key must be provided in the `spec.build.codeEntryAttributes.headers.X-V3io-Session-Key` field.
   - `codeEntryAttributes` &mdash;
-    - `headers.X-V3io-Session-Key` (dashboard: **Access key**) (Required for a platform archive file) &mdash; an Iguazio Data Science Platform access key, which is required when the download URL (`spec.build.path`) refers to an archive file in a platform data container.
-    - `workDir` (dashboard: **Work directory**) (Required) &mdash; the relative path to the function-code directory within the extracted archive-file directory.
-      The default work directory is the root of the extracted archive-file directory (`"/"`).
+      - `headers.X-V3io-Session-Key` (dashboard: **Access key**) (Required for a platform archive file) &mdash; an Iguazio Data Science Platform access key, which is required when the download URL (`spec.build.path`) refers to an archive file in a platform data container.
+      - `workDir` (dashboard: **Work directory**) (Required) &mdash; the relative path to the function-code directory within the extracted archive-file directory.
+        The default work directory is the root of the extracted archive-file directory (`"/"`).
 
 <a id="code-entry-type-archive-example"></a>
 #### Example


### PR DESCRIPTION
@omesser please merge. (The GitHub output looks good both with the previous and new list-item source-code indentation variations, but in the Nuclio doc site only the second variation results in the desired indentation.)