### PR TITLE
Add option to configure a template for image name prefix

### DIFF
--- a/cmd/dashboard/app/dashboard.go
+++ b/cmd/dashboard/app/dashboard.go
@@ -51,7 +51,7 @@ func Run(listenAddress string,
 	templatesGitPassword string,
 	templatesGithubAccessToken string,
 	defaultHTTPIngressHostTemplate string,
-	imageNameTemplate string,
+	imageNamePrefixTemplate string,
 	platformAuthorizationMode string,
 	dependantImageRegistryURL string) error {
 	var functionGitTemplateFetcher *functiontemplates.GitFunctionTemplateFetcher
@@ -153,8 +153,8 @@ func Run(listenAddress string,
 		platformInstance.SetDefaultHTTPIngressHostTemplate(defaultHTTPIngressHostTemplate)
 	}
 
-	if imageNameTemplate != "" {
-		platformInstance.SetImageNameTemplate(imageNameTemplate)
+	if imageNamePrefixTemplate != "" {
+		platformInstance.SetImageNamePrefixTemplate(imageNamePrefixTemplate)
 	}
 
 	rootLogger.InfoWith("Starting",
@@ -192,7 +192,7 @@ func Run(listenAddress string,
 		functionTemplatesRepository,
 		platformConfiguration,
 		defaultHTTPIngressHostTemplate,
-		imageNameTemplate,
+		imageNamePrefixTemplate,
 		platformAuthorizationMode,
 		dependantImageRegistryURL)
 	if err != nil {

--- a/cmd/dashboard/app/dashboard.go
+++ b/cmd/dashboard/app/dashboard.go
@@ -51,6 +51,7 @@ func Run(listenAddress string,
 	templatesGitPassword string,
 	templatesGithubAccessToken string,
 	defaultHTTPIngressHostTemplate string,
+	imageNameTemplate string,
 	platformAuthorizationMode string,
 	dependantImageRegistryURL string) error {
 	var functionGitTemplateFetcher *functiontemplates.GitFunctionTemplateFetcher
@@ -152,6 +153,10 @@ func Run(listenAddress string,
 		platformInstance.SetDefaultHTTPIngressHostTemplate(defaultHTTPIngressHostTemplate)
 	}
 
+	if imageNameTemplate != "" {
+		platformInstance.SetImageNameTemplate(imageNameTemplate)
+	}
+
 	rootLogger.InfoWith("Starting",
 		"name", platformInstance.GetName(),
 		"noPull", noPullBaseImages,
@@ -187,6 +192,7 @@ func Run(listenAddress string,
 		functionTemplatesRepository,
 		platformConfiguration,
 		defaultHTTPIngressHostTemplate,
+		imageNameTemplate,
 		platformAuthorizationMode,
 		dependantImageRegistryURL)
 	if err != nil {

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -73,6 +73,7 @@ func main() {
 	offline := flag.Bool("offline", defaultOffline, "If true, assumes no internet connectivity")
 	platformConfigurationPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
 	defaultHTTPIngressHostTemplate := flag.String("default-http-ingress-host-template", os.Getenv("NUCLIO_DASHBOARD_HTTP_INGRESS_HOST_TEMPLATE"), "Go template for the default http ingress host")
+	imageNameTemplate := flag.String("image-name-template", os.Getenv("NUCLIO_DASHBOARD_IMAGE_NAME_TEMPLATE"), "Go template for the image names")
 	platformAuthorizationMode := flag.String("platform-authorization-mode", defaultPlatformAuthorizationMode, "One of service-account (default) / authorization-header-oidc")
 	dependantImageRegistryURL := flag.String("dependant-image-registry", os.Getenv("NUCLIO_DASHBOARD_DEPENDANT_IMAGE_REGISTRY_URL"), "If passed, replaces base/on-build registry URLs with this value")
 
@@ -99,6 +100,7 @@ func main() {
 		*templatesGitPassword,
 		*templatesGithubAccessToken,
 		*defaultHTTPIngressHostTemplate,
+		*imageNameTemplate,
 		*platformAuthorizationMode,
 		*dependantImageRegistryURL); err != nil {
 

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -73,7 +73,7 @@ func main() {
 	offline := flag.Bool("offline", defaultOffline, "If true, assumes no internet connectivity")
 	platformConfigurationPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
 	defaultHTTPIngressHostTemplate := flag.String("default-http-ingress-host-template", os.Getenv("NUCLIO_DASHBOARD_HTTP_INGRESS_HOST_TEMPLATE"), "Go template for the default http ingress host")
-	imageNameTemplate := flag.String("image-name-template", os.Getenv("NUCLIO_DASHBOARD_IMAGE_NAME_TEMPLATE"), "Go template for the image names")
+	imageNamePrefixTemplate := flag.String("image-name-prefix-template", os.Getenv("NUCLIO_DASHBOARD_IMAGE_NAME_PREFIX_TEMPLATE"), "Go template for the image names prefix")
 	platformAuthorizationMode := flag.String("platform-authorization-mode", defaultPlatformAuthorizationMode, "One of service-account (default) / authorization-header-oidc")
 	dependantImageRegistryURL := flag.String("dependant-image-registry", os.Getenv("NUCLIO_DASHBOARD_DEPENDANT_IMAGE_REGISTRY_URL"), "If passed, replaces base/on-build registry URLs with this value")
 
@@ -100,7 +100,7 @@ func main() {
 		*templatesGitPassword,
 		*templatesGithubAccessToken,
 		*defaultHTTPIngressHostTemplate,
-		*imageNameTemplate,
+		*imageNamePrefixTemplate,
 		*platformAuthorizationMode,
 		*dependantImageRegistryURL); err != nil {
 

--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.5.8
+version: 0.5.9
 appVersion: 1.3.6
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.5.10
+version: 0.5.9
 appVersion: 1.3.7
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -84,6 +84,8 @@ spec:
           value: {{ .Values.dashboard.externalIPAddresses | join "," | quote }}
         - name: NUCLIO_DASHBOARD_HTTP_INGRESS_HOST_TEMPLATE
           value: {{ .Values.dashboard.httpIngressHostTemplate | quote }}
+        - name: NUCLIO_DASHBOARD_IMAGE_NAME_PREFIX_TEMPLATE
+          value: {{ .Values.dashboard.imageNamePrefixTemplate | quote }}
       volumes:
       - name: docker-sock
         hostPath:

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -24,6 +24,7 @@ dashboard:
   baseImagePullPolicy: IfNotPresent
   externalIPAddresses: []
   httpIngressHostTemplate: ""
+  imageNamePrefixTemplate: ""
 
   # Supported container builders: "kaniko", "docker"
   containerBuilderKind: "docker"

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -18,9 +18,11 @@ package common
 
 import (
 	"bufio"
+	"bytes"
 	"os"
 	"strconv"
 	"strings"
+	"text/template"
 	"time"
 	"unicode/utf8"
 
@@ -196,4 +198,38 @@ func GetEnvOrDefaultString(key string, defaultValue string) string {
 
 func GetEnvOrDefaultBool(key string, defaultValue bool) bool {
 	return strings.ToLower(GetEnvOrDefaultString(key, strconv.FormatBool(defaultValue))) == "true"
+}
+
+func RenderTemplate(text string, data map[string]interface{}) (string, error) {
+	templateToRender, err := template.New("t").Parse(text)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to create template")
+	}
+
+	return renderTemplate(templateToRender, data)
+}
+
+func RenderTemplateWithCustomDelimiters(text string,
+	data map[string]interface{},
+	leftDelimiter string,
+	rightDelimiter string) (string, error) {
+
+	templateToRender, err := template.New("t").
+		Delims(leftDelimiter, rightDelimiter).
+		Parse(text)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to create template")
+	}
+
+	return renderTemplate(templateToRender, data)
+}
+
+func renderTemplate(templateToRender *template.Template, data map[string]interface{}) (string, error) {
+	var templateToRenderBuffer bytes.Buffer
+	err := templateToRender.Execute(&templateToRenderBuffer, &data)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to execute queueName template")
+	}
+
+	return templateToRenderBuffer.String(), nil
 }

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -228,7 +228,7 @@ func renderTemplate(templateToRender *template.Template, data map[string]interfa
 	var templateToRenderBuffer bytes.Buffer
 	err := templateToRender.Execute(&templateToRenderBuffer, &data)
 	if err != nil {
-		return "", errors.Wrap(err, "Failed to execute queueName template")
+		return "", errors.Wrap(err, "Failed to execute template rendering")
 	}
 
 	return templateToRenderBuffer.String(), nil

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -218,7 +218,7 @@ func RenderTemplateWithCustomDelimiters(text string,
 		Delims(leftDelimiter, rightDelimiter).
 		Parse(text)
 	if err != nil {
-		return "", errors.Wrap(err, "Failed to create template")
+		return "", errors.Wrap(err, "Failed to create template with custom delimiters")
 	}
 
 	return renderTemplate(templateToRender, data)

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -62,6 +62,7 @@ func (fesr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restf
 			"externalIPAddresses":            externalIPAddresses,
 			"namespace":                      fesr.getNamespaceOrDefault(""),
 			"defaultHTTPIngressHostTemplate": fesr.getPlatform().GetDefaultHTTPIngressHostTemplate(),
+			"imageNameTemplate":              fesr.getPlatform().GetImageNameTemplate(),
 			"scaleToZero":                    scaleToZeroAttribute,
 		},
 	}

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -62,7 +62,7 @@ func (fesr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restf
 			"externalIPAddresses":            externalIPAddresses,
 			"namespace":                      fesr.getNamespaceOrDefault(""),
 			"defaultHTTPIngressHostTemplate": fesr.getPlatform().GetDefaultHTTPIngressHostTemplate(),
-			"imageNameTemplate":              fesr.getPlatform().GetImageNameTemplate(),
+			"imageNamePrefixTemplate":        fesr.getPlatform().GetImageNamePrefixTemplate(),
 			"scaleToZero":                    scaleToZeroAttribute,
 		},
 	}

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -58,7 +58,7 @@ type Server struct {
 	Repository                     *functiontemplates.Repository
 	platformConfiguration          *platformconfig.Config
 	defaultHTTPIngressHostTemplate string
-	imageNameTemplate              string
+	imageNamePrefixTemplate        string
 	platformAuthorizationMode      PlatformAuthorizationMode
 	dependantImageRegistryURL      string
 }
@@ -77,7 +77,7 @@ func NewServer(parentLogger logger.Logger,
 	repository *functiontemplates.Repository,
 	platformConfiguration *platformconfig.Config,
 	defaultHTTPIngressHostTemplate string,
-	imageNameTemplate string,
+	imageNamePrefixTemplate string,
 	platformAuthorizationMode string,
 	dependantImageRegistryURL string) (*Server, error) {
 
@@ -112,7 +112,7 @@ func NewServer(parentLogger logger.Logger,
 		Repository:                     repository,
 		platformConfiguration:          platformConfiguration,
 		defaultHTTPIngressHostTemplate: defaultHTTPIngressHostTemplate,
-		imageNameTemplate:              imageNameTemplate,
+		imageNamePrefixTemplate:        imageNamePrefixTemplate,
 		platformAuthorizationMode:      PlatformAuthorizationMode(platformAuthorizationMode),
 		dependantImageRegistryURL:      dependantImageRegistryURL,
 	}
@@ -182,8 +182,8 @@ func (s *Server) GetDefaultHTTPIngressHostTemplate() string {
 	return s.defaultHTTPIngressHostTemplate
 }
 
-func (s *Server) GetImageNameTemplate() string {
-	return s.imageNameTemplate
+func (s *Server) GetImageNamePrefixTemplate() string {
+	return s.imageNamePrefixTemplate
 }
 
 func (s *Server) GetDefaultNamespace() string {

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -58,6 +58,7 @@ type Server struct {
 	Repository                     *functiontemplates.Repository
 	platformConfiguration          *platformconfig.Config
 	defaultHTTPIngressHostTemplate string
+	imageNameTemplate              string
 	platformAuthorizationMode      PlatformAuthorizationMode
 	dependantImageRegistryURL      string
 }
@@ -76,6 +77,7 @@ func NewServer(parentLogger logger.Logger,
 	repository *functiontemplates.Repository,
 	platformConfiguration *platformconfig.Config,
 	defaultHTTPIngressHostTemplate string,
+	imageNameTemplate string,
 	platformAuthorizationMode string,
 	dependantImageRegistryURL string) (*Server, error) {
 
@@ -110,6 +112,7 @@ func NewServer(parentLogger logger.Logger,
 		Repository:                     repository,
 		platformConfiguration:          platformConfiguration,
 		defaultHTTPIngressHostTemplate: defaultHTTPIngressHostTemplate,
+		imageNameTemplate:              imageNameTemplate,
 		platformAuthorizationMode:      PlatformAuthorizationMode(platformAuthorizationMode),
 		dependantImageRegistryURL:      dependantImageRegistryURL,
 	}
@@ -177,6 +180,10 @@ func (s *Server) GetExternalIPAddresses() []string {
 
 func (s *Server) GetDefaultHTTPIngressHostTemplate() string {
 	return s.defaultHTTPIngressHostTemplate
+}
+
+func (s *Server) GetImageNameTemplate() string {
+	return s.imageNameTemplate
 }
 
 func (s *Server) GetDefaultNamespace() string {

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1850,7 +1850,7 @@ func (suite *miscTestSuite) TestGetExternalIPAddresses() {
 func (suite *miscTestSuite) TestGetFrontendSpec() {
 	returnedAddresses := []string{"address1", "address2", "address3"}
 	defaultHTTPIngressHostTemplate := "{{ .FunctionName }}.{{ .ProjectName }}.{{ .Namespace }}.test-system.com"
-	imageNamePrefixTemplate := "{{ .ProjectName }}-{{ .FunctionName }}-{{ .ImageName }}"
+	imageNamePrefixTemplate := "{{ .ProjectName }}-{{ .FunctionName }}-"
 	scaleToZeroConfiguration := platformconfig.ScaleToZero{
 		Mode:                     platformconfig.EnabledScaleToZeroMode,
 		ScalerInterval:           "",
@@ -1889,7 +1889,7 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
 	expectedResponseBody := `{
 		"externalIPAddresses":            	["address1", "address2", "address3"],
 		"defaultHTTPIngressHostTemplate":	"{{ .FunctionName }}.{{ .ProjectName }}.{{ .Namespace }}.test-system.com",
-		"defaultHTTPIngressHostTemplate":	"{{ .ProjectName }}-{{ .FunctionName }}-{{ .ImageName }}",
+		"defaultHTTPIngressHostTemplate":	"{{ .ProjectName }}-{{ .FunctionName }}-",
 		"namespace":                      	"",
 		"scaleToZero":						{
 			"mode": "enabled",

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -170,6 +170,15 @@ func (mp *mockPlatform) GetDefaultHTTPIngressHostTemplate() string {
 	return args.Get(0).(string)
 }
 
+func (mp *mockPlatform) SetImageNameTemplate(imageNameTemplate string) {
+	mp.Called(imageNameTemplate)
+}
+
+func (mp *mockPlatform) GetImageNameTemplate() string {
+	args := mp.Called()
+	return args.Get(0).(string)
+}
+
 // SetExternalIPAddresses configures the IP addresses invocations will use, if "via" is set to "external-ip".
 // If this is not invoked, each platform will try to discover these addresses automatically
 func (mp *mockPlatform) SetExternalIPAddresses(externalIPAddresses []string) error {
@@ -276,6 +285,7 @@ func (suite *dashboardTestSuite) SetupTest() {
 		true,
 		templateRepository,
 		nil,
+		"",
 		"",
 		"",
 		"")
@@ -1840,6 +1850,7 @@ func (suite *miscTestSuite) TestGetExternalIPAddresses() {
 func (suite *miscTestSuite) TestGetFrontendSpec() {
 	returnedAddresses := []string{"address1", "address2", "address3"}
 	defaultHTTPIngressHostTemplate := "{{ .FunctionName }}.{{ .ProjectName }}.{{ .Namespace }}.test-system.com"
+	imageNameTemplate := "{{ .ProjectName }}-{{ .FunctionName }}-{{ .ImageName }}"
 	scaleToZeroConfiguration := platformconfig.ScaleToZero{
 		Mode:                     platformconfig.EnabledScaleToZeroMode,
 		ScalerInterval:           "",
@@ -1865,6 +1876,11 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
 		Once()
 
 	suite.mockPlatform.
+		On("GetImageNameTemplate").
+		Return(imageNameTemplate, nil).
+		Once()
+
+	suite.mockPlatform.
 		On("GetScaleToZeroConfiguration").
 		Return(&scaleToZeroConfiguration, nil).
 		Once()
@@ -1873,6 +1889,7 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
 	expectedResponseBody := `{
 		"externalIPAddresses":            	["address1", "address2", "address3"],
 		"defaultHTTPIngressHostTemplate":	"{{ .FunctionName }}.{{ .ProjectName }}.{{ .Namespace }}.test-system.com",
+		"defaultHTTPIngressHostTemplate":	"{{ .ProjectName }}-{{ .FunctionName }}-{{ .ImageName }}",
 		"namespace":                      	"",
 		"scaleToZero":						{
 			"mode": "enabled",

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1894,7 +1894,7 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
 	expectedResponseBody := `{
 		"externalIPAddresses":            	["address1", "address2", "address3"],
 		"defaultHTTPIngressHostTemplate":	"{{ .FunctionName }}.{{ .ProjectName }}.{{ .Namespace }}.test-system.com",
-		"defaultHTTPIngressHostTemplate":	"{{ .ProjectName }}-{{ .FunctionName }}-",
+		"imageNamePrefixTemplate":	"{{ .ProjectName }}-{{ .FunctionName }}-",
 		"namespace":                      	"",
 		"scaleToZero":						{
 			"mode": "enabled",

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -179,6 +179,11 @@ func (mp *mockPlatform) GetImageNamePrefixTemplate() string {
 	return args.Get(0).(string)
 }
 
+func (mp *mockPlatform) RenderImageNamePrefixTemplate(projectName string, functionName string) (string, error) {
+	args := mp.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
 // SetExternalIPAddresses configures the IP addresses invocations will use, if "via" is set to "external-ip".
 // If this is not invoked, each platform will try to discover these addresses automatically
 func (mp *mockPlatform) SetExternalIPAddresses(externalIPAddresses []string) error {

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -170,11 +170,11 @@ func (mp *mockPlatform) GetDefaultHTTPIngressHostTemplate() string {
 	return args.Get(0).(string)
 }
 
-func (mp *mockPlatform) SetImageNameTemplate(imageNameTemplate string) {
-	mp.Called(imageNameTemplate)
+func (mp *mockPlatform) SetImageNamePrefixTemplate(imageNamePrefixTemplate string) {
+	mp.Called(imageNamePrefixTemplate)
 }
 
-func (mp *mockPlatform) GetImageNameTemplate() string {
+func (mp *mockPlatform) GetImageNamePrefixTemplate() string {
 	args := mp.Called()
 	return args.Get(0).(string)
 }
@@ -1850,7 +1850,7 @@ func (suite *miscTestSuite) TestGetExternalIPAddresses() {
 func (suite *miscTestSuite) TestGetFrontendSpec() {
 	returnedAddresses := []string{"address1", "address2", "address3"}
 	defaultHTTPIngressHostTemplate := "{{ .FunctionName }}.{{ .ProjectName }}.{{ .Namespace }}.test-system.com"
-	imageNameTemplate := "{{ .ProjectName }}-{{ .FunctionName }}-{{ .ImageName }}"
+	imageNamePrefixTemplate := "{{ .ProjectName }}-{{ .FunctionName }}-{{ .ImageName }}"
 	scaleToZeroConfiguration := platformconfig.ScaleToZero{
 		Mode:                     platformconfig.EnabledScaleToZeroMode,
 		ScalerInterval:           "",
@@ -1876,8 +1876,8 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
 		Once()
 
 	suite.mockPlatform.
-		On("GetImageNameTemplate").
-		Return(imageNameTemplate, nil).
+		On("GetImageNamePrefixTemplate").
+		Return(imageNamePrefixTemplate, nil).
 		Once()
 
 	suite.mockPlatform.

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -26,14 +26,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher"
 	"github.com/nuclio/nuclio/pkg/dashboard"
 	"github.com/nuclio/nuclio/pkg/dashboard/functiontemplates"
 	_ "github.com/nuclio/nuclio/pkg/dashboard/resource"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platform/test"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
-	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 	"github.com/nuclio/nuclio/pkg/restful"
 	"github.com/nuclio/nuclio/test/compare"
 
@@ -45,216 +44,6 @@ import (
 )
 
 //
-// Platform mock
-//
-
-// Platform defines the interface that any underlying function platform must provide for nuclio
-// to run over it
-type mockPlatform struct {
-	mock.Mock
-}
-
-//
-// Function
-//
-
-// Build will locally build a processor image and return its name (or the error)
-func (mp *mockPlatform) CreateFunctionBuild(createFunctionBuildOptions *platform.CreateFunctionBuildOptions) (*platform.CreateFunctionBuildResult, error) {
-	args := mp.Called(createFunctionBuildOptions)
-	return args.Get(0).(*platform.CreateFunctionBuildResult), args.Error(1)
-}
-
-// Deploy will deploy a processor image to the platform (optionally building it, if source is provided)
-func (mp *mockPlatform) CreateFunction(createFunctionOptions *platform.CreateFunctionOptions) (*platform.CreateFunctionResult, error) {
-
-	// release requester
-	if createFunctionOptions.CreationStateUpdated != nil {
-		createFunctionOptions.CreationStateUpdated <- true
-	}
-
-	args := mp.Called(createFunctionOptions)
-	return args.Get(0).(*platform.CreateFunctionResult), args.Error(1)
-}
-
-// UpdateFunction will update a previously deployed function
-func (mp *mockPlatform) UpdateFunction(updateFunctionOptions *platform.UpdateFunctionOptions) error {
-	args := mp.Called(updateFunctionOptions)
-	return args.Error(0)
-}
-
-// DeleteFunction will delete a previously deployed function
-func (mp *mockPlatform) DeleteFunction(deleteFunctionOptions *platform.DeleteFunctionOptions) error {
-	args := mp.Called(deleteFunctionOptions)
-	return args.Error(0)
-}
-
-// CreateFunctionInvocation will invoke a previously deployed function
-func (mp *mockPlatform) CreateFunctionInvocation(createFunctionInvocationOptions *platform.CreateFunctionInvocationOptions) (*platform.CreateFunctionInvocationResult, error) {
-	args := mp.Called(createFunctionInvocationOptions)
-	return args.Get(0).(*platform.CreateFunctionInvocationResult), args.Error(1)
-}
-
-// GetFunctions will list existing functions
-func (mp *mockPlatform) GetFunctions(getFunctionsOptions *platform.GetFunctionsOptions) ([]platform.Function, error) {
-	args := mp.Called(getFunctionsOptions)
-	return args.Get(0).([]platform.Function), args.Error(1)
-}
-
-//
-// Project
-//
-
-// CreateProject will probably create a new project
-func (mp *mockPlatform) CreateProject(createProjectOptions *platform.CreateProjectOptions) error {
-	args := mp.Called(createProjectOptions)
-	return args.Error(0)
-}
-
-// UpdateProject will update a previously existing project
-func (mp *mockPlatform) UpdateProject(updateProjectOptions *platform.UpdateProjectOptions) error {
-	args := mp.Called(updateProjectOptions)
-	return args.Error(0)
-}
-
-// DeleteProject will delete a previously existing project
-func (mp *mockPlatform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOptions) error {
-	args := mp.Called(deleteProjectOptions)
-	return args.Error(0)
-}
-
-// GetProjects will list existing projects
-func (mp *mockPlatform) GetProjects(getProjectsOptions *platform.GetProjectsOptions) ([]platform.Project, error) {
-	args := mp.Called(getProjectsOptions)
-	return args.Get(0).([]platform.Project), args.Error(1)
-}
-
-//
-// Function event
-//
-
-// CreateFunctionEvent will create a new function event that can later be used as a template from
-// which to invoke functions
-func (mp *mockPlatform) CreateFunctionEvent(createFunctionEventOptions *platform.CreateFunctionEventOptions) error {
-	args := mp.Called(createFunctionEventOptions)
-	return args.Error(0)
-}
-
-// UpdateFunctionEvent will update a previously existing function event
-func (mp *mockPlatform) UpdateFunctionEvent(updateFunctionEventOptions *platform.UpdateFunctionEventOptions) error {
-	args := mp.Called(updateFunctionEventOptions)
-	return args.Error(0)
-}
-
-// DeleteFunctionEvent will delete a previously existing function event
-func (mp *mockPlatform) DeleteFunctionEvent(deleteFunctionEventOptions *platform.DeleteFunctionEventOptions) error {
-	args := mp.Called(deleteFunctionEventOptions)
-	return args.Error(0)
-}
-
-// GetFunctionEvents will list existing function events
-func (mp *mockPlatform) GetFunctionEvents(getFunctionEventsOptions *platform.GetFunctionEventsOptions) ([]platform.FunctionEvent, error) {
-	args := mp.Called(getFunctionEventsOptions)
-	return args.Get(0).([]platform.FunctionEvent), args.Error(1)
-}
-
-//
-// Misc
-//
-
-func (mp *mockPlatform) SetDefaultHTTPIngressHostTemplate(defaultHTTPIngressHostTemplate string) {
-	mp.Called(defaultHTTPIngressHostTemplate)
-}
-
-func (mp *mockPlatform) GetDefaultHTTPIngressHostTemplate() string {
-	args := mp.Called()
-	return args.Get(0).(string)
-}
-
-func (mp *mockPlatform) SetImageNamePrefixTemplate(imageNamePrefixTemplate string) {
-	mp.Called(imageNamePrefixTemplate)
-}
-
-func (mp *mockPlatform) GetImageNamePrefixTemplate() string {
-	args := mp.Called()
-	return args.Get(0).(string)
-}
-
-func (mp *mockPlatform) RenderImageNamePrefixTemplate(projectName string, functionName string) (string, error) {
-	args := mp.Called()
-	return args.Get(0).(string), args.Error(1)
-}
-
-// SetExternalIPAddresses configures the IP addresses invocations will use, if "via" is set to "external-ip".
-// If this is not invoked, each platform will try to discover these addresses automatically
-func (mp *mockPlatform) SetExternalIPAddresses(externalIPAddresses []string) error {
-	args := mp.Called(externalIPAddresses)
-	return args.Error(0)
-}
-
-// GetExternalIPAddresses returns the external IP addresses invocations will use, if "via" is set to "external-ip".
-// These addresses are either set through SetExternalIPAddresses or automatically discovered
-func (mp *mockPlatform) GetExternalIPAddresses() ([]string, error) {
-	args := mp.Called()
-	return args.Get(0).([]string), args.Error(1)
-}
-
-func (mp *mockPlatform) GetScaleToZeroConfiguration() (*platformconfig.ScaleToZero, error) {
-	args := mp.Called()
-	return args.Get(0).(*platformconfig.ScaleToZero), args.Error(1)
-}
-
-// GetHealthCheckMode returns the healthcheck mode the platform requires
-func (mp *mockPlatform) GetHealthCheckMode() platform.HealthCheckMode {
-	args := mp.Called()
-	return args.Get(0).(platform.HealthCheckMode)
-}
-
-// GetName returns the platform name
-func (mp *mockPlatform) GetName() string {
-	args := mp.Called()
-	return args.String(0)
-}
-
-// GetNodes returns a slice of nodes currently in the cluster
-func (mp *mockPlatform) GetNodes() ([]platform.Node, error) {
-	args := mp.Called()
-	return args.Get(0).([]platform.Node), args.Error(1)
-}
-
-// ResolveDefaultNamespace returns the proper default resource namespace, given the current default namespace
-func (mp *mockPlatform) ResolveDefaultNamespace(defaultNamespace string) string {
-	args := mp.Called()
-	return args.Get(0).(string)
-}
-
-// GetNamespaces returns the namespaces
-func (mp *mockPlatform) GetNamespaces() ([]string, error) {
-	args := mp.Called()
-	return args.Get(0).([]string), args.Error(1)
-}
-
-func (mp *mockPlatform) GetDefaultInvokeIPAddresses() ([]string, error) {
-	args := mp.Called()
-	return args.Get(0).([]string), args.Error(1)
-}
-
-func (mp *mockPlatform) BuildAndPushContainerImage(buildOptions *containerimagebuilderpusher.BuildOptions) error {
-	return nil
-}
-
-func (mp *mockPlatform) GetOnbuildStages(onbuildArtifacts []runtime.Artifact) ([]string, error) {
-	return []string{}, nil
-}
-
-func (mp *mockPlatform) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifact) (map[string]string, error) {
-	return map[string]string{}, nil
-}
-
-func (mp *mockPlatform) GetBaseImageRegistry(registry string) string {
-	return "quay.io"
-}
-
-//
 // Test suite
 //
 
@@ -263,7 +52,7 @@ type dashboardTestSuite struct {
 	logger          logger.Logger
 	dashboardServer *dashboard.Server
 	httpServer      *httptest.Server
-	mockPlatform    *mockPlatform
+	mockPlatform    *test.MockPlatform
 }
 
 func (suite *dashboardTestSuite) SetupTest() {
@@ -271,7 +60,7 @@ func (suite *dashboardTestSuite) SetupTest() {
 	trueValue := true
 
 	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
-	suite.mockPlatform = &mockPlatform{}
+	suite.mockPlatform = &test.MockPlatform{}
 
 	templateRepository, err := functiontemplates.NewRepository(suite.logger, []functiontemplates.FunctionTemplateFetcher{})
 	suite.Require().NoError(err)

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -180,7 +180,7 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 	return deployResult, nil
 }
 
-// enrichment of create function options
+// Enrichment of create function options
 func (ap *Platform) EnrichCreateFunctionOptions(createFunctionOptions *platform.CreateFunctionOptions) error {
 
 	if err := ap.enrichProjectName(createFunctionOptions); err != nil {

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -319,7 +319,7 @@ func (ap *Platform) GetImageNamePrefixTemplate() string {
 	return ap.ImageNamePrefixTemplate
 }
 
-func (ap *Platform) RenderImageNameTemplate(projectName string, functionName string) (string, error) {
+func (ap *Platform) RenderImageNamePrefixTemplate(projectName string, functionName string) (string, error) {
 	return common.RenderTemplate(ap.ImageNamePrefixTemplate, map[string]interface{}{
 		"ProjectName":  projectName,
 		"FunctionName": functionName,
@@ -524,7 +524,7 @@ func (ap *Platform) enrichImageName(createFunctionOptions *platform.CreateFuncti
 		return nil
 	}
 
-	imagePrefix, err := ap.RenderImageNameTemplate(projectName, functionName)
+	imagePrefix, err := ap.RenderImageNamePrefixTemplate(projectName, functionName)
 
 	if err != nil {
 		return errors.Wrap(err, "Failed to render image name prefix template")

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -531,6 +531,8 @@ func (ap *Platform) enrichImageName(createFunctionOptions *platform.CreateFuncti
 	}
 
 	// if build is not required or custom image name was not asked enrichment is irrelevant
+	// note that leaving Spec.Build.Image will cause further enrichment deeper in build/builder.go.
+	// TODO: Revisit the need for this logic being stretched on so many places
 	if !functionBuildRequired || createFunctionOptions.FunctionConfig.Spec.Build.Image == "" {
 		return nil
 	}

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -48,6 +48,7 @@ type Platform struct {
 	DeployLogStreams               map[string]*LogStream
 	ContainerBuilder               containerimagebuilderpusher.BuilderPusher
 	DefaultHTTPIngressHostTemplate string
+	ImageNameTemplate              string
 }
 
 func NewPlatform(parentLogger logger.Logger, platform platform.Platform, platformConfiguration interface{}) (*Platform, error) {
@@ -308,6 +309,14 @@ func (ap *Platform) SetDefaultHTTPIngressHostTemplate(defaultHTTPIngressHostTemp
 
 func (ap *Platform) GetDefaultHTTPIngressHostTemplate() string {
 	return ap.DefaultHTTPIngressHostTemplate
+}
+
+func (ap *Platform) SetImageNameTemplate(imageNameTemplate string) {
+	ap.ImageNameTemplate = imageNameTemplate
+}
+
+func (ap *Platform) GetImageNameTemplate() string {
+	return ap.ImageNameTemplate
 }
 
 // GetExternalIPAddresses returns the external IP addresses invocations will use, if "via" is set to "external-ip".

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -185,6 +185,11 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 // Enrichment of create function options
 func (ap *Platform) EnrichCreateFunctionOptions(createFunctionOptions *platform.CreateFunctionOptions) error {
 
+	// if labels is nil assign an empty map to it
+	if createFunctionOptions.FunctionConfig.Meta.Labels == nil {
+		createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{}
+	}
+
 	if err := ap.enrichProjectName(createFunctionOptions); err != nil {
 		return errors.Wrap(err, "Failed enriching project name")
 	}
@@ -502,11 +507,6 @@ func (ap *Platform) prettifyProcessorLogLine(log []byte) (string, bool, error) {
 
 // Function must have project name - if it was not given - set to default project
 func (ap *Platform) enrichProjectName(createFunctionOptions *platform.CreateFunctionOptions) error {
-
-	// if labels is nil assign an empty map to it
-	if createFunctionOptions.FunctionConfig.Meta.Labels == nil {
-		createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{}
-	}
 
 	// if no project name was given, set it to the default project
 	if createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"] == "" {

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -527,7 +527,7 @@ func (ap *Platform) enrichImageName(createFunctionOptions *platform.CreateFuncti
 
 	functionBuildRequired, err := ap.functionBuildRequired(createFunctionOptions)
 	if err != nil {
-		return errors.Wrap(err, "Failed determining whether function should build")
+		return errors.Wrap(err, "Failed determining whether function build is required for image name enrichment")
 	}
 
 	// if build is not required or custom image name was not asked enrichment is irrelevant

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -237,7 +237,7 @@ func (ap *Platform) ValidateCreateFunctionOptions(createFunctionOptions *platfor
 func (ap *Platform) ValidateDeleteProjectOptions(deleteProjectOptions *platform.DeleteProjectOptions) error {
 	projectName := deleteProjectOptions.Meta.Name
 
-	if projectName == "default" {
+	if projectName == platform.DefaultProjectName {
 		return errors.New("Cannot delete the default project")
 	}
 
@@ -510,7 +510,7 @@ func (ap *Platform) enrichProjectName(createFunctionOptions *platform.CreateFunc
 
 	// if no project name was given, set it to the default project
 	if createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"] == "" {
-		createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"] = "default"
+		createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"] = platform.DefaultProjectName
 		ap.Logger.Debug("No project name specified. Setting to default")
 	}
 

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -319,6 +319,13 @@ func (ap *Platform) GetImageNamePrefixTemplate() string {
 	return ap.ImageNamePrefixTemplate
 }
 
+func (ap *Platform) RenderImageNameTemplate(projectName string, functionName string) (string, error) {
+	return common.RenderTemplate(ap.ImageNamePrefixTemplate, map[string]interface{}{
+		"ProjectName":  projectName,
+		"FunctionName": functionName,
+	})
+}
+
 // GetExternalIPAddresses returns the external IP addresses invocations will use, if "via" is set to "external-ip".
 // These addresses are either set through SetExternalIPAddresses or automatically discovered
 func (ap *Platform) GetExternalIPAddresses() ([]string, error) {
@@ -517,10 +524,7 @@ func (ap *Platform) enrichImageName(createFunctionOptions *platform.CreateFuncti
 		return nil
 	}
 
-	imagePrefix, err := common.RenderTemplate(ap.ImageNamePrefixTemplate, map[string]interface{}{
-		"ProjectName":  projectName,
-		"FunctionName": functionName,
-	})
+	imagePrefix, err := ap.RenderImageNameTemplate(projectName, functionName)
 
 	if err != nil {
 		return errors.Wrap(err, "Failed to render image name prefix template")

--- a/pkg/platform/factory/factory.go
+++ b/pkg/platform/factory/factory.go
@@ -85,7 +85,7 @@ func ensureDefaultProjectExistence(parentLogger logger.Logger, p platform.Platfo
 
 	projects, err := p.GetProjects(&platform.GetProjectsOptions{
 		Meta: platform.ProjectMeta{
-			Name:      "default",
+			Name:      platform.DefaultProjectName,
 			Namespace: resolvedNamespace,
 		},
 	})
@@ -98,7 +98,7 @@ func ensureDefaultProjectExistence(parentLogger logger.Logger, p platform.Platfo
 		// if we're here the default project doesn't exist. create it
 		projectConfig := platform.ProjectConfig{
 			Meta: platform.ProjectMeta{
-				Name:      "default",
+				Name:      platform.DefaultProjectName,
 				Namespace: resolvedNamespace,
 			},
 			Spec: platform.ProjectSpec{},

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -134,6 +134,10 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	// replace logger
 	createFunctionOptions.Logger = logStream.GetLogger()
 
+	if err := p.EnrichCreateFunctionOptions(createFunctionOptions); err != nil {
+		return nil, errors.Wrap(err, "Create function options enrichment failed")
+	}
+
 	if err := p.ValidateCreateFunctionOptions(createFunctionOptions); err != nil {
 		return nil, errors.Wrap(err, "Create function options validation failed")
 	}
@@ -182,7 +186,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 		}
 	}
 
-	// the builder will may update configuration, so we have to create the function in the platform only after
+	// the builder may update the configuration, so we have to create the function in the platform only after
 	// the builder does that
 	onAfterConfigUpdated := func(updatedFunctionConfig *functionconfig.Config) error {
 		var err error

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -125,6 +125,10 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	// replace logger
 	createFunctionOptions.Logger = logStream.GetLogger()
 
+	if err := p.EnrichCreateFunctionOptions(createFunctionOptions); err != nil {
+		return nil, errors.Wrap(err, "Create function options enrichment failed")
+	}
+
 	if err := p.ValidateCreateFunctionOptions(createFunctionOptions); err != nil {
 		return nil, errors.Wrap(err, "Create function options validation failed")
 	}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -109,6 +109,10 @@ type Platform interface {
 
 	GetDefaultHTTPIngressHostTemplate() string
 
+	SetImageNameTemplate(string)
+
+	GetImageNameTemplate() string
+
 	// Get scale to zero configuration
 	GetScaleToZeroConfiguration() (*platformconfig.ScaleToZero, error)
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -113,7 +113,7 @@ type Platform interface {
 
 	GetImageNamePrefixTemplate() string
 
-	RenderImageNameTemplate(projectName string, functionName string) (string, error)
+	RenderImageNamePrefixTemplate(projectName string, functionName string) (string, error)
 
 	// Get scale to zero configuration
 	GetScaleToZeroConfiguration() (*platformconfig.ScaleToZero, error)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -109,9 +109,9 @@ type Platform interface {
 
 	GetDefaultHTTPIngressHostTemplate() string
 
-	SetImageNameTemplate(string)
+	SetImageNamePrefixTemplate(string)
 
-	GetImageNameTemplate() string
+	GetImageNamePrefixTemplate() string
 
 	// Get scale to zero configuration
 	GetScaleToZeroConfiguration() (*platformconfig.ScaleToZero, error)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -113,6 +113,8 @@ type Platform interface {
 
 	GetImageNamePrefixTemplate() string
 
+	RenderImageNameTemplate(projectName string, functionName string) (string, error)
+
 	// Get scale to zero configuration
 	GetScaleToZeroConfiguration() (*platformconfig.ScaleToZero, error)
 

--- a/pkg/platform/test/mock.go
+++ b/pkg/platform/test/mock.go
@@ -1,0 +1,219 @@
+package test
+
+import (
+	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher"
+	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
+	"github.com/stretchr/testify/mock"
+)
+
+//
+// Platform mock
+//
+
+// Platform defines the interface that any underlying function platform must provide for nuclio
+// to run over it
+type MockPlatform struct {
+	mock.Mock
+}
+
+//
+// Function
+//
+
+// Build will locally build a processor image and return its name (or the error)
+func (mp *MockPlatform) CreateFunctionBuild(createFunctionBuildOptions *platform.CreateFunctionBuildOptions) (*platform.CreateFunctionBuildResult, error) {
+	args := mp.Called(createFunctionBuildOptions)
+	return args.Get(0).(*platform.CreateFunctionBuildResult), args.Error(1)
+}
+
+// Deploy will deploy a processor image to the platform (optionally building it, if source is provided)
+func (mp *MockPlatform) CreateFunction(createFunctionOptions *platform.CreateFunctionOptions) (*platform.CreateFunctionResult, error) {
+
+	// release requester
+	if createFunctionOptions.CreationStateUpdated != nil {
+		createFunctionOptions.CreationStateUpdated <- true
+	}
+
+	args := mp.Called(createFunctionOptions)
+	return args.Get(0).(*platform.CreateFunctionResult), args.Error(1)
+}
+
+// UpdateFunction will update a previously deployed function
+func (mp *MockPlatform) UpdateFunction(updateFunctionOptions *platform.UpdateFunctionOptions) error {
+	args := mp.Called(updateFunctionOptions)
+	return args.Error(0)
+}
+
+// DeleteFunction will delete a previously deployed function
+func (mp *MockPlatform) DeleteFunction(deleteFunctionOptions *platform.DeleteFunctionOptions) error {
+	args := mp.Called(deleteFunctionOptions)
+	return args.Error(0)
+}
+
+// CreateFunctionInvocation will invoke a previously deployed function
+func (mp *MockPlatform) CreateFunctionInvocation(createFunctionInvocationOptions *platform.CreateFunctionInvocationOptions) (*platform.CreateFunctionInvocationResult, error) {
+	args := mp.Called(createFunctionInvocationOptions)
+	return args.Get(0).(*platform.CreateFunctionInvocationResult), args.Error(1)
+}
+
+// GetFunctions will list existing functions
+func (mp *MockPlatform) GetFunctions(getFunctionsOptions *platform.GetFunctionsOptions) ([]platform.Function, error) {
+	args := mp.Called(getFunctionsOptions)
+	return args.Get(0).([]platform.Function), args.Error(1)
+}
+
+//
+// Project
+//
+
+// CreateProject will probably create a new project
+func (mp *MockPlatform) CreateProject(createProjectOptions *platform.CreateProjectOptions) error {
+	args := mp.Called(createProjectOptions)
+	return args.Error(0)
+}
+
+// UpdateProject will update a previously existing project
+func (mp *MockPlatform) UpdateProject(updateProjectOptions *platform.UpdateProjectOptions) error {
+	args := mp.Called(updateProjectOptions)
+	return args.Error(0)
+}
+
+// DeleteProject will delete a previously existing project
+func (mp *MockPlatform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOptions) error {
+	args := mp.Called(deleteProjectOptions)
+	return args.Error(0)
+}
+
+// GetProjects will list existing projects
+func (mp *MockPlatform) GetProjects(getProjectsOptions *platform.GetProjectsOptions) ([]platform.Project, error) {
+	args := mp.Called(getProjectsOptions)
+	return args.Get(0).([]platform.Project), args.Error(1)
+}
+
+//
+// Function event
+//
+
+// CreateFunctionEvent will create a new function event that can later be used as a template from
+// which to invoke functions
+func (mp *MockPlatform) CreateFunctionEvent(createFunctionEventOptions *platform.CreateFunctionEventOptions) error {
+	args := mp.Called(createFunctionEventOptions)
+	return args.Error(0)
+}
+
+// UpdateFunctionEvent will update a previously existing function event
+func (mp *MockPlatform) UpdateFunctionEvent(updateFunctionEventOptions *platform.UpdateFunctionEventOptions) error {
+	args := mp.Called(updateFunctionEventOptions)
+	return args.Error(0)
+}
+
+// DeleteFunctionEvent will delete a previously existing function event
+func (mp *MockPlatform) DeleteFunctionEvent(deleteFunctionEventOptions *platform.DeleteFunctionEventOptions) error {
+	args := mp.Called(deleteFunctionEventOptions)
+	return args.Error(0)
+}
+
+// GetFunctionEvents will list existing function events
+func (mp *MockPlatform) GetFunctionEvents(getFunctionEventsOptions *platform.GetFunctionEventsOptions) ([]platform.FunctionEvent, error) {
+	args := mp.Called(getFunctionEventsOptions)
+	return args.Get(0).([]platform.FunctionEvent), args.Error(1)
+}
+
+//
+// Misc
+//
+
+func (mp *MockPlatform) SetDefaultHTTPIngressHostTemplate(defaultHTTPIngressHostTemplate string) {
+	mp.Called(defaultHTTPIngressHostTemplate)
+}
+
+func (mp *MockPlatform) GetDefaultHTTPIngressHostTemplate() string {
+	args := mp.Called()
+	return args.Get(0).(string)
+}
+
+func (mp *MockPlatform) SetImageNamePrefixTemplate(imageNamePrefixTemplate string) {
+	mp.Called(imageNamePrefixTemplate)
+}
+
+func (mp *MockPlatform) GetImageNamePrefixTemplate() string {
+	args := mp.Called()
+	return args.Get(0).(string)
+}
+
+func (mp *MockPlatform) RenderImageNamePrefixTemplate(projectName string, functionName string) (string, error) {
+	args := mp.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
+// SetExternalIPAddresses configures the IP addresses invocations will use, if "via" is set to "external-ip".
+// If this is not invoked, each platform will try to discover these addresses automatically
+func (mp *MockPlatform) SetExternalIPAddresses(externalIPAddresses []string) error {
+	args := mp.Called(externalIPAddresses)
+	return args.Error(0)
+}
+
+// GetExternalIPAddresses returns the external IP addresses invocations will use, if "via" is set to "external-ip".
+// These addresses are either set through SetExternalIPAddresses or automatically discovered
+func (mp *MockPlatform) GetExternalIPAddresses() ([]string, error) {
+	args := mp.Called()
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (mp *MockPlatform) GetScaleToZeroConfiguration() (*platformconfig.ScaleToZero, error) {
+	args := mp.Called()
+	return args.Get(0).(*platformconfig.ScaleToZero), args.Error(1)
+}
+
+// GetHealthCheckMode returns the healthcheck mode the platform requires
+func (mp *MockPlatform) GetHealthCheckMode() platform.HealthCheckMode {
+	args := mp.Called()
+	return args.Get(0).(platform.HealthCheckMode)
+}
+
+// GetName returns the platform name
+func (mp *MockPlatform) GetName() string {
+	args := mp.Called()
+	return args.String(0)
+}
+
+// GetNodes returns a slice of nodes currently in the cluster
+func (mp *MockPlatform) GetNodes() ([]platform.Node, error) {
+	args := mp.Called()
+	return args.Get(0).([]platform.Node), args.Error(1)
+}
+
+// ResolveDefaultNamespace returns the proper default resource namespace, given the current default namespace
+func (mp *MockPlatform) ResolveDefaultNamespace(defaultNamespace string) string {
+	args := mp.Called()
+	return args.Get(0).(string)
+}
+
+// GetNamespaces returns the namespaces
+func (mp *MockPlatform) GetNamespaces() ([]string, error) {
+	args := mp.Called()
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (mp *MockPlatform) GetDefaultInvokeIPAddresses() ([]string, error) {
+	args := mp.Called()
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (mp *MockPlatform) BuildAndPushContainerImage(buildOptions *containerimagebuilderpusher.BuildOptions) error {
+	return nil
+}
+
+func (mp *MockPlatform) GetOnbuildStages(onbuildArtifacts []runtime.Artifact) ([]string, error) {
+	return []string{}, nil
+}
+
+func (mp *MockPlatform) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifact) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+func (mp *MockPlatform) GetBaseImageRegistry(registry string) string {
+	return "quay.io"
+}

--- a/pkg/platform/test/mock.go
+++ b/pkg/platform/test/mock.go
@@ -5,6 +5,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
+
 	"github.com/stretchr/testify/mock"
 )
 

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -137,6 +137,8 @@ type Address struct {
 // Project
 //
 
+const DefaultProjectName string = "default"
+
 type ProjectMeta struct {
 	Name        string            `json:"name,omitempty"`
 	Namespace   string            `json:"namespace,omitempty"`

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -261,6 +261,11 @@ func (b *Builder) GetFunctionPath() string {
 	return b.options.FunctionConfig.Spec.Build.Path
 }
 
+// GetProjectName returns the name of the project
+func (b *Builder) GetProjectName() string {
+	return b.options.FunctionConfig.Meta.Labels["nuclio.io/project-name"]
+}
+
 // GetFunctionName returns the name of the function
 func (b *Builder) GetFunctionName() string {
 	return b.options.FunctionConfig.Meta.Name
@@ -510,7 +515,7 @@ func (b *Builder) getImage() string {
 			}
 		}
 
-		imageName = fmt.Sprintf("%sprocessor-%s", repository, b.GetFunctionName())
+		imageName = fmt.Sprintf("%s%s-%s-processor", repository, b.GetProjectName(), b.GetFunctionName())
 	} else {
 		imageName = b.options.FunctionConfig.Spec.Build.Image
 	}

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -519,13 +519,18 @@ func (b *Builder) getImage() (string, error) {
 			}
 		}
 
-		imagePrefix, err := b.platform.RenderImageNameTemplate(b.GetProjectName(), b.GetFunctionName())
+		imagePrefix, err := b.platform.RenderImageNamePrefixTemplate(b.GetProjectName(), b.GetFunctionName())
 
 		if err != nil {
 			return "", errors.Wrap(err, "Failed to render image name prefix template")
 		}
 
-		imageName = fmt.Sprintf("%s%sprocessor", repository, imagePrefix)
+		// to keep old behaviour (before image prefix template option added)
+		if imagePrefix == "" {
+			imageName = fmt.Sprintf("%sprocessor-%s", repository, b.GetFunctionName())
+		} else {
+			imageName = fmt.Sprintf("%s%sprocessor", repository, imagePrefix)
+		}
 	} else {
 		imageName = b.options.FunctionConfig.Spec.Build.Image
 	}

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -195,7 +195,9 @@ func (suite *testSuite) TestGetImage() {
 
 	// user specified
 	suite.builder.options.FunctionConfig.Spec.Build.Image = "userSpecified"
-	suite.Require().Equal("userSpecified", suite.builder.getImage())
+	imageName, err := suite.builder.getImage()
+	suite.Require().NoError(err)
+	suite.Require().Equal("userSpecified", imageName)
 
 	// set function name and clear image name
 	suite.builder.options.FunctionConfig.Meta.Name = "test"
@@ -203,15 +205,22 @@ func (suite *testSuite) TestGetImage() {
 
 	// registry has no repository - should see "nuclio/" as repository
 	suite.builder.options.FunctionConfig.Spec.Build.Registry = "localhost:5000"
-	suite.Require().Equal("nuclio/processor-test", suite.builder.getImage())
+	imageName, err = suite.builder.getImage()
+	suite.Require().NoError(err)
+	suite.Require().Equal("nuclio/processor-test", imageName)
 
 	// registry has a repository - should not see "nuclio/" as repository
 	suite.builder.options.FunctionConfig.Spec.Build.Registry = "docker.io/foo"
-	suite.Require().Equal("processor-test", suite.builder.getImage())
+
+	imageName, err = suite.builder.getImage()
+	suite.Require().NoError(err)
+	suite.Require().Equal("processor-test", imageName)
 
 	// registry has a repository - should not see "nuclio/" as repository
 	suite.builder.options.FunctionConfig.Spec.Build.Registry = "index.docker.io/foo"
-	suite.Require().Equal("processor-test", suite.builder.getImage())
+	imageName, err = suite.builder.getImage()
+	suite.Require().NoError(err)
+	suite.Require().Equal("processor-test", imageName)
 }
 
 func (suite *testSuite) TestMergeDirectives() {


### PR DESCRIPTION
**Bug description:**
* Create nuclio function that prints "Hello"
* In "Configuration" set image name to "test1"
* Deploy function
* Create another nuclio function that prints "Goodbye"
* In "Configuration" set image name also to "test1"
* Deploy second function
* Delete pod for the first function

The result is that the first function outputs "Goodbye" instead of "Hello"

**Solution:**
Added an option to configure image name prefix template.
any prefix that includes the project and function name should fix the problem.
the template will be used in 2 points:
* default function image name - so far was `processor-{{ functionName }}` now will be 
`{{ imageNamePrefix }}processor` (if template is provided)
* enforcement on custom image names provided by the user - if the user specify a custom image name (through `spec.build.image`) it must (will be added if missing) have the configured prefix

For now, by default the template will be `""` (empty string) meaning the old behaviour will be the same. the default might be changed in the future

**Notes:** 
* If the user want to specify an image for a function (and don't want us to built it for him) he should do it using `spec.image`
* The custom image name prefix enforcement is done only if function build is required, for example, if `spec.build.mode` is set to `neverBuild`, build is not required