### PR TITLE
Fixed kaniko job naming

### DIFF
--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -316,8 +316,8 @@ func (k *Kaniko) compileJobName(image string) string {
 	}
 
 	jobName := fmt.Sprintf("%s.%s.%s", k.builderConfiguration.JobPrefix, functionName, timestamp)
-	
-	// Failback
+
+	// Fallback
 	if !k.jobNameRegex.MatchString(jobName) {
 		k.logger.DebugWith("Kaniko job name does not match k8s regex. Won't use function name", "jobName", jobName)
 		jobName = fmt.Sprintf("%s.%s", k.builderConfiguration.JobPrefix, timestamp)

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -36,7 +36,7 @@ func NewKaniko(logger logger.Logger, kubeClientSet kubernetes.Interface,
 		return nil, errors.New("Missing kaniko builder configuration")
 	}
 
-	jobNameRegex, err := regexp.Compile("[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)")
+	jobNameRegex, err := regexp.Compile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
 	if err != nil {
 		return nil, errors.New("Failed to compile job name regex")
 	}

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"regexp"
 	"strings"
 	"time"
 
@@ -25,6 +26,7 @@ type Kaniko struct {
 	kubeClientSet        kubernetes.Interface
 	logger               logger.Logger
 	builderConfiguration *ContainerBuilderConfiguration
+	jobNameRegex         *regexp.Regexp
 }
 
 func NewKaniko(logger logger.Logger, kubeClientSet kubernetes.Interface,
@@ -34,10 +36,16 @@ func NewKaniko(logger logger.Logger, kubeClientSet kubernetes.Interface,
 		return nil, errors.New("Missing kaniko builder configuration")
 	}
 
+	jobNameRegex, err := regexp.Compile("[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)")
+	if err != nil {
+		return nil, errors.New("Failed to compile job name regex")
+	}
+
 	kanikoBuilder := &Kaniko{
 		logger:               logger,
 		kubeClientSet:        kubeClientSet,
 		builderConfiguration: builderConfiguration,
+		jobNameRegex:         jobNameRegex,
 	}
 
 	return kanikoBuilder, nil
@@ -196,7 +204,7 @@ func (k *Kaniko) getKanikoJobSpec(namespace string, buildOptions *BuildOptions, 
 		MountPath: "/tmp",
 	}
 
-	jobName := k.getJobName(buildOptions.Image)
+	jobName := k.compileJobName(buildOptions.Image)
 
 	kanikoJobSpec := &batch_v1.Job{
 		ObjectMeta: meta_v1.ObjectMeta{
@@ -290,7 +298,7 @@ func (k *Kaniko) getKanikoJobSpec(namespace string, buildOptions *BuildOptions, 
 	return kanikoJobSpec
 }
 
-func (k *Kaniko) getJobName(image string) string {
+func (k *Kaniko) compileJobName(image string) string {
 
 	// Valid job name is composed from a DNS-1123 subdomains which in turn must contain only lower case
 	// alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com',
@@ -298,6 +306,7 @@ func (k *Kaniko) getJobName(image string) string {
 
 	functionName := strings.Replace(image, "/", "", -1)
 	functionName = strings.Replace(functionName, ":", "", -1)
+	functionName = strings.Replace(functionName, "-", "", -1)
 	timestamp := fmt.Sprintf("%d", time.Now().Unix())
 
 	// Truncate function name so the job name won't exceed k8s limit of 63
@@ -307,6 +316,13 @@ func (k *Kaniko) getJobName(image string) string {
 	}
 
 	jobName := fmt.Sprintf("%s.%s.%s", k.builderConfiguration.JobPrefix, functionName, timestamp)
+	
+	// Failback
+	if !k.jobNameRegex.MatchString(jobName) {
+		k.logger.DebugWith("Kaniko job name does not match k8s regex. Won't use function name", "jobName", jobName)
+		jobName = fmt.Sprintf("%s.%s", k.builderConfiguration.JobPrefix, timestamp)
+	}
+
 	return jobName
 }
 
@@ -328,7 +344,7 @@ func (k *Kaniko) waitForKanikoJobCompletion(namespace string, jobName string, Bu
 				return nil
 			}
 
-			k.logger.Debug("Kaniko job was completed successfully", "jobLogs", jobLogs)
+			k.logger.DebugWith("Kaniko job was completed successfully", "jobLogs", jobLogs)
 			return nil
 		}
 		if runningJob.Status.Failed > 0 {

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -36,6 +36,8 @@ func NewKaniko(logger logger.Logger, kubeClientSet kubernetes.Interface,
 		return nil, errors.New("Missing kaniko builder configuration")
 	}
 
+	// Valid job name is composed from a DNS-1123 subdomains which in turn must contain only lower case
+	// alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com')
 	jobNameRegex, err := regexp.Compile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
 	if err != nil {
 		return nil, errors.New("Failed to compile job name regex")
@@ -299,10 +301,6 @@ func (k *Kaniko) getKanikoJobSpec(namespace string, buildOptions *BuildOptions, 
 }
 
 func (k *Kaniko) compileJobName(image string) string {
-
-	// Valid job name is composed from a DNS-1123 subdomains which in turn must contain only lower case
-	// alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com',
-	// regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
 
 	functionName := strings.Replace(image, "/", "", -1)
 	functionName = strings.Replace(functionName, ":", "", -1)


### PR DESCRIPTION
Truncating function name may result in '-' being the last character which is invalid for k8s job name