### PR TITLE
Retry function build if docker failed to find its produced image

### DIFF
--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -229,6 +229,8 @@ ARG NUCLIO_ARCH
 		return errors.Wrap(err, "Failed to build onbuild image")
 	}
 
+	defer d.dockerClient.RemoveImage(onbuildImageName) // nolint: errcheck
+
 	// now that we have an image, we can copy the artifacts from it
 	return d.dockerClient.CopyObjectsFromImage(onbuildImageName, artifactPaths, false)
 }

--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"time"
 
 	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
@@ -20,11 +19,9 @@ const (
 )
 
 type Docker struct {
-	dockerClient                 dockerclient.Client
-	logger                       logger.Logger
-	builderConfiguration         *ContainerBuilderConfiguration
-	copyObjectsFromImageTimeout  time.Duration
-	copyObjectsFromImageInterval time.Duration
+	dockerClient         dockerclient.Client
+	logger               logger.Logger
+	builderConfiguration *ContainerBuilderConfiguration
 }
 
 func NewDocker(logger logger.Logger, builderConfiguration *ContainerBuilderConfiguration) (*Docker, error) {
@@ -35,11 +32,9 @@ func NewDocker(logger logger.Logger, builderConfiguration *ContainerBuilderConfi
 	}
 
 	dockerBuilder := &Docker{
-		dockerClient:                 dockerClient,
-		logger:                       logger,
-		builderConfiguration:         builderConfiguration,
-		copyObjectsFromImageInterval: 1 * time.Second,
-		copyObjectsFromImageTimeout:  3 * time.Minute,
+		dockerClient:         dockerClient,
+		logger:               logger,
+		builderConfiguration: builderConfiguration,
 	}
 
 	return dockerBuilder, nil
@@ -234,6 +229,6 @@ ARG NUCLIO_ARCH
 		return errors.Wrap(err, "Failed to build onbuild image")
 	}
 
-	// copy objects to built image
+	// now that we have an image, we can copy the artifacts from it
 	return d.dockerClient.CopyObjectsFromImage(onbuildImageName, artifactPaths, false)
 }

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -104,7 +104,7 @@ func (c *ShellClient) CopyObjectsFromImage(imageName string,
 	// create container from image
 	containerID, err := c.createContainer(imageName)
 	if err != nil {
-		return errors.Wrap(err, "Failed to create image")
+		return errors.Wrapf(err, "Failed to create container from %s", imageName)
 	}
 
 	// delete once done copying objects

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -677,7 +677,7 @@ func (c *ShellClient) createContainer(imageName string) (string, error) {
 			if err != nil {
 				return runResults.Stderr
 			}
-			containerID := runResults.Output
+			containerID = runResults.Output
 			containerID = strings.TrimSpace(containerID)
 			return ""
 		})

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -656,7 +656,7 @@ func (c *ShellClient) createContainer(imageName string) (string, error) {
 	var containerID string
 	retryOnErrorMessages := []string{
 
-		// sometime create container failed on not finding the image because
+		// sometimes, creating the container fails on not finding the image because
 		// docker was on high load and did not get to update its cache
 		fmt.Sprintf("^Unable to find image '%s.*' locally", imageName),
 	}


### PR DESCRIPTION
Docker might not find a local image althought it was just recently created due to high load.

Using `RetryUntilSuccessfulOnErrorPatterns ` for error caused by such case (`unable to find image 'x' locally`).