### PR TITLE
Enforce function resource version validation

### DIFF
--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -35,7 +35,7 @@ dashboard:
   imageNamePrefixTemplate: ""
 
   # Supported container builders: "kaniko", "docker"
-  containerBuilderKind: "docker"
+  containerBuilderKind: docker
 
   kaniko:
 

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -321,6 +321,10 @@ type Meta struct {
 	Namespace   string            `json:"namespace,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// opaque, readonly value, determines whether the object has changed
+	// more details @ https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions
+	ResourceVersion string            `json:"resource_version,omitempty"`
 }
 
 // GetUniqueID return unique id

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -324,7 +324,7 @@ type Meta struct {
 
 	// opaque, readonly value, determines whether the object has changed
 	// more details @ https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions
-	ResourceVersion string            `json:"resource_version,omitempty"`
+	ResourceVersion string `json:"resourceVersion,omitempty"`
 }
 
 // GetUniqueID return unique id

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -723,6 +723,11 @@ func (ap *Platform) validateResourceVersion(existingFunction platform.Function,
 	if existingFunction == nil {
 		return nil
 	}
+
+	// if not version is given, skip validation
+	if createFunctionOptions.FunctionConfig.Meta.ResourceVersion == "" {
+		return nil
+	}
 	existingFunctionConfig := existingFunction.GetConfig()
 	if existingFunctionConfig.Meta.ResourceVersion != createFunctionOptions.FunctionConfig.Meta.ResourceVersion {
 		return errors.Errorf("Resource version miss match %s != %s",

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
+	"github.com/nuclio/nuclio-sdk-go"
 )
 
 //
@@ -224,7 +225,8 @@ func (ap *Platform) ValidateCreateFunctionOptions(existingFunction platform.Func
 	}
 
 	if err := ap.validateResourceVersion(existingFunction, createFunctionOptions); err != nil {
-		return errors.Wrap(err, "Resource version validation error")
+		ap.Logger.ErrorWith("Resource version validation error", "error", err)
+		return nuclio.NewErrConflict("Function is out of sync")
 	}
 
 	return nil

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -127,7 +127,7 @@ func (suite *TestAbstractSuite) TestMinMaxReplicas() {
 		err := suite.Platform.EnrichCreateFunctionOptions(createFunctionOptions)
 		suite.NoError(err, "Failed to enrich function")
 
-		err = suite.Platform.ValidateCreateFunctionOptions(createFunctionOptions)
+		err = suite.Platform.ValidateCreateFunctionOptions(nil, createFunctionOptions)
 		if MinMaxReplicas.shouldFailValidation {
 			suite.Error(err, "Validation should fail")
 			suite.Logger.DebugWith("Validation failed as expected ", "functionName", functionName)

--- a/pkg/platform/kube/function.go
+++ b/pkg/platform/kube/function.go
@@ -51,9 +51,11 @@ func newFunction(parentLogger logger.Logger,
 	// create a config from function
 	functionConfig := functionconfig.Config{
 		Meta: functionconfig.Meta{
-			Name:      nuclioioFunction.Name,
-			Namespace: nuclioioFunction.Namespace,
-			Labels:    nuclioioFunction.Labels,
+			Name:            nuclioioFunction.Name,
+			Namespace:       nuclioioFunction.Namespace,
+			Labels:          nuclioioFunction.Labels,
+			ResourceVersion: nuclioioFunction.ResourceVersion,
+			Annotations:     nuclioioFunction.Annotations,
 		},
 		Spec: nuclioioFunction.Spec,
 	}

--- a/pkg/platform/kube/function.go
+++ b/pkg/platform/kube/function.go
@@ -49,7 +49,7 @@ func newFunction(parentLogger logger.Logger,
 	newFunction := &function{}
 
 	// create a config from function
-	functionConfig := functionconfig.Config{
+	functionConfig := &functionconfig.Config{
 		Meta: functionconfig.Meta{
 			Name:            nuclioioFunction.Name,
 			Namespace:       nuclioioFunction.Namespace,
@@ -62,7 +62,7 @@ func newFunction(parentLogger logger.Logger,
 
 	newAbstractFunction, err := platform.NewAbstractFunction(parentLogger,
 		parentPlatform,
-		&functionConfig,
+		functionConfig,
 		&nuclioioFunction.Status,
 		newFunction)
 
@@ -152,10 +152,11 @@ func (f *function) GetReplicas() (int, int) {
 func (f *function) GetConfig() *functionconfig.Config {
 	return &functionconfig.Config{
 		Meta: functionconfig.Meta{
-			Name:        f.function.Name,
-			Namespace:   f.function.Namespace,
-			Labels:      f.function.Labels,
-			Annotations: f.function.Annotations,
+			Name:            f.function.Name,
+			Namespace:       f.function.Namespace,
+			Labels:          f.function.Labels,
+			Annotations:     f.function.Annotations,
+			ResourceVersion: f.function.ResourceVersion,
 		},
 		Spec: f.function.Spec,
 	}

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -142,6 +142,17 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 		return nil, errors.Wrap(err, "Create function options validation failed")
 	}
 
+	// it's possible to pass a function without specifying any meta in the request, in that case skip getting existing function
+	if createFunctionOptions.FunctionConfig.Meta.Namespace != "" && createFunctionOptions.FunctionConfig.Meta.Name != "" {
+		existingFunctionConfig, err = p.getFunctionConfig(&createFunctionOptions.FunctionConfig.Meta)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to get existing function config")
+		}
+		if existingFunctionConfig.Meta.ResourceVersion != createFunctionOptions.FunctionConfig.Meta.ResourceVersion {
+			return nil ,errors.Wrap(err, "Resource Version miss match")
+		}
+	}
+
 	reportCreationError := func(creationError error, briefErrorsMessage string) error {
 		errorStack := bytes.Buffer{}
 		errors.PrintErrorStack(&errorStack, creationError, 20)
@@ -175,15 +186,6 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 				Message:  briefErrorsMessage,
 			},
 		})
-	}
-
-	// it's possible to pass a function without specifying any meta in the request, in that case skip getting existing function
-	if createFunctionOptions.FunctionConfig.Meta.Namespace != "" && createFunctionOptions.FunctionConfig.Meta.Name != "" {
-		existingFunctionConfig, err = p.getFunctionConfig(createFunctionOptions.FunctionConfig.Meta.Namespace,
-			createFunctionOptions.FunctionConfig.Meta.Name)
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to get existing function config")
-		}
 	}
 
 	// the builder may update the configuration, so we have to create the function in the platform only after

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -726,8 +726,8 @@ func (p *Platform) getFunction(namespace, name string) (*nuclioio.NuclioFunction
 	return function, nil
 }
 
-func (p *Platform) getFunctionConfig(namespace, name string) (*functionconfig.ConfigWithStatus, error) {
-	if functionInstance, err := p.getFunction(namespace, name); err != nil {
+func (p *Platform) getFunctionConfig(meta *functionconfig.Meta) (*functionconfig.ConfigWithStatus, error) {
+	if functionInstance, err := p.getFunction(meta.Namespace, meta.Name	); err != nil {
 		return nil, errors.Wrap(err, "Failed to get function")
 	} else if functionInstance != nil {
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -149,7 +149,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 			return nil, errors.Wrap(err, "Failed to get existing function config")
 		}
 		if existingFunctionConfig.Meta.ResourceVersion != createFunctionOptions.FunctionConfig.Meta.ResourceVersion {
-			return nil ,errors.Wrap(err, "Resource Version miss match")
+			return nil, errors.New("Resource Version miss match")
 		}
 	}
 
@@ -727,7 +727,7 @@ func (p *Platform) getFunction(namespace, name string) (*nuclioio.NuclioFunction
 }
 
 func (p *Platform) getFunctionConfig(meta *functionconfig.Meta) (*functionconfig.ConfigWithStatus, error) {
-	if functionInstance, err := p.getFunction(meta.Namespace, meta.Name	); err != nil {
+	if functionInstance, err := p.getFunction(meta.Namespace, meta.Name); err != nil {
 		return nil, errors.Wrap(err, "Failed to get function")
 	} else if functionInstance != nil {
 

--- a/pkg/platform/local/store.go
+++ b/pkg/platform/local/store.go
@@ -187,6 +187,21 @@ func (s *store) getFunctions(functionMeta *functionconfig.Meta) ([]platform.Func
 	return functions, nil
 }
 
+func (s *store) getFunction(functionMeta *functionconfig.Meta) (platform.Function, error) {
+	functions, err := s.getFunctions(functionMeta)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get functions")
+	}
+
+	if len(functions) == 0 {
+
+		// not found
+		return nil, nil
+	}
+
+	return functions[0], nil
+}
+
 func (s *store) deleteFunction(functionMeta *functionconfig.Meta) error {
 	return s.deleteResource(functionsDir, functionMeta.Namespace, functionMeta.Name)
 }

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -284,6 +284,7 @@ func (ar *AbstractResource) handleGetDetails(responseWriter http.ResponseWriter,
 }
 
 func (ar *AbstractResource) handleCreate(responseWriter http.ResponseWriter, request *http.Request) {
+	encoder := ar.encoderFactory.NewEncoder(responseWriter, ar.name)
 
 	// delegate to child
 	resourceID, attributes, err := ar.Resource.Create(request)
@@ -298,10 +299,11 @@ func (ar *AbstractResource) handleCreate(responseWriter http.ResponseWriter, req
 		return
 	}
 
-	ar.encoderFactory.NewEncoder(responseWriter, ar.name).EncodeResource(resourceID, attributes)
+	encoder.EncodeResource(resourceID, attributes)
 }
 
 func (ar *AbstractResource) handleUpdate(responseWriter http.ResponseWriter, request *http.Request) {
+	encoder := ar.encoderFactory.NewEncoder(responseWriter, ar.name)
 
 	// registered as "/:id/"
 	resourceID := chi.URLParam(request, "id")
@@ -319,7 +321,7 @@ func (ar *AbstractResource) handleUpdate(responseWriter http.ResponseWriter, req
 		return
 	}
 
-	ar.encoderFactory.NewEncoder(responseWriter, ar.name).EncodeResource(resourceID, attributes)
+	encoder.EncodeResource(resourceID, attributes)
 }
 
 func (ar *AbstractResource) handleDelete(responseWriter http.ResponseWriter, request *http.Request) {

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -257,6 +257,7 @@ func (ar *AbstractResource) handleGetList(responseWriter http.ResponseWriter, re
 }
 
 func (ar *AbstractResource) handleGetDetails(responseWriter http.ResponseWriter, request *http.Request) {
+	encoder := ar.encoderFactory.NewEncoder(responseWriter, ar.name)
 
 	// registered as "/:id/"
 	resourceID := chi.URLParam(request, "id")
@@ -279,7 +280,7 @@ func (ar *AbstractResource) handleGetDetails(responseWriter http.ResponseWriter,
 		attributes = Attributes{}
 	}
 
-	ar.encoderFactory.NewEncoder(responseWriter, ar.name).EncodeResource(resourceID, attributes)
+	encoder.EncodeResource(resourceID, attributes)
 }
 
 func (ar *AbstractResource) handleCreate(responseWriter http.ResponseWriter, request *http.Request) {


### PR DESCRIPTION
**Bug**:
User has 2 tabs opened

1. Showing project Y functions
2. Showing function X (belongs to project Y)

- From tab (1)
   - pause function X

- From tab (2)
  - update function to return 1

- From tab (1)
  - resume function X


While last action (_resume function X_) sends a `PUT /function/X` request including the previous version of the function (pre _update function to return 1_)

**Solution**:
While we are working with k8s objects, we can delegate `resourceVersion` field and ensure the sent value matches the stored one (consistency) - more information can be found [here](https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions)

Reasons why not selecting `generation`: generation is being incremented when `spec` fields are updated
since we support edit fields on meta, this will not help us resolve matching generations between client and k8s persistency

> when platform is docker, resourceVersion will be empty as for now


=============== 
In addition to that, resolve the following bugs
- resources content type header was ignored
- missing function meta annotation on get, caused to disappearance of annotations

and of course, slight refactoring, making `ValidateCreateFunctionOptions` function a bit more readable