### PR TITLE
Fix citation

### DIFF
--- a/cmd/dashboard/docker/runner.sh
+++ b/cmd/dashboard/docker/runner.sh
@@ -10,14 +10,14 @@ trap _term SIGINT
 
 echo "Running in parallel"
 
-parallel --citation
-
+# citation
 # ensure each runner gets a jobslot
 # buffer output on line basis
 # exit when the first job fails, kill all running jobs.
 # upon unexpected termination, signal jobs before killing (signal, timeout)
 # execute all *.sh files in parallel
 parallel \
+        --will-cite \
         --jobs 0 \
         --line-buffer \
         --halt now,fail=1 \


### PR DESCRIPTION
Fix nuclio dashboard image stuck on citing when running interactively (`docker run -ti`)