### PR TITLE
Fix HPA deletion condition

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -704,7 +704,7 @@ func (lc *lazyClient) createOrUpdateHorizontalPodAutoscaler(functionLabels label
 		hpa.Spec.MaxReplicas = maxReplicas
 
 		// when the min replicas equal the max replicas, there's no need for hpa resourceToUpdate
-		if function.Spec.MinReplicas == function.Spec.MaxReplicas {
+		if minReplicas == maxReplicas {
 			propogationPolicy := meta_v1.DeletePropagationForeground
 			deleteOptions := &meta_v1.DeleteOptions{
 				PropagationPolicy: &propogationPolicy,


### PR DESCRIPTION
The condition was looking on the function spec (which if the user leaves empty default to 0)
instead of looking on the closure generated values (which takes the values from the function spec, unless they are zero, than they are default to 1 (min) and 10 (max))