### PR TITLE
UI: Add validation rule to configuration; Show build error

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -53,7 +53,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.11.7",
+    "iguazio.dashboard-controls": "^0.11.9",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",

--- a/pkg/dashboard/ui/src/less/mixins.less
+++ b/pkg/dashboard/ui/src/less/mixins.less
@@ -370,8 +370,8 @@
     @primary-btn-active-box-shadow: inset 0.4px 1.9px 3px 0 .black(0.2)[@color];
 
     @primary-btn-disabled-color: .duskThree(0.24)[@color];
-    @primary-btn-disabled-bg-color: @pale-grey-three;
-    @primary-btn-disabled-border: 1px solid @pale-grey-three;
+    @primary-btn-disabled-bg-color: @pale-grey-two;
+    @primary-btn-disabled-border: 1px solid @pale-grey;
 }
 
 .remove-button-color-set() {


### PR DESCRIPTION
- Function:
  - Configuration: added validation rules to many text fields
  - on deploy, when the deploy log is displayed in a collapsible block of yellow, and deploy fails – the entire deploy log is replaced by the error message only (the same content as in the “Error” pane in the “Status” tab).
- General: fixed styling of disabled buttons

Depends on PRs https://github.com/iguazio/dashboard-controls/pull/812 https://github.com/iguazio/dashboard-controls/pull/813