### PR TITLE
Some tweaks and improvements

### DIFF
--- a/cmd/processor/Dockerfile
+++ b/cmd/processor/Dockerfile
@@ -26,6 +26,6 @@ COPY . .
 # build the processor
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags="-s -w" -o processor cmd/processor/main.go
 
-FROM golang:1.14
+FROM scratch
 
 COPY --from=builder  /processor/processor /home/nuclio/bin/processor

--- a/cmd/processor/Dockerfile
+++ b/cmd/processor/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.14
+FROM golang:1.14 as builder
 
 WORKDIR /processor
 
@@ -24,4 +24,8 @@ RUN go mod download
 COPY . .
 
 # build the processor
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags="-s -w" -o /home/nuclio/bin/processor cmd/processor/main.go
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags="-s -w" -o processor cmd/processor/main.go
+
+FROM golang:1.14
+
+COPY --from=builder  /processor/processor /home/nuclio/bin/processor

--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -101,7 +101,7 @@ func (d *Docker) GetOnbuildImageRegistry(registry string) string {
 
 func (d *Docker) buildContainerImage(buildOptions *BuildOptions) error {
 
-	d.logger.DebugWith("Building docker image", "image", buildOptions.Image)
+	d.logger.InfoWith("Building docker image", "image", buildOptions.Image)
 
 	return d.dockerClient.Build(&dockerclient.BuildOptions{
 		ContextDir:     buildOptions.ContextDir,

--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -62,7 +62,8 @@ func (d *Docker) BuildAndPushContainerImage(buildOptions *BuildOptions, namespac
 		return errors.Wrap(err, "Failed to save docker image")
 	}
 
-	d.logger.DebugWith("Docker image was successfully built and pushed into docker registry", "image", buildOptions.Image)
+	d.logger.InfoWith("Docker image was successfully built and pushed into docker registry",
+		"image", buildOptions.Image)
 
 	return nil
 }
@@ -114,7 +115,7 @@ func (d *Docker) buildContainerImage(buildOptions *BuildOptions) error {
 }
 
 func (d *Docker) pushContainerImage(image string, registryURL string) error {
-	d.logger.DebugWith("Pushing docker image into registry",
+	d.logger.InfoWith("Pushing docker image into registry",
 		"image", image,
 		"registry", registryURL)
 
@@ -138,7 +139,7 @@ func (d *Docker) saveContainerImage(buildOptions *BuildOptions) error {
 
 func (d *Docker) ensureImagesExist(buildOptions *BuildOptions, images []string) error {
 	if buildOptions.NoBaseImagePull {
-		d.logger.Debug("Skipping base images pull")
+		d.logger.DebugWith("Skipping base images pull", "images", images)
 		return nil
 	}
 

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -65,7 +65,7 @@ func NewShellClient(parentLogger logger.Logger, runner cmdrunner.CmdRunner) (*Sh
 
 // Build will build a docker image, given build options
 func (c *ShellClient) Build(buildOptions *BuildOptions) error {
-	c.logger.DebugWith("Building image", "image", buildOptions.Image)
+	c.logger.DebugWith("Building image", "buildOptions", buildOptions)
 
 	// if context dir is not passed, use the dir containing the dockerfile
 	if buildOptions.ContextDir == "" && buildOptions.DockerfilePath != "" {

--- a/pkg/nuctl/command/nuctl.go
+++ b/pkg/nuctl/command/nuctl.go
@@ -122,7 +122,7 @@ func (rc *RootCommandeer) initialize() error {
 		rc.namespace = rc.platform.ResolveDefaultNamespace(rc.namespace)
 	}
 
-	rc.loggerInstance.DebugWith("Created platform", "name", rc.platform.GetName())
+	rc.loggerInstance.InfoWith("Created platform", "name", rc.platform.GetName())
 
 	return nil
 }

--- a/pkg/processor/runtime/python/runtime.go
+++ b/pkg/processor/runtime/python/runtime.go
@@ -146,6 +146,13 @@ func (py *python) getPythonPath() string {
 }
 
 func (py *python) getPythonExePath() (string, error) {
+
+	// let user bring his own python binary
+	pythonExePath := os.Getenv("NUCLIO_PYTHON_EXE_PATH")
+	if pythonExePath != "" {
+		return exec.LookPath(pythonExePath)
+	}
+
 	baseName := "python3"
 
 	_, runtimeVersion := py.configuration.Spec.GetRuntimeNameAndVersion()


### PR DESCRIPTION
- Reduced processor image from 850mb to 30mb
- Tweak build logs (allowing better readability when using `nuctl`)
- Allow user to use different python exe path (by providing `NUCLIO_PYTHON_EXE_PATH` as environment variable)