### PR TITLE
Add default project and validate project existence on function creation

### DIFF
--- a/cmd/dashboard/app/dashboard.go
+++ b/cmd/dashboard/app/dashboard.go
@@ -69,7 +69,7 @@ func Run(listenAddress string,
 	}
 
 	// create a platform
-	platformInstance, err := factory.CreatePlatform(rootLogger, platformType, nil)
+	platformInstance, err := factory.CreatePlatform(rootLogger, platformType, nil, defaultNamespace)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create platform")
 	}

--- a/cmd/playground/app/playground.go
+++ b/cmd/playground/app/playground.go
@@ -44,7 +44,7 @@ func Run(listenAddress string,
 	}
 
 	// create a platform
-	platformInstance, err := factory.CreatePlatform(logger, platformType, nil)
+	platformInstance, err := factory.CreatePlatform(logger, platformType, nil, "")
 	if err != nil {
 		return errors.Wrap(err, "Failed to create platform")
 	}

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -118,14 +118,6 @@ func (fr *functionResource) Create(request *http.Request) (id string, attributes
 		Namespace: fr.getNamespaceFromRequest(request),
 	}
 
-	projectNameFilter, ok := functionInfo.Meta.Labels["nuclio.io/project-name"]
-	if !ok || projectNameFilter == "" {
-		responseErr = nuclio.WrapErrBadRequest(errors.New("No project name was given inside meta labels"))
-		return
-	}
-
-	getFunctionsOptions.Labels = fmt.Sprintf("nuclio.io/project-name=%s", projectNameFilter)
-
 	// TODO: Add a lock to prevent race conditions here (prevent 2 functions created with the same name)
 	functions, err := fr.getPlatform().GetFunctions(getFunctionsOptions)
 	if err != nil {

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -121,7 +121,7 @@ func (pr *projectResource) Create(request *http.Request) (id string, attributes 
 	})
 
 	if err != nil {
-		if strings.Contains(errors.Cause(err).Error(),"already exists"){
+		if strings.Contains(errors.Cause(err).Error(), "already exists") {
 			return "", nil, nuclio.WrapErrConflict(err)
 		}
 

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -121,7 +121,7 @@ func (pr *projectResource) Create(request *http.Request) (id string, attributes 
 	})
 
 	if err != nil {
-		if strings.Contains(err.Error(),"already exists"){
+		if strings.Contains(errors.Cause(err).Error(),"already exists"){
 			return "", nil, nuclio.WrapErrConflict(err)
 		}
 

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/nuclio/nuclio/pkg/dashboard"
 	"github.com/nuclio/nuclio/pkg/errors"
@@ -120,6 +121,10 @@ func (pr *projectResource) Create(request *http.Request) (id string, attributes 
 	})
 
 	if err != nil {
+		if strings.Contains(err.Error(),"already exists"){
+			return "", nil, nuclio.WrapErrConflict(err)
+		}
+
 		return "", nil, nuclio.WrapErrInternalServerError(err)
 	}
 

--- a/pkg/nuctl/command/nuctl.go
+++ b/pkg/nuctl/command/nuctl.go
@@ -151,7 +151,7 @@ func (rc *RootCommandeer) createPlatform(logger logger.Logger) (platform.Platfor
 	// ask the factory to create the appropriate platform
 	// TODO: as more platforms are supported, i imagine the last argument will be to some
 	// sort of configuration provider interface
-	platformInstance, err := factory.CreatePlatform(logger, rc.platformName, &rc.kubeConfiguration)
+	platformInstance, err := factory.CreatePlatform(logger, rc.platformName, &rc.kubeConfiguration, rc.namespace)
 
 	// set platform specific common
 	switch platformInstance.(type) {

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -174,17 +174,16 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 
 // Validation and enforcement of required function creation logic
 func (ap *Platform) ValidateCreateFunctionOptions(createFunctionOptions *platform.CreateFunctionOptions) error {
-	projectName := createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"]
 
 	// if no project name was given, set it to the default project
-	if projectName == "" {
-		projectName = "default"
+	if createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"] == "" {
+		createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"] = "default"
 	}
 
 	// validate the project exists
 	getProjectsOptions := &platform.GetProjectsOptions{
 		Meta: platform.ProjectMeta {
-			Name: projectName,
+			Name: createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"],
 			Namespace: createFunctionOptions.FunctionConfig.Meta.Namespace,
 		},
 	}

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -187,8 +187,8 @@ func (ap *Platform) ValidateCreateFunctionOptions(createFunctionOptions *platfor
 
 	// validate the project exists
 	getProjectsOptions := &platform.GetProjectsOptions{
-		Meta: platform.ProjectMeta {
-			Name: createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"],
+		Meta: platform.ProjectMeta{
+			Name:      createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"],
 			Namespace: createFunctionOptions.FunctionConfig.Meta.Namespace,
 		},
 	}

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -175,6 +175,11 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 // Validation and enforcement of required function creation logic
 func (ap *Platform) ValidateCreateFunctionOptions(createFunctionOptions *platform.CreateFunctionOptions) error {
 
+	// if labels is nil assign an empty map to it
+	if createFunctionOptions.FunctionConfig.Meta.Labels == nil {
+		createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{}
+	}
+
 	// if no project name was given, set it to the default project
 	if createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"] == "" {
 		createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"] = "default"

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -183,6 +183,7 @@ func (ap *Platform) ValidateCreateFunctionOptions(createFunctionOptions *platfor
 	// if no project name was given, set it to the default project
 	if createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"] == "" {
 		createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"] = "default"
+		ap.Logger.Debug("No project name specified. Setting to default")
 	}
 
 	// validate the project exists

--- a/pkg/platform/factory/factory.go
+++ b/pkg/platform/factory/factory.go
@@ -17,7 +17,6 @@ limitations under the License.
 package factory
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -70,11 +69,11 @@ func CreatePlatform(parentLogger logger.Logger,
 		}
 
 	default:
-		return nil, fmt.Errorf("Can't create platform - unsupported: %s", platformType)
+		return nil, errors.Errorf("Can't create platform - unsupported: %s", platformType)
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create %s platform", platformType)
+		return nil, errors.Errorf("Failed to create %s platform", platformType)
 	}
 
 	if err = ensureDefaultProjectExistence(parentLogger, newPlatform, defaultNamespace); err != nil {
@@ -109,7 +108,7 @@ func ensureDefaultProjectExistence(parentLogger logger.Logger, p platform.Platfo
 		}
 		newProject, err := platform.NewAbstractProject(parentLogger, p, projectConfig)
 		if err != nil {
-			return errors.Wrap(err, "Failed to create abstract project")
+			return errors.Wrap(err, "Failed to create abstract default project")
 		}
 
 		err = p.CreateProject(&platform.CreateProjectOptions{

--- a/pkg/platform/factory/factory.go
+++ b/pkg/platform/factory/factory.go
@@ -63,10 +63,11 @@ func CreatePlatform(parentLogger logger.Logger,
 
 			// call again, but force kube
 			newPlatform, err = CreatePlatform(parentLogger, "kube", platformConfiguration, defaultNamespace)
-		}
+		} else {
 
-		// call again, force local
-		newPlatform, err = CreatePlatform(parentLogger, "local", platformConfiguration, defaultNamespace)
+			// call again, force local
+			newPlatform, err = CreatePlatform(parentLogger, "local", platformConfiguration, defaultNamespace)
+		}
 
 	default:
 		return nil, fmt.Errorf("Can't create platform - unsupported: %s", platformType)

--- a/pkg/platform/factory/factory.go
+++ b/pkg/platform/factory/factory.go
@@ -96,7 +96,7 @@ func ensureDefaultProjectExistence(parentLogger logger.Logger, p platform.Platfo
 		return errors.New("Failed to get projects")
 	}
 
-	if len(projects) != 1 {
+	if len(projects) == 0 {
 
 		// if we're here the default project doesn't exist. create it
 		projectConfig := platform.ProjectConfig{
@@ -117,6 +117,9 @@ func ensureDefaultProjectExistence(parentLogger logger.Logger, p platform.Platfo
 		if err != nil {
 			return errors.Wrap(err, "Failed to create default project")
 		}
+
+	} else if len(projects) > 1 {
+		return errors.New("Something went wrong. There's more than one default project")
 	}
 
 	return nil

--- a/pkg/platform/factory/factory.go
+++ b/pkg/platform/factory/factory.go
@@ -102,6 +102,7 @@ func ensureDefaultProjectExistence(parentLogger logger.Logger, p platform.Platfo
 				Name:      "default",
 				Namespace: p.ResolveDefaultNamespace(defaultNamespace),
 			},
+			Spec: platform.ProjectSpec{},
 		}
 		newProject, err := platform.NewAbstractProject(parentLogger, p, projectConfig)
 		if err != nil {

--- a/pkg/platform/factory/factory.go
+++ b/pkg/platform/factory/factory.go
@@ -85,10 +85,12 @@ func CreatePlatform(parentLogger logger.Logger,
 }
 
 func ensureDefaultProjectExistence(parentLogger logger.Logger, p platform.Platform, defaultNamespace string) error {
+	resolvedNamespace := p.ResolveDefaultNamespace(defaultNamespace)
+
 	projects, err := p.GetProjects(&platform.GetProjectsOptions{
 		Meta: platform.ProjectMeta{
 			Name:      "default",
-			Namespace: defaultNamespace,
+			Namespace: resolvedNamespace,
 		},
 	})
 	if err != nil {
@@ -101,7 +103,7 @@ func ensureDefaultProjectExistence(parentLogger logger.Logger, p platform.Platfo
 		projectConfig := platform.ProjectConfig{
 			Meta: platform.ProjectMeta{
 				Name:      "default",
-				Namespace: p.ResolveDefaultNamespace(defaultNamespace),
+				Namespace: resolvedNamespace,
 			},
 			Spec: platform.ProjectSpec{},
 		}

--- a/pkg/platform/kube/controller/controller.go
+++ b/pkg/platform/kube/controller/controller.go
@@ -94,7 +94,7 @@ func NewController(parentLogger logger.Logger,
 	newController.projectOperator, err = newProjectOperator(parentLogger,
 		newController,
 		&resyncInterval)
-
+	newController.projectOperator.CreateOrUpdate()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create project operator")
 	}

--- a/pkg/platform/kube/controller/controller.go
+++ b/pkg/platform/kube/controller/controller.go
@@ -94,7 +94,6 @@ func NewController(parentLogger logger.Logger,
 	newController.projectOperator, err = newProjectOperator(parentLogger,
 		newController,
 		&resyncInterval)
-	newController.projectOperator.CreateOrUpdate()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create project operator")
 	}

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -132,6 +132,10 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	// replace logger
 	createFunctionOptions.Logger = logStream.GetLogger()
 
+	if err := p.ValidateCreateFunctionOptions(createFunctionOptions); err != nil {
+		return nil, errors.Wrap(err, "Failed in validation of function creation options")
+	}
+
 	reportCreationError := func(creationError error) error {
 		createFunctionOptions.Logger.WarnWith("Create function failed, setting function status",
 			"err", creationError)
@@ -321,21 +325,11 @@ func (p *Platform) UpdateProject(updateProjectOptions *platform.UpdateProjectOpt
 
 // DeleteProject will delete a previously existing project
 func (p *Platform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOptions) error {
-	getFunctionsOptions := &platform.GetFunctionsOptions{
-		Namespace: deleteProjectOptions.Meta.Namespace,
-		Labels:    fmt.Sprintf("nuclio.io/project-name=%s", deleteProjectOptions.Meta.Name),
+	if err := p.Platform.ValidateDeleteProjectOptions(deleteProjectOptions); err != nil {
+		return errors.Wrap(err, "Failed in validation of project deletion options")
 	}
 
-	functions, err := p.GetFunctions(getFunctionsOptions)
-	if err != nil {
-		return errors.Wrap(err, "Failed to get functions")
-	}
-
-	if len(functions) != 0 {
-		return platform.ErrProjectContainsFunctions
-	}
-
-	err = p.consumer.nuclioClientSet.NuclioV1beta1().
+	err := p.consumer.nuclioClientSet.NuclioV1beta1().
 		NuclioProjects(deleteProjectOptions.Meta.Namespace).
 		Delete(deleteProjectOptions.Meta.Name, &meta_v1.DeleteOptions{})
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -133,7 +133,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	createFunctionOptions.Logger = logStream.GetLogger()
 
 	if err := p.ValidateCreateFunctionOptions(createFunctionOptions); err != nil {
-		return nil, errors.Wrap(err, "Failed in validation of function creation options")
+		return nil, errors.Wrap(err, "Create function options validation failed")
 	}
 
 	reportCreationError := func(creationError error) error {
@@ -326,14 +326,12 @@ func (p *Platform) UpdateProject(updateProjectOptions *platform.UpdateProjectOpt
 // DeleteProject will delete a previously existing project
 func (p *Platform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOptions) error {
 	if err := p.Platform.ValidateDeleteProjectOptions(deleteProjectOptions); err != nil {
-		return errors.Wrap(err, "Failed in validation of project deletion options")
+		return errors.Wrap(err, "Delete project options validation failed")
 	}
 
-	err := p.consumer.nuclioClientSet.NuclioV1beta1().
+	if err := p.consumer.nuclioClientSet.NuclioV1beta1().
 		NuclioProjects(deleteProjectOptions.Meta.Namespace).
-		Delete(deleteProjectOptions.Meta.Name, &meta_v1.DeleteOptions{})
-
-	if err != nil {
+		Delete(deleteProjectOptions.Meta.Name, &meta_v1.DeleteOptions{}); err != nil {
 		return errors.Wrapf(err,
 			"Failed to delete project %s from namespace %s",
 			deleteProjectOptions.Meta.Name,

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -109,7 +109,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	createFunctionOptions.Logger = logStream.GetLogger()
 
 	if err := p.ValidateCreateFunctionOptions(createFunctionOptions); err != nil {
-		return nil, errors.Wrap(err, "Failed in validation of function creation options")
+		return nil, errors.Wrap(err, "Create function options validation failed")
 	}
 
 	// local currently doesn't support registries of any kind. remove push / run registry
@@ -375,7 +375,7 @@ func (p *Platform) UpdateProject(updateProjectOptions *platform.UpdateProjectOpt
 // DeleteProject will delete an existing project
 func (p *Platform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOptions) error {
 	if err := p.Platform.ValidateDeleteProjectOptions(deleteProjectOptions); err != nil {
-		return errors.Wrap(err, "Failed in validation of project deletion options")
+		return errors.Wrap(err, "Delete project options validation failed")
 	}
 	return p.localStore.deleteProject(&deleteProjectOptions.Meta)
 }

--- a/pkg/platform/test/platform_test.go
+++ b/pkg/platform/test/platform_test.go
@@ -46,7 +46,7 @@ func (suite *testSuite) SetupTest() {
 		platformName = "local"
 	}
 
-	suite.platform, err = factory.CreatePlatform(suite.logger, "kube", nil)
+	suite.platform, err = factory.CreatePlatform(suite.logger, "kube", nil, "")
 	suite.Require().NoError(err, "Platform should create successfully")
 }
 

--- a/pkg/processor/build/test/build_test.go
+++ b/pkg/processor/build/test/build_test.go
@@ -57,6 +57,7 @@ func (suite *testSuite) TestBuildFuncFromSourceWithInlineConfig() {
 
 echo $MESSAGE`
 
+	createFunctionOptions.FunctionConfig.Meta.Namespace = "default"
 	createFunctionOptions.FunctionConfig.Spec.Handler = "echo-foo-inline.sh"
 	createFunctionOptions.FunctionConfig.Spec.Runtime = "shell"
 	createFunctionOptions.FunctionConfig.Spec.Build.Path = ""

--- a/pkg/processor/build/test/build_test.go
+++ b/pkg/processor/build/test/build_test.go
@@ -91,7 +91,7 @@ func (suite *testSuite) TestBuildFunctionFromSourceCodeMaintainsSource() {
 	tempFile.WriteString("Contents of temp file")
 
 	createFunctionOptions.FunctionConfig.Meta.Name = "funcsource-test"
-	createFunctionOptions.FunctionConfig.Meta.Namespace = "test"
+	createFunctionOptions.FunctionConfig.Meta.Namespace = "default"
 	createFunctionOptions.FunctionConfig.Spec.Handler = "main:handler"
 	createFunctionOptions.FunctionConfig.Spec.Runtime = "python:3.6"
 	createFunctionOptions.FunctionConfig.Spec.Build.Path = tempFile.Name()
@@ -125,7 +125,7 @@ func (suite *testSuite) TestBuildFunctionFromSourceCodeDeployOnceNeverBuild() {
 `))
 
 	createFunctionOptions.FunctionConfig.Meta.Name = "neverbuild-test"
-	createFunctionOptions.FunctionConfig.Meta.Namespace = "test"
+	createFunctionOptions.FunctionConfig.Meta.Namespace = "default"
 	createFunctionOptions.FunctionConfig.Spec.Handler = "main:handler"
 	createFunctionOptions.FunctionConfig.Spec.Runtime = "python:3.6"
 	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = functionSourceCode
@@ -166,7 +166,7 @@ func (suite *testSuite) TestBuildFunctionFromSourceCodeNeverBuildRedeploy() {
 `))
 
 	createFunctionOptions.FunctionConfig.Meta.Name = "neverbuild-redeploy-func"
-	createFunctionOptions.FunctionConfig.Meta.Namespace = "test"
+	createFunctionOptions.FunctionConfig.Meta.Namespace = "default"
 	createFunctionOptions.FunctionConfig.Spec.Handler = "main:handler"
 	createFunctionOptions.FunctionConfig.Spec.Runtime = "python:3.6"
 	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = functionSourceCode

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -28,7 +28,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
-	"github.com/nuclio/nuclio/pkg/platform/local"
+	"github.com/nuclio/nuclio/pkg/platform/factory"
 	"github.com/nuclio/nuclio/pkg/version"
 
 	"github.com/nuclio/logger"
@@ -99,7 +99,7 @@ func (suite *TestSuite) SetupSuite() {
 	suite.DockerClient, err = dockerclient.NewShellClient(suite.Logger, nil)
 	suite.Require().NoError(err)
 
-	suite.Platform, err = local.NewPlatform(suite.Logger)
+	suite.Platform, err = factory.CreatePlatform(suite.Logger, "local", nil, "")
 	suite.Require().NoError(err)
 }
 

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -99,7 +99,7 @@ func (suite *TestSuite) SetupSuite() {
 	suite.DockerClient, err = dockerclient.NewShellClient(suite.Logger, nil)
 	suite.Require().NoError(err)
 
-	suite.Platform, err = factory.CreatePlatform(suite.Logger, "local", nil, "")
+	suite.Platform, err = factory.CreatePlatform(suite.Logger, "local", nil, "nuclio")
 	suite.Require().NoError(err)
 }
 

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -99,7 +99,7 @@ func (suite *TestSuite) SetupSuite() {
 	suite.DockerClient, err = dockerclient.NewShellClient(suite.Logger, nil)
 	suite.Require().NoError(err)
 
-	suite.Platform, err = factory.CreatePlatform(suite.Logger, "local", nil, "nuclio")
+	suite.Platform, err = factory.CreatePlatform(suite.Logger, "local", nil, "default")
 	suite.Require().NoError(err)
 }
 

--- a/pkg/processor/util/v3io/v3ioutil_test.go
+++ b/pkg/processor/util/v3io/v3ioutil_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package v3ioutil
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/nuclio/logger"
 	"github.com/stretchr/testify/suite"
 )
+
+const DefaultPort = 12345
 
 type v3ioUtilTestSuite struct {
 	suite.Suite
@@ -29,24 +32,24 @@ type v3ioUtilTestSuite struct {
 }
 
 func (suite *v3ioUtilTestSuite) TestParseURLNoContainerAlias() {
-	_, _, _, err := ParseURL("http://host:port/")
+	_, _, _, err := ParseURL(fmt.Sprintf("http://host.com:%d/", DefaultPort))
 	suite.Require().Error(err)
 }
 
 func (suite *v3ioUtilTestSuite) TestParseURLNoPath() {
-	addr, containerAlias, path, err := ParseURL("http://host:port/containerAlias")
+	addr, containerAlias, path, err := ParseURL(fmt.Sprintf("http://host.com:%d/containerAlias", DefaultPort))
 	suite.Require().NoError(err)
 
-	suite.Require().Equal("host:port", addr)
+	suite.Require().Equal(fmt.Sprintf("host.com:%d", DefaultPort), addr)
 	suite.Require().Equal("containerAlias", containerAlias)
 	suite.Require().Equal("", path)
 }
 
 func (suite *v3ioUtilTestSuite) TestParseURLWithPath() {
-	addr, containerAlias, path, err := ParseURL("http://host:port/containerAlias/path1/path2/path3/")
+	addr, containerAlias, path, err := ParseURL(fmt.Sprintf("http://host.com:%d/containerAlias/path1/path2/path3/", DefaultPort))
 	suite.Require().NoError(err)
 
-	suite.Require().Equal("host:port", addr)
+	suite.Require().Equal(fmt.Sprintf("host.com:%d", DefaultPort), addr)
 	suite.Require().Equal("containerAlias", containerAlias)
 	suite.Require().Equal("path1/path2/path3", path)
 }


### PR DESCRIPTION
Changes:
 1. Added `default` project.
   - ensure its existence (Create if doesn't exist whenever nuclio starts)
   - make `default` project not deletable
2. Validate project name on function creation
  - when no project name was given assign the function automatically to `default` project
3. Return `Conflict 409` when project creation fails on name already exists