### PR TITLE
Build fix, alpine-base update, and test fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ env:
   REPO_NAME: nuclio
   NUCLIO_LABEL: ${{ github.run_number }}
   NAMESPACE: nuclio
-  NUCTL_REGISTRY: localhost:5000
+  NUCLIO_TEST_TIMEOUT: "20m"
 
 jobs:
   lint:
@@ -74,13 +74,13 @@ jobs:
         env:
           NUCLIO_NUCTL_CREATE_SYMLINK: false
 
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v2
         with:
           name: nuctl-bin
           path: nuctl
 
   build_docker_images:
-    name: Build nuclio docker images
+    name: Build docker images
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -113,7 +113,7 @@ jobs:
             | pigz --fast > nuclio_docker_images.tar.gz
 
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: nuclio-docker-images
           path: nuclio_docker_images.tar.gz
@@ -123,7 +123,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build_docker_images
-      - build_nuctl
     steps:
       - uses: actions/checkout@v2
 
@@ -145,7 +144,7 @@ jobs:
           github token: ${{ github.token }}
 
       - name: Fetch nuclio docker images
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with:
           name: nuclio-docker-images
 
@@ -153,7 +152,8 @@ jobs:
         run: |
           kubectl create namespace ${NAMESPACE}
           docker run -d -p 5000:5000 registry:2
-          docker load -i nuclio-docker-images/nuclio_docker_images.tar.gz
+          docker load -i nuclio_docker_images.tar.gz
+          rm nuclio_docker_images.tar.gz
 
       - name: Install nuclio helm chart
         run: |
@@ -164,13 +164,51 @@ jobs:
       - name: Run nuctl tests
         run: |
           set -o pipefail
-          make test-k8s-nuctl 2>&1 | tee nuctl-test-results-${NUCLIO_LABEL}.log
+          make test-k8s-nuctl 2>&1 | tee test-k8s-nuctl-${NUCLIO_LABEL}.log
         env:
           NUCLIO_DASHBOARD_DEFAULT_ONBUILD_REGISTRY_URL: ${{ env.REPO }}
           NUCTL_REGISTRY: "localhost:5000"
 
-      - uses: actions/upload-artifact@v1
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        if: always()
         with:
-          name: Nuctl tests results
-          path: nuctl-test-results-${{ env.NUCLIO_LABEL }}.log
-        if: ${{ always() }}
+          name: test-results
+          path: test-k8s-nuctl-${{ env.NUCLIO_LABEL }}.log
+
+  test_docker_nuctl:
+    name: Test Docker nuctl
+    runs-on: ubuntu-latest
+    needs:
+      - build_docker_images
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Fetch nuclio docker images
+        uses: actions/download-artifact@v2
+        with:
+          name: nuclio-docker-images
+
+      - name: Prepare
+        run: |
+          docker load -i nuclio_docker_images.tar.gz
+          rm nuclio_docker_images.tar.gz
+
+      - name: Run nuctl tests
+        run: |
+          set -o pipefail
+          make test-docker-nuctl 2>&1 | tee test-docker-nuctl-${NUCLIO_LABEL}.log
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: test-results
+          path: test-docker-nuctl-${{ env.NUCLIO_LABEL }}.log

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ env:
   REPO_NAME: nuclio
   NUCLIO_LABEL: ${{ github.run_number }}
   NAMESPACE: nuclio
-  NUCLIO_TEST_TIMEOUT: "20m"
+  NUCLIO_GO_TEST_TIMEOUT: "20m"
 
 jobs:
   lint:

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,7 @@ NUCLIO_BUILD_ARGS_VERSION_INFO_FILE = --build-arg NUCLIO_VERSION_INFO_FILE_CONTE
 DOCKER_CLI_VERSION := 18.09.6
 
 # Nuclio test timeout
-NUCLIO_TEST_TIMEOUT ?= "10m"
-NUCLIO_GO_TEST_NUCTL_COMMAND = $(go test -v github.com/nuclio/nuclio/pkg/nuctl/... -p 1 --timeout $(NUCLIO_TEST_TIMEOUT))
+NUCLIO_GO_TEST_TIMEOUT ?= "10m"
 
 #
 #  Must be first target
@@ -379,7 +378,7 @@ lint: modules
 
 .PHONY: test-undockerized
 test-undockerized: ensure-gopath
-	go test -v --parallel 1 --timeout $(NUCLIO_TEST_TIMEOUT) ./cmd/... ./pkg/...
+	go test -v --parallel 1 --timeout $(NUCLIO_GO_TEST_TIMEOUT) ./cmd/... ./pkg/...
 
 .PHONY: test
 test: ensure-gopath build-base
@@ -401,7 +400,7 @@ test: ensure-gopath build-base
 		--env NUCLIO_LABEL=$(NUCLIO_LABEL) \
 		--env NUCLIO_ARCH=$(NUCLIO_ARCH) \
 		--env NUCLIO_OS=$(NUCLIO_OS) \
-		--env NUCLIO_TEST_TIMEOUT=$(NUCLIO_TEST_TIMEOUT) \
+		--env NUCLIO_GO_TEST_TIMEOUT=$(NUCLIO_GO_TEST_TIMEOUT) \
 		$(NUCLIO_DOCKER_TEST_TAG) \
 		/bin/bash -c "make test-undockerized"
 
@@ -419,23 +418,13 @@ test-k8s-nuctl:
 	NUCTL_EXTERNAL_IP_ADDRESSES=$(if $(NUCTL_EXTERNAL_IP_ADDRESSES),$(NUCTL_EXTERNAL_IP_ADDRESSES),"localhost") \
 		NUCTL_RUN_REGISTRY=$(NUCTL_REGISTRY) \
 		NUCTL_PLATFORM=kube \
-		NAMESPACE=$(if $(NAMESPACE),$(NAMESPACE),"default")
-		$(NUCLIO_GO_TEST_NUCTL_COMMAND)
+		NAMESPACE=$(if $(NAMESPACE),$(NAMESPACE),"default") \
+		go test -v github.com/nuclio/nuclio/pkg/nuctl/... -p 1 --timeout $(NUCLIO_GO_TEST_TIMEOUT)
 
 .PHONY: test-docker-nuctl
 test-docker-nuctl:
-	NUCTL_PLATFORM=local $(NUCLIO_GO_TEST_NUCTL_COMMAND)
-
-.PHONY: build-base
-build-base: build-builder
-	docker build \
-		--build-arg NUCLIO_LABEL=$(NUCLIO_LABEL) \
-		--file hack/docker/build/base/Dockerfile \
-		--tag nuclio-base:$(NUCLIO_LABEL) .
-	docker build \
-		--build-arg NUCLIO_LABEL=$(NUCLIO_LABEL) \
-		--file hack/docker/build/base-alpine/Dockerfile \
-		--tag nuclio-base-alpine:$(NUCLIO_LABEL) .
+	NUCTL_PLATFORM=local \
+		go test -v github.com/nuclio/nuclio/pkg/nuctl/... -p 1 --timeout $(NUCLIO_GO_TEST_TIMEOUT)
 
 .PHONY: build-base
 build-base: build-builder

--- a/Makefile
+++ b/Makefile
@@ -418,13 +418,12 @@ test-k8s-nuctl:
 	NUCTL_EXTERNAL_IP_ADDRESSES=$(if $(NUCTL_EXTERNAL_IP_ADDRESSES),$(NUCTL_EXTERNAL_IP_ADDRESSES),"localhost") \
 		NUCTL_RUN_REGISTRY=$(NUCTL_REGISTRY) \
 		NUCTL_PLATFORM=kube \
-		NAMESPACE=$(if $(NAMESPACE),$(NAMESPACE),"default") \
+		NAMESPACE=$(if $(NAMESPACE),$(NAMESPACE),"default")
 		go test -v github.com/nuclio/nuclio/pkg/nuctl/... -p 1 --timeout $(NUCLIO_GO_TEST_TIMEOUT)
 
 .PHONY: test-docker-nuctl
 test-docker-nuctl:
-	NUCTL_PLATFORM=local \
-		go test -v github.com/nuclio/nuclio/pkg/nuctl/... -p 1 --timeout $(NUCLIO_GO_TEST_TIMEOUT)
+	NUCTL_PLATFORM=local go test -v github.com/nuclio/nuclio/pkg/nuctl/... -p 1 --timeout $(NUCLIO_GO_TEST_TIMEOUT)
 
 .PHONY: build-base
 build-base: build-builder

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ NUCLIO_BUILD_ARGS_VERSION_INFO_FILE = --build-arg NUCLIO_VERSION_INFO_FILE_CONTE
 # Docker client version to be used
 DOCKER_CLI_VERSION := 18.09.6
 
+# Nuclio test timeout
+NUCLIO_TEST_TIMEOUT ?= "10m"
+NUCLIO_GO_TEST_NUCTL_COMMAND = $(go test -v github.com/nuclio/nuclio/pkg/nuctl/... -p 1 --timeout $(NUCLIO_TEST_TIMEOUT))
+
 #
 #  Must be first target
 #
@@ -375,7 +379,7 @@ lint: modules
 
 .PHONY: test-undockerized
 test-undockerized: ensure-gopath
-	go test -v ./cmd/... ./pkg/... -p 1
+	go test -v --parallel 1 --timeout $(NUCLIO_TEST_TIMEOUT) ./cmd/... ./pkg/...
 
 .PHONY: test
 test: ensure-gopath build-base
@@ -393,6 +397,11 @@ test: ensure-gopath build-base
 		--volume /tmp:/tmp \
 		--workdir $(GO_BUILD_TOOL_WORKDIR) \
 		--env NUCLIO_TEST_HOST=$(NUCLIO_TEST_HOST) \
+		--env NUCLIO_VERSION_GIT_COMMIT=$(NUCLIO_VERSION_GIT_COMMIT) \
+		--env NUCLIO_LABEL=$(NUCLIO_LABEL) \
+		--env NUCLIO_ARCH=$(NUCLIO_ARCH) \
+		--env NUCLIO_OS=$(NUCLIO_OS) \
+		--env NUCLIO_TEST_TIMEOUT=$(NUCLIO_TEST_TIMEOUT) \
 		$(NUCLIO_DOCKER_TEST_TAG) \
 		/bin/bash -c "make test-undockerized"
 
@@ -405,13 +414,28 @@ test-python:
 test-short: modules ensure-gopath
 	go test -v ./cmd/... ./pkg/... -short
 
-.PHONY: test-nuctl
+.PHONY: test-k8s-nuctl
 test-k8s-nuctl:
 	NUCTL_EXTERNAL_IP_ADDRESSES=$(if $(NUCTL_EXTERNAL_IP_ADDRESSES),$(NUCTL_EXTERNAL_IP_ADDRESSES),"localhost") \
 		NUCTL_RUN_REGISTRY=$(NUCTL_REGISTRY) \
 		NUCTL_PLATFORM=kube \
 		NAMESPACE=$(if $(NAMESPACE),$(NAMESPACE),"default")
-		go test -v github.com/nuclio/nuclio/pkg/nuctl/... -p 1
+		$(NUCLIO_GO_TEST_NUCTL_COMMAND)
+
+.PHONY: test-docker-nuctl
+test-docker-nuctl:
+	NUCTL_PLATFORM=local $(NUCLIO_GO_TEST_NUCTL_COMMAND)
+
+.PHONY: build-base
+build-base: build-builder
+	docker build \
+		--build-arg NUCLIO_LABEL=$(NUCLIO_LABEL) \
+		--file hack/docker/build/base/Dockerfile \
+		--tag nuclio-base:$(NUCLIO_LABEL) .
+	docker build \
+		--build-arg NUCLIO_LABEL=$(NUCLIO_LABEL) \
+		--file hack/docker/build/base-alpine/Dockerfile \
+		--tag nuclio-base-alpine:$(NUCLIO_LABEL) .
 
 .PHONY: build-base
 build-base: build-builder

--- a/docs/devel/contributing.md
+++ b/docs/devel/contributing.md
@@ -45,14 +45,26 @@ make build
 You should now have quite a few `nuclio/<something>` images tagged as `latest-amd64`, along with `nuctl-latest-<os>-amd64` with a `nuctl` symbolic link under `$GOPATH/bin`. Now, run a few tests:
 
 ```sh
-make lint test
+make lint test-short
 ```
 
-This may take a while (over 10 minutes) and requires only Docker.
+This is a short test suite, and requires only Docker.
 
-To run a limited kubernetes nuctl suite (Also runs in CI):
+To run integration tests (currently support docker platform, and may take a while ~60 minutes), run:
+
+```sh
+make test
+```
+
+On Nuclio CI, we run nuctl test suites against both Docker and Kubernetes platforms
+
+To run kubernetes nuctl suite locally:
 
 `NUCTL_REGISTRY=<registry> make test-k8s-nuctl`
+
+To run docker nuctl suite locally:
+
+`make test-docker-nuctl`
 
 Running more comprehensive end-to-end tests on kubernetes is currently done manually.
 

--- a/docs/reference/runtimes/nodejs/nodejs-reference.md
+++ b/docs/reference/runtimes/nodejs/nodejs-reference.md
@@ -25,7 +25,7 @@ See [Deploying Functions from a Dockerfile](/docs/tasks/deploy-functions-from-do
 ```
 ARG NUCLIO_LABEL=0.5.6
 ARG NUCLIO_ARCH=amd64
-ARG NUCLIO_BASE_IMAGE=node:10.3-alpine
+ARG NUCLIO_BASE_IMAGE=node:10.20-alpine
 ARG NUCLIO_ONBUILD_IMAGE=nuclio/handler-builder-nodejs-onbuild:${NUCLIO_LABEL}-${NUCLIO_ARCH}
 
 # Supplies processor uhttpc, used for healthcheck

--- a/pkg/common/helper_test.go
+++ b/pkg/common/helper_test.go
@@ -209,7 +209,7 @@ func (suite *RetryUntilSuccessfulOnErrorPatternsTestSuite) TestSucceedIfErrorMes
 			shouldFail: false,
 		},
 		{
-			description:   "Failed fast due to unmatched error",
+			description:   "Failed after 1 call due to unmatched error",
 			expectedCalls: 1,
 			callbackErrors: []string{
 				"A",

--- a/pkg/common/helper_test.go
+++ b/pkg/common/helper_test.go
@@ -173,7 +173,7 @@ func (suite *RetryUntilSuccessfulOnErrorPatternsTestSuite) TestSucceedIfErrorMes
 		shouldTimeout bool
 	}{
 		{
-			description:   "Succeeded after 3 retries",
+			description:   "Succeeded after 2 retries",
 			expectedCalls: 3,
 			callbackErrors: []string{
 				"First",

--- a/pkg/common/helper_test.go
+++ b/pkg/common/helper_test.go
@@ -222,7 +222,7 @@ func (suite *RetryUntilSuccessfulOnErrorPatternsTestSuite) TestSucceedIfErrorMes
 			shouldFail: true,
 		},
 		{
-			description:   "Failed due to timeout",
+			description: "Failed due to timeout",
 			callbackErrors: []string{
 				"A",
 			},

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -548,7 +548,6 @@ func (c *ShellClient) build(buildOptions *BuildOptions, buildArgs string, cacheO
 		WorkingDir:        &buildOptions.ContextDir,
 	}
 
-
 	// retry build on predefined errors that occur during race condition and collisions between
 	// shared onbuild layers
 	common.RetryUntilSuccessful(1*time.Hour, 1*time.Minute, func() bool { // nolint: errcheck

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -66,7 +66,6 @@ func NewShellClient(parentLogger logger.Logger, runner cmdrunner.CmdRunner) (*Sh
 
 // Build will build a docker image, given build options
 func (c *ShellClient) Build(buildOptions *BuildOptions) error {
-	var err error
 	c.logger.DebugWith("Building image", "buildOptions", buildOptions)
 
 	// if context dir is not passed, use the dir containing the dockerfile
@@ -89,48 +88,7 @@ func (c *ShellClient) Build(buildOptions *BuildOptions) error {
 		cacheOption = "--no-cache"
 	}
 
-	runOptions := &cmdrunner.RunOptions{
-		CaptureOutputMode: cmdrunner.CaptureOutputModeStdout,
-		WorkingDir:        &buildOptions.ContextDir,
-	}
-
-	var hostNetString string
-
-	// may contain none as a value
-	networkInterface := os.Getenv("NUCLIO_DOCKER_BUILD_NETWORK")
-	if networkInterface == "" {
-		networkInterface = common.GetEnvOrDefaultString("NUCLIO_BUILD_USE_HOST_NET", "host")
-	}
-	switch networkInterface {
-	case "host":
-		fallthrough
-	case "default":
-		fallthrough
-	case "none":
-		hostNetString = fmt.Sprintf("--network %s", networkInterface)
-	default:
-		hostNetString = ""
-	}
-
-	common.RetryUntilSuccessful(1*time.Hour, 1*time.Minute, func() bool { // nolint: errcheck
-		runResults, runErr := c.runCommand(runOptions,
-			"docker build %s --force-rm -t %s -f %s %s %s .",
-			hostNetString,
-			buildOptions.Image,
-			buildOptions.DockerfilePath,
-			cacheOption,
-			buildArgs)
-
-		// preserve error
-		err = runErr
-
-		// retry on a race condition where `--force-rm` removes a cached layer for other function build in process
-		if runErr != nil && strings.HasPrefix(runResults.Stderr, "No such image: sha256:") {
-			return false
-		}
-		return true
-	})
-	return err
+	return c.build(buildOptions, buildArgs, cacheOption)
 }
 
 // CopyObjectsFromImage copies objects (files, directories) from a given image to local storage. it does
@@ -553,4 +511,66 @@ func (c *ShellClient) getLastNonEmptyLine(lines []string, offset int) string {
 
 func (c *ShellClient) replaceSingleQuotes(input string) string {
 	return strings.Replace(input, "'", "’", -1)
+}
+
+func (c *ShellClient) resolveDockerBuildNetwork() string {
+
+	// may contain none as a value
+	networkInterface := os.Getenv("NUCLIO_DOCKER_BUILD_NETWORK")
+	if networkInterface == "" {
+		networkInterface = common.GetEnvOrDefaultString("NUCLIO_BUILD_USE_HOST_NET", "host")
+	}
+	switch networkInterface {
+	case "host":
+		fallthrough
+	case "default":
+		fallthrough
+	case "none":
+		return fmt.Sprintf("--network %s", networkInterface)
+	default:
+		return ""
+	}
+}
+
+func (c *ShellClient) build(buildOptions *BuildOptions, buildArgs string, cacheOption string) error {
+	var err error
+	retryOnErrorMessages := []string{
+
+		// when one of the underlying image is gone (from cache)
+		"No such image: sha256:",
+
+		// when overlay image is gone (from disk)
+		"failed to get digest sha256:",
+	}
+
+	runOptions := &cmdrunner.RunOptions{
+		CaptureOutputMode: cmdrunner.CaptureOutputModeStdout,
+		WorkingDir:        &buildOptions.ContextDir,
+	}
+
+
+	// retry build on predefined errors that occur during race condition and collisions between
+	// shared onbuild layers
+	common.RetryUntilSuccessful(1*time.Hour, 1*time.Minute, func() bool { // nolint: errcheck
+		runResults, runErr := c.runCommand(runOptions,
+			"docker build %s --force-rm -t %s -f %s %s %s .",
+			c.resolveDockerBuildNetwork(),
+			buildOptions.Image,
+			buildOptions.DockerfilePath,
+			cacheOption,
+			buildArgs)
+
+		// preserve error
+		err = runErr
+
+		// retry on a race condition where `--force-rm` removes a cached layer for other function build in process
+		for _, errorMessage := range retryOnErrorMessages {
+			if runErr != nil && strings.HasPrefix(runResults.Stderr, errorMessage) {
+				return false
+			}
+
+		}
+		return true
+	})
+	return err
 }

--- a/pkg/nuctl/test/suite.go
+++ b/pkg/nuctl/test/suite.go
@@ -56,6 +56,9 @@ type Suite struct {
 func (suite *Suite) SetupSuite() {
 	var err error
 
+	// update version so that linker doesn't need to inject it
+	version.SetFromEnv()
+
 	// create logger
 	suite.logger, err = nucliozap.NewNuclioZapTest("test")
 	suite.Require().NoError(err)
@@ -80,15 +83,6 @@ func (suite *Suite) SetupSuite() {
 		err = os.Setenv(nuctlPlatformEnvVarName, "local")
 		suite.Require().NoError(err)
 	}
-
-	// update version so that linker doesn't need to inject it
-	err = version.Set(&version.Info{
-		GitCommit: "c",
-		Label:     common.GetEnvOrDefaultString("NUCLIO_LABEL", "latest"),
-		Arch:      "amd64",
-		OS:        "linux",
-	})
-	suite.Require().NoError(err)
 }
 
 func (suite *Suite) TearDownSuite() {

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -61,13 +61,8 @@ type TestAbstractSuite struct {
 }
 
 func (suite *TestAbstractSuite) SetupSuite() {
-	err := version.Set(&version.Info{
-		GitCommit: "c",
-		Label:     "latest",
-		Arch:      "amd64",
-		OS:        "linux",
-	})
-	suite.Require().NoError(err, "Failed to set version info")
+	var err error
+	version.SetFromEnv()
 
 	suite.DefaultNamespace = "nuclio"
 

--- a/pkg/platform/local/platform_test.go
+++ b/pkg/platform/local/platform_test.go
@@ -50,13 +50,8 @@ type TestSuite struct {
 }
 
 func (suite *TestSuite) SetupSuite() {
-	err := version.Set(&version.Info{
-		GitCommit: "c",
-		Label:     "latest",
-		Arch:      "amd64",
-		OS:        "linux",
-	})
-	suite.Require().NoError(err, "Failed to set version info")
+	var err error
+	version.SetFromEnv()
 
 	suite.DefaultNamespace = "nuclio"
 

--- a/pkg/processor/build/runtime/nodejs/runtime.go
+++ b/pkg/processor/build/runtime/nodejs/runtime.go
@@ -40,7 +40,7 @@ func (n *nodejs) GetProcessorDockerfileInfo(versionInfo *version.Info,
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
 	// set the default base image
-	processorDockerfileInfo.BaseImage = "node:10.3-alpine"
+	processorDockerfileInfo.BaseImage = "node:10.20-alpine"
 
 	processorDockerfileInfo.ImageArtifactPaths = map[string]string{
 		"handler": "/opt/nuclio",

--- a/pkg/processor/runtime/dotnetcore/test/dotnetcore_test.go
+++ b/pkg/processor/runtime/dotnetcore/test/dotnetcore_test.go
@@ -21,7 +21,6 @@ import (
 	"path"
 	"testing"
 
-	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
 
 	"github.com/stretchr/testify/suite"
@@ -57,119 +56,93 @@ func (suite *TestSuite) TestOutputs() {
 		suite.GetFunctionPath("_outputter"))
 
 	deployOptions.FunctionConfig.Spec.Handler = "nuclio:outputter"
-	suite.DeployFunction(deployOptions, func(deployResult *platform.CreateFunctionResult) bool {
-
-		testRequests := []httpsuite.Request{
-			{
-				Name:                       "string",
-				RequestBody:                "return_string",
-				ExpectedResponseHeaders:    headersContentTypeTextPlain,
-				ExpectedResponseBody:       "a string",
-				ExpectedResponseStatusCode: &statusOK,
+	suite.DeployFunctionAndRequests(deployOptions, []*httpsuite.Request{
+		{
+			Name:                       "string",
+			RequestBody:                "return_string",
+			ExpectedResponseHeaders:    headersContentTypeTextPlain,
+			ExpectedResponseBody:       "a string",
+			ExpectedResponseStatusCode: &statusOK,
+		},
+		{
+			Name:                       "json_convert",
+			RequestBody:                "json_convert",
+			ExpectedResponseHeaders:    headersContentTypeTextPlain,
+			ExpectedResponseBody:       "{\n  \"Name\": \"John Doe\",\n  \"Email\": \"john@iguazio.com\"\n}",
+			ExpectedResponseStatusCode: &statusOK,
+		},
+		{
+			Name:                       "long body",
+			RequestBody:                longTestBody,
+			ExpectedResponseHeaders:    headersContentTypeTextPlain,
+			ExpectedResponseBody:       longTestBody,
+			ExpectedResponseStatusCode: &statusOK,
+		},
+		{
+			Name:                       "panic",
+			RequestBody:                "panic",
+			ExpectedResponseStatusCode: &statusInternalError,
+		},
+		{
+			Name:           "response object",
+			RequestHeaders: map[string]interface{}{"a": "1", "b": "2"},
+			RequestBody:    "return_response",
+			ExpectedResponseHeaders: map[string]string{
+				"a":            "1",
+				"b":            "2",
+				"h1":           "v1",
+				"h2":           "v2",
+				"Content-Type": "text/plain; charset=utf-8",
 			},
-			{
-				Name:                       "json_convert",
-				RequestBody:                "json_convert",
-				ExpectedResponseHeaders:    headersContentTypeTextPlain,
-				ExpectedResponseBody:       "{\n  \"Name\": \"John Doe\",\n  \"Email\": \"john@iguazio.com\"\n}",
-				ExpectedResponseStatusCode: &statusOK,
+			ExpectedResponseBody:       "response body",
+			ExpectedResponseStatusCode: &statusCreated,
+		},
+		{
+			Name:                       "logs - debug",
+			RequestBody:                "log",
+			RequestLogLevel:            &logLevelDebug,
+			ExpectedResponseHeaders:    headersContentTypeTextPlain,
+			ExpectedResponseBody:       "returned logs",
+			ExpectedResponseStatusCode: &statusOK,
+			ExpectedLogMessages: []string{
+				"Debug message",
+				"Info message",
+				"Warn message",
+				"Error message",
 			},
-			{
-				Name:                       "long body",
-				RequestBody:                longTestBody,
-				ExpectedResponseHeaders:    headersContentTypeTextPlain,
-				ExpectedResponseBody:       longTestBody,
-				ExpectedResponseStatusCode: &statusOK,
+		},
+		{
+			Name:                       "logs - warn",
+			RequestBody:                "log",
+			RequestLogLevel:            &logLevelWarn,
+			ExpectedResponseHeaders:    headersContentTypeTextPlain,
+			ExpectedResponseBody:       "returned logs",
+			ExpectedResponseStatusCode: &statusOK,
+			ExpectedLogMessages: []string{
+				"Warn message",
+				"Error message",
 			},
-			{
-				Name:                       "panic",
-				RequestBody:                "panic",
-				ExpectedResponseStatusCode: &statusInternalError,
-			},
-			{
-				Name:           "response object",
-				RequestHeaders: map[string]interface{}{"a": "1", "b": "2"},
-				RequestBody:    "return_response",
-				ExpectedResponseHeaders: map[string]string{
-					"a":            "1",
-					"b":            "2",
-					"h1":           "v1",
-					"h2":           "v2",
-					"Content-Type": "text/plain; charset=utf-8",
-				},
-				ExpectedResponseBody:       "response body",
-				ExpectedResponseStatusCode: &statusCreated,
-			},
-			{
-				Name:                       "logs - debug",
-				RequestBody:                "log",
-				RequestLogLevel:            &logLevelDebug,
-				ExpectedResponseHeaders:    headersContentTypeTextPlain,
-				ExpectedResponseBody:       "returned logs",
-				ExpectedResponseStatusCode: &statusOK,
-				ExpectedLogMessages: []string{
-					"Debug message",
-					"Info message",
-					"Warn message",
-					"Error message",
-				},
-			},
-			{
-				Name:                       "logs - warn",
-				RequestBody:                "log",
-				RequestLogLevel:            &logLevelWarn,
-				ExpectedResponseHeaders:    headersContentTypeTextPlain,
-				ExpectedResponseBody:       "returned logs",
-				ExpectedResponseStatusCode: &statusOK,
-				ExpectedLogMessages: []string{
-					"Warn message",
-					"Error message",
-				},
-			},
-			{
-				Name:                 "GET",
-				RequestMethod:        "GET",
-				ExpectedResponseBody: "GET",
-			},
-			{
-				Name:                       "fields",
-				RequestPath:                "/?x=1&y=2",
-				RequestBody:                "return_fields",
-				RequestLogLevel:            &logLevelWarn,
-				ExpectedResponseHeaders:    headersContentTypeTextPlain,
-				ExpectedResponseBody:       "x=1,y=2",
-				ExpectedResponseStatusCode: &statusOK,
-			},
-			{
-				Name:                 "path",
-				RequestBody:          "return_path",
-				RequestPath:          testPath,
-				ExpectedResponseBody: testPath,
-			},
-		}
-
-		for _, testRequest := range testRequests {
-			suite.Logger.DebugWith("Running sub test", "name", testRequest.Name)
-
-			// set defaults
-			if testRequest.RequestPort == 0 {
-				testRequest.RequestPort = deployResult.Port
-			}
-
-			if testRequest.RequestMethod == "" {
-				testRequest.RequestMethod = "POST"
-			}
-
-			if testRequest.RequestPath == "" {
-				testRequest.RequestPath = "/"
-			}
-
-			if !suite.SendRequestVerifyResponse(&testRequest) {
-				return false
-			}
-		}
-
-		return true
+		},
+		{
+			Name:                 "GET",
+			RequestMethod:        "GET",
+			ExpectedResponseBody: "GET",
+		},
+		{
+			Name:                       "fields",
+			RequestPath:                "/?x=1&y=2",
+			RequestBody:                "return_fields",
+			RequestLogLevel:            &logLevelWarn,
+			ExpectedResponseHeaders:    headersContentTypeTextPlain,
+			ExpectedResponseBody:       "x=1,y=2",
+			ExpectedResponseStatusCode: &statusOK,
+		},
+		{
+			Name:                 "path",
+			RequestBody:          "return_path",
+			RequestPath:          testPath,
+			ExpectedResponseBody: testPath,
+		},
 	})
 }
 

--- a/pkg/processor/trigger/cron/test/cron_test.go
+++ b/pkg/processor/trigger/cron/test/cron_test.go
@@ -60,7 +60,10 @@ func (suite *TestSuite) TestPostEventPythonInterval() {
 			"test", test,
 			"expectedOccurredEvents", expectedOccurredEvents,
 			"interval", test.interval.String())
-		suite.invokeEventRecorder(createFunctionOptions, test.duration, expectedOccurredEvents, expectedOccurredEvents)
+		suite.invokeEventRecorder(createFunctionOptions,
+			test.duration,
+			expectedOccurredEvents-1,
+			expectedOccurredEvents+1)
 	}
 }
 
@@ -98,7 +101,8 @@ func (suite *TestSuite) getCronDeployOptions() *platform.CreateFunctionOptions {
 
 func (suite *TestSuite) invokeEventRecorder(createFunctionOptions *platform.CreateFunctionOptions,
 	testDurationLength time.Duration,
-	minimumOccurredEvents, maximumOccurredEvents int) {
+	minimumOccurredEvents int,
+	maximumOccurredEvents int) {
 	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
 
 		// give time for the container to trigger its events

--- a/pkg/processor/trigger/http/test/suite/suite.go
+++ b/pkg/processor/trigger/http/test/suite/suite.go
@@ -69,15 +69,14 @@ type Request struct {
 	ExpectedResponseStatusCode    *int
 }
 
-func (r *Request) Enrich() {
+func (r *Request) Enrich(deployResult *platform.CreateFunctionResult) {
 	defaultStatusCode := http.StatusOK
 	if r.ExpectedResponseStatusCode == nil {
 		r.ExpectedResponseStatusCode = &defaultStatusCode
 	}
 
-	// by default BuildAndRunFunction will map 8080
 	if r.RequestPort == 0 {
-		r.RequestPort = 8080
+		r.RequestPort = deployResult.Port
 	}
 
 	if r.RequestPath == "" {
@@ -126,9 +125,7 @@ func (suite *TestSuite) DeployFunctionAndRequests(createFunctionOptions *platfor
 
 	return suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
 		for _, request := range requests {
-			request.Enrich()
-			request.RequestPort = deployResult.Port
-
+			request.Enrich(deployResult)
 			if !suite.SendRequestVerifyResponse(request) {
 
 				// fail fast

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,6 +20,9 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	oslib "os"
+	"runtime"
+
+	"github.com/nuclio/nuclio/pkg/common"
 
 	"github.com/nuclio/logger"
 )
@@ -78,14 +81,21 @@ func Get() (*Info, error) {
 }
 
 // Set will update the stored version info, used primarily for tests
-func Set(info *Info) error {
+func Set(info *Info) {
 	label = info.Label
 	gitCommit = info.GitCommit
 	os = info.OS
 	arch = info.Arch
 	goVersion = info.GoVersion
+}
 
-	return nil
+// SetFromEnv will update the stored version info, used primarily for tests
+func SetFromEnv() {
+	gitCommit = common.GetEnvOrDefaultString("NUCLIO_VERSION_GIT_COMMIT", "c")
+	label = common.GetEnvOrDefaultString("NUCLIO_LABEL", "latest")
+	arch = common.GetEnvOrDefaultString("NUCLIO_ARCH", "amd64")
+	os = common.GetEnvOrDefaultString("NUCLIO_OS", "linux")
+	goVersion = runtime.Version()
 }
 
 // Log will log the version, or an error


### PR DESCRIPTION
This PR introduce some fixes, update and mainly prepare the ground to auto integration tests to run

- Build fix
  - Added a retry on `failed to get digest sha256:` that happened when the overlay image is gone from disk (just like `No such image: sha256:`) that simply indicate the image is gone from cache.
- Test fixes (integ mainly)
  - Fixed transient error on cron triggers
  - Added `version.SetFromEnv()` for tests purposes to inject version during tests
  - `blastHTTP` tests - wait for function to be healthy and answer a dummy call before blasting it.
- Base image update
  - Updated base image for node to`node:10.20-alpine` due to a bug on npm
- CI updates
  - Updated packages and versions for github workflow
  - Added `nuctl docker test` that will give `nuctl` integration test against docker platform
  - Increased timeouts for tests
