### PR TITLE
K8s helm charts - Adding configmaps/secrets to pod spec annotations to invoke pod restarts

### DIFF
--- a/hack/k8s/helm/nuclio/templates/deployment/autoscaler.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/autoscaler.yaml
@@ -36,6 +36,7 @@ spec:
         nuclio.io/name: {{ template "nuclio.scalerName" . }}
       annotations:
         nuclio.io/version: {{ .Values.autoscaler.image.tag }}
+        checksum/configmap-platform: {{ include (print $.Template.BasePath "/configmap/platform.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "nuclio.serviceAccountName" . }}
       containers:

--- a/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
@@ -36,6 +36,7 @@ spec:
         nuclio.io/name: {{ template "nuclio.controllerName" . }}
       annotations:
         nuclio.io/version: {{ .Values.controller.image.tag }}
+        checksum/configmap-platform: {{ include (print $.Template.BasePath "/configmap/platform.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "nuclio.serviceAccountName" . }}
       containers:

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -36,6 +36,8 @@ spec:
         nuclio.io/class: service
       annotations:
         nuclio.io/version: {{ .Values.dashboard.image.tag }}
+        checksum/secret-registry-credentials: {{ include (print $.Template.BasePath "/secret/registry-credentials.yaml") . | sha256sum }}
+        checksum/configmap-registry-url: {{ include (print $.Template.BasePath "/configmap/registry-url.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "nuclio.serviceAccountName" . }}
       containers:

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -38,6 +38,7 @@ spec:
         nuclio.io/version: {{ .Values.dashboard.image.tag }}
         checksum/secret-registry-credentials: {{ include (print $.Template.BasePath "/secret/registry-credentials.yaml") . | sha256sum }}
         checksum/configmap-registry-url: {{ include (print $.Template.BasePath "/configmap/registry-url.yaml") . | sha256sum }}
+        checksum/configmap-platform: {{ include (print $.Template.BasePath "/configmap/platform.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "nuclio.serviceAccountName" . }}
       containers:

--- a/hack/k8s/helm/nuclio/templates/deployment/dlx.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dlx.yaml
@@ -36,6 +36,7 @@ spec:
         nuclio.io/name: {{ template "nuclio.dlxName" . }}
       annotations:
         nuclio.io/version: {{ .Values.dlx.image.tag }}
+        checksum/configmap-platform: {{ include (print $.Template.BasePath "/configmap/platform.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "nuclio.serviceAccountName" . }}
       containers:


### PR DESCRIPTION
This will ensure a pod restart upon changes of registry credentials / url and other spec changes which require restarts

- Adding docker url configmap/secret as checksums to dashboard pod template 