### PR TITLE
Fix metric response returns with zero due to blazing fast function

### DIFF
--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -85,6 +85,7 @@ class Wrapper(object):
 
         int_buf = bytearray(4)
         buf = memoryview(bytearray(self._max_message_size))
+        minimum_float_duration = sys.float_info.min
 
         while True:
 
@@ -138,8 +139,8 @@ class Wrapper(object):
                     # call the entrypoint
                     entrypoint_output = self._entrypoint(self._context, event)
 
-                    # measure duration
-                    duration = time.time() - start_time
+                    # measure duration, set to minimum float in case execution was too fast
+                    duration = time.time() - start_time or minimum_float_duration
 
                     self._write_packet_to_processor('m' + json.dumps({'duration': duration}))
 

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -348,7 +348,7 @@ func (r *AbstractRuntime) wrapperOutputHandler(conn io.Reader, resultChan chan *
 			// write back to result channel
 			resultChan <- unmarshalledResult
 		case 'm':
-			r.handleReponseMetric(data[1:])
+			r.handleResponseMetric(data[1:])
 		case 'l':
 			r.handleResponseLog(data[1:])
 		case 's':
@@ -381,7 +381,7 @@ func (r *AbstractRuntime) handleResponseLog(response []byte) {
 	logFunc(logRecord.Message, vars...)
 }
 
-func (r *AbstractRuntime) handleReponseMetric(response []byte) {
+func (r *AbstractRuntime) handleResponseMetric(response []byte) {
 	var metrics struct {
 		DurationSec float64 `json:"duration"`
 	}


### PR DESCRIPTION
added the minimum supported float64 number if duration is zero