### PR TITLE
Default MaxReplicas to MinReplicas before default value

### DIFF
--- a/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
+++ b/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
@@ -78,9 +78,11 @@ func (nf *NuclioFunction) GetComputedMinReplicas() int32 {
 			} else {
 				return int32(*nf.Spec.MinReplicas)
 			}
+		} else if nf.Spec.MaxReplicas != nil {
+			return int32(*nf.Spec.MaxReplicas)
 		} else {
 
-			// If neither Replicas nor MinReplicas is given, default to 1
+			// If neither Replicas nor MinReplicas nor MaxReplicas is given, default to 1
 			return 1
 		}
 	}
@@ -106,9 +108,11 @@ func (nf *NuclioFunction) GetComputedMaxReplicas() int32 {
 			} else {
 				return int32(*nf.Spec.MaxReplicas)
 			}
+		} else if nf.Spec.MinReplicas != nil {
+			return int32(*nf.Spec.MinReplicas)
 		} else {
 
-			// If neither Replicas nor MaxReplicas is given, default to 1
+			// If neither Replicas nor MaxReplicas nor Min Replicas is given, default to 1
 			return 1
 		}
 	}

--- a/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
+++ b/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
@@ -78,11 +78,9 @@ func (nf *NuclioFunction) GetComputedMinReplicas() int32 {
 			} else {
 				return int32(*nf.Spec.MinReplicas)
 			}
-		} else if nf.Spec.MaxReplicas != nil {
-			return int32(*nf.Spec.MaxReplicas)
 		} else {
 
-			// If neither Replicas nor MinReplicas nor MaxReplicas is given, default to 1
+			// If neither Replicas nor MinReplicas is given, default to 1
 			return 1
 		}
 	}
@@ -109,10 +107,12 @@ func (nf *NuclioFunction) GetComputedMaxReplicas() int32 {
 				return int32(*nf.Spec.MaxReplicas)
 			}
 		} else if nf.Spec.MinReplicas != nil {
+
+			// If neither Replicas nor MaxReplicas is given, but MinReplicas is given, default to it (default to no HPA)
 			return int32(*nf.Spec.MinReplicas)
 		} else {
 
-			// If neither Replicas nor MaxReplicas nor Min Replicas is given, default to 1
+			// If neither Replicas nor MaxReplicas nor MinReplicas is given, default to 1
 			return 1
 		}
 	}


### PR DESCRIPTION
`GetComputedMaxReplicas` flow is now:
1. if `Replicas` given, use it
2. if `MaxReplicas` given, use it
3. if `MinReplicas` given, use it
4. default to 1

Before this PR step 3 didn't exist which would have broken if `MinReplicas > 1` since `MaxReplicas` would default to 1 and HPA can't have `MinReplicas > MaxReplicas`

Decided to leave `GetComputedMinReplicas` flow as is:
1. if `Replicas` given, use it
2. if `MinReplicas` given, use it
3. default to 1