### PR TITLE
[Nuclio] Add name uniqueness validation to functions

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -53,7 +53,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.16.2",
+    "iguazio.dashboard-controls": "^0.16.3",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",

--- a/pkg/dashboard/ui/src/app/components/data-wrappers/create-function-data-wrapper/create-function-data-wrapper.component.js
+++ b/pkg/dashboard/ui/src/app/components/data-wrappers/create-function-data-wrapper/create-function-data-wrapper.component.js
@@ -13,6 +13,7 @@
         ctrl.templates = {};
 
         ctrl.createProject = createProject;
+        ctrl.getFunction = getFunction;
         ctrl.getProject = getProject;
         ctrl.getProjects = getProjects;
         ctrl.getTemplates = getTemplates;
@@ -35,6 +36,15 @@
                 className: 'ngdialog-theme-nuclio'
             })
                 .closePromise;
+        }
+
+        /**
+         * Gets a single function
+         * @param {Object} metadata
+         * @returns {Promise}
+         */
+        function getFunction(metadata) {
+            return NuclioFunctionsDataService.getFunction(metadata);
         }
 
         /**

--- a/pkg/dashboard/ui/src/app/components/data-wrappers/create-function-data-wrapper/create-function-data-wrapper.tpl.html
+++ b/pkg/dashboard/ui/src/app/components/data-wrappers/create-function-data-wrapper/create-function-data-wrapper.tpl.html
@@ -1,4 +1,5 @@
 <ncl-create-function
+        data-get-function="$ctrl.getFunction(metadata)"
         data-get-project="$ctrl.getProject(id)"
         data-get-projects="$ctrl.getProjects()"
         data-get-templates="$ctrl.getTemplates()"


### PR DESCRIPTION
- On creating a new function or duplicating an existing one, a function name uniqueness violation test is performed to early prevent the user from using a name that is already in use (until today the error would occur only on deploy after all fields of the function were filled)
- Triggers: the Password field now has concealed characters
- Volumes:
  - [bugfix] when naming a volume with a name that is already in use by other volume, and then deleting one of the volumes that share the same name — all volumes were deleted
  - [bugfix] when using the same mount path to a volume which is already in use and expanding another volume and focusing on its mount path field — the field got set invalid, and when fixing the collision, the field remained invalid even though the collision was resolved
- When viewing YAML of Nuclio function, or exporting it, the YAML was malformed if double quotes were used in some fields

Relates to PR https://github.com/iguazio/dashboard-controls/pull/883