### PR TITLE
Onbuild and base image registries to be controlled separately

### DIFF
--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -76,6 +76,10 @@ spec:
         - name: NUCLIO_DASHBOARD_DEFAULT_BASE_REGISTRY_URL
           value: {{ .Values.registry.defaultBaseRegistryURL }}
         {{- end }}
+        {{- if .Values.registry.defaultOnbuildRegistryURL }}
+        - name: NUCLIO_DASHBOARD_DEFAULT_ONBUILD_REGISTRY_URL
+          value: {{ .Values.registry.defaultOnbuildRegistryURL }}
+        {{- end }}
         {{- if .Values.registry.dependantImageRegistryURL }}
         - name: NUCLIO_DASHBOARD_DEPENDANT_IMAGE_REGISTRY_URL
           value: {{ .Values.registry.dependantImageRegistryURL }}

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -136,13 +136,19 @@ registry: {}
     # username: someuser
     # password: somepass
 
-  #  Use a dedicated "onbuild" images registry (pull registry).
+  #  Use a custom "base" images registry (pull registry). Default behavior will pull the default
+  #  base images from the web
   #  Note: To override a pull registry for both "onbuild" and base images, use `dependantImageRegistryURL`.
   #
   # defaultBaseRegistryURL: someUrl
 
+  #  Use a custom "onbuild" images registry (pull registry). Default behavior will pull from quay.io
+  #  Note: To override a pull registry for both "onbuild" and base images, use `dependantImageRegistryURL`.
+  #
+  # defaultOnbuildRegistryURL: someUrl
+
   # Use this registry URL as an override for both base and "onbuild" images, so they'll be pulled from the
-  # specified registry URL and not from the default registry that their name implies
+  # specified registry URL and not from the default registries
   # dependantImageRegistryURL: someUrl
 
 rbac:

--- a/pkg/containerimagebuilderpusher/containerimagebuilder.go
+++ b/pkg/containerimagebuilderpusher/containerimagebuilder.go
@@ -14,8 +14,11 @@ type BuilderPusher interface {
 	// Change Onbuild artifact paths depending on the type of the builder used
 	TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifact) (map[string]string, error)
 
-	// GetBaseImageRegistry returns onbuild base registry
+	// GetBaseImageRegistry returns base image registry
 	GetBaseImageRegistry(registry string) string
+
+	// GetBaseImageRegistry returns onbuild base registry
+	GetOnbuildImageRegistry(registry string) string
 
 	// GetDefaultRegistryCredentialsSecretName returns secret with credentials to push/pull from docker registry
 	GetDefaultRegistryCredentialsSecretName() string

--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -92,6 +92,12 @@ func (d *Docker) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifa
 }
 
 func (d *Docker) GetBaseImageRegistry(registry string) string {
+
+	// keep base image registry as is
+	return ""
+}
+
+func (d *Docker) GetOnbuildImageRegistry(registry string) string {
 	return "quay.io"
 }
 

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -134,6 +134,12 @@ func (k *Kaniko) GetBaseImageRegistry(registry string) string {
 	return k.builderConfiguration.DefaultBaseRegistryURL
 }
 
+func (k *Kaniko) GetOnbuildImageRegistry(registry string) string {
+
+	// take the onbuild images from the default base registry URL given
+	return k.builderConfiguration.DefaultBaseRegistryURL
+}
+
 func (k *Kaniko) createContainerBuildBundle(image string, contextDir string, tempDir string) (string, string, error) {
 	var err error
 

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -25,6 +25,7 @@ type ContainerBuilderConfiguration struct {
 	JobPrefix                            string
 	DefaultRegistryCredentialsSecretName string
 	DefaultBaseRegistryURL               string
+	DefaultOnbuildRegistryURL            string
 	CacheRepo                            string
 	InsecurePushRegistry                 bool
 	InsecurePullRegistry                 bool

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -365,9 +365,14 @@ func (ap *Platform) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Art
 	return ap.ContainerBuilder.TransformOnbuildArtifactPaths(onbuildArtifacts)
 }
 
-// GetBaseImageRegistry returns onbuild base registry
+// GetBaseImageRegistry returns base image registry
 func (ap *Platform) GetBaseImageRegistry(registry string) string {
 	return ap.ContainerBuilder.GetBaseImageRegistry(registry)
+}
+
+// GetOnbuildImageRegistry returns onbuild image registry
+func (ap *Platform) GetOnbuildImageRegistry(registry string) string {
+	return ap.ContainerBuilder.GetOnbuildImageRegistry(registry)
 }
 
 // // GetDefaultRegistryCredentialsSecretName returns secret with credentials to push/pull from docker registry

--- a/pkg/platform/factory/factory.go
+++ b/pkg/platform/factory/factory.go
@@ -48,7 +48,10 @@ func CreatePlatform(parentLogger logger.Logger,
 
 	case "kube":
 		containerBuilderConfiguration := getContainerBuilderConfiguration(platformConfiguration)
-		newPlatform, err = kube.NewPlatform(parentLogger, getKubeconfigPath(platformConfiguration), containerBuilderConfiguration, platformConfiguration)
+		newPlatform, err = kube.NewPlatform(parentLogger,
+			getKubeconfigPath(platformConfiguration),
+			containerBuilderConfiguration,
+			platformConfiguration)
 
 	case "auto":
 
@@ -148,26 +151,34 @@ func getContainerBuilderConfiguration(platformConfiguration interface{}) *contai
 			"gcr.io/kaniko-project/executor:v0.17.1")
 	}
 	if containerBuilderConfiguration.KanikoImagePullPolicy == "" {
-		containerBuilderConfiguration.KanikoImagePullPolicy = common.GetEnvOrDefaultString("NUCLIO_KANIKO_CONTAINER_IMAGE_PULL_POLICY",
-			"IfNotPresent")
+		containerBuilderConfiguration.KanikoImagePullPolicy = common.GetEnvOrDefaultString(
+			"NUCLIO_KANIKO_CONTAINER_IMAGE_PULL_POLICY", "IfNotPresent")
 	}
 	if containerBuilderConfiguration.JobPrefix == "" {
 		containerBuilderConfiguration.JobPrefix = common.GetEnvOrDefaultString("NUCLIO_DASHBOARD_JOB_NAME_PREFIX",
 			"kanikojob")
 	}
 
-	containerBuilderConfiguration.InsecurePushRegistry = common.GetEnvOrDefaultBool("NUCLIO_KANIKO_INSECURE_PUSH_REGISTRY", false)
-	containerBuilderConfiguration.InsecurePullRegistry = common.GetEnvOrDefaultBool("NUCLIO_KANIKO_INSECURE_PULL_REGISTRY", false)
+	containerBuilderConfiguration.InsecurePushRegistry =
+		common.GetEnvOrDefaultBool("NUCLIO_KANIKO_INSECURE_PUSH_REGISTRY", false)
+	containerBuilderConfiguration.InsecurePullRegistry =
+		common.GetEnvOrDefaultBool("NUCLIO_KANIKO_INSECURE_PULL_REGISTRY", false)
 
 	containerBuilderConfiguration.DefaultRegistryCredentialsSecretName =
 		common.GetEnvOrDefaultString("NUCLIO_REGISTRY_CREDENTIALS_SECRET_NAME", "")
 
 	if containerBuilderConfiguration.DefaultBaseRegistryURL == "" {
 		containerBuilderConfiguration.DefaultBaseRegistryURL =
-			common.GetEnvOrDefaultString("NUCLIO_DASHBOARD_DEFAULT_BASE_REGISTRY_URL", "quay.io")
+			common.GetEnvOrDefaultString("NUCLIO_DASHBOARD_DEFAULT_BASE_REGISTRY_URL", "")
 	}
 
-	containerBuilderConfiguration.CacheRepo = common.GetEnvOrDefaultString("NUCLIO_DASHBOARD_KANIKO_CACHE_REPO", "")
+	if containerBuilderConfiguration.DefaultOnbuildRegistryURL == "" {
+		containerBuilderConfiguration.DefaultOnbuildRegistryURL =
+			common.GetEnvOrDefaultString("NUCLIO_DASHBOARD_DEFAULT_ONBUILD_REGISTRY_URL", "quay.io")
+	}
+
+	containerBuilderConfiguration.CacheRepo =
+		common.GetEnvOrDefaultString("NUCLIO_DASHBOARD_KANIKO_CACHE_REPO", "")
 
 	return &containerBuilderConfiguration
 }

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -219,6 +219,10 @@ func (mp *Platform) GetBaseImageRegistry(registry string) string {
 	return "quay.io"
 }
 
+func (mp *Platform) GetOnbuildImageRegistry(registry string) string {
+	return ""
+}
+
 func (mp *Platform) GetDefaultRegistryCredentialsSecretName() string {
 	return "nuclio-registry-credentials"
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -142,7 +142,7 @@ type Platform interface {
 	// Change Onbuild artifact paths depending on the type of the builder used
 	TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifact) (map[string]string, error)
 
-	// GetBaseImageRegistry returns onbuild base registry
+	// GetOnbuildImageRegistry returns onbuild base registry
 	GetOnbuildImageRegistry(registry string) string
 
 	// GetBaseImageRegistry returns base image registry

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -143,6 +143,9 @@ type Platform interface {
 	TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifact) (map[string]string, error)
 
 	// GetBaseImageRegistry returns onbuild base registry
+	GetOnbuildImageRegistry(registry string) string
+
+	// GetBaseImageRegistry returns base image registry
 	GetBaseImageRegistry(registry string) string
 
 	// GetDefaultRegistryCredentialsSecretName returns secret with credentials to push/pull from docker registry

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1204,8 +1204,8 @@ func (b *Builder) getRuntimeProcessorDockerfileInfo(baseImageRegistry string, on
 	return processorDockerfileInfo, nil
 }
 
-func (b *Builder) resolveProcessorDockerfileInfo(baseImageRegistry string, onbuildImageRegistry string) (
-	*runtime.ProcessorDockerfileInfo, error) {
+func (b *Builder) resolveProcessorDockerfileInfo(baseImageRegistry string,
+	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 	versionInfo, err := version.Get()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get version info")
@@ -1272,17 +1272,17 @@ func (b *Builder) getProcessorDockerfileBaseImage(runtimeDefaultBaseImage string
 	switch b.options.FunctionConfig.Spec.Build.BaseImage {
 
 	// if user didn't pass anything, use default as specified in Dockerfile
-	// if a non empty baseImageRegistry was passed, use it as a registry prefix for the default base image
 	case "":
 		if baseImageRegistry == "" {
 			return runtimeDefaultBaseImage
-		} else {
-			sepIndex := strings.Index(runtimeDefaultBaseImage, "/")
-			if sepIndex != -1 {
-				runtimeDefaultBaseImage = runtimeDefaultBaseImage[sepIndex+1:]
-			}
-			return strings.Join([]string{baseImageRegistry, runtimeDefaultBaseImage}, "/")
 		}
+
+		// if a non empty baseImageRegistry was passed, use it as a registry prefix for the default base image
+		sepIndex := strings.Index(runtimeDefaultBaseImage, "/")
+		if sepIndex != -1 {
+			runtimeDefaultBaseImage = runtimeDefaultBaseImage[sepIndex+1:]
+		}
+		return strings.Join([]string{baseImageRegistry, runtimeDefaultBaseImage}, "/")
 
 	// if user specified something - use that, as is
 	// see description on https://github.com/nuclio/nuclio/pull/1544 - we don't implicitly mutate the given baseimage

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1044,7 +1044,10 @@ func (b *Builder) createProcessorDockerfile(baseImageRegistry string, onbuildIma
 	}
 
 	// log the resulting dockerfile
-	b.logger.DebugWith("Created processor Dockerfile", "dockerfileInfo", processorDockerfileInfo.DockerfileContents)
+	b.logger.DebugWith("Created processor Dockerfile",
+		"dockerfileInfo", processorDockerfileInfo.DockerfileContents,
+		"baseImageRegistry", baseImageRegistry,
+		"onbuildImageRegistry", onbuildImageRegistry)
 
 	// write the contents to the path
 	if err := ioutil.WriteFile(processorDockerfileInfo.DockerfilePath,

--- a/pkg/processor/build/runtime/dotnetcore/runtime.go
+++ b/pkg/processor/build/runtime/dotnetcore/runtime.go
@@ -18,6 +18,7 @@ package dotnetcore
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 	"github.com/nuclio/nuclio/pkg/version"
@@ -34,7 +35,8 @@ func (d *dotnetcore) GetName() string {
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (d *dotnetcore) GetProcessorDockerfileInfo(versionInfo *version.Info,
-	registryURL string) (*runtime.ProcessorDockerfileInfo, error) {
+	baseImageRegistry string,
+	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
@@ -42,7 +44,7 @@ func (d *dotnetcore) GetProcessorDockerfileInfo(versionInfo *version.Info,
 	artifact := runtime.Artifact{
 		Name: "dotnetcore-onbuild",
 		Image: fmt.Sprintf("%s/nuclio/handler-builder-dotnetcore-onbuild:%s-%s",
-			registryURL,
+			onbuildImageRegistry,
 			versionInfo.Label,
 			versionInfo.Arch),
 		Paths: map[string]string{
@@ -56,6 +58,10 @@ func (d *dotnetcore) GetProcessorDockerfileInfo(versionInfo *version.Info,
 
 	// set the default base image
 	processorDockerfileInfo.BaseImage = "mcr.microsoft.com/dotnet/core/runtime:3.1"
+	if baseImageRegistry != "" {
+		processorDockerfileInfo.BaseImage =
+			strings.Replace(processorDockerfileInfo.BaseImage, "mcr.microsoft.com", baseImageRegistry, 1)
+	}
 
 	return &processorDockerfileInfo, nil
 }

--- a/pkg/processor/build/runtime/dotnetcore/runtime.go
+++ b/pkg/processor/build/runtime/dotnetcore/runtime.go
@@ -18,8 +18,6 @@ package dotnetcore
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 	"github.com/nuclio/nuclio/pkg/version"
 )
@@ -35,7 +33,6 @@ func (d *dotnetcore) GetName() string {
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (d *dotnetcore) GetProcessorDockerfileInfo(versionInfo *version.Info,
-	baseImageRegistry string,
 	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
@@ -58,10 +55,6 @@ func (d *dotnetcore) GetProcessorDockerfileInfo(versionInfo *version.Info,
 
 	// set the default base image
 	processorDockerfileInfo.BaseImage = "mcr.microsoft.com/dotnet/core/runtime:3.1"
-	if baseImageRegistry != "" {
-		processorDockerfileInfo.BaseImage =
-			strings.Replace(processorDockerfileInfo.BaseImage, "mcr.microsoft.com", baseImageRegistry, 1)
-	}
 
 	return &processorDockerfileInfo, nil
 }

--- a/pkg/processor/build/runtime/dotnetcore/runtime.go
+++ b/pkg/processor/build/runtime/dotnetcore/runtime.go
@@ -18,6 +18,7 @@ package dotnetcore
 
 import (
 	"fmt"
+
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 	"github.com/nuclio/nuclio/pkg/version"
 )

--- a/pkg/processor/build/runtime/golang/runtime.go
+++ b/pkg/processor/build/runtime/golang/runtime.go
@@ -61,7 +61,6 @@ func (g *golang) GetName() string {
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (g *golang) GetProcessorDockerfileInfo(versionInfo *version.Info,
-	baseImageRegistry string,
 	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
@@ -92,11 +91,6 @@ func (g *golang) GetProcessorDockerfileInfo(versionInfo *version.Info,
 
 	// set the default base image
 	processorDockerfileInfo.BaseImage = "alpine:3.7"
-
-	if baseImageRegistry != "" {
-		processorDockerfileInfo.BaseImage =
-			fmt.Sprintf("%s/%s", baseImageRegistry, processorDockerfileInfo.BaseImage)
-	}
 
 	return &processorDockerfileInfo, nil
 }

--- a/pkg/processor/build/runtime/golang/runtime.go
+++ b/pkg/processor/build/runtime/golang/runtime.go
@@ -61,7 +61,8 @@ func (g *golang) GetName() string {
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (g *golang) GetProcessorDockerfileInfo(versionInfo *version.Info,
-	registryURL string) (*runtime.ProcessorDockerfileInfo, error) {
+	baseImageRegistry string,
+	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
@@ -80,7 +81,7 @@ func (g *golang) GetProcessorDockerfileInfo(versionInfo *version.Info,
 
 	// fill onbuild artifact
 	artifact := runtime.Artifact{
-		Image: fmt.Sprintf(onbuildImage, registryURL, versionInfo.Label, versionInfo.Arch),
+		Image: fmt.Sprintf(onbuildImage, onbuildImageRegistry, versionInfo.Label, versionInfo.Arch),
 		Name:  "golang-onbuild",
 		Paths: map[string]string{
 			"/home/nuclio/bin/processor":  "/usr/local/bin/processor",
@@ -91,6 +92,11 @@ func (g *golang) GetProcessorDockerfileInfo(versionInfo *version.Info,
 
 	// set the default base image
 	processorDockerfileInfo.BaseImage = "alpine:3.7"
+
+	if baseImageRegistry != "" {
+		processorDockerfileInfo.BaseImage =
+			fmt.Sprintf("%s/%s", baseImageRegistry, processorDockerfileInfo.BaseImage)
+	}
 
 	return &processorDockerfileInfo, nil
 }

--- a/pkg/processor/build/runtime/java/runtime.go
+++ b/pkg/processor/build/runtime/java/runtime.go
@@ -49,15 +49,10 @@ func (j *java) OnAfterStagingDirCreated(stagingDir string) error {
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (j *java) GetProcessorDockerfileInfo(versionInfo *version.Info,
-	baseImageRegistry string,
 	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 	processorDockerfileInfo.BaseImage = "openjdk:9-jre-slim"
-	if baseImageRegistry != "" {
-		processorDockerfileInfo.BaseImage =
-			fmt.Sprintf("%s/%s", baseImageRegistry, processorDockerfileInfo.BaseImage)
-	}
 
 	// fill onbuild artifact
 	artifact := runtime.Artifact{

--- a/pkg/processor/build/runtime/java/runtime.go
+++ b/pkg/processor/build/runtime/java/runtime.go
@@ -49,16 +49,21 @@ func (j *java) OnAfterStagingDirCreated(stagingDir string) error {
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (j *java) GetProcessorDockerfileInfo(versionInfo *version.Info,
-	registryURL string) (*runtime.ProcessorDockerfileInfo, error) {
+	baseImageRegistry string,
+	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 	processorDockerfileInfo.BaseImage = "openjdk:9-jre-slim"
+	if baseImageRegistry != "" {
+		processorDockerfileInfo.BaseImage =
+			fmt.Sprintf("%s/%s", baseImageRegistry, processorDockerfileInfo.BaseImage)
+	}
 
 	// fill onbuild artifact
 	artifact := runtime.Artifact{
 		Name: "java-onbuild",
 		Image: fmt.Sprintf("%s/nuclio/handler-builder-java-onbuild:%s-%s",
-			registryURL,
+			onbuildImageRegistry,
 			versionInfo.Label,
 			versionInfo.Arch),
 		Paths: map[string]string{

--- a/pkg/processor/build/runtime/nodejs/runtime.go
+++ b/pkg/processor/build/runtime/nodejs/runtime.go
@@ -35,12 +35,17 @@ func (n *nodejs) GetName() string {
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (n *nodejs) GetProcessorDockerfileInfo(versionInfo *version.Info,
-	registryURL string) (*runtime.ProcessorDockerfileInfo, error) {
+	baseImageRegistry string,
+	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
 	// set the default base image
 	processorDockerfileInfo.BaseImage = "node:10.3-alpine"
+	if baseImageRegistry != "" {
+		processorDockerfileInfo.BaseImage =
+			fmt.Sprintf("%s/%s", baseImageRegistry, processorDockerfileInfo.BaseImage)
+	}
 
 	processorDockerfileInfo.ImageArtifactPaths = map[string]string{
 		"handler": "/opt/nuclio",
@@ -50,7 +55,7 @@ func (n *nodejs) GetProcessorDockerfileInfo(versionInfo *version.Info,
 	artifact := runtime.Artifact{
 		Name: "nodejs-onbuild",
 		Image: fmt.Sprintf("%s/nuclio/handler-builder-nodejs-onbuild:%s-%s",
-			registryURL,
+			onbuildImageRegistry,
 			versionInfo.Label,
 			versionInfo.Arch),
 		Paths: map[string]string{

--- a/pkg/processor/build/runtime/nodejs/runtime.go
+++ b/pkg/processor/build/runtime/nodejs/runtime.go
@@ -35,17 +35,12 @@ func (n *nodejs) GetName() string {
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (n *nodejs) GetProcessorDockerfileInfo(versionInfo *version.Info,
-	baseImageRegistry string,
 	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
 	// set the default base image
 	processorDockerfileInfo.BaseImage = "node:10.3-alpine"
-	if baseImageRegistry != "" {
-		processorDockerfileInfo.BaseImage =
-			fmt.Sprintf("%s/%s", baseImageRegistry, processorDockerfileInfo.BaseImage)
-	}
 
 	processorDockerfileInfo.ImageArtifactPaths = map[string]string{
 		"handler": "/opt/nuclio",

--- a/pkg/processor/build/runtime/pypy/runtime.go
+++ b/pkg/processor/build/runtime/pypy/runtime.go
@@ -111,7 +111,6 @@ func (p *pypy) GetName() string {
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (p *pypy) GetProcessorDockerfileInfo(versionInfo *version.Info,
-	baseImageRegistry string,
 	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 	return nil, nil
 }

--- a/pkg/processor/build/runtime/pypy/runtime.go
+++ b/pkg/processor/build/runtime/pypy/runtime.go
@@ -111,7 +111,8 @@ func (p *pypy) GetName() string {
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (p *pypy) GetProcessorDockerfileInfo(versionInfo *version.Info,
-	registryURL string) (*runtime.ProcessorDockerfileInfo, error) {
+	baseImageRegistry string,
+	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 	return nil, nil
 }
 

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -36,7 +36,6 @@ func (p *python) GetName() string {
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (p *python) GetProcessorDockerfileInfo(versionInfo *version.Info,
-	baseImageRegistry string,
 	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
@@ -49,10 +48,6 @@ func (p *python) GetProcessorDockerfileInfo(versionInfo *version.Info,
 		processorDockerfileInfo.BaseImage = "python:2.7-alpine"
 	} else {
 		processorDockerfileInfo.BaseImage = "python:3.6"
-	}
-	if baseImageRegistry != "" {
-		processorDockerfileInfo.BaseImage =
-			fmt.Sprintf("%s/%s", baseImageRegistry, processorDockerfileInfo.BaseImage)
 	}
 
 	processorDockerfileInfo.ImageArtifactPaths = map[string]string{

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -36,7 +36,8 @@ func (p *python) GetName() string {
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (p *python) GetProcessorDockerfileInfo(versionInfo *version.Info,
-	registryURL string) (*runtime.ProcessorDockerfileInfo, error) {
+	baseImageRegistry string,
+	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 	pythonCommonModules := []string{
@@ -49,6 +50,10 @@ func (p *python) GetProcessorDockerfileInfo(versionInfo *version.Info,
 	} else {
 		processorDockerfileInfo.BaseImage = "python:3.6"
 	}
+	if baseImageRegistry != "" {
+		processorDockerfileInfo.BaseImage =
+			fmt.Sprintf("%s/%s", baseImageRegistry, processorDockerfileInfo.BaseImage)
+	}
 
 	processorDockerfileInfo.ImageArtifactPaths = map[string]string{
 		"handler": "/opt/nuclio",
@@ -58,7 +63,7 @@ func (p *python) GetProcessorDockerfileInfo(versionInfo *version.Info,
 	artifact := runtime.Artifact{
 		Name: "python-onbuild",
 		Image: fmt.Sprintf("%s/nuclio/handler-builder-python-onbuild:%s-%s",
-			registryURL,
+			onbuildImageRegistry,
 			versionInfo.Label,
 			versionInfo.Arch),
 		Paths: map[string]string{

--- a/pkg/processor/build/runtime/ruby/runtime.go
+++ b/pkg/processor/build/runtime/ruby/runtime.go
@@ -34,16 +34,11 @@ func (r *ruby) GetName() string {
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (r *ruby) GetProcessorDockerfileInfo(versionInfo *version.Info,
-	baseImageRegistry string,
 	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
 	processorDockerfileInfo.BaseImage = "ruby:2.4.4-alpine"
-	if baseImageRegistry != "" {
-		processorDockerfileInfo.BaseImage =
-			fmt.Sprintf("%s/%s", baseImageRegistry, processorDockerfileInfo.BaseImage)
-	}
 
 	processorDockerfileInfo.ImageArtifactPaths = map[string]string{
 		"handler": "/opt/nuclio",

--- a/pkg/processor/build/runtime/ruby/runtime.go
+++ b/pkg/processor/build/runtime/ruby/runtime.go
@@ -34,11 +34,16 @@ func (r *ruby) GetName() string {
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (r *ruby) GetProcessorDockerfileInfo(versionInfo *version.Info,
-	registryURL string) (*runtime.ProcessorDockerfileInfo, error) {
+	baseImageRegistry string,
+	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
 	processorDockerfileInfo.BaseImage = "ruby:2.4.4-alpine"
+	if baseImageRegistry != "" {
+		processorDockerfileInfo.BaseImage =
+			fmt.Sprintf("%s/%s", baseImageRegistry, processorDockerfileInfo.BaseImage)
+	}
 
 	processorDockerfileInfo.ImageArtifactPaths = map[string]string{
 		"handler": "/opt/nuclio",
@@ -48,7 +53,7 @@ func (r *ruby) GetProcessorDockerfileInfo(versionInfo *version.Info,
 	artifact := runtime.Artifact{
 		Name: "ruby-onbuild",
 		Image: fmt.Sprintf("%s/nuclio/handler-builder-ruby-onbuild:%s-%s",
-			registryURL,
+			onbuildImageRegistry,
 			versionInfo.Label,
 			versionInfo.Arch),
 		Paths: map[string]string{

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -57,7 +57,8 @@ type Runtime interface {
 	OnAfterStagingDirCreated(stagingDir string) error
 
 	// GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-	GetProcessorDockerfileInfo(versionInfo *version.Info, registryURL string) (*ProcessorDockerfileInfo, error)
+	GetProcessorDockerfileInfo(versionInfo *version.Info, baseImageRegistry string, onbuildImageRegistry string) (
+		*ProcessorDockerfileInfo, error)
 
 	// GetName returns the name of the runtime, including version if applicable
 	GetName() string

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -57,7 +57,7 @@ type Runtime interface {
 	OnAfterStagingDirCreated(stagingDir string) error
 
 	// GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-	GetProcessorDockerfileInfo(versionInfo *version.Info, baseImageRegistry string, onbuildImageRegistry string) (
+	GetProcessorDockerfileInfo(versionInfo *version.Info, onbuildImageRegistry string) (
 		*ProcessorDockerfileInfo, error)
 
 	// GetName returns the name of the runtime, including version if applicable

--- a/pkg/processor/build/runtime/shell/runtime.go
+++ b/pkg/processor/build/runtime/shell/runtime.go
@@ -34,18 +34,23 @@ func (s *shell) GetName() string {
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (s *shell) GetProcessorDockerfileInfo(versionInfo *version.Info,
-	registryURL string) (*runtime.ProcessorDockerfileInfo, error) {
+	baseImageRegistry string,
+	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
 	// set the default base image
 	processorDockerfileInfo.BaseImage = "alpine:3.7"
+	if baseImageRegistry != "" {
+		processorDockerfileInfo.BaseImage =
+			fmt.Sprintf("%s/%s", baseImageRegistry, processorDockerfileInfo.BaseImage)
+	}
 
 	// fill onbuild artifact
 	artifact := runtime.Artifact{
 		Name: "nuclio-processor",
 		Image: fmt.Sprintf("%s/nuclio/processor:%s-%s",
-			registryURL,
+			onbuildImageRegistry,
 			versionInfo.Label,
 			versionInfo.Arch),
 		Paths: map[string]string{

--- a/pkg/processor/build/runtime/shell/runtime.go
+++ b/pkg/processor/build/runtime/shell/runtime.go
@@ -34,17 +34,12 @@ func (s *shell) GetName() string {
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (s *shell) GetProcessorDockerfileInfo(versionInfo *version.Info,
-	baseImageRegistry string,
 	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
 	// set the default base image
 	processorDockerfileInfo.BaseImage = "alpine:3.7"
-	if baseImageRegistry != "" {
-		processorDockerfileInfo.BaseImage =
-			fmt.Sprintf("%s/%s", baseImageRegistry, processorDockerfileInfo.BaseImage)
-	}
 
 	// fill onbuild artifact
 	artifact := runtime.Artifact{


### PR DESCRIPTION
The motivation for this change is the need to have different behavior for the *default* base images, and custom, *user supplied* (upon function config) base images in air-gapped systems for *kaniko* container builder kind.

- Onbuild images default to `quay.io` registry, but should be point-able to any user given accessible registry in an air-gapped system (dark site).
- Base images don't have a single default registry across runtimes; Each runtime pulls a different default base image from the web (`docker.io` or `mcr` for example). Still, for *air-gapped* systems, this behavior should be overridable, such that all default base images  will be taken from a single accessible, user-provided registry. While the above remains, *user-provided base images*, would not be automatically pulled from this registry by default, to remove friction in non-air gapped systems. The idea here is that if a user wants to provide a custom base image in an air-gapped system - he can do so by pushing it to the accessible registry, which he has too, anyways; but using the *same nuclio system configuration* will not hinder non air-gapped systems to pull custom images from the web. In other words - air-gapped behavior out of the box (defaults); but non-overriding behavior for custom base images.

- For the air-gapped scenarios we formerly used `dependantImageRegistryURL` as a single flag to override both base images and onbuild images, but this is still not flexible enough because of the above restriction to allow custom base images to be pulled from the user-give registry without force-overriding. Using `dependantImageRegistryURL` will (intentionally) override the given onbuild *and base* images - it will force the user to push every baseimage he/she wishes to override into `dependantImageRegistryURL`. While air-gapped friendly, this is inconvenient for more common, non air-gapped systems.

In an attempt to nail a sweet-spot, we wish to be able to both give dark-site friendly behavior out of the box (default base images), but still allow users in internet-accessible environments to pull custom base images from the web [with the same nuclio configuration across system deployments]. So, we to override the default base images to be taken from `defaultBaseRegistryURL` while any custom base image would not be affected.
For that reason, we separated `defaultBaseRegistryURL` and `defaultOnbuildRegistryURL`