### PR TITLE
Fixing returned error handling in http trigger

### DIFF
--- a/pkg/processor/runtime/golang/test/_outputter/outputter.go
+++ b/pkg/processor/runtime/golang/test/_outputter/outputter.go
@@ -73,6 +73,9 @@ func Outputter(context *nuclio.Context, event nuclio.Event) (interface{}, error)
 		sort.Strings(fields)
 		return strings.Join(fields, ","), nil
 
+	case "return_body_error":
+		return nil, nuclio.WrapErrBadRequest(fmt.Errorf("error string body"))
+
 	case "return_path":
 		return event.GetPath(), nil
 	}

--- a/pkg/processor/runtime/golang/test/golang_test.go
+++ b/pkg/processor/runtime/golang/test/golang_test.go
@@ -49,10 +49,8 @@ func (suite *TestSuite) SetupTest() {
 }
 
 func (suite *TestSuite) TestOutputs() {
-	// TODO: Have common tests and use here and in Python
-	// see https://github.com/nuclio/nuclio/issues/227
-
 	statusOK := http.StatusOK
+	badRequest := http.StatusBadRequest
 	statusCreated := http.StatusCreated
 	statusInternalError := http.StatusInternalServerError
 	logLevelDebug := "debug"
@@ -67,6 +65,13 @@ func (suite *TestSuite) TestOutputs() {
 
 	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
 		testRequests := []httpsuite.Request{
+			{
+				Name:                       "error-check",
+				RequestBody:                "return_body_error",
+				ExpectedResponseHeaders:    headersContentTypeTextPlain,
+				ExpectedResponseBody:       "error string body",
+				ExpectedResponseStatusCode: &badRequest,
+			},
 			{
 				Name:                       "string",
 				RequestBody:                "return_string",

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -313,14 +313,15 @@ func (h *http) requestHandler(ctx *fasthttp.RequestCtx) {
 		var statusCode int
 
 		// check if the user returned an error with a status code
-		errorWithStatusCode, errorHasStatusCode := processError.(nuclio.ErrorWithStatusCode)
+		switch typedError := processError.(type) {
+		case nuclio.ErrorWithStatusCode:
+			statusCode = typedError.StatusCode()
+		case *nuclio.ErrorWithStatusCode:
+			statusCode = typedError.StatusCode()
+		default:
 
-		// if the user didn't use one of the errors with status code, return internal error
-		// otherwise return the status code the user wanted
-		if !errorHasStatusCode {
+			// if the user didn't use one of the errors with status code, return internal error
 			statusCode = net_http.StatusInternalServerError
-		} else {
-			statusCode = errorWithStatusCode.StatusCode()
 		}
 
 		ctx.Response.SetStatusCode(statusCode)

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -324,6 +324,7 @@ func (h *http) requestHandler(ctx *fasthttp.RequestCtx) {
 		}
 
 		ctx.Response.SetStatusCode(statusCode)
+		ctx.Response.SetBodyString(processError.Error())
 		return
 	}
 

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -308,7 +308,6 @@ func (h *http) requestHandler(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	// if the function returned an error - just return 500
 	if processError != nil {
 		var statusCode int
 


### PR DESCRIPTION
* handling the case where the user return pointer to `nuclio.ErrorWithStatusCode`
* writing the error message in the response body