### PR TITLE
Function ingressAddress is always empty

### DIFF
--- a/pkg/platform/kube/function.go
+++ b/pkg/platform/kube/function.go
@@ -192,7 +192,7 @@ func (f *function) Initialize([]string) error {
 		f.configuredReplicas = int(*deployment.Spec.Replicas)
 	}
 
-	if ingressErr != nil && ingress != nil && len(ingress.Status.LoadBalancer.Ingress) > 0 {
+	if ingressErr == nil && ingress != nil && len(ingress.Status.LoadBalancer.Ingress) > 0 {
 		f.ingressAddress = ingress.Status.LoadBalancer.Ingress[0].IP
 	}
 


### PR DESCRIPTION
Typo fix

Function ingress address is currently being used only for invoking function via `loadbalancer`