### PR TITLE
UI: Show "Invocations #" column in production

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -53,7 +53,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.9.25",
+    "iguazio.dashboard-controls": "^0.9.27",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- Function screen: [bugfix] status icon hides on small resolution
- Functions list: [bugfix] "invocation #" column always shows 0, and is displayed in demo-mode only

Depends on PR https://github.com/iguazio/dashboard-controls/pull/725