### PR TITLE
[DOC REVIEW for PR #1640] HTTP trigger: add CORS attributes; Kafka trigger reference: fix typo

### DIFF
--- a/docs/reference/triggers/http.md
+++ b/docs/reference/triggers/http.md
@@ -9,13 +9,13 @@ The HTTP trigger is the only trigger created by default if not configured (by de
 | port | int | The NodePort (or equivalent) on which the function will serve HTTP requests. If empty, chooses a random port within the platform range. |
 | ingresses.(name).host | string | The host to which the ingress maps. |
 | ingresses.(name).paths | list of strings | The paths that the ingress handles. Variables of the form `{{.<NAME>}}` can be specified using `.Name`, `.Namespace`, and `.Version`. For example, `/{{.Namespace}}-{{.Name}}/{{.Version}}` will result in a default ingress of `/namespace-name/version`. |
-| readBufferSize | int | Per-connection buffer size for requests' reading. |
-| cors.enabled | boolean | Whether cors is enabled per function. |
-| cors.allowOrigin | string | Indicates where the CORS originates from (Default: '*'). |
-| cors.allowMethods | list of strings | Indicates which methods can be used during the actual request (Default: HEAD, GET, POST, PUT, DELETE, OPTIONS). |
-| cors.allowHeaders | list of strings | Indicates which header field names can be used during the actual request (Default: Accept, Content-Length, Content-Type, X-nuclio-log-level). |
-| cors.allowCredentials | boolean | Indicates that the actual request can include user credentials (Default: false). |
-| cors.preflightMaxAgeSeconds | int | Indicates how long the results of a preflight request can be cached in a preflight result cache (Default: -1, not cached) |
+| readBufferSize | int | Per-connection buffer size for reading requests. |
+| cors.enabled | bool | `true` to enable cross-origin resource sharing (CORS) for each function; (default: `false`). |
+| cors.allowOrigin | string | Indicates that the CORS response can be shared with requesting code from the specified origin (`Access-Control-Allow-Origin` response header); (default: `'*'` to allow sharing with any origin, for requests without credentials). |
+| cors.allowMethods | list of strings | HTTP methods that can be used when accessing the resource in response to a preflight request (`Access-Control-Allow-Methods` response header); (default: `"HEAD, GET, POST, PUT, DELETE, OPTIONS"`). |
+| cors.allowHeaders | list of strings | HTTP headers can be used during the actual request (`Access-Control-Allow-Headers` response header); (default: `"Accept, Content-Length, Content-Type, X-nuclio-log-level"`). |
+| cors.allowCredentials | bool | `true` to allow user credentials in the actual request (`Access-Control-Allow-Credentials` response header); (default: `false`). |
+| cors.preflightMaxAgeSeconds | int | The number of seconds in which the results of a preflight request can be cached in a preflight result cache (`Access-Control-Max-Age` response header); (default: `-1` to indicate no preflight results caching). |
 
 ### Examples
 

--- a/docs/reference/triggers/http.md
+++ b/docs/reference/triggers/http.md
@@ -10,7 +10,7 @@ The HTTP trigger is the only trigger created by default if not configured (by de
 | ingresses.(name).host | string | The host to which the ingress maps. |
 | ingresses.(name).paths | list of strings | The paths that the ingress handles. Variables of the form `{{.<NAME>}}` can be specified using `.Name`, `.Namespace`, and `.Version`. For example, `/{{.Namespace}}-{{.Name}}/{{.Version}}` will result in a default ingress of `/namespace-name/version`. |
 | readBufferSize | int | Per-connection buffer size for reading requests. |
-| cors.enabled | bool | `true` to enable cross-origin resource sharing (CORS) for each function; (default: `false`). |
+| cors.enabled | bool | `true` to enable cross-origin resource sharing (CORS); (default: `false`). |
 | cors.allowOrigin | string | Indicates that the CORS response can be shared with requesting code from the specified origin (`Access-Control-Allow-Origin` response header); (default: `'*'` to allow sharing with any origin, for requests without credentials). |
 | cors.allowMethods | list of strings | HTTP methods that can be used when accessing the resource in response to a preflight request (`Access-Control-Allow-Methods` response header); (default: `"HEAD, GET, POST, PUT, DELETE, OPTIONS"`). |
 | cors.allowHeaders | list of strings | HTTP headers can be used during the actual request (`Access-Control-Allow-Headers` response header); (default: `"Accept, Content-Length, Content-Type, X-nuclio-log-level"`). |

--- a/docs/reference/triggers/http.md
+++ b/docs/reference/triggers/http.md
@@ -12,8 +12,8 @@ The HTTP trigger is the only trigger created by default if not configured (by de
 | readBufferSize | int | Per-connection buffer size for reading requests. |
 | cors.enabled | bool | `true` to enable cross-origin resource sharing (CORS); (default: `false`). |
 | cors.allowOrigin | string | Indicates that the CORS response can be shared with requesting code from the specified origin (`Access-Control-Allow-Origin` response header); (default: `'*'` to allow sharing with any origin, for requests without credentials). |
-| cors.allowMethods | list of strings | HTTP methods that can be used when accessing the resource in response to a preflight request (`Access-Control-Allow-Methods` response header); (default: `"HEAD, GET, POST, PUT, DELETE, OPTIONS"`). |
-| cors.allowHeaders | list of strings | HTTP headers can be used during the actual request (`Access-Control-Allow-Headers` response header); (default: `"Accept, Content-Length, Content-Type, X-nuclio-log-level"`). |
+| cors.allowMethods | list of strings | The allowed HTTP methods, which can be used when accessing the resource (`Access-Control-Allow-Methods` response header); (default: `"HEAD, GET, POST, PUT, DELETE, OPTIONS"`). |
+| cors.allowHeaders | list of strings | The allowed HTTP headers, which can be used when accessing the resource (`Access-Control-Allow-Headers` response header); (default: `"Accept, Content-Length, Content-Type, X-nuclio-log-level"`). |
 | cors.allowCredentials | bool | `true` to allow user credentials in the actual request (`Access-Control-Allow-Credentials` response header); (default: `false`). |
 | cors.preflightMaxAgeSeconds | int | The number of seconds in which the results of a preflight request can be cached in a preflight result cache (`Access-Control-Max-Age` response header); (default: `-1` to indicate no preflight results caching). |
 

--- a/docs/reference/triggers/kafka.md
+++ b/docs/reference/triggers/kafka.md
@@ -99,7 +99,7 @@ For more information on Nuclio function configuration, see the [function-configu
   **Type:** `object` with the following attributes -
 
   - **`enable`** (`bool`) - Enable authentication.
-  - **`user`** (`string`) - Username to be used for authenticatio.
+  - **`user`** (`string`) - Username to be used for authentication.
   - **`password`** (`string`) - Password to be used for authentication.
 
 - <a id="sessionTimeout"></a>**`sessionTimeout`** (`kafka-session-timeout`) - The timeout used to detect consumer failures when using Kafka's group management facility. The consumer sends periodic heartbeats to indicate its liveness to the broker. If no heartbeats are received by the broker before the expiration of this session timeout, the broker removes this consumer from the group and initiates rebalancing. Note that the value must be in the allowable range, as configured in the `group.min.session.timeout.ms` and `group.max.session.timeout.ms` broker configuration parameters.


### PR DESCRIPTION
@liranbg in addition to the PR #1640 HTTP trigger CORS review, I also fixed a typo in the Kafka trigger reference ("authenticatio" > "authentication") — see commit 05b9ffb. Please merge this fix also to `1.3.x` and any other active branches.