### PR TITLE
Upping controller's resync interval to 10min

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -96,7 +96,7 @@ func createController(kubeconfigPath string,
 		kubeClientSet,
 		nuclioClientSet,
 		functionresClient,
-		5*time.Minute,
+		10*time.Minute,
 		platformConfiguration)
 
 	if err != nil {


### PR DESCRIPTION
This is to handle better heavier load of nuclio functions (meaning higher number of nucliofunction crd records).
It is also possible to up the worker concurrency on the queue, but let's start with this