### PR TITLE
Docker build fix - not getting default onbuild registry correctly

### DIFF
--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -96,7 +96,10 @@ func (d *Docker) GetBaseImageRegistry(registry string) string {
 }
 
 func (d *Docker) GetOnbuildImageRegistry(registry string) string {
-	return d.builderConfiguration.DefaultOnbuildRegistryURL
+
+	// TODO: uncomment and make sure docker platform is being initialized correctly
+	// return d.builderConfiguration.DefaultOnbuildRegistryURL
+	return "quay.io"
 }
 
 func (d *Docker) buildContainerImage(buildOptions *BuildOptions) error {


### PR DESCRIPTION
Due to a bug on initializing docker platform, it is not getting the default values correctly (unlike in kube platform)

This is a hotfix for `:unstable` images until a complete fix will be done.