### PR TITLE
Add worker metrics

### DIFF
--- a/pkg/processor/metricsink/prometheus/trigger.go
+++ b/pkg/processor/metricsink/prometheus/trigger.go
@@ -24,9 +24,13 @@ import (
 )
 
 type TriggerGatherer struct {
-	trigger            trigger.Trigger
-	handledEventsTotal *prometheus.CounterVec
-	prevStatistics     trigger.Statistics
+	trigger                                     trigger.Trigger
+	handledEventsTotal                          *prometheus.CounterVec
+	workerAllocationCount                       prometheus.Counter
+	workerAllocationTotal                       *prometheus.CounterVec
+	workerAllocationWaitDurationMilliSecondsSum prometheus.Counter
+	workerAllocationWorkersAvailableTotal       prometheus.Counter
+	prevStatistics                              trigger.Statistics
 }
 
 func NewTriggerGatherer(instanceName string,
@@ -52,30 +56,78 @@ func NewTriggerGatherer(instanceName string,
 		ConstLabels: labels,
 	}, []string{"result"})
 
-	if err := metricRegistry.Register(newTriggerGatherer.handledEventsTotal); err != nil {
-		return nil, errors.Wrap(err, "Failed to register handled events metric")
+	newTriggerGatherer.workerAllocationTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name:        "nuclio_processor_worker_allocation_total",
+		Help:        "Total number of worker allocations, by result",
+		ConstLabels: labels,
+	}, []string{"result"})
+
+	newTriggerGatherer.workerAllocationCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "nuclio_processor_worker_allocation_count",
+		Help:        "Total number of worker_allocations",
+		ConstLabels: labels,
+	})
+
+	newTriggerGatherer.workerAllocationWaitDurationMilliSecondsSum = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "nuclio_processor_worker_allocation_wait_duration_milliseconds_sum",
+		Help:        "Total number of milliseconds spent waiting for a worker",
+		ConstLabels: labels,
+	})
+
+	newTriggerGatherer.workerAllocationWorkersAvailableTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "nuclio_processor_worker_allocation_workers_available_total",
+		Help:        "Total number of workers available when an allocation occurred",
+		ConstLabels: labels,
+	})
+
+	for _, collector := range []prometheus.Collector{
+		newTriggerGatherer.handledEventsTotal,
+		newTriggerGatherer.workerAllocationTotal,
+		newTriggerGatherer.workerAllocationCount,
+		newTriggerGatherer.workerAllocationWaitDurationMilliSecondsSum,
+		newTriggerGatherer.workerAllocationWorkersAvailableTotal,
+	} {
+		if err := metricRegistry.Register(collector); err != nil {
+			return nil, errors.Wrap(err, "Failed to register collector")
+		}
 	}
 
 	return newTriggerGatherer, nil
 }
 
-func (esg *TriggerGatherer) Gather() error {
+func (tg *TriggerGatherer) Gather() error {
 
 	// read current stats
-	currentStatistics := *esg.trigger.GetStatistics()
+	currentStatistics := *tg.trigger.GetStatistics()
 
 	// diff from previous to get this period
-	diffStatistics := currentStatistics.DiffFrom(&esg.prevStatistics)
+	diffStatistics := currentStatistics.DiffFrom(&tg.prevStatistics)
 
-	esg.handledEventsTotal.With(prometheus.Labels{
+	tg.handledEventsTotal.With(prometheus.Labels{
 		"result": "success",
 	}).Add(float64(diffStatistics.EventsHandleSuccessTotal))
 
-	esg.handledEventsTotal.With(prometheus.Labels{
+	tg.handledEventsTotal.With(prometheus.Labels{
 		"result": "failure",
 	}).Add(float64(diffStatistics.EventsHandleFailureTotal))
 
-	esg.prevStatistics = currentStatistics
+	tg.workerAllocationCount.Add(float64(diffStatistics.WorkerAllocatorStatistics.WorkerAllocationCount))
+	tg.workerAllocationWaitDurationMilliSecondsSum.Add(float64(diffStatistics.WorkerAllocatorStatistics.WorkerAllocationWaitDurationMilliSecondsSum))
+	tg.workerAllocationWorkersAvailableTotal.Add(float64(diffStatistics.WorkerAllocatorStatistics.WorkerAllocationWorkersAvailableTotal))
+
+	tg.workerAllocationTotal.With(prometheus.Labels{
+		"result": "success_immediate",
+	}).Add(float64(diffStatistics.WorkerAllocatorStatistics.WorkerAllocationSuccessImmediateTotal))
+
+	tg.workerAllocationTotal.With(prometheus.Labels{
+		"result": "success_after_wait",
+	}).Add(float64(diffStatistics.WorkerAllocatorStatistics.WorkerAllocationSuccessAfterWaitTotal))
+
+	tg.workerAllocationTotal.With(prometheus.Labels{
+		"result": "error_timeout",
+	}).Add(float64(diffStatistics.WorkerAllocatorStatistics.WorkerAllocationTimeoutTotal))
+
+	tg.prevStatistics = currentStatistics
 
 	return nil
 }

--- a/pkg/processor/runtime/golang/builtin.go
+++ b/pkg/processor/runtime/golang/builtin.go
@@ -17,8 +17,6 @@ limitations under the License.
 package golang
 
 import (
-	"time"
-
 	"github.com/nuclio/nuclio-sdk-go"
 )
 
@@ -36,8 +34,6 @@ func builtInHandler(context *nuclio.Context, event nuclio.Event) (interface{}, e
 		"Headers", event.GetHeaders(),
 		"ContentType", event.GetContentType(),
 		"Body", string(event.GetBody()))
-
-	time.Sleep(10 * time.Second)
 
 	return "Built in handler called", nil
 }

--- a/pkg/processor/runtime/golang/builtin.go
+++ b/pkg/processor/runtime/golang/builtin.go
@@ -18,6 +18,7 @@ package golang
 
 import (
 	"github.com/nuclio/nuclio-sdk-go"
+	"time"
 )
 
 // this is used for running a standalone processor during development
@@ -34,6 +35,8 @@ func builtInHandler(context *nuclio.Context, event nuclio.Event) (interface{}, e
 		"Headers", event.GetHeaders(),
 		"ContentType", event.GetContentType(),
 		"Body", string(event.GetBody()))
+
+	time.Sleep(3 * time.Second)
 
 	return "Built in handler called", nil
 }

--- a/pkg/processor/runtime/golang/builtin.go
+++ b/pkg/processor/runtime/golang/builtin.go
@@ -17,8 +17,9 @@ limitations under the License.
 package golang
 
 import (
-	"github.com/nuclio/nuclio-sdk-go"
 	"time"
+
+	"github.com/nuclio/nuclio-sdk-go"
 )
 
 // this is used for running a standalone processor during development

--- a/pkg/processor/timeout/timeout.go
+++ b/pkg/processor/timeout/timeout.go
@@ -69,7 +69,6 @@ func (w EventTimeoutWatcher) watch() {
 			triggerName, triggerInstance := triggerName, triggerInstance
 
 			triggerErrGroup.Go(func() error {
-				w.logger.DebugWith("Checking trigger workers", "triggerName", triggerName)
 
 				// create error group
 				workerErrGroup := errgroup.Group{}
@@ -79,8 +78,6 @@ func (w EventTimeoutWatcher) watch() {
 					workerInstance := workerInstance
 
 					workerErrGroup.Go(func() error {
-						w.logger.DebugWith("Checking worker", "triggerName", triggerName, "widx", workerInstance.GetIndex())
-
 						eventTime := workerInstance.GetEventTime()
 						if eventTime == nil {
 							return nil

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -89,6 +89,7 @@ func NewAbstractTrigger(logger logger.Logger,
 	configuration *Configuration,
 	class string,
 	kind string) (AbstractTrigger, error) {
+
 	return AbstractTrigger{
 		Logger:          logger,
 		ID:              configuration.ID,
@@ -184,6 +185,10 @@ func (at *AbstractTrigger) GetWorkers() []*worker.Worker {
 
 // GetStatistics returns trigger statistics
 func (at *AbstractTrigger) GetStatistics() *Statistics {
+
+	// copy worker allocator statistics
+	at.Statistics.WorkerAllocatorStatistics = *at.WorkerAllocator.GetStatistics()
+
 	return &at.Statistics
 }
 

--- a/pkg/processor/trigger/types.go
+++ b/pkg/processor/trigger/types.go
@@ -19,6 +19,7 @@ package trigger
 import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/worker"
 )
 
 type Configuration struct {
@@ -50,14 +51,18 @@ func NewConfiguration(ID string,
 }
 
 type Statistics struct {
-	EventsHandleSuccessTotal uint64
-	EventsHandleFailureTotal uint64
+	EventsHandleSuccessTotal  uint64
+	EventsHandleFailureTotal  uint64
+	WorkerAllocatorStatistics worker.AllocatorStatistics
 }
 
 func (s *Statistics) DiffFrom(prev *Statistics) Statistics {
+	workerAllocatorStatisticsDiff := s.WorkerAllocatorStatistics.DiffFrom(&prev.WorkerAllocatorStatistics)
+
 	return Statistics{
-		EventsHandleSuccessTotal: s.EventsHandleSuccessTotal - prev.EventsHandleSuccessTotal,
-		EventsHandleFailureTotal: s.EventsHandleFailureTotal - prev.EventsHandleFailureTotal,
+		EventsHandleSuccessTotal:  s.EventsHandleSuccessTotal - prev.EventsHandleSuccessTotal,
+		EventsHandleFailureTotal:  s.EventsHandleFailureTotal - prev.EventsHandleFailureTotal,
+		WorkerAllocatorStatistics: workerAllocatorStatisticsDiff,
 	}
 }
 

--- a/pkg/processor/worker/allocator.go
+++ b/pkg/processor/worker/allocator.go
@@ -141,7 +141,7 @@ func (fp *fixedPool) Allocate(timeout time.Duration) (*Worker, error) {
 		select {
 		case workerInstance := <-fp.workerChan:
 			fp.statistics.WorkerAllocationSuccessAfterWaitTotal++
-			fp.statistics.WorkerAllocationWaitDurationMilliSecondsSum += uint64(time.Since(waitStartAt).Milliseconds())
+			fp.statistics.WorkerAllocationWaitDurationMilliSecondsSum += uint64(time.Since(waitStartAt).Nanoseconds() / 1e6)
 			return workerInstance, nil
 		case <-time.After(timeout):
 			fp.statistics.WorkerAllocationTimeoutTotal++

--- a/pkg/processor/worker/allocator.go
+++ b/pkg/processor/worker/allocator.go
@@ -165,6 +165,6 @@ func (fp *fixedPool) GetWorkers() []*Worker {
 }
 
 // GetStatistics returns worker allocator statistics
-func (s *fixedPool) GetStatistics() *AllocatorStatistics {
-	return &s.statistics
+func (fp *fixedPool) GetStatistics() *AllocatorStatistics {
+	return &fp.statistics
 }

--- a/pkg/processor/worker/allocator.go
+++ b/pkg/processor/worker/allocator.go
@@ -118,7 +118,7 @@ func (fp *fixedPool) Allocate(timeout time.Duration) (*Worker, error) {
 	fp.statistics.WorkerAllocationCount++
 
 	// measure how many workers are available in the queue while we're allocating
-	fp.statistics.WorkerAllocationWorkersAvailableTotal = uint64(len(fp.workerChan))
+	fp.statistics.WorkerAllocationWorkersAvailableTotal += uint64(len(fp.workerChan))
 
 	// try to allocate a worker and fall back to default immediately if there's none available
 	select {
@@ -141,7 +141,7 @@ func (fp *fixedPool) Allocate(timeout time.Duration) (*Worker, error) {
 		select {
 		case workerInstance := <-fp.workerChan:
 			fp.statistics.WorkerAllocationSuccessAfterWaitTotal++
-			fp.statistics.WorkerAllocationTimeoutTotal = uint64(time.Since(waitStartAt).Milliseconds())
+			fp.statistics.WorkerAllocationWaitDurationMilliSecondsSum += uint64(time.Since(waitStartAt).Milliseconds())
 			return workerInstance, nil
 		case <-time.After(timeout):
 			fp.statistics.WorkerAllocationTimeoutTotal++

--- a/pkg/processor/worker/allocator.go
+++ b/pkg/processor/worker/allocator.go
@@ -39,6 +39,9 @@ type Allocator interface {
 
 	// get direct access to all workers for things like management / housekeeping
 	GetWorkers() []*Worker
+
+	// GetStatistics returns worker allocator statistics
+	GetStatistics() *AllocatorStatistics
 }
 
 //
@@ -47,8 +50,9 @@ type Allocator interface {
 //
 
 type singleton struct {
-	logger logger.Logger
-	worker *Worker
+	logger     logger.Logger
+	worker     *Worker
+	statistics AllocatorStatistics
 }
 
 func NewSingletonWorkerAllocator(parentLogger logger.Logger, worker *Worker) (Allocator, error) {
@@ -76,6 +80,11 @@ func (s *singleton) GetWorkers() []*Worker {
 	return []*Worker{s.worker}
 }
 
+// GetStatistics returns worker allocator statistics
+func (s *singleton) GetStatistics() *AllocatorStatistics {
+	return &s.statistics
+}
+
 //
 // Fixed pool of workers
 // Holds a fixed number of workers. When a worker is unavailable, caller is blocked
@@ -85,6 +94,7 @@ type fixedPool struct {
 	logger     logger.Logger
 	workerChan chan *Worker
 	workers    []*Worker
+	statistics AllocatorStatistics
 }
 
 func NewFixedPoolWorkerAllocator(parentLogger logger.Logger, workers []*Worker) (Allocator, error) {
@@ -93,6 +103,7 @@ func NewFixedPoolWorkerAllocator(parentLogger logger.Logger, workers []*Worker) 
 		logger:     parentLogger.GetChild("fixed_pool_allocator"),
 		workerChan: make(chan *Worker, len(workers)),
 		workers:    workers,
+		statistics: AllocatorStatistics{},
 	}
 
 	// iterate over workers, shove to pool
@@ -104,23 +115,38 @@ func NewFixedPoolWorkerAllocator(parentLogger logger.Logger, workers []*Worker) 
 }
 
 func (fp *fixedPool) Allocate(timeout time.Duration) (*Worker, error) {
+	fp.statistics.WorkerAllocationCount++
 
-	// if no timeout is specified, just try to get a worker
-	if timeout == 0 {
-		select {
-		case workerInstance := <-fp.workerChan:
-			return workerInstance, nil
-		default:
+	// measure how many workers are available in the queue while we're allocating
+	fp.statistics.WorkerAllocationWorkersAvailableTotal = uint64(len(fp.workerChan))
+
+	// try to allocate a worker and fall back to default immediately if there's none available
+	select {
+	case workerInstance := <-fp.workerChan:
+		fp.statistics.WorkerAllocationSuccessImmediateTotal++
+
+		return workerInstance, nil
+	default:
+
+		// if there's no timeout, return now
+		if timeout == 0 {
+			fp.statistics.WorkerAllocationTimeoutTotal++
 			return nil, ErrNoAvailableWorkers
 		}
-	} else {
+
+		waitStartAt := time.Now()
+
+		// if there is a timeout, try to allocate while waiting for the time
+		// to pass
 		select {
 		case workerInstance := <-fp.workerChan:
+			fp.statistics.WorkerAllocationSuccessAfterWaitTotal++
+			fp.statistics.WorkerAllocationTimeoutTotal = uint64(time.Since(waitStartAt).Milliseconds())
 			return workerInstance, nil
 		case <-time.After(timeout):
+			fp.statistics.WorkerAllocationTimeoutTotal++
 			return nil, ErrNoAvailableWorkers
 		}
-
 	}
 }
 
@@ -136,4 +162,9 @@ func (fp *fixedPool) Shareable() bool {
 // get direct access to all workers for things like management / housekeeping
 func (fp *fixedPool) GetWorkers() []*Worker {
 	return fp.workers
+}
+
+// GetStatistics returns worker allocator statistics
+func (s *fixedPool) GetStatistics() *AllocatorStatistics {
+	return &s.statistics
 }

--- a/pkg/processor/worker/types.go
+++ b/pkg/processor/worker/types.go
@@ -20,3 +20,23 @@ type Statistics struct {
 	EventsHandleSuccess uint64
 	EventsHandleError   uint64
 }
+
+type AllocatorStatistics struct {
+	WorkerAllocationCount                       uint64
+	WorkerAllocationSuccessImmediateTotal       uint64
+	WorkerAllocationSuccessAfterWaitTotal       uint64
+	WorkerAllocationTimeoutTotal                uint64
+	WorkerAllocationWaitDurationMilliSecondsSum uint64
+	WorkerAllocationWorkersAvailableTotal       uint64
+}
+
+func (s *AllocatorStatistics) DiffFrom(prev *AllocatorStatistics) AllocatorStatistics {
+	return AllocatorStatistics{
+		WorkerAllocationCount:                       s.WorkerAllocationCount - prev.WorkerAllocationCount,
+		WorkerAllocationSuccessImmediateTotal:       s.WorkerAllocationSuccessImmediateTotal - prev.WorkerAllocationSuccessImmediateTotal,
+		WorkerAllocationSuccessAfterWaitTotal:       s.WorkerAllocationSuccessAfterWaitTotal - prev.WorkerAllocationSuccessAfterWaitTotal,
+		WorkerAllocationTimeoutTotal:                s.WorkerAllocationTimeoutTotal - prev.WorkerAllocationTimeoutTotal,
+		WorkerAllocationWaitDurationMilliSecondsSum: s.WorkerAllocationWaitDurationMilliSecondsSum - prev.WorkerAllocationWaitDurationMilliSecondsSum,
+		WorkerAllocationWorkersAvailableTotal:       s.WorkerAllocationWorkersAvailableTotal - prev.WorkerAllocationWorkersAvailableTotal,
+	}
+}


### PR DESCRIPTION
1. Add worker metrics that measure worker allocation things like wait time, availability, etc
2. Minor worker allocation performance hit when a worker allocation timeout is specified now happens only when there are no workers available and a timeout is specified