### PR TITLE
Cron job robustness enhancements

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -40,7 +40,7 @@ func Run(kubeconfigPath string,
 	platformConfigurationPath string,
 	functionOperatorNumWorkersStr string,
 	functionOperatorResyncIntervalStr string,
-	cronJobStalePodsDeletionIntervalStr string,
+	cronJobStaleResourcesCleanupIntervalStr string,
 	functionEventOperatorNumWorkersStr string,
 	projectOperatorNumWorkersStr string) error {
 
@@ -50,7 +50,7 @@ func Run(kubeconfigPath string,
 		platformConfigurationPath,
 		functionOperatorNumWorkersStr,
 		functionOperatorResyncIntervalStr,
-		cronJobStalePodsDeletionIntervalStr,
+		cronJobStaleResourcesCleanupIntervalStr,
 		functionEventOperatorNumWorkersStr,
 		projectOperatorNumWorkersStr)
 	if err != nil {
@@ -72,7 +72,7 @@ func createController(kubeconfigPath string,
 	platformConfigurationPath string,
 	functionOperatorNumWorkersStr string,
 	functionOperatorResyncIntervalStr string,
-	cronJobStalePodsDeletionIntervalStr string,
+	cronJobStaleResourcesCleanupIntervalStr string,
 	functionEventOperatorNumWorkersStr string,
 	projectOperatorNumWorkersStr string) (*controller.Controller, error) {
 
@@ -91,7 +91,7 @@ func createController(kubeconfigPath string,
 		return nil, errors.Wrap(err, "Failed to parse resync interval for function operator")
 	}
 
-	cronJobStalePodsDeletionInterval, err := time.ParseDuration(cronJobStalePodsDeletionIntervalStr)
+	cronJobStaleResourcesCleanupInterval, err := time.ParseDuration(cronJobStaleResourcesCleanupIntervalStr)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to parse cron job stale pods deletion interval")
 	}
@@ -141,7 +141,7 @@ func createController(kubeconfigPath string,
 		nuclioClientSet,
 		functionresClient,
 		functionOperatorResyncInterval,
-		cronJobStalePodsDeletionInterval,
+		cronJobStaleResourcesCleanupInterval,
 		platformConfiguration,
 		functionOperatorNumWorkers,
 		functionEventOperatorNumWorkers,

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -50,7 +50,7 @@ func main() {
 	platformConfigurationPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
 	functionOperatorNumWorkersStr := flag.String("function-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_OPERATOR_NUM_WORKERS", "4"), "Set number of workers for the function operator (optional)")
 	functionOperatorResyncIntervalStr := flag.String("function-operator-resync-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_OPERATOR_RESYNC_INTERVAL", "10m"), "Set resync interval for the function operator (optional)")
-	cronJobStalePodsDeletionIntervalStr := flag.String("cron-job-stale-pods-deletion-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_CRON_JOB_STALE_PODS_DELETION_INTERVAL", "1m"), "Set interval for the deletion of stale cron job pods (optional)")
+	cronJobStaleResourcesCleanupIntervalStr := flag.String("cron-job-stale-resources-cleanup-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_CRON_JOB_STALE_RESOURCES_DELETION_INTERVAL", "1m"), "Set interval for the deletion of stale cron job resources (optional)")
 	functionEventOperatorNumWorkersStr := flag.String("function-event-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_EVENT_OPERATOR_NUM_WORKERS", "2"), "Set number of workers for the function event operator (optional)")
 	projectOperatorNumWorkersStr := flag.String("project-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_PROJECT_OPERATOR_NUM_WORKERS", "2"), "Set number of workers for the function operator (optional)")
 	flag.Parse()
@@ -73,7 +73,7 @@ func main() {
 		*platformConfigurationPath,
 		*functionOperatorNumWorkersStr,
 		*functionOperatorResyncIntervalStr,
-		*cronJobStalePodsDeletionIntervalStr,
+		*cronJobStaleResourcesCleanupIntervalStr,
 		*functionEventOperatorNumWorkersStr,
 		*projectOperatorNumWorkersStr); err != nil {
 		errors.PrintErrorStack(os.Stderr, err, 5)

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -50,7 +50,7 @@ func main() {
 	platformConfigurationPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
 	functionOperatorNumWorkersStr := flag.String("function-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_OPERATOR_NUM_WORKERS", "4"), "Set number of workers for the function operator (optional)")
 	functionOperatorResyncIntervalStr := flag.String("function-operator-resync-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_OPERATOR_RESYNC_INTERVAL", "10m"), "Set resync interval for the function operator (optional)")
-	cronJobStaleResourcesCleanupIntervalStr := flag.String("cron-job-stale-resources-cleanup-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_CRON_JOB_STALE_RESOURCES_DELETION_INTERVAL", "1m"), "Set interval for the deletion of stale cron job resources (optional)")
+	cronJobStaleResourcesCleanupIntervalStr := flag.String("cron-job-stale-resources-cleanup-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_CRON_JOB_STALE_RESOURCES_CLEANUP_INTERVAL", "1m"), "Set interval for the cleanup of stale cron job resources (optional)")
 	functionEventOperatorNumWorkersStr := flag.String("function-event-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_EVENT_OPERATOR_NUM_WORKERS", "2"), "Set number of workers for the function event operator (optional)")
 	projectOperatorNumWorkersStr := flag.String("project-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_PROJECT_OPERATOR_NUM_WORKERS", "2"), "Set number of workers for the function operator (optional)")
 	flag.Parse()

--- a/docs/reference/triggers/cron.md
+++ b/docs/reference/triggers/cron.md
@@ -8,7 +8,7 @@ Triggers the function according to a schedule or interval, with an optional body
 | :--- | :--- | :--- |
 | schedule | string | A cron-like schedule (for example, `*/5 * * * *`) |
 | interval | string | An interval (for example, `1s`, `30m`) |
-| concurrencyPolicy | string | Concurrency policy [Allow, Forbid, Replace]. (optional, defaults to "Allow". Relevant only for k8s platform)
+| concurrencyPolicy | string | Concurrency policy [Allow, Forbid, Replace]. (optional, defaults to "Forbid". Relevant only for k8s platform)
 | jobBackoffLimit | int32 | The number of retries before failing a job. (optional, defaults to 2. Relevant only for k8s platform)
 | event.body | string | The body passed in the event |
 | event.headers | map of string/int | The headers passed in the event |

--- a/pkg/platform/kube/controller/controller.go
+++ b/pkg/platform/kube/controller/controller.go
@@ -50,7 +50,7 @@ func NewController(parentLogger logger.Logger,
 	nuclioClientSet nuclioioclient.Interface,
 	functionresClient functionres.Client,
 	resyncInterval time.Duration,
-	cronJobStalePodsDeletionInterval time.Duration,
+	cronJobStaleResourcesCleanupInterval time.Duration,
 	platformConfiguration *platformconfig.Config,
 	functionOperatorNumWorkers int,
 	functionEventOperatorNumWorkers int,
@@ -114,7 +114,7 @@ func NewController(parentLogger logger.Logger,
 	// create cron job monitoring
 	newController.cronJobMonitoring = NewCronJobMonitoring(parentLogger,
 		newController,
-		&cronJobStalePodsDeletionInterval)
+		&cronJobStaleResourcesCleanupInterval)
 
 	return newController, nil
 }

--- a/pkg/platform/kube/controller/cronjobmonitoring.go
+++ b/pkg/platform/kube/controller/cronjobmonitoring.go
@@ -92,8 +92,12 @@ func (cjm *CronJobMonitoring) deleteStaleJobs() {
 
 		// check if the job is stale - a k8s bug that happens when a job fails more times than its backoff limit
 		// whenever this happens, the job will not be automatically deleted
-		if job.Spec.BackoffLimit != nil &&
-			*job.Spec.BackoffLimit <= job.Status.Failed {
+		isJobBackOffLimitExceeded := job.Spec.BackoffLimit != nil &&
+			*job.Spec.BackoffLimit <= job.Status.Failed
+
+		isJobCompleted := job.Status.Succeeded > 0
+
+		if isJobBackOffLimitExceeded || isJobCompleted {
 			err := cjm.controller.kubeClientSet.
 				BatchV1().
 				Jobs(cjm.controller.namespace).

--- a/pkg/platform/kube/controller/cronjobmonitoring.go
+++ b/pkg/platform/kube/controller/cronjobmonitoring.go
@@ -7,68 +7,109 @@ import (
 
 	"github.com/nuclio/logger"
 	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type CronJobMonitoring struct {
-	logger                           logger.Logger
-	controller                       *Controller
-	staleCronJobPodsDeletionInterval *time.Duration
+	logger                               logger.Logger
+	controller                           *Controller
+	cronJobStaleResourcesCleanupInterval *time.Duration
 }
 
 func NewCronJobMonitoring(parentLogger logger.Logger,
 	controller *Controller,
-	staleCronJobPodsDeletionInterval *time.Duration) *CronJobMonitoring {
+	cronJobStaleResourcesCleanupInterval *time.Duration) *CronJobMonitoring {
 
 	loggerInstance := parentLogger.GetChild("cron_job_monitoring")
 
 	newCronJobMonitoring := &CronJobMonitoring{
-		logger:                           loggerInstance,
-		controller:                       controller,
-		staleCronJobPodsDeletionInterval: staleCronJobPodsDeletionInterval,
+		logger:                               loggerInstance,
+		controller:                           controller,
+		cronJobStaleResourcesCleanupInterval: cronJobStaleResourcesCleanupInterval,
 	}
 
 	parentLogger.DebugWith("Successfully created cron job monitoring instance",
-		"staleCronJobPodsDeletionInterval", staleCronJobPodsDeletionInterval)
+		"cronJobStaleResourcesCleanupInterval", cronJobStaleResourcesCleanupInterval)
 
 	return newCronJobMonitoring
 }
 
-func (cjpd *CronJobMonitoring) start() {
+func (cjm *CronJobMonitoring) start() {
 
-	go cjpd.startStaleCronJobPodsDeletionLoop() // nolint: errcheck
+	go cjm.startCronJobStaleResourcesCleanupLoop() // nolint: errcheck
 
 }
 
-// delete all stale cron job pods (as k8s lacks this logic, and CronJob pods are never deleted)
-func (cjpd *CronJobMonitoring) startStaleCronJobPodsDeletionLoop() error {
-	stalePodsFieldSelector := cjpd.compileStalePodsFieldSelector()
+// cleanup all cron job related stale resources (as k8s lacks this logic)
+func (cjm *CronJobMonitoring) startCronJobStaleResourcesCleanupLoop() error {
+	stalePodsFieldSelector := cjm.compileStalePodsFieldSelector()
 
-	cjpd.logger.InfoWith("Starting stale cron job pods deletion loop",
-		"staleCronJobPodsDeletionInterval", cjpd.staleCronJobPodsDeletionInterval,
+	cjm.logger.InfoWith("Starting cron job stale resources cleanup loop",
+		"cronJobStaleResourcesCleanupInterval", cjm.cronJobStaleResourcesCleanupInterval,
 		"fieldSelectors", stalePodsFieldSelector)
 
 	for {
 
-		// sleep until next deletion time staleCronJobPodsDeletionInterval
-		time.Sleep(*cjpd.staleCronJobPodsDeletionInterval)
+		// sleep until next deletion time cronJobStaleResourcesCleanupInterval
+		time.Sleep(*cjm.cronJobStaleResourcesCleanupInterval)
 
-		err := cjpd.controller.kubeClientSet.
-			CoreV1().
-			Pods(cjpd.controller.namespace).
-			DeleteCollection(&metav1.DeleteOptions{},
-				metav1.ListOptions{
-					LabelSelector: "nuclio.io/function-cron-job-pod=true",
-					FieldSelector: stalePodsFieldSelector,
-				})
-		if err != nil {
-			cjpd.logger.WarnWith("Failed to delete stale cron job pods", "err", err)
+		cjm.deleteStalePods(stalePodsFieldSelector)
+		cjm.deleteStaleJobs()
+	}
+}
+
+func (cjm *CronJobMonitoring) deleteStalePods(stalePodsFieldSelector string) {
+	err := cjm.controller.kubeClientSet.
+		CoreV1().
+		Pods(cjm.controller.namespace).
+		DeleteCollection(&metav1.DeleteOptions{},
+			metav1.ListOptions{
+				LabelSelector: "nuclio.io/function-cron-job-pod=true",
+				FieldSelector: stalePodsFieldSelector,
+			})
+	if err != nil {
+		cjm.logger.WarnWith("Failed to delete stale cron-job pods",
+			"namespace", cjm.controller.namespace,
+			"err", err)
+	}
+}
+
+func (cjm *CronJobMonitoring) deleteStaleJobs() {
+	jobs, err := cjm.controller.kubeClientSet.
+		BatchV1().
+		Jobs(cjm.controller.namespace).
+		List(metav1.ListOptions{
+			LabelSelector: "nuclio.io/function-cron-job-pod=true",
+		})
+	if err != nil {
+		cjm.logger.WarnWith("Failed to list cron-job jobs",
+			"namespace", cjm.controller.namespace,
+			"err", err)
+	}
+
+	for _, job := range jobs.Items {
+
+		// check if the job is stale - a k8s bug that happens when a job fails more times than its backoff limit
+		// whenever this happens, the job will not be automatically deleted
+		if job.Spec.BackoffLimit != nil &&
+			*job.Spec.BackoffLimit <= job.Status.Failed {
+			err := cjm.controller.kubeClientSet.
+				BatchV1().
+				Jobs(cjm.controller.namespace).
+				Delete(job.Name, &metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				cjm.logger.WarnWith("Failed to delete cron-job job",
+					"name", job.Name,
+					"namespace", job.Namespace,
+					"err", err)
+			}
 		}
 	}
 }
 
 // create a field selector(string) for stale pods
-func (cjpd *CronJobMonitoring) compileStalePodsFieldSelector() string {
+func (cjm *CronJobMonitoring) compileStalePodsFieldSelector() string {
 	var fieldSelectors []string
 
 	// filter out non stale pods by their phase

--- a/pkg/platform/kube/controller/cronjobmonitoring.go
+++ b/pkg/platform/kube/controller/cronjobmonitoring.go
@@ -54,8 +54,8 @@ func (cjm *CronJobMonitoring) startCronJobStaleResourcesCleanupLoop() error {
 		// sleep until next deletion time cronJobStaleResourcesCleanupInterval
 		time.Sleep(*cjm.cronJobStaleResourcesCleanupInterval)
 
-		cjm.deleteStalePods(stalePodsFieldSelector)
 		cjm.deleteStaleJobs()
+		cjm.deleteStalePods(stalePodsFieldSelector)
 	}
 }
 

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1582,7 +1582,8 @@ func (lc *lazyClient) generateCronTriggerCronJobSpec(functionLabels labels.Set,
 		},
 	}
 
-	// set concurrency policy if given
+	// set concurrency policy if given (default to forbid - to protect the user from overdose of cron jobs)
+	attributes.ConcurrencyPolicy = string(batchv1beta1.ForbidConcurrent)
 	if attributes.ConcurrencyPolicy != "" {
 		spec.ConcurrencyPolicy = batchv1beta1.ConcurrencyPolicy(util.Capitalize(attributes.ConcurrencyPolicy))
 	}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1532,7 +1532,10 @@ func (lc *lazyClient) generateCronTriggerCronJobSpec(functionLabels labels.Set,
 	functionAddress := fmt.Sprintf("%s:%d", host, port)
 
 	// generate the curl command to be run by the CronJob to invoke the function
-	curlCommand := fmt.Sprintf("curl --silent %s %s", headersAsCurlArg, functionAddress)
+	// retry to invoke the function for 5 seconds (in case of connection-refused error etc..)
+	curlCommand := fmt.Sprintf("curl --silent %s %s --retry 5 --max-time 2 --retry-delay 1 --retry-max-time 5 --retry-connrefused",
+		headersAsCurlArg,
+		functionAddress)
 
 	if attributes.Event.Body != "" {
 		eventBody := attributes.Event.Body

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1532,7 +1532,7 @@ func (lc *lazyClient) generateCronTriggerCronJobSpec(functionLabels labels.Set,
 	functionAddress := fmt.Sprintf("%s:%d", host, port)
 
 	// generate the curl command to be run by the CronJob to invoke the function
-	// retry to invoke the function for 5 seconds (in case of connection-refused error etc..)
+	// invoke the function (retry for 10 seconds)
 	curlCommand := fmt.Sprintf("curl --silent %s %s --retry 10 --retry-delay 1 --retry-max-time 10 --retry-connrefused",
 		headersAsCurlArg,
 		functionAddress)

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1583,10 +1583,11 @@ func (lc *lazyClient) generateCronTriggerCronJobSpec(functionLabels labels.Set,
 	}
 
 	// set concurrency policy if given (default to forbid - to protect the user from overdose of cron jobs)
-	attributes.ConcurrencyPolicy = string(batchv1beta1.ForbidConcurrent)
+	concurrencyPolicy := batchv1beta1.ForbidConcurrent
 	if attributes.ConcurrencyPolicy != "" {
-		spec.ConcurrencyPolicy = batchv1beta1.ConcurrencyPolicy(util.Capitalize(attributes.ConcurrencyPolicy))
+		concurrencyPolicy = batchv1beta1.ConcurrencyPolicy(util.Capitalize(attributes.ConcurrencyPolicy))
 	}
+	spec.ConcurrencyPolicy = concurrencyPolicy
 
 	// set default history limit (no need for more than one - makes kube jobs api clearer)
 	spec.SuccessfulJobsHistoryLimit = &one

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1533,7 +1533,7 @@ func (lc *lazyClient) generateCronTriggerCronJobSpec(functionLabels labels.Set,
 
 	// generate the curl command to be run by the CronJob to invoke the function
 	// retry to invoke the function for 5 seconds (in case of connection-refused error etc..)
-	curlCommand := fmt.Sprintf("curl --silent %s %s --retry 5 --max-time 2 --retry-delay 1 --retry-max-time 5 --retry-connrefused",
+	curlCommand := fmt.Sprintf("curl --silent %s %s --retry 10 --retry-delay 1 --retry-max-time 10 --retry-connrefused",
 		headersAsCurlArg,
 		functionAddress)
 


### PR DESCRIPTION
1. In order to reduce stress on the system that may be caused by having multiple cron jobs with low interval, we decided to set the default concurrencyPolicy to 'Forbid'

2. In order to decrease the failure rate of cron jobs, we're now retrying to perform the Curl operation for 10 seconds

3. Added `deleteStaleJobs()` task to the `cronJobStaleResourcesCleanup` cycle - as there're failed jobs that stay forever up on a specific bug (when jobFailures > jobBackoffLimit)