### PR TITLE
Remove dashboard bind-mount to docker socket when using Kaniko container builder

### DIFF
--- a/cmd/dashboard/app/dashboard.go
+++ b/cmd/dashboard/app/dashboard.go
@@ -157,14 +157,15 @@ func Run(listenAddress string,
 		platformInstance.SetImageNamePrefixTemplate(imageNamePrefixTemplate)
 	}
 
-	rootLogger.InfoWith("Starting",
+	rootLogger.InfoWith("Starting dashboard",
 		"name", platformInstance.GetName(),
 		"noPull", noPullBaseImages,
 		"offline", offline,
 		"defaultCredRefreshInterval", defaultCredRefreshIntervalString,
 		"defaultNamespace", defaultNamespace,
 		"version", version.Get(),
-		"platformConfiguration", platformConfiguration)
+		"platformConfiguration", platformConfiguration,
+		"containerBuilderKind", platformInstance.GetContainerBuilderKind())
 
 	// see if the platform has anything to say about the namespace
 	defaultNamespace = platformInstance.ResolveDefaultNamespace(defaultNamespace)
@@ -177,6 +178,7 @@ func Run(listenAddress string,
 	}
 
 	server, err := dashboard.NewServer(rootLogger,
+		platformInstance.GetContainerBuilderKind(),
 		dockerKeyDir,
 		defaultRegistryURL,
 		defaultRunRegistryURL,

--- a/hack/k8s/helm/nuclio/README.md
+++ b/hack/k8s/helm/nuclio/README.md
@@ -38,7 +38,6 @@ read -s mypassword
 <enter your password>
 
 kubectl create secret docker-registry nuclio-registry-credentials \
-    --namespace nuclio \
     --docker-username <username> \
     --docker-password $mypassword \
     --docker-server <registry name> \
@@ -51,7 +50,7 @@ unset mypassword
 There are no special flags required when installing in AKS or vanilla Kubernetes:
 
 ``` sh
-helm install nuclio --namespace nuclio nuclio/nuclio
+helm install nuclio nuclio/nuclio
 ```
 
 ### Install on GKE (or when using GCR)
@@ -59,7 +58,6 @@ If you're using GCR as your image registry, there is a small quirk where the log
 
 ``` sh
 helm install nuclio \
-    --namespace nuclio \
 	--set registry.pushPullUrl gcr.io/<your project name> \
 	nuclio/nuclio
 ```
@@ -75,7 +73,6 @@ By not providing a registry secret name (`registry.secretName`) nor credentials 
 
 ``` sh
 helm install nuclio \
-    --namespace nuclio \
     --set registry.pushPullUrl=localhost:5000 \
 	nuclio/nuclio
 ```

--- a/hack/k8s/helm/nuclio/README.md
+++ b/hack/k8s/helm/nuclio/README.md
@@ -37,7 +37,8 @@ Create the secret:
 read -s mypassword
 <enter your password>
 
-kubectl create secret docker-registry nuclio-registry-credentials --namespace nuclio \
+kubectl create secret docker-registry nuclio-registry-credentials \
+    --namespace nuclio \
     --docker-username <username> \
     --docker-password $mypassword \
     --docker-server <registry name> \
@@ -50,14 +51,15 @@ unset mypassword
 There are no special flags required when installing in AKS or vanilla Kubernetes:
 
 ``` sh
-helm install --namespace nuclio --name nuclio nuclio/nuclio
+helm install nuclio --namespace nuclio nuclio/nuclio
 ```
 
 ### Install on GKE (or when using GCR)
 If you're using GCR as your image registry, there is a small quirk where the login URL is different from the push/pull URL. By default, Nuclio will take the push/pull URL from the secret, but in this case we need to let Nuclio know what the push/pull URL is:
 
 ``` sh
-helm install \
+helm install nuclio \
+    --namespace nuclio \
 	--set registry.pushPullUrl gcr.io/<your project name> \
 	nuclio/nuclio
 ```
@@ -72,7 +74,8 @@ docker run -d -p 5000:5000 registry:2
 By not providing a registry secret name (`registry.secretName`) nor credentials (`registry.credentials.username` / `registry.credentials.password`), Nuclio will understand credentials are not needed, and not try to load Docker secrets.
 
 ``` sh
-helm install \
+helm install nuclio \
+    --namespace nuclio \
     --set registry.pushPullUrl=localhost:5000 \
 	nuclio/nuclio
 ```
@@ -83,6 +86,7 @@ kubectl port-forward $(kubectl get pod -l nuclio.io/app=dashboard -o jsonpath='{
 ```
 
 ### Advanced: Run on Docker for Mac as a core Nuclio developer, with an insecure registry
+In this example we will install and run nuclio in the default namespace, for simplicity
 
 Build the images locally (with your modified code) by running this on the repo root directory:
 ```sh
@@ -96,7 +100,7 @@ docker run -d -p 5000:5000 registry:2
 
 Make sure your images are up to date and install the helm chart using the latest tag:
 ```sh
-helm install \
+helm install nuclio \
     --set registry.pushPullUrl=localhost:5000 \
 	--set controller.image.tag=latest-amd64 \
 	--set dashboard.image.tag=latest-amd64 \

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -48,8 +48,10 @@ spec:
         ports:
         - containerPort: 8070
         volumeMounts:
+        {{- if eq .Values.dashboard.containerBuilderKind "docker" }}
         - mountPath: /var/run/docker.sock
           name: docker-sock
+        {{- end }}
         {{- if or .Values.registry.secretName .Values.registry.credentials }}
         - name: registry-credentials
           mountPath: "/etc/nuclio/dashboard/registry-credentials"
@@ -125,9 +127,11 @@ spec:
         - name: NUCLIO_DASHBOARD_IMAGE_NAME_PREFIX_TEMPLATE
           value: {{ .Values.dashboard.imageNamePrefixTemplate | quote }}
       volumes:
+      {{- if eq .Values.dashboard.containerBuilderKind "docker" }}
       - name: docker-sock
         hostPath:
           path: /var/run/docker.sock
+      {{- end }}
       {{- if or .Values.registry.secretName .Values.registry.credentials }}
       - name: registry-credentials
         secret:

--- a/pkg/containerimagebuilderpusher/containerimagebuilder.go
+++ b/pkg/containerimagebuilderpusher/containerimagebuilder.go
@@ -5,6 +5,9 @@ import "github.com/nuclio/nuclio/pkg/processor/build/runtime"
 // BuilderPusher is a builder of container images
 type BuilderPusher interface {
 
+	// GetKind returns the kind (docker/kaniko)
+	GetKind() string
+
 	// BuildAndPushContainerImage builds container image and pushes it into container registry
 	BuildAndPushContainerImage(buildOptions *BuildOptions, namespace string) error
 

--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -40,6 +40,10 @@ func NewDocker(logger logger.Logger, builderConfiguration *ContainerBuilderConfi
 	return dockerBuilder, nil
 }
 
+func (d *Docker) GetKind() string {
+	return "docker"
+}
+
 func (d *Docker) BuildAndPushContainerImage(buildOptions *BuildOptions, namespace string) error {
 
 	err := d.gatherArtifactsForSingleStageDockerfile(buildOptions)

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -53,6 +53,10 @@ func NewKaniko(logger logger.Logger, kubeClientSet kubernetes.Interface,
 	return kanikoBuilder, nil
 }
 
+func (k *Kaniko) GetKind() string {
+	return "kaniko"
+}
+
 func (k *Kaniko) BuildAndPushContainerImage(buildOptions *BuildOptions, namespace string) error {
 	bundleFilename, assetPath, err := k.createContainerBuildBundle(buildOptions.Image, buildOptions.ContextDir, buildOptions.TempDir)
 	if err != nil {

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -67,6 +67,7 @@ func (suite *dashboardTestSuite) SetupTest() {
 
 	// create a mock platform
 	suite.dashboardServer, err = dashboard.NewServer(suite.logger,
+		suite.mockPlatform.GetContainerBuilderKind(),
 		"",
 		"",
 		"",

--- a/pkg/dockercreds/dockercred.go
+++ b/pkg/dockercreds/dockercred.go
@@ -89,7 +89,7 @@ func (dc *dockerCred) initialize() error {
 		dc.credentials.RefreshInterval = dc.defaultRefreshInterval
 	}
 
-	// if user didn't specify "https://" in the url, add it. otherwise don't
+	// if user didn't specify "https://" in the url, add it
 	if !strings.HasPrefix(dc.credentials.URL, "https://") {
 		dc.credentials.URL = "https://" + dc.credentials.URL
 	}

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -445,6 +445,11 @@ func (ap *Platform) GetDefaultRegistryCredentialsSecretName() string {
 	return ap.ContainerBuilder.GetDefaultRegistryCredentialsSecretName()
 }
 
+// GetContainerBuilderKind returns the container-builder kind
+func (ap *Platform) GetContainerBuilderKind() string {
+	return ap.ContainerBuilder.GetKind()
+}
+
 func (ap *Platform) functionBuildRequired(createFunctionOptions *platform.CreateFunctionOptions) (bool, error) {
 
 	// if neverBuild was passed explicitly don't build

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -100,7 +100,8 @@ func NewPlatform(parentLogger logger.Logger,
 	}
 
 	// create container builder
-	if containerBuilderConfiguration != nil && containerBuilderConfiguration.Kind == "kaniko" {
+	if containerBuilderConfiguration != nil &&
+		containerBuilderConfiguration.Kind == "kaniko" {
 		newPlatform.ContainerBuilder, err = containerimagebuilderpusher.NewKaniko(newPlatform.Logger,
 			newPlatform.consumer.kubeClientSet, containerBuilderConfiguration)
 		if err != nil {

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -100,8 +100,7 @@ func NewPlatform(parentLogger logger.Logger,
 	}
 
 	// create container builder
-	if containerBuilderConfiguration != nil &&
-		containerBuilderConfiguration.Kind == "kaniko" {
+	if containerBuilderConfiguration != nil && containerBuilderConfiguration.Kind == "kaniko" {
 		newPlatform.ContainerBuilder, err = containerimagebuilderpusher.NewKaniko(newPlatform.Logger,
 			newPlatform.consumer.kubeClientSet, containerBuilderConfiguration)
 		if err != nil {

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -23,6 +23,10 @@ type Platform struct {
 // Function
 //
 
+func (mp *Platform) GetContainerBuilderKind() string {
+	return "docker"
+}
+
 // Build will locally build a processor image and return its name (or the error)
 func (mp *Platform) CreateFunctionBuild(createFunctionBuildOptions *platform.CreateFunctionBuildOptions) (*platform.CreateFunctionBuildResult, error) {
 	args := mp.Called(createFunctionBuildOptions)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -153,4 +153,7 @@ type Platform interface {
 
 	// Save build logs from platform logger to function store or k8s
 	SaveFunctionDeployLogs(functionName, namespace string) error
+
+	// GetContainerBuilderKind returns the container-builder kind
+	GetContainerBuilderKind() string
 }

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -830,6 +830,7 @@ func (b *Builder) createRuntime() (runtime.Runtime, error) {
 
 	// create a runtime instance
 	runtimeInstance, err := runtimeFactory.(runtime.Factory).Create(b.logger,
+		b.platform.GetContainerBuilderKind(),
 		b.stagingDir,
 		&b.options.FunctionConfig)
 

--- a/pkg/processor/build/runtime/dotnetcore/factory.go
+++ b/pkg/processor/build/runtime/dotnetcore/factory.go
@@ -27,10 +27,11 @@ import (
 type factory struct{}
 
 func (f *factory) Create(logger logger.Logger,
+	containerBuilderKind string,
 	stagingDir string,
 	functionConfig *functionconfig.Config) (runtime.Runtime, error) {
 
-	abstractRuntime, err := runtime.NewAbstractRuntime(logger, stagingDir, functionConfig)
+	abstractRuntime, err := runtime.NewAbstractRuntime(logger, containerBuilderKind, stagingDir, functionConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create abstract runtime")
 	}

--- a/pkg/processor/build/runtime/golang/factory.go
+++ b/pkg/processor/build/runtime/golang/factory.go
@@ -27,10 +27,11 @@ import (
 type factory struct{}
 
 func (f *factory) Create(logger logger.Logger,
+	containerBuilderKind string,
 	stagingDir string,
 	functionConfig *functionconfig.Config) (runtime.Runtime, error) {
 
-	abstractRuntime, err := runtime.NewAbstractRuntime(logger, stagingDir, functionConfig)
+	abstractRuntime, err := runtime.NewAbstractRuntime(logger, containerBuilderKind, stagingDir, functionConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create abstract runtime")
 	}

--- a/pkg/processor/build/runtime/java/factory.go
+++ b/pkg/processor/build/runtime/java/factory.go
@@ -27,10 +27,11 @@ import (
 type factory struct{}
 
 func (f *factory) Create(logger logger.Logger,
+	containerBuilderKind string,
 	stagingDir string,
 	functionConfig *functionconfig.Config) (runtime.Runtime, error) {
 
-	abstractRuntime, err := runtime.NewAbstractRuntime(logger, stagingDir, functionConfig)
+	abstractRuntime, err := runtime.NewAbstractRuntime(logger, containerBuilderKind, stagingDir, functionConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create abstract runtime")
 	}

--- a/pkg/processor/build/runtime/nodejs/factory.go
+++ b/pkg/processor/build/runtime/nodejs/factory.go
@@ -27,10 +27,11 @@ import (
 type factory struct{}
 
 func (f *factory) Create(logger logger.Logger,
+	containerBuilderKind string,
 	stagingDir string,
 	functionConfig *functionconfig.Config) (runtime.Runtime, error) {
 
-	abstractRuntime, err := runtime.NewAbstractRuntime(logger, stagingDir, functionConfig)
+	abstractRuntime, err := runtime.NewAbstractRuntime(logger, containerBuilderKind, stagingDir, functionConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create abstract runtime")
 	}

--- a/pkg/processor/build/runtime/pypy/factory.go
+++ b/pkg/processor/build/runtime/pypy/factory.go
@@ -27,10 +27,11 @@ import (
 type factory struct{}
 
 func (f *factory) Create(logger logger.Logger,
+	containerBuilderKind string,
 	stagingDir string,
 	functionConfig *functionconfig.Config) (runtime.Runtime, error) {
 
-	abstractRuntime, err := runtime.NewAbstractRuntime(logger, stagingDir, functionConfig)
+	abstractRuntime, err := runtime.NewAbstractRuntime(logger, containerBuilderKind, stagingDir, functionConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create abstract runtime")
 	}

--- a/pkg/processor/build/runtime/pypy/runtime.go
+++ b/pkg/processor/build/runtime/pypy/runtime.go
@@ -61,7 +61,7 @@ func (p *pypy) GetProcessorBaseImage() (string, error) {
 	}
 
 	// make sure the image exists. don't pull if instructed not to
-	if !p.FunctionConfig.Spec.Build.NoBaseImagesPull {
+	if !p.FunctionConfig.Spec.Build.NoBaseImagesPull && p.DockerClient != nil {
 		if err := p.DockerClient.PullImage(baseImage); err != nil {
 			return "", errors.Wrapf(err, "Can't pull %q", baseImage)
 		}

--- a/pkg/processor/build/runtime/python/factory.go
+++ b/pkg/processor/build/runtime/python/factory.go
@@ -27,10 +27,11 @@ import (
 type factory struct{}
 
 func (f *factory) Create(logger logger.Logger,
+	containerBuilderKind string,
 	stagingDir string,
 	functionConfig *functionconfig.Config) (runtime.Runtime, error) {
 
-	abstractRuntime, err := runtime.NewAbstractRuntime(logger, stagingDir, functionConfig)
+	abstractRuntime, err := runtime.NewAbstractRuntime(logger, containerBuilderKind, stagingDir, functionConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create abstract runtime")
 	}

--- a/pkg/processor/build/runtime/ruby/factory.go
+++ b/pkg/processor/build/runtime/ruby/factory.go
@@ -27,10 +27,11 @@ import (
 type factory struct{}
 
 func (f *factory) Create(logger logger.Logger,
+	containerBuilderKind string,
 	stagingDir string,
 	functionConfig *functionconfig.Config) (runtime.Runtime, error) {
 
-	abstractRuntime, err := runtime.NewAbstractRuntime(logger, stagingDir, functionConfig)
+	abstractRuntime, err := runtime.NewAbstractRuntime(logger, containerBuilderKind, stagingDir, functionConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create abstract runtime")
 	}

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -68,7 +68,7 @@ type Runtime interface {
 }
 
 type Factory interface {
-	Create(logger.Logger, string, *functionconfig.Config) (Runtime, error)
+	Create(logger.Logger, string, string, *functionconfig.Config) (Runtime, error)
 }
 
 type AbstractRuntime struct {
@@ -81,6 +81,7 @@ type AbstractRuntime struct {
 }
 
 func NewAbstractRuntime(logger logger.Logger,
+	containerBuilderKind string,
 	stagingDir string,
 	functionConfig *functionconfig.Config) (*AbstractRuntime, error) {
 	var err error
@@ -98,9 +99,11 @@ func NewAbstractRuntime(logger logger.Logger,
 	}
 
 	// create a docker client
-	newRuntime.DockerClient, err = dockerclient.NewShellClient(newRuntime.Logger, newRuntime.CmdRunner)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create docker client")
+	if containerBuilderKind == "docker" {
+		newRuntime.DockerClient, err = dockerclient.NewShellClient(newRuntime.Logger, newRuntime.CmdRunner)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to create docker client")
+		}
 	}
 
 	return newRuntime, nil

--- a/pkg/processor/build/runtime/shell/factory.go
+++ b/pkg/processor/build/runtime/shell/factory.go
@@ -27,10 +27,11 @@ import (
 type factory struct{}
 
 func (f *factory) Create(logger logger.Logger,
+	containerBuilderKind string,
 	stagingDir string,
 	functionConfig *functionconfig.Config) (runtime.Runtime, error) {
 
-	abstractRuntime, err := runtime.NewAbstractRuntime(logger, stagingDir, functionConfig)
+	abstractRuntime, err := runtime.NewAbstractRuntime(logger, containerBuilderKind, stagingDir, functionConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create abstract runtime")
 	}


### PR DESCRIPTION
- This removes the hostpath & volume for the host dockerd socket from the dashboard deployment.
- Hence, no usage of docker can or should be made when kaniko is used

Not requiring docker bind mount was the main drive behind integrating kaniko, because mounting the docker socket embodies several security issues (hospath, host IPC, escalation via docker) puts restriction on running user vs host fs permissions (observed in openshift default scc) etc