### PR TITLE
UI: Consider `httpPort: 0` as invocation URL N/A or not deployed

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -53,7 +53,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.11.5",
+    "iguazio.dashboard-controls": "^0.11.7",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- [bugfix] Port 0 is displayed instead of N/A invocation URL or “Not yet deployed” message
- [bugfix] When exiting “Edit Project” dialog by pressing the ESC key an unrelated error occurs

Depends on PR https://github.com/iguazio/dashboard-controls/pull/810