### PR TITLE
Docs - Running nuclio in production over k8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Nuclio is extremely fast: a single function instance can process hundreds of tho
 This is 10-100 times faster than some other frameworks. To learn more about how Nuclio works, see the Nuclio [architecture](/docs/concepts/architecture.md) documentation, read this review of [Nuclio vs. AWS Lambda](https://theburningmonk.com/2019/04/comparing-nuclio-and-aws-lambda/), or watch the [Nuclio serverless and AI webinar](https://www.youtube.com/watch?v=pTCx569Kd4A).
 You can find links to additional articles and tutorials on the [Nuclio web site](https://nuclio.io/).
 
+Nuclio secure: Nuclio is now integrated with [Kaniko](https://github.com/GoogleContainerTools/kaniko) to allow a secure and production-ready way of building docker images at run time.
+
 For further questions and support, [click to join](https://lit-oasis-83353.herokuapp.com) the [Nuclio Slack](https://nuclio-io.slack.com) workspace.
 
 ## Why another "serverless" project?

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Nuclio is extremely fast: a single function instance can process hundreds of tho
 This is 10-100 times faster than some other frameworks. To learn more about how Nuclio works, see the Nuclio [architecture](/docs/concepts/architecture.md) documentation, read this review of [Nuclio vs. AWS Lambda](https://theburningmonk.com/2019/04/comparing-nuclio-and-aws-lambda/), or watch the [Nuclio serverless and AI webinar](https://www.youtube.com/watch?v=pTCx569Kd4A).
 You can find links to additional articles and tutorials on the [Nuclio web site](https://nuclio.io/).
 
-Nuclio secure: Nuclio is now integrated with [Kaniko](https://github.com/GoogleContainerTools/kaniko) to allow a secure and production-ready way of building docker images at run time.
+Nuclio is secure: Nuclio is integrated with [Kaniko](https://github.com/GoogleContainerTools/kaniko) to allow a secure and production-ready way of building docker images at run time.
 
 For further questions and support, [click to join](https://lit-oasis-83353.herokuapp.com) the [Nuclio Slack](https://nuclio-io.slack.com) workspace.
 

--- a/docs/setup/k8s/getting-started-k8s.md
+++ b/docs/setup/k8s/getting-started-k8s.md
@@ -89,5 +89,6 @@ See the following resources to make the best of your new Nuclio environment:
 - [Deploying functions](/docs/tasks/deploying-functions.md)
 - [Invoking functions by name with an ingress](/docs/concepts/k8s/function-ingress.md)
 - [More function examples](/hack/examples/README.md)
+- [Running Nuclio in production environment over k8s](/docs/setup/k8s/running-in-production-k8s.md)
 - [References](/docs/reference/)
 

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -81,7 +81,8 @@ That being said, here are a few guidelines to get you on your way:
 When dealing with production deployments, bind-mounting the docker socket into Nuclio dashboard's pod is a bit of a no-no. Having access to the host machine's docker daemon by the Nuclio dashboard is akin to giving it root access to the machine.
 This is understandably a concern for real production use cases. Ideally, no pod should access the docker daemon directly, but since Nuclio is a docker based serverless framework, it needs the ability to build [OCI images](https://github.com/opencontainers/image-spec) at run time.
 While there are several alternatives to bind-mounting the docker socket, we have opted to integrate [Kaniko](https://github.com/GoogleContainerTools/kaniko) as a production-ready alternative to build ICO images in a secured way in latest versions.
-It is well maintained, stable, easy to use, and provides an ample set of features
+It is well maintained, stable, easy to use, and provides an ample set of features.
+Kaniko is available to use as of version 1.3.15 of Nuclio, currently only on k8s.
 
 To deploy nuclio and direct it to use the Kaniko engine to build images, apply the appropriate helm values as such:
 

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -66,9 +66,11 @@ We know these things can get tricky! If you want access to a fully-managed, dark
 
 That being said, here are a few guidelines to get you on your way:
 
-- Set `Values.offline=true` in the helm values, to put nuclio in "offline" mode. Set `dashboard.baseImagePullPolicy=Never`. In this mode you'll also want to freeze and control the values of all the `*.image.repository` and `*.image.tag` configuration keys to the image names and tags which are available to your k8s deployment in the offline environment.
+- Set `Values.offline=true` in the helm values, to put nuclio in "offline" mode. Set `dashboard.baseImagePullPolicy=Never`.
+  In this mode you'll also want to freeze and control the values of all the `*.image.repository` and `*.image.tag` configuration keys to the image names and tags which are available to your k8s deployment in the offline environment.
+  And `*.image.pullPolicy` to `Never` or `IfNotPresent` to make sure k8s won't try to access the web to fetch images.
 - Needless to say, in this scenario, you will configure nuclio with `registry.pushPullUrl` which is reachable from your system.
-- the processor and onbuild images will also have to be available to the dashboard in your environment, as they must be available for the `docker build` process (or alternatively to [kaniko](#using-kaniko-as-an-image-builder)).
+- The processor and onbuild images will also have to be available to the dashboard in your environment, as they must be available for the building process - (by `docker build`, or [kaniko](#using-kaniko-as-an-image-builder)).
   This can be tricky as you have to either make those images available to the k8s docker daemon or pull-able from a reachable registry, where they should be preloaded. Use `Values.registy.defaultBaseRegistryURL` to point nuclio at searching in your registry for those images, rather then at the default location of `quay.io/nuclio`.
   To save some work on setting up a registry and preloading the onbuild images to it (or as a reference to what it should include) - take a look at the [prebaked-registry](https://github.com/nuclio/prebaked-registry).
 - For the Nuclio templates library to be available to you, you'll have to package that yourself, and have it served locally, somewhere within reach of your system. To point Nuclio to it, set `Values.dashboard.templatesArchiveAddress` to where you serve the templates.

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -88,7 +88,7 @@ We know these things can get a bit tricky. If you want access to a fully-managed
 
 That being said, here are a few guidelines to get you on your way:
 
-- Most definitely [version freeze](#version-freezing). Also, use `*.image.pullPolicy` to `Never` or `IfNotPresent` to make sure k8s won't try to access the web to fetch images at any point in time.
+- Most definitely [version freeze](#version-freezing). Also, set `*.image.pullPolicy` to `Never` or `IfNotPresent` to make sure k8s won't try to access the web to fetch images at any point in time.
 - Set `Values.offline=true` in the helm values, to put nuclio in "offline" mode. Set `dashboard.baseImagePullPolicy=Never`.
 - Needless to say, in this scenario, you will configure nuclio with `registry.pushPullUrl` which is reachable from your system.
 - The processor and onbuild images will also have to be available to the dashboard in your environment, as they must be available for the building process - (by `docker build`, or [kaniko](#using-kaniko-as-an-image-builder)).

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -3,7 +3,7 @@
 After familiarizing yourself with Nuclio, and [deploying it over k8s](/docs/setup/k8s/getting-started-k8s.md) you may find yourself looking for extra configuration knobs, and proper practices for using it in a production environment.
 In [Iguazio](https://www.iguazio.com/) we integrated Nuclio as part of our [Data science PaaS](https://www.iguazio.com/platform/), and it is in extensive use in production, for both our customers and ourselves, running various workloads.
 
-In this document you can find more advanced configuration options, and some practices which address the needs of running Nuclio in production environments. 
+Here you will find more advanced configuration options, and some practices which address the needs of running Nuclio in production environments. 
 
 
 #### In this document

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -90,8 +90,8 @@ That being said, here are a few guidelines to get you on your way:
 
 - Most definitely [version freeze](#version-freezing). Also, set `*.image.pullPolicy` to `Never` or `IfNotPresent` to make sure k8s won't try to access the web to fetch images at any point in time.
 - Set `Values.offline=true` in the helm values, to put nuclio in "offline" mode. Set `dashboard.baseImagePullPolicy=Never`.
-- Needless to say, in this scenario, you will configure nuclio with `registry.pushPullUrl` which is reachable from your system.
-- The processor and onbuild images will also have to be available to the dashboard in your environment, as they must be available for the building process - (by `docker build`, or [kaniko](#using-kaniko-as-an-image-builder)).
+- Needless to say, in this scenario, you will have to configure nuclio with `registry.pushPullUrl` which is reachable from your system.
+- The processor and onbuild images will also have to be accessible to the dashboard in your environment, as they are required for the building process - (by `docker build`, or [kaniko](#using-kaniko-as-an-image-builder)).
   This can be tricky as you have to either make those images available to the k8s docker daemon or pull-able from a reachable registry, where they should be preloaded. Use `Values.registy.defaultBaseRegistryURL` to point nuclio at searching in your registry for those images, rather then at the default location of `quay.io/nuclio`.
   To save some work on setting up a registry and preloading the onbuild images to it (or as a reference to what it should include) - take a look at the [prebaked-registry](https://github.com/nuclio/prebaked-registry).
 - For the Nuclio templates library to be available to you, you'll have to package that yourself, and have it served locally, somewhere within reach of your system. To point Nuclio to it, set `Values.dashboard.templatesArchiveAddress` to where you serve the templates.

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -33,7 +33,7 @@ Below is a quick example of how to setup the a specific stable version of nuclio
     read -s mypassword
     <enter your password>
     
-    kubectl create secret docker-registry registry-credentials --namespace nuclio \
+    kubectl create secret docker-registry registry-credentials \
         --docker-username <username> \
         --docker-password $mypassword \
         --docker-server <URL> \
@@ -50,9 +50,9 @@ Below is a quick example of how to setup the a specific stable version of nuclio
     helm install \
         --set registry.secretName=registry-credentials \
         --set registry.pushPullUrl=<your registry URL> \
-        --set controller.image.tag=1.3.14-amd64 \
-        --set dashboard.image.tag=1.3.14-amd64\
-        .
+        --set controller.image.tag=<version>-amd64 \
+        --set dashboard.image.tag=<version>-amd64 \
+        ./hack/k8s/helm/nuclio/
     ```
 
   See [the helm chart's values file](/hack/k8s/helm/nuclio/values.yaml) for a full list of configurable parameters
@@ -105,8 +105,8 @@ To deploy nuclio and direct it to use the Kaniko engine to build images, apply t
         --set registry.secretName=registry-credentials \
         --set registry.pushPullUrl=<your registry URL> \
         --set dashboard.containerBuilderKind=kaniko \
-        --set controller.image.tag=1.3.14-amd64 \
-        --set dashboard.image.tag=1.3.14-amd64\
+        --set controller.image.tag=<version>-amd64 \
+        --set dashboard.image.tag=<version>-amd64\
         .
     ```
 

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -49,7 +49,7 @@ Below is a quick example of how to setup the latest stable version of nuclio via
         .
     ```
   
-  See full [values file](/hack/k8s/helm/nuclio/values.yaml) for a full list of configurable parameters
+  See [the helm chart's values file](/hack/k8s/helm/nuclio/values.yaml) for a full list of configurable parameters
 
 ## Multi Tenancy
 

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -17,7 +17,7 @@ Here you will find more advanced configuration options, and some practices which
 
 Even though you may, of course, use any of the available methods, we find that heavy-lifting over k8s is best done with helm charts.
 Nuclio's [helm chart](/hack/k8s/helm/nuclio/) is our preferred mode of deploying Nuclio in [Iguazio](https://www.iguazio.com/) as of writing this document.
-This is also where you'll find most of the production oriented features appearing first, and is the most closely maintained form of deployment.
+This is also where you'll find most of the production oriented features appearing first, and is the most tightly maintained form of deployment.
 
 Below is a quick example of how to setup the latest stable version of nuclio via helm charts:
 

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -1,0 +1,104 @@
+# Running Nuclio over k8s in production
+
+After familiarizing yourself with Nuclio, and [deploying it over k8s](/docs/setup/k8s/getting-started-k8s.md) you may find yourself looking for extra configuration knobs, and proper practices for using it in a production environment.
+In [Iguazio](https://www.iguazio.com/) we integrated Nuclio as part of our [Data science PaaS](https://www.iguazio.com/platform/), and it is in extensive use in production, for both our customers and ourselves, running various workloads.
+
+In this document you can find more advanced configuration options, and some practices which address the needs of running Nuclio in production environments. 
+
+
+#### In this document
+
+- [Preferred installation method](#preferred-installation-method)
+- [Multi Tenancy](#multi-tenancy)
+- [Dark site operation](#dark-site-operation)
+- [Using Kaniko as an image builder](#using-kaniko-as-an-image-builder)
+
+## Preferred installation method
+
+Even though you may, of course, use any of the available methods, we find that heavy-lifting over k8s is best done with helm charts. and so, Nuclio's [helm chart](/hack/k8s/helm/nuclio/) is our preferred mode of deploying Nuclio.
+This is also where you'll find most of the production oriented features appearing first, and is the most closely maintained form of deployment.
+
+Below is a quick example of how to setup the latest stable version of nuclio via helm charts:
+
+- Create a namespace for your functions, and a secret with your intended registry's credentials
+    ```sh
+    kubectl create namespace nuclio
+    ```
+    ```sh
+    read -s mypassword
+    <enter your password>
+    
+    kubectl create secret docker-registry registry-credentials --namespace nuclio \
+        --docker-username <username> \
+        --docker-password $mypassword \
+        --docker-server <URL> \
+        --docker-email ignored@nuclio.io
+    
+    unset mypassword
+    ```
+ - Checkout the nuclio project and install nuclio from its helm chart: 
+    ```sh
+    git checkout https://github.com/nuclio/nuclio.git
+    
+    helm install \
+        --set registry.secretName=registry-credentials \
+        --set registry.pushPullUrl=<your registry URL> \
+        --set controller.image.tag=latest-amd64 \
+        --set dashboard.image.tag=latest-amd64\
+        .
+    ```
+  
+  See full [values file](/hack/k8s/helm/nuclio/values.yaml) for a full list of configurable parameters
+
+## Multi Tenancy
+
+Implementation of multi-tenancy can be done in many different forms and to various degrees. Our experience have led us to adopt the k8s approach of tenant isolation using namespaces.
+- To achieve tenant separation for various nuclio projects and functions, and to avoid cross-tenant contamination and resource races, we have opted to deploy in each namespace a fully functioning Nuclio deployment, and configure Nuclio's controller to be namespaced.
+  This means the controller will handle Nuclio resources (functions, function-events, projects) only within its own namespace. This is supported via `Values.controller.namespace` in the helm chart values.  
+- To provide ample separation on the docker image level, we highly recommend that the Nuclio deployments of various tenants will not share docker registries, or will not share a tenant, if some a multi tenant registry is used (like `docker.io` or `quay.io`) 
+ 
+## Dark site operation
+
+We have received various questions about running Nuclio in air-gapped environments. Nuclio is fully dark-site compatible, and supports the appropriate configuration to avoid any outside access.
+These guidelines refer to more advanced use cases and they assume the surrounding work (devops!) can be done by the targeted user.
+We know these things can get tricky! If you want access to a fully-managed, darksite-friendly, batteries-included, Nuclio deployment, packaged with **Lots** of other goodies - do check out the enterprise grade [Iguazio Data science PaaS](https://www.iguazio.com/platform/)! 
+
+That being said, here are a few guidelines to get you on your way:
+
+- Set `Values.offline=true` in the helm values, to put nuclio in "offline" mode. Set `dashboard.baseImagePullPolicy=Never`. In this mode you'll also want to freeze and control the values of all the `*.image.repository` and `*.image.tag` configuration keys to the image names and tags which are available to your k8s deployment in the offline environment.
+- Needless to say, in this scenario, you will configure nuclio with `registry.pushPullUrl` which is reachable from your system.
+- the processor and onbuild images will also have to be available to the dashboard in your environment, as they must be available for the `docker build` process (or alternatively to [kaniko](#using-kaniko-as-an-image-builder)).
+  This can be tricky as you have to either make those images available to the k8s docker daemon or pull-able from a reachable registry, where they should be preloaded. Use `Values.registy.defaultBaseRegistryURL` to point nuclio at searching in your registry for those images, rather then at the default location of `quay.io/nuclio`.
+  To save some work on setting up a registry and preloading the onbuild images to it (or as a reference to what it should include) - take a look at the [prebaked-registry](https://github.com/nuclio/prebaked-registry).
+- For the Nuclio templates library to be available to you, you'll have to package that yourself, and have it served locally, somewhere within reach of your system. To point Nuclio to it, set `Values.dashboard.templatesArchiveAddress` to where you serve the templates.
+
+
+## Using Kaniko as an image builder
+
+When dealing with production deployments, bind-mounting the docker socket into Nuclio dashboard's pod is a bit of a no-no. Having access to the host machine's docker daemon by the Nuclio dashboard is akin to giving it root access to the machine.
+This is understandably a concern for real production use cases. Ideally, no pod should access the docker daemon directly, but since Nuclio is a docker based serverless framework, it needs the ability to build [OCI images](https://github.com/opencontainers/image-spec) at run time.
+While there are several alternatives to bind-mounting the docker socket, we have opted to integrate [Kaniko](https://github.com/GoogleContainerTools/kaniko) as a production-ready alternative to build ICO images in a secured way in latest versions.
+It is well maintained, stable, easy to use, and provides an ample set of features
+
+To deploy nuclio and direct it to use the Kaniko engine to build images, apply the appropriate helm values as such:
+
+    ```sh
+    helm install \
+        --set registry.secretName=registry-credentials \
+        --set registry.pushPullUrl=<your registry URL> \
+        --set dashboard.containerBuilderKind=kaniko \
+        --set controller.image.tag=latest-amd64 \
+        --set dashboard.image.tag=latest-amd64\
+        .
+    ```
+
+Simple enough, right?
+
+A few notes though:
+- If running in an air-gapped / "dark" environment, kaniko's executor image must also be available to your k8s cluster
+- Kaniko *requires* that you work with a registry, which is used to push the resulting function images to, it is no longer possible to have an image built and be available on the host docker daemon.
+  This means you must configure a `Values.registry.pushPullUrl` for kaniko to push the resulting images to, as well as possibly `Values.registry.defaultBaseRegistryURL` if the onbuild / base images are not preloaded or otherwise available on your `pushPullUrl` at the time of function build.
+
+We should also mention that we are looking into enabling docker-in-docker (dind) as a possible mode of operation.
+
+

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -1,4 +1,4 @@
-# Running Nuclio over k8s in production
+# Running Nuclio over Kubernetes in production
 
 After familiarizing yourself with Nuclio, and [deploying it over k8s](/docs/setup/k8s/getting-started-k8s.md) you may find yourself looking for extra configuration knobs, and proper practices for using it in a production environment.
 In [Iguazio](https://www.iguazio.com/) we integrated Nuclio as part of our [Data science PaaS](https://www.iguazio.com/platform/), and it is in extensive use in production, for both our customers and ourselves, running various workloads.

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -9,9 +9,11 @@ Here you will find more advanced configuration options, and some practices which
 #### In this document
 
 - [Preferred installation method](#preferred-installation-method)
+- [Version freezing](#version-freezing)
 - [Multi Tenancy](#multi-tenancy)
-- [Dark site operation](#dark-site-operation)
+- [Air gapped (dark site) operation](#air-gapped-dark-site-operation)
 - [Using Kaniko as an image builder](#using-kaniko-as-an-image-builder)
+
 
 ## Preferred installation method
 
@@ -19,12 +21,14 @@ Even though you may, of course, use any of the available methods, we find that h
 Nuclio's [helm chart](/hack/k8s/helm/nuclio/) is our preferred mode of deploying Nuclio in [Iguazio](https://www.iguazio.com/) as of writing this document.
 This is also where you'll find most of the production oriented features appearing first, and is the most tightly maintained form of deployment.
 
-Below is a quick example of how to setup the latest stable version of nuclio via helm charts:
+Below is a quick example of how to setup the a specific stable version of nuclio (1.3.14) via helm charts:
 
 - Create a namespace for your functions, and a secret with your intended registry's credentials
+
     ```sh
     kubectl create namespace nuclio
     ```
+
     ```sh
     read -s mypassword
     <enter your password>
@@ -37,19 +41,22 @@ Below is a quick example of how to setup the latest stable version of nuclio via
     
     unset mypassword
     ```
+
  - Checkout the nuclio project and install nuclio from its helm chart: 
+
     ```sh
     git checkout https://github.com/nuclio/nuclio.git
     
     helm install \
         --set registry.secretName=registry-credentials \
         --set registry.pushPullUrl=<your registry URL> \
-        --set controller.image.tag=latest-amd64 \
-        --set dashboard.image.tag=latest-amd64\
+        --set controller.image.tag=1.3.14-amd64 \
+        --set dashboard.image.tag=1.3.14-amd64\
         .
     ```
-  
+
   See [the helm chart's values file](/hack/k8s/helm/nuclio/values.yaml) for a full list of configurable parameters
+
 
 ## Multi Tenancy
 
@@ -57,18 +64,25 @@ Implementation of multi-tenancy can be done in many different forms and to vario
 - To achieve tenant separation for various nuclio projects and functions, and to avoid cross-tenant contamination and resource races, we have opted to deploy in each namespace a fully functioning Nuclio deployment, and configure Nuclio's controller to be namespaced.
   This means the controller will handle Nuclio resources (functions, function-events, projects) only within its own namespace. This is supported via `Values.controller.namespace` in the helm chart values.  
 - To provide ample separation on the docker image level, we highly recommend that the Nuclio deployments of various tenants will not share docker registries, or will not share a tenant, if a multi-tenant registry is used (like `docker.io` or `quay.io`) 
- 
-## Dark site operation
 
-We have received various questions about running Nuclio in air-gapped environments. Nuclio is fully dark-site compatible, and supports the appropriate configuration to avoid any outside access.
-These guidelines refer to more advanced use cases and they assume the surrounding work (devops!) can be done by the targeted user.
-We know these things can get tricky! If you want access to a fully-managed, darksite-friendly, batteries-included, Nuclio deployment, packaged with **Lots** of other goodies - do check out the enterprise grade [Iguazio Data science PaaS](https://www.iguazio.com/platform/)! 
+
+## Version freezing
+
+- Working in production, you need reproducibility and consistency. This means you will not be working with latest stable version, but qualify a specific version and freeze it in your Nuclio configuration ([helm chart values file](/hack/k8s/helm/nuclio/values.yaml)).
+  Stick with this version until you qualify a newer one to work with your system. Since we adhere to backwards compatibility standards between patch versions, and even minor version bumps usually do not break major functionality, the process of qualifying a newer nuclio version should hopefully be short and easy.
+  To version freeze via helm values, set all of the `*.image.repository` and `*.image.tag` configuration keys to the image names and tags which represenr your chosen version's images and are available to your k8s deployment (in case of an [air-gapped installation](#air-gapped-dark-site-operation)).
+ 
+ 
+## Air gapped (dark site) operation
+
+We have received various questions about running Nuclio in air gapped environments. Nuclio is fully air-gap compatible, and supports the appropriate configuration to avoid any outside access.
+These guidelines refer to more advanced use cases and they assume the surrounding work (read: devops) can be done by the targeted user.
+We know these things can get a bit tricky. If you want access to a fully-managed, air-gap-friendly, batteries-included, Nuclio deployment, packaged with **Lots** of other goodies - do check out the enterprise grade [Iguazio Data science PaaS](https://www.iguazio.com/platform/)! 
 
 That being said, here are a few guidelines to get you on your way:
 
+- Most definitely [version freeze](#version-freezing). Also, use `*.image.pullPolicy` to `Never` or `IfNotPresent` to make sure k8s won't try to access the web to fetch images at any point in time.
 - Set `Values.offline=true` in the helm values, to put nuclio in "offline" mode. Set `dashboard.baseImagePullPolicy=Never`.
-  In this mode you'll also want to freeze and control the values of all the `*.image.repository` and `*.image.tag` configuration keys to the image names and tags which are available to your k8s deployment in the offline environment.
-  And `*.image.pullPolicy` to `Never` or `IfNotPresent` to make sure k8s won't try to access the web to fetch images.
 - Needless to say, in this scenario, you will configure nuclio with `registry.pushPullUrl` which is reachable from your system.
 - The processor and onbuild images will also have to be available to the dashboard in your environment, as they must be available for the building process - (by `docker build`, or [kaniko](#using-kaniko-as-an-image-builder)).
   This can be tricky as you have to either make those images available to the k8s docker daemon or pull-able from a reachable registry, where they should be preloaded. Use `Values.registy.defaultBaseRegistryURL` to point nuclio at searching in your registry for those images, rather then at the default location of `quay.io/nuclio`.
@@ -80,7 +94,7 @@ That being said, here are a few guidelines to get you on your way:
 
 When dealing with production deployments, bind-mounting the docker socket into Nuclio dashboard's pod is a bit of a no-no. Having access to the host machine's docker daemon by the Nuclio dashboard is akin to giving it root access to the machine.
 This is understandably a concern for real production use cases. Ideally, no pod should access the docker daemon directly, but since Nuclio is a docker based serverless framework, it needs the ability to build [OCI images](https://github.com/opencontainers/image-spec) at run time.
-While there are several alternatives to bind-mounting the docker socket, we have opted to integrate [Kaniko](https://github.com/GoogleContainerTools/kaniko) as a production-ready alternative to build ICO images in a secured way in latest versions.
+While there are several alternatives to bind-mounting the docker socket, we have opted to integrate [Kaniko](https://github.com/GoogleContainerTools/kaniko) as a production-ready alternative to build OCI images in a secured way in latest versions.
 It is well maintained, stable, easy to use, and provides an ample set of features.
 Kaniko is available to use as of version 1.3.15 of Nuclio, currently only on k8s.
 
@@ -91,15 +105,15 @@ To deploy nuclio and direct it to use the Kaniko engine to build images, apply t
         --set registry.secretName=registry-credentials \
         --set registry.pushPullUrl=<your registry URL> \
         --set dashboard.containerBuilderKind=kaniko \
-        --set controller.image.tag=latest-amd64 \
-        --set dashboard.image.tag=latest-amd64\
+        --set controller.image.tag=1.3.14-amd64 \
+        --set dashboard.image.tag=1.3.14-amd64\
         .
     ```
 
 Simple enough, right?
 
 A few notes though:
-- If running in an air-gapped / "dark" environment, kaniko's executor image must also be available to your k8s cluster
+- If running in an air-gapped environment, kaniko's executor image must also be available to your k8s cluster
 - Kaniko *requires* that you work with a registry, which is used to push the resulting function images to, it is no longer possible to have an image built and be available on the host docker daemon.
   This means you must configure a `Values.registry.pushPullUrl` for kaniko to push the resulting images to, as well as possibly `Values.registry.defaultBaseRegistryURL` if the onbuild / base images are not preloaded or otherwise available on your `pushPullUrl` at the time of function build.
 

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -56,7 +56,7 @@ Below is a quick example of how to setup the latest stable version of nuclio via
 Implementation of multi-tenancy can be done in many different forms and to various degrees. Our experience have led us to adopt the k8s approach of tenant isolation using namespaces.
 - To achieve tenant separation for various nuclio projects and functions, and to avoid cross-tenant contamination and resource races, we have opted to deploy in each namespace a fully functioning Nuclio deployment, and configure Nuclio's controller to be namespaced.
   This means the controller will handle Nuclio resources (functions, function-events, projects) only within its own namespace. This is supported via `Values.controller.namespace` in the helm chart values.  
-- To provide ample separation on the docker image level, we highly recommend that the Nuclio deployments of various tenants will not share docker registries, or will not share a tenant, if some a multi tenant registry is used (like `docker.io` or `quay.io`) 
+- To provide ample separation on the docker image level, we highly recommend that the Nuclio deployments of various tenants will not share docker registries, or will not share a tenant, if a multi-tenant registry is used (like `docker.io` or `quay.io`) 
  
 ## Dark site operation
 

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -15,7 +15,8 @@ Here you will find more advanced configuration options, and some practices which
 
 ## Preferred installation method
 
-Even though you may, of course, use any of the available methods, we find that heavy-lifting over k8s is best done with helm charts. and so, Nuclio's [helm chart](/hack/k8s/helm/nuclio/) is our preferred mode of deploying Nuclio.
+Even though you may, of course, use any of the available methods, we find that heavy-lifting over k8s is best done with helm charts.
+Nuclio's [helm chart](/hack/k8s/helm/nuclio/) is our preferred mode of deploying Nuclio in [Iguazio](https://www.iguazio.com/) as of writing this document.
 This is also where you'll find most of the production oriented features appearing first, and is the most closely maintained form of deployment.
 
 Below is a quick example of how to setup the latest stable version of nuclio via helm charts:

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -61,14 +61,14 @@ spec:
         - name: NUCLIO_CONTAINER_BUILDER_KIND
           value: {{ .Values.dashboard.containerBuilderKind }}
         - name: NUCLIO_KANIKO_CONTAINER_IMAGE
-          value: {{ .Values.kaniko.image.repository }}:{{ .Values.kaniko.image.tag }}
+          value: {{ .Values.dashboard.kaniko.image.repository }}:{{ .Values.dashboard.kaniko.image.tag }}
         - name: NUCLIO_KANIKO_CONTAINER_IMAGE_PULL_POLICY
-          value: {{ .Values.kaniko.image.pullPolicy }}
-        {{- if .Values.dashboard.insecurePushRegistry }}
+          value: {{ .Values.dashboard.kaniko.image.pullPolicy }}
+        {{- if .Values.dashboard.kaniko.insecurePushRegistry }}
         - name: NUCLIO_KANIKO_INSECURE_PUSH_REGISTRY
           value: "true"
         {{- end }}
-        {{- if .Values.dashboard.insecurePullRegistry }}
+        {{- if .Values.dashboard.kaniko.insecurePullRegistry }}
         - name: NUCLIO_KANIKO_INSECURE_PULL_REGISTRY
           value: "true"
         {{- end }}
@@ -76,9 +76,9 @@ spec:
         - name: NUCLIO_DASHBOARD_DEFAULT_BASE_REGISTRY_URL
           value: {{ .Values.registry.defaultBaseRegistryURL }}
         {{- end }}
-        {{- if .Values.registry.cacheRepo }}
+        {{- if .Values.dashboard.kaniko.cacheRepo }}
         - name: NUCLIO_DASHBOARD_KANIKO_CACHE_REPO
-          value: {{ .Values.registry.cacheRepo }}
+          value: {{ .Values.dashboard.kaniko.cacheRepo }}
         {{- end }}
 #        - name: NUCLIO_DASHBOARD_RUN_REGISTRY_URL
 #          value: "localhost:5000"

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -60,6 +60,10 @@ spec:
           value: {{ template "nuclio.dashboardName" . }}
         - name: NUCLIO_CONTAINER_BUILDER_KIND
           value: {{ .Values.dashboard.containerBuilderKind }}
+        - name: NUCLIO_KANIKO_CONTAINER_IMAGE
+          value: {{ .Values.kaniko.image.repository }}:{{ .Values.kaniko.image.tag }}
+        - name: NUCLIO_KANIKO_CONTAINER_IMAGE_PULL_POLICY
+          value: {{ .Values.kaniko.image.pullPolicy }}
         {{- if .Values.dashboard.insecurePushRegistry }}
         - name: NUCLIO_KANIKO_INSECURE_PUSH_REGISTRY
           value: "true"

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -39,7 +39,7 @@ dashboard:
 
   kaniko:
 
-    #  Set this flag to specify a remote repository that will be used to store cached layers (kaniko only)
+    #  Set this flag to specify a remote repository that will be used to store cached layers
     #
     # cacheRepo: someurl
 

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -46,6 +46,9 @@ dashboard:
   # Uncomment to configure node port
   # nodePort: 32050
 
+  # Uncomment if you serve the templates locally (for offline environments) - else will be pulled from github
+  # templatesArchiveAddress: <url>
+
   ingress:
     enabled: false
     annotations: {}
@@ -58,6 +61,12 @@ dashboard:
     #  - secretName: nuclio-tls
     #    hosts:
     #      - nuclio.local
+
+kaniko:
+  image:
+    repository: gcr.io/kaniko-project/executor
+    tag: v0.17.1
+    pullPolicy: IfNotPresent
 
 autoscaler:
   enabled: false

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -37,11 +37,22 @@ dashboard:
   # Supported container builders: "kaniko", "docker"
   containerBuilderKind: "docker"
 
-  # Set this flag to push images to a plain HTTP registry (kaniko only)
-  insecurePushRegistry: false
+  kaniko:
 
-  # Set this flag to pull images from a plain HTTP registry (kaniko only)
-  insecurePullRegistry: false
+    #  Set this flag to specify a remote repository that will be used to store cached layers (kaniko only)
+    #
+    # cacheRepo: someurl
+
+    # Set this flag to push images to a plain HTTP registry
+    insecurePushRegistry: false
+
+    # Set this flag to pull images from a plain HTTP registry
+    insecurePullRegistry: false
+
+    image:
+      repository: gcr.io/kaniko-project/executor
+      tag: v0.17.1
+      pullPolicy: IfNotPresent
 
   # Uncomment to configure node port
   # nodePort: 32050
@@ -61,12 +72,6 @@ dashboard:
     #  - secretName: nuclio-tls
     #    hosts:
     #      - nuclio.local
-
-kaniko:
-  image:
-    repository: gcr.io/kaniko-project/executor
-    tag: v0.17.1
-    pullPolicy: IfNotPresent
 
 autoscaler:
   enabled: false
@@ -102,7 +107,7 @@ registry: {}
   #
   #  kubectl get secret <secret-name> -n <source-namespace> -o yaml \
   #     | sed s/"namespace: <source-namespace>"/"namespace: <destination-namespace>"/ \
-  #     | kubectl apply -n <destination-namespace> -f -
+  #     | kubectl apply -f -
   #
   #
   # If you'd still like to have this managed as part of the helm chart, populate
@@ -133,10 +138,6 @@ registry: {}
   #  Use dedicated base/onbuild images registry (pull registry)
   #
   # defaultBaseRegistryURL: someurl
-
-  #  Set this flag to specify a remote repository that will be used to store cached layers (kaniko only)
-  #
-  # cacheRepo: someurl
 
 rbac:
 

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -225,10 +225,11 @@ func (k *Kaniko) getKanikoJobSpec(namespace string, buildOptions *BuildOptions, 
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:         "kaniko-executor",
-							Image:        k.builderConfiguration.KanikoImage,
-							Args:         buildArgs,
-							VolumeMounts: []v1.VolumeMount{tmpFolderVolumeMount},
+							Name:            "kaniko-executor",
+							Image:           k.builderConfiguration.KanikoImage,
+							ImagePullPolicy: v1.PullPolicy(k.builderConfiguration.KanikoImagePullPolicy),
+							Args:            buildArgs,
+							VolumeMounts:    []v1.VolumeMount{tmpFolderVolumeMount},
 						},
 					},
 					InitContainers: []v1.Container{

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -21,6 +21,7 @@ type ContainerBuilderConfiguration struct {
 	Kind                                 string
 	BusyBoxImage                         string
 	KanikoImage                          string
+	KanikoImagePullPolicy                string
 	JobPrefix                            string
 	DefaultRegistryCredentialsSecretName string
 	DefaultBaseRegistryURL               string

--- a/pkg/platform/factory/factory.go
+++ b/pkg/platform/factory/factory.go
@@ -147,6 +147,10 @@ func getContainerBuilderConfiguration(platformConfiguration interface{}) *contai
 		containerBuilderConfiguration.KanikoImage = common.GetEnvOrDefaultString("NUCLIO_KANIKO_CONTAINER_IMAGE",
 			"gcr.io/kaniko-project/executor:v0.17.1")
 	}
+	if containerBuilderConfiguration.KanikoImagePullPolicy == "" {
+		containerBuilderConfiguration.KanikoImagePullPolicy = common.GetEnvOrDefaultString("NUCLIO_KANIKO_CONTAINER_IMAGE_PULL_POLICY",
+			"IfNotPresent")
+	}
 	if containerBuilderConfiguration.JobPrefix == "" {
 		containerBuilderConfiguration.JobPrefix = common.GetEnvOrDefaultString("NUCLIO_DASHBOARD_JOB_NAME_PREFIX",
 			"kanikojob")


### PR DESCRIPTION
- Added a new `running-in-production-k8s.md` doc to help orient users towards using nuclio in production
- Properly passing `kaniko` executor image details to dashboard from helm values