### PR TITLE
Increase msgpack for python

### DIFF
--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -53,9 +53,10 @@ class Wrapper(object):
         # make a writeable file from processor
         self._processor_sock_wfile = self._processor_sock.makefile('w')
 
-        # since this wrapper is behind a processor that pre-handle the traffic & request, it is not mandatory
-        # to provide security over max buffer size. The request limit should be handled on the processor level.
-        self._unpacker = msgpack.Unpacker(raw=False)
+        # since this wrapper is behind the nuclio processor, in which pre-handle the traffic & request
+        # it is not mandatory to provide security over max buffer size.
+        # the request limit should be handled on the processor level.
+        self._unpacker = msgpack.Unpacker(raw=False, max_buffer_size=2**32-1)
 
         # get handler module
         entrypoint_module = sys.modules[self._entrypoint.__module__]

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -245,6 +245,7 @@ func (suite *TestSuite) GetDeployOptions(functionName string, functionPath strin
 	createFunctionOptions.FunctionConfig.Meta.Name = functionName
 	createFunctionOptions.FunctionConfig.Spec.Runtime = suite.Runtime
 	createFunctionOptions.FunctionConfig.Spec.Build.Path = functionPath
+	createFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{}
 
 	suite.TempDir = suite.CreateTempDir()
 	createFunctionOptions.FunctionConfig.Spec.Build.TempDir = suite.TempDir

--- a/pkg/processor/trigger/http/test/suite/suite.go
+++ b/pkg/processor/trigger/http/test/suite/suite.go
@@ -138,12 +138,11 @@ func (suite *TestSuite) DeployFunctionAndRequests(createFunctionOptions *platfor
 
 // SendRequestVerifyResponse sends a request and verifies we got expected response
 func (suite *TestSuite) SendRequestVerifyResponse(request *Request) bool {
-
 	suite.Logger.DebugWith("Sending request",
 		"requestPort", request.RequestPort,
 		"requestPath", request.RequestPath,
 		"requestHeaders", request.RequestHeaders,
-		"requestBody", request.RequestBody,
+		"requestBodyLength", len(request.RequestBody),
 		"requestLogLevel", request.RequestLogLevel)
 
 	// Send request to proper url

--- a/test/_functions/common/empty/python/empty.py
+++ b/test/_functions/common/empty/python/empty.py
@@ -1,0 +1,16 @@
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def handler(context, event):
+    return ""


### PR DESCRIPTION
Msgpack by default limit the max buffer to 1MB to avoid denial of service.
Since the msgpack is part of python runtime wrapper, it is not required to ensure/validate the max buffer as the [processor](https://github.com/nuclio/nuclio#processor) will take of it by ensuring the body size is less than the allowed max body configuration.