### PR TITLE
Improve logs and format kaniko logs

### DIFF
--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -182,7 +182,7 @@ func (p *Processor) Start() error {
 		if err = trigger.Start(nil); err != nil {
 			p.logger.ErrorWith("Failed to start trigger",
 				"kind", trigger.GetKind(),
-				"err", err)
+				"err", err.Error())
 			return errors.Wrap(err, "Failed to start trigger")
 		}
 	}
@@ -304,9 +304,9 @@ func (p *Processor) createTriggers(processorConfiguration *processor.Configurati
 				p.namedWorkerAllocators)
 
 			if err != nil {
-				p.logger.ErrorWith("Failed to create %s trigger",
+				p.logger.ErrorWith("Failed to create trigger",
 					"kind", triggerConfiguration.Kind,
-					"err", err)
+					"err", err.Error())
 				return errors.Wrapf(err, "Failed to create trigger")
 			}
 

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -84,6 +84,8 @@ func StringSliceContainsString(slice []string, str string) bool {
 	return false
 }
 
+// strips out ANSI Colors chars from string
+// example: "\u001b[31mHelloWorld" -> "HelloWorld"
 func RemoveANSIColorsFromString(s string) string {
 	ansi := "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
 	re := regexp.MustCompile(ansi)

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
@@ -81,6 +82,13 @@ func StringSliceContainsString(slice []string, str string) bool {
 	}
 
 	return false
+}
+
+func RemoveANSIColorsFromString(s string) string {
+	ansi := "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
+	re := regexp.MustCompile(ansi)
+
+	return re.ReplaceAllString(s, "")
 }
 
 // RetryUntilSuccessful calls callback every interval for duration until it returns true

--- a/pkg/common/map.go
+++ b/pkg/common/map.go
@@ -107,7 +107,7 @@ func StringInSlice(a string, list []string) bool {
 func CreateKeyValuePairs(m map[string]string) string {
 	b := new(bytes.Buffer)
 	for key, value := range m {
-		fmt.Fprintf(b, "%s=\"%s\",\n", key, value) // nolint: errcheck
+		fmt.Fprintf(b, "%s=\"%s\" || ", key, value) // nolint: errcheck
 	}
 
 	generatedString := b.String()
@@ -115,7 +115,7 @@ func CreateKeyValuePairs(m map[string]string) string {
 	if len(generatedString) != 0 {
 
 		// remove last `,\n`
-		generatedString = generatedString[:len(generatedString)-3]
+		generatedString = generatedString[:len(generatedString)-4]
 	}
 	return generatedString
 }

--- a/pkg/common/map.go
+++ b/pkg/common/map.go
@@ -115,7 +115,7 @@ func CreateKeyValuePairs(m map[string]string) string {
 
 	if len(generatedString) != 0 {
 
-		// remove last `,\n`
+		// remove last delimiter
 		generatedString = generatedString[:len(generatedString)-len(delimiter)]
 	}
 	return generatedString

--- a/pkg/common/map.go
+++ b/pkg/common/map.go
@@ -106,8 +106,9 @@ func StringInSlice(a string, list []string) bool {
 
 func CreateKeyValuePairs(m map[string]string) string {
 	b := new(bytes.Buffer)
+	delimiter := " || "
 	for key, value := range m {
-		fmt.Fprintf(b, "%s=\"%s\" || ", key, value) // nolint: errcheck
+		fmt.Fprintf(b, "%s=\"%s\"%s", key, value, delimiter) // nolint: errcheck
 	}
 
 	generatedString := b.String()
@@ -115,7 +116,7 @@ func CreateKeyValuePairs(m map[string]string) string {
 	if len(generatedString) != 0 {
 
 		// remove last `,\n`
-		generatedString = generatedString[:len(generatedString)-4]
+		generatedString = generatedString[:len(generatedString)-len(delimiter)]
 	}
 	return generatedString
 }

--- a/pkg/common/map_test.go
+++ b/pkg/common/map_test.go
@@ -26,6 +26,15 @@ type MapTestSuite struct {
 	suite.Suite
 }
 
+func (ts *MapTestSuite) TestCreateKeyValuePair() {
+	source := map[string]string{
+		"a":  "b",
+		"c":  "d",
+	}
+	keyValuePairs := CreateKeyValuePairs(source)
+	ts.Require().Equal("a=\"b\" || c=\"d\"", keyValuePairs)
+}
+
 func (ts *MapTestSuite) TestMapStringInterfaceGetOrDefault() {
 	source := map[string]interface{}{
 		"k_str1":  "str1",

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -3,7 +3,6 @@ package containerimagebuilderpusher
 import (
 	"bufio"
 	"fmt"
-	"github.com/nuclio/nuclio/pkg/common"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -11,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/errors"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -192,7 +192,10 @@ func (k *Kaniko) getKanikoJobSpec(namespace string, buildOptions *BuildOptions, 
 
 	// Truncate function name so the job name won't exceed k8s limit of 63
 	functionNameLimit := 63 - (len(k.builderConfiguration.JobPrefix) + len(timestamp) + 2)
-	functionName = functionName[0:functionNameLimit]
+	if len(functionName) > functionNameLimit {
+		functionName = functionName[0:functionNameLimit]
+	}
+
 	jobName := fmt.Sprintf("%s.%s.%s", k.builderConfiguration.JobPrefix, functionName, timestamp)
 
 	kanikoJobSpec := &batch_v1.Job{

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -525,15 +525,18 @@ func (ap *Platform) getMessageAndArgs(message string, args *string, log []byte) 
 	}
 
 	// format result depending on args/additional kwargs existence
-	if argsAsString != "" && additionalKwargsAsString != "" {
-		return fmt.Sprintf("%s [%s || %s]", message, argsAsString, additionalKwargsAsString)
-	} else if argsAsString != "" {
-		return fmt.Sprintf("%s [%s]", message, argsAsString)
-	} else if additionalKwargsAsString != "" {
-		return fmt.Sprintf("%s [%s]", message, additionalKwargsAsString)
+	var messageArgsList []string
+	if argsAsString != "" {
+		messageArgsList = append(messageArgsList, argsAsString)
 	}
-
-	return message
+	if additionalKwargsAsString != "" {
+		messageArgsList = append(messageArgsList, additionalKwargsAsString)
+	}
+	if len(messageArgsList) > 0 {
+		return fmt.Sprintf("%s [%s]", message, strings.Join(messageArgsList, " || "))
+	} else {
+		return message
+	}
 }
 
 func (ap *Platform) getLogLineAdditionalKwargs(log []byte) (map[string]string, error) {
@@ -545,16 +548,17 @@ func (ap *Platform) getLogLineAdditionalKwargs(log []byte) (map[string]string, e
 
 	additionalKwargs := map[string]string{}
 
+	defaultArgs := []string{"time", "datetime", "level", "message", "with", "more"}
+
 	// validate it is a suitable special arg
 	for argKey, argValue := range logAsMap {
 
 		// validate it is indeed an additional arg - it isn't a default arg
-		defaultArgs := []string{"time", "datetime", "level", "message", "with", "more"}
 		if common.StringSliceContainsString(defaultArgs, argKey) {
 			continue
 		}
 
-		// make sure it is a a flat arg - means its value is a string
+		// ensure argument is a string
 		if _, ok := argValue.(string); !ok {
 			continue
 		}

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -534,9 +534,9 @@ func (ap *Platform) getMessageAndArgs(message string, args *string, log []byte) 
 	}
 	if len(messageArgsList) > 0 {
 		return fmt.Sprintf("%s [%s]", message, strings.Join(messageArgsList, " || "))
-	} else {
-		return message
 	}
+
+	return message
 }
 
 func (ap *Platform) getLogLineAdditionalKwargs(log []byte) (map[string]string, error) {

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -508,7 +508,7 @@ func (ap *Platform) prettifyProcessorLogLine(log []byte) (string, string, error)
 	return res, briefLogLine, nil
 }
 
-func (ap *Platform) getMessageAndArgs (message string, args *string, log []byte) string {
+func (ap *Platform) getMessageAndArgs(message string, args *string, log []byte) string {
 	var argsAsString, additionalKwargsAsString string
 	additionalKwargs, err := ap.getLogLineAdditionalKwargs(log)
 	if err != nil {


### PR DESCRIPTION
Changes:
 - Remove ANSI colors from kaniko logs - it makes it non human readable, and doesn't compile with colors when printed on the UI
 - Attach kwargs of logs when formatting and prettifying them (used to not show them before)
 - Fixed kaniko truncation bug (string index out of bound)