### PR TITLE
Brief logging fixes

### DIFF
--- a/pkg/common/consts.go
+++ b/pkg/common/consts.go
@@ -1,0 +1,7 @@
+package common
+
+type ReusedMessage string
+
+const (
+	UnexpectedTerminationChildProcess ReusedMessage = "Unexpected termination of child process"
+)

--- a/pkg/common/map.go
+++ b/pkg/common/map.go
@@ -104,6 +104,12 @@ func StringInSlice(a string, list []string) bool {
 	return false
 }
 
+// Create a string from the given strings map by key and value (unordered)
+// If the given map is nil return an empty string
+// For example:
+// CreateKeyValuePairs(map[string]string{"a_key": "a_val", "b_key": "b_val"}) will return one of these:
+// a_key="a_val" || b_key="b_val"
+// b_key="b_val" || a_key="a_val"
 func CreateKeyValuePairs(m map[string]string) string {
 	b := new(bytes.Buffer)
 	delimiter := " || "

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -432,6 +433,7 @@ func (ap *Platform) functionBuildRequired(createFunctionOptions *platform.Create
 
 func (ap *Platform) GetProcessorLogsAndBriefError(scanner *bufio.Scanner) (string, string) {
 	var formattedProcessorLogs, briefErrorsMessage string
+	var stopWritingRawLinesToBriefErrorsMessage bool
 
 	briefErrorsArray := &[]string{}
 
@@ -442,7 +444,19 @@ func (ap *Platform) GetProcessorLogsAndBriefError(scanner *bufio.Scanner) (strin
 
 			// when it is unstructured just add the log as a text
 			formattedProcessorLogs += rawLogLine + "\n"
-			*briefErrorsArray = append(*briefErrorsArray, rawLogLine)
+
+			// if there's a panic or call stack is printed,
+			// stop appending raw log lines to the briefErrorsMessage (unnecessary information from now on)
+			// this information can still be found in the full log
+			if strings.HasPrefix(rawLogLine, "panic: Wrapper") ||
+				strings.HasPrefix(rawLogLine, "Call stack:") {
+				stopWritingRawLinesToBriefErrorsMessage = true
+			}
+
+			if !stopWritingRawLinesToBriefErrorsMessage {
+				*briefErrorsArray = append(*briefErrorsArray, rawLogLine)
+			}
+
 			continue
 		}
 
@@ -463,10 +477,13 @@ func (ap *Platform) GetProcessorLogsAndBriefError(scanner *bufio.Scanner) (strin
 // Prettifies log line, and returns - (formattedLogLine, briefLogLine, error)
 // when line shouldn't be added to brief error message - briefLogLine will be an empty string ("")
 func (ap *Platform) prettifyProcessorLogLine(log []byte) (string, string, error) {
+	var workerID string
+
 	logStruct := struct {
 		Time    *string `json:"time"`
 		Level   *string `json:"level"`
 		Message *string `json:"message"`
+		Name    *string `json:"name,omitempty"`
 		More    *string `json:"more,omitempty"`
 	}{}
 
@@ -477,6 +494,7 @@ func (ap *Platform) prettifyProcessorLogLine(log []byte) (string, string, error)
 			Datetime *string           `json:"datetime"`
 			Level    *string           `json:"level"`
 			Message  *string           `json:"message"`
+			Name     *string           `json:"name,omitempty"`
 			With     map[string]string `json:"with,omitempty"`
 		}{}
 
@@ -492,9 +510,14 @@ func (ap *Platform) prettifyProcessorLogLine(log []byte) (string, string, error)
 		logStruct.Time = &unparsedTime
 		logStruct.Level = wrapperLogStruct.Level
 		logStruct.Message = wrapperLogStruct.Message
+		logStruct.Name = wrapperLogStruct.Name
 
-		more := common.CreateKeyValuePairs(wrapperLogStruct.With)
-		logStruct.More = &more
+		if wrapperLogStruct.With != nil {
+			workerID = wrapperLogStruct.With["worker_id"]
+
+			more := common.CreateKeyValuePairs(wrapperLogStruct.With)
+			logStruct.More = &more
+		}
 
 	} else {
 
@@ -516,7 +539,13 @@ func (ap *Platform) prettifyProcessorLogLine(log []byte) (string, string, error)
 
 	logLevel := strings.ToUpper(*logStruct.Level)[0]
 
-	messageAndArgs := ap.getMessageAndArgs(*logStruct.Message, logStruct.More, log)
+	// if worker ID wasn't explicitly given as an arg, infer worker ID from logger name
+	if workerID == "" {
+		workerID = ap.inferWorkerID(logStruct.Name)
+	}
+
+	messageAndArgs := ap.getMessageAndArgs(*logStruct.Message, logStruct.More, log, workerID)
+
 
 	res := fmt.Sprintf("[%s] (%c) %s",
 		parsedTime.Format("15:04:05.000"),
@@ -524,14 +553,32 @@ func (ap *Platform) prettifyProcessorLogLine(log []byte) (string, string, error)
 		messageAndArgs)
 
 	briefLogLine := ""
-	if ap.shouldAddToBriefErrorsMessage(logLevel, *logStruct.Message) {
+	if ap.shouldAddToBriefErrorsMessage(logLevel, *logStruct.Message, workerID) {
 		briefLogLine = messageAndArgs
 	}
 
 	return res, briefLogLine, nil
 }
 
-func (ap *Platform) getMessageAndArgs(message string, args *string, log []byte) string {
+// get the worker ID from the logger name, for example:
+// "processor.http.w5.python.logger" -> 5
+func (ap *Platform) inferWorkerID(loggerName *string) string {
+	if loggerName == nil {
+		return ""
+	}
+
+	// if the logger name is the following pattern, extract the worker ID from it
+	processorRe := regexp.MustCompile(`^processor\..*\.w[0-9]+\..*`)
+	if processorRe.MatchString(*loggerName) {
+		splitName := strings.Split(*loggerName, ".")
+		return splitName[2][1:]
+	}
+
+	return ""
+}
+
+func (ap *Platform) getMessageAndArgs(message string, args *string, log []byte, workerID string) string {
+
 	var argsAsString, additionalKwargsAsString string
 	additionalKwargs, err := ap.getLogLineAdditionalKwargs(log)
 	if err != nil {
@@ -544,6 +591,10 @@ func (ap *Platform) getMessageAndArgs(message string, args *string, log []byte) 
 	}
 
 	if additionalKwargs != nil {
+		if workerID != "" {
+			additionalKwargs["worker_id"] = workerID
+		}
+
 		additionalKwargsAsString = common.CreateKeyValuePairs(additionalKwargs)
 	}
 
@@ -571,7 +622,7 @@ func (ap *Platform) getLogLineAdditionalKwargs(log []byte) (map[string]string, e
 
 	additionalKwargs := map[string]string{}
 
-	defaultArgs := []string{"time", "datetime", "level", "message", "with", "more"}
+	defaultArgs := []string{"time", "datetime", "level", "message", "with", "more", "name"}
 
 	// validate it is a suitable special arg
 	for argKey, argValue := range logAsMap {
@@ -592,15 +643,28 @@ func (ap *Platform) getLogLineAdditionalKwargs(log []byte) (map[string]string, e
 	return additionalKwargs, nil
 }
 
-func (ap *Platform) shouldAddToBriefErrorsMessage(logLevel uint8, logMessage string) bool {
+func (ap *Platform) shouldAddToBriefErrorsMessage(logLevel uint8, logMessage, workerID string) bool {
 	knownFailureSubstrings := [...]string{"Failed to connect to broker"}
+	ignoreFailureSubstrings := [...]string{"Unexpected termination of child process"}
 
+	// when the log message contains a failure that should be ignored
+	for _, ignoreFailureSubstring := range ignoreFailureSubstrings {
+		if strings.Contains(logMessage, ignoreFailureSubstring) {
+			return false
+		}
+	}
+
+	// show errors only of the first worker
+	// done to prevent error duplication from several workers
+	if workerID != "" && workerID != "0" {
+		return false
+	}
 	// when log level is warning or above
 	if logLevel != 'D' && logLevel != 'I' {
 		return true
 	}
 
-	// when the log message contains a known failure prefix
+	// when the log message contains a known failure substring
 	for _, knownFailureSubstring := range knownFailureSubstrings {
 		if strings.Contains(logMessage, knownFailureSubstring) {
 			return true

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -546,7 +546,6 @@ func (ap *Platform) prettifyProcessorLogLine(log []byte) (string, string, error)
 
 	messageAndArgs := ap.getMessageAndArgs(*logStruct.Message, logStruct.More, log, workerID)
 
-
 	res := fmt.Sprintf("[%s] (%c) %s",
 		parsedTime.Format("15:04:05.000"),
 		logLevel,

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -577,11 +577,7 @@ func (ap *Platform) tryInferWorkerID(loggerName string) string {
 func (ap *Platform) getMessageAndArgs(message string, args string, log []byte, workerID string) string {
 	var additionalKwargsAsString string
 
-	additionalKwargs, err := ap.getLogLineAdditionalKwargs(log)
-	if err != nil {
-		ap.Logger.WarnWith("Failed to get log line's additional kwargs",
-			"logLineMessage", message)
-	}
+	additionalKwargs, _ := ap.getLogLineAdditionalKwargs(log)
 
 	additionalKwargsAsString = common.CreateKeyValuePairs(additionalKwargs)
 

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -30,6 +30,9 @@ const (
 	PanicFunctionLogsFilePath = "test/logs_examples/panic"
 	GoWithCallStackFunctionLogsFilePath = "test/logs_examples/go_with_call_stack"
 	SpecialSubstringsFunctionLogsFilePath = "test/logs_examples/special_substrings"
+	FunctionLogsFile = "function_logs.txt"
+	FormattedFunctionLogsFile = "formatted_function_logs.txt"
+	BriefErrorsMessageFile = "brief_errors_message.txt"
 )
 
 // GetProjects will list existing projects
@@ -178,24 +181,24 @@ func (suite *TestAbstractSuite) TestGetProcessorLogsWithSpecialSubstrings() {
 	suite.testGetProcessorLogs(SpecialSubstringsFunctionLogsFilePath)
 }
 
-// Test the GetProcessLogs() generates the expected formattedPodLogs and BriefErrorsMessage
-// Expects the following files inside functionLogsFilePath:
-// - function_logs.log
-// - formatted_function_logs.log
-// - brief_errors_message.log
+// Test that GetProcessorLogs() generates the expected formattedPodLogs and briefErrorsMessage
+// Expects 3 files inside functionLogsFilePath: (kept in these constants)
+// - FunctionLogsFile
+// - FormattedFunctionLogsFile
+// - BriefErrorsMessageFile
 func (suite *TestAbstractSuite) testGetProcessorLogs(functionLogsFilePath string) {
-	functionLogsFile, err := os.Open(path.Join(functionLogsFilePath, "function_logs.txt"))
+	functionLogsFile, err := os.Open(path.Join(functionLogsFilePath, FunctionLogsFile))
 	suite.NoError(err, "Failed to read function logs file")
 
 	functionLogsScanner := bufio.NewScanner(functionLogsFile)
 
 	formattedPodLogs, briefErrorsMessage := suite.Platform.GetProcessorLogsAndBriefError(functionLogsScanner)
 
-	expectedFormattedFunctionLogsFileBytes, err := ioutil.ReadFile(path.Join(functionLogsFilePath, "formatted_function_logs.txt"))
+	expectedFormattedFunctionLogsFileBytes, err := ioutil.ReadFile(path.Join(functionLogsFilePath, FormattedFunctionLogsFile))
 	suite.NoError(err, "Failed to read formatted function logs file")
 	suite.Assert().Equal(string(expectedFormattedFunctionLogsFileBytes), formattedPodLogs)
 
-	expectedBriefErrorsMessageFileBytes, err := ioutil.ReadFile(path.Join(functionLogsFilePath, "brief_errors_message.txt"))
+	expectedBriefErrorsMessageFileBytes, err := ioutil.ReadFile(path.Join(functionLogsFilePath, BriefErrorsMessageFile))
 	suite.NoError(err, "Failed to read brief errors message file")
 	suite.Assert().Equal(string(expectedBriefErrorsMessageFileBytes), briefErrorsMessage)
 }

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -184,18 +184,18 @@ func (suite *TestAbstractSuite) TestGetProcessorLogsWithSpecialSubstrings() {
 // - formatted_function_logs.log
 // - brief_errors_message.log
 func (suite *TestAbstractSuite) testGetProcessorLogs(functionLogsFilePath string) {
-	functionLogsFile, err := os.Open(path.Join(functionLogsFilePath, "function_logs.log"))
+	functionLogsFile, err := os.Open(path.Join(functionLogsFilePath, "function_logs.txt"))
 	suite.NoError(err, "Failed to read function logs file")
 
 	functionLogsScanner := bufio.NewScanner(functionLogsFile)
 
 	formattedPodLogs, briefErrorsMessage := suite.Platform.GetProcessorLogsAndBriefError(functionLogsScanner)
 
-	expectedFormattedFunctionLogsFileBytes, err := ioutil.ReadFile(path.Join(functionLogsFilePath, "formatted_function_logs.log"))
+	expectedFormattedFunctionLogsFileBytes, err := ioutil.ReadFile(path.Join(functionLogsFilePath, "formatted_function_logs.txt"))
 	suite.NoError(err, "Failed to read formatted function logs file")
 	suite.Assert().Equal(string(expectedFormattedFunctionLogsFileBytes), formattedPodLogs)
 
-	expectedBriefErrorsMessageFileBytes, err := ioutil.ReadFile(path.Join(functionLogsFilePath, "brief_errors_message.log"))
+	expectedBriefErrorsMessageFileBytes, err := ioutil.ReadFile(path.Join(functionLogsFilePath, "brief_errors_message.txt"))
 	suite.NoError(err, "Failed to read brief errors message file")
 	suite.Assert().Equal(string(expectedBriefErrorsMessageFileBytes), briefErrorsMessage)
 }

--- a/pkg/platform/abstract/test/logs_examples/go_with_call_stack/brief_errors_message.txt
+++ b/pkg/platform/abstract/test/logs_examples/go_with_call_stack/brief_errors_message.txt
@@ -1,0 +1,3 @@
+
+Error - plugin: symbol Handler not found in plugin github.com/nuclio/handler
+    .../pkg/processor/runtime/golang/pluginloader.go:58

--- a/pkg/platform/abstract/test/logs_examples/go_with_call_stack/formatted_function_logs.txt
+++ b/pkg/platform/abstract/test/logs_examples/go_with_call_stack/formatted_function_logs.txt
@@ -1,0 +1,16 @@
+[13:51:42.816] (D) Creating worker pool [num=1]
+
+Error - plugin: symbol Handler not found in plugin github.com/nuclio/handler
+    .../pkg/processor/runtime/golang/pluginloader.go:58
+
+Call stack:
+Can't find handler "Handler" in "/opt/nuclio/handler.so"
+    .../pkg/processor/runtime/golang/pluginloader.go:58
+Failed to load handler
+    .../pkg/processor/runtime/golang/runtime.go:54
+Failed to create runtime
+    .../nuclio/nuclio/pkg/processor/worker/factory.go:95
+Failed to create worker
+    .../nuclio/nuclio/pkg/processor/worker/factory.go:122
+Failed to create workers
+    .../nuclio/nuclio/pkg/processor/worker/factory.go:132

--- a/pkg/platform/abstract/test/logs_examples/go_with_call_stack/function_logs.txt
+++ b/pkg/platform/abstract/test/logs_examples/go_with_call_stack/function_logs.txt
@@ -1,0 +1,16 @@
+{"level":"debug","time":"2020-02-27T13:51:42.816Z","name":"processor.http","message":"Creating worker pool","more":"num=1"}
+
+Error - plugin: symbol Handler not found in plugin github.com/nuclio/handler
+    .../pkg/processor/runtime/golang/pluginloader.go:58
+
+Call stack:
+Can't find handler "Handler" in "/opt/nuclio/handler.so"
+    .../pkg/processor/runtime/golang/pluginloader.go:58
+Failed to load handler
+    .../pkg/processor/runtime/golang/runtime.go:54
+Failed to create runtime
+    .../nuclio/nuclio/pkg/processor/worker/factory.go:95
+Failed to create worker
+    .../nuclio/nuclio/pkg/processor/worker/factory.go:122
+Failed to create workers
+    .../nuclio/nuclio/pkg/processor/worker/factory.go:132

--- a/pkg/platform/abstract/test/logs_examples/multi_worker/brief_errors_message.txt
+++ b/pkg/platform/abstract/test/logs_examples/multi_worker/brief_errors_message.txt
@@ -1,0 +1,2 @@
+Processor worker_0 error
+Handler not found [worker_id="0"]

--- a/pkg/platform/abstract/test/logs_examples/multi_worker/formatted_function_logs.txt
+++ b/pkg/platform/abstract/test/logs_examples/multi_worker/formatted_function_logs.txt
@@ -1,0 +1,4 @@
+[12:10:04.805] (E) Processor worker_0 error
+[12:10:04.807] (E) Processor worker_1 error
+[12:10:04.902] (E) Handler not found [worker_id="0"]
+[12:10:04.906] (E) Handler not found [worker_id="1"]

--- a/pkg/platform/abstract/test/logs_examples/multi_worker/function_logs.txt
+++ b/pkg/platform/abstract/test/logs_examples/multi_worker/function_logs.txt
@@ -1,0 +1,4 @@
+{"level":"error","time":"2020-02-27T12:10:04.805Z","name":"processor.http.w0.python.logger","message":"Processor worker_0 error"}
+{"level":"error","time":"2020-02-27T12:10:04.807Z","name":"processor.http.w1.python.logger","message":"Processor worker_1 error"}
+l{"datetime": "2020-02-27 12:10:04,902", "level": "error", "message": "Handler not found", "with": {"worker_id": "0"}}
+l{"datetime": "2020-02-27 12:10:04,906", "level": "error", "message": "Handler not found", "with": {"worker_id": "1"}}

--- a/pkg/platform/abstract/test/logs_examples/panic/brief_errors_message.txt
+++ b/pkg/platform/abstract/test/logs_examples/panic/brief_errors_message.txt
@@ -1,0 +1,1 @@
+[12:10:04.805] (E) Some error [err="Handler not found"]

--- a/pkg/platform/abstract/test/logs_examples/panic/formatted_function_logs.txt
+++ b/pkg/platform/abstract/test/logs_examples/panic/formatted_function_logs.txt
@@ -1,0 +1,8 @@
+[12:10:04.805] (E) Some error [err="Handler not found"]
+panic: Wrapper process for worker 0 exited unexpectedly with: exit status 1
+
+goroutine 99 [running]:
+github.com/nuclio/nuclio/pkg/processor/runtime/rpc.(*AbstractRuntime).watchWrapperProcess(0xc4204573f0)
+    /go/src/github.com/nuclio/nuclio/pkg/processor/runtime/rpc/abstract.go:453 +0x5bb
+created by github.com/nuclio/nuclio/pkg/processor/runtime/rpc.(*AbstractRuntime).startWrapper
+    /go/src/github.com/nuclio/nuclio/pkg/processor/runtime/rpc/abstract.go:232 +0x1c8

--- a/pkg/platform/abstract/test/logs_examples/panic/function_logs.txt
+++ b/pkg/platform/abstract/test/logs_examples/panic/function_logs.txt
@@ -1,0 +1,8 @@
+[12:10:04.805] (E) Some error [err="Handler not found"]
+panic: Wrapper process for worker 0 exited unexpectedly with: exit status 1
+
+goroutine 99 [running]:
+github.com/nuclio/nuclio/pkg/processor/runtime/rpc.(*AbstractRuntime).watchWrapperProcess(0xc4204573f0)
+    /go/src/github.com/nuclio/nuclio/pkg/processor/runtime/rpc/abstract.go:453 +0x5bb
+created by github.com/nuclio/nuclio/pkg/processor/runtime/rpc.(*AbstractRuntime).startWrapper
+    /go/src/github.com/nuclio/nuclio/pkg/processor/runtime/rpc/abstract.go:232 +0x1c8

--- a/pkg/platform/abstract/test/logs_examples/special_substrings/brief_errors_message.txt
+++ b/pkg/platform/abstract/test/logs_examples/special_substrings/brief_errors_message.txt
@@ -1,0 +1,1 @@
+Error - Failed to connect to broker

--- a/pkg/platform/abstract/test/logs_examples/special_substrings/formatted_function_logs.txt
+++ b/pkg/platform/abstract/test/logs_examples/special_substrings/formatted_function_logs.txt
@@ -1,0 +1,2 @@
+[12:10:04.910] (E) Unexpected termination of child process [status="exit status 1"]
+[12:10:04.950] (D) Error - Failed to connect to broker

--- a/pkg/platform/abstract/test/logs_examples/special_substrings/function_logs.txt
+++ b/pkg/platform/abstract/test/logs_examples/special_substrings/function_logs.txt
@@ -1,0 +1,2 @@
+{"level":"error","time":"2020-02-27T12:10:04.910Z","name":"processor.http.w0.python.logger","message":"Unexpected termination of child process","error":null,"status":"exit status 1"}
+{"level":"debug","time":"2020-02-27T12:10:04.950Z","name":"processor.http.w0.python.logger","message":"Error - Failed to connect to broker"}

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -273,6 +273,9 @@ def run_wrapper():
     # way all output goes to stdout until a socket is available and then switches exclusively to socket
     root_logger.set_handler('default', sys.stdout, nuclio_sdk.logger.JSONFormatter())
 
+    # bind worker_id to the logger
+    root_logger.bind(worker_id=args.worker_id)
+
     try:
 
         # create a new wrapper

--- a/pkg/processor/runtime/python/py/requirements.txt
+++ b/pkg/processor/runtime/python/py/requirements.txt
@@ -1,3 +1,3 @@
 mock==2.0.0
-nuclio-sdk==0.1.1
+nuclio-sdk==0.1.2
 msgpack==0.6.1

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -439,6 +439,7 @@ func (r *AbstractRuntime) watchWrapperProcess() {
 		return
 	}
 
+	// NOTE: this error message is filtered when reading logs (on shouldAddToBriefErrorsMessage())- consider that when changing it!
 	r.Logger.ErrorWith("Unexpected termination of child process",
 		"error", processWaitResult.Err,
 		"status", processWaitResult.ProcessState.String())

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -439,8 +439,7 @@ func (r *AbstractRuntime) watchWrapperProcess() {
 		return
 	}
 
-	// NOTE: this error message is filtered when reading logs (on shouldAddToBriefErrorsMessage())- consider that when changing it!
-	r.Logger.ErrorWith("Unexpected termination of child process",
+	r.Logger.ErrorWith(common.UnexpectedTerminationChildProcess,
 		"error", processWaitResult.Err,
 		"status", processWaitResult.ProcessState.String())
 


### PR DESCRIPTION
Improving and fixing **brief errors log** on several deployment failure cases.

Changes:
---
- On multiple workers trigger - show only the errors of the first worker
- Remove redundant Call Stack log lines
- Remove redundant lines after a Worker fails with panic

_(all those lines can still be found in the full log)_