### PR TITLE
UI: Triggers: Add Max Workers to Kafka trigger & more (see desc)

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -53,7 +53,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.16.0",
+    "iguazio.dashboard-controls": "^0.16.1",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- Function screen:
  - Navigation tabs: fix wrong coloring
  - Configuration tab › Volumes section: [bugfix] when two (or more) volume entries are expanded and there is uniqueness violation in some field among the expanded volume entries (so the same field in each entry is marked as invalid) — if then an entry is modified to be valid and is applied successfully, the rest of the expanded entries will be re-evaluated for their validity status, because they now may become valid.
  - Triggers tab:
    - Max Workers field:
      - Turned into a *number* input field instead of regular *text* input field
      - Added upper limit of 100000
    - for Cron trigger kind: added Max Workers and Worker Availability Timeout Millis fields
    - for Kafka trigger kind: added Max Workers field

Depends on PR https://github.com/iguazio/dashboard-controls/pull/870