### PR TITLE
Show k8s events on deployment failure

### DIFF
--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.5.2
+version: 0.5.3
 appVersion: 1.3.1
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/templates/role/function-deployer.yaml
+++ b/hack/k8s/helm/nuclio/templates/role/function-deployer.yaml
@@ -23,7 +23,7 @@ metadata:
     release: {{ .Release.Name }}
 rules:
 - apiGroups: [""]
-  resources: ["services", "configmaps", "pods", "pods/log"]
+  resources: ["services", "configmaps", "pods", "pods/log", "events"]
   verbs: ["*"]
 - apiGroups: ["apps", "extensions"]
   resources: ["deployments"]

--- a/pkg/platform/kube/deployer.go
+++ b/pkg/platform/kube/deployer.go
@@ -254,7 +254,7 @@ func (d *deployer) getFunctionPodLogsAndEvents(namespace string, name string) (s
 		podWarningEvents, err := d.getFunctionPodWarningEvents(namespace, pod.Name)
 		if err != nil {
 			podLogsMessage += "Failed to get pod events\n"
-		} else if briefErrorMessage == "" && podWarningEvents != ""{
+		} else if briefErrorMessage == "" && podWarningEvents != "" {
 
 			// if there is no brief error message and there are warning events - add them
 			podLogsMessage += "\n* Warning events:\n" + podWarningEvents

--- a/pkg/platform/kube/deployer.go
+++ b/pkg/platform/kube/deployer.go
@@ -253,7 +253,7 @@ func (d *deployer) getFunctionPodLogsAndEvents(namespace string, name string) (s
 
 		podWarningEvents, err := d.getFunctionPodWarningEvents(namespace, pod.Name)
 		if err != nil {
-			podLogsMessage += "Failed to get pod events\n"
+			podLogsMessage += "Failed to get pod warning events: " + err.Error() + "\n"
 		} else if briefErrorMessage == "" && podWarningEvents != "" {
 
 			// if there is no brief error message and there are warning events - add them
@@ -268,8 +268,7 @@ func (d *deployer) getFunctionPodLogsAndEvents(namespace string, name string) (s
 func (d *deployer) getFunctionPodWarningEvents(namespace string, podName string) (string, error) {
 	eventList, err := d.consumer.kubeClientSet.CoreV1().Events(namespace).List(meta_v1.ListOptions{})
 	if err != nil {
-		d.logger.InfoWith("Failed to get pod events", "err", err)
-		return "", nil
+		return "", err
 	}
 
 	var podWarningEvents string

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -68,7 +68,7 @@ class Wrapper(object):
             try:
                 getattr(entrypoint_module, 'init_context')(self._context)
             except:
-                self._logger.error_with('Exception raised while running init_context')
+                self._logger.error('Exception raised while running init_context')
                 raise
 
         # replace the default output with the process socket
@@ -234,8 +234,8 @@ class Wrapper(object):
 
         try:
             entrypoint_address = getattr(module, entrypoint)
-        except Exception as err:
-            self._logger.error_with('Handler not found', handler=handler)
+        except Exception:
+            self._logger.error_with('Handler not found', handler=handler, module_name=module_name)
             raise
 
         return entrypoint_address
@@ -323,9 +323,9 @@ def run_wrapper():
                                    args.worker_id,
                                    args.trigger_name)
 
-    except Exception as err:
+    except Exception as exc:
         root_logger.error_with('Caught unhandled exception while initializing',
-                              err=str(err),
+                              err=str(exc),
                               traceback=traceback.format_exc())
 
         raise SystemExit(1)

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -68,7 +68,7 @@ class Wrapper(object):
             try:
                 getattr(entrypoint_module, 'init_context')(self._context)
             except:
-                self._logger.warn_with('Exception raised while running init_context')
+                self._logger.error_with('Exception raised while running init_context')
                 raise
 
         # replace the default output with the process socket
@@ -235,7 +235,7 @@ class Wrapper(object):
         try:
             entrypoint_address = getattr(module, entrypoint)
         except Exception as err:
-            self._logger.warn_with('Handler not found', handler=handler)
+            self._logger.error_with('Handler not found', handler=handler)
             raise
 
         return entrypoint_address
@@ -324,7 +324,7 @@ def run_wrapper():
                                    args.trigger_name)
 
     except Exception as err:
-        root_logger.warn_with('Caught unhandled exception while initializing',
+        root_logger.error_with('Caught unhandled exception while initializing',
                               err=str(err),
                               traceback=traceback.format_exc())
 

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -235,7 +235,7 @@ class Wrapper(object):
         try:
             entrypoint_address = getattr(module, entrypoint)
         except Exception:
-            self._logger.error_with('Handler not found', handler=handler, module_name=module_name)
+            self._logger.error_with('Handler not found', handler=handler)
             raise
 
         return entrypoint_address


### PR DESCRIPTION
Some deployment errors can be found only in k8s events. (like failed to perform volume mount, insufficient memory etc..)
When deployment fails and pod fails to start - show k8s events (warnings only)
