### PR TITLE
Removed python body size limitation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,17 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Run short test suites
-        run: make test-short
+        run: |
+          set -o pipefail
+          make test-short 2>&1 | tee test-short-${NUCLIO_LABEL}.log
+
+      - name: Upload short test results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: test-results
+          path: test-short-${{ env.NUCLIO_LABEL }}.log
+
 
   build_nuctl:
     name: Build nuctl
@@ -213,3 +223,21 @@ jobs:
         with:
           name: test-results
           path: test-docker-nuctl-${{ env.NUCLIO_LABEL }}.log
+
+  test_python:
+    name: Test python
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run short test suites
+        run: |
+          set -o pipefail
+          make test-python 2>&1 | tee test-python-${NUCLIO_LABEL}.log
+
+      - name: Upload test python results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: test-results
+          path: test-python-${{ env.NUCLIO_LABEL }}.log

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Run short test suites
+      - name: Run short test
         run: |
           set -o pipefail
           make test-short 2>&1 | tee test-short-${NUCLIO_LABEL}.log
@@ -230,7 +230,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run short test suites
+      - name: Run python test
         run: |
           set -o pipefail
           make test-python 2>&1 | tee test-python-${NUCLIO_LABEL}.log

--- a/Makefile
+++ b/Makefile
@@ -412,8 +412,8 @@ test: ensure-gopath build-base
 
 .PHONY: test-python
 test-python:
-	docker build -f pkg/processor/runtime/python/test/Dockerfile.py3-test .
-	docker build -f pkg/processor/runtime/python/test/Dockerfile.py2-test .
+	docker build --no-cache --build-arg PYTHON_IMAGE_TAG=3.6-slim-stretch -f pkg/processor/runtime/python/test/Dockerfile .
+	docker build --no-cache --build-arg PYTHON_IMAGE_TAG=2.7-slim-stretch -f pkg/processor/runtime/python/test/Dockerfile .
 
 .PHONY: test-short
 test-short: modules ensure-gopath

--- a/Makefile
+++ b/Makefile
@@ -412,8 +412,14 @@ test: ensure-gopath build-base
 
 .PHONY: test-python
 test-python:
-	docker build --no-cache --build-arg PYTHON_IMAGE_TAG=3.6-slim-stretch -f pkg/processor/runtime/python/test/Dockerfile .
-	docker build --no-cache --build-arg PYTHON_IMAGE_TAG=2.7-slim-stretch -f pkg/processor/runtime/python/test/Dockerfile .
+	docker build \
+		--build-arg CACHEBUST=$(shell date +%s) \
+		--build-arg PYTHON_IMAGE_TAG=3.6-slim-stretch \
+		-f pkg/processor/runtime/python/test/Dockerfile .
+	docker build \
+		--build-arg CACHEBUST=$(shell date +%s) \
+		--build-arg PYTHON_IMAGE_TAG=2.7-slim-stretch \
+		-f pkg/processor/runtime/python/test/Dockerfile .
 
 .PHONY: test-short
 test-short: modules ensure-gopath

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -88,7 +88,6 @@ class Wrapper(object):
         """Read event from socket, send out reply"""
 
         int_buf = bytearray(4)
-        buf = memoryview(bytearray(self._max_message_size))
         minimum_float_duration = sys.float_info.min
 
         while True:
@@ -116,19 +115,18 @@ class Wrapper(object):
 
                 cumulative_bytes_read = 0
                 while cumulative_bytes_read < bytes_to_read:
-                    view = buf[cumulative_bytes_read:bytes_to_read]
                     bytes_to_read_now = bytes_to_read - cumulative_bytes_read
-                    bytes_read = self._processor_sock.recv_into(view, bytes_to_read_now)
+                    bytes_read = self._processor_sock.recv(bytes_to_read_now)
 
                     # client disconnect
                     if not bytes_read:
+
                         # If socket is done, we can't log
                         print('Client disconnect')
                         return
 
-                    cumulative_bytes_read += bytes_read
-
-                self._unpacker.feed(buf[:cumulative_bytes_read])
+                    self._unpacker.feed(bytes_read)
+                    cumulative_bytes_read += len(bytes_read)
 
                 msg = next(self._unpacker)
 

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -28,10 +28,6 @@ import nuclio_sdk.logger
 
 
 class Wrapper(object):
-
-    # hard limit of 50mb
-    _max_message_size = 50 * 1024 * 1024
-
     def __init__(self,
                  logger,
                  handler,
@@ -108,7 +104,7 @@ class Wrapper(object):
                 bytes_to_read += int_buf[2] << 8
                 bytes_to_read += int_buf[1] << 16
                 bytes_to_read += int_buf[0] << 24
-                if bytes_to_read > self._max_message_size or bytes_to_read <= 0:
+                if bytes_to_read <= 0:
                     # If socket is done, we can't log
                     print('Illegal message size: ' + str(bytes_to_read))
                     return

--- a/pkg/processor/runtime/python/py/requirements/dev.txt
+++ b/pkg/processor/runtime/python/py/requirements/dev.txt
@@ -1,0 +1,2 @@
+pytest
+futures

--- a/pkg/processor/runtime/python/py/requirements/dev.txt
+++ b/pkg/processor/runtime/python/py/requirements/dev.txt
@@ -1,2 +1,3 @@
 pytest
-futures
+matplotlib
+memory_profiler

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -1,73 +1,39 @@
-# Copyright 2017 The Nuclio Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
+import functools
 import json
 import logging
 import os
-import sys
 import tempfile
 import threading
-import time
 import unittest
+import socket
+import struct
+import base64
+import concurrent.futures.thread
+
+import msgpack
+import nuclio_sdk
+import operator
+import sys
+import time
 
 import _nuclio_wrapper as wrapper
-import nuclio_sdk
 
 # python2/3 differences
 if sys.version_info[:2] >= (3, 0):
     from socketserver import UnixStreamServer, BaseRequestHandler
     from unittest import mock
 else:
-    from SocketServer import UnixStreamServer, BaseRequestHandler, StreamRequestHandler
+    from SocketServer import UnixStreamServer, BaseRequestHandler
     import mock
-
-
-class MockSocket:
-    class EOF(BaseException):
-        # Don't make this subclass of Exception, handler catches these
-        pass
-
-    def __init__(self, data):
-        self._io = io.BytesIO(data)
-        self._i = 0
-        self.written = []
-
-    def makefile(self, mode):
-        return self
-
-    def recv(self, size):
-        chunk = self._io.read(size)
-        if not chunk:
-            raise MockSocket.EOF
-
-        return chunk
-
-    def write(self, data):
-        self.written.append(data)
-
-    def flush(self):
-        pass
-
-    def readline(self):
-        return self._io.readline()
 
 
 class TestSubmitEvents(unittest.TestCase):
 
     def setUp(self):
-        self._temp_path = tempfile.mkdtemp()
+        self._temp_path = tempfile.mkdtemp(prefix='nuclio-test-py-wrapper')
 
         # write handler to temp path
         self._handler_path = self._write_handler(self._temp_path)
@@ -83,29 +49,91 @@ class TestSubmitEvents(unittest.TestCase):
 
         # create logger
         self._logger = nuclio_sdk.Logger(logging.DEBUG)
-        self._logger.set_handler('default', sys.stdout, nuclio_sdk.logger.HumanReadableFormatter())
+        self._logger.set_handler('test-default', sys.stdout, nuclio_sdk.logger.HumanReadableFormatter())
 
         # create a wrapper
         self._wrapper = wrapper.Wrapper(self._logger, 'reverser:handler', self._socket_path, 'test')
 
     def tearDown(self):
         sys.path.remove(self._temp_path)
-
+        self._wrapper._processor_sock.close()
+        self._unix_stream_server.server_close()
         self._unix_stream_server.shutdown()
+        self._unix_stream_server_thread.join()
 
-    def test_event(self):
-        event = nuclio_sdk.Event(body='reverse this')
+    def test_event_bigger_than_message_size(self):
+        self._wrapper._max_message_size = 1024
+        dummy_text = self._wrapper._max_message_size * 'a'
 
-        time.sleep(1)
+        self._send_event(nuclio_sdk.Event(body=dummy_text))
 
-        # write the event to the transport
-        line = event.to_json() + '\n'
-        self._unix_stream_server._connection_socket.send(line.encode('utf-8'))
+        self._wrapper._entrypoint = mock.MagicMock()
+        self._wrapper._entrypoint.assert_not_called()
+        self._wrapper.serve_requests(num_requests=1)
+
+    def test_large_event(self):
+        self._wrapper._max_message_size = 1 * 1024 * 1024  # 10mb
+        event = nuclio_sdk.Event(body='')
+
+        # fill event body as much as possible
+        while self._get_packed_event_body_len(event) < self._wrapper._max_message_size:
+            times_to_add = int((self._wrapper._max_message_size - self._get_packed_event_body_len(event)) / 2)
+            if times_to_add == 0:
+                break
+            event.body += 'a' * times_to_add
+
+        # send the event
+        t = threading.Thread(target=self._send_event, args=(event,))
+        t.start()
 
         # handle one request
         self._wrapper.serve_requests(num_requests=1)
+        t.join()
 
-        time.sleep(3)
+        self._wait_until_received_messages(4)
+
+    def test_single_event(self):
+        reverse_text = 'reverse this'
+
+        # send the event
+        threading.Thread(target=self._send_event, args=(nuclio_sdk.Event(_id=1, body=reverse_text),)).start()
+
+        self._wrapper.serve_requests(num_requests=1)
+
+        # processor start, function log line, response body, duration messages
+        self._wait_until_received_messages(4)
+
+        # extract the response
+        response = next(message['body']
+                        for message in self._unix_stream_server._messages
+                        if message['type'] == 'r')
+        response_body = response['body'][::-1]
+
+        if sys.version_info[:2] < (3, 0):
+
+            # blame is on nuclio_sdk/event.py:80
+            response_body = base64.b64decode(response_body)
+
+        self.assertEqual(reverse_text, response_body)
+
+    def test_blast_events(self):
+        """Test when many >> 10 events are being sent in parallel"""
+
+        def record_event(recorded_events, ctx, event):
+            recorded_events.add(event.id)
+
+        recorded_event_ids = set()
+        expected_events_length = 10000
+
+        t = threading.Thread(target=self._send_events, args=(expected_events_length,))
+        t.start()
+
+        self._wrapper._entrypoint = functools.partial(record_event, recorded_event_ids)
+        self._wrapper.serve_requests(num_requests=expected_events_length)
+        t.join()
+
+        # record incoming events
+        self.assertEqual(expected_events_length, len(recorded_event_ids), 'Wrong number of events')
 
     def test_multi_event(self):
         """Test when two events fit inside on TCP packet"""
@@ -115,27 +143,75 @@ class TestSubmitEvents(unittest.TestCase):
             recorded_events.append(event)
             return 'OK'
 
-        events = [nuclio_sdk.Event(body='e{}'.format(i)) for i in range(7)]
-        text = '\n'.join(event.to_json() for event in events) + '\n'
-        sock = MockSocket(text.encode('utf-8'))
-        self._wrapper._processor_sock = sock
+        num_of_events = 10
+        self._send_events(num_of_events)
         self._wrapper._entrypoint = event_recorder
-        try:
-            self._wrapper.serve_requests()
-        except MockSocket.EOF:
-            pass
+        self._wrapper.serve_requests(num_of_events)
+        self.assertEqual(num_of_events, len(recorded_events), 'wrong number of events')
 
-        self.assertEqual(
-            len(events), len(recorded_events), 'wrong number of events')
+        for recorded_event_index, recorded_event in enumerate(sorted(recorded_events, key=operator.attrgetter('id'))):
+            self.assertEqual(recorded_event_index, recorded_event.id)
+            response_body = recorded_event.body
+
+            if sys.version_info[:2] < (3, 0):
+
+                # blame is on nuclio_sdk/event.py:80
+                response_body = base64.b64decode(response_body)
+
+            self.assertEqual('e{}'.format(recorded_event_index), response_body)
+
+    def _send_event(self, event):
+        self._wait_for_socket_creation()
+
+        # pack exactly as processor or wrapper explodes
+        body = msgpack.Packer().pack(self._event_to_dict(event))
+        body_len = struct.pack(">I", len(body))
+
+        # first write body length
+        self._unix_stream_server._connection_socket.sendall(body_len)
+
+        # then write body content
+        self._unix_stream_server._connection_socket.sendall(body)
+
+    def _get_packed_event_body_len(self, event):
+        return len(msgpack.Packer().pack(self._event_to_dict(event)))
+
+    def _event_to_dict(self, event):
+        return json.loads(event.to_json())
+
+    def _send_events(self, num_of_events):
+        events = [
+            nuclio_sdk.Event(_id=i, body='e{}'.format(i))
+            for i in range(num_of_events)
+        ]
+        for event in events:
+            self._send_event(event)
+
+    def _wait_for_socket_creation(self, timeout=10, interval=0.1):
+
+        # wait for socket connection
+        while self._unix_stream_server._connection_socket is None and timeout > 0:
+            time.sleep(interval)
+            timeout -= interval
+
+    def _wait_until_received_messages(self, minimum_messages_length, timeout=10, interval=1):
+        while timeout > 0:
+            time.sleep(interval)
+            current_messages_length = len(self._unix_stream_server._messages)
+            if current_messages_length >= minimum_messages_length:
+                break
+            self._logger.debug_with('Waiting for messages to arrive',
+                                    current_messages_length=current_messages_length,
+                                    minimum_messages_length=minimum_messages_length)
+            timeout -= interval
 
     def _create_unix_stream_server(self, socket_path):
         unix_stream_server = _SingleConnectionUnixStreamServer(socket_path, _Connection)
 
         # create a thread and listen forever on server
-        unix_stream_server_thread = threading.Thread(target=unix_stream_server.serve_forever)
-        unix_stream_server_thread.daemon = True
-        unix_stream_server_thread.start()
-
+        self._unix_stream_server_thread = threading.Thread(target=unix_stream_server.serve_forever)
+        self._unix_stream_server_thread.daemon = True
+        self._unix_stream_server_thread.start()
         return unix_stream_server
 
     def _write_handler(self, temp_path):
@@ -146,7 +222,7 @@ is_py2 = sys.version_info[:2] < (3, 0)
 def handler(ctx, event):
     """Return reversed body as string"""
     body = event.body
-    if not is_py2:
+    if not is_py2 and isinstance(body, bytes):
         body = body.decode('utf-8')
     ctx.logger.warn('the end is nigh')
     return body[::-1]
@@ -165,7 +241,7 @@ class _SingleConnectionUnixStreamServer(UnixStreamServer):
     def __init__(self, server_address, RequestHandlerClass, bind_and_activate=True):
         UnixStreamServer.__init__(self, server_address, RequestHandlerClass, bind_and_activate)
 
-        self._connection_socket = None
+        self._connection_socket = None  # type: socket.socket
         self._messages = []
 
 
@@ -190,7 +266,7 @@ class _Connection(BaseRequestHandler):
 
                 message = {
                     'type': line[0],
-                    'body': json.loads(line[1:])
+                    'body': json.loads(line[1:]) if line[0] != 's' else ''
                 }
 
                 self.server._messages.append(message)
@@ -202,7 +278,6 @@ class _Connection(BaseRequestHandler):
 class TestCallFunction(unittest.TestCase):
 
     def setUp(self):
-
         # provided by _connection_provider
         self._mockConnection = mock.MagicMock()
 
@@ -223,21 +298,25 @@ class TestCallFunction(unittest.TestCase):
         # send the event
         response = self._platform.call_function('function-name', event)
 
-        self.assertEqual(self._mockConnection.url, 'somens-function-name:8080')
+        self.assertEqual(self._mockConnection.url, 'nuclio-somens-function-name:8080')
         self._mockConnection.request.assert_called_with(event.method,
                                                         event.path,
                                                         body=json.dumps({'a': 'some_body'}),
-                                                        headers={'Content-Type': 'application/json'})
+                                                        headers={
+                                                            'Content-Type': 'application/json',
+                                                            'X-Nuclio-Target': 'function-name'
+                                                        })
 
         self.assertEqual({'b': 'some_response'}, response.body)
         self.assertEqual('application/json', response.content_type)
         self.assertEqual(204, response.status_code)
 
     def test_get_function_url(self):
-        self.assertEqual(nuclio_sdk.Platform('local', 'ns')._get_function_url('function-name'), 'ns-function-name:8080')
-        self.assertEqual(nuclio_sdk.Platform('kube', 'ns')._get_function_url('function-name'), 'function-name:8080')
+        self.assertEqual(nuclio_sdk.Platform('local', 'ns')._get_function_url('function-name'),
+                         'nuclio-ns-function-name:8080')
+        self.assertEqual(nuclio_sdk.Platform('kube', 'ns')._get_function_url('function-name'),
+                         'nuclio-function-name:8080')
 
-    def _connection_provider(self, url):
+    def _connection_provider(self, url, timeout=None):
         self._mockConnection.url = url
-
         return self._mockConnection

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -183,6 +183,8 @@ class TestSubmitEvents(unittest.TestCase):
 
         # pack exactly as processor or wrapper explodes
         body = msgpack.Packer().pack(self._event_to_dict(event))
+
+        # big endian body len
         body_len = struct.pack(">I", len(body))
 
         # first write body length

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -164,27 +164,33 @@ class TestSubmitEvents(unittest.TestCase):
 
             self.assertEqual('e{}'.format(recorded_event_index), response_body)
 
-    def test_memory_profiling_1(self):
-        self._run_memory_profiling(100)
-
-    def test_memory_profiling_1k(self):
-        self._run_memory_profiling(1000)
-
-    def test_memory_profiling_10k(self):
-        self._run_memory_profiling(10000)
-
-    def test_memory_profiling_100k(self):
-        self._run_memory_profiling(100000)
-
-    def _run_memory_profiling(self, num_of_events):
-        self._wrapper._entrypoint = mock.MagicMock()
-        self._wrapper._entrypoint.return_value = {}
-        threading.Thread(target=self._send_events, args=(num_of_events,)).start()
-        with open('test_memory_profiling_{0}'.format(num_of_events), 'w') as f:
-            memory_profiler.profile(self._wrapper.serve_requests,
-                                    precision=4,
-                                    stream=f)(num_requests=num_of_events)
-        self.assertEqual(num_of_events, self._wrapper._entrypoint.call_count, 'Received unexpected number of events')
+    # # to run memory profiling test, uncomment the test below
+    # # and from terminal run with
+    # # > mprof run python -m py.test test_wrapper.py::TestSubmitEvents::test_memory_profiling_100_<num>
+    # # and to get its plot use:
+    # # > mprof plot --backend agg --output <filename>.png
+    # def test_memory_profiling_100(self):
+    #     self._run_memory_profiling(100)
+    #
+    # def test_memory_profiling_1k(self):
+    #     self._run_memory_profiling(1000)
+    #
+    # def test_memory_profiling_10k(self):
+    #     self._run_memory_profiling(10000)
+    #
+    # def test_memory_profiling_100k(self):
+    #     self._run_memory_profiling(100000)
+    #
+    # def _run_memory_profiling(self, num_of_events):
+    #     self._wrapper._entrypoint = mock.MagicMock()
+    #     self._wrapper._entrypoint.return_value = {}
+    #     threading.Thread(target=self._send_events, args=(num_of_events,)).start()
+    #     with open('test_memory_profiling_{0}.txt'.format(num_of_events), 'w') as f:
+    #         profiled_serve_requests_func = memory_profiler.profile(self._wrapper.serve_requests,
+    #                                                                precision=4,
+    #                                                                stream=f)
+    #         profiled_serve_requests_func(num_requests=num_of_events)
+    #     self.assertEqual(num_of_events, self._wrapper._entrypoint.call_count, 'Received unexpected number of events')
 
     def _send_event(self, event):
 

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -1,3 +1,14 @@
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
@@ -16,7 +27,6 @@ import time
 import unittest
 
 import _nuclio_wrapper as wrapper
-import memory_profiler
 import msgpack
 import nuclio_sdk
 

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -11,7 +11,6 @@ import unittest
 import socket
 import struct
 import base64
-import concurrent.futures.thread
 
 import msgpack
 import nuclio_sdk

--- a/pkg/processor/runtime/python/test/Dockerfile
+++ b/pkg/processor/runtime/python/test/Dockerfile
@@ -22,4 +22,5 @@ RUN apt-get update && apt-get install gcc -y
 
 COPY pkg/processor/runtime/python .
 
+ARG CACHEBUST=1
 RUN ./test/test.sh

--- a/pkg/processor/runtime/python/test/Dockerfile
+++ b/pkg/processor/runtime/python/test/Dockerfile
@@ -11,10 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM python:2.7-slim-stretch
 
-RUN pip install mock pytest
+ARG PYTHON_IMAGE_TAG=3.6-slim-stretch
+
+FROM python:$PYTHON_IMAGE_TAG
+
 WORKDIR /nuclio
+
 COPY pkg/processor/runtime/python .
-RUN find . -depth -name *.pyc -exec rm -rf {} \;
-RUN python -m pytest -v .
+
+RUN ./test/test.sh

--- a/pkg/processor/runtime/python/test/Dockerfile
+++ b/pkg/processor/runtime/python/test/Dockerfile
@@ -18,6 +18,8 @@ FROM python:$PYTHON_IMAGE_TAG
 
 WORKDIR /nuclio
 
+RUN apt-get update && apt-get install gcc -y
+
 COPY pkg/processor/runtime/python .
 
 RUN ./test/test.sh

--- a/pkg/processor/runtime/python/test/test.sh
+++ b/pkg/processor/runtime/python/test/test.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2017 The Nuclio Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,10 +13,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM python:3.6-slim-stretch
 
-RUN pip install pytest
-WORKDIR /nuclio
-COPY pkg/processor/runtime/python .
-RUN find . -depth -name __pycache__ -exec rm -rf {} \;
-RUN python -m pytest -v .
+# exit on failure
+set -o errexit
+
+# show command before execute
+set -o xtrace
+
+# shared
+python -m pip install -r py/requirements/common.txt
+
+# dev
+python -m pip install -r py/requirements/dev.txt
+
+# determine runtime version and install its packages
+if [[ $(python -V 2>&1) =~ 2\.7 ]]; then
+    python -m pip install -r py/requirements/python2.txt
+else
+    python -m pip install -r py/requirements/python3_6.txt
+fi
+
+# remove python cached
+find . -depth -name __pycache__ -exec rm -rf {} \;
+
+# run tests
+python -m pytest -v .

--- a/pkg/processor/runtime/python/test/test.sh
+++ b/pkg/processor/runtime/python/test/test.sh
@@ -34,7 +34,11 @@ else
 fi
 
 # remove python cached
-find . -depth -name __pycache__ -exec rm -rf {} \;
+find ./py \
+    -name ".pytest_cache" -type d \
+    -o -name "*.pyc" \
+    -o -name "__pycache__" -type d \
+    | xargs rm -rf
 
 # run tests
 python -m pytest -v .


### PR DESCRIPTION
Motivation is #1696 and now it is possible after #1689 is merged.

Since the processor handle the max body size limit before reaching out to the python wrapper.

Bonus 👉 : removal of the preallocated buffer (on python wrapper side) of 4mb cause to reduction of `4mb * workers`

CI Bonus: running python wrapper tests to ensure no breakage is made.

Attached are logs of a deployed nuclio [function](https://raw.githubusercontent.com/nuclio/nuclio/development/hack/examples/python/empty/empty.py) running on 20 cores machine

Executed with `./hey -n 20 -c 20 -z 2m`

Pre change:
```
PID %MEM %CPU   RSS    SZ    VSZ
142936  0.0 12.1 18552 19882  79528
142943  0.0  9.5 18320 19856  79424
142949  0.0  9.4 18320 19856  79424
142950  0.0  9.3 18316 19851  79404
142951  0.0 12.6 18556 19882  79528
142952  0.0  9.3 18320 19856  79424
142953  0.0  9.5 18320 19856  79424
142954  0.0  9.6 18320 19856  79424
142955  0.0  9.3 18320 19856  79424
142956  0.0  9.3 18320 19856  79424
142957  0.0  9.5 18320 19856  79424
142958  0.0  9.4 18320 19856  79424
142959  0.0  9.4 18316 19856  79424
142961  0.0  9.4 18324 19856  79424
142969  0.0  9.4 18320 19856  79424
142974  0.0  9.4 18324 19856  79424
142975  0.0  9.3 18320 19856  79424
142982  0.0  9.4 18320 19856  79424
142992  0.0  9.5 18320 19856  79424
142998  0.0  9.4 18324 19856  79424
```

Post change:
```
PID %MEM %CPU   RSS    SZ    VSZ
151786  0.0  3.5 14440 18857  75428
151788  0.0  3.4 14204 18830  75320
151791  0.0  3.5 14448 18857  75428
151792  0.0  3.5 14208 18831  75324
151794  0.0  3.5 14204 18830  75320
151795  0.0  3.5 14204 18831  75324
151796  0.0  3.4 14444 18857  75428
151797  0.0  3.5 14200 18830  75320
151798  0.0  3.5 14208 18831  75324
151799  0.0  3.5 14440 18857  75428
151800  0.0  3.5 14200 18826  75304
151801  0.0  3.5 14208 18826  75304
151802  0.0  3.4 14440 18857  75428
151803  0.0  3.5 14208 18820  75280
151818  0.0  3.5 14204 18830  75320
151827  0.0  3.5 14204 18830  75320
151831  0.0  3.5 14204 18830  75320
151851  0.0  3.5 14200 18830  75320
151866  0.0  3.5 14212 18831  75324
151868  0.0  3.5 14204 18830  75320
```
