### PR TITLE
Convert local file function deployment to image code entry type

### DIFF
--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -228,7 +228,12 @@ func (b *Builder) Build(options *platform.CreateFunctionBuildOptions) (*platform
 
 	// copy the configuration we enriched, restoring any fields that should not be leaked externally
 	enrichedConfiguration := b.options.FunctionConfig
-	enrichedConfiguration.Spec.Build.Path = b.originalFunctionConfig.Spec.Build.Path
+
+	if enrichedConfiguration.Spec.Build.CodeEntryType == ImageEntryType {
+		enrichedConfiguration.Spec.Build.Path = ""
+	} else {
+		enrichedConfiguration.Spec.Build.Path = b.originalFunctionConfig.Spec.Build.Path
+	}
 
 	// if a callback is registered, call back
 	if b.options.OnAfterConfigUpdate != nil {
@@ -248,8 +253,8 @@ func (b *Builder) Build(options *platform.CreateFunctionBuildOptions) (*platform
 		return nil, errors.Wrap(err, "Failed to build processor image")
 	}
 
-	if b.options.FunctionConfig.Spec.Image == "@set-after-build" {
-		b.options.FunctionConfig.Spec.Image = processorImage
+	if enrichedConfiguration.Spec.Build.CodeEntryType == ImageEntryType {
+		enrichedConfiguration.Spec.Image = processorImage
 	}
 
 	buildResult := &platform.CreateFunctionBuildResult{
@@ -558,7 +563,6 @@ func (b *Builder) resolveFunctionPath(functionPath string) (string, error) {
 			b.options.FunctionConfig.Spec.Build.CodeEntryType = ArchiveEntryType
 		} else {
 			b.options.FunctionConfig.Spec.Build.CodeEntryType = ImageEntryType
-			b.options.FunctionConfig.Spec.Image = "@set-after-build"
 		}
 	}
 


### PR DESCRIPTION
When deploying a function with a **local archive/jar** path (for example - `nuctl deploy newfunc -p ~/func.jar ...`) set the function's code entry type to `image`, reasons:
 - it will appear nicely on the UI
 - it will be re-deployable - because the image is the only artifact that is reachable when redeploying from the UI
This change applies only to archive/jar paths - because other files, are source code files (`.py`,`.go`...) and will be filled into the functionSourceCode.

When deploying given a **remote  jar/archive** path - the code entry type will be set to `archive`, to match the flow we are performing on the UI