### PR TITLE
UI: Fix wrong validation rules for label and annotation keys

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -53,7 +53,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.15.2",
+    "iguazio.dashboard-controls": "^0.15.3",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
Function » Configuration » Labels & Annotations » Key: [bugfix] wrong validation rules disallowed entering uppercase letters to the name part of the key

Depends on PR https://github.com/iguazio/dashboard-controls/pull/852