### PR TITLE
fix the deployment configuration for the deprecated apiVersion

### DIFF
--- a/hack/k8s/resources/nuclio.yaml
+++ b/hack/k8s/resources/nuclio.yaml
@@ -81,6 +81,11 @@ metadata:
   namespace: nuclio
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      nuclio.io/app: controller
+      nuclio.io/env: test
+      nuclio.io/class: service
   template:
     metadata:
       labels:
@@ -108,6 +113,11 @@ metadata:
   namespace: nuclio
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      nuclio.io/env: test
+      nuclio.io/app: dashboard
+      nuclio.io/class: service
   template:
     metadata:
       labels:

--- a/hack/k8s/resources/nuclio.yaml
+++ b/hack/k8s/resources/nuclio.yaml
@@ -74,7 +74,7 @@ metadata:
 
 # The nuclio controller listens for changes on the function CRD and creates the proper deployment, service, etc
 # for the function
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nuclio-controller
@@ -101,7 +101,7 @@ spec:
 ---
 
 # The Nuclio dashboard offers a UI to manage functions
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nuclio-dashboard


### PR DESCRIPTION
the apps/v1beta1 has been deprecated, Deployment is no longer valid under this version.

This PR is to fix the broken deployment configuration due to the above.

Further details:
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals

