### PR TITLE
Bump to 1.2.2

### DIFF
--- a/hack/aks/resources/nuclio.yaml
+++ b/hack/aks/resources/nuclio.yaml
@@ -88,11 +88,11 @@ spec:
         nuclio.io/app: controller
         nuclio.io/class: service
       annotations:
-        nuclio.io/version: 1.2.1
+        nuclio.io/version: 1.2.2
     spec:
       containers:
       - name: nuclio-controller
-        image: quay.io/nuclio/controller:1.2.1-amd64
+        image: quay.io/nuclio/controller:1.2.2-amd64
         env:
         - name: NUCLIO_CONTROLLER_IMAGE_PULL_SECRETS
           value: registry-credentials
@@ -115,11 +115,11 @@ spec:
         nuclio.io/app: dashboard
         nuclio.io/class: service
       annotations:
-        nuclio.io/version: 1.2.1
+        nuclio.io/version: 1.2.2
     spec:
       containers:
       - name: nuclio-dashboard
-        image: quay.io/nuclio/dashboard:1.2.1-amd64
+        image: quay.io/nuclio/dashboard:1.2.2-amd64
         ports:
         - containerPort: 8070
         volumeMounts:

--- a/hack/gke/resources/nuclio.yaml
+++ b/hack/gke/resources/nuclio.yaml
@@ -88,11 +88,11 @@ spec:
         nuclio.io/app: controller
         nuclio.io/class: service
       annotations:
-        nuclio.io/version: 1.2.1
+        nuclio.io/version: 1.2.2
     spec:
       containers:
       - name: nuclio-controller
-        image: quay.io/nuclio/controller:1.2.1-amd64
+        image: quay.io/nuclio/controller:1.2.2-amd64
         env:
         - name: NUCLIO_CONTROLLER_IMAGE_PULL_SECRETS
           value: registry-credentials
@@ -115,11 +115,11 @@ spec:
         nuclio.io/app: dashboard
         nuclio.io/class: service
       annotations:
-        nuclio.io/version: 1.2.1
+        nuclio.io/version: 1.2.2
     spec:
       containers:
       - name: nuclio-dashboard
-        image: quay.io/nuclio/dashboard:1.2.1-amd64
+        image: quay.io/nuclio/dashboard:1.2.2-amd64
         ports:
         - containerPort: 8070
         volumeMounts:

--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
 version: 0.4.17
-appVersion: 1.2.1
+appVersion: 1.2.2
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io
 sources:

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -6,7 +6,7 @@ controller:
   enabled: true
   image:
     repository: quay.io/nuclio/controller
-    tag: 1.2.1-amd64
+    tag: 1.2.2-amd64
     pullPolicy: IfNotPresent  
 
   # Uncomment to have the controller to listen only the namespace's events, 
@@ -19,7 +19,7 @@ dashboard:
   replicas: 1
   image:
     repository: quay.io/nuclio/dashboard
-    tag: 1.2.1-amd64
+    tag: 1.2.2-amd64
     pullPolicy: IfNotPresent
   baseImagePullPolicy: IfNotPresent
   externalIPAddresses: []
@@ -45,7 +45,7 @@ autoscaler:
   replicas: 1
   image:
     repository: quay.io/nuclio/autoscaler
-    tag: 1.2.1-amd64
+    tag: 1.2.2-amd64
     pullPolicy: IfNotPresent
 
 dlx:
@@ -53,7 +53,7 @@ dlx:
   replicas: 1
   image:
     repository: quay.io/nuclio/dlx
-    tag: 1.2.1-amd64
+    tag: 1.2.2-amd64
     pullPolicy: IfNotPresent
 
 registry:

--- a/hack/k8s/resources/nuclio.yaml
+++ b/hack/k8s/resources/nuclio.yaml
@@ -93,11 +93,11 @@ spec:
         nuclio.io/app: controller
         nuclio.io/class: service
       annotations:
-        nuclio.io/version: 1.2.1
+        nuclio.io/version: 1.2.2
     spec:
       containers:
       - name: nuclio-controller
-        image: quay.io/nuclio/controller:1.2.1-amd64
+        image: quay.io/nuclio/controller:1.2.2-amd64
         env:
         - name: NUCLIO_CONTROLLER_IMAGE_PULL_SECRETS
           value: registry-credentials
@@ -125,11 +125,11 @@ spec:
         nuclio.io/app: dashboard
         nuclio.io/class: service
       annotations:
-        nuclio.io/version: 1.2.1
+        nuclio.io/version: 1.2.2
     spec:
       containers:
       - name: nuclio-dashboard
-        image: quay.io/nuclio/dashboard:1.2.1-amd64
+        image: quay.io/nuclio/dashboard:1.2.2-amd64
         ports:
         - containerPort: 8070
         volumeMounts:


### PR DESCRIPTION
The version bump patch 345497633660dd0499ff460b3820fd8d7f6c9173
provided version 1.2.1 although it doesn't look it exist in quay.io

$ docker pull quay.io/nuclio/controller:1.2.1-amd6
Error response from daemon: manifest for quay.io/nuclio/controller:1.2.1-amd6 not found

$ docker pull quay.io/nuclio/dashboard:1.2.1-amd64
Error response from daemon: unknown: Tag 1.2.1-amd64 was deleted or has expired. To pull, revive via time machine

Proper latest version seems to be 1.2.2 based on Github tags.

Signed-off-by: Alexis de Talhouët <adetalhouet89@gmail.com>