### PR TITLE
Disable fasthttp log all errors feature

### DIFF
--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -105,7 +105,6 @@ func (h *http) Start(checkpoint functionconfig.Checkpoint) error {
 		Handler:        h.requestHandler,
 		Name:           "nuclio",
 		ReadBufferSize: h.configuration.ReadBufferSize,
-		LogAllErrors:   true,
 		Logger:         NewFastHTTPLogger(h.Logger),
 	}
 


### PR DESCRIPTION
Disabling as fasthttp implementation contains string comparison which will reduce performance