### PR TITLE
Fix - function "fails-fast" when redeploying with a higher number of replicas

### DIFF
--- a/pkg/platform/kube/deployer.go
+++ b/pkg/platform/kube/deployer.go
@@ -210,13 +210,6 @@ func isFunctionDeploymentFailed(consumer *consumer,
 
 		for _, containerStatus := range pod.Status.ContainerStatuses {
 
-			// check if the pod has terminated with an error
-			if containerStatus.State.Terminated != nil &&
-				containerStatus.State.Terminated.Reason == "Error" {
-
-				return true, errors.Errorf("NuclioFunction pod (%s) container exited with an error", pod.Name)
-			}
-
 			if pod.Status.ContainerStatuses[0].State.Waiting != nil {
 
 				// check if the pod is on a crashLoopBackoff


### PR DESCRIPTION
**Bug:**
"NuclioFunction pod (nuclio-somefunc-56bcc67685-z6q9p) container exited with an error" error is shown when replicas is increased on function re-deploy.

This happened as a result of the orchestration mechanism of k8s, that lifts more pods then it should, and then makes one of them exit to reach the wanted number of replicas.

In the same moment the redundant new pod was marked as 'Exited' with an error, we caught it, and failed-fast the function because of it.

**Solution:**
Removing the part where we fail-fast when the container is in "Exited" state.
This will prevent this bug, and will not harm the fail-fast mechanism, because when the function deploy should _really_ fail fast it will change it state to "crashLoopBackoff"