### PR TITLE
Fix port allocation for functions running under docker platform

### DIFF
--- a/pkg/dockerclient/dockerclient.go
+++ b/pkg/dockerclient/dockerclient.go
@@ -56,8 +56,11 @@ type Client interface {
 	// GetContainerLogs returns raw logs from a given container ID
 	GetContainerLogs(containerID string) (string, error)
 
-	// GetContainers returns a list of container IDs which match a certain criteria
+	// GetContainers returns a list of containers which match a certain criteria
 	GetContainers(*GetContainerOptions) ([]Container, error)
+
+	// GetContainer returns the first matching container which match a certain criteria
+	GetContainer(*GetContainerOptions) (*Container, error)
 
 	// GetContainerEvents returns a list of container events which occurred within a time range
 	GetContainerEvents(containerName string, since string, until string) ([]string, error)

--- a/pkg/dockerclient/dockerclient.go
+++ b/pkg/dockerclient/dockerclient.go
@@ -59,9 +59,6 @@ type Client interface {
 	// GetContainers returns a list of containers which match a certain criteria
 	GetContainers(*GetContainerOptions) ([]Container, error)
 
-	// GetContainer returns the first matching container which match a certain criteria
-	GetContainer(*GetContainerOptions) (*Container, error)
-
 	// GetContainerEvents returns a list of container events which occurred within a time range
 	GetContainerEvents(containerName string, since string, until string) ([]string, error)
 

--- a/pkg/dockerclient/mock.go
+++ b/pkg/dockerclient/mock.go
@@ -95,11 +95,6 @@ func (mdc *MockDockerClient) GetContainers(options *GetContainerOptions) ([]Cont
 	return nil, nil
 }
 
-// GetContainer returns the first matching container which match a certain criteria
-func (mdc *MockDockerClient) GetContainer(options *GetContainerOptions) (*Container, error) {
-	return nil, nil
-}
-
 // GetContainerEvents returns a list of container events which occurred within a time range
 func (mdc *MockDockerClient) GetContainerEvents(containerName string, since string, until string) ([]string, error) {
 	return nil, nil

--- a/pkg/dockerclient/mock.go
+++ b/pkg/dockerclient/mock.go
@@ -95,6 +95,11 @@ func (mdc *MockDockerClient) GetContainers(options *GetContainerOptions) ([]Cont
 	return nil, nil
 }
 
+// GetContainer returns the first matching container which match a certain criteria
+func (mdc *MockDockerClient) GetContainer(options *GetContainerOptions) (*Container, error) {
+	return nil, nil
+}
+
 // GetContainerEvents returns a list of container events which occurred within a time range
 func (mdc *MockDockerClient) GetContainerEvents(containerName string, since string, until string) ([]string, error) {
 	return nil, nil

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -159,7 +159,11 @@ func (c *ShellClient) RunContainer(imageName string, runOptions *RunOptions) (st
 	portsArgument := ""
 
 	for localPort, dockerPort := range runOptions.Ports {
-		portsArgument += fmt.Sprintf("-p %d:%d ", localPort, dockerPort)
+		if localPort == RunOptionsNoPort {
+			portsArgument += fmt.Sprintf("-p %d ", dockerPort)
+		} else {
+			portsArgument += fmt.Sprintf("-p %d:%d ", localPort, dockerPort)
+		}
 	}
 
 	restartPolicy := ""
@@ -491,6 +495,18 @@ func (c *ShellClient) GetContainers(options *GetContainerOptions) ([]Container, 
 	}
 
 	return containersInfo, nil
+}
+
+// GetContainer returns the first matching container which match a certain criteria
+func (c *ShellClient) GetContainer(options *GetContainerOptions) (*Container, error) {
+	containers, err := c.GetContainers(options)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get container")
+	}
+	if len(containers) == 0 {
+		return nil, errors.New("No container were matching criteria")
+	}
+	return &containers[0], nil
 }
 
 // GetContainerEvents returns a list of container events which occurred within a time range

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -497,18 +497,6 @@ func (c *ShellClient) GetContainers(options *GetContainerOptions) ([]Container, 
 	return containersInfo, nil
 }
 
-// GetContainer returns the first matching container which match a certain criteria
-func (c *ShellClient) GetContainer(options *GetContainerOptions) (*Container, error) {
-	containers, err := c.GetContainers(options)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get container")
-	}
-	if len(containers) == 0 {
-		return nil, errors.New("No container were matching criteria")
-	}
-	return &containers[0], nil
-}
-
 // GetContainerEvents returns a list of container events which occurred within a time range
 func (c *ShellClient) GetContainerEvents(containerName string, since string, until string) ([]string, error) {
 	runResults, err := c.runCommand(nil, "docker events --filter container=%s --since %s --until %s",

--- a/pkg/dockerclient/types.go
+++ b/pkg/dockerclient/types.go
@@ -29,6 +29,7 @@ const (
 	RestartPolicyNameOnFailure     RestartPolicyName = "on-failure"
 )
 
+// RunOptionsNoPort urge docker shell client not to map an explicit source port (but rather a random one)
 const RunOptionsNoPort int = -1
 
 // LogInOptions are options for logging in

--- a/pkg/dockerclient/types.go
+++ b/pkg/dockerclient/types.go
@@ -29,6 +29,8 @@ const (
 	RestartPolicyNameOnFailure     RestartPolicyName = "on-failure"
 )
 
+const RunOptionsNoPort int = -1
+
 // LogInOptions are options for logging in
 type LogInOptions struct {
 	Username string

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -44,6 +44,7 @@ import (
 //
 
 const (
+	FunctionContainerHTTPPort      = 8080
 	DefaultReadinessTimeoutSeconds = 60
 	DefaultTargetCPU               = 75
 )

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -62,7 +62,6 @@ import (
 )
 
 const (
-	containerHTTPPort             = 8080
 	containerHTTPPortName         = "http"
 	containerMetricPort           = 8090
 	containerMetricPortName       = "metrics"
@@ -1411,7 +1410,7 @@ func (lc *lazyClient) populateServiceSpec(functionLabels labels.Set,
 		spec.Ports = []v1.ServicePort{
 			{
 				Name: containerHTTPPortName,
-				Port: int32(containerHTTPPort),
+				Port: int32(abstract.FunctionContainerHTTPPort),
 			},
 		}
 		if serviceTypeIsNodePort {
@@ -1766,7 +1765,7 @@ func (lc *lazyClient) populateDeploymentContainer(functionLabels labels.Set,
 	container.Ports = []v1.ContainerPort{
 		{
 			Name:          containerHTTPPortName,
-			ContainerPort: containerHTTPPort,
+			ContainerPort: abstract.FunctionContainerHTTPPort,
 			Protocol:      "TCP",
 		},
 	}

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platform/abstract"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
@@ -212,7 +213,7 @@ func (suite *lazyTestSuite) TestPlatformServicePorts() {
 	toServicePorts := suite.client.ensureServicePortsExist([]v1.ServicePort{
 		{
 			Name:     containerHTTPPortName,
-			Port:     int32(containerHTTPPort),
+			Port:     int32(abstract.FunctionContainerHTTPPort),
 			NodePort: 12345,
 		},
 	}, []v1.ServicePort{
@@ -228,7 +229,7 @@ func (suite *lazyTestSuite) TestPlatformServicePorts() {
 	toServicePorts = suite.client.ensureServicePortsExist([]v1.ServicePort{
 		{
 			Name:     containerHTTPPortName,
-			Port:     int32(containerHTTPPort),
+			Port:     int32(abstract.FunctionContainerHTTPPort),
 			NodePort: 12345,
 		},
 	}, []v1.ServicePort{

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"os"
 	"path"
 	"strconv"
@@ -516,21 +515,6 @@ func (p *Platform) SaveFunctionDeployLogs(functionName, namespace string) error 
 	})
 }
 
-func (p *Platform) getFreeLocalPort() (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
-	if err != nil {
-		return 0, err
-	}
-
-	l, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		return 0, err
-	}
-
-	defer l.Close() // nolint: errcheck
-	return l.Addr().(*net.TCPAddr).Port, nil
-}
-
 func (p *Platform) deployFunction(createFunctionOptions *platform.CreateFunctionOptions,
 	previousHTTPPort int) (*platform.CreateFunctionResult, error) {
 
@@ -540,92 +524,48 @@ func (p *Platform) deployFunction(createFunctionOptions *platform.CreateFunction
 		return nil, errors.Wrap(err, "Failed to create function platform configuration")
 	}
 
-	// get function port - either from configuration, from the previous deployment or from a free port
-	functionHTTPPort, err := p.getFunctionHTTPPort(createFunctionOptions, previousHTTPPort)
+	volumesMap, err := p.compileDeployFunctionVolumesMap(createFunctionOptions)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get function HTTP port")
+		return nil, errors.Wrap(err, "Failed to compile volumes map")
 	}
-
-	createFunctionOptions.Logger.DebugWith("Function port allocated",
-		"port", functionHTTPPort,
-		"previousHTTPPort", previousHTTPPort)
-
-	labels := map[string]string{
-		"nuclio.io/platform":      "local",
-		"nuclio.io/namespace":     createFunctionOptions.FunctionConfig.Meta.Namespace,
-		"nuclio.io/function-name": createFunctionOptions.FunctionConfig.Meta.Name,
-		"nuclio.io/function-spec": p.encodeFunctionSpec(&createFunctionOptions.FunctionConfig.Spec),
-	}
-
-	for labelName, labelValue := range createFunctionOptions.FunctionConfig.Meta.Labels {
-		labels[labelName] = labelValue
-	}
-
-	marshalledAnnotations := p.marshallAnnotations(createFunctionOptions.FunctionConfig.Meta.Annotations)
-	if marshalledAnnotations != nil {
-		labels["nuclio.io/annotations"] = string(marshalledAnnotations)
-	}
-
-	// create processor configuration at a temporary location unless user specified a configuration
-	localProcessorConfigPath, err := p.createProcessorConfig(createFunctionOptions)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create processor configuration")
-	}
-
-	// create volumes string[string] map for volumes
-	volumesMap := map[string]string{
-		localProcessorConfigPath: path.Join("/", "etc", "nuclio", "config", "processor", "processor.yaml"),
-	}
-
-	for _, volume := range createFunctionOptions.FunctionConfig.Spec.Volumes {
-
-		// only add hostpath volumes
-		if volume.Volume.HostPath != nil {
-			volumesMap[volume.Volume.HostPath.Path] = volume.VolumeMount.MountPath
-		}
-	}
-
-	envMap := map[string]string{}
-	for _, env := range createFunctionOptions.FunctionConfig.Spec.Env {
-		envMap[env.Name] = env.Value
-	}
+	labels := p.compileDeployFunctionLabels(createFunctionOptions)
+	envMap := p.compileDeployFunctionEnvMap(createFunctionOptions)
 
 	// run the docker image
-	containerID, err := p.dockerClient.RunContainer(createFunctionOptions.FunctionConfig.Spec.Image, &dockerclient.RunOptions{
+	runContainerOptions := &dockerclient.RunOptions{
 		ContainerName: p.GetContainerNameByCreateFunctionOptions(createFunctionOptions),
-		Ports:         map[int]int{functionHTTPPort: 8080},
+		Ports:         map[int]int{dockerclient.RunOptionsNoPort: abstract.FunctionContainerHTTPPort},
 		Env:           envMap,
 		Labels:        labels,
 		Volumes:       volumesMap,
 		Network:       functionPlatformConfiguration.Network,
 		RestartPolicy: functionPlatformConfiguration.RestartPolicy,
-	})
+	}
 
+	// get function port - either from configuration, from the previous deployment or from a free port
+	functionHTTPPort, err := p.getFunctionHTTPPort(createFunctionOptions, previousHTTPPort)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get function HTTP port")
+	}
+	if functionHTTPPort != 0 {
+		p.Logger.DebugWith("Running container with a specific port",
+			"functionHTTPPort", functionHTTPPort)
+		runContainerOptions.Ports = map[int]int{functionHTTPPort: abstract.FunctionContainerHTTPPort}
+	}
+	containerID, err := p.dockerClient.RunContainer(createFunctionOptions.FunctionConfig.Spec.Image,
+		runContainerOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to run docker container")
 	}
 
-	p.Logger.InfoWith("Waiting for function to be ready", "timeout", createFunctionOptions.FunctionConfig.Spec.ReadinessTimeoutSeconds)
-
-	var readinessTimeout time.Duration
-	if createFunctionOptions.FunctionConfig.Spec.ReadinessTimeoutSeconds != 0 {
-		readinessTimeout = time.Duration(createFunctionOptions.FunctionConfig.Spec.ReadinessTimeoutSeconds) * time.Second
-	} else {
-		readinessTimeout = abstract.DefaultReadinessTimeoutSeconds * time.Second
+	timeout := createFunctionOptions.FunctionConfig.Spec.ReadinessTimeoutSeconds
+	if err := p.waitForContainer(containerID, timeout); err != nil {
+		return nil, err
 	}
 
-	if err = p.dockerClient.AwaitContainerHealth(containerID, &readinessTimeout); err != nil {
-		var errMessage string
-
-		// try to get error logs
-		containerLogs, getContainerLogsErr := p.dockerClient.GetContainerLogs(containerID)
-		if getContainerLogsErr == nil {
-			errMessage = fmt.Sprintf("Function wasn't ready in time. Logs:\n%s", containerLogs)
-		} else {
-			errMessage = fmt.Sprintf("Function wasn't ready in time (couldn't fetch logs: %s)", getContainerLogsErr.Error())
-		}
-
-		return nil, errors.Wrap(err, errMessage)
+	functionHTTPPort, err = p.resolveDeployedFunctionHTTPPort(containerID)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to resolve deployed function HTTP port")
 	}
 
 	return &platform.CreateFunctionResult{
@@ -698,18 +638,12 @@ func (p *Platform) getFunctionHTTPPort(createFunctionOptions *platform.CreateFun
 
 	// if there was a previous deployment and no configuration - use that
 	if previousHTTPPort != 0 {
+		createFunctionOptions.Logger.DebugWith("Using previous deployment HTTP port ",
+			"previousHTTPPort", previousHTTPPort)
 		return previousHTTPPort, nil
 	}
 
-	// get a free local port
-	freeLocalPort, err := p.getFreeLocalPort()
-	if err != nil {
-		return -1, errors.Wrap(err, "Failed to get free local port")
-	}
-
-	p.Logger.DebugWith("Found free local port", "port", freeLocalPort)
-
-	return freeLocalPort, nil
+	return 0, nil
 }
 
 func (p *Platform) GetContainerNameByCreateFunctionOptions(createFunctionOptions *platform.CreateFunctionOptions) string {
@@ -719,13 +653,26 @@ func (p *Platform) GetContainerNameByCreateFunctionOptions(createFunctionOptions
 }
 
 func (p *Platform) getContainerHTTPTriggerPort(container *dockerclient.Container) int {
-	ports := container.HostConfig.PortBindings["8080/tcp"]
-	if len(ports) == 0 {
+	functionHostPort := dockerclient.Port(fmt.Sprintf("%d/tcp", abstract.FunctionContainerHTTPPort))
+
+	portBindings := container.HostConfig.PortBindings[functionHostPort]
+	ports := container.NetworkSettings.Ports[functionHostPort]
+	if len(portBindings) == 0 && len(ports) == 0 {
 		return 0
 	}
 
-	httpPort, _ := strconv.Atoi(ports[0].HostPort)
+	port := ""
+	if portBindings[0].HostPort != "" {
 
+		// if user specified a port, it will get here
+		port = portBindings[0].HostPort
+	} else {
+
+		// if no port was specified
+		port = ports[0].HostPort
+	}
+
+	httpPort, _ := strconv.Atoi(port)
 	return httpPort
 }
 
@@ -923,4 +870,92 @@ func (p *Platform) checkAndSetFunctionHealthy(containerID string, function platf
 		Config: *function.GetConfig(),
 		Status: *functionStatus,
 	})
+}
+
+func (p *Platform) waitForContainer(containerID string, timeout int) error {
+	p.Logger.InfoWith("Waiting for function to be ready",
+		"timeout", timeout)
+
+	var readinessTimeout time.Duration
+	if timeout != 0 {
+		readinessTimeout = time.Duration(timeout) * time.Second
+	} else {
+		readinessTimeout = abstract.DefaultReadinessTimeoutSeconds * time.Second
+	}
+
+	if err := p.dockerClient.AwaitContainerHealth(containerID, &readinessTimeout); err != nil {
+		var errMessage string
+
+		// try to get error logs
+		containerLogs, getContainerLogsErr := p.dockerClient.GetContainerLogs(containerID)
+		if getContainerLogsErr == nil {
+			errMessage = fmt.Sprintf("Function wasn't ready in time. Logs:\n%s", containerLogs)
+		} else {
+			errMessage = fmt.Sprintf("Function wasn't ready in time (couldn't fetch logs: %s)", getContainerLogsErr.Error())
+		}
+
+		return errors.Wrap(err, errMessage)
+	}
+	return nil
+}
+
+func (p *Platform) compileDeployFunctionVolumesMap(createFunctionOptions *platform.CreateFunctionOptions) (map[string]string, error) {
+
+	// create processor configuration at a temporary location unless user specified a configuration
+	localProcessorConfigPath, err := p.createProcessorConfig(createFunctionOptions)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create processor configuration")
+	}
+
+	// create volumes string[string] map for volumes
+	volumesMap := map[string]string{
+		localProcessorConfigPath: path.Join("/", "etc", "nuclio", "config", "processor", "processor.yaml"),
+	}
+
+	for _, volume := range createFunctionOptions.FunctionConfig.Spec.Volumes {
+
+		// only add hostpath volumes
+		if volume.Volume.HostPath != nil {
+			volumesMap[volume.Volume.HostPath.Path] = volume.VolumeMount.MountPath
+		}
+	}
+	return volumesMap, nil
+}
+
+func (p *Platform) compileDeployFunctionEnvMap(createFunctionOptions *platform.CreateFunctionOptions) map[string]string {
+	envMap := map[string]string{}
+	for _, env := range createFunctionOptions.FunctionConfig.Spec.Env {
+		envMap[env.Name] = env.Value
+	}
+	return envMap
+}
+
+func (p *Platform) compileDeployFunctionLabels(createFunctionOptions *platform.CreateFunctionOptions) map[string]string {
+	labels := map[string]string{
+		"nuclio.io/platform":      "local",
+		"nuclio.io/namespace":     createFunctionOptions.FunctionConfig.Meta.Namespace,
+		"nuclio.io/function-name": createFunctionOptions.FunctionConfig.Meta.Name,
+		"nuclio.io/function-spec": p.encodeFunctionSpec(&createFunctionOptions.FunctionConfig.Spec),
+	}
+
+	for labelName, labelValue := range createFunctionOptions.FunctionConfig.Meta.Labels {
+		labels[labelName] = labelValue
+	}
+
+	marshalledAnnotations := p.marshallAnnotations(createFunctionOptions.FunctionConfig.Meta.Annotations)
+	if marshalledAnnotations != nil {
+		labels["nuclio.io/annotations"] = string(marshalledAnnotations)
+	}
+	return labels
+}
+
+func (p *Platform) resolveDeployedFunctionHTTPPort(containerID string) (int, error) {
+	container, err := p.dockerClient.GetContainer(&dockerclient.GetContainerOptions{
+		ID: containerID,
+	})
+	if err != nil {
+		return 0, errors.Wrap(err, "Failed to get container")
+	}
+
+	return p.getContainerHTTPTriggerPort(container), nil
 }

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -669,14 +669,12 @@ func (p *Platform) getContainerHTTPTriggerPort(container *dockerclient.Container
 		return 0
 	}
 
-	port := ""
-	if portBindings[0].HostPort != "" {
+	// by default take the port binding, as if the user requested
+	port := portBindings[0].HostPort
 
-		// if user specified a port, it will get here
-		port = portBindings[0].HostPort
-	} else {
+	if port == "" {
 
-		// if no port was specified
+		// in case the user did not set an explicit port, take the random port assigned by docker
 		port = ports[0].HostPort
 	}
 


### PR DESCRIPTION
The current behavior is that nuclio build process allocates a "free" port and uses it to run the function container.
The issue is that the mechanism of "allocating" a port, releasing it, and using it to run a function container, does not ensure us it would be usable if allocated.
e.g. when system is under high load, the OS would still respond that the port is in use. (Happens mostly on our CI)

The solution is to let docker pick a random port, and build process will resolve it once container is running

Note: all explained above is for a case where user did *not* specify a port for his function http trigger.