### PR TITLE
Import and Export Functions & Projects in backend

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -73,7 +73,7 @@ func (fr *functionResource) GetAll(request *http.Request) (map[string]restful.At
 		return nil, errors.Wrap(err, "Failed to get functions")
 	}
 
-	exportFunction := fr.GetBooleanParam(restful.ParamExport, request)
+	exportFunction := fr.GetBoolUrlParam(restful.ParamExport, request)
 
 	// create a map of attributes keyed by the function id (name)
 	for _, function := range functions {
@@ -110,7 +110,7 @@ func (fr *functionResource) GetByID(request *http.Request, id string) (restful.A
 	}
 	function := functions[0]
 
-	exportFunction := fr.GetBooleanParam(restful.ParamExport, request)
+	exportFunction := fr.GetBoolUrlParam(restful.ParamExport, request)
 	if exportFunction {
 		return fr.export(function), nil
 	}

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -243,6 +243,8 @@ func (fr *functionResource) prepareFunctionForExport(functionMeta *functionconfi
 	functionMeta.Annotations[functionconfig.FunctionAnnotationSkipBuild] = strconv.FormatBool(true)
 	functionMeta.Annotations[functionconfig.FunctionAnnotationSkipDeploy] = strconv.FormatBool(true)
 
+	functionMeta.Namespace = ""
+
 	// artifacts are created unique to the cluster not needed to be returned to any client of nuclio REST API
 	functionSpec.RunRegistry = ""
 	functionSpec.Build.Registry = ""

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -264,6 +264,15 @@ func (fr *functionResource) prepareFunctionForExport(functionMeta *functionconfi
 	if functionSpec.Build.FunctionSourceCode != "" {
 		functionSpec.Image = ""
 	}
+
+	// remove secrets and passwords from triggers
+	newTriggers := functionSpec.Triggers
+	for triggerName, trigger := range newTriggers {
+		trigger.Password = ""
+		trigger.Secret = ""
+		newTriggers[triggerName] = trigger
+	}
+	functionSpec.Triggers = newTriggers
 }
 
 func (fr *functionResource) storeAndDeployFunction(functionInfo *functionInfo, request *http.Request) error {

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -229,41 +229,6 @@ func (fr *functionResource) export(function platform.Function) restful.Attribute
 	return attributes
 }
 
-func (fr *functionResource) exportFunctionEvents(function platform.Function) (attributes restful.Attributes) {
-
-	attributes = restful.Attributes{}
-
-	getFunctionEventOptions := platform.GetFunctionEventsOptions{
-		Meta: platform.FunctionEventMeta{
-			Name:      "",
-			Namespace: function.GetConfig().Meta.Namespace,
-			Labels: map[string]string{
-				"nuclio.io/function-name": function.GetConfig().Meta.Name,
-			},
-		},
-	}
-
-	functionEvents, err := fr.getPlatform().GetFunctionEvents(&getFunctionEventOptions)
-
-	if err != nil {
-
-		// if an error occurs just return zero events
-		fr.Logger.DebugWith("Function has no function events, returning 0 events",
-			"functionName", function.GetConfig().Meta.Name)
-		return
-	}
-
-	// create a map of attributes keyed by the function event id (name)
-	for _, functionEvent := range functionEvents {
-		attributes[functionEvent.GetConfig().Meta.Name] = restful.Attributes{
-			"metadata": functionEvent.GetConfig().Meta,
-			"spec":     functionEvent.GetConfig().Spec,
-		}
-	}
-
-	return
-}
-
 func (fr *functionResource) prepareFunctionForExport(functionMeta *functionconfig.Meta, functionSpec *functionconfig.Spec) {
 
 	fr.Logger.DebugWith("Preparing function for export", "functionName", functionMeta.Name)

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -73,7 +73,7 @@ func (fr *functionResource) GetAll(request *http.Request) (map[string]restful.At
 		return nil, errors.Wrap(err, "Failed to get functions")
 	}
 
-	exportFunction := fr.GetBoolUrlParam(restful.ParamExport, request)
+	exportFunction := fr.GetBoolURLParam(restful.ParamExport, request)
 
 	// create a map of attributes keyed by the function id (name)
 	for _, function := range functions {
@@ -110,7 +110,7 @@ func (fr *functionResource) GetByID(request *http.Request, id string) (restful.A
 	}
 	function := functions[0]
 
-	exportFunction := fr.GetBoolUrlParam(restful.ParamExport, request)
+	exportFunction := fr.GetBoolURLParam(restful.ParamExport, request)
 	if exportFunction {
 		return fr.export(function), nil
 	}

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -195,6 +195,8 @@ func (fr *functionResource) Export(function platform.Function) restful.Attribute
 	functionSpec := function.GetConfig().Spec
 	functionMeta := function.GetConfig().Meta
 
+	fr.Logger.DebugWith("Exporting function", "function", functionMeta.Name)
+
 	fr.prepareFunctionForExport(&functionMeta, &functionSpec)
 
 	attributes := restful.Attributes{
@@ -237,12 +239,17 @@ func (fr *functionResource) ExportFunctionEvents(function platform.Function) res
 
 func (fr *functionResource) prepareFunctionForExport(functionMeta *functionconfig.Meta, functionSpec *functionconfig.Spec) {
 
+	fr.Logger.DebugWith("Preparing function for export", "function", functionMeta.Name)
+
 	if functionMeta.Annotations == nil {
 		functionMeta.Annotations = map[string]string{}
 	}
+
+	// add annotations for not deploying or building on import
 	functionMeta.Annotations[functionconfig.FunctionAnnotationSkipBuild] = strconv.FormatBool(true)
 	functionMeta.Annotations[functionconfig.FunctionAnnotationSkipDeploy] = strconv.FormatBool(true)
 
+	// scrub namespace from function meta
 	functionMeta.Namespace = ""
 
 	// artifacts are created unique to the cluster not needed to be returned to any client of nuclio REST API
@@ -251,11 +258,6 @@ func (fr *functionResource) prepareFunctionForExport(functionMeta *functionconfi
 	if functionSpec.Build.FunctionSourceCode != "" {
 		functionSpec.Image = ""
 	}
-
-	//if functionSpec.MinReplicas != nil && functionSpec.MaxReplicas != nil &&
-	//	*functionSpec.MinReplicas > 0 && *functionSpec.MaxReplicas > 0 {
-	//	functionSpec.Replicas = nil
-	//}
 }
 
 func (fr *functionResource) storeAndDeployFunction(functionInfo *functionInfo, request *http.Request) error {

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -286,8 +286,7 @@ func (pr *projectResource) importProject(projectImportInfoInstance *projectImpor
 			}
 			functionImport.Meta.Labels["nuclio.io/project-name"] = projectImportInfoInstance.Project.Meta.Name
 
-			err = pr.importFunction(functionImport, authConfig)
-			if err != nil {
+			if err = pr.importFunction(functionImport, authConfig); err != nil {
 				pr.Logger.WarnWith("Failed posting function", "functionName", functionName, "err", err)
 				functionCreateChan <- restful.Attributes{
 					"function": functionName,

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -19,7 +19,6 @@ package resource
 import (
 	"encoding/json"
 	"fmt"
-	uuid "github.com/satori/go.uuid"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -33,6 +32,7 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/nuclio-sdk-go"
+	uuid "github.com/satori/go.uuid"
 )
 
 type projectResource struct {

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -159,9 +159,14 @@ func (pr *projectResource) GetCustomRoutes() ([]restful.CustomRoute, error) {
 }
 
 func (pr *projectResource) Export(project platform.Project) restful.Attributes {
+	projectMeta := project.GetConfig().Meta
+
+	// clean namespace from project
+	projectMeta.Namespace = ""
+
 	attributes := restful.Attributes{
 		"project": restful.Attributes{
-			"metadata": project.GetConfig().Meta,
+			"metadata": projectMeta,
 			"spec":     project.GetConfig().Spec,
 		},
 		"functions": map[string]restful.Attributes{},

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -71,7 +71,7 @@ func (pr *projectResource) GetAll(request *http.Request) (map[string]restful.Att
 		return nil, errors.Wrap(err, "Failed to get projects")
 	}
 
-	exportProject := pr.GetBooleanParam(restful.ParamExport, request)
+	exportProject := pr.GetBoolUrlParam(restful.ParamExport, request)
 
 	// create a map of attributes keyed by the project id (name)
 	for _, project := range projects {
@@ -110,7 +110,7 @@ func (pr *projectResource) GetByID(request *http.Request, id string) (restful.At
 	}
 	project := projects[0]
 
-	exportProject := pr.GetBooleanParam(restful.ParamExport, request)
+	exportProject := pr.GetBoolUrlParam(restful.ParamExport, request)
 	if exportProject {
 		return pr.export(project), nil
 	}
@@ -121,7 +121,7 @@ func (pr *projectResource) GetByID(request *http.Request, id string) (restful.At
 // Create deploys a project
 func (pr *projectResource) Create(request *http.Request) (id string, attributes restful.Attributes, responseErr error) {
 
-	importProject := pr.GetBooleanParam(restful.ParamImport, request)
+	importProject := pr.GetBoolUrlParam(restful.ParamImport, request)
 	if importProject {
 		projectImportInfo, responseErr := pr.getProjectImportInfoFromRequest(request)
 		if responseErr != nil {

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -17,11 +17,16 @@ limitations under the License.
 package resource
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/dashboard"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/restful"
@@ -37,6 +42,13 @@ type projectResource struct {
 type projectInfo struct {
 	Meta *platform.ProjectMeta `json:"metadata,omitempty"`
 	Spec *platform.ProjectSpec `json:"spec,omitempty"`
+}
+
+type projectImportInfo struct {
+	Project   *projectInfo
+	Functions map[string]*struct {
+		Function *functionInfo
+	}
 }
 
 // GetAll returns all projects
@@ -60,9 +72,15 @@ func (pr *projectResource) GetAll(request *http.Request) (map[string]restful.Att
 		return nil, errors.Wrap(err, "Failed to get projects")
 	}
 
+	exportProject := pr.GetBooleanParam(restful.ParamExport, request)
+
 	// create a map of attributes keyed by the project id (name)
 	for _, project := range projects {
-		response[project.GetConfig().Meta.Name] = pr.projectToAttributes(project)
+		if exportProject {
+			response[project.GetConfig().Meta.Name] = pr.Export(project)
+		} else {
+			response[project.GetConfig().Meta.Name] = pr.projectToAttributes(project)
+		}
 	}
 
 	return response, nil
@@ -92,21 +110,97 @@ func (pr *projectResource) GetByID(request *http.Request, id string) (restful.At
 		return nil, nuclio.NewErrNotFound("Project not found")
 	}
 
+	exportProject := pr.GetBooleanParam(restful.ParamExport, request)
+	if exportProject {
+		return pr.Export(project[0]), nil
+	}
+
 	return pr.projectToAttributes(project[0]), nil
 }
 
 // Create deploys a project
 func (pr *projectResource) Create(request *http.Request) (id string, attributes restful.Attributes, responseErr error) {
 
+	importProject := pr.GetBooleanParam(restful.ParamImport, request)
+	if importProject {
+		projectImportInfo, responseErr := pr.getProjectImportInfoFromRequest(request)
+		if responseErr != nil {
+			return "", nil, responseErr
+		}
+
+		return pr.importProject(projectImportInfo)
+	}
+
 	projectInfo, responseErr := pr.getProjectInfoFromRequest(request, true)
 	if responseErr != nil {
 		return
 	}
 
+	return pr.createProject(projectInfo)
+}
+
+// returns a list of custom routes for the resource
+func (pr *projectResource) GetCustomRoutes() ([]restful.CustomRoute, error) {
+
+	// since delete and update by default assume /resource/{id} and we want to get the id/namespace from the body
+	// we need to register custom routes
+	return []restful.CustomRoute{
+		{
+			Pattern:   "/",
+			Method:    http.MethodPut,
+			RouteFunc: pr.updateProject,
+		},
+		{
+			Pattern:   "/",
+			Method:    http.MethodDelete,
+			RouteFunc: pr.deleteProject,
+		},
+	}, nil
+}
+
+func (pr *projectResource) Export(project platform.Project) restful.Attributes {
+	attributes := restful.Attributes{
+		"project": restful.Attributes{
+			"metadata": project.GetConfig().Meta,
+			"spec":     project.GetConfig().Spec,
+		},
+		"functions": map[string]restful.Attributes{},
+	}
+
+	functionsMap := map[string]restful.Attributes{}
+
+	getFunctionsOptions := &platform.GetFunctionsOptions{
+		Name:      "",
+		Namespace: project.GetConfig().Meta.Namespace,
+		Labels:    fmt.Sprintf("nuclio.io/project-name=%s", project.GetConfig().Meta.Name),
+	}
+
+	functions, err := pr.getPlatform().GetFunctions(getFunctionsOptions)
+
+	if err != nil {
+		return attributes
+	}
+
+	// create a map of attributes keyed by the function id (name)
+	for _, function := range functions {
+		functionsMap[function.GetConfig().Meta.Name] = restful.Attributes{
+			"function": functionResourceInstance.Export(function),
+			"events":   functionResourceInstance.ExportFunctionEvents(function),
+		}
+	}
+
+	attributes["functions"] = functionsMap
+
+	return attributes
+}
+
+func (pr *projectResource) createProject(projectInfoInstance *projectInfo) (id string,
+	attributes restful.Attributes, responseErr error) {
+
 	// create a project config
 	projectConfig := platform.ProjectConfig{
-		Meta: *projectInfo.Meta,
-		Spec: *projectInfo.Spec,
+		Meta: *projectInfoInstance.Meta,
+		Spec: *projectInfoInstance.Spec,
 	}
 
 	// create a project
@@ -134,23 +228,106 @@ func (pr *projectResource) Create(request *http.Request) (id string, attributes 
 	return
 }
 
-// returns a list of custom routes for the resource
-func (pr *projectResource) GetCustomRoutes() ([]restful.CustomRoute, error) {
+func (pr *projectResource) importProject(projectImportInfoInstance *projectImportInfo) (id string,
+	attributes restful.Attributes, responseErr error) {
 
-	// since delete and update by default assume /resource/{id} and we want to get the id/namespace from the body
-	// we need to register custom routes
-	return []restful.CustomRoute{
-		{
-			Pattern:   "/",
-			Method:    http.MethodPut,
-			RouteFunc: pr.updateProject,
-		},
-		{
-			Pattern:   "/",
-			Method:    http.MethodDelete,
-			RouteFunc: pr.deleteProject,
-		},
-	}, nil
+	projects, err := pr.getPlatform().GetProjects(&platform.GetProjectsOptions{
+		Meta: *projectImportInfoInstance.Project.Meta,
+	})
+	if err != nil || len(projects) == 0 {
+		err = pr.createAndWaitForProjectCreation(projectImportInfoInstance.Project)
+		if err != nil {
+			return "", nil, nuclio.WrapErrInternalServerError(err)
+		}
+	}
+
+	var failedFunctions []restful.Attributes
+	for functionName, functionImport := range projectImportInfoInstance.Functions {
+		if functionImport.Function.Meta.Labels == nil {
+			functionImport.Function.Meta.Labels = map[string]string{}
+		}
+		functionImport.Function.Meta.Labels["nuclio.io/project-name"] = projectImportInfoInstance.Project.Meta.Name
+
+		err = pr.postFunctionForImport(functionImport.Function)
+		if err != nil {
+			pr.Logger.WarnWith("Failed posting function", "name", functionName, "err", err)
+			failedFunctions = append(failedFunctions, restful.Attributes{
+				"function": functionName,
+				"error":    err.Error(),
+			})
+		}
+	}
+
+	attributes = restful.Attributes{
+		"createdFunctionAmount": len(projectImportInfoInstance.Functions) - len(failedFunctions),
+		"failedFunctionsAmount": len(failedFunctions),
+		"failedFunctions":       failedFunctions,
+	}
+
+	return
+}
+
+func (pr *projectResource) postFunctionForImport(functionInfo *functionInfo) error {
+	jsonStr, err := json.Marshal(functionInfo)
+	if err != nil {
+		return err
+	}
+	urlStr := "http://localhost" + pr.getListenAddress() + "/api/functions"
+	request, err := http.NewRequest("POST", urlStr, bytes.NewBuffer(jsonStr))
+	if err != nil {
+		return err
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode == http.StatusConflict {
+		return errors.New("function name already exists")
+	}
+	if response.StatusCode != http.StatusAccepted {
+		return errors.New("received unexpected status code: " + strconv.FormatInt(int64(response.StatusCode), 10))
+	}
+
+	return nil
+}
+
+func (pr *projectResource) createAndWaitForProjectCreation(projectInfoInstance *projectInfo) error {
+
+	// create a project config
+	projectConfig := platform.ProjectConfig{
+		Meta: *projectInfoInstance.Meta,
+		Spec: *projectInfoInstance.Spec,
+	}
+
+	// create a project
+	newProject, err := platform.NewAbstractProject(pr.Logger, pr.getPlatform(), projectConfig)
+	if err != nil {
+		return nuclio.WrapErrInternalServerError(err)
+	}
+
+	// just deploy. the status is async through polling
+	err = pr.getPlatform().CreateProject(&platform.CreateProjectOptions{
+		ProjectConfig: *newProject.GetConfig(),
+	})
+	if err != nil {
+		return nuclio.WrapErrInternalServerError(err)
+	}
+
+	err = common.RetryUntilSuccessful(30*time.Second, 1*time.Second, func() bool {
+		projects, err := pr.getPlatform().GetProjects(&platform.GetProjectsOptions{
+			Meta: *projectInfoInstance.Meta,
+		})
+		return err == nil && len(projects) > 0
+	})
+	if err != nil {
+		return nuclio.WrapErrInternalServerError(err)
+	}
+
+	return nil
 }
 
 func (pr *projectResource) deleteProject(request *http.Request) (*restful.CustomRouteFuncResponse, error) {
@@ -259,6 +436,38 @@ func (pr *projectResource) getProjectInfoFromRequest(request *http.Request, name
 		return nil, nuclio.WrapErrBadRequest(errors.Wrap(err, "Failed to parse JSON body"))
 	}
 
+	err = pr.processProjectInfo(&projectInfoInstance, nameRequired)
+	if err != nil {
+		return nil, nuclio.WrapErrBadRequest(errors.Wrap(err, "Project Info Object Invalid"))
+	}
+
+	return &projectInfoInstance, nil
+}
+
+func (pr *projectResource) getProjectImportInfoFromRequest(request *http.Request) (*projectImportInfo, error) {
+
+	// read body
+	body, err := ioutil.ReadAll(request.Body)
+	if err != nil {
+		return nil, nuclio.WrapErrInternalServerError(errors.Wrap(err, "Failed to read body"))
+	}
+
+	projectImportInfoInstance := projectImportInfo{}
+	err = json.Unmarshal(body, &projectImportInfoInstance)
+	if err != nil {
+		return nil, nuclio.WrapErrBadRequest(errors.Wrap(err, "Failed to parse JSON body"))
+	}
+
+	err = pr.processProjectInfo(projectImportInfoInstance.Project, true)
+	if err != nil {
+		return nil, nuclio.WrapErrBadRequest(errors.Wrap(err, "Project Info Object Invalid"))
+	}
+
+	return &projectImportInfoInstance, nil
+}
+
+func (pr *projectResource) processProjectInfo(projectInfoInstance *projectInfo, nameRequired bool) error {
+
 	// override namespace if applicable
 	if projectInfoInstance.Meta != nil {
 		projectInfoInstance.Meta.Namespace = pr.getNamespaceOrDefault(projectInfoInstance.Meta.Namespace)
@@ -270,10 +479,10 @@ func (pr *projectResource) getProjectInfoFromRequest(request *http.Request, name
 		projectInfoInstance.Meta.Namespace == "" {
 		err := errors.New("Project name must be provided in metadata")
 
-		return nil, nuclio.WrapErrBadRequest(err)
+		return nuclio.WrapErrBadRequest(err)
 	}
 
-	return &projectInfoInstance, nil
+	return nil
 }
 
 // register the resource

--- a/pkg/dashboard/resource/resource.go
+++ b/pkg/dashboard/resource/resource.go
@@ -75,3 +75,7 @@ func (r *resource) getRequestAuthConfig(request *http.Request) (*platform.AuthCo
 	// the default behavior
 	return nil, nil
 }
+
+func (r *resource) getListenAddress() string {
+	return r.GetServer().(*dashboard.Server).ListenAddress
+}

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -657,7 +657,7 @@ func (suite *functionTestSuite) TestExportFunctionSuccessful() {
 	returnedFunction.Config.Spec.Replicas = &replicas
 
 	// verify
-	verifyGetFunctions := func(getFunctionsOptions *platform.GetFunctionsOptions) bool {
+	verifyGetFunctionsOptions := func(getFunctionsOptions *platform.GetFunctionsOptions) bool {
 		suite.Require().Equal("f1", getFunctionsOptions.Name)
 		suite.Require().Equal("f1Namespace", getFunctionsOptions.Namespace)
 
@@ -665,7 +665,7 @@ func (suite *functionTestSuite) TestExportFunctionSuccessful() {
 	}
 
 	suite.mockPlatform.
-		On("GetFunctions", mock.MatchedBy(verifyGetFunctions)).
+		On("GetFunctions", mock.MatchedBy(verifyGetFunctionsOptions)).
 		Return([]platform.Function{&returnedFunction}, nil).
 		Once()
 
@@ -693,6 +693,81 @@ func (suite *functionTestSuite) TestExportFunctionSuccessful() {
 
 	suite.sendRequest("GET",
 		"/api/functions/f1?export=true",
+		headers,
+		nil,
+		&expectedStatusCode,
+		expectedResponseBody)
+
+	suite.mockPlatform.AssertExpectations(suite.T())
+}
+
+func (suite *functionTestSuite) TestExportFunctionListSuccessful() {
+	replicas := 10
+	returnedFunction1 := platform.AbstractFunction{}
+	returnedFunction1.Config.Meta.Name = "f1"
+	returnedFunction1.Config.Meta.Namespace = "fNamespace"
+	returnedFunction1.Config.Spec.Replicas = &replicas
+
+	returnedFunction2 := platform.AbstractFunction{}
+	returnedFunction2.Config.Meta.Name = "f2"
+	returnedFunction2.Config.Meta.Namespace = "fNamespace"
+	returnedFunction2.Config.Spec.Replicas = &replicas
+
+	// verify
+	verifyGetFunctionsOptions := func(getFunctionsOptions *platform.GetFunctionsOptions) bool {
+		suite.Require().Equal("", getFunctionsOptions.Name)
+		suite.Require().Equal("fNamespace", getFunctionsOptions.Namespace)
+
+		return true
+	}
+
+	suite.mockPlatform.
+		On("GetFunctions", mock.MatchedBy(verifyGetFunctionsOptions)).
+		Return([]platform.Function{&returnedFunction1, &returnedFunction2}, nil).
+		Once()
+
+	headers := map[string]string{
+		"x-nuclio-function-namespace": "fNamespace",
+	}
+
+	expectedStatusCode := http.StatusOK
+	expectedResponseBody := `{
+	"f1": {
+		"metadata": {
+			"name": "f1",
+			"annotations": {
+				"skip-build": "true",
+				"skip-deploy": "true"
+			}
+		},
+		"spec": {
+			"resources": {},
+			"build": {},
+			"platform": {},
+			"replicas": 10,
+			"eventTimeout": ""
+		}
+	},
+	"f2": {
+		"metadata": {
+			"name": "f2",
+			"annotations": {
+				"skip-build": "true",
+				"skip-deploy": "true"
+			}
+		},
+		"spec": {
+			"resources": {},
+			"build": {},
+			"platform": {},
+			"replicas": 10,
+			"eventTimeout": ""
+		}
+	}
+}`
+
+	suite.sendRequest("GET",
+		"/api/functions/?export=true",
 		headers,
 		nil,
 		&expectedStatusCode,
@@ -988,13 +1063,7 @@ func (suite *projectTestSuite) TestExportProjectSuccessful() {
 
 	suite.mockPlatform.
 		On("GetFunctionEvents", mock.MatchedBy(verifyGetFunctionEvents)).
-		Return([]platform.FunctionEvent{}, nil).
-		Once()
-
-	suite.mockPlatform.
-		On("GetFunctionEvents", mock.MatchedBy(verifyGetFunctionEvents)).
-		Return([]platform.FunctionEvent{}, nil).
-		Once()
+		Return([]platform.FunctionEvent{}, nil).Twice()
 
 	headers := map[string]string{
 		"x-nuclio-project-namespace": "fNamespace",
@@ -1053,6 +1122,140 @@ func (suite *projectTestSuite) TestExportProjectSuccessful() {
 
 	suite.sendRequest("GET",
 		"/api/projects/p1?export=true",
+		headers,
+		nil,
+		&expectedStatusCode,
+		expectedResponseBody)
+
+	suite.mockPlatform.AssertExpectations(suite.T())
+}
+
+func (suite *projectTestSuite) TestExportProjectListSuccessful() {
+	returnedFunction1 := platform.AbstractFunction{}
+	returnedFunction1.Config.Meta.Name = "f1"
+	returnedFunction1.Config.Meta.Namespace = "fNamespace"
+	returnedFunction1.Config.Spec.Runtime = "r1"
+
+	returnedFunction2 := platform.AbstractFunction{}
+	returnedFunction2.Config.Meta.Name = "f2"
+	returnedFunction2.Config.Meta.Namespace = "fNamespace"
+	returnedFunction2.Config.Spec.Runtime = "r2"
+
+	returnedProject1 := platform.AbstractProject{}
+	returnedProject1.ProjectConfig.Meta.Name = "p1"
+	returnedProject1.ProjectConfig.Meta.Namespace = "fNamespace"
+
+	returnedProject2 := platform.AbstractProject{}
+	returnedProject2.ProjectConfig.Meta.Name = "p2"
+	returnedProject2.ProjectConfig.Meta.Namespace = "fNamespace"
+
+	// verify
+	verifyGetProjects := func(getProjectsOptions *platform.GetProjectsOptions) bool {
+		suite.Require().Equal("", getProjectsOptions.Meta.Name)
+		suite.Require().Equal("fNamespace", getProjectsOptions.Meta.Namespace)
+
+		return true
+	}
+	verifyGetFunctions := func(getFunctionsOptions *platform.GetFunctionsOptions) bool {
+		suite.Require().Equal("", getFunctionsOptions.Name)
+		suite.Require().Equal("fNamespace", getFunctionsOptions.Namespace)
+
+		return true
+	}
+	verifyGetFunctionEvents := func(getFunctionEventsOptions *platform.GetFunctionEventsOptions) bool {
+		suite.Require().Equal("fNamespace", getFunctionEventsOptions.Meta.Namespace)
+
+		return true
+	}
+
+	suite.mockPlatform.
+		On("GetProjects", mock.MatchedBy(verifyGetProjects)).
+		Return([]platform.Project{&returnedProject1, &returnedProject2}, nil).
+		Once()
+
+	suite.mockPlatform.
+		On("GetFunctions", mock.MatchedBy(verifyGetFunctions)).
+		Return([]platform.Function{&returnedFunction1}, nil).
+		Once()
+
+	suite.mockPlatform.
+		On("GetFunctions", mock.MatchedBy(verifyGetFunctions)).
+		Return([]platform.Function{&returnedFunction2}, nil).
+		Once()
+
+	suite.mockPlatform.
+		On("GetFunctionEvents", mock.MatchedBy(verifyGetFunctionEvents)).
+		Return([]platform.FunctionEvent{}, nil).Twice()
+
+	headers := map[string]string{
+		"x-nuclio-project-namespace": "fNamespace",
+		"x-nuclio-function-namespace": "fNamespace",
+	}
+
+	expectedStatusCode := http.StatusOK
+	expectedResponseBody := `{
+	"p1": {
+		"project": {
+			"metadata": {
+				"name": "p1"
+			},
+			"spec": {}
+		},
+		"functions": {
+			"f1": {
+				"function": {
+					"metadata": {
+						"name": "f1",
+						"annotations": {
+							"skip-build": "true",
+							"skip-deploy": "true"
+						}
+					},
+					"spec": {
+						"resources": {},
+						"build": {},
+						"platform": {},
+						"runtime": "r1",
+						"eventTimeout": ""
+					}
+				},
+				"events": {}
+			}
+		}
+	},
+	"p2": {
+		"project": {
+			"metadata": {
+				"name": "p2"
+			},
+			"spec": {}
+		},
+		"functions": {
+			"f2": {
+				"function": {
+					"metadata": {
+						"name": "f2",
+						"annotations": {
+							"skip-build": "true",
+							"skip-deploy": "true"
+						}
+					},
+					"spec": {
+						"resources": {},
+						"build": {},
+						"platform": {},
+						"runtime": "r2",
+						"eventTimeout": ""
+					}
+				},
+				"events": {}
+			}
+		}
+	}
+}`
+
+	suite.sendRequest("GET",
+		"/api/projects/?export=true",
 		headers,
 		nil,
 		&expectedStatusCode,
@@ -1262,6 +1465,216 @@ func (suite *projectTestSuite) TestDeleteNoName() {
 
 func (suite *projectTestSuite) TestDeleteNoNamespace() {
 	suite.sendRequestNoNamespace("DELETE")
+}
+
+func (suite *projectTestSuite) TestImportSuccessful() {
+	createdProject := platform.AbstractProject{}
+	createdProject.ProjectConfig.Meta.Name = "p1"
+	createdProject.ProjectConfig.Meta.Namespace = "p1Namespace"
+	createdProject.ProjectConfig.Spec.Description = "p1Description"
+
+	// verify
+	verifyGetProjects := func(getProjectsOptions *platform.GetProjectsOptions) bool {
+		suite.Require().Equal("p1", getProjectsOptions.Meta.Name)
+		suite.Require().Equal("p1Namespace", getProjectsOptions.Meta.Namespace)
+
+		return true
+	}
+	verifyCreateProject := func(createProjectOptions *platform.CreateProjectOptions) bool {
+		suite.Require().Equal("p1", createProjectOptions.ProjectConfig.Meta.Name)
+		suite.Require().Equal("p1Namespace", createProjectOptions.ProjectConfig.Meta.Namespace)
+		suite.Require().Equal("p1Description", createProjectOptions.ProjectConfig.Spec.Description)
+
+		return true
+	}
+	verifyCreateFunction := func(createFunctionOptions *platform.CreateFunctionOptions) bool {
+		suite.Require().Equal("f1", createFunctionOptions.FunctionConfig.Meta.Name)
+		suite.Require().Equal("p1Namespace", createFunctionOptions.FunctionConfig.Meta.Namespace)
+		suite.Require().Equal("p1", createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"])
+
+		return true
+	}
+	verifyGetFunctions := func(getFunctionsOptions *platform.GetFunctionsOptions) bool {
+		suite.Require().Equal("f1", getFunctionsOptions.Name)
+		suite.Require().Equal("p1Namespace", getFunctionsOptions.Namespace)
+		return true
+	}
+
+	suite.mockPlatform.
+		On("GetProjects", mock.MatchedBy(verifyGetProjects)).
+		Return([]platform.Project{}, nil).
+		Once()
+
+	suite.mockPlatform.
+		On("CreateProject", mock.MatchedBy(verifyCreateProject)).
+		Return(nil).
+		Once()
+
+	suite.mockPlatform.
+		On("GetProjects", mock.MatchedBy(verifyGetProjects)).
+		Return([]platform.Project{&createdProject}, nil).
+		Once()
+
+	suite.mockPlatform.
+		On("GetFunctions", mock.MatchedBy(verifyGetFunctions)).
+		Return([]platform.Function{}, nil).
+		Once()
+
+	suite.mockPlatform.
+		On("CreateFunction", mock.MatchedBy(verifyCreateFunction)).
+		Return(&platform.CreateFunctionResult{}, nil).
+		Once()
+
+	headers := map[string]string{
+		"x-nuclio-wait-function-action": "true",
+	}
+
+	expectedStatusCode := http.StatusCreated
+	requestBody := `{
+	"project": {
+		"metadata": {
+			"name": "p1",
+			"namespace": "p1Namespace"
+		},
+		"spec": {
+			"description": "p1Description"
+		}
+	},
+	"functions": {
+		"f1": {
+			"function": {
+				"metadata": {
+					"name": "f1",
+					"namespace": "p1Namespace"
+				},
+				"spec": {
+					"resources": {},
+					"build": {},
+					"platform": {},
+					"runtime": "r1"
+				}
+			}
+		}
+	}
+}`
+
+	expectedResponseBody := `{
+	"createdFunctionsAmount": 1,
+	"failedFunctions": null,
+	"failedFunctionsAmount": 0
+}`
+
+	suite.sendRequest("POST",
+		"/api/projects?import=true",
+		headers,
+		bytes.NewBufferString(requestBody),
+		&expectedStatusCode,
+		expectedResponseBody)
+
+	suite.mockPlatform.AssertExpectations(suite.T())
+}
+
+func (suite *projectTestSuite) TestImportFunctionExistsSuccessful() {
+	existingFunction1 := platform.AbstractFunction{}
+	existingFunction1.Config.Meta.Name = "f1"
+	existingFunction1.Config.Meta.Namespace = "p1Namespace"
+	existingFunction1.Config.Spec.Runtime = "r1"
+
+	createdProject := platform.AbstractProject{}
+	createdProject.ProjectConfig.Meta.Name = "p1"
+	createdProject.ProjectConfig.Meta.Namespace = "p1Namespace"
+	createdProject.ProjectConfig.Spec.Description = "p1Description"
+
+
+	// verify
+	verifyGetProjects := func(getProjectsOptions *platform.GetProjectsOptions) bool {
+		suite.Require().Equal("p1", getProjectsOptions.Meta.Name)
+		suite.Require().Equal("p1Namespace", getProjectsOptions.Meta.Namespace)
+
+		return true
+	}
+	verifyCreateProject := func(createProjectOptions *platform.CreateProjectOptions) bool {
+		suite.Require().Equal("p1", createProjectOptions.ProjectConfig.Meta.Name)
+		suite.Require().Equal("p1Namespace", createProjectOptions.ProjectConfig.Meta.Namespace)
+		suite.Require().Equal("p1Description", createProjectOptions.ProjectConfig.Spec.Description)
+
+		return true
+	}
+	verifyGetFunctions := func(getFunctionsOptions *platform.GetFunctionsOptions) bool {
+		suite.Require().Equal("f1", getFunctionsOptions.Name)
+		suite.Require().Equal("p1Namespace", getFunctionsOptions.Namespace)
+		return true
+	}
+
+	suite.mockPlatform.
+		On("GetProjects", mock.MatchedBy(verifyGetProjects)).
+		Return([]platform.Project{}, nil).
+		Once()
+
+	suite.mockPlatform.
+		On("CreateProject", mock.MatchedBy(verifyCreateProject)).
+		Return(nil).
+		Once()
+
+	suite.mockPlatform.
+		On("GetProjects", mock.MatchedBy(verifyGetProjects)).
+		Return([]platform.Project{&createdProject}, nil).
+		Once()
+
+	suite.mockPlatform.
+		On("GetFunctions", mock.MatchedBy(verifyGetFunctions)).
+		Return([]platform.Function{&existingFunction1}, nil).
+		Once()
+
+
+	expectedStatusCode := http.StatusCreated
+	requestBody := `{
+	"project": {
+		"metadata": {
+			"name": "p1",
+			"namespace": "p1Namespace"
+		},
+		"spec": {
+			"description": "p1Description"
+		}
+	},
+	"functions": {
+		"f1": {
+			"function": {
+				"metadata": {
+					"name": "f1",
+					"namespace": "p1Namespace"
+				},
+				"spec": {
+					"resources": {},
+					"build": {},
+					"platform": {},
+					"runtime": "r1"
+				}
+			}
+		}
+	}
+}`
+
+	expectedResponseBody := `{
+	"createdFunctionsAmount": 0,
+	"failedFunctions": [
+		{
+			"error": "Function name already exists",
+			"function": "f1"
+		}
+	],
+	"failedFunctionsAmount": 1
+}`
+
+	suite.sendRequest("POST",
+		"/api/projects?import=true",
+		nil,
+		bytes.NewBufferString(requestBody),
+		&expectedStatusCode,
+		expectedResponseBody)
+
+	suite.mockPlatform.AssertExpectations(suite.T())
 }
 
 func (suite *projectTestSuite) sendRequestNoMetadata(method string) {

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1100,58 +1100,53 @@ func (suite *projectTestSuite) TestExportProjectSuccessful() {
 	},
 	"functions": {
 		"f1": {
-			"events": {
-				"fe1": {
-					"metadata": {
-						"name": "fe1",
-						"namespace": "fNamespace",
-						"labels": {
-							"nuclio.io/function-name": "f1"
-						}
-					},
-					"spec": {
-						"displayName": "fe1DisplayName",
-						"triggerName": "fe1TriggerName",
-						"triggerKind": "fe1TriggerKind",
-						"body": "fe1Body"
-					}
+			"metadata": {
+				"name": "f1",
+				"annotations": {
+					"skip-build": "true",
+					"skip-deploy": "true"
 				}
 			},
-			"function": {
-				"metadata": {
-					"name": "f1",
-					"annotations": {
-						"skip-build": "true",
-						"skip-deploy": "true"
-					}
-				},
-				"spec": {
-					"resources": {},
-					"build": {},
-					"platform": {},
-					"runtime": "r1",
-					"eventTimeout": ""
-				}
+			"spec": {
+				"resources": {},
+				"build": {},
+				"platform": {},
+				"runtime": "r1",
+				"eventTimeout": ""
 			}
 		},
 		"f2": {
-			"function": {
-				"metadata": {
-					"name": "f2",
-					"annotations": {
-						"skip-build": "true",
-						"skip-deploy": "true"
-					}
-				},
-				"spec": {
-					"resources": {},
-					"build": {},
-					"platform": {},
-					"runtime": "r2",
-					"eventTimeout": ""
+			"metadata": {
+				"name": "f2",
+				"annotations": {
+					"skip-build": "true",
+					"skip-deploy": "true"
 				}
 			},
-			"events": {}
+			"spec": {
+				"resources": {},
+				"build": {},
+				"platform": {},
+				"runtime": "r2",
+				"eventTimeout": ""
+			}
+		}
+	},
+	"functionEvents": {
+		"fe1": {
+			"metadata": {
+				"name": "fe1",
+				"namespace": "fNamespace",
+				"labels": {
+					"nuclio.io/function-name": "f1"
+				}
+			},
+			"spec": {
+				"displayName": "fe1DisplayName",
+				"triggerName": "fe1TriggerName",
+				"triggerKind": "fe1TriggerKind",
+				"body": "fe1Body"
+			}
 		}
 	}
 }`
@@ -1239,25 +1234,23 @@ func (suite *projectTestSuite) TestExportProjectListSuccessful() {
 		},
 		"functions": {
 			"f1": {
-				"function": {
-					"metadata": {
-						"name": "f1",
-						"annotations": {
-							"skip-build": "true",
-							"skip-deploy": "true"
-						}
-					},
-					"spec": {
-						"resources": {},
-						"build": {},
-						"platform": {},
-						"runtime": "r1",
-						"eventTimeout": ""
+				"metadata": {
+					"name": "f1",
+					"annotations": {
+						"skip-build": "true",
+						"skip-deploy": "true"
 					}
 				},
-				"events": {}
+				"spec": {
+					"resources": {},
+					"build": {},
+					"platform": {},
+					"runtime": "r1",
+					"eventTimeout": ""
+				}
 			}
-		}
+		},
+		"functionEvents": {}
 	},
 	"p2": {
 		"project": {
@@ -1268,25 +1261,23 @@ func (suite *projectTestSuite) TestExportProjectListSuccessful() {
 		},
 		"functions": {
 			"f2": {
-				"function": {
-					"metadata": {
-						"name": "f2",
-						"annotations": {
-							"skip-build": "true",
-							"skip-deploy": "true"
-						}
-					},
-					"spec": {
-						"resources": {},
-						"build": {},
-						"platform": {},
-						"runtime": "r2",
-						"eventTimeout": ""
+				"metadata": {
+					"name": "f2",
+					"annotations": {
+						"skip-build": "true",
+						"skip-deploy": "true"
 					}
 				},
-				"events": {}
+				"spec": {
+					"resources": {},
+					"build": {},
+					"platform": {},
+					"runtime": "r2",
+					"eventTimeout": ""
+				}
 			}
-		}
+		},
+		"functionEvents": {}
 	}
 }`
 
@@ -1589,43 +1580,48 @@ func (suite *projectTestSuite) TestImportSuccessful() {
 	},
 	"functions": {
 		"f1": {
-			"function": {
-				"metadata": {
-					"name": "f1",
-					"namespace": "p1Namespace"
-				},
-				"spec": {
-					"resources": {},
-					"build": {},
-					"platform": {},
-					"runtime": "r1"
+			"metadata": {
+				"name": "f1",
+				"namespace": "p1Namespace"
+			},
+			"spec": {
+				"resources": {},
+				"build": {},
+				"platform": {},
+				"runtime": "r1"
+			}
+		}
+	},
+	"functionEvents": {
+		"fe1": {
+			"metadata": {
+				"name": "fe1",
+				"namespace": "p1Namespace",
+				"labels": {
+					"nuclio.io/function-name": "f1"
 				}
 			},
-			"events": {
-				"fe1": {
-					"metadata": {
-						"name": "fe1",
-						"namespace": "p1Namespace",
-						"labels": {
-							"nuclio.io/function-name": "f1"
-						}
-					},
-					"spec": {
-						"displayName": "fe1DisplayName",
-						"triggerName": "fe1TriggerName",
-						"triggerKind": "fe1TriggerKind",
-						"body": "fe1Body"
-					}
-				}
+			"spec": {
+				"displayName": "fe1DisplayName",
+				"triggerName": "fe1TriggerName",
+				"triggerKind": "fe1TriggerKind",
+				"body": "fe1Body"
 			}
 		}
 	}
 }`
 
 	expectedResponseBody := `{
-	"createdFunctionsAmount": 1,
-	"failedFunctions": null,
-	"failedFunctionsAmount": 0
+	"functionImportResult": {
+		"createdAmount": 1,
+		"failedFunctions": null,
+		"failedAmount": 0
+	},
+	"functionEventImportResult": {
+		"createdAmount": 1,
+		"failedFunctionEvents": null,
+		"failedAmount": 0
+	}
 }`
 
 	suite.sendRequest("POST",
@@ -1702,48 +1698,58 @@ func (suite *projectTestSuite) TestImportFunctionExistsSuccessful() {
 	},
 	"functions": {
 		"f1": {
-			"function": {
-				"metadata": {
-					"name": "f1",
-					"namespace": "p1Namespace"
-				},
-				"spec": {
-					"resources": {},
-					"build": {},
-					"platform": {},
-					"runtime": "r1"
+			"metadata": {
+				"name": "f1",
+				"namespace": "p1Namespace"
+			},
+			"spec": {
+				"resources": {},
+				"build": {},
+				"platform": {},
+				"runtime": "r1"
+			}
+		}
+	},
+	"functionEvents": {
+		"fe1": {
+			"metadata": {
+				"name": "fe1",
+				"namespace": "fNamespace",
+				"labels": {
+					"nuclio.io/function-name": "f1"
 				}
 			},
-			"events": {
-				"fe1": {
-					"metadata": {
-						"name": "fe1",
-						"namespace": "fNamespace",
-						"labels": {
-							"nuclio.io/function-name": "f1"
-						}
-					},
-					"spec": {
-						"displayName": "fe1DisplayName",
-						"triggerName": "fe1TriggerName",
-						"triggerKind": "fe1TriggerKind",
-						"body": "fe1Body"
-					}
-				}
+			"spec": {
+				"displayName": "fe1DisplayName",
+				"triggerName": "fe1TriggerName",
+				"triggerKind": "fe1TriggerKind",
+				"body": "fe1Body"
 			}
 		}
 	}
 }`
 
 	expectedResponseBody := `{
-	"createdFunctionsAmount": 0,
-	"failedFunctions": [
-		{
-			"error": "Function name already exists",
-			"function": "f1"
-		}
-	],
-	"failedFunctionsAmount": 1
+	"functionImportResult": {
+		"createdAmount": 0,
+		"failedFunctions": [
+			{
+				"error": "Function name already exists",
+				"function": "f1"
+			}
+		],
+		"failedAmount": 1
+	},
+	"functionEventImportResult": {
+		"createdAmount": 0,
+		"failedFunctionEvents": [
+			{
+				"error": "Event belongs to function that failed import: f1",
+				"functionEvent": "fe1DisplayName"
+			}
+		],
+		"failedAmount": 1
+	}
 }`
 
 	suite.sendRequest("POST",

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -315,6 +315,11 @@ func (s *Spec) GetEventTimeout() (time.Duration, error) {
 	return timeout, err
 }
 
+const (
+	FunctionAnnotationSkipBuild  = "skip-build"
+	FunctionAnnotationSkipDeploy = "skip-deploy"
+)
+
 // Meta identifies a function
 type Meta struct {
 	Name        string            `json:"name,omitempty"`

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -362,6 +362,7 @@ const (
 	FunctionStateReady                            FunctionState = "ready"
 	FunctionStateError                            FunctionState = "error"
 	FunctionStateScaledToZero                     FunctionState = "scaledToZero"
+	FunctionStateImported                         FunctionState = "imported"
 )
 
 func FunctionStateInSlice(a FunctionState, list []FunctionState) bool {

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -334,28 +334,28 @@ func (m *Meta) GetUniqueID() string {
 	return m.Namespace + ":" + m.Name
 }
 
-func (m *Meta) SkipDeploy() bool {
-	var skipFunctionDeploy bool
-	if skipFunctionBuildStr, ok := m.Annotations[FunctionAnnotationSkipDeploy]; ok {
-		skipFunctionDeploy, _ = strconv.ParseBool(skipFunctionBuildStr)
-	}
-	return skipFunctionDeploy
-}
-
-func (m *Meta) SkipBuild() bool {
-	var skipFunctionDeploy bool
-	if skipFunctionBuildStr, ok := m.Annotations[FunctionAnnotationSkipBuild]; ok {
-		skipFunctionDeploy, _ = strconv.ParseBool(skipFunctionBuildStr)
-	}
-	return skipFunctionDeploy
-}
-
 func (m *Meta) RemoveSkipDeployAnnotation() {
 	delete(m.Annotations, FunctionAnnotationSkipDeploy)
 }
 
 func (m *Meta) RemoveSkipBuildAnnotation() {
 	delete(m.Annotations, FunctionAnnotationSkipBuild)
+}
+
+func SkipDeploy(annotations map[string]string) bool {
+	var skipFunctionDeploy bool
+	if skipFunctionBuildDeploy, ok := annotations[FunctionAnnotationSkipDeploy]; ok {
+		skipFunctionDeploy, _ = strconv.ParseBool(skipFunctionBuildDeploy)
+	}
+	return skipFunctionDeploy
+}
+
+func SkipBuild(annotations map[string]string) bool {
+	var skipFunctionBuild bool
+	if skipFunctionBuildStr, ok := annotations[FunctionAnnotationSkipBuild]; ok {
+		skipFunctionBuild, _ = strconv.ParseBool(skipFunctionBuildStr)
+	}
+	return skipFunctionBuild
 }
 
 // Config holds the configuration of a function - meta and spec

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -18,6 +18,7 @@ package functionconfig
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -331,6 +332,30 @@ type Meta struct {
 // GetUniqueID return unique id
 func (m *Meta) GetUniqueID() string {
 	return m.Namespace + ":" + m.Name
+}
+
+func (m *Meta) SkipDeploy() bool {
+	var skipFunctionDeploy bool
+	if skipFunctionBuildStr, ok := m.Annotations[FunctionAnnotationSkipDeploy]; ok {
+		skipFunctionDeploy, _ = strconv.ParseBool(skipFunctionBuildStr)
+	}
+	return skipFunctionDeploy
+}
+
+func (m *Meta) SkipBuild() bool {
+	var skipFunctionDeploy bool
+	if skipFunctionBuildStr, ok := m.Annotations[FunctionAnnotationSkipBuild]; ok {
+		skipFunctionDeploy, _ = strconv.ParseBool(skipFunctionBuildStr)
+	}
+	return skipFunctionDeploy
+}
+
+func (m *Meta) RemoveSkipDeployAnnotation() {
+	delete(m.Annotations, FunctionAnnotationSkipDeploy)
+}
+
+func (m *Meta) RemoveSkipBuildAnnotation() {
+	delete(m.Annotations, FunctionAnnotationSkipBuild)
 }
 
 // Config holds the configuration of a function - meta and spec

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -342,7 +342,7 @@ func (m *Meta) RemoveSkipBuildAnnotation() {
 	delete(m.Annotations, FunctionAnnotationSkipBuild)
 }
 
-func SkipDeploy(annotations map[string]string) bool {
+func ShouldSkipDeploy(annotations map[string]string) bool {
 	var skipFunctionDeploy bool
 	if skipFunctionBuildDeploy, ok := annotations[FunctionAnnotationSkipDeploy]; ok {
 		skipFunctionDeploy, _ = strconv.ParseBool(skipFunctionBuildDeploy)
@@ -350,7 +350,7 @@ func SkipDeploy(annotations map[string]string) bool {
 	return skipFunctionDeploy
 }
 
-func SkipBuild(annotations map[string]string) bool {
+func ShouldSkipBuild(annotations map[string]string) bool {
 	var skipFunctionBuild bool
 	if skipFunctionBuildStr, ok := annotations[FunctionAnnotationSkipBuild]; ok {
 		skipFunctionBuild, _ = strconv.ParseBool(skipFunctionBuildStr)

--- a/pkg/functionconfig/types_test.go
+++ b/pkg/functionconfig/types_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package functionconfig
+
+import (
+	"testing"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type TypesTestSuite struct {
+	suite.Suite
+	logger logger.Logger
+}
+
+func (suite *TypesTestSuite) SetupTest() {
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
+}
+
+func (suite *ReaderTestSuite) TestFunctionMetaSkipDeployAnnotationTrue() {
+	for _, testCase := range []struct {
+		Annotations map[string]string
+		ExpectedResult bool
+	}{
+		{
+			Annotations: map[string]string{
+				FunctionAnnotationSkipDeploy: "true",
+			},
+			ExpectedResult: true,
+		},
+		{
+			Annotations: map[string]string{
+				FunctionAnnotationSkipDeploy: "false",
+			},
+			ExpectedResult: false,
+		},
+		{
+			Annotations: map[string]string{},
+			ExpectedResult: false,
+		},
+	} {
+		functionMeta := Meta{
+			Annotations: testCase.Annotations,
+		}
+		suite.Assert().Equal(testCase.ExpectedResult, SkipDeploy(functionMeta.Annotations))
+	}
+}
+
+func (suite *ReaderTestSuite) TestFunctionMetaSkipBuildAnnotationTrue() {
+	for _, testCase := range []struct {
+		Annotations map[string]string
+		ExpectedResult bool
+	}{
+		{
+			Annotations: map[string]string{
+				FunctionAnnotationSkipBuild: "true",
+			},
+			ExpectedResult: true,
+		},
+		{
+			Annotations: map[string]string{
+				FunctionAnnotationSkipBuild: "false",
+			},
+			ExpectedResult: false,
+		},
+		{
+			Annotations: map[string]string{},
+			ExpectedResult: false,
+		},
+	} {
+		functionMeta := Meta{
+			Annotations: testCase.Annotations,
+		}
+		suite.Assert().Equal(testCase.ExpectedResult, SkipBuild(functionMeta.Annotations))
+	}
+}
+
+func TestTypesTestSuite(t *testing.T) {
+	suite.Run(t, new(TypesTestSuite))
+}

--- a/pkg/functionconfig/types_test.go
+++ b/pkg/functionconfig/types_test.go
@@ -58,7 +58,7 @@ func (suite *ReaderTestSuite) TestFunctionMetaSkipDeployAnnotationTrue() {
 		functionMeta := Meta{
 			Annotations: testCase.Annotations,
 		}
-		suite.Assert().Equal(testCase.ExpectedResult, SkipDeploy(functionMeta.Annotations))
+		suite.Assert().Equal(testCase.ExpectedResult, ShouldSkipDeploy(functionMeta.Annotations))
 	}
 }
 
@@ -87,7 +87,7 @@ func (suite *ReaderTestSuite) TestFunctionMetaSkipBuildAnnotationTrue() {
 		functionMeta := Meta{
 			Annotations: testCase.Annotations,
 		}
-		suite.Assert().Equal(testCase.ExpectedResult, SkipBuild(functionMeta.Annotations))
+		suite.Assert().Equal(testCase.ExpectedResult, ShouldSkipBuild(functionMeta.Annotations))
 	}
 }
 

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -128,8 +129,13 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 	// clear build mode
 	createFunctionOptions.FunctionConfig.Spec.Build.Mode = ""
 
+	skipFunctionBuild := false
+	if skipFunctionBuildStr, ok := createFunctionOptions.FunctionConfig.Meta.Annotations[functionconfig.FunctionAnnotationSkipBuild]; ok {
+		skipFunctionBuild, _ = strconv.ParseBool(skipFunctionBuildStr)
+	}
+
 	// check if we need to build the image
-	if functionBuildRequired {
+	if functionBuildRequired && !skipFunctionBuild {
 		buildResult, buildErr = ap.platform.CreateFunctionBuild(&platform.CreateFunctionBuildOptions{
 			Logger:                     createFunctionOptions.Logger,
 			FunctionConfig:             createFunctionOptions.FunctionConfig,

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -188,7 +188,7 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 	}
 
 	if skipFunctionDeploy {
-		ap.Logger.Debug("Deployer skipped deploy step because of skip-deploy annotation")
+		ap.Logger.Info("Skipped deployment due to import")
 		return &platform.CreateFunctionResult{
 			CreateFunctionBuildResult: platform.CreateFunctionBuildResult{
 				Image:                 createFunctionOptions.FunctionConfig.Spec.Image,

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -129,11 +129,11 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 	// clear build mode
 	createFunctionOptions.FunctionConfig.Spec.Build.Mode = ""
 
-	skipFunctionBuild := false
+	var skipFunctionBuild bool
 	if skipFunctionBuildStr, ok := createFunctionOptions.FunctionConfig.Meta.Annotations[functionconfig.FunctionAnnotationSkipBuild]; ok {
 		skipFunctionBuild, _ = strconv.ParseBool(skipFunctionBuildStr)
 	}
-	skipFunctionDeploy := false
+	var skipFunctionDeploy bool
 	if skipFunctionDeployStr, ok := createFunctionOptions.FunctionConfig.Meta.Annotations[functionconfig.FunctionAnnotationSkipDeploy]; ok {
 		skipFunctionDeploy, _ = strconv.ParseBool(skipFunctionDeployStr)
 	}
@@ -188,7 +188,7 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 	}
 
 	if skipFunctionDeploy {
-		ap.Logger.Info("Skipped deployment due to import")
+		ap.Logger.Info("Skipping function deployment")
 		return &platform.CreateFunctionResult{
 			CreateFunctionBuildResult: platform.CreateFunctionBuildResult{
 				Image:                 createFunctionOptions.FunctionConfig.Spec.Image,

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -100,8 +100,6 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 	createFunctionOptions.Logger.InfoWith("Deploying function",
 		"name", createFunctionOptions.FunctionConfig.Meta.Name)
 
-	skipDeploy := functionconfig.ShouldSkipDeploy(createFunctionOptions.FunctionConfig.Meta.Annotations)
-
 	var buildResult *platform.CreateFunctionBuildResult
 	var buildErr error
 
@@ -177,16 +175,6 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 	deployResult, err := onAfterBuild(buildResult, buildErr)
 	if buildErr != nil || err != nil {
 		return nil, errors.Wrap(err, "Failed to deploy function")
-	}
-
-	if skipDeploy {
-		ap.Logger.Info("Skipping function deployment")
-		return &platform.CreateFunctionResult{
-			CreateFunctionBuildResult: platform.CreateFunctionBuildResult{
-				Image:                 createFunctionOptions.FunctionConfig.Spec.Image,
-				UpdatedFunctionConfig: createFunctionOptions.FunctionConfig,
-			},
-		}, nil
 	}
 
 	// sanity

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -100,6 +100,8 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 	createFunctionOptions.Logger.InfoWith("Deploying function",
 		"name", createFunctionOptions.FunctionConfig.Meta.Name)
 
+	skipDeploy := functionconfig.ShouldSkipDeploy(createFunctionOptions.FunctionConfig.Meta.Annotations)
+
 	var buildResult *platform.CreateFunctionBuildResult
 	var buildErr error
 
@@ -128,10 +130,8 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 	// clear build mode
 	createFunctionOptions.FunctionConfig.Spec.Build.Mode = ""
 
-	skipDeploy := functionconfig.SkipDeploy(createFunctionOptions.FunctionConfig.Meta.Annotations)
-
 	// check if we need to build the image
-	if functionBuildRequired && !functionconfig.SkipBuild(createFunctionOptions.FunctionConfig.Meta.Annotations) {
+	if functionBuildRequired && !functionconfig.ShouldSkipBuild(createFunctionOptions.FunctionConfig.Meta.Annotations) {
 		buildResult, buildErr = ap.platform.CreateFunctionBuild(&platform.CreateFunctionBuildOptions{
 			Logger:                     createFunctionOptions.Logger,
 			FunctionConfig:             createFunctionOptions.FunctionConfig,

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -128,8 +128,10 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 	// clear build mode
 	createFunctionOptions.FunctionConfig.Spec.Build.Mode = ""
 
+	skipDeploy := functionconfig.SkipDeploy(createFunctionOptions.FunctionConfig.Meta.Annotations)
+
 	// check if we need to build the image
-	if functionBuildRequired && !createFunctionOptions.FunctionConfig.Meta.SkipBuild() {
+	if functionBuildRequired && !functionconfig.SkipBuild(createFunctionOptions.FunctionConfig.Meta.Annotations) {
 		buildResult, buildErr = ap.platform.CreateFunctionBuild(&platform.CreateFunctionBuildOptions{
 			Logger:                     createFunctionOptions.Logger,
 			FunctionConfig:             createFunctionOptions.FunctionConfig,
@@ -177,7 +179,7 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 		return nil, errors.Wrap(err, "Failed to deploy function")
 	}
 
-	if createFunctionOptions.FunctionConfig.Meta.SkipDeploy() {
+	if skipDeploy {
 		ap.Logger.Info("Skipping function deployment")
 		return &platform.CreateFunctionResult{
 			CreateFunctionBuildResult: platform.CreateFunctionBuildResult{

--- a/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
+++ b/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
@@ -24,6 +24,7 @@ func (nf *NuclioFunction) GetComputedReplicas() *int32 {
 	one := int32(1)
 
 	if nf.Spec.Disable ||
+		nf.Status.State == functionconfig.FunctionStateImported ||
 		nf.Status.State == functionconfig.FunctionStateScaledToZero ||
 		nf.Status.State == functionconfig.FunctionStateWaitingForScaleResourcesToZero {
 		return &zero

--- a/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
+++ b/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
@@ -3,6 +3,7 @@ package v1beta1
 import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
+	"strconv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -117,6 +118,14 @@ func (nf *NuclioFunction) GetComputedMaxReplicas() int32 {
 			return 1
 		}
 	}
+}
+
+func (nf *NuclioFunction) SkipDeploy() bool {
+	var skipFunctionDeploy bool
+	if skipFunctionBuildStr, ok := nf.Annotations[functionconfig.FunctionAnnotationSkipDeploy]; ok {
+		skipFunctionDeploy, _ = strconv.ParseBool(skipFunctionBuildStr)
+	}
+	return skipFunctionDeploy
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
+++ b/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
@@ -3,8 +3,6 @@ package v1beta1
 import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
-	"strconv"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -118,14 +116,6 @@ func (nf *NuclioFunction) GetComputedMaxReplicas() int32 {
 			return 1
 		}
 	}
-}
-
-func (nf *NuclioFunction) SkipDeploy() bool {
-	var skipFunctionDeploy bool
-	if skipFunctionBuildStr, ok := nf.Annotations[functionconfig.FunctionAnnotationSkipDeploy]; ok {
-		skipFunctionDeploy, _ = strconv.ParseBool(skipFunctionBuildStr)
-	}
-	return skipFunctionDeploy
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
+++ b/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
@@ -3,6 +3,7 @@ package v1beta1
 import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"strconv"
 	"strings"
 	"time"
 
@@ -115,11 +114,7 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 		return nil
 	}
 
-	var skipFunctionDeploy bool
-	if skipFunctionBuildStr, ok := function.Annotations[functionconfig.FunctionAnnotationSkipDeploy]; ok {
-		skipFunctionDeploy, _ = strconv.ParseBool(skipFunctionBuildStr)
-	}
-	if skipFunctionDeploy {
+	if function.SkipDeploy() {
 		fo.logger.InfoWith("Skipping function deploy",
 			"name", function.Name,
 			"state", function.Status.State,

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -125,7 +125,7 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 			"state", function.Status.State,
 			"namespace", function.Namespace)
 		return fo.setFunctionStatus(function, &functionconfig.Status{
-			State: functionconfig.FunctionStateScaledToZero,
+			State: functionconfig.FunctionStateImported,
 		})
 	}
 

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -114,7 +114,7 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 		return nil
 	}
 
-	if function.SkipDeploy() {
+	if functionconfig.SkipDeploy(function.Annotations) {
 		fo.logger.InfoWith("Skipping function deploy",
 			"name", function.Name,
 			"state", function.Status.State,

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -115,12 +115,12 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 		return nil
 	}
 
-	skipFunctionDeploy := false
+	var skipFunctionDeploy bool
 	if skipFunctionBuildStr, ok := function.Annotations[functionconfig.FunctionAnnotationSkipDeploy]; ok {
 		skipFunctionDeploy, _ = strconv.ParseBool(skipFunctionBuildStr)
 	}
 	if skipFunctionDeploy {
-		fo.logger.InfoWith("NuclioFunction has skip-deploy annotation, probably from import, skipping create/update",
+		fo.logger.InfoWith("Skipping function deploy",
 			"name", function.Name,
 			"state", function.Status.State,
 			"namespace", function.Namespace)

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -114,7 +114,7 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 		return nil
 	}
 
-	if functionconfig.SkipDeploy(function.Annotations) {
+	if functionconfig.ShouldSkipDeploy(function.Annotations) {
 		fo.logger.InfoWith("Skipping function deploy",
 			"name", function.Name,
 			"state", function.Status.State,

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -170,7 +170,6 @@ func (lc *lazyClient) CreateOrUpdate(ctx context.Context, function *nuclioio.Nuc
 	skipFunctionDeploy := false
 	if skipFunctionBuildStr, ok := function.Annotations[functionconfig.FunctionAnnotationSkipDeploy]; ok {
 		skipFunctionDeploy, _ = strconv.ParseBool(skipFunctionBuildStr)
-		delete(function.Annotations, functionconfig.FunctionAnnotationSkipDeploy)
 	}
 	if skipFunctionDeploy {
 		return &resources, nil

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -167,6 +167,15 @@ func (lc *lazyClient) CreateOrUpdate(ctx context.Context, function *nuclioio.Nuc
 
 	resources := lazyResources{}
 
+	skipFunctionDeploy := false
+	if skipFunctionBuildStr, ok := function.Annotations[functionconfig.FunctionAnnotationSkipDeploy]; ok {
+		skipFunctionDeploy, _ = strconv.ParseBool(skipFunctionBuildStr)
+		delete(function.Annotations, functionconfig.FunctionAnnotationSkipDeploy)
+	}
+	if skipFunctionDeploy {
+		return &resources, nil
+	}
+
 	platformConfig := lc.platformConfigurationProvider.GetPlatformConfiguration()
 	for _, augmentedConfig := range platformConfig.FunctionAugmentedConfigs {
 

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -167,14 +167,6 @@ func (lc *lazyClient) CreateOrUpdate(ctx context.Context, function *nuclioio.Nuc
 
 	resources := lazyResources{}
 
-	skipFunctionDeploy := false
-	if skipFunctionBuildStr, ok := function.Annotations[functionconfig.FunctionAnnotationSkipDeploy]; ok {
-		skipFunctionDeploy, _ = strconv.ParseBool(skipFunctionBuildStr)
-	}
-	if skipFunctionDeploy {
-		return &resources, nil
-	}
-
 	platformConfig := lc.platformConfigurationProvider.GetPlatformConfiguration()
 	for _, augmentedConfig := range platformConfig.FunctionAugmentedConfigs {
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -199,6 +199,8 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 			return errors.Wrap(err, "Failed to get function")
 		}
 
+		// if the function already exists then it either doesn't have the FunctionAnnotationSkipDeploy annotation, or it
+		// was imported and has the annotation, but on this recreate it shouldn't. So the annotation should be removed.
 		if existingFunctionInstance != nil {
 			delete(createFunctionOptions.FunctionConfig.Meta.Annotations, functionconfig.FunctionAnnotationSkipDeploy)
 		}
@@ -225,6 +227,9 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	}
 
 	onAfterBuild := func(buildResult *platform.CreateFunctionBuildResult, buildErr error) (*platform.CreateFunctionResult, error) {
+
+		// after a function build (or skip-build) if the annotation FunctionAnnotationSkipBuild exists, it should be removed
+		// so next time, the build will happen.
 		delete(createFunctionOptions.FunctionConfig.Meta.Annotations, functionconfig.FunctionAnnotationSkipBuild)
 
 		if buildErr != nil {

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -202,7 +202,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 		// if the function already exists then it either doesn't have the FunctionAnnotationSkipDeploy annotation, or it
 		// was imported and has the annotation, but on this recreate it shouldn't. So the annotation should be removed.
 		if existingFunctionInstance != nil {
-			delete(createFunctionOptions.FunctionConfig.Meta.Annotations, functionconfig.FunctionAnnotationSkipDeploy)
+			createFunctionOptions.FunctionConfig.Meta.RemoveSkipDeployAnnotation()
 		}
 
 		// create or update the function if existing. FunctionInstance is nil, the function will be created
@@ -230,7 +230,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 
 		// after a function build (or skip-build) if the annotation FunctionAnnotationSkipBuild exists, it should be removed
 		// so next time, the build will happen.
-		delete(createFunctionOptions.FunctionConfig.Meta.Annotations, functionconfig.FunctionAnnotationSkipBuild)
+		createFunctionOptions.FunctionConfig.Meta.RemoveSkipBuildAnnotation()
 
 		if buildErr != nil {
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -199,6 +199,10 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 			return errors.Wrap(err, "Failed to get function")
 		}
 
+		if existingFunctionInstance != nil {
+			delete(createFunctionOptions.FunctionConfig.Meta.Annotations, functionconfig.FunctionAnnotationSkipDeploy)
+		}
+
 		// create or update the function if existing. FunctionInstance is nil, the function will be created
 		// with the configuration and status. if it exists, it will be updated with the configuration and status.
 		// the goal here is for the function to exist prior to building so that it is gettable
@@ -221,6 +225,8 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	}
 
 	onAfterBuild := func(buildResult *platform.CreateFunctionBuildResult, buildErr error) (*platform.CreateFunctionResult, error) {
+		delete(createFunctionOptions.FunctionConfig.Meta.Annotations, functionconfig.FunctionAnnotationSkipBuild)
+
 		if buildErr != nil {
 
 			// try to report the error

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -216,7 +216,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 			return nil, buildErr
 		}
 
-		skipFunctionDeploy := createFunctionOptions.FunctionConfig.Meta.SkipDeploy()
+		skipFunctionDeploy := functionconfig.SkipDeploy(createFunctionOptions.FunctionConfig.Meta.Annotations)
 
 		// after a function build (or skip-build) if the annotations FunctionAnnotationSkipBuild or FunctionAnnotationSkipDeploy
 		// exist, they should be removed so next time, the build will happen.

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -227,7 +227,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 		var createFunctionResult *platform.CreateFunctionResult
 		var deployErr error
 		functionStatus := functionconfig.Status{
-			State: functionconfig.FunctionStateScaledToZero,
+			State: functionconfig.FunctionStateImported,
 		}
 
 		if !skipFunctionDeploy {

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -225,12 +225,13 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 		delete(createFunctionOptions.FunctionConfig.Meta.Annotations, functionconfig.FunctionAnnotationSkipBuild)
 
 		var createFunctionResult *platform.CreateFunctionResult
+		var deployErr error
 		functionStatus := functionconfig.Status{
 			State: functionconfig.FunctionStateScaledToZero,
 		}
 
 		if !skipFunctionDeploy {
-			createFunctionResult, deployErr := p.deployFunction(createFunctionOptions, previousHTTPPort)
+			createFunctionResult, deployErr = p.deployFunction(createFunctionOptions, previousHTTPPort)
 			if deployErr != nil {
 				reportCreationError(deployErr) // nolint: errcheck
 				return nil, deployErr

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -216,15 +216,12 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 			return nil, buildErr
 		}
 
-		var skipFunctionDeploy bool
-		if skipFunctionBuildStr, ok := createFunctionOptions.FunctionConfig.Meta.Annotations[functionconfig.FunctionAnnotationSkipDeploy]; ok {
-			skipFunctionDeploy, _ = strconv.ParseBool(skipFunctionBuildStr)
-			delete(createFunctionOptions.FunctionConfig.Meta.Annotations, functionconfig.FunctionAnnotationSkipDeploy)
-		}
+		skipFunctionDeploy := createFunctionOptions.FunctionConfig.Meta.SkipDeploy()
 
-		// after a function build (or skip-build) if the annotation FunctionAnnotationSkipBuild exists, it should be removed
-		// so next time, the build will happen.
-		delete(createFunctionOptions.FunctionConfig.Meta.Annotations, functionconfig.FunctionAnnotationSkipBuild)
+		// after a function build (or skip-build) if the annotations FunctionAnnotationSkipBuild or FunctionAnnotationSkipDeploy
+		// exist, they should be removed so next time, the build will happen.
+		createFunctionOptions.FunctionConfig.Meta.RemoveSkipDeployAnnotation()
+		createFunctionOptions.FunctionConfig.Meta.RemoveSkipBuildAnnotation()
 
 		var createFunctionResult *platform.CreateFunctionResult
 		var deployErr error

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -240,6 +240,14 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 				HTTPPort: createFunctionResult.Port,
 				State:    functionconfig.FunctionStateReady,
 			}
+		} else {
+			p.Logger.Info("Skipping function deployment")
+			createFunctionResult = &platform.CreateFunctionResult{
+				CreateFunctionBuildResult: platform.CreateFunctionBuildResult{
+					Image:                 createFunctionOptions.FunctionConfig.Spec.Image,
+					UpdatedFunctionConfig: createFunctionOptions.FunctionConfig,
+				},
+			}
 		}
 
 		// update the function

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -216,7 +216,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 			return nil, buildErr
 		}
 
-		skipFunctionDeploy := functionconfig.SkipDeploy(createFunctionOptions.FunctionConfig.Meta.Annotations)
+		skipFunctionDeploy := functionconfig.ShouldSkipDeploy(createFunctionOptions.FunctionConfig.Meta.Annotations)
 
 		// after a function build (or skip-build) if the annotations FunctionAnnotationSkipBuild or FunctionAnnotationSkipDeploy
 		// exist, they should be removed so next time, the build will happen.

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -216,12 +216,14 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 			return nil, buildErr
 		}
 
-		skipFunctionDeploy := false
+		var skipFunctionDeploy bool
 		if skipFunctionBuildStr, ok := createFunctionOptions.FunctionConfig.Meta.Annotations[functionconfig.FunctionAnnotationSkipDeploy]; ok {
 			skipFunctionDeploy, _ = strconv.ParseBool(skipFunctionBuildStr)
 			delete(createFunctionOptions.FunctionConfig.Meta.Annotations, functionconfig.FunctionAnnotationSkipDeploy)
 		}
 
+		// after a function build (or skip-build) if the annotation FunctionAnnotationSkipBuild exists, it should be removed
+		// so next time, the build will happen.
 		delete(createFunctionOptions.FunctionConfig.Meta.Annotations, functionconfig.FunctionAnnotationSkipBuild)
 
 		var createFunctionResult *platform.CreateFunctionResult

--- a/pkg/platform/local/platform_test.go
+++ b/pkg/platform/local/platform_test.go
@@ -132,18 +132,18 @@ func (suite *TestSuite) TestImportFunctionFlow() {
 	// Create the function
 	createFunctionOptions := suite.GetMockDeploymentFunction("echoer")
 	createFunctionOptions.FunctionConfig.Meta.Annotations = map[string]string{
-		"skip-build": "true",
-		"skip-deploy": "true",
+		functionconfig.FunctionAnnotationSkipBuild: "true",
+		functionconfig.FunctionAnnotationSkipDeploy: "true",
 	}
 	createdFunction, err := suite.Platform.CreateFunction(createFunctionOptions)
-	suite.NoError(err, "Could not create function")
+	suite.NoError(err, "Failed to create function")
 
 	// Get the functions from local store
 	functions, err := suite.Platform.GetFunctions(&platform.GetFunctionsOptions{
 		Namespace: createdFunction.CreateFunctionBuildResult.UpdatedFunctionConfig.Meta.Namespace,
 		Name:      createdFunction.CreateFunctionBuildResult.UpdatedFunctionConfig.Meta.Name,
 	})
-	suite.NoError(err, "Could not get functions")
+	suite.NoError(err, "Failed to get functions")
 	suite.Len(functions, 1, "Expected to find the newly created function")
 	function := functions[0]
 
@@ -164,14 +164,14 @@ func (suite *TestSuite) TestImportFunctionFlow() {
 		},
 	}
 	recreatedFunction, err := suite.Platform.CreateFunction(recreateFunctionOptions)
-	suite.NoError(err, "Could not create function")
+	suite.NoError(err, "Failed to create function")
 
 	// Get the recreated functions from local store
 	recreatedFunctions, err := suite.Platform.GetFunctions(&platform.GetFunctionsOptions{
 		Namespace: recreatedFunction.CreateFunctionBuildResult.UpdatedFunctionConfig.Meta.Namespace,
 		Name:      recreatedFunction.CreateFunctionBuildResult.UpdatedFunctionConfig.Meta.Name,
 	})
-	suite.NoError(err, "Could not get functions")
+	suite.NoError(err, "Failed to get functions")
 	suite.Len(functions, 1, "Expected to find the newly created function")
 	function = recreatedFunctions[0]
 

--- a/pkg/platform/local/platform_test.go
+++ b/pkg/platform/local/platform_test.go
@@ -148,7 +148,7 @@ func (suite *TestSuite) TestImportFunctionFlow() {
 	function := functions[0]
 
 	// Check its state is scaled to zero and not deployed
-	suite.Equal(function.GetStatus().State, functionconfig.FunctionStateScaledToZero)
+	suite.Equal(function.GetStatus().State, functionconfig.FunctionStateImported)
 
 	// Check that the annotations have been removed
 	_, skipBuildExists := function.GetConfig().Meta.Annotations["skip-build"]

--- a/pkg/platform/local/platform_test.go
+++ b/pkg/platform/local/platform_test.go
@@ -126,6 +126,59 @@ func (suite *TestSuite) TestValidateFunctionContainersHealthiness() {
 	suite.Require().Equal(function.GetStatus().State, functionconfig.FunctionStateError)
 }
 
+// Test function import without deploy and build, then deploy calls build and deploy
+func (suite *TestSuite) TestImportFunctionFlow() {
+
+	// Create the function
+	createFunctionOptions := suite.GetMockDeploymentFunction("echoer")
+	createFunctionOptions.FunctionConfig.Meta.Annotations = map[string]string{
+		"skip-build": "true",
+		"skip-deploy": "true",
+	}
+	createdFunction, err := suite.Platform.CreateFunction(createFunctionOptions)
+	suite.NoError(err, "Could not create function")
+
+	// Get the functions from local store
+	functions, err := suite.Platform.GetFunctions(&platform.GetFunctionsOptions{
+		Namespace: createdFunction.CreateFunctionBuildResult.UpdatedFunctionConfig.Meta.Namespace,
+		Name:      createdFunction.CreateFunctionBuildResult.UpdatedFunctionConfig.Meta.Name,
+	})
+	suite.NoError(err, "Could not get functions")
+	suite.Len(functions, 1, "Expected to find the newly created function")
+	function := functions[0]
+
+	// Check its state is scaled to zero and not deployed
+	suite.Equal(function.GetStatus().State, functionconfig.FunctionStateScaledToZero)
+
+	// Check that the annotations have been removed
+	_, skipBuildExists := function.GetConfig().Meta.Annotations["skip-build"]
+	_, skipDeployExists := function.GetConfig().Meta.Annotations["skip-deploy"]
+	suite.Assert().False(skipBuildExists)
+	suite.Assert().False(skipDeployExists)
+
+	recreateFunctionOptions := &platform.CreateFunctionOptions{
+		Logger:         suite.Logger,
+		FunctionConfig: functionconfig.Config{
+			Meta: function.GetConfig().Meta,
+			Spec: function.GetConfig().Spec,
+		},
+	}
+	recreatedFunction, err := suite.Platform.CreateFunction(recreateFunctionOptions)
+	suite.NoError(err, "Could not create function")
+
+	// Get the recreated functions from local store
+	recreatedFunctions, err := suite.Platform.GetFunctions(&platform.GetFunctionsOptions{
+		Namespace: recreatedFunction.CreateFunctionBuildResult.UpdatedFunctionConfig.Meta.Namespace,
+		Name:      recreatedFunction.CreateFunctionBuildResult.UpdatedFunctionConfig.Meta.Name,
+	})
+	suite.NoError(err, "Could not get functions")
+	suite.Len(functions, 1, "Expected to find the newly created function")
+	function = recreatedFunctions[0]
+
+	// Check its state is scaled to zero and not deployed
+	suite.Equal(function.GetStatus().State, functionconfig.FunctionStateReady)
+}
+
 // GetDeployOptions populates a platform.CreateFunctionOptions structure from function name and path
 func (suite *TestSuite) GetMockDeploymentFunction(functionName string) *platform.CreateFunctionOptions {
 	functionConfig := *functionconfig.NewConfig()

--- a/pkg/platform/local/platform_test.go
+++ b/pkg/platform/local/platform_test.go
@@ -147,7 +147,7 @@ func (suite *TestSuite) TestImportFunctionFlow() {
 	suite.Len(functions, 1, "Expected to find the newly created function")
 	function := functions[0]
 
-	// Check its state is scaled to zero and not deployed
+	// Check its state is imported and not deployed
 	suite.Equal(function.GetStatus().State, functionconfig.FunctionStateImported)
 
 	// Check that the annotations have been removed
@@ -175,7 +175,7 @@ func (suite *TestSuite) TestImportFunctionFlow() {
 	suite.Len(functions, 1, "Expected to find the newly created function")
 	function = recreatedFunctions[0]
 
-	// Check its state is scaled to zero and not deployed
+	// Check its state is ready
 	suite.Equal(function.GetStatus().State, functionconfig.FunctionStateReady)
 }
 

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -189,21 +189,96 @@ func (ar *AbstractResource) GetRouter() chi.Router {
 	return ar.router
 }
 
-func (ar *AbstractResource) GetBooleanParam(paramKey string, request *http.Request) bool {
-	var importFunction bool
-	var err error
+func (ar *AbstractResource) parseUrlParamValue(paramValue string) interface{} {
+	parsedBool, err := strconv.ParseBool(paramValue)
+	if err == nil {
+		return parsedBool
+	}
 
+	parsedInt, err := strconv.ParseInt(paramValue, 10, 64)
+	if err == nil {
+		return parsedInt
+	}
+
+	parsedUint, err := strconv.ParseUint(paramValue, 10, 64)
+	if err == nil {
+		return parsedUint
+	}
+
+	parsedFloat, err := strconv.ParseFloat(paramValue, 10)
+	if err == nil {
+		return parsedFloat
+	}
+
+	return paramValue
+}
+
+func (ar *AbstractResource) GetUrlParams(paramKey string, request *http.Request) []interface{} {
 	paramValues, ok := request.URL.Query()[paramKey]
 	if !ok || len(paramValues) == 0 {
+		return nil
+	}
+
+	var values []interface{}
+	for _, value := range paramValues {
+		values = append(values, ar.parseUrlParamValue(value))
+	}
+
+	return values
+}
+
+func (ar *AbstractResource) GetUrlParam(paramKey string, request *http.Request) interface{} {
+	paramValues, ok := request.URL.Query()[paramKey]
+	if !ok || len(paramValues) == 0 {
+		return nil
+	}
+
+	return ar.parseUrlParamValue(paramValues[0])
+}
+
+func (ar *AbstractResource) GetBoolUrlParam(paramKey string, request *http.Request) bool {
+	booleanParam, ok := ar.GetUrlParam(paramKey, request).(bool)
+	if !ok {
 		return false
 	}
 
-	importFunction, err = strconv.ParseBool(paramValues[0])
-	if err != nil {
-		return false
+	return booleanParam
+}
+
+func (ar *AbstractResource) GetInt64UrlParam(paramKey string, request *http.Request) int64 {
+	int64Param, ok := ar.GetUrlParam(paramKey, request).(int64)
+	if !ok {
+		return 0
 	}
 
-	return importFunction
+	return int64Param
+}
+
+func (ar *AbstractResource) GetUint64UrlParam(paramKey string, request *http.Request) uint64 {
+	uint64Param, ok := ar.GetUrlParam(paramKey, request).(uint64)
+	if !ok {
+		return 0
+	}
+
+	return uint64Param
+}
+
+func (ar *AbstractResource) GetFloatUrlParam(paramKey string, request *http.Request) float64 {
+	float64Param, ok := ar.GetUrlParam(paramKey, request).(float64)
+	if !ok {
+		return 0
+	}
+
+	return float64Param
+}
+
+func (ar *AbstractResource) GetStringUrlParam(paramKey string, request *http.Request) string {
+	stringParam, ok := ar.GetUrlParam(paramKey, request).(string)
+	if !ok {
+		return ""
+	}
+
+	return stringParam
 }
 
 func (ar *AbstractResource) registerRoutes() error {

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -189,16 +189,16 @@ func (ar *AbstractResource) GetRouter() chi.Router {
 	return ar.router
 }
 
-func (ar *AbstractResource) GetBooleanParam(param string, request *http.Request) bool {
+func (ar *AbstractResource) GetBooleanParam(paramKey string, request *http.Request) bool {
 	var importFunction bool
 	var err error
 
-	importKeys, ok := request.URL.Query()[param]
-	if !ok || len(importKeys) == 0 {
+	paramValues, ok := request.URL.Query()[paramKey]
+	if !ok || len(paramValues) == 0 {
 		return false
 	}
 
-	importFunction, err = strconv.ParseBool(importKeys[0])
+	importFunction, err = strconv.ParseBool(paramValues[0])
 	if err != nil {
 		return false
 	}

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -189,7 +189,7 @@ func (ar *AbstractResource) GetRouter() chi.Router {
 	return ar.router
 }
 
-func (ar *AbstractResource) parseUrlParamValue(paramValue string) interface{} {
+func (ar *AbstractResource) parseURLParamValue(paramValue string) interface{} {
 	parsedBool, err := strconv.ParseBool(paramValue)
 	if err == nil {
 		return parsedBool
@@ -213,7 +213,7 @@ func (ar *AbstractResource) parseUrlParamValue(paramValue string) interface{} {
 	return paramValue
 }
 
-func (ar *AbstractResource) GetUrlParams(paramKey string, request *http.Request) []interface{} {
+func (ar *AbstractResource) GetURLParams(paramKey string, request *http.Request) []interface{} {
 	paramValues, ok := request.URL.Query()[paramKey]
 	if !ok || len(paramValues) == 0 {
 		return nil
@@ -221,23 +221,23 @@ func (ar *AbstractResource) GetUrlParams(paramKey string, request *http.Request)
 
 	var values []interface{}
 	for _, value := range paramValues {
-		values = append(values, ar.parseUrlParamValue(value))
+		values = append(values, ar.parseURLParamValue(value))
 	}
 
 	return values
 }
 
-func (ar *AbstractResource) GetUrlParam(paramKey string, request *http.Request) interface{} {
+func (ar *AbstractResource) GetURLParam(paramKey string, request *http.Request) interface{} {
 	paramValues, ok := request.URL.Query()[paramKey]
 	if !ok || len(paramValues) == 0 {
 		return nil
 	}
 
-	return ar.parseUrlParamValue(paramValues[0])
+	return ar.parseURLParamValue(paramValues[0])
 }
 
-func (ar *AbstractResource) GetBoolUrlParam(paramKey string, request *http.Request) bool {
-	booleanParam, ok := ar.GetUrlParam(paramKey, request).(bool)
+func (ar *AbstractResource) GetBoolURLParam(paramKey string, request *http.Request) bool {
+	booleanParam, ok := ar.GetURLParam(paramKey, request).(bool)
 	if !ok {
 		return false
 	}
@@ -245,8 +245,8 @@ func (ar *AbstractResource) GetBoolUrlParam(paramKey string, request *http.Reque
 	return booleanParam
 }
 
-func (ar *AbstractResource) GetInt64UrlParam(paramKey string, request *http.Request) int64 {
-	int64Param, ok := ar.GetUrlParam(paramKey, request).(int64)
+func (ar *AbstractResource) GetInt64URLParam(paramKey string, request *http.Request) int64 {
+	int64Param, ok := ar.GetURLParam(paramKey, request).(int64)
 	if !ok {
 		return 0
 	}
@@ -254,8 +254,8 @@ func (ar *AbstractResource) GetInt64UrlParam(paramKey string, request *http.Requ
 	return int64Param
 }
 
-func (ar *AbstractResource) GetUint64UrlParam(paramKey string, request *http.Request) uint64 {
-	uint64Param, ok := ar.GetUrlParam(paramKey, request).(uint64)
+func (ar *AbstractResource) GetUint64URLParam(paramKey string, request *http.Request) uint64 {
+	uint64Param, ok := ar.GetURLParam(paramKey, request).(uint64)
 	if !ok {
 		return 0
 	}
@@ -263,8 +263,8 @@ func (ar *AbstractResource) GetUint64UrlParam(paramKey string, request *http.Req
 	return uint64Param
 }
 
-func (ar *AbstractResource) GetFloatUrlParam(paramKey string, request *http.Request) float64 {
-	float64Param, ok := ar.GetUrlParam(paramKey, request).(float64)
+func (ar *AbstractResource) GetFloatURLParam(paramKey string, request *http.Request) float64 {
+	float64Param, ok := ar.GetURLParam(paramKey, request).(float64)
 	if !ok {
 		return 0
 	}
@@ -272,8 +272,8 @@ func (ar *AbstractResource) GetFloatUrlParam(paramKey string, request *http.Requ
 	return float64Param
 }
 
-func (ar *AbstractResource) GetStringUrlParam(paramKey string, request *http.Request) string {
-	stringParam, ok := ar.GetUrlParam(paramKey, request).(string)
+func (ar *AbstractResource) GetStringURLParam(paramKey string, request *http.Request) string {
+	stringParam, ok := ar.GetURLParam(paramKey, request).(string)
 	if !ok {
 		return ""
 	}

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 
 	"github.com/nuclio/nuclio/pkg/registry"
 
@@ -92,6 +93,11 @@ const (
 	ResourceMethodCreate
 	ResourceMethodUpdate
 	ResourceMethodDelete
+)
+
+const (
+	ParamImport = "import"
+	ParamExport = "export"
 )
 
 // AbstractResource is base for resources
@@ -181,6 +187,23 @@ func (ar *AbstractResource) GetCustomRoutes() ([]CustomRoute, error) {
 // GetRouter returns raw routes, those that don't return an attribute
 func (ar *AbstractResource) GetRouter() chi.Router {
 	return ar.router
+}
+
+func (ar *AbstractResource) GetBooleanParam(param string, request *http.Request) bool {
+	var importFunction bool
+	var err error
+
+	importKeys, ok := request.URL.Query()[param]
+	if !ok || len(importKeys) == 0 {
+		return false
+	}
+
+	importFunction, err = strconv.ParseBool(importKeys[0])
+	if err != nil {
+		return false
+	}
+
+	return importFunction
 }
 
 func (ar *AbstractResource) registerRoutes() error {

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -213,7 +213,7 @@ func (ar *AbstractResource) parseURLParamValue(paramValue string) interface{} {
 	return paramValue
 }
 
-func (ar *AbstractResource) GetURLParams(paramKey string, request *http.Request) []interface{} {
+func (ar *AbstractResource) GetURLParamValues(paramKey string, request *http.Request) []interface{} {
 	paramValues, ok := request.URL.Query()[paramKey]
 	if !ok || len(paramValues) == 0 {
 		return nil
@@ -227,7 +227,7 @@ func (ar *AbstractResource) GetURLParams(paramKey string, request *http.Request)
 	return values
 }
 
-func (ar *AbstractResource) GetURLParam(paramKey string, request *http.Request) interface{} {
+func (ar *AbstractResource) GetURLParamValue(paramKey string, request *http.Request) interface{} {
 	paramValues, ok := request.URL.Query()[paramKey]
 	if !ok || len(paramValues) == 0 {
 		return nil
@@ -236,46 +236,46 @@ func (ar *AbstractResource) GetURLParam(paramKey string, request *http.Request) 
 	return ar.parseURLParamValue(paramValues[0])
 }
 
-func (ar *AbstractResource) GetBoolURLParam(paramKey string, request *http.Request) bool {
-	booleanParam, ok := ar.GetURLParam(paramKey, request).(bool)
+func (ar *AbstractResource) GetURLParamBoolOrDefault(request *http.Request, paramKey string, defaultValue bool) bool {
+	booleanParam, ok := ar.GetURLParamValue(paramKey, request).(bool)
 	if !ok {
-		return false
+		return defaultValue
 	}
 
 	return booleanParam
 }
 
-func (ar *AbstractResource) GetInt64URLParam(paramKey string, request *http.Request) int64 {
-	int64Param, ok := ar.GetURLParam(paramKey, request).(int64)
+func (ar *AbstractResource) GetURLParamInt64OrDefault(request *http.Request, paramKey string, defaultValue int64) int64 {
+	int64Param, ok := ar.GetURLParamValue(paramKey, request).(int64)
 	if !ok {
-		return 0
+		return defaultValue
 	}
 
 	return int64Param
 }
 
-func (ar *AbstractResource) GetUint64URLParam(paramKey string, request *http.Request) uint64 {
-	uint64Param, ok := ar.GetURLParam(paramKey, request).(uint64)
+func (ar *AbstractResource) GetURLParamUint64OrDefault(request *http.Request, paramKey string, defaultValue uint64) uint64 {
+	uint64Param, ok := ar.GetURLParamValue(paramKey, request).(uint64)
 	if !ok {
-		return 0
+		return defaultValue
 	}
 
 	return uint64Param
 }
 
-func (ar *AbstractResource) GetFloatURLParam(paramKey string, request *http.Request) float64 {
-	float64Param, ok := ar.GetURLParam(paramKey, request).(float64)
+func (ar *AbstractResource) GetURLParamFloatOrDefault(request *http.Request, paramKey string, defaultValue float64) float64 {
+	float64Param, ok := ar.GetURLParamValue(paramKey, request).(float64)
 	if !ok {
-		return 0
+		return defaultValue
 	}
 
 	return float64Param
 }
 
-func (ar *AbstractResource) GetStringURLParam(paramKey string, request *http.Request) string {
-	stringParam, ok := ar.GetURLParam(paramKey, request).(string)
+func (ar *AbstractResource) GetURLParamStringOrDefault(request *http.Request, paramKey string, defaultValue string) string {
+	stringParam, ok := ar.GetURLParamValue(paramKey, request).(string)
 	if !ok {
-		return ""
+		return defaultValue
 	}
 
 	return stringParam


### PR DESCRIPTION
Added the following functionalities for a Import/Export system:
Export:
- On `GET /api/functions[:/id]?export=true`: Scrub parts of the function data(like status) which is irrelevant to the export and add 2 annotations(`skip-build`, and `skip-deploy`) for the later import.
- On `GET /api/projects[:/id]?export=true`: Exports the project with all its function(in their exported format) and their function events.

Import:
- On `POST /api/functions`: If the function is posted with the above annotations, during this POST, the function will not be built or deployed, and the annotations are removed so on the next update, the function will be built and deployed.
- On `POST /api/projects?import=true`: This deals with the output of `GET /api/projects[:/id]?export=true` so it imports the project with it's given functions. If a project with the same name exists, the import merges the projects. If one or more of the functions with the same name exists, those specific functions won't be imported but the rest will.
- On `PUT /api/functions/:id`: New validation added - if the function was imported but not deployed, user cannot set disable to be true.