### PR TITLE
Add shell metrics

### DIFF
--- a/pkg/processor/runtime/shell/runtime.go
+++ b/pkg/processor/runtime/shell/runtime.go
@@ -110,7 +110,7 @@ func (s *shell) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (
 	}
 
 	// calculate call duration
-	duration := time.Since(start)
+	callDuration := time.Since(startTime)
 
 	// add duration to sum
 	s.Statistics.DurationMilliSecondsSum += uint64(duration.Nanoseconds() / 1000000)

--- a/pkg/processor/runtime/shell/runtime.go
+++ b/pkg/processor/runtime/shell/runtime.go
@@ -113,7 +113,7 @@ func (s *shell) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (
 	callDuration := time.Since(startTime)
 
 	// add duration to sum
-	s.Statistics.DurationMilliSecondsSum += uint64(duration.Nanoseconds() / 1000000)
+	s.Statistics.DurationMilliSecondsSum += uint64(callDuration.Nanoseconds() / 1000000)
 	s.Statistics.DurationMilliSecondsCount++
 
 	s.Logger.DebugWith("Shell executed",

--- a/pkg/processor/runtime/shell/runtime.go
+++ b/pkg/processor/runtime/shell/runtime.go
@@ -100,11 +100,21 @@ func (s *shell) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (
 	// add event stuff to env
 	cmd.Env = append(cmd.Env, s.getEnvFromEvent(event)...)
 
+	// save timestamp
+	start := time.Now()
+
 	// run the command
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to run shell command")
 	}
+
+	// calculate call duration
+	duration := time.Since(start)
+
+	// add duration to sum
+	s.Statistics.DurationMilliSecondsSum += uint64(duration.Nanoseconds() / 1000000)
+	s.Statistics.DurationMilliSecondsCount++
 
 	s.Logger.DebugWith("Shell executed",
 		"eventID", event.GetID())

--- a/pkg/processor/runtime/shell/runtime.go
+++ b/pkg/processor/runtime/shell/runtime.go
@@ -101,7 +101,7 @@ func (s *shell) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (
 	cmd.Env = append(cmd.Env, s.getEnvFromEvent(event)...)
 
 	// save timestamp
-	start := time.Now()
+	startTime := time.Now()
 
 	// run the command
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
Some runtimes are missing metric output in runtime handler. #1248
I added shell runtime metrics.

Prometheus is here:
![image](https://user-images.githubusercontent.com/17234046/76841732-8aac4300-687c-11ea-9b27-d6ebcfd69d85.png)
