### PR TITLE
Local platform fail fast when container exited

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -381,6 +381,11 @@ lint: modules
 test-undockerized: ensure-gopath
 	go test -v -p 1 --timeout $(NUCLIO_GO_TEST_TIMEOUT) ./cmd/... ./pkg/...
 
+
+.PHONY: fmt
+fmt:
+	gofmt -s -w .
+
 .PHONY: test
 test: ensure-gopath build-base
 	docker build \

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -576,7 +576,7 @@ func (suite *functionTestSuite) TestInvokeSuccessful() {
 		suite.Require().Equal(requestPath[1:], createFunctionInvocationOptions.Path)
 
 		// expect only to receive the function headers (those that don't start with x-nuclio
-		for headerKey, _ := range createFunctionInvocationOptions.Headers {
+		for headerKey := range createFunctionInvocationOptions.Headers {
 			suite.Require().False(strings.HasPrefix(headerKey, "x-nuclio"))
 		}
 

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -373,7 +373,7 @@ func (c *ShellClient) AwaitContainerHealth(containerID string, timeout *time.Dur
 
 				// container exited, bail out
 				if container.State.Status == "exited" {
-					containerHealthy <- errors.Errorf("Container exited with status: %s", container.State.ExitCode)
+					containerHealthy <- errors.Errorf("Container exited with status: %d", container.State.ExitCode)
 					return
 				}
 

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -396,9 +396,9 @@ func (c *ShellClient) AwaitContainerHealth(containerID string, timeout *time.Dur
 
 	// wait for either the container to be healthy or the timeout
 	select {
-	case err := <- containerHealthy:
+	case err := <-containerHealthy:
 		if err != nil {
-			return errors.Wrapf(err,"Container %s is not healthy", containerID)
+			return errors.Wrapf(err, "Container %s is not healthy", containerID)
 		}
 		c.logger.DebugWith("Container is healthy", "containerID", containerID)
 	case <-timeoutChan:

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -377,6 +377,13 @@ func (c *ShellClient) AwaitContainerHealth(containerID string, timeout *time.Dur
 					return
 				}
 
+				// container is dead, bail out
+				// https://docs.docker.com/engine/reference/commandline/ps/#filtering
+				if container.State.Status == "dead" {
+					containerHealthy <- errors.New("Container seems to be dead")
+					return
+				}
+
 				// wait a bit before retrying
 				c.logger.DebugWith("Container not healthy yet, retrying soon",
 					"timeout", timeout,

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -358,25 +358,32 @@ func (c *ShellClient) AwaitContainerHealth(containerID string, timeout *time.Dur
 		inspectInterval := 100 * time.Millisecond
 
 		for !timedOut {
+			containers, err := c.GetContainers(&GetContainerOptions{
+				ID:      containerID,
+				Stopped: true,
+			})
+			if err == nil && len(containers) > 0 {
+				container := containers[0]
 
-			// inspect the container's health, return if it's healthy
-			runResult, err := c.runCommand(nil, "docker inspect --format '{{json .State.Health.Status}}' %s", containerID)
-			if err == nil {
-				stdoutLines := strings.Split(runResult.Output, "\n")
-				lastStdoutLine := c.getLastNonEmptyLine(stdoutLines, 0)
-
-				if lastStdoutLine == `"healthy"` {
+				// container is healthy
+				if container.State.Health.Status == "healthy" {
 					containerHealthy <- nil
 					return
 				}
-			}
 
-			// wait a bit before retrying
-			c.logger.DebugWith("Container not healthy yet, retrying soon",
-				"timeout", timeout,
-				"containerID", containerID,
-				"inspectOutput", runResult.Output,
-				"nextCheckIn", inspectInterval)
+				// container exited, bail out
+				if container.State.Status == "exited" {
+					containerHealthy <- errors.Errorf("Container exited with status: %s", container.State.ExitCode)
+					return
+				}
+
+				// wait a bit before retrying
+				c.logger.DebugWith("Container not healthy yet, retrying soon",
+					"timeout", timeout,
+					"containerID", containerID,
+					"containerState", container.State,
+					"nextCheckIn", inspectInterval)
+			}
 
 			time.Sleep(inspectInterval)
 
@@ -389,7 +396,10 @@ func (c *ShellClient) AwaitContainerHealth(containerID string, timeout *time.Dur
 
 	// wait for either the container to be healthy or the timeout
 	select {
-	case <-containerHealthy:
+	case err := <- containerHealthy:
+		if err != nil {
+			return errors.Wrapf(err,"Container %s is not healthy", containerID)
+		}
 		c.logger.DebugWith("Container is healthy", "containerID", containerID)
 	case <-timeoutChan:
 		timedOut = true
@@ -427,6 +437,11 @@ func (c *ShellClient) GetContainers(options *GetContainerOptions) ([]Container, 
 		nameFilterArgument = fmt.Sprintf(`--filter "name=^/%s$" `, options.Name)
 	}
 
+	idFilterArgument := ""
+	if options.ID != "" {
+		idFilterArgument = fmt.Sprintf(`--filter "id=%s"`, options.ID)
+	}
+
 	labelFilterArgument := ""
 	for labelName, labelValue := range options.Labels {
 		labelFilterArgument += fmt.Sprintf(`--filter "label=%s=%s" `,
@@ -435,8 +450,9 @@ func (c *ShellClient) GetContainers(options *GetContainerOptions) ([]Container, 
 	}
 
 	runResult, err := c.runCommand(nil,
-		"docker ps --quiet %s %s %s",
+		"docker ps --quiet %s %s %s %s",
 		stoppedContainersArgument,
+		idFilterArgument,
 		nameFilterArgument,
 		labelFilterArgument)
 

--- a/pkg/dockerclient/types.go
+++ b/pkg/dockerclient/types.go
@@ -75,6 +75,7 @@ type GetContainerOptions struct {
 	Name    string
 	Labels  map[string]string
 	Stopped bool
+	ID      string
 }
 
 // ContainerJSONBase contains response of Engine API:
@@ -118,6 +119,22 @@ type ContainerState struct {
 	Error      string
 	StartedAt  string
 	FinishedAt string
+	Health     *Health
+}
+
+// Health stores container health state
+type Health struct {
+	Status        string
+	FailingStreak int
+	Log           []HealthLog
+}
+
+// HealthLog stores container health logs
+type HealthLog struct {
+	Start    string
+	End      string
+	ExitCode int
+	Output   string
 }
 
 // MountPoint represents a mount point configuration inside the container.

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -639,8 +639,8 @@ func (suite *functionDeployTestSuite) TestBuildAndDeployFromFileWithOverriddenAr
 	// use deploy with the image we just created
 	err = suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose"},
 		map[string]string{
-			"run-image": imageName,
-			"file":      path.Join(suite.GetFunctionsDir(), "common", "json-parser-with-function-config", "python", "function-different-spec.yaml"),
+			"run-image":    imageName,
+			"file":         path.Join(suite.GetFunctionsDir(), "common", "json-parser-with-function-config", "python", "function-different-spec.yaml"),
 			"min-replicas": fmt.Sprintf("%d", minReplicas),
 		})
 

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -794,8 +794,7 @@ func (p *Platform) ValidateFunctionContainersHealthiness() {
 
 			// get function container by name
 			containers, err := p.dockerClient.GetContainers(&dockerclient.GetContainerOptions{
-				Name:    containerName,
-				Stopped: true,
+				Name: containerName,
 			})
 			if err != nil {
 				p.Logger.WarnWith("Failed to get containers by name",
@@ -806,8 +805,9 @@ func (p *Platform) ValidateFunctionContainersHealthiness() {
 
 			// if function container does not exists, mark as unhealthy
 			if len(containers) == 0 {
-				p.Logger.WarnWith("No containers were found",
-					"functionName", functionName)
+				p.Logger.WarnWith("No containers were found", "functionName", functionName)
+
+				// no running containers were found for function, set function unhealthy
 				if err := p.setFunctionUnhealthy(function); err != nil {
 					p.Logger.ErrorWith("Failed to set function unhealthy",
 						"err", err,

--- a/pkg/platform/local/test/platform_test.go
+++ b/pkg/platform/local/test/platform_test.go
@@ -65,6 +65,9 @@ func (suite *TestSuite) TestRunFunctionContainerWithCustomRestartPolicy() {
 	suite.DeployFunctionExpectError(createFunctionOptions,
 		func(deployResult *platform.CreateFunctionResult) bool {
 
+			// give some time to docker to log its events
+			time.Sleep(5 * time.Second)
+
 			// sample container events
 			restartEventsUntil := time.Now()
 			containerEvents, err := suite.DockerClient.GetContainerEvents(containerName,

--- a/pkg/platform/local/test/platform_test.go
+++ b/pkg/platform/local/test/platform_test.go
@@ -118,7 +118,7 @@ func (suite *TestSuite) TestValidateFunctionContainersHealthiness() {
 
 			// Function is healthy again
 			function = suite.getFunction(functionName)
-			suite.Require().Equal(function.GetStatus().State, functionconfig.FunctionStateReady)
+			suite.Require().Equal(functionconfig.FunctionStateReady, function.GetStatus().State)
 
 			return true
 		})

--- a/pkg/platform/local/test/platform_test.go
+++ b/pkg/platform/local/test/platform_test.go
@@ -65,7 +65,7 @@ func (suite *TestSuite) TestRunFunctionContainerWithCustomRestartPolicy() {
 	suite.DeployFunctionExpectError(createFunctionOptions,
 		func(deployResult *platform.CreateFunctionResult) bool {
 
-			// give some time to docker to log its events
+			// give some time to docker to flush its events
 			time.Sleep(5 * time.Second)
 
 			// sample container events

--- a/pkg/processor/test/readinesstimeout/suite_test.go
+++ b/pkg/processor/test/readinesstimeout/suite_test.go
@@ -39,7 +39,7 @@ func (suite *readinessTimeoutTestSuite) TestPythonNoReadinessTimeout() {
 	suite.deployFailingPythonFunction(0)
 
 	// fail faster than the default 30 second timeout
-	suite.Require().LessOrEqual(time.Since(beforeTime), 30*time.Second)
+	suite.Require().LessOrEqual(time.Since(beforeTime).Seconds(), float64(30))
 }
 
 // Deploys a failing Python function. Expect the function to fail after 10 seconds
@@ -49,7 +49,7 @@ func (suite *readinessTimeoutTestSuite) TestPythonSpecifiedReadinessTimeout() {
 	suite.deployFailingPythonFunction(readinessTimeoutSeconds)
 
 	// fail faster than the specified 20 second timeout
-	suite.Require().LessOrEqual(time.Since(beforeTime), time.Duration(readinessTimeoutSeconds)*time.Second)
+	suite.Require().LessOrEqual(time.Since(beforeTime).Seconds(), float64(readinessTimeoutSeconds))
 }
 
 func (suite *readinessTimeoutTestSuite) deployFailingPythonFunction(readinessTimeoutSeconds int) {

--- a/pkg/processor/test/readinesstimeout/suite_test.go
+++ b/pkg/processor/test/readinesstimeout/suite_test.go
@@ -38,18 +38,18 @@ func (suite *readinessTimeoutTestSuite) TestPythonNoReadinessTimeout() {
 	beforeTime := time.Now()
 	suite.deployFailingPythonFunction(0)
 
-	// the default timeout is 30 seconds - it must have timed out after that
-	suite.Require().True(time.Since(beforeTime) >= 30*time.Second)
+	// fail faster than the default 30 second timeout
+	suite.Require().LessOrEqual(time.Since(beforeTime), 30*time.Second)
 }
 
 // Deploys a failing Python function. Expect the function to fail after 10 seconds
 func (suite *readinessTimeoutTestSuite) TestPythonSpecifiedReadinessTimeout() {
-
+	readinessTimeoutSeconds := 20
 	beforeTime := time.Now()
-	suite.deployFailingPythonFunction(10)
+	suite.deployFailingPythonFunction(readinessTimeoutSeconds)
 
-	// the default timeout is 30 seconds - it must have timed out after that
-	suite.Require().True(time.Since(beforeTime) <= 29*time.Second)
+	// fail faster than the specified 20 second timeout
+	suite.Require().LessOrEqual(time.Since(beforeTime), time.Duration(readinessTimeoutSeconds)*time.Second)
 }
 
 func (suite *readinessTimeoutTestSuite) deployFailingPythonFunction(readinessTimeoutSeconds int) {

--- a/pkg/processor/timeout/timeout_test.go
+++ b/pkg/processor/timeout/timeout_test.go
@@ -83,7 +83,7 @@ func (suite *eventTimeoutSuite) TestWatcher() {
 	suite.Require().NoError(err, "Can't create logger")
 
 	mockTrigger := &mockTestTrigger{
-		workers: []*worker.Worker{&worker.Worker{}},
+		workers: []*worker.Worker{{}},
 	}
 
 	mockTrigger.On("GetWorkers").Return(mockTrigger.GetWorkers())

--- a/test/_functions/common/event-returner/golang/eventreturner.go
+++ b/test/_functions/common/event-returner/golang/eventreturner.go
@@ -39,21 +39,21 @@ func EventReturner(context *nuclio.Context, event nuclio.Event) (interface{}, er
 		TypeVersion    string                 `json:"typeVersion,omitempty"`
 		Version        string                 `json:"version,omitempty"`
 		Body           []byte                 `json:"body,omitempty"`
-	} {
-		ID: event.GetID(),
-		TriggerKind: event.GetTriggerInfo().GetKind(),
-		ContentType: event.GetContentType(),
-		Headers: event.GetHeaders(),
-		Timestamp: event.GetTimestamp(),
-		Path: event.GetPath(),
-		URL: event.GetURL(),
-		Method: event.GetMethod(),
-		ShardID: event.GetShardID(),
+	}{
+		ID:             event.GetID(),
+		TriggerKind:    event.GetTriggerInfo().GetKind(),
+		ContentType:    event.GetContentType(),
+		Headers:        event.GetHeaders(),
+		Timestamp:      event.GetTimestamp(),
+		Path:           event.GetPath(),
+		URL:            event.GetURL(),
+		Method:         event.GetMethod(),
+		ShardID:        event.GetShardID(),
 		TotalNumShards: event.GetTotalNumShards(),
-		Type: event.GetType(),
-		TypeVersion: event.GetTypeVersion(),
-		Version: event.GetVersion(),
-		Body: event.GetBody(),
+		Type:           event.GetType(),
+		TypeVersion:    event.GetTypeVersion(),
+		Version:        event.GetVersion(),
+		Body:           event.GetBody(),
 	}
 
 	return json.Marshal(&eventFields)

--- a/test/_functions/common/long-initialization/golang/sleepy.go
+++ b/test/_functions/common/long-initialization/golang/sleepy.go
@@ -27,5 +27,5 @@ func Handler(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
 }
 
 func init() {
-	time.Sleep(5*time.Second)
+	time.Sleep(5 * time.Second)
 }

--- a/test/compare/compare_test.go
+++ b/test/compare/compare_test.go
@@ -52,8 +52,8 @@ var (
 		{map[int]int{1: 1}, map[int]int{1: 1}, true},
 		{map[int]int{1: 2}, map[int]int{1: 1}, false},
 		{map[int]float32{1: 1}, map[int]int{1: 1}, false}, // different type
-		{map[int][]int{1: []int{1, 2, 3}}, map[int][]int{1: []int{2, 3, 1}}, true},
-		{map[int][]int{1: []int{1, 2}}, map[int][]int{1: []int{2, 3}}, false},
+		{map[int][]int{1: {1, 2, 3}}, map[int][]int{1: {2, 3, 1}}, true},
+		{map[int][]int{1: {1, 2}}, map[int][]int{1: {2, 3}}, false},
 	}
 )
 


### PR DESCRIPTION
When waiting for container healthy, if container exited, no need to wait until it becomes healthy as when running on local platform, nothing will restart / resolve its issue so fail-fast, that would save some valuable time waiting for doomed functions