### PR TITLE
UI: Fix `namespace` instead of `platformKind` (erann's fault)

### DIFF
--- a/pkg/dashboard/ui/src/app/app.run.js
+++ b/pkg/dashboard/ui/src/app/app.run.js
@@ -31,7 +31,7 @@
                             imageNamePrefixTemplate: lodash.get(response, 'imageNamePrefixTemplate', ''),
                             ingressHostTemplate: lodash.get(response, 'defaultHTTPIngressHostTemplate', ''),
                             namespace: lodash.get(response, 'namespace', ''),
-                            platformKind: lodash.get(response, 'namespace', ''),
+                            platformKind: lodash.get(response, 'platformKind', ''),
                             scaleToZero: lodash.get(response, 'scaleToZero', {})
                         });
                     });


### PR DESCRIPTION
Originated in PR https://github.com/nuclio/nuclio/pull/1676

Shame on me, shame on me, shame on me!