### PR TITLE
Lock go version (1.14.3)

### DIFF
--- a/cmd/autoscaler/Dockerfile
+++ b/cmd/autoscaler/Dockerfile
@@ -27,6 +27,6 @@ FROM alpine:3.11
 WORKDIR /home/nuclio
 
 COPY --from=build-plugin /nuclio/plugin.so ./plugins/plugin.so
-COPY --from=quay.io/v3io/autoscaler:v0.3.1 /home/v3io/bin/autoscaler ./autoscaler
+COPY --from=quay.io/v3io/autoscaler:v0.3.2 /home/v3io/bin/autoscaler ./autoscaler
 
 CMD [ "/home/nuclio/autoscaler" ]

--- a/cmd/dlx/Dockerfile
+++ b/cmd/dlx/Dockerfile
@@ -27,6 +27,6 @@ FROM alpine:3.11
 WORKDIR /home/nuclio
 
 COPY --from=build-plugin /nuclio/plugin.so ./plugins/plugin.so
-COPY --from=quay.io/v3io/dlx:v0.3.1 /home/v3io/bin/dlx ./dlx
+COPY --from=quay.io/v3io/dlx:v0.3.2 /home/v3io/bin/dlx ./dlx
 
 CMD [ "/home/nuclio/dlx" ]

--- a/hack/docker/build/base-alpine/Dockerfile
+++ b/hack/docker/build/base-alpine/Dockerfile
@@ -17,7 +17,7 @@ ARG NUCLIO_LABEL
 
 FROM nuclio-builder:$NUCLIO_LABEL as builder
 
-FROM golang:1.14-alpine3.11
+FROM golang:1.14.3-alpine3.11
 
 ENV GOOS=linux
 

--- a/hack/docker/build/base/Dockerfile
+++ b/hack/docker/build/base/Dockerfile
@@ -17,7 +17,7 @@ ARG NUCLIO_LABEL
 
 FROM nuclio-builder:$NUCLIO_LABEL as builder
 
-FROM golang:1.14
+FROM golang:1.14.3
 
 ENV GOOS=linux
 

--- a/hack/docker/build/builder/Dockerfile
+++ b/hack/docker/build/builder/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.14
+FROM golang:1.14.3
 
 ENV GOOS=linux
 ENV GOARCH=amd64

--- a/pkg/functionconfig/reader_test.go
+++ b/pkg/functionconfig/reader_test.go
@@ -174,7 +174,7 @@ func (suite *ReaderTestSuite) TestToDeployOptions() {
 	//
 	//name: function-name
 	//namespace: function-namespace
-	//runtime: golang:1.14
+	//runtime: golang
 	//handler: some.module:handler
 	//triggers:
 	//

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -103,7 +103,7 @@ func addBuildFlags(cmd *cobra.Command, config *functionconfig.Config, commands *
 	cmd.Flags().StringVarP(&config.Spec.Build.FunctionConfigPath, "file", "f", "", "Path to a function-configuration file")
 	cmd.Flags().StringVarP(&config.Spec.Build.Image, "image", "i", "", "Name of a container image (default - the function name)")
 	cmd.Flags().StringVarP(&config.Spec.Build.Registry, "registry", "r", os.Getenv("NUCTL_REGISTRY"), "URL of a container registry (env: NUCTL_REGISTRY)")
-	cmd.Flags().StringVarP(&config.Spec.Runtime, "runtime", "", "", "Runtime (for example, \"golang\", \"golang:1.14\", \"python:3.6\")")
+	cmd.Flags().StringVarP(&config.Spec.Runtime, "runtime", "", "", "Runtime (for example, \"golang\", \"python:3.6\")")
 	cmd.Flags().StringVarP(&config.Spec.Handler, "handler", "", "", "Name of a function handler")
 	cmd.Flags().BoolVarP(&config.Spec.Build.NoBaseImagesPull, "no-pull", "", false, "Don't pull base images - use local versions")
 	cmd.Flags().BoolVarP(&config.Spec.Build.NoCleanup, "no-cleanup", "", false, "Don't clean up temporary directories")

--- a/pkg/playground/fixtures/source.go
+++ b/pkg/playground/fixtures/source.go
@@ -22,7 +22,7 @@ var Sources = map[string]string{
 // Super simple Golang function that echoes back the body it receives
 //
 // Note: The first build takes longer as it performs one time initializations (e.g.
-// pulls golang:1.14-alpine3.11 from docker hub).
+// pulls golang:1.14.3-alpine3.11 from docker hub).
 //
 
 package main

--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
@@ -21,7 +21,7 @@ FROM nuclio-base:$NUCLIO_LABEL as build-processor
 RUN GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-s -w" -o /home/nuclio/bin/processor cmd/processor/main.go
 
 # Build the plugin
-FROM golang:1.14
+FROM golang:1.14.3
 
 # Store processor binary
 COPY --from=build-processor /home/nuclio/bin/processor /home/nuclio/bin/processor

--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile.alpine
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile.alpine
@@ -22,7 +22,7 @@ FROM nuclio-base-alpine:$NUCLIO_LABEL as build-processor
 RUN GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-s -w" -o /home/nuclio/bin/processor cmd/processor/main.go
 
 # Build the plugin
-FROM golang:1.14-alpine3.11
+FROM golang:1.14.3-alpine3.11
 
 # Download required packages for plugin compilation
 RUN apk --update --no-cache add git gcc musl-dev file


### PR DESCRIPTION
Follow up with https://github.com/v3io/scaler/pull/39


Locking go version on 1.14.3 so clients will no panic on `plugin was built with a different version of package internal/cpu` when CGO runtime version is different