### PR TITLE
Detail endpoints to return 404 on missing resources

### DIFF
--- a/pkg/dashboard/resource/functionevent.go
+++ b/pkg/dashboard/resource/functionevent.go
@@ -99,7 +99,7 @@ func (fer *functionEventResource) GetByID(request *http.Request, id string) (res
 	}
 
 	if len(functionEvent) == 0 {
-		return nil, nil
+		return nil, nuclio.ErrNotFound
 	}
 
 	return fer.functionEventToAttributes(functionEvent[0]), nil

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -89,7 +89,7 @@ func (pr *projectResource) GetByID(request *http.Request, id string) (restful.At
 	}
 
 	if len(project) == 0 {
-		return nil, nil
+		return nil, nuclio.ErrNotFound
 	}
 
 	return pr.projectToAttributes(project[0]), nil


### PR DESCRIPTION
To align with the healthy behaviour (see https://github.com/nuclio/nuclio/pull/1483)
Aligning `GET` on `/api/projects/:id` and `/api/functionevent/:id`