### PR TITLE
Reduce chance of k8s resource name conflicts with external resources

### DIFF
--- a/pkg/platform/kube/deployer.go
+++ b/pkg/platform/kube/deployer.go
@@ -214,8 +214,8 @@ func (d *deployer) getFunctionPodLogsAndEvents(namespace string, name string) (s
 	functionPods, listPodErr := d.consumer.kubeClientSet.CoreV1().
 		Pods(namespace).
 		List(meta_v1.ListOptions{
-		LabelSelector: fmt.Sprintf("nuclio.io/function-name=%s", name),
-	})
+			LabelSelector: fmt.Sprintf("nuclio.io/function-name=%s", name),
+		})
 
 	if listPodErr != nil {
 		podLogsMessage += fmt.Sprintf("Failed to list pods: %s\n", listPodErr.Error())

--- a/pkg/platform/kube/deployer.go
+++ b/pkg/platform/kube/deployer.go
@@ -185,7 +185,9 @@ func waitForFunctionReadiness(loggerInstance logger.Logger,
 	conditionFunc := func() (bool, error) {
 
 		// get the appropriate function CR
-		function, err = consumer.nuclioClientSet.NuclioV1beta1().NuclioFunctions(namespace).Get(name, meta_v1.GetOptions{})
+		function, err = consumer.nuclioClientSet.NuclioV1beta1().
+			NuclioFunctions(namespace).
+			Get(name, meta_v1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
@@ -209,7 +211,9 @@ func (d *deployer) getFunctionPodLogsAndEvents(namespace string, name string) (s
 	podLogsMessage := "\nPod logs:\n"
 
 	// list pods
-	functionPods, listPodErr := d.consumer.kubeClientSet.CoreV1().Pods(namespace).List(meta_v1.ListOptions{
+	functionPods, listPodErr := d.consumer.kubeClientSet.CoreV1().
+		Pods(namespace).
+		List(meta_v1.ListOptions{
 		LabelSelector: fmt.Sprintf("nuclio.io/function-name=%s", name),
 	})
 
@@ -236,7 +240,10 @@ func (d *deployer) getFunctionPodLogsAndEvents(namespace string, name string) (s
 		podLogsMessage += "\n* " + pod.Name + "\n"
 
 		maxLogLines := int64(MaxLogLines)
-		logsRequest, getLogsErr := d.consumer.kubeClientSet.CoreV1().Pods(namespace).GetLogs(pod.Name, &v1.PodLogOptions{TailLines: &maxLogLines}).Stream()
+		logsRequest, getLogsErr := d.consumer.kubeClientSet.CoreV1().
+			Pods(namespace).
+			GetLogs(pod.Name, &v1.PodLogOptions{TailLines: &maxLogLines}).
+			Stream()
 		if getLogsErr != nil {
 			podLogsMessage += "Failed to read logs: " + getLogsErr.Error() + "\n"
 		} else {

--- a/pkg/platform/kube/deployer.go
+++ b/pkg/platform/kube/deployer.go
@@ -62,7 +62,8 @@ func (d *deployer) createOrUpdateFunction(functionInstance *nuclioio.NuclioFunct
 	functionExisted := functionInstance != nil
 
 	createFunctionOptions.Logger.DebugWith("Creating/updating function",
-		"existed", functionExisted)
+		"existed", functionExisted,
+		"name", functionInstance.Name)
 
 	if !functionExisted {
 		functionInstance = &nuclioio.NuclioFunction{}

--- a/pkg/platform/kube/function.go
+++ b/pkg/platform/kube/function.go
@@ -110,7 +110,7 @@ func (f *function) Initialize([]string) error {
 			}
 
 			// there should be only one
-			if len(deploymentList.Items) !=  1 {
+			if len(deploymentList.Items) != 1 {
 				deploymentErr = fmt.Errorf("Found unexptected number of deployments for function %s: %d",
 					f.function.Name,
 					len(deploymentList.Items))
@@ -165,7 +165,7 @@ func (f *function) Initialize([]string) error {
 					f.function.Name,
 					len(ingressList.Items))
 
-			// there can be 0
+				// there can be 0
 			} else if len(ingressList.Items) == 1 {
 				ingress = &ingressList.Items[0]
 			}

--- a/pkg/platform/kube/function.go
+++ b/pkg/platform/kube/function.go
@@ -110,8 +110,10 @@ func (f *function) Initialize([]string) error {
 			}
 
 			// there should be only one
-			if len(deploymentList.Items) > 1 {
-				deploymentErr = errors.New("Found more then 1 deployment for function")
+			if len(deploymentList.Items) !=  1 {
+				deploymentErr = fmt.Errorf("Found unexptected number of deployments for function %s: %s",
+					f.function.Name,
+					len(deploymentList.Items))
 			} else {
 				deployment = &deploymentList.Items[0]
 			}
@@ -133,8 +135,10 @@ func (f *function) Initialize([]string) error {
 			}
 
 			// there should be only one
-			if len(serviceList.Items) > 1 {
-				serviceErr = errors.New("Found more then 1 service for function")
+			if len(serviceList.Items) != 1 {
+				serviceErr = fmt.Errorf("Found unexptected number of services for function %s: %s",
+					f.function.Name,
+					len(deploymentList.Items))
 			} else {
 				service = &serviceList.Items[0]
 			}
@@ -154,13 +158,17 @@ func (f *function) Initialize([]string) error {
 				return
 			}
 
-			// there should be only one
 			if len(ingressList.Items) > 1 {
-				ingressErr = errors.New("Found more then 1 ingress for function")
-			} else {
+
+				// no more then one
+				ingressErr = fmt.Errorf("Found more then 1 ingress for function %s: %s",
+					f.function.Name,
+					len(ingressList.Items))
+
+			// there can be 0
+			} else if len(ingressList.Items) == 1 {
 				ingress = &ingressList.Items[0]
 			}
-
 		}
 
 		waitGroup.Done()

--- a/pkg/platform/kube/function.go
+++ b/pkg/platform/kube/function.go
@@ -123,7 +123,6 @@ func (f *function) Initialize([]string) error {
 	}()
 
 	// get service info
-	// get deployment info
 	go func() {
 		if serviceList == nil {
 			serviceList, serviceErr = f.consumer.kubeClientSet.CoreV1().

--- a/pkg/platform/kube/function.go
+++ b/pkg/platform/kube/function.go
@@ -111,7 +111,7 @@ func (f *function) Initialize([]string) error {
 
 			// there should be only one
 			if len(deploymentList.Items) !=  1 {
-				deploymentErr = fmt.Errorf("Found unexptected number of deployments for function %s: %s",
+				deploymentErr = fmt.Errorf("Found unexptected number of deployments for function %s: %d",
 					f.function.Name,
 					len(deploymentList.Items))
 			} else {
@@ -136,7 +136,7 @@ func (f *function) Initialize([]string) error {
 
 			// there should be only one
 			if len(serviceList.Items) != 1 {
-				serviceErr = fmt.Errorf("Found unexptected number of services for function %s: %s",
+				serviceErr = fmt.Errorf("Found unexptected number of services for function %s: %d",
 					f.function.Name,
 					len(deploymentList.Items))
 			} else {
@@ -161,7 +161,7 @@ func (f *function) Initialize([]string) error {
 			if len(ingressList.Items) > 1 {
 
 				// no more then one
-				ingressErr = fmt.Errorf("Found more then 1 ingress for function %s: %s",
+				ingressErr = fmt.Errorf("Found more then 1 ingress for function %s: %d",
 					f.function.Name,
 					len(ingressList.Items))
 

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1397,7 +1397,7 @@ func (lc *lazyClient) populateConfigMap(functionLabels labels.Set,
 }
 
 func (lc *lazyClient) configMapNameFromFunctionName(functionName string) string {
-	return functionName
+	return fmt.Sprintf("nucliofunction-%s", functionName)
 }
 
 func (lc *lazyClient) getFunctionVolumeAndMounts(function *nuclioio.NuclioFunction) ([]v1.Volume, []v1.VolumeMount) {
@@ -1469,9 +1469,7 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(function *nuclioio.NuclioFuncti
 			}
 		}
 
-		lc.logger.DebugWith("Adding volume",
-			"configVolume",
-			configVolume)
+		lc.logger.DebugWith("Adding volume", "configVolume", configVolume)
 
 		volumes = append(volumes, configVolume.Volume)
 		volumeMounts = append(volumeMounts, configVolume.VolumeMount)

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1433,27 +1433,27 @@ func (lc *lazyClient) populateConfigMap(functionLabels labels.Set,
 }
 
 func (lc *lazyClient) deploymentNameFromFunctionName(functionName string) string {
-	return fmt.Sprintf("nucliofunction-%s", functionName)
+	return fmt.Sprintf("nuclio-%s", functionName)
 }
 
 func (lc *lazyClient) podNameFromFunctionName(functionName string) string {
-	return fmt.Sprintf("nucliofunction-%s", functionName)
+	return fmt.Sprintf("nuclio-%s", functionName)
 }
 
 func (lc *lazyClient) configMapNameFromFunctionName(functionName string) string {
-	return fmt.Sprintf("nucliofunction-%s", functionName)
+	return fmt.Sprintf("nuclio-%s", functionName)
 }
 
 func (lc *lazyClient) hpaNameFromFunctionName(functionName string) string {
-	return fmt.Sprintf("nucliofunction-%s", functionName)
+	return fmt.Sprintf("nuclio-%s", functionName)
 }
 
 func (lc *lazyClient) ingressNameFromFunctionName(functionName string) string {
-	return fmt.Sprintf("nucliofunction-%s", functionName)
+	return fmt.Sprintf("nuclio-%s", functionName)
 }
 
 func (lc *lazyClient) serviceNameFromFunctionName(functionName string) string {
-	return fmt.Sprintf("nucliofunction-%s", functionName)
+	return fmt.Sprintf("nuclio-%s", functionName)
 }
 
 func (lc *lazyClient) getFunctionVolumeAndMounts(function *nuclioio.NuclioFunction) ([]v1.Volume, []v1.VolumeMount) {

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -802,7 +802,7 @@ func (lc *lazyClient) createOrUpdateHorizontalPodAutoscaler(functionLabels label
 		return lc.kubeClientSet.AutoscalingV2beta1().
 			HorizontalPodAutoscalers(function.Namespace).
 			Get(lc.hpaNameFromFunctionName(function.Name),
-			meta_v1.GetOptions{})
+				meta_v1.GetOptions{})
 	}
 
 	horizontalPodAutoscalerIsDeleting := func(resource interface{}) bool {


### PR DESCRIPTION
Far from air tight, but simple and will cover 99% of cases

This needs to be reopened when we have a strategy to avoid function name collision between same-namespace projects (in which case we might prefix everything or some other crazy notion)