### PR TITLE
Use sync.Map for DeployLogStreams locking mechanism

### DIFF
--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -129,7 +129,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	}
 
 	// save the log stream for the name
-	p.DeployLogStreams[createFunctionOptions.FunctionConfig.Meta.GetUniqueID()] = logStream
+	p.DeployLogStreams.Store(createFunctionOptions.FunctionConfig.Meta.GetUniqueID(), logStream)
 
 	// replace logger
 	createFunctionOptions.Logger = logStream.GetLogger()
@@ -253,14 +253,7 @@ func (p *Platform) GetFunctions(getFunctionsOptions *platform.GetFunctionsOption
 		return nil, errors.Wrap(err, "Failed to get functions")
 	}
 
-	// iterate over functions and enrich with deploy logs
-	for _, function := range functions {
-
-		// enrich with build logs
-		if deployLogStream, exists := p.DeployLogStreams[function.GetConfig().Meta.GetUniqueID()]; exists {
-			deployLogStream.ReadLogs(nil, &function.GetStatus().Logs)
-		}
-	}
+	p.EnrichFunctionsWithDeployLogStream(functions)
 
 	return functions, nil
 }


### PR DESCRIPTION
When creating many functions in parallel while trying to get functions it panics as `DeployLogStreams` is not yet safe concurrency read/write

Using `sync.Map` we achieve a locking mechanism to make `DeployLogStreams` concurrency safe (aka thread-safe)

Dev logs:
```
fatal error: concurrent map writes

goroutine 602 [running]:
runtime.throw(0x17964b4, 0x15)
	/usr/local/go/src/runtime/panic.go:616 +0x81 fp=0xc42073de18 sp=0xc42073ddf8 pc=0x42add1
runtime.mapassign_faststr(0x156a2a0, 0xc42024bc50, 0xc420d41b80, 0x19, 0x1)
	/usr/local/go/src/runtime/hashmap_fast.go:779 +0x3ce fp=0xc42073de88 sp=0xc42073de18 pc=0x40b8fe
github.com/nuclio/nuclio/pkg/platform/kube.(*Platform).CreateFunction(0xc4204951c0, 0xc42046fc00, 0x239b828, 0xc420a43440, 0x4)
	/go/src/github.com/nuclio/nuclio/pkg/platform/kube/platform.go:132 +0x162 fp=0xc42073df10 sp=0xc42073de88 pc=0x13459d2
github.com/nuclio/nuclio/pkg/dashboard/resource.(*functionResource).storeAndDeployFunction.func1(0x239b828, 0xc42000bf80, 0xc42004e3f0, 0x0, 0xc420866ae0, 0xc42004e380)
	/go/src/github.com/nuclio/nuclio/pkg/dashboard/resource/function.go:225 +0x27d fp=0xc42073dfb0 sp=0xc42073df10 pc=0x13c349d
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:2361 +0x1 fp=0xc42073dfb8 sp=0xc42073dfb0 pc=0x4596f1
created by github.com/nuclio/nuclio/pkg/dashboard/resource.(*functionResource).storeAndDeployFunction
	/go/src/github.com/nuclio/nuclio/pkg/dashboard/resource/function.go:197 +0x129
```