### PR TITLE
Fix multiple python pip packages

### DIFF
--- a/pkg/common/runtime.go
+++ b/pkg/common/runtime.go
@@ -1,0 +1,32 @@
+package common
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+)
+
+func GetPythonExePath(logger logger.Logger, runtimeVersion string) (string, error) {
+	baseName := "python3"
+
+	if strings.HasPrefix(runtimeVersion, "2") {
+		baseName = "python2"
+	}
+
+	exePath, err := exec.LookPath(baseName)
+	if err == nil {
+		return exePath, nil
+	}
+
+	logger.WarnWith("Can't find specific python exe", "name", baseName)
+
+	// Try just "python"
+	exePath, err = exec.LookPath("python")
+	if err == nil {
+		return exePath, nil
+	}
+
+	return "", errors.Wrap(err, "Can't find python executable")
+}

--- a/pkg/common/runtime.go
+++ b/pkg/common/runtime.go
@@ -9,6 +9,13 @@ import (
 )
 
 func GetPythonExePath(logger logger.Logger, runtimeVersion string) (string, error) {
+
+	// allow user to provide with default python exe path
+	defaultPythonExePath := GetEnvOrDefaultString("NUCLIO_PYTHON_EXE_PATH", "")
+	if defaultPythonExePath != "" {
+		return defaultPythonExePath, nil
+	}
+
 	baseName := "python3"
 
 	if strings.HasPrefix(runtimeVersion, "2") {

--- a/pkg/processor/build/runtime/python/factory.go
+++ b/pkg/processor/build/runtime/python/factory.go
@@ -35,7 +35,7 @@ func (f *factory) Create(logger logger.Logger,
 		return nil, errors.Wrap(err, "Failed to create abstract runtime")
 	}
 
-	return &python{
+	return &Python{
 		AbstractRuntime: abstractRuntime,
 	}, nil
 }

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -28,17 +28,17 @@ import (
 	"github.com/nuclio/errors"
 )
 
-type python struct {
+type Python struct {
 	*runtime.AbstractRuntime
 }
 
 // GetName returns the name of the runtime, including version if applicable
-func (p *python) GetName() string {
+func (p *Python) GetName() string {
 	return "python"
 }
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-func (p *python) GetProcessorDockerfileInfo(versionInfo *version.Info,
+func (p *Python) GetProcessorDockerfileInfo(versionInfo *version.Info,
 	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}

--- a/pkg/processor/build/runtime/python/test/runtime_test.go
+++ b/pkg/processor/build/runtime/python/test/runtime_test.go
@@ -1,0 +1,59 @@
+package test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtime/python"
+	"github.com/nuclio/nuclio/pkg/version"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type testRunTimeSuite struct {
+	suite.Suite
+	Logger         logger.Logger
+	Version        version.Info
+	FunctionConfig *functionconfig.Config
+}
+
+func (suite *testRunTimeSuite) SetupSuite() {
+	var err error
+	suite.Logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err, "Failed to create nuclio zap logger")
+	suite.Version = version.Info{}
+	err = os.Setenv("NUCLIO_PYTHON_EXE_PATH", "pythonX")
+	suite.Require().NoError(err, "Failed to set nuclio python exe path")
+	suite.FunctionConfig = functionconfig.NewConfig()
+}
+
+func (suite *testRunTimeSuite) TearDownTestSuite() {
+	var err error
+	err = os.Unsetenv("NUCLIO_PYTHON_EXE_PATH")
+	suite.Require().NoError(err, "Failed to unset nuclio python exe path")
+}
+
+func (suite *testRunTimeSuite) TestPythonExePath() {
+	pythonRuntime := suite.buildRuntime()
+	processorDockerInfo, err := pythonRuntime.GetProcessorDockerfileInfo(&suite.Version, "a")
+	suite.Require().NoError(err)
+	suite.True(strings.HasPrefix(processorDockerInfo.Directives["postCopy"][0].Value, "pythonX"),
+		"Python exe path should start with test overridden value")
+}
+
+func (suite *testRunTimeSuite) buildRuntime() *python.Python {
+	pyRuntime, err := runtime.NewAbstractRuntime(suite.Logger, "/tmp/stagingDir", suite.FunctionConfig)
+	suite.Require().NoError(err)
+	return &python.Python{
+		AbstractRuntime: pyRuntime,
+	}
+}
+
+func TestRuntime(t *testing.T) {
+	suite.Run(t, new(testRunTimeSuite))
+}


### PR DESCRIPTION
Scenario:
Having multiple python interpreters, each have its own pip packages, can cause the python exe runtime not having installed nuclio requirements

Fix:
Use python runtime executable pip module
