### PR TITLE
Fix http trigger port type assertion

### DIFF
--- a/.run/(kube) nuctl test.run.xml
+++ b/.run/(kube) nuctl test.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="(kube) nuctl test" type="GoTestRunConfiguration" factoryName="Go Test">
     <module name="nuclio" />
     <working_directory value="$PROJECT_DIR$/pkg/nuctl/test" />
-    <go_parameters value="-ldflags=&quot;-X github.com/v3io/version-go.label=246&quot;" />
+    <go_parameters value="-ldflags=&quot;-X github.com/v3io/version-go.label=latest&quot;" />
     <parameters value=" -testify.m ^TestBuild$" />
     <envs>
       <env name="NUCTL_NAMESPACE" value="default" />

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -307,7 +307,17 @@ func (s *Spec) GetHTTPPort() int {
 					return int(typedHTTPPort)
 				case int64:
 					return int(typedHTTPPort)
+				case uint:
+					return int(typedHTTPPort)
+				case uint8:
+					return int(typedHTTPPort)
+				case uint16:
+					return int(typedHTTPPort)
+				case uint32:
+					return int(typedHTTPPort)
 				case uint64:
+					return int(typedHTTPPort)
+				case float32:
 					return int(typedHTTPPort)
 				case float64:
 					return int(typedHTTPPort)

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -299,6 +299,12 @@ func (s *Spec) GetHTTPPort() int {
 			httpPort, httpPortValid := trigger.Attributes["port"]
 			if httpPortValid {
 				switch typedHTTPPort := httpPort.(type) {
+				case int8:
+					return int(typedHTTPPort)
+				case int16:
+					return int(typedHTTPPort)
+				case int32:
+					return int(typedHTTPPort)
 				case int64:
 					return int(typedHTTPPort)
 				case uint64:

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -299,6 +299,8 @@ func (s *Spec) GetHTTPPort() int {
 			httpPort, httpPortValid := trigger.Attributes["port"]
 			if httpPortValid {
 				switch typedHTTPPort := httpPort.(type) {
+				case int64:
+					return int(typedHTTPPort)
 				case uint64:
 					return int(typedHTTPPort)
 				case float64:

--- a/pkg/nuctl/command/get.go
+++ b/pkg/nuctl/command/get.go
@@ -60,7 +60,6 @@ type getFunctionCommandeer struct {
 	*getCommandeer
 	getFunctionsOptions platform.GetFunctionsOptions
 	output              string
-	withStatus          bool
 }
 
 func newGetFunctionCommandeer(getCommandeer *getCommandeer) *getFunctionCommandeer {
@@ -101,36 +100,20 @@ func newGetFunctionCommandeer(getCommandeer *getCommandeer) *getFunctionCommande
 				return nil
 			}
 
-			rendererFunc := commandeer.renderFunctionConfig
-			if commandeer.withStatus {
-				rendererFunc = commandeer.renderFunctionConfigWithStatus
-			}
-
 			// render the functions
 			return common.RenderFunctions(commandeer.rootCommandeer.loggerInstance,
 				functions,
 				commandeer.output,
 				cmd.OutOrStdout(),
-				rendererFunc)
+				commandeer.renderFunctionConfigWithStatus)
 		},
 	}
 
 	cmd.PersistentFlags().StringVarP(&commandeer.getFunctionsOptions.Labels, "labels", "l", "", "Function labels (lbl1=val1[,lbl2=val2,...])")
 	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", common.OutputFormatText, "Output format - \"text\", \"wide\", \"yaml\", or \"json\"")
-	cmd.PersistentFlags().BoolVarP(&commandeer.withStatus, "with-status", "s", false, "Whether to return function status along its config")
 	commandeer.cmd = cmd
 
 	return commandeer
-}
-
-func (g *getFunctionCommandeer) renderFunctionConfig(functions []platform.Function,
-	renderer func(interface{}) error) error {
-	for _, function := range functions {
-		if err := renderer(function.GetConfig()); err != nil {
-			return errors.Wrap(err, "Failed to render function config")
-		}
-	}
-	return nil
 }
 
 func (g *getFunctionCommandeer) renderFunctionConfigWithStatus(functions []platform.Function,

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -744,7 +744,7 @@ func (suite *functionDeployTestSuite) TestDeployWithResourceVersion() {
 	// redeploy the function with a small change, to ensure the resource version is changed
 
 	// get the current deployed function, save its resource version
-	deployedFunction, err := suite.getFunctionInFormat(functionConfig.Meta.Name, nuctlcommon.OutputFormatYAML, true)
+	deployedFunction, err := suite.getFunctionInFormat(functionConfig.Meta.Name, nuctlcommon.OutputFormatYAML)
 	suite.Require().NoError(err)
 
 	// save it for next step, to be used as a "stale" resource vresion
@@ -773,7 +773,7 @@ func (suite *functionDeployTestSuite) TestDeployWithResourceVersion() {
 	suite.Require().NoError(err)
 
 	// get the redeployed function, extract its latest resource version
-	redeployedFunction, err := suite.getFunctionInFormat(functionConfig.Meta.Name, nuctlcommon.OutputFormatYAML, true)
+	redeployedFunction, err := suite.getFunctionInFormat(functionConfig.Meta.Name, nuctlcommon.OutputFormatYAML)
 	suite.Require().NoError(err)
 
 	// sanity, ensure retrieved redeployed function resource version is not empty
@@ -828,7 +828,7 @@ func (suite *functionDeployTestSuite) TestDeployWithResourceVersion() {
 	err = common.RetryUntilSuccessful(1*time.Minute, 3*time.Second, func() bool {
 
 		// get the deployed function, we're gonna inspect its resource version
-		deployedFunction, err = suite.getFunctionInFormat(functionConfig.Meta.Name, nuctlcommon.OutputFormatYAML, true)
+		deployedFunction, err = suite.getFunctionInFormat(functionConfig.Meta.Name, nuctlcommon.OutputFormatYAML)
 		return err == nil && deployedFunction.Meta.ResourceVersion != functionResourceVersion
 	})
 	suite.Require().NoErrorf(err, "Resource version should have been changed (real: %s, expected: %s)",
@@ -859,7 +859,7 @@ func (suite *functionDeployTestSuite) TestDeployAndRedeployHTTPTriggerPortChange
 	// wait for function to become ready
 	suite.waitForFunctionState(functionName, functionconfig.FunctionStateReady)
 
-	deployedFunctionConfig, err := suite.getFunctionInFormat(functionName, nuctlcommon.OutputFormatYAML, true)
+	deployedFunctionConfig, err := suite.getFunctionInFormat(functionName, nuctlcommon.OutputFormatYAML)
 	suite.Require().NoError(err)
 
 	// ensure allocated http port is returned
@@ -889,7 +889,7 @@ func (suite *functionDeployTestSuite) TestDeployAndRedeployHTTPTriggerPortChange
 
 	suite.outputBuffer.Reset()
 
-	deployedFunctionConfig, err = suite.getFunctionInFormat(functionName, nuctlcommon.OutputFormatYAML, true)
+	deployedFunctionConfig, err = suite.getFunctionInFormat(functionName, nuctlcommon.OutputFormatYAML)
 	suite.Require().NoError(err)
 
 	suite.Require().Equal(desiredHTTPPort, deployedFunctionConfig.Status.HTTPPort)
@@ -1149,7 +1149,7 @@ func (suite *functionGetTestSuite) TestGet() {
 		// reset buffer
 		suite.outputBuffer.Reset()
 
-		parsedFunction, err := suite.getFunctionInFormat(testCase.FunctionName, testCase.OutputFormat, true)
+		parsedFunction, err := suite.getFunctionInFormat(testCase.FunctionName, testCase.OutputFormat)
 
 		// ensure parsing went well, and response is valid (json/yaml)
 		suite.Require().NoError(err, "Failed to unmarshal function")

--- a/pkg/nuctl/test/suite.go
+++ b/pkg/nuctl/test/suite.go
@@ -232,8 +232,7 @@ func (suite *Suite) assertFunctionImported(functionName string, imported bool) {
 }
 
 func (suite *Suite) getFunctionInFormat(functionName string,
-	outputFormat string,
-	withStatus bool) (*functionconfig.ConfigWithStatus, error) {
+	outputFormat string) (*functionconfig.ConfigWithStatus, error) {
 	suite.outputBuffer.Reset()
 	var err error
 
@@ -241,14 +240,10 @@ func (suite *Suite) getFunctionInFormat(functionName string,
 	suite.Require().NotEmpty(functionName, "Function name must not be empty")
 
 	// get function in format
-	namedArgs := map[string]string{
-		"output": outputFormat,
-	}
-	args := []string{"get", "function", functionName}
-	if withStatus {
-		args = append(args, "--with-status")
-	}
-	if err = suite.ExecuteNuctl(args, namedArgs); err != nil {
+	if err = suite.ExecuteNuctl([]string{"get", "function", functionName},
+		map[string]string{
+			"output": outputFormat,
+		}); err != nil {
 		return nil, errors.Wrapf(err, "Failed to get function %s", functionName)
 	}
 
@@ -269,9 +264,7 @@ func (suite *Suite) getFunctionInFormat(functionName string,
 
 func (suite *Suite) waitForFunctionState(functionName string, expectedState functionconfig.FunctionState) {
 	err := common.RetryUntilSuccessful(1*time.Minute, 5*time.Second, func() bool {
-		functionConfigWithStatus, err := suite.getFunctionInFormat(functionName,
-			nuctlcommon.OutputFormatYAML,
-			true)
+		functionConfigWithStatus, err := suite.getFunctionInFormat(functionName, nuctlcommon.OutputFormatYAML)
 		if err != nil {
 			suite.logger.ErrorWith("Waiting for function readiness failed", "err", err)
 			return false

--- a/pkg/nuctl/test/suite.go
+++ b/pkg/nuctl/test/suite.go
@@ -267,7 +267,7 @@ func (suite *Suite) getFunctionInFormat(functionName string,
 	return &parsedFunction, err
 }
 
-func (suite *Suite) waitForFunctionState(functionName string, state functionconfig.FunctionState) {
+func (suite *Suite) waitForFunctionState(functionName string, expectedState functionconfig.FunctionState) {
 	err := common.RetryUntilSuccessful(1*time.Minute, 5*time.Second, func() bool {
 		functionConfigWithStatus, err := suite.getFunctionInFormat(functionName,
 			nuctlcommon.OutputFormatYAML,
@@ -276,15 +276,18 @@ func (suite *Suite) waitForFunctionState(functionName string, state functionconf
 			suite.logger.ErrorWith("Waiting for function readiness failed", "err", err)
 			return false
 		}
-		if functionConfigWithStatus.Status.State != state {
+		if functionConfigWithStatus.Status.State != expectedState {
 			suite.logger.DebugWith("Function state is not ready yet",
-				"expectedState", state,
+				"expectedState", expectedState,
 				"currentState", functionConfigWithStatus.Status.State)
 			return false
 		}
 		return true
 	})
-	suite.Require().NoError(err)
+	suite.Require().NoErrorf(err,
+		"Failed to wait for function '%s' with expected state '%s'",
+		functionName,
+		expectedState)
 }
 
 func (suite *Suite) writeFunctionConfigToTempFile(functionConfig *functionconfig.Config,

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -182,7 +182,9 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 	}
 
 	// indicate that we're done
-	createFunctionOptions.Logger.InfoWith("Function deploy complete", "httpPort", deployResult.Port)
+	createFunctionOptions.Logger.InfoWith("Function deploy complete",
+		"functionName", deployResult.UpdatedFunctionConfig.Meta.Name,
+		"httpPort", deployResult.Port)
 
 	return deployResult, nil
 }

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1421,7 +1421,7 @@ func (lc *lazyClient) populateServiceSpec(functionLabels labels.Set,
 		}
 		lc.logger.DebugWith("Updating service node port",
 			"functionName", function.Name,
-			"port", spec.Ports)
+			"ports", spec.Ports)
 	}
 
 	// check if platform requires additional ports

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1400,6 +1400,7 @@ func (lc *lazyClient) populateServiceSpec(functionLabels labels.Set,
 
 	spec.Type = function.Spec.ServiceType
 	serviceTypeIsNodePort := spec.Type == v1.ServiceTypeNodePort
+	functionHTTPPort := function.Spec.GetHTTPPort()
 
 	// update the service's node port on the following conditions:
 	// 1. this is a new service (spec.Ports is an empty list)
@@ -1414,10 +1415,13 @@ func (lc *lazyClient) populateServiceSpec(functionLabels labels.Set,
 			},
 		}
 		if serviceTypeIsNodePort {
-			spec.Ports[0].NodePort = int32(function.Spec.GetHTTPPort())
+			spec.Ports[0].NodePort = int32(functionHTTPPort)
 		} else {
 			spec.Ports[0].NodePort = 0
 		}
+		lc.logger.DebugWith("Updating service node port",
+			"functionName", function.Name,
+			"port", spec.Ports)
 	}
 
 	// check if platform requires additional ports


### PR DESCRIPTION
Bug:
1. Create function without http trigger
2. Function deployed successfully, a random port number X was allocated
3. Redeploy function with http trigger with a specific port Y
4. Function still listen on port X

Expected:
Function listen on port Y

RCA:
When giving an HTTP trigger, the port is unmarshaled from the `attributes` block (each trigger has an attributes block for additional trigger attributes)
Since the unmarshaling return with int of type 64, which was not expected for the type assertion, the port was not converted and returned with 0

Solution:
Adding type assertion for int64 as well


Bonus:
- Test to cover function port changing between first and second deployments
-  `nuctl get function [function-name]` returns with status
