### PR TITLE
Changing function spec replicas fields + fixing scale up bug

### DIFF
--- a/pkg/dashboard/functiontemplates/render_test.go
+++ b/pkg/dashboard/functiontemplates/render_test.go
@@ -35,8 +35,8 @@ func (suite *testSuite) SetupSuite() {
 }
 
 func (suite *testSuite) TestFunctionTemplateRender() {
-	minReplicas := int32(1)
-	maxReplicas := int32(2)
+	minReplicas := 1
+	maxReplicas := 2
 	expectedFunctionConfig := &functionconfig.Config{
 		Spec: functionconfig.Spec{
 			Handler:     "myhandler",

--- a/pkg/dashboard/functiontemplates/render_test.go
+++ b/pkg/dashboard/functiontemplates/render_test.go
@@ -35,11 +35,13 @@ func (suite *testSuite) SetupSuite() {
 }
 
 func (suite *testSuite) TestFunctionTemplateRender() {
+	minReplicas := int32(1)
+	maxReplicas := int32(2)
 	expectedFunctionConfig := &functionconfig.Config{
 		Spec: functionconfig.Spec{
 			Handler:     "myhandler",
-			MinReplicas: 1,
-			MaxReplicas: 2,
+			MinReplicas: &minReplicas,
+			MaxReplicas: &maxReplicas,
 			Runtime:     "python:3.6",
 		},
 	}

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -343,7 +343,7 @@ type functionTestSuite struct {
 }
 
 func (suite *functionTestSuite) TestGetDetailSuccessful() {
-	replicas := int32(10)
+	replicas := 10
 	returnedFunction := platform.AbstractFunction{}
 	returnedFunction.Config.Meta.Name = "f1"
 	returnedFunction.Config.Meta.Namespace = "f1Namespace"

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -343,10 +343,11 @@ type functionTestSuite struct {
 }
 
 func (suite *functionTestSuite) TestGetDetailSuccessful() {
+	replicas := int32(10)
 	returnedFunction := platform.AbstractFunction{}
 	returnedFunction.Config.Meta.Name = "f1"
 	returnedFunction.Config.Meta.Namespace = "f1Namespace"
-	returnedFunction.Config.Spec.Replicas = 10
+	returnedFunction.Config.Spec.Replicas = &replicas
 
 	// verify
 	verifyGetFunctions := func(getFunctionsOptions *platform.GetFunctionsOptions) bool {

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -217,9 +217,9 @@ type Spec struct {
 	Resources               v1.ResourceRequirements `json:"resources,omitempty"`
 	Image                   string                  `json:"image,omitempty"`
 	ImageHash               string                  `json:"imageHash,omitempty"`
-	Replicas                *int32                  `json:"replicas,omitempty"`
-	MinReplicas             *int32                  `json:"minReplicas,omitempty"`
-	MaxReplicas             *int32                  `json:"maxReplicas,omitempty"`
+	Replicas                *int                    `json:"replicas,omitempty"`
+	MinReplicas             *int                    `json:"minReplicas,omitempty"`
+	MaxReplicas             *int                    `json:"maxReplicas,omitempty"`
 	TargetCPU               int                     `json:"targetCPU,omitempty"`
 	DataBindings            map[string]DataBinding  `json:"dataBindings,omitempty"`
 	Triggers                map[string]Trigger      `json:"triggers,omitempty"`

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -324,7 +324,6 @@ func NewConfig() *Config {
 		Meta: Meta{
 			Namespace: "default",
 		},
-		Spec: Spec{},
 	}
 }
 

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -217,9 +217,9 @@ type Spec struct {
 	Resources               v1.ResourceRequirements `json:"resources,omitempty"`
 	Image                   string                  `json:"image,omitempty"`
 	ImageHash               string                  `json:"imageHash,omitempty"`
-	Replicas                int                     `json:"replicas,omitempty"`
-	MinReplicas             int                     `json:"minReplicas,omitempty"`
-	MaxReplicas             int                     `json:"maxReplicas,omitempty"`
+	Replicas                *int32                  `json:"replicas,omitempty"`
+	MinReplicas             *int32                  `json:"minReplicas,omitempty"`
+	MaxReplicas             *int32                  `json:"maxReplicas,omitempty"`
 	TargetCPU               int                     `json:"targetCPU,omitempty"`
 	DataBindings            map[string]DataBinding  `json:"dataBindings,omitempty"`
 	Triggers                map[string]Trigger      `json:"triggers,omitempty"`

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -324,9 +324,7 @@ func NewConfig() *Config {
 		Meta: Meta{
 			Namespace: "default",
 		},
-		Spec: Spec{
-			Replicas: nil,
-		},
+		Spec: Spec{},
 	}
 }
 

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -325,7 +325,7 @@ func NewConfig() *Config {
 			Namespace: "default",
 		},
 		Spec: Spec{
-			Replicas: 1,
+			Replicas: nil,
 		},
 	}
 }

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -214,7 +214,7 @@ func addDeployFlags(cmd *cobra.Command,
 	cmd.Flags().StringVarP(&commandeer.encodedLabels, "labels", "l", "", "Additional function labels (lbl1=val1[,lbl2=val2,...])")
 	cmd.Flags().VarP(&commandeer.encodedEnv, "env", "e", "Environment variables env1=val1")
 	cmd.Flags().BoolVarP(&functionConfig.Spec.Disabled, "disabled", "d", false, "Start the function as disabled (don't run yet)")
-	cmd.Flags().Int32VarP(&commandeer.replicas, "replicas", "", -1, "Set to 1 to use a static number of replicas")
+	cmd.Flags().Int32VarP(&commandeer.replicas, "replicas", "", -1, "Set to any non-negative integer to use a static number of replicas")
 	cmd.Flags().Int32Var(&commandeer.minReplicas, "min-replicas", -1, "Minimal number of function replicas")
 	cmd.Flags().Int32Var(&commandeer.maxReplicas, "max-replicas", -1, "Maximal number of function replicas")
 	cmd.Flags().IntVar(&functionConfig.Spec.TargetCPU, "target-cpu", 75, "Target CPU when auto-scaling, in percentage")

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -51,6 +51,9 @@ type deployCommandeer struct {
 	encodedBuildCodeEntryAttributes string
 	inputImageFile                  string
 	loggerLevel                     string
+	replicas                        int32
+	minReplicas                     int32
+	maxReplicas                     int32
 }
 
 func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
@@ -159,6 +162,27 @@ func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
 				}
 			}
 
+			// check if replicas is set (-1 is the default - counted as not set)
+			if commandeer.replicas == -1 {
+				commandeer.functionConfig.Spec.Replicas = nil
+			} else {
+				commandeer.functionConfig.Spec.Replicas = &commandeer.replicas
+			}
+
+			// check if minReplicas is set (-1 is the default - counted as not set)
+			if commandeer.minReplicas == -1 {
+				commandeer.functionConfig.Spec.MinReplicas = nil
+			} else {
+				commandeer.functionConfig.Spec.MinReplicas = &commandeer.minReplicas
+			}
+
+			// check if maxReplicas is set (-1 is the default - counted as not set)
+			if commandeer.maxReplicas == -1 {
+				commandeer.functionConfig.Spec.MaxReplicas = nil
+			} else {
+				commandeer.functionConfig.Spec.MaxReplicas = &commandeer.maxReplicas
+			}
+
 			// update function
 			commandeer.functionConfig.Meta.Namespace = rootCommandeer.namespace
 			commandeer.functionConfig.Spec.Build.Commands = commandeer.commands
@@ -190,9 +214,9 @@ func addDeployFlags(cmd *cobra.Command,
 	cmd.Flags().StringVarP(&commandeer.encodedLabels, "labels", "l", "", "Additional function labels (lbl1=val1[,lbl2=val2,...])")
 	cmd.Flags().VarP(&commandeer.encodedEnv, "env", "e", "Environment variables env1=val1")
 	cmd.Flags().BoolVarP(&functionConfig.Spec.Disabled, "disabled", "d", false, "Start the function as disabled (don't run yet)")
-	cmd.Flags().IntVarP(&functionConfig.Spec.Replicas, "replicas", "", 1, "Set to 1 to use a static number of replicas")
-	cmd.Flags().IntVar(&functionConfig.Spec.MinReplicas, "min-replicas", 0, "Minimal number of function replicas")
-	cmd.Flags().IntVar(&functionConfig.Spec.MaxReplicas, "max-replicas", 0, "Maximal number of function replicas")
+	cmd.Flags().Int32VarP(&commandeer.replicas, "replicas", "", -1, "Set to 1 to use a static number of replicas")
+	cmd.Flags().Int32Var(&commandeer.minReplicas, "min-replicas", -1, "Minimal number of function replicas")
+	cmd.Flags().Int32Var(&commandeer.maxReplicas, "max-replicas", -1, "Maximal number of function replicas")
 	cmd.Flags().IntVar(&functionConfig.Spec.TargetCPU, "target-cpu", 75, "Target CPU when auto-scaling, in percentage")
 	cmd.Flags().BoolVar(&functionConfig.Spec.Publish, "publish", false, "Publish the function")
 	cmd.Flags().StringVar(&commandeer.encodedDataBindings, "data-bindings", "{}", "JSON-encoded data bindings for the function")

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -51,9 +51,9 @@ type deployCommandeer struct {
 	encodedBuildCodeEntryAttributes string
 	inputImageFile                  string
 	loggerLevel                     string
-	replicas                        int32
-	minReplicas                     int32
-	maxReplicas                     int32
+	replicas                        int
+	minReplicas                     int
+	maxReplicas                     int
 }
 
 func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
@@ -208,9 +208,9 @@ func addDeployFlags(cmd *cobra.Command,
 	cmd.Flags().StringVarP(&commandeer.encodedLabels, "labels", "l", "", "Additional function labels (lbl1=val1[,lbl2=val2,...])")
 	cmd.Flags().VarP(&commandeer.encodedEnv, "env", "e", "Environment variables env1=val1")
 	cmd.Flags().BoolVarP(&functionConfig.Spec.Disabled, "disabled", "d", false, "Start the function as disabled (don't run yet)")
-	cmd.Flags().Int32VarP(&commandeer.replicas, "replicas", "", -1, "Set to any non-negative integer to use a static number of replicas")
-	cmd.Flags().Int32Var(&commandeer.minReplicas, "min-replicas", -1, "Minimal number of function replicas")
-	cmd.Flags().Int32Var(&commandeer.maxReplicas, "max-replicas", -1, "Maximal number of function replicas")
+	cmd.Flags().IntVarP(&commandeer.replicas, "replicas", "", -1, "Set to any non-negative integer to use a static number of replicas")
+	cmd.Flags().IntVar(&commandeer.minReplicas, "min-replicas", -1, "Minimal number of function replicas")
+	cmd.Flags().IntVar(&commandeer.maxReplicas, "max-replicas", -1, "Maximal number of function replicas")
 	cmd.Flags().IntVar(&functionConfig.Spec.TargetCPU, "target-cpu", 75, "Target CPU when auto-scaling, in percentage")
 	cmd.Flags().BoolVar(&functionConfig.Spec.Publish, "publish", false, "Publish the function")
 	cmd.Flags().StringVar(&commandeer.encodedDataBindings, "data-bindings", "{}", "JSON-encoded data bindings for the function")

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -162,24 +162,18 @@ func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
 				}
 			}
 
-			// check if replicas is set (-1 is the default - counted as not set)
-			if commandeer.replicas == -1 {
-				commandeer.functionConfig.Spec.Replicas = nil
-			} else {
+			// any negative value counted as not set (meaning leaving commandeer.functionConfig.Spec.Replicas as nil)
+			if commandeer.replicas >= 0 {
 				commandeer.functionConfig.Spec.Replicas = &commandeer.replicas
 			}
 
-			// check if minReplicas is set (-1 is the default - counted as not set)
-			if commandeer.minReplicas == -1 {
-				commandeer.functionConfig.Spec.MinReplicas = nil
-			} else {
+			// any negative value counted as not set (meaning leaving commandeer.functionConfig.Spec.MinReplicas as nil)
+			if commandeer.minReplicas >= 0 {
 				commandeer.functionConfig.Spec.MinReplicas = &commandeer.minReplicas
 			}
 
-			// check if maxReplicas is set (-1 is the default - counted as not set)
-			if commandeer.maxReplicas == -1 {
-				commandeer.functionConfig.Spec.MaxReplicas = nil
-			} else {
+			// any negative value counted as not set (meaning leaving commandeer.functionConfig.Spec.MaxReplicas as nil)
+			if commandeer.maxReplicas >= 0 {
 				commandeer.functionConfig.Spec.MaxReplicas = &commandeer.maxReplicas
 			}
 

--- a/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
+++ b/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
@@ -31,7 +31,8 @@ func (nf *NuclioFunction) GetComputedReplicas() *int32 {
 		if *nf.Spec.Replicas < 0 {
 			return &zero
 		} else {
-			return nf.Spec.Replicas
+			replicas := int32(*nf.Spec.Replicas)
+			return &replicas
 		}
 	} else {
 
@@ -63,7 +64,7 @@ func (nf *NuclioFunction) GetComputedMinReplicas() int32 {
 		if *nf.Spec.Replicas < 0 {
 			return 0
 		} else {
-			return *nf.Spec.Replicas
+			return int32(*nf.Spec.Replicas)
 		}
 	} else {
 		if nf.Spec.MinReplicas != nil {
@@ -72,7 +73,7 @@ func (nf *NuclioFunction) GetComputedMinReplicas() int32 {
 			if *nf.Spec.MinReplicas < 0 {
 				return 0
 			} else {
-				return *nf.Spec.MinReplicas
+				return int32(*nf.Spec.MinReplicas)
 			}
 		} else {
 
@@ -88,19 +89,19 @@ func (nf *NuclioFunction) GetComputedMaxReplicas() int32 {
 	if nf.Spec.Replicas != nil {
 
 		// Negative values -> 0
-		if *nf.Spec.Replicas <= 0 {
+		if *nf.Spec.Replicas < 0 {
 			return 0
 		} else {
-			return *nf.Spec.Replicas
+			return int32(*nf.Spec.Replicas)
 		}
 	} else {
 		if nf.Spec.MaxReplicas != nil {
 
 			// Negative values -> 0
-			if *nf.Spec.MaxReplicas <= 0 {
+			if *nf.Spec.MaxReplicas < 0 {
 				return 0
 			} else {
-				return *nf.Spec.MaxReplicas
+				return int32(*nf.Spec.MaxReplicas)
 			}
 		} else {
 

--- a/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
+++ b/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
@@ -69,7 +69,7 @@ func (nf *NuclioFunction) GetSpecMinReplicas() int32 {
 				minReplicas = *nf.Spec.MinReplicas
 			}
 		} else {
-			minReplicas = 0
+			minReplicas = 1
 		}
 	}
 
@@ -93,7 +93,7 @@ func (nf *NuclioFunction) GetSpecMaxReplicas() int32 {
 				maxReplicas = *nf.Spec.MaxReplicas
 			}
 		} else {
-			maxReplicas = 10
+			maxReplicas = 1
 		}
 	}
 

--- a/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
+++ b/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
@@ -19,7 +19,7 @@ type NuclioFunction struct {
 	Status functionconfig.Status `json:"status,omitempty"`
 }
 
-func (nf *NuclioFunction) GetSpecReplicas() *int32 {
+func (nf *NuclioFunction) GetComputedReplicas() *int32 {
 	var replicas *int32
 	zero := int32(0)
 	one := int32(1)
@@ -37,7 +37,7 @@ func (nf *NuclioFunction) GetSpecReplicas() *int32 {
 	} else {
 
 		// If the user hasn't specified desired replicas - base on the MinReplicas
-		minReplicas := nf.GetSpecMinReplicas()
+		minReplicas := nf.GetComputedMinReplicas()
 
 		if minReplicas > 0 {
 			replicas = &minReplicas
@@ -59,7 +59,7 @@ func (nf *NuclioFunction) GetSpecReplicas() *int32 {
 
 }
 
-func (nf *NuclioFunction) GetSpecMinReplicas() int32 {
+func (nf *NuclioFunction) GetComputedMinReplicas() int32 {
 	var minReplicas int32
 
 	// Replicas takes precedence over MinReplicas, so if given override with its value
@@ -90,7 +90,7 @@ func (nf *NuclioFunction) GetSpecMinReplicas() int32 {
 	return minReplicas
 }
 
-func (nf *NuclioFunction) GetSpecMaxReplicas() int32 {
+func (nf *NuclioFunction) GetComputedMaxReplicas() int32 {
 	var maxReplicas int32
 
 	// Replicas takes precedence over MaxReplicas, so if given override with its value

--- a/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
+++ b/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
@@ -19,6 +19,83 @@ type NuclioFunction struct {
 	Status functionconfig.Status `json:"status,omitempty"`
 }
 
+func (nf *NuclioFunction) GetSpecReplicas() *int32 {
+	var replicas int32
+
+	// only when function is scaled to zero or disabled, allow for replicas to be set to zero
+	if nf.Spec.Disabled || nf.Status.State == functionconfig.FunctionStateScaledToZero {
+		replicas = 0
+	} else if nf.Spec.Replicas != nil {
+		if *nf.Spec.Replicas <= 0 {
+			replicas = 0
+		} else {
+			replicas = *nf.Spec.Replicas
+		}
+	} else {
+		minReplicas := nf.GetSpecMinReplicas()
+
+		if minReplicas > 0 {
+			replicas = minReplicas
+		} else {
+			replicas = -1
+		}
+	}
+
+	if replicas == -1 {
+		return nil
+	} else {
+		return &replicas
+	}
+}
+
+func (nf *NuclioFunction) GetSpecMinReplicas() int32 {
+	var minReplicas int32
+
+	if nf.Spec.Replicas != nil {
+		if *nf.Spec.Replicas <= 0 {
+			minReplicas = 0
+		} else {
+			minReplicas = *nf.Spec.Replicas
+		}
+	} else {
+		if nf.Spec.MinReplicas != nil {
+			if *nf.Spec.MinReplicas <= 0 {
+				minReplicas = 0
+			} else {
+				minReplicas = *nf.Spec.MinReplicas
+			}
+		} else {
+			minReplicas = 0
+		}
+	}
+
+	return minReplicas
+}
+
+func (nf *NuclioFunction) GetSpecMaxReplicas() int32 {
+	var maxReplicas int32
+
+	if nf.Spec.Replicas != nil {
+		if *nf.Spec.Replicas <= 0 {
+			maxReplicas = 0
+		} else {
+			maxReplicas = *nf.Spec.Replicas
+		}
+	} else {
+		if nf.Spec.MaxReplicas != nil {
+			if *nf.Spec.MaxReplicas <= 0 {
+				maxReplicas = 0
+			} else {
+				maxReplicas = *nf.Spec.MaxReplicas
+			}
+		} else {
+			maxReplicas = 10
+		}
+	}
+
+	return maxReplicas
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // NuclioFunctionList is a list of NuclioFunction resources

--- a/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
+++ b/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
@@ -37,7 +37,11 @@ func (nf *NuclioFunction) GetSpecReplicas() *int32 {
 		if minReplicas > 0 {
 			replicas = minReplicas
 		} else {
-			replicas = -1
+			if nf.Status.State == functionconfig.FunctionStateWaitingForResourceConfiguration {
+				replicas = 1
+			} else {
+				replicas = -1
+			}
 		}
 	}
 

--- a/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
+++ b/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
@@ -20,105 +20,94 @@ type NuclioFunction struct {
 }
 
 func (nf *NuclioFunction) GetComputedReplicas() *int32 {
-	var replicas *int32
 	zero := int32(0)
 	one := int32(1)
 
 	if nf.Spec.Disabled || nf.Status.State == functionconfig.FunctionStateScaledToZero {
-		replicas = &zero
+		return &zero
 	} else if nf.Spec.Replicas != nil {
 
 		// Negative values -> 0
 		if *nf.Spec.Replicas < 0 {
-			replicas = &zero
+			return &zero
 		} else {
-			replicas = nf.Spec.Replicas
+			return nf.Spec.Replicas
 		}
 	} else {
 
-		// If the user hasn't specified desired replicas - base on the MinReplicas
-		minReplicas := nf.GetComputedMinReplicas()
+		// The user hasn't specified desired replicas
+		// If the function doesn't have resources yet (creating/scaling up from zero) - base on the MinReplicas or default to 1
+		if nf.Status.State == functionconfig.FunctionStateWaitingForResourceConfiguration {
+			minReplicas := nf.GetComputedMinReplicas()
 
-		if minReplicas > 0 {
-			replicas = &minReplicas
+			if minReplicas > 0 {
+				return &minReplicas
+			} else {
+				return &one
+			}
 		} else {
 
-			// If the function doesn't have resources yet (creating/scaling up from zero) - start from 1
-			if nf.Status.State == functionconfig.FunctionStateWaitingForResourceConfiguration {
-				replicas = &one
-			} else {
-
-				// Should get here only in case of update of an existing deployment,
-				// sending nil meaning leave the existing replicas as is
-				replicas = nil
-			}
+			// Should get here only in case of update of an existing deployment,
+			// sending nil meaning leave the existing replicas as is
+			return nil
 		}
 	}
-
-	return replicas
-
 }
 
 func (nf *NuclioFunction) GetComputedMinReplicas() int32 {
-	var minReplicas int32
 
 	// Replicas takes precedence over MinReplicas, so if given override with its value
 	if nf.Spec.Replicas != nil {
 
 		// Negative values -> 0
 		if *nf.Spec.Replicas < 0 {
-			minReplicas = 0
+			return 0
 		} else {
-			minReplicas = *nf.Spec.Replicas
+			return *nf.Spec.Replicas
 		}
 	} else {
 		if nf.Spec.MinReplicas != nil {
 
 			// Negative values -> 0
 			if *nf.Spec.MinReplicas < 0 {
-				minReplicas = 0
+				return 0
 			} else {
-				minReplicas = *nf.Spec.MinReplicas
+				return *nf.Spec.MinReplicas
 			}
 		} else {
 
 			// If neither Replicas nor MinReplicas is given, default to 1
-			minReplicas = 1
+			return 1
 		}
 	}
-
-	return minReplicas
 }
 
 func (nf *NuclioFunction) GetComputedMaxReplicas() int32 {
-	var maxReplicas int32
 
 	// Replicas takes precedence over MaxReplicas, so if given override with its value
 	if nf.Spec.Replicas != nil {
 
 		// Negative values -> 0
 		if *nf.Spec.Replicas <= 0 {
-			maxReplicas = 0
+			return 0
 		} else {
-			maxReplicas = *nf.Spec.Replicas
+			return *nf.Spec.Replicas
 		}
 	} else {
 		if nf.Spec.MaxReplicas != nil {
 
 			// Negative values -> 0
 			if *nf.Spec.MaxReplicas <= 0 {
-				maxReplicas = 0
+				return 0
 			} else {
-				maxReplicas = *nf.Spec.MaxReplicas
+				return *nf.Spec.MaxReplicas
 			}
 		} else {
 
 			// If neither Replicas nor MaxReplicas is given, default to 1
-			maxReplicas = 1
+			return 1
 		}
 	}
-
-	return maxReplicas
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -665,7 +665,7 @@ func (lc *lazyClient) createOrUpdateHorizontalPodAutoscaler(functionLabels label
 
 	minReplicas := function.GetComputedMinReplicas()
 	maxReplicas := function.GetComputedMaxReplicas()
-	lc.logger.DebugWith("Got min/max replicas", "minReplicas", minReplicas, "maxReplicas", maxReplicas)
+	lc.logger.DebugWith("Create/Update hpa", "minReplicas", minReplicas, "maxReplicas", maxReplicas)
 
 	// hpa min replicas must be equal or greater than 1
 	if minReplicas < 1 {
@@ -742,7 +742,7 @@ func (lc *lazyClient) createOrUpdateHorizontalPodAutoscaler(functionLabels label
 				PropagationPolicy: &propogationPolicy,
 			}
 
-			lc.logger.DebugWith("Min and max replicas spec equal, deleting hpa", "name", hpa.Name)
+			lc.logger.DebugWith("Deleting hpa - min replicas and max replicas are equal", "name", hpa.Name)
 
 			err := lc.kubeClientSet.AutoscalingV2beta1().HorizontalPodAutoscalers(function.Namespace).Delete(hpa.Name, deleteOptions)
 			return nil, err

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/apimachinery/pkg/types"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -49,6 +48,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 )

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -506,7 +506,7 @@ func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 		return nil, errors.Wrap(err, "Failed to get pod annotations")
 	}
 
-	replicas := function.GetSpecReplicas()
+	replicas := function.GetComputedReplicas()
 	lc.logger.DebugWith("Got replicas", "replicas", replicas)
 	deploymentAnnotations, err := lc.getDeploymentAnnotations(function)
 	if err != nil {
@@ -643,13 +643,13 @@ func (lc *lazyClient) enrichDeploymentFromPlatformConfiguration(functionLabels l
 func (lc *lazyClient) createOrUpdateHorizontalPodAutoscaler(functionLabels labels.Set,
 	function *nuclioio.NuclioFunction) (*autos_v2.HorizontalPodAutoscaler, error) {
 
-	minReplicas := function.GetSpecMinReplicas()
+	minReplicas := function.GetComputedMinReplicas()
 
 	// hpa min replicas must be greater than 1
 	if minReplicas <= 1 {
 		minReplicas = int32(1)
 	}
-	maxReplicas := function.GetSpecMaxReplicas()
+	maxReplicas := function.GetComputedMaxReplicas()
 
 	targetCPU := int32(function.Spec.TargetCPU)
 	if targetCPU == 0 {

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -591,8 +591,7 @@ func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 				"currentReplicas", deployment.Status.Replicas)
 			if deployment.Status.Replicas > maxReplicas {
 				replicas = &maxReplicas
-			}
-			if deployment.Status.Replicas < minReplicas {
+			} else if deployment.Status.Replicas < minReplicas {
 				replicas = &minReplicas
 			}
 		}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -507,7 +507,11 @@ func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 	}
 
 	replicas := function.GetComputedReplicas()
-	lc.logger.DebugWith("Got replicas", "replicas", replicas)
+	if replicas != nil {
+		lc.logger.DebugWith("Got replicas", "replicas", *replicas)
+	} else {
+		lc.logger.DebugWith("Got nil replicas")
+	}
 	deploymentAnnotations, err := lc.getDeploymentAnnotations(function)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get function annotations")

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -594,7 +594,14 @@ func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 			return nil, err
 		}
 
-		return lc.kubeClientSet.AppsV1beta1().Deployments(function.Namespace).Update(deployment)
+		body, err := json.Marshal(deployment)
+		if err != nil {
+			return "", errors.Wrap(err, "Failed to marshal deployment resource")
+		}
+
+		return lc.kubeClientSet.AppsV1beta1().Deployments(function.Namespace).Patch(deployment.Name,
+			types.MergePatchType,
+			body)
 	}
 
 	resource, err := lc.createOrUpdateResource("deployment",

--- a/pkg/platform/kube/resourcescaler/resourcescaler.go
+++ b/pkg/platform/kube/resourcescaler/resourcescaler.go
@@ -83,7 +83,7 @@ func (n *NuclioResourceScaler) GetResources() ([]scaler_types.Resource, error) {
 	for _, function := range functions.Items {
 
 		// don't include functions that aren't in ready state or that min replicas is larger than zero
-		if function.GetSpecMinReplicas() <= 0 && function.Status.State == functionconfig.FunctionStateReady {
+		if function.GetComputedMinReplicas() <= 0 && function.Status.State == functionconfig.FunctionStateReady {
 			functionList = append(functionList, scaler_types.Resource(function.Name))
 		}
 	}

--- a/pkg/platform/kube/resourcescaler/resourcescaler.go
+++ b/pkg/platform/kube/resourcescaler/resourcescaler.go
@@ -83,7 +83,7 @@ func (n *NuclioResourceScaler) GetResources() ([]scaler_types.Resource, error) {
 	for _, function := range functions.Items {
 
 		// don't include functions that aren't in ready state or that min replicas is larger than zero
-		if function.Spec.MinReplicas == 0 && function.Status.State == functionconfig.FunctionStateReady {
+		if function.GetSpecMinReplicas() <= 0 && function.Status.State == functionconfig.FunctionStateReady {
 			functionList = append(functionList, scaler_types.Resource(function.Name))
 		}
 	}

--- a/pkg/playground/resource/function.go
+++ b/pkg/playground/resource/function.go
@@ -169,7 +169,7 @@ func (f *function) createDeployOptions() *platform.CreateFunctionOptions {
 	}
 
 	createFunctionOptions.FunctionConfig = f.attributes.Config
-	createFunctionOptions.FunctionConfig.Spec.Replicas = 1
+	createFunctionOptions.FunctionConfig.Spec.Replicas = nil
 	createFunctionOptions.FunctionConfig.Spec.Build.NoBaseImagesPull = server.NoPullBaseImages
 	createFunctionOptions.FunctionConfig.Spec.ReadinessTimeoutSeconds = 30
 	createFunctionOptions.Logger = f.muxLogger

--- a/pkg/playground/resource/function.go
+++ b/pkg/playground/resource/function.go
@@ -169,7 +169,6 @@ func (f *function) createDeployOptions() *platform.CreateFunctionOptions {
 	}
 
 	createFunctionOptions.FunctionConfig = f.attributes.Config
-	createFunctionOptions.FunctionConfig.Spec.Replicas = nil
 	createFunctionOptions.FunctionConfig.Spec.Build.NoBaseImagesPull = server.NoPullBaseImages
 	createFunctionOptions.FunctionConfig.Spec.ReadinessTimeoutSeconds = 30
 	createFunctionOptions.Logger = f.muxLogger


### PR DESCRIPTION
Changes:
* Function spec replicas fields (`Replicas`, `MinReplicas`, `MaxReplicas`) changed to be `*int` instead of `int` to enable the `nil` value, which is there to mark "Not given"

* `Replicas` takes precedence over `MinReplicas/MaxReplicas`, e.g. if the given spec is:
```
Replicas: 3,
MinReplicas: 1,
MaxReplicas: 5
```
than in practice `MinReplicas` and `MaxReplicas` will be 3 (meaning no scale up/down will be active)

* if neither `Replicas` nor `MinReplicas` nor `MaxReplicas` is given, these defaults will be applied:
```
Replicas: nil,
MinReplicas: 1,
MaxReplicas: 1
```

* (Bugfix) The nuclio function crd operator changed to patch the deployment on update instead of updating it. 
Updating the deployment caused to override the deployment's replicas on every update, which in case of a scaled up function, could cause to an unwanted scale down (overriding the deployment's replicas to the function's spec replicas which is mostly 1)