### PR TITLE
Make function labels immutable

### DIFF
--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -33,7 +33,7 @@ The `metadata` section includes the following attributes:
 | :--- | :--- | :--- |
 | name | string | The name of the function |
 | namespace | string | A level of isolation provided by the platform (e.g., Kubernetes) |
-| labels | map | A list of key-value tags that are used for looking up the function |
+| labels | map | A list of key-value tags that are used for looking up the function (immutable, can't update after first deployment) |
 | annotations | map | A list of annotations based on the key-value tags |
 
 ### Example

--- a/pkg/platform/kube/deployer.go
+++ b/pkg/platform/kube/deployer.go
@@ -70,7 +70,7 @@ func (d *deployer) createOrUpdateFunction(functionInstance *nuclioio.NuclioFunct
 	}
 
 	// convert config, status -> function
-	d.populateFunction(&createFunctionOptions.FunctionConfig, functionStatus, functionInstance)
+	d.populateFunction(&createFunctionOptions.FunctionConfig, functionStatus, functionInstance, functionExisted)
 
 	createFunctionOptions.Logger.DebugWith("Populated function with configuration and status",
 		"function", functionInstance)
@@ -97,15 +97,20 @@ func (d *deployer) createOrUpdateFunction(functionInstance *nuclioio.NuclioFunct
 
 func (d *deployer) populateFunction(functionConfig *functionconfig.Config,
 	functionStatus *functionconfig.Status,
-	functionInstance *nuclioio.NuclioFunction) {
+	functionInstance *nuclioio.NuclioFunction,
+	functionExisted bool) {
 
 	functionInstance.Spec = functionConfig.Spec
 
 	// set meta
 	functionInstance.Name = functionConfig.Meta.Name
 	functionInstance.Namespace = functionConfig.Meta.Namespace
-	functionInstance.Labels = functionConfig.Meta.Labels
 	functionInstance.Annotations = functionConfig.Meta.Annotations
+
+	// set labels only on function creation (never on update)
+	if !functionExisted {
+		functionInstance.Labels = functionConfig.Meta.Labels
+	}
 
 	// set alias as "latest" for now
 	functionInstance.Spec.Alias = "latest"

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -575,12 +575,9 @@ func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 	updateDeployment := func(resource interface{}) (interface{}, error) {
 		deployment := resource.(*apps_v1beta1.Deployment)
 
-		deployment.Labels = functionLabels
 		deployment.Annotations = deploymentAnnotations
 		deployment.Spec.Replicas = &replicas
 		deployment.Spec.Template.Annotations = podAnnotations
-		deployment.Spec.Template.Labels = functionLabels
-		deployment.Spec.Selector.MatchLabels = functionLabels
 		lc.populateDeploymentContainer(functionLabels, function, &deployment.Spec.Template.Spec.Containers[0])
 		deployment.Spec.Template.Spec.Volumes = volumes
 		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = volumeMounts

--- a/pkg/processor/runtime/golang/test/timeout_test.go
+++ b/pkg/processor/runtime/golang/test/timeout_test.go
@@ -48,7 +48,7 @@ func (suite *TimeoutTestSuite) SetupTest() {
 }
 
 func (suite *TimeoutTestSuite) TestTimeout() {
-	eventTimeout := 100 * time.Millisecond
+	eventTimeout := 300 * time.Millisecond
 	createFunctionOptions := suite.GetDeployOptions("timeout", suite.GetFunctionPath("timeout"))
 	createFunctionOptions.FunctionConfig.Spec.EventTimeout = eventTimeout.String()
 

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
@@ -219,7 +220,9 @@ func (suite *TestSuite) DeployFunctionAndRedeploy(createFunctionOptions *platfor
 
 // GetNuclioSourceDir returns path to nuclio source directory
 func (suite *TestSuite) GetNuclioSourceDir() string {
-	return path.Join(os.Getenv("GOPATH"), "src", "github.com", "nuclio", "nuclio")
+	// Take the first
+	goPath := strings.Split(os.Getenv("GOPATH"), ":")[0]
+	return path.Join(goPath, "src", "github.com", "nuclio", "nuclio")
 }
 
 // GetTestFunctionsDir returns the test function dir


### PR DESCRIPTION
It seems that on k8s v1 (we're using v1beta1) label selector became immutable.
It was done because updating label selector caused unexpected behavior that wasn't properly handled.

In this PR we make function's  `Meta.Labels` immutable - it will always stay the same as it was set on the first deployment