### PR TITLE
Retry on function build failed due to missing cached layer

### DIFF
--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -111,7 +111,7 @@ func (c *ShellClient) Build(buildOptions *BuildOptions) error {
 		hostNetString = ""
 	}
 
-	return common.RetryUntilSuccessful(time.Hour*1, 1*time.Minute, func() bool {
+	return common.RetryUntilSuccessful(1*time.Hour, 1*time.Minute, func() bool {
 		runResults, err := c.runCommand(runOptions,
 			"docker build %s --force-rm -t %s -f %s %s %s .",
 			hostNetString,

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -111,15 +111,21 @@ func (c *ShellClient) Build(buildOptions *BuildOptions) error {
 		hostNetString = ""
 	}
 
-	_, err := c.runCommand(runOptions,
-		"docker build %s --force-rm -t %s -f %s %s %s .",
-		hostNetString,
-		buildOptions.Image,
-		buildOptions.DockerfilePath,
-		cacheOption,
-		buildArgs)
+	return common.RetryUntilSuccessful(time.Hour*1, 1*time.Minute, func() bool {
+		runResults, err := c.runCommand(runOptions,
+			"docker build %s --force-rm -t %s -f %s %s %s .",
+			hostNetString,
+			buildOptions.Image,
+			buildOptions.DockerfilePath,
+			cacheOption,
+			buildArgs)
 
-	return err
+		// retry on a race condition where `--force-rm` removes a cached layer for other function build in process
+		if err != nil && strings.HasPrefix(runResults.Stderr, "No such image: sha256:") {
+			return false
+		}
+		return true
+	})
 }
 
 // CopyObjectsFromImage copies objects (files, directories) from a given image to local storage. it does


### PR DESCRIPTION
Bug description:
Upon function build burst, there's a race condition between a built function that removes its cached layers to a new function being built that try to reused that very cached layer.
Since we use `--force-rm` to eliminate both successful & failed builds containers, we strike with an error `No such image: sha256:....\n` in which tells us that the cached layer we are trying to retrieve is gone. (we distinguish between existing image and cached layer when using `sha256:` as a prefix to the cached layer name)

To tackle this we are left with 2 options
1. Use the default `--rm=true` in which eliminate successful builds only, but that means we would need to handle removal of failed build leftovers (containers and etc)
2. Retry when such an error happened

option (2) is implemented here, as we don't need to "reinvent" the wheel with doing what `docker` has already gave us freely.
