### PR TITLE
UI: Build: Fix Gulp v3 failure on newer NodeJs versions

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -58,6 +58,7 @@
     "merge2": "^0.3.6",
     "moment": "^2.24.0",
     "monaco-editor": "^0.13.1",
+    "natives": "^1.1.6",
     "ng-dialog": "~1.4.0",
     "ng-file-upload": "~12.2.13",
     "ng-i18next": "^1.0.5",


### PR DESCRIPTION
See https://github.com/gulpjs/gulp/issues/2246

This dependency could be removed if Gulp v3 will no longer be used in this codebase (for example, migrate to Gulp v4, or Webpack).

Relates to PR https://github.com/iguazio/dashboard-controls/pull/1030