### PR TITLE
Add skip flag to nuctl import projects

### DIFF
--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -332,12 +332,13 @@ func (i *importProjectCommandeer) importProjects(projectImportConfigs map[string
 		if i.shouldSkipProject(projectConfig) {
 			i.rootCommandeer.loggerInstance.DebugWith("Skipping import for project",
 				"projectName", projectConfig.Project.Meta.Name)
-		} else {
-			i.rootCommandeer.loggerInstance.DebugWith("Importing project",
-				"projectName", projectConfig.Project.Meta.Name)
-			if err := i.importProject(projectConfig); err != nil {
-				return errors.Wrap(err, "Failed to import project")
-			}
+			continue
+		}
+
+		i.rootCommandeer.loggerInstance.DebugWith("Importing project",
+			"projectName", projectConfig.Project.Meta.Name)
+		if err := i.importProject(projectConfig); err != nil {
+			return errors.Wrap(err, "Failed to import project")
 		}
 	}
 	return nil


### PR DESCRIPTION
On `nuctl import projects <projectManifestFile>` it is possible to add the flag `--skip <projectName>[,<projectName>,...]` to skip importing specific projects from the given project manifest.