### PR TITLE
Cron job fixes

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -50,7 +50,7 @@ func main() {
 	platformConfigurationPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
 	functionOperatorNumWorkersStr := flag.String("function-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_OPERATOR_NUM_WORKERS", "4"), "Set number of workers for the function operator (optional)")
 	functionOperatorResyncIntervalStr := flag.String("function-operator-resync-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_OPERATOR_RESYNC_INTERVAL", "10m"), "Set resync interval for the function operator (optional)")
-	cronJobStalePodsDeletionIntervalStr := flag.String("cron-job-stale-pods-deletion-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_CRON_JOB_STALE_PODS_DELETION_INTERVAL", "30s"), "Set interval for the deletion of stale cron job pods (optional)")
+	cronJobStalePodsDeletionIntervalStr := flag.String("cron-job-stale-pods-deletion-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_CRON_JOB_STALE_PODS_DELETION_INTERVAL", "1m"), "Set interval for the deletion of stale cron job pods (optional)")
 	functionEventOperatorNumWorkersStr := flag.String("function-event-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_EVENT_OPERATOR_NUM_WORKERS", "2"), "Set number of workers for the function event operator (optional)")
 	projectOperatorNumWorkersStr := flag.String("project-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_PROJECT_OPERATOR_NUM_WORKERS", "2"), "Set number of workers for the function operator (optional)")
 	flag.Parse()

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -50,7 +50,7 @@ func main() {
 	platformConfigurationPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
 	functionOperatorNumWorkersStr := flag.String("function-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_OPERATOR_NUM_WORKERS", "4"), "Set number of workers for the function operator (optional)")
 	functionOperatorResyncIntervalStr := flag.String("function-operator-resync-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_OPERATOR_RESYNC_INTERVAL", "10m"), "Set resync interval for the function operator (optional)")
-	cronJobStalePodsDeletionIntervalStr := flag.String("cron-job-stale-pods-deletion-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_CRON_JOB_STALE_PODS_DELETION_INTERVAL", "10m"), "Set interval for the deletion of stale cron job pods (optional)")
+	cronJobStalePodsDeletionIntervalStr := flag.String("cron-job-stale-pods-deletion-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_CRON_JOB_STALE_PODS_DELETION_INTERVAL", "30s"), "Set interval for the deletion of stale cron job pods (optional)")
 	functionEventOperatorNumWorkersStr := flag.String("function-event-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_EVENT_OPERATOR_NUM_WORKERS", "2"), "Set number of workers for the function event operator (optional)")
 	projectOperatorNumWorkersStr := flag.String("project-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_PROJECT_OPERATOR_NUM_WORKERS", "2"), "Set number of workers for the function operator (optional)")
 	flag.Parse()

--- a/docs/reference/triggers/cron.md
+++ b/docs/reference/triggers/cron.md
@@ -9,6 +9,7 @@ Triggers the function according to a schedule or interval, with an optional body
 | schedule | string | A cron-like schedule (for example, `*/5 * * * *`) |
 | interval | string | An interval (for example, `1s`, `30m`) |
 | concurrencyPolicy | string | Concurrency policy [Allow, Forbid, Replace]. (optional, defaults to "Allow". Relevant only for k8s platform)
+| jobBackoffLimit | string | The number of retries before failing a job. (optional, defaults to "2". Relevant only for k8s platform)
 | event.body | string | The body passed in the event |
 | event.headers | map of string/int | The headers passed in the event |
 
@@ -38,4 +39,5 @@ triggers:
     attributes:
       interval: 10s
       concurrencyPolicy: "Allow"
+      jobBackoffLimit: "4"
 ```

--- a/docs/reference/triggers/cron.md
+++ b/docs/reference/triggers/cron.md
@@ -9,7 +9,7 @@ Triggers the function according to a schedule or interval, with an optional body
 | schedule | string | A cron-like schedule (for example, `*/5 * * * *`) |
 | interval | string | An interval (for example, `1s`, `30m`) |
 | concurrencyPolicy | string | Concurrency policy [Allow, Forbid, Replace]. (optional, defaults to "Allow". Relevant only for k8s platform)
-| jobBackoffLimit | string | The number of retries before failing a job. (optional, defaults to "2". Relevant only for k8s platform)
+| jobBackoffLimit | int32 | The number of retries before failing a job. (optional, defaults to 2. Relevant only for k8s platform)
 | event.body | string | The body passed in the event |
 | event.headers | map of string/int | The headers passed in the event |
 
@@ -39,5 +39,5 @@ triggers:
     attributes:
       interval: 10s
       concurrencyPolicy: "Allow"
-      jobBackoffLimit: "4"
+      jobBackoffLimit: 2
 ```

--- a/pkg/platform/kube/controller/cronjobmonitoring.go
+++ b/pkg/platform/kube/controller/cronjobmonitoring.go
@@ -53,6 +53,8 @@ func (cjpd *CronJobMonitoring) startStaleCronJobPodsDeletionLoop() error {
 		// sleep until next deletion time staleCronJobPodsDeletionInterval
 		time.Sleep(*cjpd.staleCronJobPodsDeletionInterval)
 
+		cjpd.logger.Debug("Deleting stale cron job pods")
+
 		err := cjpd.controller.kubeClientSet.
 			CoreV1().
 			Pods(cjpd.controller.namespace).

--- a/pkg/platform/kube/controller/cronjobmonitoring.go
+++ b/pkg/platform/kube/controller/cronjobmonitoring.go
@@ -53,8 +53,6 @@ func (cjpd *CronJobMonitoring) startStaleCronJobPodsDeletionLoop() error {
 		// sleep until next deletion time staleCronJobPodsDeletionInterval
 		time.Sleep(*cjpd.staleCronJobPodsDeletionInterval)
 
-		cjpd.logger.Debug("Deleting stale cron job pods")
-
 		err := cjpd.controller.kubeClientSet.
 			CoreV1().
 			Pods(cjpd.controller.namespace).

--- a/pkg/platform/kube/deployer.go
+++ b/pkg/platform/kube/deployer.go
@@ -192,7 +192,7 @@ func isFunctionDeploymentFailed(consumer *consumer,
 	pods, err := consumer.kubeClientSet.CoreV1().
 		Pods(namespace).
 		List(metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("nuclio.io/function-name=%s", name),
+			LabelSelector: fmt.Sprintf("nuclio.io/function-name=%s,nuclio.io/class=function", name),
 		})
 	if err != nil {
 		return false, errors.Wrap(err, "Failed to get pods")

--- a/pkg/platform/kube/deployer.go
+++ b/pkg/platform/kube/deployer.go
@@ -192,7 +192,7 @@ func isFunctionDeploymentFailed(consumer *consumer,
 	pods, err := consumer.kubeClientSet.CoreV1().
 		Pods(namespace).
 		List(metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("nuclio.io/function-name=%s,nuclio.io/class=function", name),
+			LabelSelector: compileListFunctionPodsLabelSelector(name),
 		})
 	if err != nil {
 		return false, errors.Wrap(err, "Failed to get pods")
@@ -240,6 +240,10 @@ func isFunctionDeploymentFailed(consumer *consumer,
 	}
 
 	return false, nil
+}
+
+func compileListFunctionPodsLabelSelector(functionName string) string {
+	return fmt.Sprintf("nuclio.io/function-name=%s,nuclio.io/function-cron-job-pod!=true", functionName)
 }
 
 func waitForFunctionReadiness(loggerInstance logger.Logger,
@@ -296,7 +300,7 @@ func (d *deployer) getFunctionPodLogsAndEvents(namespace string, name string) (s
 	functionPods, listPodErr := d.consumer.kubeClientSet.CoreV1().
 		Pods(namespace).
 		List(metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("nuclio.io/function-name=%s", name),
+			LabelSelector: compileListFunctionPodsLabelSelector(name),
 		})
 
 	if listPodErr != nil {

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1493,7 +1493,7 @@ func (lc *lazyClient) generateCronTriggerCronJobSpec(functionLabels labels.Set,
 		Schedule          string
 		Interval          string
 		ConcurrencyPolicy string
-		JobBackoffLimit   string
+		JobBackoffLimit   int32
 		Event             cron.Event
 	}
 
@@ -1555,12 +1555,9 @@ func (lc *lazyClient) generateCronTriggerCronJobSpec(functionLabels labels.Set,
 	}
 
 	// get cron job retries until failing a job (default=2)
-	jobBackoffLimit := int32(2)
-	if attributes.JobBackoffLimit != "" {
-		parsedCronJobJobRetries, err := strconv.Atoi(attributes.JobBackoffLimit)
-		if err != nil {
-			jobBackoffLimit = int32(parsedCronJobJobRetries)
-		}
+	jobBackoffLimit := attributes.JobBackoffLimit
+	if jobBackoffLimit == 0 {
+		jobBackoffLimit = 2
 	}
 
 	spec.JobTemplate = batchv1beta1.JobTemplateSpec{

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1553,8 +1553,18 @@ func (lc *lazyClient) generateCronTriggerCronJobSpec(functionLabels labels.Set,
 			eventBodyCurlArg)
 	}
 
+
+	// get cron job retries until failing a job
+	parsedCronJobJobRetries, err := strconv.Atoi(common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_CRON_TRIGGER_CRON_JOB_JOB_RETRIES",
+		"2"))
+	if err == nil {
+		parsedCronJobJobRetries = 2
+	}
+
+	cronJobJobRetries := int32(parsedCronJobJobRetries)
 	spec.JobTemplate = batchv1beta1.JobTemplateSpec{
 		Spec: batchv1.JobSpec{
+			BackoffLimit: &cronJobJobRetries,
 			Template: v1.PodTemplateSpec{
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1555,8 +1555,7 @@ func (lc *lazyClient) generateCronTriggerCronJobSpec(functionLabels labels.Set,
 
 
 	// get cron job retries until failing a job
-	parsedCronJobJobRetries, err := strconv.Atoi(common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_CRON_TRIGGER_CRON_JOB_JOB_RETRIES",
-		"2"))
+	parsedCronJobJobRetries, err := strconv.Atoi(common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_CRON_TRIGGER_CRON_JOB_JOB_RETRIES", "2"))
 	if err == nil {
 		parsedCronJobJobRetries = 2
 	}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1486,7 +1486,7 @@ func (lc *lazyClient) generateCronTriggerCronJobSpec(functionLabels labels.Set,
 	resources Resources,
 	cronTrigger functionconfig.Trigger) (*batchv1beta1.CronJobSpec, error) {
 	var err error
-
+	one := int32(1)
 	spec := batchv1beta1.CronJobSpec{}
 
 	type cronAttributes struct {
@@ -1559,8 +1559,8 @@ func (lc *lazyClient) generateCronTriggerCronJobSpec(functionLabels labels.Set,
 	if err == nil {
 		parsedCronJobJobRetries = 2
 	}
-
 	cronJobJobRetries := int32(parsedCronJobJobRetries)
+
 	spec.JobTemplate = batchv1beta1.JobTemplateSpec{
 		Spec: batchv1.JobSpec{
 			BackoffLimit: &cronJobJobRetries,
@@ -1584,6 +1584,10 @@ func (lc *lazyClient) generateCronTriggerCronJobSpec(functionLabels labels.Set,
 	if attributes.ConcurrencyPolicy != "" {
 		spec.ConcurrencyPolicy = batchv1beta1.ConcurrencyPolicy(util.Capitalize(attributes.ConcurrencyPolicy))
 	}
+
+	// set default history limit (no need for more than one - makes kube jobs api clearer)
+	spec.SuccessfulJobsHistoryLimit = &one
+	spec.FailedJobsHistoryLimit = &one
 
 	return &spec, nil
 }

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1553,7 +1553,6 @@ func (lc *lazyClient) generateCronTriggerCronJobSpec(functionLabels labels.Set,
 			eventBodyCurlArg)
 	}
 
-
 	// get cron job retries until failing a job
 	parsedCronJobJobRetries, err := strconv.Atoi(common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_CRON_TRIGGER_CRON_JOB_JOB_RETRIES", "2"))
 	if err == nil {


### PR DESCRIPTION
Cron job fixes.

Changes:
- Changed "cronJobStalePodsDeletionInterval" to be 1min instead of 10min (prevent many stale pods running on the system)
- Limit job history to 1 (makes kube jobs api clearer)
- Added `jobBackoffLimit` to cron trigger spec. Limiting the number of retries before failing a job (defaults to 2, to reduce stress on the system - relevant especially for triggers with low cron interval)
- Fix - prevent functionPods List from selecting cron-job pods