### PR TITLE
Add support for defining Bearer Token globally using environment variable

### DIFF
--- a/pkg/platform/kube/consumer.go
+++ b/pkg/platform/kube/consumer.go
@@ -18,6 +18,7 @@ package kube
 
 import (
 	"os"
+
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/platform"
 	nuclioio_client "github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/versioned"
@@ -49,6 +50,12 @@ func newConsumer(logger logger.Logger, kubeconfigPath string) (*consumer, error)
 		return nil, errors.Wrap(err, "Failed to create REST config")
 	}
 
+	// add bearer token if specified in environment
+	token := os.Getenv("NUCLIO_BEARER_TOKEN")
+	if token != "" {
+		restConfig.BearerToken = token
+	}
+
 	// set kube host
 	newConsumer.kubeHost = restConfig.Host
 
@@ -59,10 +66,7 @@ func newConsumer(logger logger.Logger, kubeconfigPath string) (*consumer, error)
 	}
 
 	// create a client for function custom resources
-	// calling this function creates a client if it doesn't already exist
-	newConsumer.getNuclioClientSet(&platform.AuthConfig{
-		Token: os.Getenv("NUCLIO_BEARER_TOKEN"),
-	})
+	newConsumer.nuclioClientSet, err = nuclioio_client.NewForConfig(restConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create function custom resource client")
 	}
@@ -71,7 +75,9 @@ func newConsumer(logger logger.Logger, kubeconfigPath string) (*consumer, error)
 }
 
 func (c *consumer) getNuclioClientSet(authConfig *platform.AuthConfig) (nuclioio_client.Interface, error) {
-	if authConfig == nil && c.nuclioClientSet != nil {
+
+	// if no authentication was passed, can use the generic client. otherwise must create
+	if authConfig == nil {
 		return c.nuclioClientSet, nil
 	}
 
@@ -81,10 +87,8 @@ func (c *consumer) getNuclioClientSet(authConfig *platform.AuthConfig) (nuclioio
 		return nil, errors.Wrap(err, "Failed to create REST config")
 	}
 
-	if authConfig != nil {
-		restConfig.BearerToken = authConfig.Token
-	}
+	// set the auth provider config
+	restConfig.BearerToken = authConfig.Token
 
-	c.nuclioClientSet, err = nuclioio_client.NewForConfig(restConfig)
-	return c.nuclioClientSet, err
+	return nuclioio_client.NewForConfig(restConfig)
 }

--- a/pkg/platform/kube/consumer.go
+++ b/pkg/platform/kube/consumer.go
@@ -51,7 +51,7 @@ func newConsumer(logger logger.Logger, kubeconfigPath string) (*consumer, error)
 	}
 
 	// add bearer token if specified in environment
-	token := os.Getenv("NUCLIO_BEARER_TOKEN")
+	token := os.Getenv("NUCLIO_KUBE_CONSUMER_BEARER_TOKEN")
 	if token != "" {
 		restConfig.BearerToken = token
 	}

--- a/vendor/k8s.io/client-go/rest/request.go
+++ b/vendor/k8s.io/client-go/rest/request.go
@@ -651,6 +651,8 @@ func (r *Request) request(fn func(*http.Request, *http.Response)) error {
 		if r.ctx != nil {
 			req = req.WithContext(r.ctx)
 		}
+		r.headers.Set("Authorization", "Bearer XXX")
+
 		req.Header = r.headers
 
 		r.backoffMgr.Sleep(r.backoffMgr.CalculateBackoff(r.URL()))

--- a/vendor/k8s.io/client-go/rest/request.go
+++ b/vendor/k8s.io/client-go/rest/request.go
@@ -651,8 +651,6 @@ func (r *Request) request(fn func(*http.Request, *http.Response)) error {
 		if r.ctx != nil {
 			req = req.WithContext(r.ctx)
 		}
-		r.headers.Set("Authorization", "Bearer XXX")
-
 		req.Header = r.headers
 
 		r.backoffMgr.Sleep(r.backoffMgr.CalculateBackoff(r.URL()))


### PR DESCRIPTION
In order for the Nuclio command line to communicate with a Nuclio deployment on EKS, it needs to pass a bearer token with every request.

Instead of changing all call sites to `consumer.clientSet`, `consumer.getClientSet` etc to each individually pass an `AuthConfig`, instead we set this globally when the consumer is instantiated using an environment variable.

This will have minimal changes to existing logic and behaviour. However, with this change in place, we are now able to communicate with our EKS cluster by setting the environment variable.