### PR TITLE
Populate version when runtime is python 

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -211,6 +211,11 @@ func (ap *Platform) EnrichCreateFunctionOptions(createFunctionOptions *platform.
 			ap.GetDefaultRegistryCredentialsSecretName()
 	}
 
+	// `python` is just a reference
+	if createFunctionOptions.FunctionConfig.Spec.Runtime == "python" {
+		createFunctionOptions.FunctionConfig.Spec.Runtime = "python:3.6"
+	}
+
 	return nil
 }
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -472,12 +472,6 @@ func (b *Builder) validateAndEnrichConfiguration() error {
 		b.options.FunctionConfig.Spec.Runtime = b.runtime.GetName()
 	}
 
-	if b.options.FunctionConfig.Spec.Runtime == "python" {
-
-		// python is just a reference
-		b.options.FunctionConfig.Spec.Runtime = "python:3.6"
-	}
-
 	// if the function handler isn't set, ask runtime
 	if b.options.FunctionConfig.Spec.Handler == "" {
 		functionHandlers, err := b.runtime.DetectFunctionHandlers(b.GetFunctionPath())

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -472,6 +472,12 @@ func (b *Builder) validateAndEnrichConfiguration() error {
 		b.options.FunctionConfig.Spec.Runtime = b.runtime.GetName()
 	}
 
+	if b.options.FunctionConfig.Spec.Runtime == "python" {
+
+		// python is just a reference
+		b.options.FunctionConfig.Spec.Runtime = "python:3.6"
+	}
+
 	// if the function handler isn't set, ask runtime
 	if b.options.FunctionConfig.Spec.Handler == "" {
 		functionHandlers, err := b.runtime.DetectFunctionHandlers(b.GetFunctionPath())


### PR DESCRIPTION
Python is just a reference to 3.6.
To unmask what is running, enrichment should dereference between python to its actuall running runtime version.