### PR TITLE
Added CORS support

### DIFF
--- a/docs/reference/triggers/http.md
+++ b/docs/reference/triggers/http.md
@@ -66,7 +66,7 @@ triggers:
   myCORSHttpTrigger:
     kind: "http"
     attributes:
-      CORS:
+      cors:
         enabled: true
         allowOrigin: "foo.bar"
         allowHeaders:

--- a/docs/reference/triggers/http.md
+++ b/docs/reference/triggers/http.md
@@ -9,15 +9,30 @@ The HTTP trigger is the only trigger created by default if not configured (by de
 | port | int | The NodePort (or equivalent) on which the function will serve HTTP requests. If empty, chooses a random port within the platform range. |
 | ingresses.(name).host | string | The host to which the ingress maps. |
 | ingresses.(name).paths | list of strings | The paths that the ingress handles. Variables of the form `{{.<NAME>}}` can be specified using `.Name`, `.Namespace`, and `.Version`. For example, `/{{.Namespace}}-{{.Name}}/{{.Version}}` will result in a default ingress of `/namespace-name/version`. |
+| readBufferSize | int | Per-connection buffer size for requests' reading. |
+| cors.enabled | boolean | Whether cors is enabled per function. |
+| cors.allowOrigin | string | Indicates where the CORS originates from (Default: '*'). |
+| cors.allowMethods | list of strings | Indicates which methods can be used during the actual request (Default: HEAD, GET, POST, PUT, DELETE, OPTIONS). |
+| cors.allowHeaders | list of strings | Indicates which header field names can be used during the actual request (Default: Accept, Content-Length, Content-Type, X-nuclio-log-level). |
+| cors.allowCredentials | boolean | Indicates that the actual request can include user credentials (Default: false). |
+| cors.preflightMaxAgeSeconds | int | Indicates how long the results of a preflight request can be cached in a preflight result cache (Default: -1, not cached) |
 
 ### Examples
 
-Without ingresseses -
+With 4 workers -
 
 ```yaml
 triggers:
   myHttpTrigger:
     maxWorkers: 4
+    kind: "http"
+```
+
+With predefined port number -
+
+```yaml
+triggers:
+  myHttpTrigger:
     kind: "http"
     attributes:
       port: 32001
@@ -28,10 +43,8 @@ With ingresseses -
 ```yaml
 triggers:
   myHttpTrigger:
-    maxWorkers: 4
     kind: "http"
     attributes:
-      port: 32001
   
       # See "Invoking Functions By Name With Kubernetes Ingresses" for more details
       # on configuring ingresses
@@ -46,3 +59,27 @@ triggers:
           - "MyFunctions/{{.Name}}/{{.Version}}"
 ```
 
+with CORS -
+
+```yaml
+triggers:
+  myCORSHttpTrigger:
+    kind: "http"
+    attributes:
+      CORS:
+        enabled: true
+        allowOrigin: "foo.bar"
+        allowHeaders:
+          - "Accept"
+          - "Content-Length"
+          - "Content-Type"
+          - "X-nuclio-log-level"
+          - "MyCustomAllowedRequestHeader"
+        allowMethods:
+          - "GET"
+          - "HEAD"
+          - "POST"
+          - "PATCH"
+        allowCredentials: false
+        preflightMaxAgeSeconds: 3600
+```

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -89,6 +89,17 @@ func StringSliceContainsString(slice []string, str string) bool {
 	return false
 }
 
+// returns whether the input str is in the slice case-insensitive
+func StringSliceContainsStringCaseInsensitive(slice []string, str string) bool {
+	for _, stringInSlice := range slice {
+		if strings.EqualFold(stringInSlice, str) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // strips out ANSI Colors chars from string
 // example: "\u001b[31mHelloWorld" -> "HelloWorld"
 func RemoveANSIColorsFromString(s string) string {

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -30,6 +30,7 @@ import (
 	"text/template"
 	"time"
 	"unicode/utf8"
+	"unsafe"
 
 	"github.com/nuclio/errors"
 )
@@ -303,4 +304,12 @@ func GetSourceDir() string {
 			return dirName
 		}
 	}
+}
+
+func ByteSlice2String(b []byte) string {
+
+	// https://golang.org/src/strings/builder.go#L45
+	// effectively converts bytes to string
+	// !! use with caution as returned string is mutable !!
+	return *(*string)(unsafe.Pointer(&b))
 }

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -317,7 +317,7 @@ func GetSourceDir() string {
 	}
 }
 
-func ByteSlice2String(b []byte) string {
+func ByteSliceToString(b []byte) string {
 
 	// https://golang.org/src/strings/builder.go#L45
 	// effectively converts bytes to string

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -226,11 +226,7 @@ func (suite *TestSuite) GetTestFunctionsDir() string {
 func (suite *TestSuite) GetTestHost() string {
 
 	// If an env var is set, use that. otherwise localhost
-	if os.Getenv("NUCLIO_TEST_HOST") != "" {
-		return os.Getenv("NUCLIO_TEST_HOST")
-	}
-
-	return "localhost"
+	return common.GetEnvOrDefaultString("NUCLIO_TEST_HOST", "localhost")
 }
 
 // GetDeployOptions populates a platform.CreateFunctionOptions structure from function name and path

--- a/pkg/processor/trigger/http/cors/cors.go
+++ b/pkg/processor/trigger/http/cors/cors.go
@@ -1,0 +1,106 @@
+package cors
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/nuclio/nuclio/pkg/common"
+
+	"github.com/valyala/fasthttp"
+)
+
+type CORS struct {
+	Enabled bool
+
+	// allow configuration
+	AllowOrigin      string
+	AllowMethods     []string
+	AllowHeaders     []string
+	AllowCredentials bool
+
+	// preflight
+	PreflightRequestMethod string
+	PreflightMaxAgeSeconds int64
+
+	// computed
+	allowMethodsStr           string
+	allowHeadersStr           string
+	preflightMaxAgeSecondsStr string
+	allowCredentialsStr       string
+	simpleMethods             []string
+}
+
+func NewCORS() *CORS {
+	return &CORS{
+		Enabled:     true,
+		AllowOrigin: "*",
+		AllowMethods: []string{
+			fasthttp.MethodHead,
+			fasthttp.MethodGet,
+			fasthttp.MethodPost,
+			fasthttp.MethodPut,
+			fasthttp.MethodDelete,
+			fasthttp.MethodOptions,
+		},
+		AllowHeaders: []string{
+			fasthttp.HeaderAccept,
+			fasthttp.HeaderContentLength,
+			fasthttp.HeaderContentType,
+
+			// nuclio custom
+			"X-nuclio-log-level",
+		},
+		AllowCredentials:       false,
+		PreflightRequestMethod: fasthttp.MethodOptions,
+		PreflightMaxAgeSeconds: -1, // disable cache by default
+	}
+}
+
+func (c *CORS) IsSetAndMatchOrigin(origin string) bool {
+	if origin == "" {
+		return false
+	}
+	return c.AllowOrigin == "*" || origin == c.AllowOrigin
+}
+
+func (c *CORS) IsSetAndMatchMethod(method string) bool {
+	return method != "" &&
+		(method == c.PreflightRequestMethod || common.StringSliceContainsString(c.AllowMethods, method))
+}
+
+func (c *CORS) AreMatchHeaders(headers []string) bool {
+	for _, header := range headers {
+		if !common.StringSliceContainsStringCaseInsensitive(c.AllowHeaders, header) {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *CORS) GetComputedAllowMethodsStr() string {
+	if c.allowMethodsStr == "" {
+		c.allowMethodsStr = strings.Join(c.AllowMethods, ", ")
+	}
+	return c.allowMethodsStr
+}
+
+func (c *CORS) GetComputedAllowHeadersStr() string {
+	if c.allowHeadersStr == "" {
+		c.allowHeadersStr = strings.Join(c.AllowHeaders, ", ")
+	}
+	return c.allowHeadersStr
+}
+
+func (c *CORS) GetComputedAllowCredentialsHeaderStr() string {
+	if c.allowCredentialsStr == "" {
+		c.allowCredentialsStr = strconv.FormatBool(c.AllowCredentials)
+	}
+	return c.allowHeadersStr
+}
+
+func (c *CORS) GetComputedPreflightMaxAgeSecondsStr() string {
+	if c.preflightMaxAgeSecondsStr == "" {
+		c.preflightMaxAgeSecondsStr = strconv.FormatInt(c.PreflightMaxAgeSeconds, 10)
+	}
+	return c.preflightMaxAgeSecondsStr
+}

--- a/pkg/processor/trigger/http/cors/cors.go
+++ b/pkg/processor/trigger/http/cors/cors.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cors
 
 import (

--- a/pkg/processor/trigger/http/cors/cors.go
+++ b/pkg/processor/trigger/http/cors/cors.go
@@ -72,19 +72,19 @@ func NewCORS() *CORS {
 	}
 }
 
-func (c *CORS) IsSetAndMatchOrigin(origin string) bool {
+func (c *CORS) OriginAllowed(origin string) bool {
 	if origin == "" {
 		return false
 	}
 	return c.AllowOrigin == "*" || origin == c.AllowOrigin
 }
 
-func (c *CORS) IsSetAndMatchMethod(method string) bool {
+func (c *CORS) MethodAllowed(method string) bool {
 	return method != "" &&
 		(method == c.PreflightRequestMethod || common.StringSliceContainsString(c.AllowMethods, method))
 }
 
-func (c *CORS) AreMatchHeaders(headers []string) bool {
+func (c *CORS) HeadersAllowed(headers []string) bool {
 	for _, header := range headers {
 		if !common.StringSliceContainsStringCaseInsensitive(c.AllowHeaders, header) {
 			return false
@@ -93,28 +93,28 @@ func (c *CORS) AreMatchHeaders(headers []string) bool {
 	return true
 }
 
-func (c *CORS) GetComputedAllowMethodsStr() string {
+func (c *CORS) EncodedAllowMethods() string {
 	if c.allowMethodsStr == "" {
 		c.allowMethodsStr = strings.Join(c.AllowMethods, ", ")
 	}
 	return c.allowMethodsStr
 }
 
-func (c *CORS) GetComputedAllowHeadersStr() string {
+func (c *CORS) EncodeAllowHeaders() string {
 	if c.allowHeadersStr == "" {
 		c.allowHeadersStr = strings.Join(c.AllowHeaders, ", ")
 	}
 	return c.allowHeadersStr
 }
 
-func (c *CORS) GetComputedAllowCredentialsHeaderStr() string {
+func (c *CORS) EncodeAllowCredentialsHeader() string {
 	if c.allowCredentialsStr == "" {
 		c.allowCredentialsStr = strconv.FormatBool(c.AllowCredentials)
 	}
 	return c.allowHeadersStr
 }
 
-func (c *CORS) GetComputedPreflightMaxAgeSecondsStr() string {
+func (c *CORS) EncodePreflightMaxAgeSeconds() string {
 	if c.preflightMaxAgeSecondsStr == "" {
 		c.preflightMaxAgeSecondsStr = strconv.FormatInt(c.PreflightMaxAgeSeconds, 10)
 	}

--- a/pkg/processor/trigger/http/http_test.go
+++ b/pkg/processor/trigger/http/http_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2018 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"net"
+	nethttp "net/http"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/processor/test/suite"
+	"github.com/nuclio/nuclio/pkg/processor/trigger"
+	httpcors "github.com/nuclio/nuclio/pkg/processor/trigger/http/cors"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/fasthttputil"
+)
+
+type TestSuite struct {
+	processorsuite.TestSuite
+	trigger             http
+	fastDummyHttpServer *fasthttputil.InmemoryListener
+}
+
+func (suite *TestSuite) SetupSuite() {
+	suite.TestSuite.SetupSuite()
+	suite.trigger = http{
+		AbstractTrigger: trigger.AbstractTrigger{
+			Logger:          suite.Logger,
+			WorkerAllocator: nil,
+		},
+		events: []Event{},
+		configuration: &Configuration{
+			Configuration: trigger.Configuration{
+				Trigger: functionconfig.Trigger{
+					URL: ":0", // let OS pick a port for me
+				},
+				ID: "999",
+			},
+			ReadBufferSize: DefaultReadBufferSize,
+			CORS:           *httpcors.NewCORS(),
+		},
+	}
+	suite.fastDummyHttpServer = fasthttputil.NewInmemoryListener()
+	go func() {
+		err := fasthttp.Serve(suite.fastDummyHttpServer, suite.trigger.handleRequest())
+		if err != nil {
+			suite.Require().NoError(err, "Failed to serve")
+		}
+	}()
+}
+
+func (suite *TestSuite) TearDownSuite() {
+	suite.fastDummyHttpServer.Close() // nolint: errcheck
+}
+
+func (suite *TestSuite) TestCORS() {
+	client := suite.getClient()
+	for _, testCase := range []struct {
+		CORSAllowOrigin            string
+		RequestOrigin              string
+		RequestMethod              string
+		RequestHeaders             []string
+		ExpectedResponseStatusCode int
+		ExpectedResponseHeaders    map[string]string
+	}{
+
+		// happy flow
+		{
+			CORSAllowOrigin: "foo.bar",
+			RequestOrigin:   "foo.bar",
+			RequestMethod:   "GET",
+			RequestHeaders: []string{
+				"X-Nuclio-log-level",
+			},
+			ExpectedResponseStatusCode: fasthttp.StatusOK,
+			ExpectedResponseHeaders: map[string]string{
+				"Access-Control-Allow-Origin":  "foo.bar",
+				"Access-Control-Allow-Methods": "HEAD, GET, POST, PUT, DELETE, OPTIONS",
+				"Access-Control-Max-Age":       "-1",
+				"Access-Control-Allow-Headers": "Accept, Content-Length, Content-Type, X-nuclio-log-level",
+			},
+		},
+
+		// invalid origin
+		{
+			CORSAllowOrigin:            "foo.bar",
+			RequestOrigin:              "baz.bar",
+			RequestMethod:              "GET",
+			ExpectedResponseStatusCode: fasthttp.StatusBadRequest,
+		},
+
+		// invalid request header
+		{
+			RequestOrigin: "foo.bar",
+			RequestMethod: "GET",
+			RequestHeaders: []string{
+				"Not-supported-header",
+			},
+			ExpectedResponseStatusCode: fasthttp.StatusBadRequest,
+		},
+
+		// invalid request method
+		{
+			RequestOrigin:              "foo.bar",
+			RequestMethod:              "ABC",
+			ExpectedResponseStatusCode: fasthttp.StatusBadRequest,
+		},
+	} {
+		suite.Logger.DebugWith("Testing CORS", "testCase", testCase)
+
+		// set cors configuration
+		cors := httpcors.NewCORS()
+		if testCase.CORSAllowOrigin != "" {
+			cors.AllowOrigin = testCase.CORSAllowOrigin
+		}
+		suite.trigger.configuration.CORS = *cors
+
+		// create request, use OPTIONS to trigger preflight flow
+		request, err := nethttp.NewRequest(fasthttp.MethodOptions, "http://foo.bar/", nil)
+		suite.NoError(err, "Failed to create new request")
+
+		// set preflight required headers
+		request.Header.Set("Origin", testCase.RequestOrigin)
+		request.Header.Set("Access-Control-Request-Method", testCase.RequestMethod)
+		for _, headerName := range testCase.RequestHeaders {
+			request.Header.Add("Access-Control-Request-Headers", headerName)
+		}
+
+		// do request
+		response, err := client.Do(request)
+		suite.Require().NoError(err, "Failed to do request")
+		suite.Logger.DebugWith("Received response",
+			"headers", response.Header,
+			"statusCode", response.StatusCode)
+
+		// check for response status code
+		suite.Equal(testCase.ExpectedResponseStatusCode, response.StatusCode)
+
+		// check for response headers
+		for headerName, headerValue := range testCase.ExpectedResponseHeaders {
+			suite.Equal(response.Header.Get(headerName), headerValue)
+		}
+	}
+
+}
+
+func (suite *TestSuite) getClient() *nethttp.Client {
+	return &nethttp.Client{
+		Transport: &nethttp.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return suite.fastDummyHttpServer.Dial()
+			},
+		},
+	}
+}
+
+func TestHTTPSuite(t *testing.T) {
+	suite.Run(t, new(TestSuite))
+}

--- a/pkg/processor/trigger/http/test/suite/http_test.go
+++ b/pkg/processor/trigger/http/test/suite/http_test.go
@@ -38,7 +38,7 @@ func (suite *HTTPTestSuite) SetupTest() {
 	suite.triggerName = "testHTTP"
 }
 
-func (suite *HTTPTestSuite) TestPostCORS() {
+func (suite *HTTPTestSuite) TestCORS() {
 	allowHeaders := "Accept, Content-Length, Content-Type, X-nuclio-log-level"
 	allowMethods := "OPTIONS, GET, POST, HEAD, PUT"
 	allowOrigin := "foo.bar"

--- a/pkg/processor/trigger/http/test/suite/http_test.go
+++ b/pkg/processor/trigger/http/test/suite/http_test.go
@@ -43,7 +43,7 @@ func (suite *HTTPTestSuite) TestCORS() {
 	allowMethods := "OPTIONS, GET, POST, HEAD, PUT"
 	allowOrigin := "foo.bar"
 	createFunctionOptions := suite.getHTTPDeployOptions()
-	createFunctionOptions.FunctionConfig.Spec.Triggers[suite.triggerName].Attributes["CORS"] = map[string]interface{}{
+	createFunctionOptions.FunctionConfig.Spec.Triggers[suite.triggerName].Attributes["cors"] = map[string]interface{}{
 		"enabled":      true,
 		"allowOrigin":  allowOrigin,
 		"allowHeaders": strings.Split(allowHeaders, ", "),

--- a/pkg/processor/trigger/http/test/suite/http_test.go
+++ b/pkg/processor/trigger/http/test/suite/http_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2018 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpsuite
+
+import (
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platform"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/valyala/fasthttp"
+)
+
+type HTTPTestSuite struct {
+	TestSuite
+	triggerName string
+}
+
+func (suite *HTTPTestSuite) SetupTest() {
+	suite.TestSuite.SetupTest()
+	suite.triggerName = "testHTTP"
+}
+
+func (suite *HTTPTestSuite) TestPostCORS() {
+	allowHeaders := "Accept, Content-Length, Content-Type, X-nuclio-log-level"
+	allowMethods := "OPTIONS, GET, POST, HEAD, PUT"
+	allowOrigin := "foo.bar"
+	createFunctionOptions := suite.getHTTPDeployOptions()
+	createFunctionOptions.FunctionConfig.Spec.Triggers[suite.triggerName].Attributes["CORS"] = map[string]interface{}{
+		"enabled":      true,
+		"allowOrigin":  allowOrigin,
+		"allowHeaders": strings.Split(allowHeaders, ", "),
+		"allowMethods": strings.Split(allowMethods, ", "),
+	}
+	validPreflightResponseStatusCode := fasthttp.StatusOK
+	invalidPreflightResponseStatusCode := fasthttp.StatusBadRequest
+	suite.DeployFunctionAndRequests(createFunctionOptions,
+		[]*Request{
+
+			// Happy flow
+			{
+				RequestMethod: "OPTIONS",
+				RequestHeaders: map[string]interface{}{
+					"Origin":                         allowOrigin,
+					"Access-Control-Request-Method":  "POST",
+					"Access-Control-Request-Headers": "X-nuclio-log-level",
+				},
+				ExpectedResponseStatusCode: &validPreflightResponseStatusCode,
+				ExpectedResponseHeadersValues: map[string][]string{
+					"Access-Control-Allow-Methods": {allowMethods},
+					"Access-Control-Allow-Headers": {allowHeaders},
+					"Access-Control-Allow-Origin":  {allowOrigin},
+				},
+			},
+
+			// Disallowed request method
+			{
+				RequestMethod: "OPTIONS",
+				RequestHeaders: map[string]interface{}{
+					"Origin":                        allowOrigin,
+					"Access-Control-Request-Method": "ABC",
+				},
+				ExpectedResponseStatusCode: &invalidPreflightResponseStatusCode,
+			},
+		})
+}
+
+func (suite *HTTPTestSuite) getHTTPDeployOptions() *platform.CreateFunctionOptions {
+	createFunctionOptions := suite.GetDeployOptions("event_recorder",
+		suite.GetFunctionPath(path.Join("event_recorder_python")))
+
+	createFunctionOptions.FunctionConfig.Spec.Runtime = "python"
+	createFunctionOptions.FunctionConfig.Meta.Name = "http-trigger-test"
+	createFunctionOptions.FunctionConfig.Spec.Build.Path = path.Join(suite.GetTestFunctionsDir(),
+		"common",
+		"event-recorder",
+		"python",
+		"event_recorder.py")
+	createFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{
+		suite.triggerName: {
+			Kind:       "http",
+			Attributes: map[string]interface{}{},
+		},
+	}
+	return createFunctionOptions
+}
+
+func TestIntegrationSuite(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	suite.Run(t, new(HTTPTestSuite))
+}

--- a/pkg/processor/trigger/http/test/suite/suite.go
+++ b/pkg/processor/trigger/http/test/suite/suite.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -135,15 +134,8 @@ func (suite *TestSuite) SendRequestVerifyResponse(request *Request) bool {
 		"requestBody", request.RequestBody,
 		"requestLogLevel", request.RequestLogLevel)
 
-	baseURL := "localhost"
-
-	// change verify-url if needed to ask from docker ip
-	if os.Getenv("NUCLIO_TEST_HOST") != "" {
-		baseURL = os.Getenv("NUCLIO_TEST_HOST")
-	}
-
 	// Send request to proper url
-	url := fmt.Sprintf("http://%s:%d%s", baseURL, request.RequestPort, request.RequestPath)
+	url := fmt.Sprintf("http://%s:%d%s", suite.GetTestHost(), request.RequestPort, request.RequestPath)
 
 	// create a request
 	httpRequest, err := http.NewRequest(request.RequestMethod, url, strings.NewReader(request.RequestBody))

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -436,7 +436,6 @@ func (h *http) preflightRequestValidation(ctx *fasthttp.RequestCtx, origin strin
 
 		// ensure request headers allowed (it can also be empty)
 		if !h.configuration.CORS.HeadersAllowed(strings.Split(headers, ", ")) {
-			h.UpdateStatistics(false)
 			return false
 		}
 	}

--- a/pkg/processor/trigger/http/types.go
+++ b/pkg/processor/trigger/http/types.go
@@ -56,8 +56,11 @@ func NewConfiguration(ID string,
 	}
 
 	if newConfiguration.CORS.Enabled {
+
+		// take defaults
 		_cors := cors.NewCORS()
 
+		// override with custom configuration if provided
 		if len(newConfiguration.CORS.AllowHeaders) > 0 {
 			_cors.AllowHeaders = newConfiguration.CORS.AllowHeaders
 		}
@@ -73,6 +76,8 @@ func NewConfiguration(ID string,
 		if newConfiguration.CORS.AllowCredentials {
 			_cors.AllowCredentials = newConfiguration.CORS.AllowCredentials
 		}
+
+		_cors.PreflightMaxAgeSeconds = newConfiguration.CORS.PreflightMaxAgeSeconds
 
 		newConfiguration.CORS = *_cors
 	}

--- a/pkg/processor/trigger/http/types.go
+++ b/pkg/processor/trigger/http/types.go
@@ -29,7 +29,7 @@ import (
 type Configuration struct {
 	trigger.Configuration
 	ReadBufferSize int
-	CORS           cors.CORS
+	CORS           *cors.CORS
 }
 
 const DefaultReadBufferSize = 16 * 1024
@@ -55,32 +55,36 @@ func NewConfiguration(ID string,
 		newConfiguration.ReadBufferSize = DefaultReadBufferSize
 	}
 
-	if newConfiguration.CORS.Enabled {
+	if newConfiguration.CORS != nil && newConfiguration.CORS.Enabled {
+		newConfiguration.CORS = createCORSConfiguration(newConfiguration.CORS)
+	}
+	return &newConfiguration, nil
+}
 
-		// take defaults
-		_cors := cors.NewCORS()
+func createCORSConfiguration(CORSConfiguration *cors.CORS) *cors.CORS {
 
-		// override with custom configuration if provided
-		if len(newConfiguration.CORS.AllowHeaders) > 0 {
-			_cors.AllowHeaders = newConfiguration.CORS.AllowHeaders
-		}
+	// take defaults
+	corsInstance := cors.NewCORS()
 
-		if len(newConfiguration.CORS.AllowMethods) > 0 {
-			_cors.AllowMethods = newConfiguration.CORS.AllowMethods
-		}
-
-		if newConfiguration.CORS.AllowOrigin != "" {
-			_cors.AllowOrigin = newConfiguration.CORS.AllowOrigin
-		}
-
-		if newConfiguration.CORS.AllowCredentials {
-			_cors.AllowCredentials = newConfiguration.CORS.AllowCredentials
-		}
-
-		_cors.PreflightMaxAgeSeconds = newConfiguration.CORS.PreflightMaxAgeSeconds
-
-		newConfiguration.CORS = *_cors
+	// override with custom configuration if provided
+	if len(CORSConfiguration.AllowHeaders) > 0 {
+		corsInstance.AllowHeaders = CORSConfiguration.AllowHeaders
 	}
 
-	return &newConfiguration, nil
+	if len(CORSConfiguration.AllowMethods) > 0 {
+		corsInstance.AllowMethods = CORSConfiguration.AllowMethods
+	}
+
+	if CORSConfiguration.AllowOrigin != "" {
+		corsInstance.AllowOrigin = CORSConfiguration.AllowOrigin
+	}
+
+	if CORSConfiguration.AllowCredentials {
+		corsInstance.AllowCredentials = CORSConfiguration.AllowCredentials
+	}
+
+	corsInstance.PreflightMaxAgeSeconds = CORSConfiguration.PreflightMaxAgeSeconds
+
+	return corsInstance
+
 }

--- a/pkg/processor/trigger/http/types.go
+++ b/pkg/processor/trigger/http/types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
+	"github.com/nuclio/nuclio/pkg/processor/trigger/http/cors"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/nuclio/errors"
@@ -28,6 +29,7 @@ import (
 type Configuration struct {
 	trigger.Configuration
 	ReadBufferSize int
+	CORS           cors.CORS
 }
 
 const DefaultReadBufferSize = 16 * 1024
@@ -51,6 +53,28 @@ func NewConfiguration(ID string,
 
 	if newConfiguration.ReadBufferSize == 0 {
 		newConfiguration.ReadBufferSize = DefaultReadBufferSize
+	}
+
+	if newConfiguration.CORS.Enabled {
+		_cors := cors.NewCORS()
+
+		if len(newConfiguration.CORS.AllowHeaders) > 0 {
+			_cors.AllowHeaders = newConfiguration.CORS.AllowHeaders
+		}
+
+		if len(newConfiguration.CORS.AllowMethods) > 0 {
+			_cors.AllowMethods = newConfiguration.CORS.AllowMethods
+		}
+
+		if newConfiguration.CORS.AllowOrigin != "" {
+			_cors.AllowOrigin = newConfiguration.CORS.AllowOrigin
+		}
+
+		if newConfiguration.CORS.AllowCredentials {
+			_cors.AllowCredentials = newConfiguration.CORS.AllowCredentials
+		}
+
+		newConfiguration.CORS = *_cors
 	}
 
 	return &newConfiguration, nil

--- a/pkg/processor/trigger/http/types.go
+++ b/pkg/processor/trigger/http/types.go
@@ -30,6 +30,8 @@ type Configuration struct {
 	ReadBufferSize int
 }
 
+const DefaultReadBufferSize = 16 * 1024
+
 func NewConfiguration(ID string,
 	triggerConfiguration *functionconfig.Trigger,
 	runtimeConfiguration *runtime.Configuration) (*Configuration, error) {
@@ -48,7 +50,7 @@ func NewConfiguration(ID string,
 	}
 
 	if newConfiguration.ReadBufferSize == 0 {
-		newConfiguration.ReadBufferSize = 16 * 1024
+		newConfiguration.ReadBufferSize = DefaultReadBufferSize
 	}
 
 	return &newConfiguration, nil

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -17,7 +17,6 @@ limitations under the License.
 package trigger
 
 import (
-	"fmt"
 	"runtime/debug"
 	"strings"
 	"sync/atomic"
@@ -243,7 +242,7 @@ func (at *AbstractTrigger) HandleSubmitPanic(workerInstance *worker.Worker,
 			"stack",
 			string(callStack))
 
-		*submitError = fmt.Errorf("Caught panic: %s", err)
+		*submitError = errors.Errorf("Caught panic: %s", err)
 
 		if workerInstance != nil {
 			workerInstance.ResetEventTime()


### PR DESCRIPTION
tl;dr: Implemented https://github.com/nuclio/nuclio/issues/640
with some additional stuff (such as max-age, credentials)

To support CORS by the [following guideline](https://www.w3.org/TR/cors/#access-control-allow-methods-response-header), we required to ensure the function respond to a preflight requests (default on method `OPTIONS`), that have a price for the processor not delegating the request to the function (meaning, function will not be able to answer to `OPTIONS` when CORS is enabled)

A CORS is valid when returned code is 200, and invalid otherwise (currently, it will return 400 to any bad preflight request)
