### PR TITLE
BugFix - Made Dockerfile for golang wait for chmod to complete fully on disk before running script

### DIFF
--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
@@ -52,7 +52,7 @@ ONBUILD COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} ./
 ONBUILD ARG NUCLIO_BUILD_OFFLINE
 
 # Run moduler to ensure go modules exists and downloaded
-ONBUILD RUN mv /moduler.sh . && chmod +x moduler.sh && ./moduler.sh
+ONBUILD RUN mv /moduler.sh . && chmod +x moduler.sh && sync && ./moduler.sh
 
 # Compile handler as plugin
 ONBUILD RUN GOOS=linux GOARCH=amd64 go build -mod=mod -buildmode=plugin -o /home/nuclio/bin/handler.so .


### PR DESCRIPTION
When system is in a heavy load, sometimes building a go function would fail with this message:
```
Error - exit status 126
    .../nuclio/nuclio/pkg/cmdrunner/cmdrunner.go:131

Call stack:
stdout:
Sending build context to Docker daemon  3.964MB
Step 1/3 : FROM quay.io/nuclio/handler-builder-golang-onbuild:unstable-amd64-alpine
# Executing 5 build triggers
 ---> Running in fba76b7cd32c
Removing intermediate container fba76b7cd32c
 ---> Running in 65b11a397eda
Removing intermediate container 65b11a397eda
 ---> Running in 9b2fbdb35383
/bin/sh: ./moduler.sh: Text file busy
Removing intermediate container 9b2fbdb35383

stderr:
The command '/bin/sh -c mv /moduler.sh . && chmod +x moduler.sh && ./moduler.sh' returned a non-zero code: 126

    .../nuclio/nuclio/pkg/cmdrunner/cmdrunner.go:131
Failed to build onbuild image
    .../nuclio/nuclio/pkg/processor/build/builder.go:1345
Failed to copy objects from onbuild
    .../nuclio/nuclio/pkg/processor/build/builder.go:1271
Failed to gather artifacts for single stage Dockerfile
    .../nuclio/nuclio/pkg/processor/build/builder.go:1036
Failed to get Dockerfile contents
    .../nuclio/nuclio/pkg/processor/build/builder.go:888
Failed to create processor dockerfile
    .../nuclio/nuclio/pkg/processor/build/builder.go:865
Failed to create processor dockerfile
```

Looking in to [this discussion](https://github.com/moby/moby/issues/9547) at one of Docker's repositories, this happened because the `chmod` didn't complete writing to the disk before running the script.
The suggested workaround was to add a `sync` between the `chmod` and the run.