### PR TITLE
Allow configuring http max body size

### DIFF
--- a/docs/reference/triggers/http.md
+++ b/docs/reference/triggers/http.md
@@ -10,6 +10,7 @@ The HTTP trigger is the only trigger created by default if not configured (by de
 | ingresses.(name).host | string | The host to which the ingress maps. |
 | ingresses.(name).paths | list of strings | The paths that the ingress handles. Variables of the form `{{.<NAME>}}` can be specified using `.Name`, `.Namespace`, and `.Version`. For example, `/{{.Namespace}}-{{.Name}}/{{.Version}}` will result in a default ingress of `/namespace-name/version`. |
 | readBufferSize | int | Per-connection buffer size for reading requests. |
+| maxRequestBodySize | int | Maximum request body size. |
 | cors.enabled | bool | `true` to enable cross-origin resource sharing (CORS); (default: `false`). |
 | cors.allowOrigin | string | Indicates that the CORS response can be shared with requesting code from the specified origin (`Access-Control-Allow-Origin` response header); (default: `'*'` to allow sharing with any origin, for requests without credentials). |
 | cors.allowMethods | list of strings | The allowed HTTP methods, which can be used when accessing the resource (`Access-Control-Allow-Methods` response header); (default: `"HEAD, GET, POST, PUT, DELETE, OPTIONS"`). |
@@ -19,13 +20,15 @@ The HTTP trigger is the only trigger created by default if not configured (by de
 
 ### Examples
 
-With 4 workers -
+With 4 workers and maximum body size of 1kb -
 
 ```yaml
 triggers:
   myHttpTrigger:
     maxWorkers: 4
     kind: "http"
+    attributes:
+      maxRequestBodySize: 1024
 ```
 
 With predefined port number -

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -101,13 +101,15 @@ func (h *http) Start(checkpoint functionconfig.Checkpoint) error {
 	h.Logger.InfoWith("Starting",
 		"listenAddress", h.configuration.URL,
 		"readBufferSize", h.configuration.ReadBufferSize,
+		"maxRequestBodySize", h.configuration.MaxRequestBodySize,
 		"cors", h.configuration.CORS)
 
 	h.server = &fasthttp.Server{
-		Handler:        h.onRequestFromFastHTTP(),
-		Name:           "nuclio",
-		ReadBufferSize: h.configuration.ReadBufferSize,
-		Logger:         NewFastHTTPLogger(h.Logger),
+		Handler:            h.onRequestFromFastHTTP(),
+		Name:               "nuclio",
+		ReadBufferSize:     h.configuration.ReadBufferSize,
+		Logger:             NewFastHTTPLogger(h.Logger),
+		MaxRequestBodySize: h.configuration.MaxRequestBodySize,
 	}
 
 	// start listening
@@ -231,7 +233,7 @@ func (h *http) onRequestFromFastHTTP() fasthttp.RequestHandler {
 func (h *http) handlePreflightRequest(ctx *fasthttp.RequestCtx) {
 
 	// default to bad preflight request unless all specifications are valid
-	ctx.SetStatusCode(fasthttp.StatusBadRequest)
+	ctx.SetStatusCode(net_http.StatusBadRequest)
 
 	origin := common.ByteSliceToString(ctx.Request.Header.Peek("Origin"))
 	if !h.preflightRequestValidation(ctx, origin) {
@@ -261,7 +263,7 @@ func (h *http) handlePreflightRequest(ctx *fasthttp.RequestCtx) {
 		h.configuration.CORS.EncodeAllowHeaders())
 
 	// specifications met, set preflight request as OK
-	ctx.SetStatusCode(fasthttp.StatusOK)
+	ctx.SetStatusCode(net_http.StatusOK)
 	h.UpdateStatistics(true)
 }
 

--- a/pkg/processor/trigger/http/types.go
+++ b/pkg/processor/trigger/http/types.go
@@ -26,13 +26,19 @@ import (
 	"github.com/nuclio/errors"
 )
 
+const DefaultReadBufferSize = 16 * 1024
+const DefaultMaxRequestBodySize = 4 * 1024 * 1024
+
 type Configuration struct {
 	trigger.Configuration
 	ReadBufferSize int
-	CORS           *cors.CORS
-}
 
-const DefaultReadBufferSize = 16 * 1024
+	// NOTE: Modifying the max request body size affect with gradually memory consumption increasing
+	// as the entire request being read into the memory
+	// https://github.com/valyala/fasthttp/issues/667#issuecomment-540965683
+	MaxRequestBodySize int
+	CORS               *cors.CORS
+}
 
 func NewConfiguration(ID string,
 	triggerConfiguration *functionconfig.Trigger,
@@ -53,6 +59,10 @@ func NewConfiguration(ID string,
 
 	if newConfiguration.ReadBufferSize == 0 {
 		newConfiguration.ReadBufferSize = DefaultReadBufferSize
+	}
+
+	if newConfiguration.MaxRequestBodySize == 0 {
+		newConfiguration.MaxRequestBodySize = DefaultMaxRequestBodySize
 	}
 
 	if newConfiguration.CORS != nil && newConfiguration.CORS.Enabled {


### PR DESCRIPTION
Making fast http max request body size configurable allowing us to tweak & modify allowed request body size in essense of
1. Limiting the request body buffer to a smaller than default (4mb)
2. Increasing the allowed body size (for those of you sending large request body)

Note:
Since this change is only on the processor size, the limitation on runtimes such as python will not accept (2) yet. This will followed by another pr to make it configurable on the runtime side.