### PR TITLE
Make delete resource idempotent

### DIFF
--- a/pkg/nuctl/command/nuctl.go
+++ b/pkg/nuctl/command/nuctl.go
@@ -114,7 +114,7 @@ func (rc *RootCommandeer) initialize() error {
 
 	rc.platform, err = rc.createPlatform(rc.loggerInstance)
 	if err != nil {
-		return errors.Wrap(err, "Failed to create logger")
+		return errors.Wrap(err, "Failed to create platform")
 	}
 
 	// use default namespace by platform if specified

--- a/pkg/platform/kube/deleter.go
+++ b/pkg/platform/kube/deleter.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -54,8 +55,11 @@ func (d *deleter) delete(consumer *consumer, deleteFunctionOptions *platform.Del
 	}
 
 	// get specific function CR
-	err = nuclioClientSet.NuclioV1beta1().NuclioFunctions(deleteFunctionOptions.FunctionConfig.Meta.Namespace).Delete(resourceName, &meta_v1.DeleteOptions{})
-	if err != nil {
+	err = nuclioClientSet.
+		NuclioV1beta1().
+		NuclioFunctions(deleteFunctionOptions.FunctionConfig.Meta.Namespace).
+		Delete(resourceName, &meta_v1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
 		return errors.Wrap(err, "Failed to delete function CR")
 	}
 

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -318,13 +318,7 @@ func (p *Platform) DeleteFunction(deleteFunctionOptions *platform.DeleteFunction
 
 	// delete the function from the local store
 	err := p.localStore.deleteFunction(&deleteFunctionOptions.FunctionConfig.Meta)
-	if err != nil {
-
-		// propagate not found errors
-		if err == nuclio.ErrNotFound {
-			return err
-		}
-
+	if err != nil && err != nuclio.ErrNotFound {
 		p.Logger.WarnWith("Failed to delete function from local store", "err", err.Error())
 	}
 
@@ -369,10 +363,6 @@ func (p *Platform) DeleteFunction(deleteFunctionOptions *platform.DeleteFunction
 	containersInfo, err := p.dockerClient.GetContainers(getContainerOptions)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get containers")
-	}
-
-	if len(containersInfo) == 0 {
-		return nil
 	}
 
 	// iterate over contains and delete them. It's possible that under some weird circumstances


### PR DESCRIPTION
Bug: When deleting (`DELETE /api/<resource>/<resource-id>`) a non-existing resource, an error is returned as `Internal Server Error (500)`

To solve that, we ensure _delete_ action on resources are idempotent