### PR TITLE
Allow control of dependant registry URL override in helm chart

### DIFF
--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -98,12 +98,12 @@ If you select to handle the implementation yourself, follow these guidelines; th
 - Set `offline` to `true` to put Nuclio in "offline" mode.
 - Set `dashboard.baseImagePullPolicy` to `Never`.
 - Set `registry.pushPullUrl` to a registry URL that's reachable from your system.
-- <a id="air-gapped-envir-processor-n-onbuild-images"></a>Ensure that the processor and "onbuild" images are accessible to the dashboard in your environment, as they're required for the build process (either by `docker build` or [Kaniko](#using-kaniko-as-an-image-builder)).
+- <a id="air-gapped-envir-base-n-onbuild-images"></a>Ensure that base, "onbuild" and processor images are accessible to the dashboard in your environment, as they're required for the build process (either by `docker build` or [Kaniko](#using-kaniko-as-an-image-builder)).
   You can achieve this using either of the following methods:
 
-  - Make the images available to the Kubernetes Docker daemon.
+  - Make the images available on the host Docker daemon (local cache).
   - Preload the images to a registry that's accessible to your system, to allow pulling the images from the registry.
-    When using this method, set `registy.defaultBaseRegistryURL` to the URL of an accessible local registry that contains the preloaded images (thus overriding the default location of `quay.io/nuclio`, which isn't accessible in air-gapped environments).
+    When using this method, set `registy.dependantImageRegistryURL` to the URL of an accessible local registry that contains the preloaded images (thus overriding the default location of `quay.io/nuclio`, which isn't accessible in air-gapped environments).
     <br/><br/>
     > **Note:** To save yourself some work, you can use the [prebaked Nuclio registry](https://github.com/nuclio/prebaked-registry), either as-is or as a reference for creating your own local registry with preloaded images.
 
@@ -136,7 +136,7 @@ This is rather straightforward; however, note the following:
 - When running in an [air-gapped environment](#air-gapped-deployment), Kaniko's executor image must also be available to your Kubernetes cluster.
 - Kaniko requires that you work with a registry to which push the resulting function images.
   It doesn't support accessing images on the host Docker daemon.
-  Therefore, you must set `registry.pushPullUrl` to the URL of the registry to which Kaniko should push the resulting images, and in air-gapped environments, you must also set `registry.defaultBaseRegistryURL` to the URL of an accessible local registry that contains the preloaded processor and "onbuild" images (see [Air-gapped deployment](#air-gapped-envir-processor-n-onbuild-images)).
+  Therefore, you must set `registry.pushPullUrl` to the URL of the registry to which Kaniko should push the resulting images, and in air-gapped environments, you must also set `registry.dependantImageRegistryURL` to the URL of an accessible local registry that contains the preloaded base, "onbuild" and processor images (see [Air-gapped deployment](#air-gapped-envir-base-n-onbuild-images)).
 - `quay.io` doesn't support nested repositories.
   If you're using Kaniko as a container builder and `quay.io` as a registry (`--set registry.pushPullUrl=quay.io/<repo name>`), add the following to your configuration to allow Kaniko caching to push successfully; (replace the `<repo name>` placeholder with the name of your repository):
     ```sh

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -98,7 +98,7 @@ If you select to handle the implementation yourself, follow these guidelines; th
 - Set `offline` to `true` to put Nuclio in "offline" mode.
 - Set `dashboard.baseImagePullPolicy` to `Never`.
 - Set `registry.pushPullUrl` to a registry URL that's reachable from your system.
-- <a id="air-gapped-envir-base-n-onbuild-images"></a>Ensure that base, "onbuild" and processor images are accessible to the dashboard in your environment, as they're required for the build process (either by `docker build` or [Kaniko](#using-kaniko-as-an-image-builder)).
+- <a id="air-gapped-envir-base-n-onbuild-images"></a>Ensure that base, "onbuild", and processor images are accessible to the dashboard in your environment, as they're required for the build process (either by `docker build` or [Kaniko](#using-kaniko-as-an-image-builder)).
   You can achieve this using either of the following methods:
 
   - Make the images available on the host Docker daemon (local cache).
@@ -136,7 +136,7 @@ This is rather straightforward; however, note the following:
 - When running in an [air-gapped environment](#air-gapped-deployment), Kaniko's executor image must also be available to your Kubernetes cluster.
 - Kaniko requires that you work with a registry to which push the resulting function images.
   It doesn't support accessing images on the host Docker daemon.
-  Therefore, you must set `registry.pushPullUrl` to the URL of the registry to which Kaniko should push the resulting images, and in air-gapped environments, you must also set `registry.dependantImageRegistryURL` to the URL of an accessible local registry that contains the preloaded base, "onbuild" and processor images (see [Air-gapped deployment](#air-gapped-envir-base-n-onbuild-images)).
+  Therefore, you must set `registry.pushPullUrl` to the URL of the registry to which Kaniko should push the resulting images, and in air-gapped environments, you must also set `registry.dependantImageRegistryURL` to the URL of an accessible local registry that contains the preloaded base, "onbuild", and processor images (see [Air-gapped deployment](#air-gapped-envir-base-n-onbuild-images)).
 - `quay.io` doesn't support nested repositories.
   If you're using Kaniko as a container builder and `quay.io` as a registry (`--set registry.pushPullUrl=quay.io/<repo name>`), add the following to your configuration to allow Kaniko caching to push successfully; (replace the `<repo name>` placeholder with the name of your repository):
     ```sh

--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.5.15
+version: 0.5.16
 appVersion: 1.3.15
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -76,6 +76,10 @@ spec:
         - name: NUCLIO_DASHBOARD_DEFAULT_BASE_REGISTRY_URL
           value: {{ .Values.registry.defaultBaseRegistryURL }}
         {{- end }}
+        {{- if .Values.registry.dependantImageRegistryURL }}
+        - name: NUCLIO_DASHBOARD_DEPENDANT_IMAGE_REGISTRY_URL
+          value: {{ .Values.registry.dependantImageRegistryURL }}
+        {{- end }}
         {{- if .Values.dashboard.kaniko.cacheRepo }}
         - name: NUCLIO_DASHBOARD_KANIKO_CACHE_REPO
           value: {{ .Values.dashboard.kaniko.cacheRepo }}

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -138,7 +138,11 @@ registry: {}
 
   #  Use dedicated base/onbuild images registry (pull registry)
   #
-  # defaultBaseRegistryURL: someurl
+  # defaultBaseRegistryURL: someUrl
+
+  # Use this registry url as an override for both base and onbuild images,
+  # so they will be pulled from the given registry URL and not from the default registry their name implies
+  # dependantImageRegistryURL: someUrl
 
 rbac:
 

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -136,7 +136,7 @@ registry: {}
     # username: someuser
     # password: somepass
 
-  #  Use dedicated base/onbuild images registry (pull registry)
+  #  Use dedicated onbuild images registry (pull registry)
   #
   # defaultBaseRegistryURL: someUrl
 

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -120,14 +120,14 @@ registry: {}
   # secretName: registry-credentials
 
   # In some cases the docker server URL in the registry secrets isn't the same as the URL with which
-  # you push and pull. For example, in GKE you login to `gcr.io` (or some other regional URL) yet have
-  # to push/pull from `gcr.io/<project-name>. If this is the case, specify the url here and it will be
-  # used instead of the url in the secrets
+  # you push and pull. For example, in GKE you log into `gcr.io` (or some other regional URL) yet have
+  # to push/pull from `gcr.io/<project-name>. If this is the case, specify the URL here and it will be
+  # used instead of the URL in the secrets
   #
   # pushPullUrl: gcr.io/<project-name>
 
   # In case you'd like helm to generate the secret for you, `loginUrl` specifies
-  # the URL with which the components in nuclio will try to login to
+  # the URL with which the components in nuclio will try to log into
   #
   # loginUrl: someurl
 
@@ -136,12 +136,13 @@ registry: {}
     # username: someuser
     # password: somepass
 
-  #  Use dedicated onbuild images registry (pull registry)
+  #  Use a dedicated "onbuild" images registry (pull registry).
+  #  Note: To override a pull registry for both "onbuild" and base images, use `dependantImageRegistryURL`.
   #
   # defaultBaseRegistryURL: someUrl
 
-  # Use this registry url as an override for both base and onbuild images,
-  # so they will be pulled from the given registry URL and not from the default registry their name implies
+  # Use this registry URL as an override for both base and "onbuild" images, so they'll be pulled from the
+  # specified registry URL and not from the default registry that their name implies
   # dependantImageRegistryURL: someUrl
 
 rbac:


### PR DESCRIPTION
Needed to override base image (whether default or given) - for true kaniko darksite