### PR TITLE
Increasing fasthttp server read buffer size from 4KB to 16KB

### DIFF
--- a/pkg/processor/trigger/http/types.go
+++ b/pkg/processor/trigger/http/types.go
@@ -48,7 +48,7 @@ func NewConfiguration(ID string,
 	}
 
 	if newConfiguration.ReadBufferSize == 0 {
-		newConfiguration.ReadBufferSize = 4 * 1024
+		newConfiguration.ReadBufferSize = 16 * 1024
 	}
 
 	return &newConfiguration, nil


### PR DESCRIPTION
We want to pass JWT tokens to the function through the request headers.
Tried with a basic JWT coming from Dex and it exploded on too big header