### PR TITLE
UI: Fix invocation URL "Not yet deployed" for scaled-to-zero func

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -53,7 +53,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.13.0",
+    "iguazio.dashboard-controls": "^0.13.1",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- Function » Status: [bugfix] invocation URL was “Not yet deployed” when function was in scaled-to-zero state, even though it had a properly working invocation URL (which was displayed correctly in function list screen)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/830