### PR TITLE
IG-13850: Base registry fix

### DIFF
--- a/pkg/containerimagebuilderpusher/containerimagebuilder.go
+++ b/pkg/containerimagebuilderpusher/containerimagebuilder.go
@@ -14,6 +14,6 @@ type BuilderPusher interface {
 	// Change Onbuild artifact paths depending on the type of the builder used
 	TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifact) (map[string]string, error)
 
-	// GetBaseRegistry returns onbuild base registry
-	GetBaseRegistry(registry string) string
+	// GetBaseImageRegistry returns onbuild base registry
+	GetBaseImageRegistry(registry string) string
 }

--- a/pkg/containerimagebuilderpusher/containerimagebuilder.go
+++ b/pkg/containerimagebuilderpusher/containerimagebuilder.go
@@ -13,4 +13,7 @@ type BuilderPusher interface {
 
 	// Change Onbuild artifact paths depending on the type of the builder used
 	TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifact) (map[string]string, error)
+
+	// GetBaseRegistry returns onbuild base registry
+	GetBaseRegistry(registry string) string
 }

--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -85,6 +85,10 @@ func (d *Docker) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifa
 	return relativeOnbuildArtifactPaths, nil
 }
 
+func (d *Docker) GetBaseRegistry(registry string) string {
+	return "quay.io"
+}
+
 func (d *Docker) buildContainerImage(buildOptions *BuildOptions) error {
 
 	d.logger.DebugWith("Building docker image", "image", buildOptions.Image)

--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -85,7 +85,7 @@ func (d *Docker) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifa
 	return relativeOnbuildArtifactPaths, nil
 }
 
-func (d *Docker) GetBaseRegistry(registry string) string {
+func (d *Docker) GetBaseImageRegistry(registry string) string {
 	return "quay.io"
 }
 

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -114,6 +114,10 @@ func (k *Kaniko) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifa
 	return stagedArtifactPaths, nil
 }
 
+func (k *Kaniko) GetBaseRegistry(registry string) string {
+	return registry
+}
+
 func (k *Kaniko) createContainerBuildBundle(image string, contextDir string, tempDir string) (string, string, error) {
 	var err error
 

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -114,7 +114,7 @@ func (k *Kaniko) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifa
 	return stagedArtifactPaths, nil
 }
 
-func (k *Kaniko) GetBaseRegistry(registry string) string {
+func (k *Kaniko) GetBaseImageRegistry(registry string) string {
 	return registry
 }
 

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -230,6 +230,11 @@ func (mp *mockPlatform) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime
 	return map[string]string{}, nil
 }
 
+func (mp *mockPlatform) GetBaseRegistry(registry string) string {
+	return "quay.io"
+}
+
+
 //
 // Test suite
 //

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -230,7 +230,7 @@ func (mp *mockPlatform) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime
 	return map[string]string{}, nil
 }
 
-func (mp *mockPlatform) GetBaseRegistry(registry string) string {
+func (mp *mockPlatform) GetBaseImageRegistry(registry string) string {
 	return "quay.io"
 }
 

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -327,9 +327,9 @@ func (ap *Platform) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Art
 	return ap.ContainerBuilder.TransformOnbuildArtifactPaths(onbuildArtifacts)
 }
 
-// GetBaseRegistry returns onbuild base registry
-func (ap *Platform) GetBaseRegistry(registry string) string {
-	return ap.ContainerBuilder.GetBaseRegistry(registry)
+// GetBaseImageRegistry returns onbuild base registry
+func (ap *Platform) GetBaseImageRegistry(registry string) string {
+	return ap.ContainerBuilder.GetBaseImageRegistry(registry)
 }
 
 func (ap *Platform) functionBuildRequired(createFunctionOptions *platform.CreateFunctionOptions) (bool, error) {

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -327,6 +327,11 @@ func (ap *Platform) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Art
 	return ap.ContainerBuilder.TransformOnbuildArtifactPaths(onbuildArtifacts)
 }
 
+// GetBaseRegistry returns onbuild base registry
+func (ap *Platform) GetBaseRegistry(registry string) string {
+	return ap.ContainerBuilder.GetBaseRegistry(registry)
+}
+
 func (ap *Platform) functionBuildRequired(createFunctionOptions *platform.CreateFunctionOptions) (bool, error) {
 
 	// if neverBuild was passed explicitly don't build

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -132,6 +132,6 @@ type Platform interface {
 	// Change Onbuild artifact paths depending on the type of the builder used
 	TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifact) (map[string]string, error)
 
-	// GetBaseRegistry returns onbuild base registry
-	GetBaseRegistry(registry string) string
+	// GetBaseImageRegistry returns onbuild base registry
+	GetBaseImageRegistry(registry string) string
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -131,4 +131,7 @@ type Platform interface {
 
 	// Change Onbuild artifact paths depending on the type of the builder used
 	TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifact) (map[string]string, error)
+
+	// GetBaseRegistry returns onbuild base registry
+	GetBaseRegistry(registry string) string
 }

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -946,10 +946,13 @@ func (b *Builder) buildProcessorImage() (string, error) {
 		return "", errors.Wrap(err, "Failed to get build args")
 	}
 
-	// Use dedicated base images registry (pull registry) if defined, default to push registry if not
+	// Use dedicated base images registry (pull registry) if defined
+	// If base registry is not defined will use the following:
+	//     - for docker builder: quay.io
+	//     - for kaniko builder: push registry
 	registry := b.options.FunctionConfig.Spec.Build.BaseImageRegistry
 	if len(registry) == 0 {
-		registry = b.options.FunctionConfig.Spec.Build.Registry
+		registry = b.platform.GetBaseRegistry(b.options.FunctionConfig.Spec.Build.Registry)
 	}
 
 	var BuildTimeoutSeconds int64

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -952,7 +952,7 @@ func (b *Builder) buildProcessorImage() (string, error) {
 	//     - for kaniko builder: push registry
 	registry := b.options.FunctionConfig.Spec.Build.BaseImageRegistry
 	if len(registry) == 0 {
-		registry = b.platform.GetBaseRegistry(b.options.FunctionConfig.Spec.Build.Registry)
+		registry = b.platform.GetBaseImageRegistry(b.options.FunctionConfig.Spec.Build.Registry)
 	}
 
 	var BuildTimeoutSeconds int64

--- a/pkg/processor/build/runtime/dotnetcore/runtime.go
+++ b/pkg/processor/build/runtime/dotnetcore/runtime.go
@@ -42,7 +42,7 @@ func (d *dotnetcore) GetProcessorDockerfileInfo(versionInfo *version.Info,
 	artifact := runtime.Artifact{
 		Name: "dotnetcore-onbuild",
 		Image: fmt.Sprintf("%s/nuclio/handler-builder-dotnetcore-onbuild:%s-%s",
-			d.GetRegistry(registryURL),
+			registryURL,
 			versionInfo.Label,
 			versionInfo.Arch),
 		Paths: map[string]string{

--- a/pkg/processor/build/runtime/golang/runtime.go
+++ b/pkg/processor/build/runtime/golang/runtime.go
@@ -79,7 +79,7 @@ func (g *golang) GetProcessorDockerfileInfo(versionInfo *version.Info,
 
 	// fill onbuild artifact
 	artifact := runtime.Artifact{
-		Image: fmt.Sprintf(onbuildImage, g.GetRegistry(registryURL), versionInfo.Label, versionInfo.Arch),
+		Image: fmt.Sprintf(onbuildImage, registryURL, versionInfo.Label, versionInfo.Arch),
 		Name:  "golang-onbuild",
 		Paths: map[string]string{
 			"/home/nuclio/bin/processor":  "/usr/local/bin/processor",

--- a/pkg/processor/build/runtime/java/runtime.go
+++ b/pkg/processor/build/runtime/java/runtime.go
@@ -57,7 +57,7 @@ func (j *java) GetProcessorDockerfileInfo(versionInfo *version.Info,
 	artifact := runtime.Artifact{
 		Name: "java-onbuild",
 		Image: fmt.Sprintf("%s/nuclio/handler-builder-java-onbuild:%s-%s",
-			j.GetRegistry(registryURL),
+			registryURL,
 			versionInfo.Label,
 			versionInfo.Arch),
 		Paths: map[string]string{

--- a/pkg/processor/build/runtime/nodejs/runtime.go
+++ b/pkg/processor/build/runtime/nodejs/runtime.go
@@ -50,7 +50,7 @@ func (n *nodejs) GetProcessorDockerfileInfo(versionInfo *version.Info,
 	artifact := runtime.Artifact{
 		Name: "nodejs-onbuild",
 		Image: fmt.Sprintf("%s/nuclio/handler-builder-nodejs-onbuild:%s-%s",
-			n.GetRegistry(registryURL),
+			registryURL,
 			versionInfo.Label,
 			versionInfo.Arch),
 		Paths: map[string]string{

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -53,7 +53,7 @@ func (p *python) GetProcessorDockerfileInfo(versionInfo *version.Info,
 	artifact := runtime.Artifact{
 		Name: "python-onbuild",
 		Image: fmt.Sprintf("%s/nuclio/handler-builder-python-onbuild:%s-%s",
-			p.GetRegistry(registryURL),
+			registryURL,
 			versionInfo.Label,
 			versionInfo.Arch),
 		Paths: map[string]string{

--- a/pkg/processor/build/runtime/ruby/runtime.go
+++ b/pkg/processor/build/runtime/ruby/runtime.go
@@ -48,7 +48,7 @@ func (r *ruby) GetProcessorDockerfileInfo(versionInfo *version.Info,
 	artifact := runtime.Artifact{
 		Name: "ruby-onbuild",
 		Image: fmt.Sprintf("%s/nuclio/handler-builder-ruby-onbuild:%s-%s",
-			r.GetRegistry(registryURL),
+			registryURL,
 			versionInfo.Label,
 			versionInfo.Arch),
 		Paths: map[string]string{

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -161,10 +161,3 @@ func (ar *AbstractRuntime) DetectFunctionHandlers(functionPath string) ([]string
 
 	return []string{fmt.Sprintf("%s:%s", functionFileName, "handler")}, nil
 }
-
-func (ar *AbstractRuntime) GetRegistry(registryURL string) string {
-	if len(registryURL) == 0 {
-		return "quay.io"
-	}
-	return registryURL
-}

--- a/pkg/processor/build/runtime/shell/runtime.go
+++ b/pkg/processor/build/runtime/shell/runtime.go
@@ -45,7 +45,7 @@ func (s *shell) GetProcessorDockerfileInfo(versionInfo *version.Info,
 	artifact := runtime.Artifact{
 		Name: "nuclio-processor",
 		Image: fmt.Sprintf("%s/nuclio/processor:%s-%s",
-			s.GetRegistry(registryURL),
+			registryURL,
 			versionInfo.Label,
 			versionInfo.Arch),
 		Paths: map[string]string{


### PR DESCRIPTION
Use dedicated base images registry (pull registry) if defined
If base registry is not defined will use the following:
     - for docker builder: quay.io
     - for kaniko builder: push registry