### PR TITLE
Fix - Java project structure double creation

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -216,7 +216,7 @@ func GetEnvOrDefaultBool(key string, defaultValue bool) bool {
 // for example if the following dir existed "/my-project/src/main/java" then IsJavaProjectDir("/my-project") -> true
 func IsJavaProjectDir(dirPath string) bool {
 	javaProjectStructurePath := path.Join(dirPath, "src", "main", "java")
-	if _, err := os.Stat(javaProjectStructurePath); os.IsNotExist(err) {
+	if _, err := os.Stat(javaProjectStructurePath); err != nil {
 		return false
 	}
 

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"math"
 	"os"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -209,6 +210,17 @@ func GetEnvOrDefaultString(key string, defaultValue string) string {
 
 func GetEnvOrDefaultBool(key string, defaultValue bool) bool {
 	return strings.ToLower(GetEnvOrDefaultString(key, strconv.FormatBool(defaultValue))) == "true"
+}
+
+// Checks if the given @dirPath is in a java project structure
+// for example if the following dir existed "/my-project/src/main/java" then IsJavaProjectDir("/my-project") -> true
+func IsJavaProjectDir(dirPath string) bool {
+	javaProjectStructurePath := path.Join(dirPath, "src", "main", "java")
+	if _, err := os.Stat(javaProjectStructurePath); os.IsNotExist(err) {
+		return false
+	}
+
+	return true
 }
 
 func RenderTemplate(text string, data map[string]interface{}) (string, error) {

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -897,13 +897,13 @@ func (b *Builder) prepareStagingDir() error {
 		return errors.Wrapf(err, "Failed to create handler path in staging @ %s", handlerDirIncludingSubPath)
 	}
 
-	// first, tell the specific runtime to do its thing
-	if err := b.runtime.OnAfterStagingDirCreated(b.stagingDir); err != nil {
+	// copy any objects the runtime needs into staging
+	if err := b.copyHandlerToStagingDir(handlerSubPath); err != nil {
 		return errors.Wrap(err, "Failed to prepare staging dir")
 	}
 
-	// copy any objects the runtime needs into staging
-	if err := b.copyHandlerToStagingDir(handlerSubPath); err != nil {
+	// first, tell the specific runtime to do its thing
+	if err := b.runtime.OnAfterStagingDirCreated(b.stagingDir); err != nil {
 		return errors.Wrap(err, "Failed to prepare staging dir")
 	}
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -891,7 +891,7 @@ func (b *Builder) prepareStagingDir() error {
 
 	handlerSubPath := b.getHandlerSubPath()
 
-	// make sure the handler stagind dir exists
+	// make sure the handler staging dir exists
 	handlerDirIncludingSubPath := path.Join(handlerDirInStaging, handlerSubPath)
 	if err := os.MkdirAll(handlerDirIncludingSubPath, 0755); err != nil {
 		return errors.Wrapf(err, "Failed to create handler path in staging @ %s", handlerDirIncludingSubPath)
@@ -910,12 +910,11 @@ func (b *Builder) prepareStagingDir() error {
 	return nil
 }
 
-
 func (b *Builder) getHandlerSubPath() string {
 
 	// when it is a java function, and it is not structured as a java project - apply java project structure
 	if b.runtime.GetName() == "java" && !common.IsJavaProjectDir(b.options.FunctionConfig.Spec.Build.Path) {
-		return path.Join( "src", "main", "java")
+		return path.Join("src", "main", "java")
 	}
 
 	return ""

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1138,6 +1138,12 @@ func (b *Builder) getRuntimeCommentParser(logger logger.Logger, runtimeName stri
 }
 
 func (b *Builder) getHandlerDir(stagingDir string) string {
+
+	// when it is a java function, and it is not structured as a java project - apply java project structure
+	if b.runtime.GetName() == "java" && !common.IsJavaProjectDir(b.options.FunctionConfig.Spec.Build.Path) {
+		stagingDir = path.Join(stagingDir, "src", "main", "java")
+	}
+
 	return path.Join(stagingDir, "handler")
 }
 

--- a/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
@@ -39,7 +39,7 @@ COPY --from=processor /home/nuclio/bin/processor /home/gradle/bin/processor
 # Build user handler jar
 #
 
-RUN mkdir -p /home/gradle/src/userHandler/src/main/java
+RUN mkdir -p /home/gradle/src/userHandler
 
 # Copy the user handler builder script
 COPY pkg/processor/build/runtime/java/docker/onbuild/build-user-handler.sh /home/gradle/src/userHandler/build-user-handler.sh
@@ -54,9 +54,9 @@ ONBUILD COPY handler/build.gradle /home/gradle/src/userHandler
 # Specify the directory where the handler is kept. By default it is the context dir, but it is overridable
 ONBUILD ARG NUCLIO_BUILD_LOCAL_HANDLER_DIR=.
 
-# Copy the entire code to /home/gradle/src/userHandler/src/main/java, where gradle expects it to reside. Note that
+# Copy the entire code to /home/gradle/src/userHandler, where gradle expects it to reside. Note that
 # this will also copy build.gradle... but we'll ignore it
-ONBUILD COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} /home/gradle/src/userHandler/src/main/java
+ONBUILD COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} /home/gradle/src/userHandler
 
 # Run the handle builder to create /home/gradle/src/userHandler/build/libs/user-handler.jar.
 ONBUILD RUN cd /home/gradle/src/userHandler \

--- a/pkg/processor/build/runtime/java/runtime.go
+++ b/pkg/processor/build/runtime/java/runtime.go
@@ -71,11 +71,26 @@ func (j *java) GetProcessorDockerfileInfo(versionInfo *version.Info,
 }
 
 func (j *java) createGradleBuildScript(stagingBuildDir string) error {
-	gradleBuildScriptPath := path.Join(stagingBuildDir, "handler", "build.gradle")
+	handlerPath := path.Join(stagingBuildDir, "handler")
 
 	// if user supplied gradle build script - use it
+	gradleBuildScriptPath := path.Join(handlerPath, "build.gradle")
 	if common.IsFile(gradleBuildScriptPath) {
 		j.Logger.DebugWith("Found user gradle build script, using it", "path", gradleBuildScriptPath)
+		return nil
+	}
+
+	// if the given function files weren't in the standard structure, the gradle might be inside /src/main/java
+	// move build.gradle to the expected path
+	alternativeGradleBuildScriptPath := path.Join(handlerPath, "src", "main", "java", "build.gradle")
+	if common.IsFile(alternativeGradleBuildScriptPath) {
+		j.Logger.DebugWith("Found user gradle build script in alternative path, moving and using it", "path", alternativeGradleBuildScriptPath)
+
+		// move the file to where it's expected to be
+		err := os.Rename(alternativeGradleBuildScriptPath, gradleBuildScriptPath)
+		if err != nil {
+			return errors.Wrap(err, "Failed to move build.gradle from alternative path to expected path")
+		}
 		return nil
 	}
 


### PR DESCRIPTION
```
Reminder:
Standard java project directory structure is - `src/main/java`
```
This fix prevents double creation of standard directory structure, an example for this:
if a given nuclio Java function is already in the structure `src/main/java` a double structure will be `/src/main/java/src/main/java/...`