### PR TITLE
UI: Default function event request body type to Text + more

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -53,7 +53,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.16.3",
+    "iguazio.dashboard-controls": "^0.16.6",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
- Function list: [bugfix] sorting by “Status” column was broken.
- Function:
  - Test pane: when selecting a saved function event, its request body type now defaults to “Text” instead of “File”.
  - Configuration:
    - Build › Image: added template prefix if exists, and what the default would be if the field is left empty. 
![nuclio_configuration_build_image-name_no-prefix](https://user-images.githubusercontent.com/13918850/74174291-58377680-4c3c-11ea-96db-eca4972aa1d1.png) 
![nuclio_configuration_build_image-name_prefix](https://user-images.githubusercontent.com/13918850/74174305-5c639400-4c3c-11ea-9bad-c7ee95f4a7fb.png)
    - Labels: added a tooltip when labels are disabled on already-deployed functions. 
![nuclio_configuration_labels_disabled-tooltip](https://user-images.githubusercontent.com/13918850/74174188-2e7e4f80-4c3c-11ea-8d64-1afaa19fe4f1.png)
  - Triggers: [bugfix] after a function is deployed and the success ribbon appears, if a trigger was deleted it caused the action bar (where the deploy button is) to be hidden. 
![image](https://user-images.githubusercontent.com/13918850/74174447-a482b680-4c3c-11ea-9437-ab7d036fb7f8.png)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/897