### PR TITLE
Fix timeout test suites

### DIFF
--- a/pkg/processor/build/inlineparser/jarparser_test.go
+++ b/pkg/processor/build/inlineparser/jarparser_test.go
@@ -3,6 +3,7 @@ package inlineparser
 import (
 	"archive/zip"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/nuclio/zap"
@@ -27,7 +28,7 @@ type JarParserTestSuite struct {
 }
 
 func (suite *JarParserTestSuite) createJar() string {
-	tmpFile, err := ioutil.TempFile("", "nucilo-test-jar")
+	tmpFile, err := ioutil.TempFile("", "nuclio-test-jar")
 	suite.Require().NoError(err)
 
 	defer tmpFile.Close()
@@ -49,6 +50,7 @@ func (suite *JarParserTestSuite) TestJarParser() {
 	suite.Require().NoError(err)
 
 	jarPath := suite.createJar()
+	defer os.Remove(jarPath) // nolint: errcheck
 	parser := NewJarParser(logger)
 	config, err := parser.Parse(jarPath)
 	suite.Require().NoError(err)

--- a/pkg/processor/build/inlineparser/parser_test.go
+++ b/pkg/processor/build/inlineparser/parser_test.go
@@ -18,6 +18,7 @@ package inlineparser
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/nuclio/logger"
@@ -61,9 +62,11 @@ def handler(context, event):
     body = simplejson.loads(event.body.decode('utf-8'))
     return body['return_this']
 `
-	tmpFile, err := ioutil.TempFile("", "nucilio-parser-test")
+	tmpFile, err := ioutil.TempFile("", "nuclio-parser-test")
 	suite.Require().NoError(err)
-	tmpFile.Close()
+	suite.Require().NoError(tmpFile.Close())
+
+	defer os.Remove(tmpFile.Name()) // nolint: errcheck
 
 	err = ioutil.WriteFile(tmpFile.Name(), []byte(content), 0600)
 	suite.Require().NoError(err)
@@ -100,9 +103,11 @@ def handler(context, event):
     body = simplejson.loads(event.body.decode('utf-8'))
     return body['return_this']
 `
-	tmpFile, err := ioutil.TempFile("", "nucilio-parser-test")
+	tmpFile, err := ioutil.TempFile("", "nuclio-parser-test")
 	suite.Require().NoError(err)
-	tmpFile.Close()
+	suite.Require().NoError(tmpFile.Close())
+
+	defer os.Remove(tmpFile.Name()) // nolint: errcheck
 
 	err = ioutil.WriteFile(tmpFile.Name(), []byte(content), 0600)
 	suite.Require().NoError(err)
@@ -132,9 +137,11 @@ func (suite *InlineParserTestSuite) TestBlockWithError() {
 def handler(context, event):
 	pass
 `
-	tmpFile, err := ioutil.TempFile("", "nucilio-parser-test")
+	tmpFile, err := ioutil.TempFile("", "nuclio-parser-test")
 	suite.Require().NoError(err)
-	tmpFile.Close()
+	suite.Require().NoError(tmpFile.Close())
+
+	defer os.Remove(tmpFile.Name()) // nolint: errcheck
 
 	err = ioutil.WriteFile(tmpFile.Name(), []byte(content), 0600)
 	suite.Require().NoError(err)

--- a/pkg/processor/build/runtime/golang/test/golang_test.go
+++ b/pkg/processor/build/runtime/golang/test/golang_test.go
@@ -34,6 +34,7 @@ type testSuite struct {
 
 func (suite *testSuite) SetupSuite() {
 	suite.TestSuite.SetupSuite()
+	suite.Runtime = "golang"
 
 	suite.TestSuite.RuntimeSuite = suite
 	suite.TestSuite.ArchivePattern = "golang"
@@ -78,7 +79,7 @@ func (suite *testSuite) TestBuildWithContextInitializer() {
 
 func (suite *testSuite) GetFunctionInfo(functionName string) buildsuite.FunctionInfo {
 	functionInfo := buildsuite.FunctionInfo{
-		Runtime: "golang",
+		Runtime: suite.Runtime,
 	}
 
 	switch functionName {

--- a/pkg/processor/build/runtime/java/test/java_test.go
+++ b/pkg/processor/build/runtime/java/test/java_test.go
@@ -41,7 +41,7 @@ func (suite *TestSuite) SetupSuite() {
 
 func (suite *TestSuite) GetFunctionInfo(functionName string) buildsuite.FunctionInfo {
 	functionInfo := buildsuite.FunctionInfo{
-		Runtime: "java",
+		Runtime: suite.TestSuite.Runtime,
 	}
 
 	switch functionName {

--- a/pkg/processor/runtime/golang/test/timeout_test.go
+++ b/pkg/processor/runtime/golang/test/timeout_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
 
 	"github.com/stretchr/testify/suite"
@@ -51,33 +50,22 @@ func (suite *TimeoutTestSuite) TestTimeout() {
 	eventTimeout := 300 * time.Millisecond
 	createFunctionOptions := suite.GetDeployOptions("timeout", suite.GetFunctionPath("timeout"))
 	createFunctionOptions.FunctionConfig.Spec.EventTimeout = eventTimeout.String()
+	okStatusCode := http.StatusOK
+	timeoutStatusCode := http.StatusRequestTimeout
 
-	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
-
-		expectedResponseCode := http.StatusOK
-		testRequest := httpsuite.Request{
+	suite.DeployFunctionAndRequests(createFunctionOptions, []*httpsuite.Request{
+		{
 			RequestBody:    suite.genTimeoutRequest(time.Millisecond),
 			RequestHeaders: requestHeaders,
-			RequestPort:    deployResult.Port,
-			RequestMethod:  "POST",
 
-			ExpectedResponseStatusCode: &expectedResponseCode,
-		}
-
-		if !suite.SendRequestVerifyResponse(&testRequest) {
-			return false
-		}
-
-		expectedResponseCode = http.StatusRequestTimeout
-		testRequest = httpsuite.Request{
+			ExpectedResponseStatusCode: &timeoutStatusCode,
+		},
+		{
 			RequestBody:    suite.genTimeoutRequest(time.Second),
 			RequestHeaders: requestHeaders,
-			RequestPort:    deployResult.Port,
-			RequestMethod:  "POST",
 
-			ExpectedResponseStatusCode: &expectedResponseCode,
-		}
-		return suite.SendRequestVerifyResponse(&testRequest)
+			ExpectedResponseStatusCode: &okStatusCode,
+		},
 	})
 }
 

--- a/pkg/processor/runtime/golang/test/timeout_test.go
+++ b/pkg/processor/runtime/golang/test/timeout_test.go
@@ -48,7 +48,8 @@ func (suite *TimeoutTestSuite) SetupTest() {
 
 func (suite *TimeoutTestSuite) TestTimeout() {
 	eventTimeout := 300 * time.Millisecond
-	createFunctionOptions := suite.GetDeployOptions("timeout", suite.GetFunctionPath("timeout"))
+	createFunctionOptions := suite.GetDeployOptions("timeout",
+		suite.GetFunctionPath("timeout"))
 	createFunctionOptions.FunctionConfig.Spec.EventTimeout = eventTimeout.String()
 	okStatusCode := http.StatusOK
 	timeoutStatusCode := http.StatusRequestTimeout
@@ -58,13 +59,13 @@ func (suite *TimeoutTestSuite) TestTimeout() {
 			RequestBody:    suite.genTimeoutRequest(time.Millisecond),
 			RequestHeaders: requestHeaders,
 
-			ExpectedResponseStatusCode: &timeoutStatusCode,
+			ExpectedResponseStatusCode: &okStatusCode,
 		},
 		{
 			RequestBody:    suite.genTimeoutRequest(time.Second),
 			RequestHeaders: requestHeaders,
 
-			ExpectedResponseStatusCode: &okStatusCode,
+			ExpectedResponseStatusCode: &timeoutStatusCode,
 		},
 	})
 }

--- a/pkg/processor/runtime/java/test/java_test.go
+++ b/pkg/processor/runtime/java/test/java_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
 
 	"github.com/stretchr/testify/suite"
@@ -178,21 +177,15 @@ func (suite *TestSuite) TestCustomOptions() {
 		path.Join(suite.GetTestFunctionsDir(), "java", "memory"))
 
 	createFunctionOptions.FunctionConfig.Spec.Handler = "nuclio-test-memory-handler.jar:MemoryHandler"
+	bodyVerifier := func(body []byte) {
+		maxMemory := "Max: 536870912"
 
-	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
-		bodyVerifier := func(body []byte) {
-			maxMemory := "Max: 536870912"
-
-			bodyStr := string(body)
-			suite.Require().Truef(strings.Contains(bodyStr, maxMemory), "bad response:\n%s", bodyStr)
-		}
-
-		testRequest := httpsuite.Request{
-			RequestPort:          deployResult.Port,
-			RequestMethod:        "GET",
-			ExpectedResponseBody: bodyVerifier,
-		}
-		return suite.SendRequestVerifyResponse(&testRequest)
+		bodyStr := string(body)
+		suite.Require().Truef(strings.Contains(bodyStr, maxMemory), "bad response:\n%s", bodyStr)
+	}
+	suite.DeployFunctionAndRequest(createFunctionOptions, &httpsuite.Request{
+		RequestMethod:        "GET",
+		ExpectedResponseBody: bodyVerifier,
 	})
 }
 

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -257,39 +257,33 @@ func (suite *testSuite) TestCustomEvent() {
 		"Testheaderkey2": "testHeaderValue2",
 	}
 
-	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
-		bodyVerifier := func(body []byte) {
-			unmarshalledBody := eventFields{}
+	bodyVerifier := func(body []byte) {
+		unmarshalledBody := eventFields{}
 
-			// read the body JSON
-			err := json.Unmarshal(body, &unmarshalledBody)
-			suite.Require().NoError(err)
+		// read the body JSON
+		err := json.Unmarshal(body, &unmarshalledBody)
+		suite.Require().NoError(err)
 
-			suite.Require().Equal("testBody", unmarshalledBody.Body)
-			suite.Require().Equal(requestPath, unmarshalledBody.Path)
-			suite.Require().Equal(requestMethod, unmarshalledBody.Method)
-			suite.Require().Equal("http", unmarshalledBody.TriggerKind)
+		suite.Require().Equal("testBody", unmarshalledBody.Body)
+		suite.Require().Equal(requestPath, unmarshalledBody.Path)
+		suite.Require().Equal(requestMethod, unmarshalledBody.Method)
+		suite.Require().Equal("http", unmarshalledBody.TriggerKind)
 
-			// compare known headers
-			for requestHeaderKey, requestHeaderValue := range requestHeaders {
-				suite.Require().Equal(requestHeaderValue, unmarshalledBody.Headers[requestHeaderKey])
-			}
-
-			// ID must be a UUID
-			_, err = uuid.FromString(string(unmarshalledBody.ID))
-			suite.Require().NoError(err)
+		// compare known headers
+		for requestHeaderKey, requestHeaderValue := range requestHeaders {
+			suite.Require().Equal(requestHeaderValue, unmarshalledBody.Headers[requestHeaderKey])
 		}
 
-		testRequest := httpsuite.Request{
-			RequestBody:          "testBody",
-			RequestHeaders:       requestHeaders,
-			RequestPort:          deployResult.Port,
-			RequestMethod:        requestMethod,
-			RequestPath:          requestPath,
-			ExpectedResponseBody: bodyVerifier,
-		}
-
-		return suite.SendRequestVerifyResponse(&testRequest)
+		// ID must be a UUID
+		_, err = uuid.FromString(string(unmarshalledBody.ID))
+		suite.Require().NoError(err)
+	}
+	suite.DeployFunctionAndRequest(createFunctionOptions, &httpsuite.Request{
+		RequestBody:          "testBody",
+		RequestHeaders:       requestHeaders,
+		RequestMethod:        requestMethod,
+		RequestPath:          requestPath,
+		ExpectedResponseBody: bodyVerifier,
 	})
 }
 

--- a/pkg/processor/test/callfunction/golang/suite.go
+++ b/pkg/processor/test/callfunction/golang/suite.go
@@ -55,36 +55,30 @@ func (suite *CallFunctionTestSuite) TestCallFunction() {
 	calleeDeployOptions.FunctionConfig.Spec.Platform.Attributes = map[string]interface{}{"network": networkName}
 	callerDeployOptions.FunctionConfig.Spec.Platform.Attributes = map[string]interface{}{"network": networkName}
 
+	requestBody := fmt.Sprintf(`{"callee_name": "%s"}`, calleeDeployOptions.FunctionConfig.Meta.Name)
+	callerRequestBodyVerifier := func(body []byte) {
+		var parsedResponseBody map[string]string
+		err := json.Unmarshal(body, &parsedResponseBody)
+		suite.HTTPSuite.Require().Nil(err)
+
+		suite.HTTPSuite.Require().Equal(1, len(parsedResponseBody))
+		value, found := parsedResponseBody["from_callee"]
+		suite.HTTPSuite.Require().True(found)
+		suite.HTTPSuite.Require().Equal("returned_value", value)
+	}
+
 	// deploy the callee function
 	suite.HTTPSuite.DeployFunction(calleeDeployOptions, func(deployResult *platform.CreateFunctionResult) bool {
 
 		// now deploy the caller function
-		suite.HTTPSuite.DeployFunction(callerDeployOptions, func(deployResult *platform.CreateFunctionResult) bool {
-
-			requestBody := fmt.Sprintf(`{"callee_name": "%s"}`, calleeDeployOptions.FunctionConfig.Meta.Name)
-			bodyVerifier := func(body []byte) {
-				var parsedResponseBody map[string]string
-				err := json.Unmarshal(body, &parsedResponseBody)
-				suite.HTTPSuite.Require().Nil(err)
-
-				suite.HTTPSuite.Require().Equal(1, len(parsedResponseBody))
-				value, found := parsedResponseBody["from_callee"]
-				suite.HTTPSuite.Require().True(found)
-				suite.HTTPSuite.Require().Equal("returned_value", value)
-			}
-
-			testRequest := httpsuite.Request{
-				RequestBody:    requestBody,
-				RequestHeaders: map[string]interface{}{"Content-Type": "application/json"},
-				RequestMethod:  "POST",
-				RequestPort:    deployResult.Port,
-				ExpectedResponseHeaders: map[string]string{
-					"X-Callee-Received-Header": "caller_header",
-				},
-				ExpectedResponseBody: bodyVerifier,
-			}
-
-			return suite.HTTPSuite.SendRequestVerifyResponse(&testRequest)
+		suite.HTTPSuite.DeployFunctionAndRequest(callerDeployOptions, &httpsuite.Request{
+			RequestBody:    requestBody,
+			RequestHeaders: map[string]interface{}{"Content-Type": "application/json"},
+			RequestMethod:  "POST",
+			ExpectedResponseHeaders: map[string]string{
+				"X-Callee-Received-Header": "caller_header",
+			},
+			ExpectedResponseBody: callerRequestBodyVerifier,
 		})
 
 		return true

--- a/pkg/processor/test/callfunction/golang/suite.go
+++ b/pkg/processor/test/callfunction/golang/suite.go
@@ -57,7 +57,6 @@ func (suite *CallFunctionTestSuite) TestCallFunction() {
 	callerDeployOptions.FunctionConfig.Spec.Platform.Attributes = map[string]interface{}{"network": networkName}
 
 	createdHTTPStatusCode := http.StatusCreated
-	requestBody := fmt.Sprintf(`{"callee_name": "%s"}`, calleeDeployOptions.FunctionConfig.Meta.Name)
 	callerRequestBodyVerifier := func(body []byte) {
 		var parsedResponseBody map[string]string
 		err := json.Unmarshal(body, &parsedResponseBody)
@@ -74,7 +73,7 @@ func (suite *CallFunctionTestSuite) TestCallFunction() {
 
 		// now deploy the caller function
 		suite.HTTPSuite.DeployFunctionAndRequest(callerDeployOptions, &httpsuite.Request{
-			RequestBody:    requestBody,
+			RequestBody:    fmt.Sprintf(`{"callee_name": "%s"}`, calleeDeployOptions.FunctionConfig.Meta.Name),
 			RequestHeaders: map[string]interface{}{"Content-Type": "application/json"},
 			RequestMethod:  "POST",
 			ExpectedResponseHeaders: map[string]string{

--- a/pkg/processor/test/callfunction/golang/suite.go
+++ b/pkg/processor/test/callfunction/golang/suite.go
@@ -19,6 +19,7 @@ package callfunction
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"path"
 
 	"github.com/nuclio/nuclio/pkg/dockerclient"
@@ -55,11 +56,12 @@ func (suite *CallFunctionTestSuite) TestCallFunction() {
 	calleeDeployOptions.FunctionConfig.Spec.Platform.Attributes = map[string]interface{}{"network": networkName}
 	callerDeployOptions.FunctionConfig.Spec.Platform.Attributes = map[string]interface{}{"network": networkName}
 
+	createdHTTPStatusCode := http.StatusCreated
 	requestBody := fmt.Sprintf(`{"callee_name": "%s"}`, calleeDeployOptions.FunctionConfig.Meta.Name)
 	callerRequestBodyVerifier := func(body []byte) {
 		var parsedResponseBody map[string]string
 		err := json.Unmarshal(body, &parsedResponseBody)
-		suite.HTTPSuite.Require().Nil(err)
+		suite.HTTPSuite.Require().NoError(err)
 
 		suite.HTTPSuite.Require().Equal(1, len(parsedResponseBody))
 		value, found := parsedResponseBody["from_callee"]
@@ -78,7 +80,8 @@ func (suite *CallFunctionTestSuite) TestCallFunction() {
 			ExpectedResponseHeaders: map[string]string{
 				"X-Callee-Received-Header": "caller_header",
 			},
-			ExpectedResponseBody: callerRequestBodyVerifier,
+			ExpectedResponseBody:       callerRequestBodyVerifier,
+			ExpectedResponseStatusCode: &createdHTTPStatusCode,
 		})
 
 		return true

--- a/pkg/processor/test/callfunction/python/suite.go
+++ b/pkg/processor/test/callfunction/python/suite.go
@@ -19,6 +19,7 @@ package callfunction
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"path"
 
 	"github.com/nuclio/nuclio/pkg/dockerclient"
@@ -56,6 +57,7 @@ func (suite *CallFunctionTestSuite) TestCallFunction() {
 	calleeDeployOptions.FunctionConfig.Spec.Platform.Attributes = map[string]interface{}{"network": networkName}
 	callerDeployOptions.FunctionConfig.Spec.Platform.Attributes = map[string]interface{}{"network": networkName}
 
+	createdHTTPStatusCode := http.StatusCreated
 	callerRequestBodyVerifier := func(body []byte) {
 		parsedBody := map[string]string{}
 
@@ -79,7 +81,8 @@ func (suite *CallFunctionTestSuite) TestCallFunction() {
 			ExpectedResponseHeaders: map[string]string{
 				"X-Callee-Received-Header": "caller_header",
 			},
-			ExpectedResponseBody: callerRequestBodyVerifier,
+			ExpectedResponseBody:       callerRequestBodyVerifier,
+			ExpectedResponseStatusCode: &createdHTTPStatusCode,
 		})
 
 		return true

--- a/pkg/processor/test/cloudevents/suite.go
+++ b/pkg/processor/test/cloudevents/suite.go
@@ -55,35 +55,29 @@ func (suite *CloudEventsTestSuite) TestStructuredCloudEvent() {
     "data": "valid xml"
 }`, now)
 
-	suite.HTTPSuite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
-		bodyVerifier := func(body []byte) {
-			unmarshalledBody := suite.decodeResponse(body)
+	bodyVerifier := func(body []byte) {
+		unmarshalledBody := suite.decodeResponse(body)
 
-			require := suite.HTTPSuite.Require()
+		require := suite.HTTPSuite.Require()
 
-			require.Equal("valid xml", unmarshalledBody.Body)
-			require.Equal(requestPath, unmarshalledBody.Path)
-			require.Equal(requestMethod, unmarshalledBody.Method)
-			require.Equal("/mycontext", unmarshalledBody.TriggerKind)
-			require.Equal("0.1", unmarshalledBody.Version)
-			require.Equal("com.example.someevent", unmarshalledBody.Type)
-			require.Equal("1.0", unmarshalledBody.TypeVersion)
-			require.Equal("A234-1234-1234", string(unmarshalledBody.ID))
-			require.Equal(now, unmarshalledBody.Timestamp.Format(time.RFC3339))
-			require.Equal(map[string]interface{}{"comExampleExtension": "value"}, unmarshalledBody.Headers)
-			require.Equal("text/xml", unmarshalledBody.ContentType)
-		}
-
-		testRequest := httpsuite.Request{
-			RequestBody:          requestBody,
-			RequestHeaders:       map[string]interface{}{"Content-Type": "application/cloudevents+json"},
-			RequestPort:          deployResult.Port,
-			RequestMethod:        requestMethod,
-			RequestPath:          requestPath,
-			ExpectedResponseBody: bodyVerifier,
-		}
-
-		return suite.HTTPSuite.SendRequestVerifyResponse(&testRequest)
+		require.Equal("valid xml", unmarshalledBody.Body)
+		require.Equal(requestPath, unmarshalledBody.Path)
+		require.Equal(requestMethod, unmarshalledBody.Method)
+		require.Equal("/mycontext", unmarshalledBody.TriggerKind)
+		require.Equal("0.1", unmarshalledBody.Version)
+		require.Equal("com.example.someevent", unmarshalledBody.Type)
+		require.Equal("1.0", unmarshalledBody.TypeVersion)
+		require.Equal("A234-1234-1234", string(unmarshalledBody.ID))
+		require.Equal(now, unmarshalledBody.Timestamp.Format(time.RFC3339))
+		require.Equal(map[string]interface{}{"comExampleExtension": "value"}, unmarshalledBody.Headers)
+		require.Equal("text/xml", unmarshalledBody.ContentType)
+	}
+	suite.HTTPSuite.DeployFunctionAndRequest(createFunctionOptions, &httpsuite.Request{
+		RequestBody:          requestBody,
+		RequestHeaders:       map[string]interface{}{"Content-Type": "application/cloudevents+json"},
+		RequestMethod:        requestMethod,
+		RequestPath:          requestPath,
+		ExpectedResponseBody: bodyVerifier,
 	})
 }
 
@@ -105,35 +99,29 @@ func (suite *CloudEventsTestSuite) TestBinaryCloudEvent() {
 	requestMethod := "POST"
 	requestPath := "/testPath"
 	requestBody := "valid xml"
+	bodyVerifier := func(body []byte) {
+		unmarshalledBody := suite.decodeResponse(body)
 
-	suite.HTTPSuite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
-		bodyVerifier := func(body []byte) {
-			unmarshalledBody := suite.decodeResponse(body)
+		var require = suite.HTTPSuite.Require()
 
-			var require = suite.HTTPSuite.Require()
+		require.Equal(requestBody, unmarshalledBody.Body)
+		require.Equal(requestPath, unmarshalledBody.Path)
+		require.Equal(requestMethod, unmarshalledBody.Method)
+		require.Equal("/mycontext", unmarshalledBody.TriggerKind)
+		require.Equal("0.1", unmarshalledBody.Version)
+		require.Equal("com.example.someevent", unmarshalledBody.Type)
+		require.Equal("1.0", unmarshalledBody.TypeVersion)
+		require.Equal("A234-1234-1234", string(unmarshalledBody.ID))
+		require.Equal(now, unmarshalledBody.Timestamp.Format(time.RFC3339))
+		require.Equal("text/xml", unmarshalledBody.ContentType)
+	}
 
-			require.Equal(requestBody, unmarshalledBody.Body)
-			require.Equal(requestPath, unmarshalledBody.Path)
-			require.Equal(requestMethod, unmarshalledBody.Method)
-			require.Equal("/mycontext", unmarshalledBody.TriggerKind)
-			require.Equal("0.1", unmarshalledBody.Version)
-			require.Equal("com.example.someevent", unmarshalledBody.Type)
-			require.Equal("1.0", unmarshalledBody.TypeVersion)
-			require.Equal("A234-1234-1234", string(unmarshalledBody.ID))
-			require.Equal(now, unmarshalledBody.Timestamp.Format(time.RFC3339))
-			require.Equal("text/xml", unmarshalledBody.ContentType)
-		}
-
-		testRequest := httpsuite.Request{
-			RequestBody:          requestBody,
-			RequestHeaders:       headers,
-			RequestPort:          deployResult.Port,
-			RequestMethod:        requestMethod,
-			RequestPath:          requestPath,
-			ExpectedResponseBody: bodyVerifier,
-		}
-
-		return suite.HTTPSuite.SendRequestVerifyResponse(&testRequest)
+	suite.HTTPSuite.DeployFunctionAndRequest(createFunctionOptions, &httpsuite.Request{
+		RequestBody:          requestBody,
+		RequestHeaders:       headers,
+		RequestMethod:        requestMethod,
+		RequestPath:          requestPath,
+		ExpectedResponseBody: bodyVerifier,
 	})
 }
 

--- a/pkg/processor/test/offline/suite_test.go
+++ b/pkg/processor/test/offline/suite_test.go
@@ -21,7 +21,6 @@ import (
 	"path"
 	"testing"
 
-	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
 
 	"github.com/stretchr/testify/suite"
@@ -48,14 +47,9 @@ func (suite *offlineTestSuite) TestGolang() {
 	createFunctionOptions.FunctionConfig.Spec.Build.NoCache = true
 	createFunctionOptions.FunctionConfig.Spec.Runtime = "golang"
 	createFunctionOptions.FunctionConfig.Spec.Handler = "WithModules"
-
-	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
-		testRequest := httpsuite.Request{
-			RequestMethod:        "GET",
-			RequestPort:          deployResult.Port,
-			ExpectedResponseBody: "from_go_modules",
-		}
-		return suite.SendRequestVerifyResponse(&testRequest)
+	suite.DeployFunctionAndRequest(createFunctionOptions, &httpsuite.Request{
+		RequestMethod:        "GET",
+		ExpectedResponseBody: "from_go_modules",
 	})
 }
 
@@ -68,14 +62,10 @@ func (suite *offlineTestSuite) TestJava() {
 	createFunctionOptions.FunctionConfig.Spec.Runtime = "java"
 	createFunctionOptions.FunctionConfig.Spec.Handler = "Reverser"
 
-	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
-		testRequest := httpsuite.Request{
-			RequestBody:          "abcd",
-			RequestMethod:        "POST",
-			RequestPort:          deployResult.Port,
-			ExpectedResponseBody: "dcba",
-		}
-		return suite.SendRequestVerifyResponse(&testRequest)
+	suite.DeployFunctionAndRequest(createFunctionOptions, &httpsuite.Request{
+		RequestBody:          "abcd",
+		RequestMethod:        "POST",
+		ExpectedResponseBody: "dcba",
 	})
 }
 

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -168,7 +168,7 @@ func (suite *TestSuite) TearDownTest() {
 			time.Sleep(2 * time.Second)
 
 			if logs, err := suite.DockerClient.GetContainerLogs(suite.containerID); err == nil {
-				suite.Logger.WarnWith("Test failed, retreived logs", "logs", logs)
+				suite.Logger.WarnWith("Test failed, retrieved logs", "logs", logs)
 			} else {
 				suite.Logger.WarnWith("Failed to get docker logs on failure", "err", err)
 			}

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -53,13 +53,13 @@ type OnAfterContainerRun func(deployResult *platform.CreateFunctionResult) bool
 // function container (through an trigger of some sort)
 type TestSuite struct {
 	suite.Suite
-	Logger                 logger.Logger
-	DockerClient           dockerclient.Client
-	Platform               platform.Platform
-	TestID                 string
-	Runtime                string
-	RuntimeDir             string
-	FunctionDir            string
+	Logger       logger.Logger
+	DockerClient dockerclient.Client
+	Platform     platform.Platform
+	TestID       string
+	Runtime      string
+	RuntimeDir   string
+	FunctionDir  string
 
 	containerID            string
 	createdTempDirs        []string

--- a/pkg/processor/trigger/http/test/suite/suite.go
+++ b/pkg/processor/trigger/http/test/suite/suite.go
@@ -151,7 +151,7 @@ func (suite *TestSuite) SendRequestVerifyResponse(request *Request) bool {
 		err = common.RetryUntilSuccessful(request.RetryUntilSuccessfulDuration,
 			request.RetryUntilSuccessfulInterval,
 			func() bool {
-				httpResponse, err = suite.SendRequest(request)
+				httpResponse, err = suite.sendRequest(request)
 				if err != nil {
 					return false
 				}
@@ -159,7 +159,7 @@ func (suite *TestSuite) SendRequestVerifyResponse(request *Request) bool {
 			})
 
 	} else {
-		httpResponse, err = suite.SendRequest(request)
+		httpResponse, err = suite.sendRequest(request)
 	}
 
 	// if we fail to connect, fail, so callee might retry

--- a/pkg/processor/trigger/http/test/suite/suite.go
+++ b/pkg/processor/trigger/http/test/suite/suite.go
@@ -68,6 +68,10 @@ type Request struct {
 	ExpectedResponseHeaders       map[string]string
 	ExpectedResponseHeadersValues map[string][]string
 	ExpectedResponseStatusCode    *int
+
+	RetryUntilSuccessfulStatusCode *int
+	RetryUntilSuccessfulDuration   time.Duration
+	RetryUntilSuccessfulInterval   time.Duration
 }
 
 func (r *Request) Enrich(deployResult *platform.CreateFunctionResult) {
@@ -139,36 +143,24 @@ func (suite *TestSuite) DeployFunctionAndRequests(createFunctionOptions *platfor
 
 // SendRequestVerifyResponse sends a request and verifies we got expected response
 func (suite *TestSuite) SendRequestVerifyResponse(request *Request) bool {
-	suite.Logger.DebugWith("Sending request",
-		"requestPort", request.RequestPort,
-		"requestPath", request.RequestPath,
-		"requestHeaders", request.RequestHeaders,
-		"requestBodyLength", len(request.RequestBody),
-		"requestLogLevel", request.RequestLogLevel)
+	var httpResponse *http.Response
+	var err error
 
-	// Send request to proper url
-	url := fmt.Sprintf("http://%s:%d%s", suite.GetTestHost(), request.RequestPort, request.RequestPath)
+	// retry
+	if request.RetryUntilSuccessfulStatusCode != nil {
+		err = common.RetryUntilSuccessful(request.RetryUntilSuccessfulDuration,
+			request.RetryUntilSuccessfulInterval,
+			func() bool {
+				httpResponse, err = suite.SendRequest(request)
+				if err != nil {
+					return false
+				}
+				return httpResponse.StatusCode == *request.RetryUntilSuccessfulStatusCode
+			})
 
-	// create a request
-	httpRequest, err := http.NewRequest(request.RequestMethod, url, strings.NewReader(request.RequestBody))
-	suite.Require().NoError(err)
-
-	// if there are request headers, add them
-	if request.RequestHeaders != nil {
-		for requestHeaderName, requestHeaderValue := range request.RequestHeaders {
-			httpRequest.Header.Add(requestHeaderName, fmt.Sprintf("%v", requestHeaderValue))
-		}
 	} else {
-		httpRequest.Header.Add("Content-Type", "text/plain")
+		httpResponse, err = suite.SendRequest(request)
 	}
-
-	// if there is a log level, add the header
-	if request.RequestLogLevel != nil {
-		httpRequest.Header.Add("X-nuclio-log-level", *request.RequestLogLevel)
-	}
-
-	// invoke the function
-	httpResponse, err := suite.httpClient.Do(httpRequest)
 
 	// if we fail to connect, fail, so callee might retry
 	if err != nil && common.MatchStringPatterns([]string{
@@ -282,6 +274,39 @@ func (suite *TestSuite) SendRequestVerifyResponse(request *Request) bool {
 	}
 
 	return true
+}
+
+func (suite *TestSuite) sendRequest(request *Request) (*http.Response, error) {
+	suite.Logger.DebugWith("Sending request",
+		"requestPort", request.RequestPort,
+		"requestPath", request.RequestPath,
+		"requestHeaders", request.RequestHeaders,
+		"requestBodyLength", len(request.RequestBody),
+		"requestLogLevel", request.RequestLogLevel)
+
+	// Send request to proper url
+	url := fmt.Sprintf("http://%s:%d%s", suite.GetTestHost(), request.RequestPort, request.RequestPath)
+
+	// create a request
+	httpRequest, err := http.NewRequest(request.RequestMethod, url, strings.NewReader(request.RequestBody))
+	suite.Require().NoError(err)
+
+	// if there are request headers, add them
+	if request.RequestHeaders != nil {
+		for requestHeaderName, requestHeaderValue := range request.RequestHeaders {
+			httpRequest.Header.Add(requestHeaderName, fmt.Sprintf("%v", requestHeaderValue))
+		}
+	} else {
+		httpRequest.Header.Add("Content-Type", "text/plain")
+	}
+
+	// if there is a log level, add the header
+	if request.RequestLogLevel != nil {
+		httpRequest.Header.Add("X-nuclio-log-level", *request.RequestLogLevel)
+	}
+
+	// invoke the function
+	return suite.httpClient.Do(httpRequest)
 }
 
 // subMap returns a subset of source with only the keys in keys

--- a/pkg/processor/trigger/http/test/suite/suite.go
+++ b/pkg/processor/trigger/http/test/suite/suite.go
@@ -179,15 +179,16 @@ func (suite *TestSuite) SendRequestVerifyResponse(request *Request) bool {
 
 	suite.Require().NoError(err, "Failed to send request")
 
+	body, err := ioutil.ReadAll(httpResponse.Body)
+	suite.Require().NoError(err)
+
 	if request.ExpectedResponseStatusCode != nil {
 		suite.Require().Equal(*request.ExpectedResponseStatusCode,
 			httpResponse.StatusCode,
-			"Got unexpected status code with request body (%s)",
-			request.RequestBody)
+			"Got unexpected status code with request body (%s) and response body (%s)",
+			request.RequestBody,
+			body)
 	}
-
-	body, err := ioutil.ReadAll(httpResponse.Body)
-	suite.Require().NoError(err)
 
 	// verify header correctness
 	// the httpResponse may contain more headers. just check that all the expected

--- a/test/_functions/python/timeout/timeout.py
+++ b/test/_functions/python/timeout/timeout.py
@@ -20,8 +20,9 @@ import re
 
 def parse_duration(duration):
     """Parse duration in '2.3s' format to float (seconds)"""
+
     # '10ms', '2.3s', ...
-    match = re.match('(\d+(\.\d+)?)([a-z]+)', duration)
+    match = re.match(r'(\d+(\.\d+)?)([a-z]+)', duration)
     if not match:
         return None
 


### PR DESCRIPTION
When functions with python runtime hit a worker timeout it restarts automatically, sometimes the second request comes a bit before the actual restart and cause the test to fail

Migrated all `suite.DeployFunction` calls to `suite.DeployFunctionAndRequest` for those implementing `SendRequestAndVerify` within the _postDeployRequestVerifications_

Added `RetryUntilSuccessfulStatusCode` fields (along with `RetryUntilSuccessfulDuration`, `RetryUntilSuccessfulInterval`) so that upon verifying request (on `suite.DeployFunctionAndRequest`), it will retry upon failures