### PR TITLE
[DOC REVIEW for PR #1648] v3ioStream trigger reference: new example using v3ctl

### DIFF
--- a/docs/reference/triggers/v3iostream.md
+++ b/docs/reference/triggers/v3iostream.md
@@ -141,8 +141,6 @@ done;
 
 After the command completes successfully, the stream is ready for consumption by a Nuclio function. To test this, do the following from the dashboard's **Projects** page, to define and deploy a function that consumes the stream records and uses a `v3ioStream` trigger.
 
-> **Note:** Before you deploy the function, ensure that the log-forwarder service is enabled (see the **Services** dashboard page), so that you can view the function logs.
-
 1.  Select an existing project or create a new project, and then create a new Python function. Select to create the function from scratch.
 
 2.  On the function page, in the **Code** tab, set **Code entry type** to "Source code (edit online)" (default), and enter the following code in the **Source code** text box to define a function that logs the shard-ID event body and sleeps for 5 seconds:
@@ -171,7 +169,7 @@ After the command completes successfully, the stream is ready for consumption by
 
 4.  Select **Deploy** to deploy your function.
 
-After the deployment succeeds, check the logs of the function pods (see the **Logs** dashboard page) and watch the events being handled (see the **Events** dashboard page). The logs should contain the following:
+After the deployment succeeds, check the logs of the function pods and see the information about the Nuclio events that are handled by the function. You can view the logs by running `kubectl` from a platform web-shell or a Jupyter Notebook service, or from the platform dashboard's **Logs** page (when the log-forwarder service is enabled). The logs should contain the following:
 ```
 { ... "message":"Got event","more":"shard_id=<shard ID> || body=shard-<shard ID>-record-<record ID> || worker_id=<worker ID>" ...}
 ```

--- a/docs/reference/triggers/v3iostream.md
+++ b/docs/reference/triggers/v3iostream.md
@@ -123,7 +123,7 @@ The stream has a retention period of 24 hours (`--retention-period`) and 32 shar
     --shard-count 32
 ```
 
-Now, use the `create stream record` CLI command to add 10 records (IDs `1`-`10`) to each stream shard (`--shard-id`, which is set to a zero-based shard ID - `0`-`9`).
+Now, use the `create stream record` CLI command to add 10 records (IDs `1`-`10`) to each stream shard (`--shard-id`, which is set to a zero-based shard ID - `0`-`31`).
 For test purposes, the ingested record data in the example is a string denoting the shard and record IDs - `shard-$shard_id-record-$record_id` (`--data`).
 As in the `create stream` command, the stream path is set to a "test-stream-0" stream in the root directory of the "users" data container, by using the stream-path argument and the `--container` option.
 ```sh

--- a/docs/reference/triggers/v3iostream.md
+++ b/docs/reference/triggers/v3iostream.md
@@ -35,7 +35,7 @@ Upon receiving its shard assignment, the replica spawns a Go routine ("thread") 
 
 For each read message, Nuclio "marks" the sequence number as handled. Periodically, the latest marked sequence number for each shard is "committed" (written to the shard's offset attribute). This allows future replicas to pick up where the previous replica left off without affecting performance.
 
-<a id="example"></a>
+<a id="consumption-example"></a>
 ### Consumption example
 
 To illustrate the consumption mechanism, assume a deployed Nuclio function with minimum and maximum replicas configurations of`3`; the function is configured to read from a `/my-stream` stream with 12 shards using the consumer group `my-consumer-group`.
@@ -100,6 +100,7 @@ As of Nuclio v1.1.33 / v1.3.20, you can configure the following configuration pa
 
 > **Note:** In future versions of Nuclio, it's planned that the dashboard will better reflect the role of the configuration parameters and add more parameters (such as session timeout and heartbeat interval, which are currently always set to the default values of 10s and 3s, respectively, unless you edit the function-configuration file).
 
+<a id="example"></a>
 ## Example
 
 The easiet way to set up a stream is with v3ctl. [Download the latest release](https://github.com/v3io/v3ctl/releases), rename it to v3ctl and make it an executable (`chmod +x`). Use it to create a stream with 32 shards:

--- a/docs/reference/triggers/v3iostream.md
+++ b/docs/reference/triggers/v3iostream.md
@@ -159,7 +159,8 @@ After the command completes successfully, the stream is ready for consumption by
 
     - **URL** - `http://v3io-webapi:8081/users/test-stream-0@cg0`.
     - **Max Workers** - `8`.
-      (You can also set this to a higher number, but then you'll have 8 workers reading all the shards.)
+      This value signifies the number of workers assigned to handle all the shards.
+      You can also set it to a different number.
     - **Seek To** - `Earliest`.
       (If you use `Latest`, only records that are ingested after the function is deployed will be read, so you won't read the records that you already added in the previous step.)
     - **Password** - a valid platform access key.

--- a/docs/reference/triggers/v3iostream.md
+++ b/docs/reference/triggers/v3iostream.md
@@ -157,7 +157,7 @@ After the command completes successfully, the stream is ready for consumption by
     In the **Name** text box, enter the trigger name "V3IO stream", and in the **Class** field select "V3IO stream" from the drop-down list.
     Use the following trigger configuration:
 
-    - **URL** - `http://v3io-webapi:8081/users/test-stream-0@cg0`.
+    - **URL** - `http://v3io-webapi:8081/users/test-stream-0@cg0` (where `/users/test-stream-0` is the stream path and `cg0` is the name of the consumer group to use).
     - **Max Workers** - `8`.
       This value signifies the number of workers assigned to handle all the shards.
       You can also set it to a different number.

--- a/docs/reference/triggers/v3iostream.md
+++ b/docs/reference/triggers/v3iostream.md
@@ -143,7 +143,7 @@ After the command completes successfully, the stream is ready for consumption by
 
 > **Note:** Before you deploy the function, ensure that the log-forwarder service is enabled (see the **Services** dashboard page), so that you can view the function logs.
 
-1.  Select and existing project or create a new project, and then create a new Python function. Select to create the function from scratch.
+1.  Select an existing project or create a new project, and then create a new Python function. Select to create the function from scratch.
 
 2.  On the function page, in the **Code** tab, set **Code entry type** to "Source code (edit online)" (default), and enter the following code in the **Source code** text box to define a function that logs the shard-ID event body and sleeps for 5 seconds:
     ```python


### PR DESCRIPTION
@pavius NOTE: As I wrote you on Slack, the value of the function trigger's `URL` configuration field — `http://v3io-webapi:8081/users/test-stream-0@cg0` seems wrong to me.
(a) The `@cg0` at the end seems wrong.
(b) I'm not sure whether it should be `http://v3io-webapi:8081` or the API URL of the user platform's web-APIs service.
UPDATE: Eran confirmed that the URL is correct and explained that `@cg0` at the end is the consumer group, as described earlier in the same document (when we explain how to set the **URL** dashboard field). => @pavius I've now slightly edited the description of the **URL** UI field in the example to clarify this — commit 9339c4c:
> **URL** - `http://v3io-webapi:8081/users/test-stream-0@cg0` (where `/users/test-stream-0` is the stream path and `cg0` is the name of the consumer group to use).

Also note that I edited the `v3ctl` code examples, as I also detailed on Slack:
1. In the `create stream record` example, I moved the stream path (`test-stream-0`) from the end of the `--data` line at the end of the command, to the start of the command, before the options (as done in the `create stream` example).
2. In the delete-stream example at the end, I changed the command name from `create` to `delete`.