### PR TITLE
Backport .dockerignore improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,12 @@
+*
+
+!pkg
+!cmd
+!test
+!vendor
+
 pkg/dashboard/ui/node_modules
-pkg/dashboard/ui/vendor
 pkg/dashboard/ui/dist
+
+**/Dockerfile
+**/Dockerfile.alpine


### PR DESCRIPTION
- Avoid shoving .git into built docker images (🤦 )
- Ignore changes made on `Dockerfiles` forcing the entire layers to be rebuilt
