### PR TITLE
GH Actions - Adding periodic tests

### DIFF
--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -2,7 +2,7 @@ name: Periodic
 on:
   schedule:
   #  - cron:  '0 0 1/1 * *'
-  - cron:  '*/5 * 1/1 * *'
+  - cron:  '*/30 * 1/1 * *'
 jobs:
   build:
     name: Periodic Regression

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -26,3 +26,5 @@ jobs:
     - name: Test full
 #      run: make test
       run: make test-kafka
+      env:
+        NUCLIO_TEST_HOST: 172.17.0.1

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -10,8 +10,6 @@ jobs:
     steps:
     - name: hostname dis
       run: hostname
-    - name: Build
-      run: make build
     - name: curl ifconfig.me
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -1,8 +1,8 @@
 name: Periodic
 on:
   schedule:
-#  - cron:  '0 0 1/1 * *'
-  - cron:  '*/10 * 1/1 * *'
+  - cron:  '0 0 1/1 * *'
+
 jobs:
   build:
     name: Periodic Regression

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -1,8 +1,8 @@
 name: Periodic
 on:
   schedule:
-  - cron:  '0 0 1/1 * *'
-#  - cron:  '*/10 * 1/1 * *'
+#  - cron:  '0 0 1/1 * *'
+  - cron:  '*/10 * 1/1 * *'
 jobs:
   build:
     name: Periodic Regression
@@ -24,4 +24,5 @@ jobs:
         NUCLIO_NUCTL_CREATE_SYMLINK: false
 
     - name: Test full
-      run: make test
+#      run: make test
+      run: make test-kafka

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -20,8 +20,8 @@ jobs:
 
     - name: Build
       run: make build
+      env:
+        NUCLIO_NUCTL_CREATE_SYMLINK: false
 
     - name: Test full
       run: make build test
-      env:
-        NUCLIO_NUCTL_CREATE_SYMLINK: false

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -2,7 +2,7 @@ name: Periodic
 on:
   schedule:
 #  - cron:  '0 0 1/1 * *'
-  - cron:  '*/10 * 1/1 * *'
+  - cron:  '*/30 * 1/1 * *'
 jobs:
   build:
     name: Periodic Regression
@@ -26,4 +26,4 @@ jobs:
 
     - name: Test full
 #      run: make test
-      run: NUCLIO_TEST_HOST=$(hostname) make test-kafka
+      run: NUCLIO_TEST_HOST=$(curl ifconfig.me) make test-kafka

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -1,8 +1,8 @@
 name: Periodic
 on:
   schedule:
-  - cron:  '0 0 1/1 * *'
-
+#  - cron:  '0 0 1/1 * *'
+  - cron:  '*/10 * 1/1 * *'
 jobs:
   build:
     name: Periodic Regression
@@ -18,7 +18,10 @@ jobs:
     - name: Freeing up disk space
       run: docker system prune --all --force
 
-    - name: Build & Test
+    - name: Build
+      run: make build
+
+    - name: Test full
       run: make build test
       env:
         NUCLIO_NUCTL_CREATE_SYMLINK: false

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -5,7 +5,7 @@ on:
   - cron:  '*/10 * 1/1 * *'
 jobs:
   build:
-    name: Nuclio Periodic Regression
+    name: Periodic Regression
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -8,7 +8,11 @@ jobs:
     name: Periodic Regression
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
+    - name: hostname dis
+      run: hostname
+    - name: Build
+      run: make build
+    - name: curl ifconfig.me
       uses: actions/checkout@v2
       with:
         ref: development
@@ -25,6 +29,4 @@ jobs:
 
     - name: Test full
 #      run: make test
-      run: make test-kafka
-      env:
-        NUCLIO_TEST_HOST: 172.17.0.1
+      run: NUCLIO_TEST_HOST=$(hostname) make test-kafka

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -13,8 +13,6 @@ jobs:
     - name: curl ifconfig.me
       run: curl ifconfig.me
     - uses: actions/checkout@v2
-      with:
-        ref: development
 
     # since github-actions gives us 14G only, and fills it up with some garbage
     # we will free up some space for us (~2GB)

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -1,0 +1,22 @@
+name: Periodic
+on:
+  schedule:
+#  - cron:  '0 0 1/1 * *'
+  - cron:  '*/10 * 1/1 * *'
+jobs:
+  build:
+    name: Nuclio Periodic Regression
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: development
+
+    # since github-actions gives us 14G only, and fills it up with some garbage
+    # we will free up some space for us (~2GB)
+    - name: Freeing up disk space
+      run: docker system prune --all --force
+
+    - name: Build & Test
+      run: make build test

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -20,3 +20,5 @@ jobs:
 
     - name: Build & Test
       run: make build test
+      env:
+        NUCLIO_NUCTL_CREATE_SYMLINK: false

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -24,4 +24,4 @@ jobs:
         NUCLIO_NUCTL_CREATE_SYMLINK: false
 
     - name: Test full
-      run: make build test
+      run: make test

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -2,7 +2,7 @@ name: Periodic
 on:
   schedule:
 #  - cron:  '0 0 1/1 * *'
-  - cron:  '*/30 * 1/1 * *'
+  - cron:  '*/5 * 1/1 * *'
 jobs:
   build:
     name: Periodic Regression

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -1,8 +1,7 @@
 name: Periodic
 on:
   schedule:
-  #  - cron:  '0 0 1/1 * *'
-  - cron:  '*/30 * 1/1 * *'
+  - cron:  '0 */12 * * *'
 jobs:
   build:
     name: Periodic Regression

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -1,17 +1,13 @@
 name: Periodic
 on:
   schedule:
-#  - cron:  '0 0 1/1 * *'
+  #  - cron:  '0 0 1/1 * *'
   - cron:  '*/5 * 1/1 * *'
 jobs:
   build:
     name: Periodic Regression
     runs-on: ubuntu-latest
     steps:
-    - name: hostname dis
-      run: hostname
-    - name: curl ifconfig.me
-      run: curl ifconfig.me
     - uses: actions/checkout@v2
 
     # since github-actions gives us 14G only, and fills it up with some garbage
@@ -24,9 +20,5 @@ jobs:
       env:
         NUCLIO_NUCTL_CREATE_SYMLINK: false
 
-    - name: Test full
-#      run: make test
-      run: make test-kafka
-      env:
-        NUCLIO_TEST_HOST: 172.17.0.1
-
+    - name: Test periodic
+      run: make test-periodic

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -26,4 +26,7 @@ jobs:
 
     - name: Test full
 #      run: make test
-      run: NUCLIO_TEST_HOST=$(hostname) make test-kafka
+      run: make test-kafka
+      env:
+        NUCLIO_TEST_HOST: 172.17.0.1
+

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -1,8 +1,8 @@
 name: Periodic
 on:
   schedule:
-#  - cron:  '0 0 1/1 * *'
-  - cron:  '*/10 * 1/1 * *'
+  - cron:  '0 0 1/1 * *'
+#  - cron:  '*/10 * 1/1 * *'
 jobs:
   build:
     name: Periodic Regression

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -26,4 +26,4 @@ jobs:
 
     - name: Test full
 #      run: make test
-      run: NUCLIO_TEST_HOST=$(curl ifconfig.me) make test-kafka
+      run: make test-kafka

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -11,7 +11,8 @@ jobs:
     - name: hostname dis
       run: hostname
     - name: curl ifconfig.me
-      uses: actions/checkout@v2
+      run: curl ifconfig.me
+    - uses: actions/checkout@v2
       with:
         ref: development
 

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -26,4 +26,4 @@ jobs:
 
     - name: Test full
 #      run: make test
-      run: make test-kafka
+      run: NUCLIO_TEST_HOST=$(hostname) make test-kafka

--- a/Makefile
+++ b/Makefile
@@ -430,7 +430,7 @@ test-kafka: ensure-gopath build-base
 		--env NUCLIO_OS=$(NUCLIO_OS) \
 		--env NUCLIO_GO_TEST_TIMEOUT=$(NUCLIO_GO_TEST_TIMEOUT) \
 		$(NUCLIO_DOCKER_TEST_TAG) \
-		/bin/bash -c "make test-kafka-undockerized"
+		/bin/bash -c "NUCLIO_TEST_HOST=$$(hostname) make test-kafka-undockerized"
 
 .PHONY: test-python
 test-python:

--- a/Makefile
+++ b/Makefile
@@ -429,6 +429,7 @@ test-kafka: ensure-gopath build-base
 		--env NUCLIO_ARCH=$(NUCLIO_ARCH) \
 		--env NUCLIO_OS=$(NUCLIO_OS) \
 		--env NUCLIO_GO_TEST_TIMEOUT=$(NUCLIO_GO_TEST_TIMEOUT) \
+		--env NUCLIO_TEST_HOST=$(hostname) \
 		$(NUCLIO_DOCKER_TEST_TAG) \
 		/bin/bash -c "make test-kafka-undockerized"
 

--- a/Makefile
+++ b/Makefile
@@ -409,7 +409,7 @@ test: ensure-gopath build-base
 		/bin/bash -c "make test-undockerized"
 
 .PHONY: test-kafka
-test: ensure-gopath build-base
+test-kafka: ensure-gopath build-base
 	docker build \
 		--build-arg NUCLIO_LABEL=$(NUCLIO_LABEL) \
 		--build-arg DOCKER_CLI_VERSION=$(DOCKER_CLI_VERSION) \

--- a/Makefile
+++ b/Makefile
@@ -430,7 +430,7 @@ test-kafka: ensure-gopath build-base
 		--env NUCLIO_OS=$(NUCLIO_OS) \
 		--env NUCLIO_GO_TEST_TIMEOUT=$(NUCLIO_GO_TEST_TIMEOUT) \
 		$(NUCLIO_DOCKER_TEST_TAG) \
-		/bin/bash -c "NUCLIO_TEST_HOST=$$(hostname) make test-kafka-undockerized"
+		/bin/bash -c "make test-kafka-undockerized"
 
 .PHONY: test-python
 test-python:

--- a/Makefile
+++ b/Makefile
@@ -380,18 +380,25 @@ test-undockerized: ensure-gopath
 test-kafka-undockerized: ensure-gopath
 	go test -v -p 1 --timeout $(NUCLIO_GO_TEST_TIMEOUT) ./pkg/processor/trigger/kafka/...
 
+# This is to work around hostname resolution issues for saram and kafka in CI
+.PHONY: test-periodic-undockerized
+test-periodic-undockerized: ensure-gopath
+	go test -v -p 1 --timeout $(NUCLIO_GO_TEST_TIMEOUT) $(shell go list ./cmd/... ./pkg/... | grep -v trigger/kafka)
+
 .PHONY: fmt
 fmt:
 	gofmt -s -w .
 
-.PHONY: test
-test: ensure-gopath build-base
+.PHONY: build-test
+build-test: ensure-gopath build-base
 	docker build \
 		--build-arg NUCLIO_LABEL=$(NUCLIO_LABEL) \
 		--build-arg DOCKER_CLI_VERSION=$(DOCKER_CLI_VERSION) \
 		--file $(NUCLIO_DOCKER_TEST_DOCKERFILE_PATH) \
 		--tag $(NUCLIO_DOCKER_TEST_TAG) .
 
+.PHONY: test
+test: build-test
 	docker run \
 		--rm \
 		--volume /var/run/docker.sock:/var/run/docker.sock \
@@ -408,14 +415,26 @@ test: ensure-gopath build-base
 		$(NUCLIO_DOCKER_TEST_TAG) \
 		/bin/bash -c "make test-undockerized"
 
-.PHONY: test-kafka
-test-kafka: ensure-gopath build-base
-	docker build \
-		--build-arg NUCLIO_LABEL=$(NUCLIO_LABEL) \
-		--build-arg DOCKER_CLI_VERSION=$(DOCKER_CLI_VERSION) \
-		--file $(NUCLIO_DOCKER_TEST_DOCKERFILE_PATH) \
-		--tag $(NUCLIO_DOCKER_TEST_TAG) .
+.PHONY: test-periodic
+test-periodic: build-test
+	docker run \
+		--rm \
+		--volume /var/run/docker.sock:/var/run/docker.sock \
+		--volume $(GOPATH)/bin:/go/bin \
+		--volume $(shell pwd):$(GO_BUILD_TOOL_WORKDIR) \
+		--volume /tmp:/tmp \
+		--workdir $(GO_BUILD_TOOL_WORKDIR) \
+		--env NUCLIO_TEST_HOST=$(NUCLIO_TEST_HOST) \
+		--env NUCLIO_VERSION_GIT_COMMIT=$(NUCLIO_VERSION_GIT_COMMIT) \
+		--env NUCLIO_LABEL=$(NUCLIO_LABEL) \
+		--env NUCLIO_ARCH=$(NUCLIO_ARCH) \
+		--env NUCLIO_OS=$(NUCLIO_OS) \
+		--env NUCLIO_GO_TEST_TIMEOUT=$(NUCLIO_GO_TEST_TIMEOUT) \
+		$(NUCLIO_DOCKER_TEST_TAG) \
+		/bin/bash -c "make test-periodic-undockerized"
 
+.PHONY: test-kafka
+test-kafka: build-test
 	docker run \
 		--rm \
 		--volume /var/run/docker.sock:/var/run/docker.sock \

--- a/Makefile
+++ b/Makefile
@@ -429,7 +429,6 @@ test-kafka: ensure-gopath build-base
 		--env NUCLIO_ARCH=$(NUCLIO_ARCH) \
 		--env NUCLIO_OS=$(NUCLIO_OS) \
 		--env NUCLIO_GO_TEST_TIMEOUT=$(NUCLIO_GO_TEST_TIMEOUT) \
-		--env NUCLIO_TEST_HOST=$(hostname) \
 		$(NUCLIO_DOCKER_TEST_TAG) \
 		/bin/bash -c "make test-kafka-undockerized"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Periodic](https://github.com/omesser/nuclio/workflows/Periodic/badge.svg)
+![Periodic](https://github.com/nuclio/nuclio/workflows/Periodic/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/nuclio/nuclio)](https://goreportcard.com/report/github.com/nuclio/nuclio)
 [![Slack](https://img.shields.io/badge/slack-join%20chat%20%E2%86%92-e01563.svg)](https://lit-oasis-83353.herokuapp.com/)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/nuclio/nuclio.svg?branch=master)](https://travis-ci.org/nuclio/nuclio)
+![Periodic](https://github.com/omesser/nuclio/workflows/Periodic/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/nuclio/nuclio)](https://goreportcard.com/report/github.com/nuclio/nuclio)
 [![Slack](https://img.shields.io/badge/slack-join%20chat%20%E2%86%92-e01563.svg)](https://lit-oasis-83353.herokuapp.com/)
 

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -229,7 +229,9 @@ func (suite *TestSuite) GetTestFunctionsDir() string {
 func (suite *TestSuite) GetTestHost() string {
 
 	// If an env var is set, use that. otherwise localhost
-	return common.GetEnvOrDefaultString("NUCLIO_TEST_HOST", "localhost")
+	resolvedTestHost := common.GetEnvOrDefaultString("NUCLIO_TEST_HOST", "localhost")
+	suite.Logger.InfoWith("Resolved Test hostname", "resolvedTestHost", resolvedTestHost)
+	return resolvedTestHost
 }
 
 // GetDeployOptions populates a platform.CreateFunctionOptions structure from function name and path

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -230,7 +230,9 @@ func (suite *TestSuite) GetTestHost() string {
 
 	// If an env var is set, use that. otherwise localhost
 	resolvedTestHost := common.GetEnvOrDefaultString("NUCLIO_TEST_HOST", "localhost")
-	suite.Logger.InfoWith("Resolved Test hostname", "resolvedTestHost", resolvedTestHost)
+	if suite.Logger != nil {
+		suite.Logger.InfoWith("Resolved Test hostname", "resolvedTestHost", resolvedTestHost)
+	}
 	return resolvedTestHost
 }
 

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -229,11 +229,7 @@ func (suite *TestSuite) GetTestFunctionsDir() string {
 func (suite *TestSuite) GetTestHost() string {
 
 	// If an env var is set, use that. otherwise localhost
-	resolvedTestHost := common.GetEnvOrDefaultString("NUCLIO_TEST_HOST", "localhost")
-	if suite.Logger != nil {
-		suite.Logger.InfoWith("Resolved Test hostname", "resolvedTestHost", resolvedTestHost)
-	}
-	return resolvedTestHost
+	return common.GetEnvOrDefaultString("NUCLIO_TEST_HOST", "localhost")
 }
 
 // GetDeployOptions populates a platform.CreateFunctionOptions structure from function name and path

--- a/pkg/processor/trigger/kafka/test/kafka_test.go
+++ b/pkg/processor/trigger/kafka/test/kafka_test.go
@@ -32,6 +32,7 @@ type testSuite struct {
 	*triggertest.AbstractBrokerSuite
 	broker        *sarama.Broker
 	producer      sarama.SyncProducer
+	brokerURL     string
 	topic         string
 	consumerGroup string
 	initialOffset string
@@ -54,10 +55,11 @@ func newTestSuite() *testSuite {
 func (suite *testSuite) SetupSuite() {
 	suite.AbstractBrokerSuite.SetupSuite()
 
-	suite.Logger.Info("Creating broker resources")
+	suite.brokerURL = fmt.Sprintf("%s:9092", suite.BrokerHost)
+	suite.Logger.Info("Creating broker resources", "brokerURL", suite.brokerURL)
 
 	// create broker
-	suite.broker = sarama.NewBroker(fmt.Sprintf("%s:9092", suite.BrokerHost))
+	suite.broker = sarama.NewBroker(suite.brokerURL)
 
 	brokerConfig := sarama.NewConfig()
 	brokerConfig.Version = sarama.V0_10_1_0
@@ -76,13 +78,13 @@ func (suite *testSuite) SetupSuite() {
 	}
 
 	// create topic
-	resp, err := suite.broker.CreateTopics(&createTopicsRequest)
+	response, err := suite.broker.CreateTopics(&createTopicsRequest)
 	suite.Require().NoError(err, "Failed to create topic")
 
-	suite.Logger.InfoWith("Created topic", "topic", suite.topic, "response", resp)
+	suite.Logger.InfoWith("Created topic", "topic", suite.topic, "response", response)
 
 	// create a sync producer
-	suite.producer, err = sarama.NewSyncProducer([]string{fmt.Sprintf("%s:9092", suite.BrokerHost)}, nil)
+	suite.producer, err = sarama.NewSyncProducer([]string{suite.brokerURL}, nil)
 	suite.Require().NoError(err, "Failed to create sync producer")
 }
 
@@ -99,7 +101,7 @@ func (suite *testSuite) TestReceiveRecords() {
 	}
 	createFunctionOptions.FunctionConfig.Spec.Triggers["my-kafka"] = functionconfig.Trigger{
 		Kind: "kafka-cluster",
-		URL:  fmt.Sprintf("%s:9092", suite.BrokerHost),
+		URL:  suite.brokerURL,
 		Attributes: map[string]interface{}{
 			"topics":        []string{suite.topic},
 			"consumerGroup": suite.consumerGroup,

--- a/pkg/processor/trigger/kafka/test/kafka_test.go
+++ b/pkg/processor/trigger/kafka/test/kafka_test.go
@@ -56,7 +56,7 @@ func (suite *testSuite) SetupSuite() {
 	suite.AbstractBrokerSuite.SetupSuite()
 
 	suite.brokerURL = fmt.Sprintf("%s:9092", suite.BrokerHost)
-	suite.Logger.Info("Creating broker resources", "brokerURL", suite.brokerURL)
+	suite.Logger.InfoWith("Creating broker resources", "brokerURL", suite.brokerURL)
 
 	// create broker
 	suite.broker = sarama.NewBroker(suite.brokerURL)

--- a/pkg/processor/trigger/test/broker.go
+++ b/pkg/processor/trigger/test/broker.go
@@ -69,7 +69,7 @@ func (suite *AbstractBrokerSuite) SetupSuite() {
 	// get container information
 	imageName, runOptions := suite.brokerSuite.GetContainerRunInfo()
 
-	suite.Logger.InfoWith("Starting broker", "imageName", imageName)
+	suite.Logger.InfoWith("Starting broker", "imageName", imageName, "BrokerHost", suite.BrokerHost)
 
 	// start the broker
 	if imageName != "" {


### PR DESCRIPTION
- Adding periodic (12h intervals) tests to run on the default branch (`development` today)
- This runs `make test-periodic` (~2h runtime) - which is the full test suite, *without* kafka trigger tests which I could not get to work in the GH actions VM (hostname resolution sarama <-> kafka) - This needs to be fixed and added asap
- Leaving in some minor fixes and changes I've made to `Makefile`, introducing `test-build` reuse, allowing to run the `test-periodic` targets easily, and also `test-kafka` specifically which should ease future testing.
- Minor logging changes in test suites