### PR TITLE
Update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,9 @@
+*
+!pkg
+!cmd
+!test
+!vendor
+
 pkg/dashboard/ui/node_modules
 pkg/dashboard/ui/vendor
 pkg/dashboard/ui/dist


### PR DESCRIPTION
Move on to whitelist strategy on dockerignore as many files are unneeded and some subdirectories (such as `.git`, it which take ~200mb) takes too much time to copy
