### PR TITLE
Improve docker platform function containers healthiness

### DIFF
--- a/pkg/dockerclient/dockerclient.go
+++ b/pkg/dockerclient/dockerclient.go
@@ -47,6 +47,12 @@ type Client interface {
 	// RemoveContainer removes a container given a container ID
 	RemoveContainer(containerID string) error
 
+	// StopContainer removes a container given a container ID
+	StopContainer(containerID string) error
+
+	// StartContainer starts a container given a container ID
+	StartContainer(containerID string) error
+
 	// GetContainerLogs returns raw logs from a given container ID
 	GetContainerLogs(containerID string) (string, error)
 

--- a/pkg/dockerclient/mock.go
+++ b/pkg/dockerclient/mock.go
@@ -75,6 +75,16 @@ func (mdc *MockDockerClient) RemoveContainer(containerID string) error {
 	return nil
 }
 
+// StopContainer stops a container given a container ID
+func (mdc *MockDockerClient) StopContainer(containerID string) error {
+	return nil
+}
+
+// StartContainer stops a container given a container ID
+func (mdc *MockDockerClient) StartContainer(containerID string) error {
+	return nil
+}
+
 // GetContainerLogs returns raw logs from a given container ID
 func (mdc *MockDockerClient) GetContainerLogs(containerID string) (string, error) {
 	return "", nil

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -298,6 +298,18 @@ func (c *ShellClient) RemoveContainer(containerID string) error {
 	return err
 }
 
+// StopContainer stops a container given a container ID
+func (c *ShellClient) StopContainer(containerID string) error {
+	_, err := c.runCommand(nil, "docker stop %s", containerID)
+	return err
+}
+
+// StartContainer stops a container given a container ID
+func (c *ShellClient) StartContainer(containerID string) error {
+	_, err := c.runCommand(nil, "docker start %s", containerID)
+	return err
+}
+
 // GetContainerLogs returns raw logs from a given container ID
 // Concatenating stdout and stderr since there's no way to re-interlace them
 func (c *ShellClient) GetContainerLogs(containerID string) (string, error) {

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -344,6 +344,7 @@ func (c *ShellClient) AwaitContainerHealth(containerID string, timeout *time.Dur
 
 			// wait a bit before retrying
 			c.logger.DebugWith("Container not healthy yet, retrying soon",
+				"containerID", containerID,
 				"inspectOutput", runResult.Output,
 				"nextCheckIn", inspectInterval)
 
@@ -359,15 +360,21 @@ func (c *ShellClient) AwaitContainerHealth(containerID string, timeout *time.Dur
 	// wait for either the container to be healthy or the timeout
 	select {
 	case <-containerHealthy:
-		c.logger.Debug("Container is healthy")
+		c.logger.DebugWith("Container is healthy", "containerID", containerID)
 	case <-timeoutChan:
 		timedOut = true
 
 		containerLogs, err := c.GetContainerLogs(containerID)
 		if err != nil {
-			c.logger.ErrorWith("Container wasn't healthy within timeout (failed to get logs)", "timeout", timeout, "err", err)
+			c.logger.ErrorWith("Container wasn't healthy within timeout (failed to get logs)",
+				"containerID", containerID,
+				"timeout", timeout,
+				"err", err)
 		} else {
-			c.logger.WarnWith("Container wasn't healthy within timeout", "timeout", timeout, "logs", containerLogs)
+			c.logger.WarnWith("Container wasn't healthy within timeout",
+				"containerID", containerID,
+				"timeout", timeout,
+				"logs", containerLogs)
 		}
 
 		return errors.New("Container wasn't healthy in time")

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
@@ -56,6 +57,7 @@ type Platform struct {
 }
 
 const Mib = 1048576
+const UnhealthyContainerErrorMessage = "Container is not healthy (detected by nuclio platform)"
 
 // NewPlatform instantiates a new local platform
 func NewPlatform(parentLogger logger.Logger,
@@ -749,8 +751,7 @@ func (p *Platform) ValidateFunctionContainersHealthiness() {
 		p.Logger.WarnWith("Cannot not get namespaces", "err", err)
 		return
 	}
-	var unhealthyFunctions []*functionconfig.Config
-	var functionsFailedToMarkUnhealthy []*functionconfig.Config
+
 	for _, namespace := range namespaces {
 
 		// get functions for that namespace
@@ -758,22 +759,25 @@ func (p *Platform) ValidateFunctionContainersHealthiness() {
 			Namespace: namespace,
 		})
 		if err != nil {
-			p.Logger.WarnWith("Cannot get functions to validate",
+			p.Logger.WarnWith("Failed to get namespaced functions",
 				"namespace", namespace,
 				"err", err)
 			continue
 		}
 
-		// For each function, we will check if its container is healthy
-		// in case it is not healthy (or container is missing), update function status
-		// and mark its state to error
+		// check each function container healthiness and update function's status correspondingly
 		for _, function := range functions {
 			functionConfig := function.GetConfig()
-			functionState := function.GetStatus().State
+			functionStatus := function.GetStatus()
 			functionName := functionConfig.Meta.Name
-			if functionState != functionconfig.FunctionStateReady {
 
-				// Skipping checking of not-ready functions
+			functionIsReady := functionStatus.State == functionconfig.FunctionStateReady
+			functionWasSetAsUnhealthy := functionStatus.State == functionconfig.FunctionStateError &&
+				strings.EqualFold(UnhealthyContainerErrorMessage, functionStatus.Message)
+
+			if !(functionIsReady || functionWasSetAsUnhealthy) {
+
+				// cannot be monitored
 				continue
 			}
 
@@ -787,40 +791,73 @@ func (p *Platform) ValidateFunctionContainersHealthiness() {
 				},
 			})
 
-			if err := p.markFunctionUnhealthy(containerID, functionConfig); err != nil {
-				functionsFailedToMarkUnhealthy = append(functionsFailedToMarkUnhealthy, functionConfig)
-			} else {
-				unhealthyFunctions = append(unhealthyFunctions, functionConfig)
+			// check ready function to ensure its container is healthy
+			if functionIsReady {
+				if err := p.checkAndSetFunctionUnhealthy(containerID, function); err != nil {
+					p.Logger.ErrorWith("Failed to check and set function unhealthy",
+						"err", err,
+						"functionName", functionName,
+						"namespace", namespace)
+				}
+			}
 
+			// check unhealthy function to see if its container id is healthy again
+			if functionWasSetAsUnhealthy {
+				if err := p.checkAndSetFunctionHealthy(containerID, function); err != nil {
+					p.Logger.ErrorWith("Failed to check and set function healthy",
+						"err", err,
+						"functionName", functionName,
+						"namespace", namespace)
+				}
 			}
 		}
 	}
-
-	if len(unhealthyFunctions) > 0 {
-		p.Logger.InfoWith(fmt.Sprintf("Successfully marked %d functions as unhealthy",
-			len(unhealthyFunctions)),
-			"unhealthyFunctions", unhealthyFunctions)
-	}
-	if len(functionsFailedToMarkUnhealthy) > 0 {
-		p.Logger.WarnWith(fmt.Sprintf("Failed to mark %d functions as unhealthy",
-			len(functionsFailedToMarkUnhealthy)),
-			"functionsFailedToMarkUnhealthy", functionsFailedToMarkUnhealthy)
-	}
 }
 
-func (p *Platform) markFunctionUnhealthy(containerID string, functionConfig *functionconfig.Config) error {
-
+func (p *Platform) checkAndSetFunctionUnhealthy(containerID string, function platform.Function) error {
 	if err := p.dockerClient.AwaitContainerHealth(containerID,
 		&p.functionContainersHealthinessTimeout); err != nil {
+		functionStatus := function.GetStatus()
 
-		// function container is not healthy or missing, mark function state as error
+		// set function state to error
+		functionStatus.State = functionconfig.FunctionStateError
+
+		// set unhealthy error message
+		functionStatus.Message = UnhealthyContainerErrorMessage
+
+		p.Logger.WarnWith("Setting function state as unhealthy",
+			"functionName", function.GetConfig().Meta.Name,
+			"functionStatus", functionStatus)
+
+		// function container is not healthy or missing, set function state as error
 		return p.localStore.createOrUpdateFunction(&functionconfig.ConfigWithStatus{
-			Config: *functionConfig,
-			Status: functionconfig.Status{
-				State:   functionconfig.FunctionStateError,
-				Message: "Container is not healthy",
-			},
+			Config: *function.GetConfig(),
+			Status: *functionStatus,
 		})
 	}
 	return nil
+}
+
+func (p *Platform) checkAndSetFunctionHealthy(containerID string, function platform.Function) error {
+	if err := p.dockerClient.AwaitContainerHealth(containerID,
+		&p.functionContainersHealthinessTimeout); err != nil {
+		return errors.Wrapf(err, "Failed to ensure healthiness for container id %s", containerID)
+	}
+	functionStatus := function.GetStatus()
+
+	// set function as ready
+	functionStatus.State = functionconfig.FunctionStateReady
+
+	// unset error message
+	functionStatus.Message = ""
+
+	p.Logger.InfoWith("Setting function state as ready",
+		"functionName", function.GetConfig().Meta.Name,
+		"functionStatus", functionStatus)
+
+	// function container is not healthy or missing, set function state as error
+	return p.localStore.createOrUpdateFunction(&functionconfig.ConfigWithStatus{
+		Config: *function.GetConfig(),
+		Status: *functionStatus,
+	})
 }

--- a/pkg/platform/local/platform_test.go
+++ b/pkg/platform/local/platform_test.go
@@ -99,6 +99,11 @@ func (suite *TestSuite) TestValidateFunctionContainersHealthiness() {
 
 	function := suite.getFunction(functionName, namespace)
 
+	// delete function when done
+	defer suite.Platform.DeleteFunction(&platform.DeleteFunctionOptions{
+		FunctionConfig: *function.GetConfig(),
+	})
+
 	// Check its state is ready
 	suite.Equal(function.GetStatus().State, functionconfig.FunctionStateReady)
 
@@ -143,6 +148,11 @@ func (suite *TestSuite) TestImportFunctionFlow() {
 
 	function := suite.getFunction(createdFunction.CreateFunctionBuildResult.UpdatedFunctionConfig.Meta.Name,
 		createdFunction.CreateFunctionBuildResult.UpdatedFunctionConfig.Meta.Namespace)
+
+	// delete function when done
+	defer suite.Platform.DeleteFunction(&platform.DeleteFunctionOptions{
+		FunctionConfig: *function.GetConfig(),
+	})
 
 	// Check its state is imported and not deployed
 	suite.Equal(function.GetStatus().State, functionconfig.FunctionStateImported)


### PR DESCRIPTION
This pr will allow nuclio dashboard to monitor unhealthy function containers to validate whether its containers are healthy so the function state would be set to `ready` again.

That will complete issue #1668 in terms of monitoring function states when function container healthiness changes.

In order to ensure the monitor is on, it is required to provide nuclio-dashboard with env `NUCLIO_CHECK_FUNCTION_CONTAINERS_HEALTHINESS` with value of `true`

The monitor will work on two modes
- check healthy function against its container health, if container isn't healthy, set function as unhealthy as well
- check unhealthy function, that its state was previously changed by nuclio, against its container health, if container is healthy, set function as healthy as well