### PR TITLE
Fix appending latest

### DIFF
--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -491,6 +491,12 @@ func (b *Builder) validateAndEnrichConfiguration() error {
 		b.processorImage.imageName = processorImageName
 	}
 
+	splitProcessorImageName := strings.Split(b.processorImage.imageName, ":")
+	if len(splitProcessorImageName) == 2 {
+		b.processorImage.imageName = splitProcessorImageName[0]
+		b.processorImage.imageTag = splitProcessorImageName[1]
+	}
+
 	// if tag isn't set - set latest
 	if b.processorImage.imageTag == "" {
 		b.processorImage.imageTag = "latest"
@@ -501,7 +507,7 @@ func (b *Builder) validateAndEnrichConfiguration() error {
 		"platform", b.options.PlatformName,
 		"dependantImagesRegistryURL", b.options.DependantImagesRegistryURL,
 		"outputImageFile", b.options.OutputImageFile,
-		"pi", b.processorImage)
+		"processorImage", b.processorImage)
 
 	return nil
 }

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -493,7 +493,6 @@ func (b *Builder) validateAndEnrichConfiguration() error {
 
 	splitProcessorImageName := strings.Split(b.processorImage.imageName, ":")
 	if len(splitProcessorImageName) == 2 {
-		b.processorImage.imageName = splitProcessorImageName[0]
 		b.processorImage.imageTag = splitProcessorImageName[1]
 	}
 


### PR DESCRIPTION
Bug: If image name is given, and contains a tag (e.g.: `v1.2`), it will defaults to `imageName:v1.2:latest`
