### PR TITLE
Fix resolving content type

### DIFF
--- a/pkg/nuctl/command/invoke.go
+++ b/pkg/nuctl/command/invoke.go
@@ -185,7 +185,6 @@ func (i *invokeCommandeer) populateContentType() {
 	}
 }
 
-
 func (i *invokeCommandeer) resolveBody() ([]byte, error) {
 
 	// try resolve body from flag
@@ -336,4 +335,3 @@ func (i *invokeCommandeer) outputResponseBody(invokeResult *platform.CreateFunct
 
 	return nil
 }
-

--- a/pkg/nuctl/command/invoke.go
+++ b/pkg/nuctl/command/invoke.go
@@ -93,7 +93,8 @@ func newInvokeCommandeer(rootCommandeer *RootCommandeer) *invokeCommandeer {
 				commandeer.createFunctionInvocationOptions.Headers.Set(headerName, headerValue)
 			}
 
-			commandeer.createFunctionInvocationOptions.Headers.Set("Content-Type", commandeer.contentType)
+			// resolve and set content type
+			commandeer.populateContentType()
 
 			// verify correctness of logger level
 			switch commandeer.createFunctionInvocationOptions.LogLevelName {
@@ -128,7 +129,7 @@ func newInvokeCommandeer(rootCommandeer *RootCommandeer) *invokeCommandeer {
 		},
 	}
 
-	cmd.Flags().StringVarP(&commandeer.contentType, "content-type", "c", "application/json", "HTTP Content-Type")
+	cmd.Flags().StringVarP(&commandeer.contentType, "content-type", "c", "", "HTTP Content-Type")
 	cmd.Flags().StringVarP(&commandeer.createFunctionInvocationOptions.Path, "path", "p", "", "Path to the function to invoke")
 	cmd.Flags().StringVarP(&commandeer.createFunctionInvocationOptions.Method, "method", "m", "", "HTTP method for invoking the function")
 	cmd.Flags().StringVarP(&commandeer.body, "body", "b", "", "HTTP message body")
@@ -165,6 +166,25 @@ func (i *invokeCommandeer) outputInvokeResult(createFunctionInvocationOptions *p
 
 	return nil
 }
+
+func (i *invokeCommandeer) populateContentType() {
+	headers := i.createFunctionInvocationOptions.Headers
+
+	// given as flag
+	if i.contentType != "" {
+
+		// add because it might not be empty (could be added via `--headers content-type=<x>`
+		headers.Add("Content-Type", i.contentType)
+	}
+
+	// not given at all
+	if headers.Get("Content-Type") == "" {
+
+		// default to `text/plain`
+		headers.Set("Content-Type", "text/plain")
+	}
+}
+
 
 func (i *invokeCommandeer) resolveBody() ([]byte, error) {
 
@@ -316,3 +336,4 @@ func (i *invokeCommandeer) outputResponseBody(invokeResult *platform.CreateFunct
 
 	return nil
 }
+

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -675,10 +675,10 @@ func (suite *functionDeployTestSuite) TestBuildAndDeployFromFileWithOverriddenAr
 	// try a few times to invoke, until it succeeds
 	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"invoke", functionName},
 		map[string]string{
-			"method": "POST",
-			"body":   fmt.Sprintf(`{"return_this": "%s"}`, randomString),
+			"method":       "POST",
+			"body":         fmt.Sprintf(`{"return_this": "%s"}`, randomString),
 			"content-type": "application/json",
-			"via":    "external-ip",
+			"via":          "external-ip",
 		},
 		false)
 	suite.Require().NoError(err)
@@ -732,10 +732,10 @@ func (suite *functionDeployTestSuite) TestDeployWithResourceVersion() {
 	// try a few times to invoke, until it succeeds
 	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"invoke", functionConfig.Meta.Name},
 		map[string]string{
-			"method": "POST",
-			"body":   `{"return_this": "abc"}`,
+			"method":       "POST",
+			"body":         `{"return_this": "abc"}`,
 			"content-type": "application/json",
-			"via":    "external-ip",
+			"via":          "external-ip",
 		}, false)
 	suite.Require().NoError(err)
 
@@ -764,10 +764,10 @@ func (suite *functionDeployTestSuite) TestDeployWithResourceVersion() {
 	// wait for function to be deployed
 	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"invoke", functionConfig.Meta.Name},
 		map[string]string{
-			"method": "POST",
-			"body":   `{"return_this": "abc"}`,
+			"method":       "POST",
+			"body":         `{"return_this": "abc"}`,
 			"content-type": "application/json",
-			"via":    "external-ip",
+			"via":          "external-ip",
 		}, false)
 	suite.Require().NoError(err)
 

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -231,9 +231,10 @@ func (suite *functionDeployTestSuite) TestDeployFromFunctionConfig() {
 	// try a few times to invoke, until it succeeds
 	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"invoke", functionName},
 		map[string]string{
-			"method": "POST",
-			"body":   fmt.Sprintf(`{"return_this": "%s"}`, randomString),
-			"via":    "external-ip",
+			"method":       "POST",
+			"body":         fmt.Sprintf(`{"return_this": "%s"}`, randomString),
+			"content-type": "application/json",
+			"via":          "external-ip",
 		},
 		false)
 	suite.Require().NoError(err)
@@ -603,9 +604,10 @@ func (suite *functionDeployTestSuite) TestBuildAndDeployFromFile() {
 	// try a few times to invoke, until it succeeds
 	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"invoke", functionName},
 		map[string]string{
-			"method": "POST",
-			"body":   fmt.Sprintf(`{"return_this": "%s"}`, randomString),
-			"via":    "external-ip",
+			"method":       "POST",
+			"body":         fmt.Sprintf(`{"return_this": "%s"}`, randomString),
+			"content-type": "application/json",
+			"via":          "external-ip",
 		},
 		false)
 	suite.Require().NoError(err)
@@ -675,6 +677,7 @@ func (suite *functionDeployTestSuite) TestBuildAndDeployFromFileWithOverriddenAr
 		map[string]string{
 			"method": "POST",
 			"body":   fmt.Sprintf(`{"return_this": "%s"}`, randomString),
+			"content-type": "application/json",
 			"via":    "external-ip",
 		},
 		false)
@@ -731,6 +734,7 @@ func (suite *functionDeployTestSuite) TestDeployWithResourceVersion() {
 		map[string]string{
 			"method": "POST",
 			"body":   `{"return_this": "abc"}`,
+			"content-type": "application/json",
 			"via":    "external-ip",
 		}, false)
 	suite.Require().NoError(err)
@@ -762,6 +766,7 @@ func (suite *functionDeployTestSuite) TestDeployWithResourceVersion() {
 		map[string]string{
 			"method": "POST",
 			"body":   `{"return_this": "abc"}`,
+			"content-type": "application/json",
 			"via":    "external-ip",
 		}, false)
 	suite.Require().NoError(err)

--- a/pkg/platform/abstract/invoker.go
+++ b/pkg/platform/abstract/invoker.go
@@ -94,12 +94,6 @@ func (i *invoker) invoke(createFunctionInvocationOptions *platform.CreateFunctio
 		body = bytes.NewBuffer(createFunctionInvocationOptions.Body)
 	}
 
-	i.logger.InfoWith("Executing function",
-		"method", createFunctionInvocationOptions.Method,
-		"url", fullpath,
-		"body", body,
-	)
-
 	// issue the request
 	req, err = http.NewRequest(createFunctionInvocationOptions.Method, fullpath, body)
 	if err != nil {
@@ -114,6 +108,11 @@ func (i *invoker) invoke(createFunctionInvocationOptions *platform.CreateFunctio
 	if createFunctionInvocationOptions.LogLevelName != "none" && req.Header.Get("x-nuclio-log-level") == "" {
 		req.Header.Set("x-nuclio-log-level", createFunctionInvocationOptions.LogLevelName)
 	}
+
+	i.logger.InfoWith("Executing function",
+		"method", createFunctionInvocationOptions.Method,
+		"url", fullpath,
+		"headers", req.Header)
 
 	response, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
- Populate from `--content-type` flag, then from given headers (`--headers content-type=<X>`)
- If population return with no content type, default to `http.DetectContentType` value
- Allow populating content type from both `--content-type` flag and `--header content-type=<X>`)