### PR TITLE
Show call stack on build function failures (on brief errors message - a.k.a the 'Error' pane)

### DIFF
--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -143,7 +143,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 		return nil, errors.Wrap(err, "Create function options validation failed")
 	}
 
-	reportCreationError := func(creationError error, briefErrorsMessage string) error {
+	reportCreationError := func(creationError error, briefErrorsMessage string, clearCallStack bool) error {
 		errorStack := bytes.Buffer{}
 		errors.PrintErrorStack(&errorStack, creationError, 20)
 
@@ -159,7 +159,9 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 			}
 		}
 
-		briefErrorsMessage = p.clearCallStack(briefErrorsMessage)
+		if clearCallStack {
+			briefErrorsMessage = p.clearCallStack(briefErrorsMessage)
+		}
 
 		createFunctionOptions.Logger.WarnWith("Create function failed, setting function status",
 			"errorStack", errorStack.String())
@@ -224,7 +226,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 		if buildErr != nil {
 
 			// try to report the error
-			reportCreationError(buildErr, "") // nolint: errcheck
+			reportCreationError(buildErr, "", false) // nolint: errcheck
 
 			return nil, buildErr
 		}
@@ -237,7 +239,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 		if deployErr != nil {
 
 			// try to report the error
-			reportCreationError(deployErr, briefErrorsMessage) // nolint: errcheck
+			reportCreationError(deployErr, briefErrorsMessage, true) // nolint: errcheck
 
 			return nil, deployErr
 		}

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -152,10 +152,17 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 			errorStack.Truncate(4 * Mib)
 		}
 
-		// if no brief error message was passed, set it to be root cause
+		// when no brief error message was passed - infer it from the creation error
 		if briefErrorsMessage == "" {
-			if rootCause := errors.RootCause(creationError); rootCause != nil {
+			rootCause := errors.RootCause(creationError)
+
+			// when clearCallStack is requested and there's a root cause - set it to be the specific root cause
+			if clearCallStack && rootCause != nil {
 				briefErrorsMessage = rootCause.Error()
+
+			// otherwise, set it to be the whole error stack
+			} else {
+				briefErrorsMessage = errorStack.String()
 			}
 		}
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -160,7 +160,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 			if clearCallStack && rootCause != nil {
 				briefErrorsMessage = rootCause.Error()
 
-			// otherwise, set it to be the whole error stack
+				// otherwise, set it to be the whole error stack
 			} else {
 				briefErrorsMessage = errorStack.String()
 			}


### PR DESCRIPTION
When function deployments fails on `build` stage - we want to present the _call stack_ inside the `Error` pane (as shown on the image below) - because this is where the relevant information to debug this problem is at 
(Before this fix the only thing that was shown inside the error pane was the exit status code)
<img width="780" alt="Screen Shot 2020-04-22 at 16 42 57" src="https://user-images.githubusercontent.com/23615798/79989310-5d286a00-84b8-11ea-9cff-8b7a2f31b5c1.png">