### PR TITLE
RBAC fix for multi-namespaced nuclio installation

### DIFF
--- a/hack/k8s/helm/nuclio/templates/role/crd-admin.yaml
+++ b/hack/k8s/helm/nuclio/templates/role/crd-admin.yaml
@@ -30,6 +30,9 @@ rules:
   - apiGroups: ["nuclio.io"]
     resources: ["nucliofunctions", "nuclioprojects", "nucliofunctionevents"]
     verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["list"]
 
 {{- else if eq .Values.rbac.crdAccessMode "namespaced" }}
 

--- a/hack/k8s/helm/nuclio/templates/role/function-deployer.yaml
+++ b/hack/k8s/helm/nuclio/templates/role/function-deployer.yaml
@@ -13,11 +13,18 @@
 # limitations under the License.
 
 {{- if .Values.rbac.create }}
-# All access to services, configmaps, deployments, ingresses and HPAs limited to the nuclio namespace
+# All access to services, configmaps, deployments, ingresses, HPAs, cronJobs
+# are conditionally limited to the nuclio namespace or cluster-wide
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- if eq .Values.rbac.crdAccessMode "cluster" }}
+kind: ClusterRole
+metadata:
+  name: {{ template "nuclio.functionDeployerName" . }}-clusterrole
+{{- else }}
 kind: Role
 metadata:
   name: {{ template "nuclio.functionDeployerName" . }}-role
+{{- end }}
   labels:
     app: {{ template "nuclio.nuclioName" . }}
     release: {{ .Release.Name }}

--- a/hack/k8s/helm/nuclio/templates/rolebinding/function-deployer.yaml
+++ b/hack/k8s/helm/nuclio/templates/rolebinding/function-deployer.yaml
@@ -15,6 +15,26 @@
 {{- if .Values.rbac.create }}
 # Bind the service account (used by controller / dashboard) to the function-deployer role,
 # allowing them to create deployments, services, etc
+
+{{- if eq .Values.rbac.crdAccessMode "cluster" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "nuclio.functionDeployerName" . }}-clusterrolebinding
+  labels:
+    app: {{ template "nuclio.nuclioName" . }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "nuclio.functionDeployerName" . }}-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: {{ template "nuclio.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+
+{{- else }}
+
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
@@ -30,4 +50,7 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "nuclio.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+
+{{- end }}
+
 {{- end }}

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -162,8 +162,11 @@ rbac:
 
   # serviceAccountName: service-account-name
 
-  # Allow / deny cluster-wide CRD access. values: "cluster", "namespaced".
-  # If set to "namespaced" dashboard will not be able to create nuclio resources in any namespace other than the one in which it is installed
+  # Allow / deny cluster-wide resource access. values: "cluster", "namespaced".
+  # If set to "namespaced" dashboard will not be able to create nuclio resources in any namespace other
+  # than the one in which it is installed
+  # Likewise, for "namespaced", the controller won't be able to act on these nuclio resources in any
+  # namespace other than the one in which it is installed
   crdAccessMode: cluster
 
 crd:

--- a/hack/k8s/resources/nuclio-rbac.yaml
+++ b/hack/k8s/resources/nuclio-rbac.yaml
@@ -68,7 +68,9 @@ rules:
 - apiGroups: ["nuclio.io"]
   resources: ["nucliofunctions", "nuclioprojects", "nucliofunctionevents"]
   verbs: ["*"]
-
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
 ---
 
 # Bind the "nuclio" service account (used by controller / dashboard) to the nuclio-functioncr-admin role,

--- a/hack/k8s/resources/nuclio-rbac.yaml
+++ b/hack/k8s/resources/nuclio-rbac.yaml
@@ -68,9 +68,7 @@ rules:
 - apiGroups: ["nuclio.io"]
   resources: ["nucliofunctions", "nuclioprojects", "nucliofunctionevents"]
   verbs: ["*"]
-- apiGroups: [""]
-  resources: ["namespaces"]
-  verbs: ["list"]
+
 ---
 
 # Bind the "nuclio" service account (used by controller / dashboard) to the nuclio-functioncr-admin role,


### PR DESCRIPTION
- Function deployer can be a cluster role (and need cluster role binding) if in multi-namepace mode. Other wise:
  1. Broken for all but the same namespace of controller / release (if helm)
   2. cronJob stale pod monitor will fail Listing pods in cluster scope
- Missing namespaces in cluster role