### PR TITLE
Nuctl update local directory path function as image CET

### DIFF
--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -481,6 +481,53 @@ func (suite *functionDeployTestSuite) TestBuildWithSaveDeployWithLoad() {
 	suite.Require().Contains(suite.outputBuffer.String(), "+gnirts siht esrever-")
 }
 
+// Expecting the Code Entry Type to be modified to image
+func (suite *functionDeployTestSuite) TestDeployFromLocalDirPath() {
+	randomString := xid.New().String()
+	uniqueSuffix := "-" + randomString
+	imageName := "nuclio/deploy-local-dir" + uniqueSuffix
+	functionName := "local-dir-reverser"
+
+	err := suite.ExecuteNutcl([]string{"deploy", functionName, "--verbose", "--no-pull"},
+		map[string]string{
+			"path":    path.Join(suite.GetFunctionsDir(), "common", "reverser", "python"),
+			"runtime": "python:3.6",
+			"handler": "reverser:handler",
+		})
+
+	suite.Require().NoError(err)
+
+	// make sure to clean up after the test
+	defer suite.dockerClient.RemoveImage(imageName)
+
+	// use nuctl to delete the function when we're done
+	defer suite.ExecuteNutcl([]string{"delete", "fu", functionName}, nil)
+
+	// check that the function's CET was modified to 'image'
+	err = suite.ExecuteNutcl([]string{"get", "function", functionName, "-o yaml"}, nil)
+	suite.Require().NoError(err)
+	suite.Require().Contains(suite.outputBuffer.String(), "codeEntryType: image")
+
+	// try a few times to invoke, until it succeeds
+	err = common.RetryUntilSuccessful(60*time.Second, 1*time.Second, func() bool {
+
+		// invoke the function
+		err = suite.ExecuteNutcl([]string{"invoke", functionName},
+			map[string]string{
+				"method": "POST",
+				"body":   "-reverse this string+",
+				"via":    "external-ip",
+			})
+
+		return err == nil
+	})
+
+	suite.Require().NoError(err)
+
+	// check that invoke printed the value
+	suite.Require().Contains(suite.outputBuffer.String(), "+gnirts siht esrever-")
+}
+
 type functionGetTestSuite struct {
 	Suite
 }

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -504,7 +504,10 @@ func (suite *functionDeployTestSuite) TestDeployFromLocalDirPath() {
 	defer suite.ExecuteNutcl([]string{"delete", "fu", functionName}, nil)
 
 	// check that the function's CET was modified to 'image'
-	err = suite.ExecuteNutcl([]string{"get", "function", functionName, "-o yaml"}, nil)
+	err = suite.ExecuteNutcl([]string{"get", "function", functionName},
+		map[string]string{
+			"output": "yaml",
+		})
 	suite.Require().NoError(err)
 	suite.Require().Contains(suite.outputBuffer.String(), "codeEntryType: image")
 
@@ -521,7 +524,6 @@ func (suite *functionDeployTestSuite) TestDeployFromLocalDirPath() {
 
 		return err == nil
 	})
-
 	suite.Require().NoError(err)
 
 	// check that invoke printed the value

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -646,7 +646,7 @@ func (b *Builder) resolveFunctionPath(functionPath string) (string, string, erro
 	}
 
 	// when no code entry type was passed and it's an archive or jar
-	if codeEntryType == "" && (util.IsCompressed(resolvedPath) || util.IsJar(resolvedPath)) {
+	if codeEntryType == "" && (util.IsCompressed(resolvedPath) || util.IsJar(resolvedPath) || common.IsDir(resolvedPath)) {
 
 		// if it's a URL, set it as an archive code entry type, otherwise save the built image so it'll be possible to redeploy
 		if isURL {


### PR DESCRIPTION
Set it to `Image` CET so it will be redeploy-able via the UI