### PR TITLE
[Nuclio] Import: skip/override functions with same name

### DIFF
--- a/pkg/dashboard/ui/src/app/shared/services/import.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/import.service.js
@@ -54,7 +54,7 @@
                     $q.all(importProjectPromisesList)
                         .then(function () {
                             resolve();
-                            checkConflictFunctionsList()
+                            checkConflictFunctionsList();
                         });
                 };
 
@@ -96,7 +96,7 @@
                     }
                 })
                 .then(function () {
-                    return NuclioProjectsDataService.getProjects()
+                    return NuclioProjectsDataService.getProjects();
                 })
                 .then(function () {
                     var projectName = lodash.get(project, 'metadata.name');
@@ -163,13 +163,12 @@
             openConfirmDialog(currentFunction.metadata.name, currentProject)
                 .then(function (data) {
                     if (data.value.option === 'allProjects') {
-                        lodash.mapKeys(conflictProjectsData, function (functionsList, projectName) {
+                        lodash.forEach(conflictProjectsData, function (functionsList, projectName) {
                             resolveConflictFunctionsInProject(functionsList, projectName, data.value.action, data.value.option);
                         });
-                    } else if (data.value.option === 'singleProject') {
-                        resolveConflictFunctionsInProject(conflictProjectsData[currentProject], currentProject, data.value.action, data.value.option);
                     } else {
-                        resolveConflictFunctionsInProject([currentFunction], currentProject, data.value.action, data.value.option);
+                        var functions = data.value.option === 'singleProject' ? conflictProjectsData[currentProject] : [currentFunction];
+                        resolveConflictFunctionsInProject(functions, currentProject, data.value.action, data.value.option);
                     }
                 });
         }

--- a/pkg/dashboard/ui/src/app/shared/services/import.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/import.service.js
@@ -107,7 +107,8 @@
                             .catch(function (error) {
                                 if (error.status === 409) {
                                     if (lodash.has(conflictProjectsData, projectName)) {
-                                        return conflictProjectsData[projectName].push(func);
+                                        conflictProjectsData[projectName].push(func);
+                                        return conflictProjectsData[projectName];
                                     } else {
                                         return lodash.set(conflictProjectsData, [projectName], [func]);
                                     }

--- a/pkg/dashboard/ui/src/app/shared/services/import.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/import.service.js
@@ -4,9 +4,13 @@
     angular.module('nuclio.app')
         .factory('ImportService', ImportService);
 
-    function ImportService($q, $i18next, i18next, lodash, YAML, DialogsService, NuclioFunctionsDataService,
+    function ImportService($q, $i18next, i18next, lodash,ngDialog, YAML, DialogsService, NuclioFunctionsDataService,
                            NuclioProjectsDataService) {
         var lng = i18next.language;
+
+        var conflictProjectsData = {};
+        var displayAllOptions = false;
+        var importProjectPromisesList = [];
 
         return {
             importFile: importFile
@@ -30,10 +34,12 @@
                         var importedData = YAML.parse(reader.result);
 
                         if (lodash.has(importedData, 'project')) {
-                            importProject(importedData.project, resolve, reject);
+                            displayAllOptions = false;
+                            importProjectPromisesList.push(importProject(importedData.project, reject));
                         } else if (lodash.has(importedData, 'projects')) {
+                            displayAllOptions = true;
                             lodash.forEach(importedData.projects, function (project) {
-                                importProject(project, resolve, reject);
+                                importProjectPromisesList.push(importProject(project, reject));
                             });
                         } else {
                             throw new Error('invalid yaml');
@@ -41,9 +47,15 @@
                     } catch (error) {
                         DialogsService.alert($i18next.t('common:ERROR_MSG.IMPORT_YAML_FILE', {lng: lng}))
                             .then(function () {
-                                reject(error)
+                                reject(error);
                             });
                     }
+
+                    $q.all(importProjectPromisesList)
+                        .then(function () {
+                            resolve();
+                            checkConflictFunctionsList()
+                        });
                 };
 
                 reader.readAsText(file);
@@ -55,15 +67,25 @@
         //
 
         /**
+         * Checks if conflict functions list not empty
+         */
+
+        function checkConflictFunctionsList() {
+            if (!lodash.isEmpty(conflictProjectsData)) {
+                resolveConflict();
+            }
+        }
+
+        /**
          * Imports new project and deploy all functions of this project
          * @param {Object} project
-         * @param {function} [onSuccess] - a callback function to call on success (no arguments passed)
          * @param {function} [onFailure] - a callback function to call on failure (the error is passed as 1st argument)
+         * @returns {Promise}
          */
-        function importProject(project, onSuccess, onFailure) {
+        function importProject(project, onFailure) {
             var projectData = lodash.omit(project, 'spec.functions');
 
-            NuclioProjectsDataService.createProject(projectData)
+            return NuclioProjectsDataService.createProject(projectData)
                 .catch(function (error) {
 
                     // swallow "409 Conflict" errors
@@ -74,28 +96,109 @@
                     }
                 })
                 .then(function () {
-                    return NuclioProjectsDataService.getProjects();
+                    return NuclioProjectsDataService.getProjects()
                 })
                 .then(function () {
                     var projectName = lodash.get(project, 'metadata.name');
                     var functions = lodash.get(project, 'spec.functions');
 
-                    lodash.forEach(functions, function (func) {
-                        NuclioFunctionsDataService.createFunction(func, projectName);
+                    var checkedFunctionList = lodash.map(functions, function (func) {
+                        return NuclioFunctionsDataService.createFunction(func, projectName)
+                            .catch(function (error) {
+                                if (error.status === 409) {
+                                    if (lodash.has(conflictProjectsData, projectName)) {
+                                        return conflictProjectsData[projectName].push(func);
+                                    } else {
+                                        return lodash.set(conflictProjectsData, [projectName], [func]);
+                                    }
+                                }
+                            });
                     });
 
-                    if (lodash.isFunction(onSuccess)) {
-                        onSuccess()
-                    }
+                    return $q.all(checkedFunctionList);
                 })
                 .catch(function (error) {
                     DialogsService.alert($i18next.t('common:ERROR_MSG.IMPORT_PROJECT', {lng: lng}))
                         .then(function () {
                             if (lodash.isFunction(onFailure)) {
-                                onFailure(error)
+                                onFailure(error);
                             }
                         });
                 });
+        }
+
+        /**
+         * Opens confirm dialog
+         * @returns {Object} closeOptions
+         */
+        function openConfirmDialog(functionName, projectName) {
+            var data = {
+                displayAllOptions: displayAllOptions,
+                dialogTitle: $i18next.t('common:OVERRIDE_FUNCTION_CONFIRM', {lng: lng, functionName: functionName, projectName: projectName})
+            };
+
+            return ngDialog.open({
+                template: '<igz-import-project-dialog ' +
+                    'data-display-all-options="ngDialogData.displayAllOptions" ' +
+                    'data-close-dialog="closeThisDialog({action, option})" ' +
+                    'data-dialog-title="ngDialogData.dialogTitle">' +
+                    '</igz-import-project-dialog>',
+                plain: true,
+                data: data,
+                className: 'ngdialog-theme-iguazio image-dialog'
+            })
+                .closePromise
+                .then(function (closeOptions) {
+                    return closeOptions;
+                });
+        }
+
+        /**
+         * Handles action and option for resolve conflict function
+         */
+        function resolveConflict() {
+            var currentProject = lodash.keys(conflictProjectsData)[0];
+            var currentFunction = lodash.get(conflictProjectsData, [currentProject] + '[0]');
+
+            openConfirmDialog(currentFunction.metadata.name, currentProject)
+                .then(function (data) {
+                    if (data.value.option === 'allProjects') {
+                        lodash.mapKeys(conflictProjectsData, function (functionsList, projectName) {
+                            resolveConflictFunctionsInProject(functionsList, projectName, data.value.action, data.value.option);
+                        });
+                    } else if (data.value.option === 'singleProject') {
+                        resolveConflictFunctionsInProject(conflictProjectsData[currentProject], currentProject, data.value.action, data.value.option);
+                    } else {
+                        resolveConflictFunctionsInProject([currentFunction], currentProject, data.value.action, data.value.option);
+                    }
+                });
+        }
+
+        /**
+         * Resolves conflict functions in a project
+         * @param {Array.<Object>} functions
+         * @param {string} projectID - project name
+         * @param {string} action
+         * @param {string} option
+         */
+        function resolveConflictFunctionsInProject(functions, projectID, action, option) {
+            lodash.forEach(functions, function (func) {
+                if (action === 'replace') {
+                    NuclioFunctionsDataService.updateFunction(func, projectID);
+                }
+            });
+
+            if (option === 'singleFunction') {
+                conflictProjectsData[projectID].shift();
+            }
+
+            if (lodash.isEmpty(conflictProjectsData[projectID]) || option === 'singleProject') {
+                lodash.unset(conflictProjectsData, [projectID])
+            }
+
+            if (option !== 'allProjects') {
+                checkConflictFunctionsList();
+            }
         }
     }
 }());

--- a/pkg/dashboard/ui/src/less/mixins.less
+++ b/pkg/dashboard/ui/src/less/mixins.less
@@ -212,6 +212,46 @@
     @accordion-panel-default-border-color: @alto-three;
 }
 
+.more-info-color-set() {
+    @icon-help-round-before-color: .duskThree(0.64)[@color];
+    @icon-help-round-before-bg-color: none;
+    @icon-help-round-hover-before-color: @dusk-three;
+
+    @icon-help-description-hover-color: none;
+
+    @row-description-box-shadow: 0 4px 12px 2px .black(0.25)[@color];
+    @row-description-bg-color: @white;
+    @row-description-color: @dusk-three;
+
+    @row-description-triangle-color: @white;
+}
+
+.multiple-checkboxes-color-set() {
+    @checkboxes-dropdown-field-border: 1px solid @pale-grey;
+    @checkboxes-dropdown-field-color: @dusk-three;
+    @checkboxes-dropdown-field-opened-bg-color: @pale-grey-two;
+
+    @checkboxes-dropdown-container-bg-color: @white;
+    @checkboxes-dropdown-container-box-shadow: 0 4px 10px 0 .black(0.25)[@color];
+    @checkboxes-dropdown-container-color: @dusk-three;
+
+    @checkboxes-search-input-color: @pale-grey;
+    @checkboxes-search-input-border: 2px solid @pale-grey;
+    @checkboxes-search-input-active-color: @dusk-three;
+    @checkboxes-search-input-active-border: 2px solid @dusk-three;
+
+    @checkboxes-group-border-bottom: 2px solid @pale-grey;
+
+    @checkboxes-group-name-color: @french-grey;
+
+    @checkboxes-add-item-btn-color: @dark-sky-blue;
+
+    @master-checkbox-color: @mountain-mist;
+    @master-checkbox-checked-color: @dark-sky-blue;
+
+    @checkboxes-list-option-color: @dusk-three;
+}
+
 .number-input-color-set() {
     @number-input-color: @dusk-three;
     @number-input-bg-color: @white;
@@ -293,20 +333,6 @@
     @dropdown-menu-list-box-shadow: 0 4px 10px 0 .black(0.25)[@color];
     @dropdown-menu-item-name-color: @dusk-three;
     @dropdown-menu-item-hover-bg-color: @pale-grey-two;
-}
-
-.more-info-color-set() {
-    @icon-help-round-before-color: .duskThree(0.64)[@color];
-    @icon-help-round-before-bg-color: none;
-    @icon-help-round-hover-before-color: @dusk-three;
-
-    @icon-help-description-hover-color: none;
-
-    @row-description-box-shadow: 0 4px 12px 2px .black(0.25)[@color];
-    @row-description-bg-color: @white;
-    @row-description-color: @dusk-three;
-
-    @row-description-triangle-color: @white;
 }
 
 .splash-screen-color-set() {

--- a/pkg/dashboard/ui/src/less/palette.less
+++ b/pkg/dashboard/ui/src/less/palette.less
@@ -93,6 +93,7 @@
 @foam: #eff9fd;
 @fountain-blue: #53bdb3;
 @fountain-blue-two: #54bdb5;
+@french-grey: #c0bec5;
 @gallery: #ebebeb;
 @gallery-two: #ececec;
 @gallery-three: #f0f0f0;


### PR DESCRIPTION
- Import/export projects: improve UX flow by allowing the users to choose between skipping or replacing conflicted function names within the same project, and allowing to take the same action for all subsequent conflicted functions in the same imported project, or in all subsequent projects as well.
![image](https://user-images.githubusercontent.com/13918850/79250486-5af65800-7e87-11ea-9582-f5e34504f4fa.png)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/968