### PR TITLE
Fix parallel not running all jobs on single-core machines

### DIFF
--- a/cmd/dashboard/docker/runner.sh
+++ b/cmd/dashboard/docker/runner.sh
@@ -12,11 +12,13 @@ echo "Running in parallel"
 
 parallel --citation
 
+# ensure each runner gets a jobslot
 # buffer output on line basis
 # exit when the first job fails, kill all running jobs.
 # upon unexpected termination, signal jobs before killing (signal, timeout)
 # execute all *.sh files in parallel
 parallel \
+        --jobs 0 \
         --line-buffer \
         --halt now,fail=1 \
         --termseq INT,200,TERM,100,KILL,25 \


### PR DESCRIPTION
using `--jobs 0` to unlimit # of jobslots