### PR TITLE
Fix function deployment failure when deploying with more than 1 controller pod

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -425,7 +425,7 @@ func (lc *lazyClient) createOrUpdateResource(resourceName string,
 				}
 
 				// this case could happen if several controllers are running in parallel. (may happen on rolling upgrade of the controller)
-				lc.logger.DebugWith("Got \"resource already exists\" error on creation. Retrying",
+				lc.logger.WarnWith("Got \"resource already exists\" error on creation. Retrying (Perhaps more than 1 controller is running?)",
 					"name", resourceName,
 					"err", err.Error())
 				continue

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -431,6 +431,7 @@ func (lc *lazyClient) createOrUpdateResource(resourceName string,
 				continue
 			}
 
+			lc.logger.DebugWith("Resource created", "name", resourceName)
 			return resource, nil
 		}
 


### PR DESCRIPTION
**Bug:**
When more than 1 nuclio-controller is running (happens during rolling-upgrade) and a function is deployed - deployment will fail with "configmaps _function-name_ already exists" (configmap is just the first resource to be created on function deployment flow)
This happens because the second controller will try to create the function's configmap after the first already has - and it will change the function's state to _error_.

**Solution:**
Solves this problem by just retrying to create/update the resource whenever this happens - so on the second iteration it will just update the resource (because it already exists) instead of creating.