### PR TITLE
Fix function creation report error failed on existing function

### DIFF
--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -880,9 +880,9 @@ func (suite *functionDeployTestSuite) TestDeployWaitReadinessTimeoutBeforeFailur
 
 	// set a bad handler name - so that the deployment will fail
 	namedArgs := map[string]string{
-		"path":    path.Join(suite.GetFunctionsDir(), "common", "reverser", "python"),
-		"runtime": "python",
-		"handler": "reverser:bad-handler-name",
+		"path":              path.Join(suite.GetFunctionsDir(), "common", "reverser", "python"),
+		"runtime":           "python",
+		"handler":           "reverser:bad-handler-name",
 		"readiness-timeout": "60",
 	}
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -145,11 +145,19 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 		return nil, errors.Wrap(err, "Create function options validation failed")
 	}
 
-	existingFunctionInstance, existingFunctionConfig, err =
-		p.getFunctionInstanceAndConfig(createFunctionOptions.FunctionConfig.Meta.Namespace,
-			createFunctionOptions.FunctionConfig.Meta.Name)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get existing function config")
+	// it's possible to pass a function without specifying any meta in the request, in that case skip getting existing function
+	// with appropriate namespace and name
+	// e.g. ./nuctl deploy --path /path/to/function-with-function.yaml (function.yaml specifying the name and namespace)
+	// TODO: We should enrich the createFunctionOptions.FunctionConfig meta & spec before reaching here
+	// And delete this check
+	if createFunctionOptions.FunctionConfig.Meta.Namespace != "" &&
+		createFunctionOptions.FunctionConfig.Meta.Name != "" {
+		existingFunctionInstance, existingFunctionConfig, err =
+			p.getFunctionInstanceAndConfig(createFunctionOptions.FunctionConfig.Meta.Namespace,
+				createFunctionOptions.FunctionConfig.Meta.Name)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to get existing function config")
+		}
 	}
 
 	// if function exists, perform some validation with new function create options

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -147,7 +147,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 
 	existingFunctionInstance, existingFunctionConfig, err =
 		p.getFunctionInstanceAndConfig(createFunctionOptions.FunctionConfig.Meta.Namespace,
-		createFunctionOptions.FunctionConfig.Meta.Name)
+			createFunctionOptions.FunctionConfig.Meta.Name)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get existing function config")
 	}

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -812,7 +812,6 @@ func (b *Builder) readFunctionConfigFile(functionConfigPath string) error {
 
 func (b *Builder) createRuntime() (runtime.Runtime, error) {
 	runtimeName, err := b.getRuntimeName()
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -58,7 +58,10 @@ func (r *Registry) Get(kind string) (interface{}, error) {
 	if !found {
 
 		// registries register things on package initialization; no place for error handling
-		return nil, errors.Errorf("Registry for %s failed to find: %s", r.className, kind)
+		return nil, errors.Errorf("Registry for %s failed to find: %s (Available registries: %v)",
+			r.className,
+			kind,
+			r.GetKinds())
 	}
 
 	return registree, nil

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -58,10 +58,7 @@ func (r *Registry) Get(kind string) (interface{}, error) {
 	if !found {
 
 		// registries register things on package initialization; no place for error handling
-		return nil, errors.Errorf("Registry for %s failed to find: %s (Available registries: %v)",
-			r.className,
-			kind,
-			r.GetKinds())
+		return nil, errors.Errorf("Registry for %s failed to find: %s", r.className, kind)
 	}
 
 	return registree, nil


### PR DESCRIPTION
Bug:
1. create a function
2. redeploy while function build phase failed (e.g.: failed to find handler / runtime)
3. process failed with "Report creation failed" instead of "Failed to find handler"

The reason it failed is because the `existingFunctionInstance` was not populated when build failed.

Solution, resolve both existingFunctionConfig and existingFunctionInstance at the same time.