### PR TITLE
bump dotnet 2.0 to 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ More examples can be found in the **[hack/examples](hack/examples/README.md)** N
     - [Function-Configuration Reference](/docs/reference/function-configuration/function-configuration-reference.md)
     - [Triggers](/docs/reference/triggers)
     - [nuctl](/docs/reference/nuctl)
-    - [Runtime - .NET Core 2](/docs/reference/runtimes/dotnetcore/writing-a-dotnetcore-function.md)
+    - [Runtime - .NET Core 3.1](/docs/reference/runtimes/dotnetcore/writing-a-dotnetcore-function.md)
     - [Runtime - Shell](/docs/reference/runtimes/shell/writing-a-shell-function.md)
 - [Examples](hack/examples/README.md)
 - [Roadmap](ROADMAP.md)

--- a/docs/reference/runtimes/dotnetcore/dotnetcore-reference.md
+++ b/docs/reference/runtimes/dotnetcore/dotnetcore-reference.md
@@ -37,9 +37,9 @@ For example, the following file defines a dependency on the `Microsoft.NET.Sdk` 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />

--- a/docs/reference/runtimes/dotnetcore/writing-a-dotnetcore-function.md
+++ b/docs/reference/runtimes/dotnetcore/writing-a-dotnetcore-function.md
@@ -1,4 +1,4 @@
-# Writing a .NET Core 2 Function
+# Writing a .NET Core 3.1 Function
 
 This guide uses practical examples to guide you through the process of writing serverless .NET Core functions.
 
@@ -10,7 +10,7 @@ This guide uses practical examples to guide you through the process of writing s
 
 ## Overview
 
-The .NET Core runtime allows function developers to create serverless functions using [.NET Core 2](https://dotnet.github.io/). This guide walks you through the function-creation process.
+The .NET Core runtime allows function developers to create serverless functions using [.NET Core 3.1](https://dotnet.microsoft.com/). This guide walks you through the function-creation process.
 
 ## Deploy a .NET Core function
 

--- a/hack/examples/README.md
+++ b/hack/examples/README.md
@@ -34,7 +34,7 @@ To help you make the most of Nuclio, the following function examples are provide
 - [Reverser](nodejs/reverser) (`reverser`): Returns the reverse of the body received in the event.
 - [Dates](nodejs/dates) (`dates`): Uses **moment.js** (which is installed as part of the build) to add a specified amount of time to `"now"`, and returns this amount as a string.
 
-## .NET Core 2.0 examples
+## .NET Core 3.1 examples
 
 - [Reverser](dotnetcore/reverser) (`reverser`): Returns the reverse of the body received in the event.
 - [Hello World](dotnetcore/helloworld):  (`helloworld`): A simple function that showcases structured logging, unstructured logging and a structured response.

--- a/pkg/processor/build/runtime/dotnetcore/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/dotnetcore/docker/onbuild/Dockerfile
@@ -19,7 +19,7 @@ ARG NUCLIO_ARCH=amd64
 FROM quay.io/nuclio/processor:${NUCLIO_LABEL}-${NUCLIO_ARCH} as processor
 
 # Supplies wrapper and nuclio-sdk-dotnetcore
-FROM microsoft/dotnet:2-sdk as builder
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as builder
 
 # Copy processor
 COPY --from=processor /home/nuclio/bin/processor /home/nuclio/bin/processor

--- a/pkg/processor/build/runtime/dotnetcore/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/dotnetcore/docker/onbuild/Dockerfile
@@ -26,8 +26,7 @@ COPY --from=processor /home/nuclio/bin/processor /home/nuclio/bin/processor
 
 # Get .NET core SDK to /home/nuclio/src/nuclio-sdk-dotnetcore
 
-# FIXME (should be: https://github.com/nuclio/nuclio-sdk-dotnetcore/archive/master.tar.gz)
-RUN curl -L "https://github.com/liranbg/nuclio-sdk-dotnetcore/archive/dotnet3.1.tar.gz" -o nuclio-sdk-dotnetcore.tar.gz && \
+RUN curl -L "https://github.com/nuclio/nuclio-sdk-dotnetcore/archive/dotnet3.1.tar.gz" -o nuclio-sdk-dotnetcore.tar.gz && \
     mkdir -p /home/nuclio/src/nuclio-sdk-dotnetcore && \
     tar -xvf nuclio-sdk-dotnetcore.tar.gz --strip-components=1 -C /home/nuclio/src/nuclio-sdk-dotnetcore
 

--- a/pkg/processor/build/runtime/dotnetcore/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/dotnetcore/docker/onbuild/Dockerfile
@@ -25,7 +25,9 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as builder
 COPY --from=processor /home/nuclio/bin/processor /home/nuclio/bin/processor
 
 # Get .NET core SDK to /home/nuclio/src/nuclio-sdk-dotnetcore
-RUN curl -L https://github.com/nuclio/nuclio-sdk-dotnetcore/archive/master.tar.gz -o nuclio-sdk-dotnetcore.tar.gz && \
+
+# FIXME (should be: https://github.com/nuclio/nuclio-sdk-dotnetcore/archive/master.tar.gz)
+RUN curl -L "https://github.com/liranbg/nuclio-sdk-dotnetcore/archive/dotnet3.1.tar.gz" -o nuclio-sdk-dotnetcore.tar.gz && \
     mkdir -p /home/nuclio/src/nuclio-sdk-dotnetcore && \
     tar -xvf nuclio-sdk-dotnetcore.tar.gz --strip-components=1 -C /home/nuclio/src/nuclio-sdk-dotnetcore
 

--- a/pkg/processor/build/runtime/dotnetcore/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/dotnetcore/docker/onbuild/Dockerfile
@@ -25,7 +25,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as builder
 COPY --from=processor /home/nuclio/bin/processor /home/nuclio/bin/processor
 
 # Get .NET core SDK to /home/nuclio/src/nuclio-sdk-dotnetcore
-
 RUN curl -L "https://github.com/nuclio/nuclio-sdk-dotnetcore/archive/dotnet3.1.tar.gz" -o nuclio-sdk-dotnetcore.tar.gz && \
     mkdir -p /home/nuclio/src/nuclio-sdk-dotnetcore && \
     tar -xvf nuclio-sdk-dotnetcore.tar.gz --strip-components=1 -C /home/nuclio/src/nuclio-sdk-dotnetcore

--- a/pkg/processor/build/runtime/dotnetcore/docker/onbuild/handler.csproj
+++ b/pkg/processor/build/runtime/dotnetcore/docker/onbuild/handler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/pkg/processor/build/runtime/dotnetcore/runtime.go
+++ b/pkg/processor/build/runtime/dotnetcore/runtime.go
@@ -55,7 +55,7 @@ func (d *dotnetcore) GetProcessorDockerfileInfo(versionInfo *version.Info,
 	processorDockerfileInfo.OnbuildArtifacts = []runtime.Artifact{artifact}
 
 	// set the default base image
-	processorDockerfileInfo.BaseImage = "microsoft/dotnet:2-runtime"
+	processorDockerfileInfo.BaseImage = "mcr.microsoft.com/dotnet/core/runtime:3.1"
 
 	return &processorDockerfileInfo, nil
 }

--- a/pkg/processor/runtime/dotnetcore/test/_outputter/handler.csproj
+++ b/pkg/processor/runtime/dotnetcore/test/_outputter/handler.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />

--- a/pkg/processor/runtime/dotnetcore/wrapper.csproj
+++ b/pkg/processor/runtime/dotnetcore/wrapper.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <DefaultItemExcludes>test/**;$(DefaultItemExcludes)</DefaultItemExcludes>


### PR DESCRIPTION
Upgrading due to a bug on 2.x & deprecation of `netstandardapp`

- [x] dotnet 2.0 to 3.1 (LTS)
- [x] Language version 7.2 -> 8.0
- [x] Deprecation of `netstandardapp` (https://github.com/NuGet/Home/issues/2524)
- [x] Fix invalid dynamic loader (dll)

Bug logs:
```
Error loading function: Could not load file or assembly 'Microsoft.CSharp, Version=4.0.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'., Path: /opt/nuclio/handler/handler.dll, Type: nuclio, Function: parser

Unhandled Exception: System.Exception: Error loading function: Could not load file or assembly 'Microsoft.CSharp, Version=4.0.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'., Path: /opt/nuclio/handler/handler.dll, Type: nuclio, Function: parser
   at processor.Wrapper.CreateTypeAndFunction(String dllPath, String typeName, String methodName) in /home/nuclio/src/wrapper/Wrapper.cs:line 59
   at processor.Program.Main(String[] args) in /home/nuclio/src/wrapper/Program.cs:line 26
   at processor.Program.<Main>(String[] args)
```