### PR TITLE
Fixed nuctl get resource as yaml/json returned with info level logs

### DIFF
--- a/pkg/nuctl/command/get.go
+++ b/pkg/nuctl/command/get.go
@@ -30,10 +30,10 @@ import (
 )
 
 const (
-	outputFormatText = "text"
-	outputFormatWide = "wide"
-	outputFormatJSON = "json"
-	outputFormatYAML = "yaml"
+	OutputFormatText = "text"
+	OutputFormatWide = "wide"
+	OutputFormatJSON = "json"
+	OutputFormatYAML = "yaml"
 )
 
 type getCommandeer struct {
@@ -113,7 +113,7 @@ func newGetFunctionCommandeer(getCommandeer *getCommandeer) *getFunctionCommande
 	}
 
 	cmd.PersistentFlags().StringVarP(&commandeer.getFunctionsOptions.Labels, "labels", "l", "", "Function labels (lbl1=val1[,lbl2=val2,...])")
-	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", outputFormatText, "Output format - \"text\", \"wide\", \"yaml\", or \"json\"")
+	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", OutputFormatText, "Output format - \"text\", \"wide\", \"yaml\", or \"json\"")
 
 	commandeer.cmd = cmd
 
@@ -133,9 +133,9 @@ func (g *getFunctionCommandeer) renderFunctions(functions []platform.Function, f
 	rendererInstance := renderer.NewRenderer(writer)
 
 	switch format {
-	case outputFormatText, outputFormatWide:
+	case OutputFormatText, OutputFormatWide:
 		header := []string{"Namespace", "Name", "Project", "State", "Node Port", "Replicas"}
-		if format == outputFormatWide {
+		if format == OutputFormatWide {
 			header = append(header, []string{
 				"Labels",
 				"Ingresses",
@@ -159,7 +159,7 @@ func (g *getFunctionCommandeer) renderFunctions(functions []platform.Function, f
 			}
 
 			// add fields for wide view
-			if format == outputFormatWide {
+			if format == OutputFormatWide {
 				functionFields = append(functionFields, []string{
 					common.StringMapToString(function.GetConfig().Meta.Labels),
 					g.formatFunctionIngresses(function),
@@ -171,9 +171,9 @@ func (g *getFunctionCommandeer) renderFunctions(functions []platform.Function, f
 		}
 
 		rendererInstance.RenderTable(header, functionRecords)
-	case outputFormatYAML:
+	case OutputFormatYAML:
 		return g.renderFunctionConfig(functions, rendererInstance.RenderYAML)
-	case outputFormatJSON:
+	case OutputFormatJSON:
 		return g.renderFunctionConfig(functions, rendererInstance.RenderJSON)
 	}
 
@@ -262,7 +262,7 @@ func newGetProjectCommandeer(getCommandeer *getCommandeer) *getProjectCommandeer
 		},
 	}
 
-	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", outputFormatText, "Output format - \"text\", \"wide\", \"yaml\", or \"json\"")
+	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", OutputFormatText, "Output format - \"text\", \"wide\", \"yaml\", or \"json\"")
 
 	commandeer.cmd = cmd
 
@@ -274,9 +274,9 @@ func (g *getProjectCommandeer) renderProjects(projects []platform.Project, forma
 	rendererInstance := renderer.NewRenderer(writer)
 
 	switch format {
-	case outputFormatText, outputFormatWide:
+	case OutputFormatText, OutputFormatWide:
 		header := []string{"Namespace", "Name", "Display Name"}
-		if format == outputFormatWide {
+		if format == OutputFormatWide {
 			header = append(header, []string{
 				"Description",
 			}...)
@@ -295,7 +295,7 @@ func (g *getProjectCommandeer) renderProjects(projects []platform.Project, forma
 			}
 
 			// add fields for wide view
-			if format == outputFormatWide {
+			if format == OutputFormatWide {
 				projectFields = append(projectFields, []string{
 					project.GetConfig().Spec.Description,
 				}...)
@@ -306,9 +306,9 @@ func (g *getProjectCommandeer) renderProjects(projects []platform.Project, forma
 		}
 
 		rendererInstance.RenderTable(header, projectRecords)
-	case outputFormatYAML:
+	case OutputFormatYAML:
 		return g.renderProjectConfig(projects, rendererInstance.RenderYAML)
-	case outputFormatJSON:
+	case OutputFormatJSON:
 		return g.renderProjectConfig(projects, rendererInstance.RenderJSON)
 	}
 
@@ -379,7 +379,7 @@ func newGetFunctionEventCommandeer(getCommandeer *getCommandeer) *getFunctionEve
 	}
 
 	cmd.PersistentFlags().StringVarP(&commandeer.functionName, "function", "f", "", "Filter by owning function (optional)")
-	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", outputFormatText, "Output format - \"text\", \"wide\", \"yaml\", or \"json\"")
+	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", OutputFormatText, "Output format - \"text\", \"wide\", \"yaml\", or \"json\"")
 
 	commandeer.cmd = cmd
 
@@ -391,9 +391,9 @@ func (g *getFunctionEventCommandeer) renderFunctionEvents(functionEvents []platf
 	rendererInstance := renderer.NewRenderer(writer)
 
 	switch format {
-	case outputFormatText, outputFormatWide:
+	case OutputFormatText, OutputFormatWide:
 		header := []string{"Namespace", "Name", "Display Name", "Function", "Trigger Name", "Trigger Kind"}
-		if format == outputFormatWide {
+		if format == OutputFormatWide {
 			header = append(header, []string{
 				"Body",
 			}...)
@@ -415,7 +415,7 @@ func (g *getFunctionEventCommandeer) renderFunctionEvents(functionEvents []platf
 			}
 
 			// add fields for wide view
-			if format == outputFormatWide {
+			if format == OutputFormatWide {
 				functionEventFields = append(functionEventFields, []string{
 					functionEvent.GetConfig().Spec.Body,
 				}...)
@@ -426,9 +426,9 @@ func (g *getFunctionEventCommandeer) renderFunctionEvents(functionEvents []platf
 		}
 
 		rendererInstance.RenderTable(header, functionEventRecords)
-	case outputFormatYAML:
+	case OutputFormatYAML:
 		return g.renderFunctionEventConfig(functionEvents, rendererInstance.RenderYAML)
-	case outputFormatJSON:
+	case OutputFormatJSON:
 		return g.renderFunctionEventConfig(functionEvents, rendererInstance.RenderJSON)
 	}
 

--- a/pkg/nuctl/command/nuctl.go
+++ b/pkg/nuctl/command/nuctl.go
@@ -122,8 +122,7 @@ func (rc *RootCommandeer) initialize() error {
 		rc.namespace = rc.platform.ResolveDefaultNamespace(rc.namespace)
 	}
 
-	rc.loggerInstance.InfoWith("Created platform", "name", rc.platform.GetName())
-
+	rc.loggerInstance.DebugWith("Created platform", "name", rc.platform.GetName())
 	return nil
 }
 

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -586,30 +586,38 @@ func (suite *functionGetTestSuite) TestGet() {
 
 	for _, testCase := range []struct {
 		FunctionName string
-		GetOutput    string
+		OutputFormat string
 	}{
 		{
 			FunctionName: functionNames[0],
-			GetOutput:    command.OutputFormatJSON,
+			OutputFormat: command.OutputFormatJSON,
 		},
 		{
 			FunctionName: functionNames[0],
-			GetOutput:    command.OutputFormatYAML,
+			OutputFormat: command.OutputFormatYAML,
 		},
 	} {
 		// reset buffer
 		suite.outputBuffer.Reset()
+
 		parsedFunction := functionconfig.Config{}
 
-		err = suite.ExecuteNuctl([]string{"get", "function", testCase.FunctionName, "--output", testCase.GetOutput}, nil)
+		// get function in format
+		err = suite.ExecuteNuctl([]string{"get", "function", testCase.FunctionName, "--output", testCase.OutputFormat}, nil)
 		suite.Require().NoError(err)
-		switch testCase.GetOutput {
+
+		// unmarshal response correspondingly to output format
+		switch testCase.OutputFormat {
 		case command.OutputFormatJSON:
 			err = json.Unmarshal(suite.outputBuffer.Bytes(), &parsedFunction)
 		case command.OutputFormatYAML:
 			err = yaml.Unmarshal(suite.outputBuffer.Bytes(), &parsedFunction)
 		}
+
+		// ensure parsing went well, and response is valid (json/yaml)
 		suite.Require().NoError(err, "Failed to unmarshal function")
+
+		// sanity, we got the function we asked for
 		suite.Assert().Equal(testCase.FunctionName, parsedFunction.Meta.Name)
 	}
 }


### PR DESCRIPTION
- Added test to ensure `nuctl get function --output json|yaml` returns with a valid `json|yaml`
- Info level logging -> debug level to avoid unneeded loggings  upon `nuctl get <resource>`