### PR TITLE
Fix gpu allocation on redeploy

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -578,12 +578,7 @@ func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 		if err := lc.enrichDeploymentFromPlatformConfiguration(function, deployment, method); err != nil {
 			return nil, err
 		}
-
-		deployment, err = lc.kubeClientSet.AppsV1beta1().Deployments(function.Namespace).Create(deployment)
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to create deployment")
-		}
-		return lc.updateDeploymentStrategy(deployment, function)
+		return lc.kubeClientSet.AppsV1beta1().Deployments(function.Namespace).Create(deployment)
 	}
 
 	updateDeployment := func(resource interface{}) (interface{}, error) {

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -670,17 +670,13 @@ func (lc *lazyClient) resolveDefaultDeploymentStrategy(function *nuclioio.Nuclio
 	// so k8s will kill the existing pod\function and create the new one
 	if gpuResource, ok := function.Spec.Resources.Limits[nvidiaGpuResourceName]; ok {
 
-		// user specifically asked for 0 gpus, retain the rolling update
-		if gpuResource.IsZero() {
-			return apps_v1beta1.RollingUpdateDeploymentStrategyType
-		} else {
-
-			// requested gpus, change to recreate
+		// requested a gpu resource, change to recreate
+		if !gpuResource.IsZero() {
 			return apps_v1beta1.RecreateDeploymentStrategyType
 		}
 	}
 
-	// no gpu resources, set to rollingUpdate (default)
+	// no gpu resources requested, set to rollingUpdate (default)
 	return apps_v1beta1.RollingUpdateDeploymentStrategyType
 }
 

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -660,6 +660,7 @@ func (lc *lazyClient) enrichDeploymentFromPlatformConfiguration(function *nuclio
 	// if no strategy was given by the user, use defaults
 	if allowPopulateDefaultDeploymentStrategy {
 		lc.populateDefaultDeploymentStrategy(function, &deployment.Spec.Strategy)
+		lc.logger.DebugWith("Strategy populated", "populatedStrategy", deployment.Spec.Strategy)
 	}
 	return nil
 }
@@ -1214,12 +1215,10 @@ func (lc *lazyClient) populateDefaultDeploymentStrategy(function *nuclioio.Nucli
 	if gpuResource, ok := function.Spec.Resources.Limits[nvidiaGpuResourceName]; ok {
 		if !gpuResource.IsZero() {
 			strategy.Type = apps_v1beta1.RecreateDeploymentStrategyType
-
-			// must be omitted if strategy type is != rollingUpdate
 			strategy.RollingUpdate = nil
 			lc.logger.DebugWith("Changing deployment strategy",
 				"name", function.Name,
-				"type", strategy.Type)
+				"strategy", strategy)
 		}
 	}
 }

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1214,6 +1214,9 @@ func (lc *lazyClient) populateDefaultDeploymentStrategy(function *nuclioio.Nucli
 	if gpuResource, ok := function.Spec.Resources.Limits[nvidiaGpuResourceName]; ok {
 		if !gpuResource.IsZero() {
 			strategy.Type = apps_v1beta1.RecreateDeploymentStrategyType
+
+			// must be omitted if strategy type is != rollingUpdate
+			strategy.RollingUpdate = nil
 			lc.logger.DebugWith("Changing deployment strategy",
 				"name", function.Name,
 				"type", strategy.Type)

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -759,7 +759,6 @@ func (lc *lazyClient) enrichDeploymentFromPlatformConfiguration(function *nuclio
 		if allowSetDefaultDeploymentStrategy {
 			deployment.Spec.Strategy.Type = lc.resolveDefaultDeploymentStrategy(function)
 		}
-		break
 	}
 	return nil
 }

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -733,7 +733,7 @@ func (lc *lazyClient) updateDeploymentStrategy(deployment *apps_v1beta1.Deployme
 
 func (lc *lazyClient) enrichDeploymentFromPlatformConfiguration(function *nuclioio.NuclioFunction,
 	deployment *apps_v1beta1.Deployment, method deploymentResourceMethod) error {
-	var allowChangeDeploymentStrategy = true
+	var allowSetDefaultDeploymentStrategy = true
 
 	// get deployment augmented configurations
 	deploymentAugmentedConfigs, err := lc.getDeploymentAugmentedConfigs(function)
@@ -745,7 +745,7 @@ func (lc *lazyClient) enrichDeploymentFromPlatformConfiguration(function *nuclio
 	for _, augmentedConfig := range deploymentAugmentedConfigs {
 		if augmentedConfig.Kubernetes.Deployment.Spec.Strategy.Type != "" ||
 			augmentedConfig.Kubernetes.Deployment.Spec.Strategy.RollingUpdate != nil {
-			allowChangeDeploymentStrategy = false
+			allowSetDefaultDeploymentStrategy = false
 		}
 		if err := mergo.Merge(&deployment.Spec, &augmentedConfig.Kubernetes.Deployment.Spec); err != nil {
 			return errors.Wrap(err, "Failed to merge deployment spec")
@@ -756,7 +756,7 @@ func (lc *lazyClient) enrichDeploymentFromPlatformConfiguration(function *nuclio
 
 	// on create, change inplace the deployment strategy
 	case createDeploymentResourceMethod:
-		if allowChangeDeploymentStrategy {
+		if allowSetDefaultDeploymentStrategy {
 			deployment.Spec.Strategy.Type = lc.resolveDefaultDeploymentStrategy(function)
 		}
 		break

--- a/pkg/processor/build/test/build_test.go
+++ b/pkg/processor/build/test/build_test.go
@@ -509,7 +509,7 @@ func (suite *testSuite) TestBuildFuncFromRemoteArchiveRedeploy() {
 			Spec: functionconfig.Spec{
 				Env: []v1.EnvVar{
 					{
-						Name: "MANIPULATION_KIND",
+						Name:  "MANIPULATION_KIND",
 						Value: "reverse",
 					},
 				},
@@ -535,7 +535,7 @@ func (suite *testSuite) TestBuildFuncFromRemoteArchiveRedeploy() {
 
 	// validate that when redeploying it works and the function uses another image than before
 	redeployFunctionOptions := &platform.CreateFunctionOptions{
-		Logger: suite.Logger,
+		Logger:         suite.Logger,
 		FunctionConfig: deployResult.UpdatedFunctionConfig,
 	}
 	redeployResult := suite.DeployFunctionAndRequest(redeployFunctionOptions,
@@ -578,7 +578,7 @@ func (suite *testSuite) TestBuildFuncFromLocalArchiveRedeployUsesSameImage() {
 
 	// validate that when redeploying it works and the function uses the same image as before
 	redeployFunctionOptions := &platform.CreateFunctionOptions{
-		Logger: suite.Logger,
+		Logger:         suite.Logger,
 		FunctionConfig: deployResult.UpdatedFunctionConfig,
 	}
 	redeployResult := suite.DeployFunctionAndRequest(redeployFunctionOptions,


### PR DESCRIPTION
Occurs when function is firstly created with non-gpu resources

This happen because of the patch strategy is being used for updating deployment resource.
While marshaling the deployment resource, the deployment strategy `rollingUpdate` field is being omitted and thus, its configuration on the server is not being deleted but preserved. that interfere with changing the deployment strategy type to `Recreate`