### PR TITLE
Fix loading jar from archive code entry, and set "python:3.6" as default python3.6 base image

### DIFF
--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1507,8 +1507,8 @@ func (b *Builder) resolveFunctionPathFromURL(functionPath string, codeEntryType 
 		}
 
 		isArchive := codeEntryType == S3EntryType ||
-			codeEntryType == ArchiveEntryType ||
-			codeEntryType == GithubEntryType
+			codeEntryType == GithubEntryType ||
+			(codeEntryType == ArchiveEntryType && !util.IsJar(functionPath))
 
 		tempDir, err := b.mkDirUnderTemp("download")
 		if err != nil {
@@ -1536,8 +1536,7 @@ func (b *Builder) resolveFunctionPathFromURL(functionPath string, codeEntryType 
 			return "", errors.Wrap(err, "Failed to download file")
 		}
 
-		if (codeEntryType == S3EntryType || codeEntryType == GithubEntryType || codeEntryType == ArchiveEntryType) &&
-			!util.IsCompressed(tempFile.Name()) {
+		if isArchive && !util.IsCompressed(tempFile.Name()) {
 			return "", errors.New("Downloaded file type is not supported. (expected an archive)")
 		}
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1508,7 +1508,10 @@ func (b *Builder) resolveFunctionPathFromURL(functionPath string, codeEntryType 
 
 		isArchive := codeEntryType == S3EntryType ||
 			codeEntryType == GithubEntryType ||
-			(codeEntryType == ArchiveEntryType && !util.IsJar(functionPath))
+			codeEntryType == ArchiveEntryType
+
+		// jar is an exception - we want it to remain compressed, as our java runtime processor expects to get it
+		isArchive = isArchive && !util.IsJar(functionPath)
 
 		tempDir, err := b.mkDirUnderTemp("download")
 		if err != nil {

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -40,7 +40,7 @@ func (p *python) GetProcessorDockerfileInfo(versionInfo *version.Info) (*runtime
 	if p.FunctionConfig.Spec.Runtime == "python:2.7" {
 		processorDockerfileInfo.BaseImage = "python:2.7-alpine"
 	} else {
-		processorDockerfileInfo.BaseImage = "python:3.6-alpine"
+		processorDockerfileInfo.BaseImage = "python:3.6"
 	}
 
 	processorDockerfileInfo.OnbuildArtifactPaths = map[string]string{

--- a/pkg/processor/build/util/decompress.go
+++ b/pkg/processor/build/util/decompress.go
@@ -61,10 +61,14 @@ func (d *Decompressor) Decompress(source string, target string) error {
 func IsCompressed(source string) bool {
 
 	// Jars are special case
-	if strings.ToLower(path.Ext(source)) == ".jar" {
+	if IsJar(source) {
 		return false
 	}
 
 	fileArchiver := archiver.MatchingFormat(source)
 	return fileArchiver != nil
+}
+
+func IsJar(source string) bool {
+	return strings.ToLower(path.Ext(source)) == ".jar"
 }


### PR DESCRIPTION
Changes:
- Updated `isArchive` boolean to be set to `false` whenever it is "archive" code entry and a jar file is given as its path, to make it possible to load java functions as jar file this way using the UI.
- Changed python3.6 default base image to be "python:3.6" instead of "python:3.6-alpine"