### PR TITLE
Periodic test - run only for upstream repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-    - name: Dump GitHub context
+    - name: Dump github context
       run: echo "$GITHUB_CONTEXT"
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,16 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+    - name: Dump GitHub context
+      run: echo "$GITHUB_CONTEXT"
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+
+    - name: Dump runner context
+      run: echo "$RUNNER_CONTEXT"
+      env:
+        RUNNER_CONTEXT: ${{ toJson(runner) }}
+
     - uses: actions/checkout@v2
 
     - uses: actions/setup-go@v2

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository.fork == false || github.repository.owner.name == 'omesser'
 
     steps:
-    - name: Dump GitHub context
+    - name: Dump github context
       run: echo "$GITHUB_CONTEXT"
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -1,12 +1,29 @@
 name: Periodic
+
 on:
   schedule:
   - cron:  '0 */12 * * *'
+
 jobs:
   build:
     name: Periodic Regression
     runs-on: ubuntu-latest
+
+    # let's not run this on every fork
+    # ugh: https://github.community/t/passing-an-array-literal-to-contains-function-causes-syntax-error/17213
+    if: github.repository.owner.name == 'nuclio' || github.repository.owner.name == 'omesser'
+
     steps:
+    - name: Dump GitHub context
+      run: echo "$GITHUB_CONTEXT"
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+
+    - name: Dump runner context
+      run: echo "$RUNNER_CONTEXT"
+      env:
+        RUNNER_CONTEXT: ${{ toJson(runner) }}
+
     - uses: actions/checkout@v2
 
     # since github-actions gives us 14G only, and fills it up with some garbage

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # let's not run this on every fork
-    # ugh: https://github.community/t/passing-an-array-literal-to-contains-function-causes-syntax-error/17213
-    if: github.repository.owner.name == 'nuclio' || github.repository.owner.name == 'omesser'
+    if: github.repository.fork == false || github.repository.owner.name == 'omesser'
 
     steps:
     - name: Dump GitHub context

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -9,8 +9,8 @@ jobs:
     name: Periodic Regression
     runs-on: ubuntu-latest
 
-    # let's not run this on every fork
-    if: github.repository.fork == false || github.repository.owner.name == 'omesser'
+    # let's not run this on every fork, comment this out when developing periodic on your fork
+    if: github.repository.fork == false
 
     steps:
     - name: Dump github context

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,10 +16,10 @@ env:
 
 jobs:
   release:
-    name: Release Nuclio
+    name: Release
     runs-on: ubuntu-latest
     steps:
-    - name: Dump GitHub context
+    - name: Dump github context
       run: echo "$GITHUB_CONTEXT"
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}


### PR DESCRIPTION
It's wasteful to spam all forker's repos with periodic, changing GH action's periodic workflow to only run on main repo

Adding missing github context dumps for debugability