### PR TITLE
Fix: docker build network env is overridden in case of `none`

### DIFF
--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -18,6 +18,7 @@ package dockerclient
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -93,8 +94,12 @@ func (c *ShellClient) Build(buildOptions *BuildOptions) error {
 	}
 
 	var hostNetString string
-	networkInterface := common.GetEnvOrDefaultString("NUCLIO_DOCKER_BUILD_NETWORK",
-		common.GetEnvOrDefaultString("NUCLIO_BUILD_USE_HOST_NET", "host"))
+
+	// may contain none as a value
+	networkInterface := os.Getenv("NUCLIO_DOCKER_BUILD_NETWORK")
+	if networkInterface == "" {
+		networkInterface = common.GetEnvOrDefaultString("NUCLIO_BUILD_USE_HOST_NET", "host")
+	}
 	switch networkInterface {
 	case "host":
 		fallthrough


### PR DESCRIPTION
Bug: `NUCLIO_DOCKER_BUILD_NETWORK` env may be initialized with `none`, in that case, `common.GetEnvOrDefaultString` will default it to an empty string ("").

`NUCLIO_BUILD_USE_HOST_NET` is default in case no `NUCLIO_DOCKER_BUILD_NETWORK` is given.
