### PR TITLE
Allow kaniko to use nuclio registry credentials

### DIFF
--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -215,9 +215,9 @@ func (k *Kaniko) getKanikoJobSpec(namespace string, buildOptions *BuildOptions, 
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:         "kaniko-executor",
-							Image:        k.builderConfiguration.KanikoImage,
-							Args:         buildArgs,
+							Name:  "kaniko-executor",
+							Image: k.builderConfiguration.KanikoImage,
+							Args:  buildArgs,
 							VolumeMounts: []v1.VolumeMount{
 								tmpFolderVolumeMount,
 								{
@@ -267,7 +267,7 @@ func (k *Kaniko) getKanikoJobSpec(namespace string, buildOptions *BuildOptions, 
 									SecretName: "nuclio-registry-credentials",
 									Items: []v1.KeyToPath{
 										{
-											Key: ".dockerconfigjson",
+											Key:  ".dockerconfigjson",
 											Path: "config.json",
 										},
 									},

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -218,17 +218,11 @@ func (k *Kaniko) getKanikoJobSpec(namespace string, buildOptions *BuildOptions, 
 							Name:         "kaniko-executor",
 							Image:        k.builderConfiguration.KanikoImage,
 							Args:         buildArgs,
-							Env: []v1.EnvVar{
-								{
-									Name:  "DOCKER_CONFIG",
-									Value: "/kaniko/secrets",
-								},
-							},
 							VolumeMounts: []v1.VolumeMount{
 								tmpFolderVolumeMount,
 								{
 									Name:      "docker-config",
-									MountPath: "/kaniko/secrets",
+									MountPath: "/kaniko/.docker",
 									ReadOnly:  true,
 								},
 							},
@@ -271,6 +265,12 @@ func (k *Kaniko) getKanikoJobSpec(namespace string, buildOptions *BuildOptions, 
 							VolumeSource: v1.VolumeSource{
 								Secret: &v1.SecretVolumeSource{
 									SecretName: "nuclio-registry-credentials",
+									Items: []v1.KeyToPath{
+										{
+											Key: ".dockerconfigjson",
+											Path: "config.json",
+										},
+									},
 								},
 							},
 						},

--- a/pkg/dockercreds/dockercred.go
+++ b/pkg/dockercreds/dockercred.go
@@ -232,7 +232,7 @@ func extractMetaFromKeyPath(keyPath string) (string, string, string, error) {
 
 func (dc *dockerCred) login() error {
 	dc.dockerCreds.logger.DebugWith("Logging in",
-		"url", dc.path,
+		"path", dc.path,
 		"user", dc.credentials.Username)
 
 	// try to login

--- a/pkg/platform/factory/factory.go
+++ b/pkg/platform/factory/factory.go
@@ -136,17 +136,20 @@ func getContainerBuilderConfiguration(platformConfiguration interface{}) *contai
 
 	// if some of the parameters are undefined, try environment variables
 	if containerBuilderConfiguration.Kind == "" {
-		containerBuilderConfiguration.Kind = common.GetEnvOrDefaultString("NUCLIO_CONTAINER_BUILDER_KIND", "docker")
+		containerBuilderConfiguration.Kind = common.GetEnvOrDefaultString("NUCLIO_CONTAINER_BUILDER_KIND",
+			"docker")
 	}
 	if containerBuilderConfiguration.BusyBoxImage == "" {
-		containerBuilderConfiguration.BusyBoxImage = common.GetEnvOrDefaultString("NUCLIO_BUSYBOX_CONTAINER_IMAGE", "busybox:1.31.0")
+		containerBuilderConfiguration.BusyBoxImage = common.GetEnvOrDefaultString("NUCLIO_BUSYBOX_CONTAINER_IMAGE",
+			"busybox:1.31.1")
 	}
 	if containerBuilderConfiguration.KanikoImage == "" {
 		containerBuilderConfiguration.KanikoImage = common.GetEnvOrDefaultString("NUCLIO_KANIKO_CONTAINER_IMAGE",
-			"gcr.io/kaniko-project/executor:v0.13.0")
+			"gcr.io/kaniko-project/executor:v0.17.0")
 	}
 	if containerBuilderConfiguration.JobPrefix == "" {
-		containerBuilderConfiguration.JobPrefix = common.GetEnvOrDefaultString("NUCLIO_DASHBOARD_JOB_NAME_PREFIX", "kanikojob")
+		containerBuilderConfiguration.JobPrefix = common.GetEnvOrDefaultString("NUCLIO_DASHBOARD_JOB_NAME_PREFIX",
+			"kanikojob")
 	}
 
 	if common.GetEnvOrDefaultBool("NUCLIO_KANIKO_INSECURE_REGISTRY", false) {


### PR DESCRIPTION
Issue:
Kaniko does not use registry credentials secret, that leads to `error checking push permissions -- make sure you entered the correct tag name, and that you are authenticated correctly, and try again` error.

Solution:
Adding `nuclio-registry-credentials` to kaniko's job spec