### PR TITLE
Fix citation issue with GNU parallel in runner script for dashboard

### DIFF
--- a/cmd/dashboard/docker/runner.sh
+++ b/cmd/dashboard/docker/runner.sh
@@ -10,7 +10,7 @@ trap _term SIGINT
 
 echo "Running in parallel"
 
-parallel --citation
+echo 'will cite' | parallel --citation 1> /dev/null 2> /dev/null &
 
 # ensure each runner gets a jobslot
 # buffer output on line basis


### PR DESCRIPTION
GNU parallel's citation message causes issues with the runner script for the dashboard. This causes the dashboard to fail on Kubernetes with 'Back-off restarting failed container'.

When running the Nuclio dashboard image locally, the problem with GNU parallel is obvious:

```bash
docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock quay.io/nuclio/dashboard:1.4.2-amd64
```

It shows the citation message (as requested with `parallel --citation`) and the script can only continue after Ctrl+D.

If we enter the Docker container, we can fix manually:

```bash
docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock quay.io/nuclio/dashboard:1.4.2-amd64 sh
echo 'will cite' | parallel --citation 1> /dev/null 2> /dev/null &
./runner.sh
```

The script now runs correctly without additional intervention. 

This PR's modification pipes the required text ("will cite") to GNU parallel and redirects all output and errors to /dev/null, so that the script can run as expected.