### PR TITLE
Cors fix: preflight request max age cache should be 5 seconds by default

### DIFF
--- a/pkg/processor/trigger/http/cors/cors.go
+++ b/pkg/processor/trigger/http/cors/cors.go
@@ -36,7 +36,7 @@ type CORS struct {
 
 	// preflight
 	PreflightRequestMethod string
-	PreflightMaxAgeSeconds int
+	PreflightMaxAgeSeconds *int
 
 	// encoded
 	allowMethodsStr           string
@@ -46,7 +46,7 @@ type CORS struct {
 }
 
 func NewCORS() *CORS {
-	return &CORS{
+	cors := &CORS{
 		Enabled: true,
 		AllowOrigins: []string{
 			"*",
@@ -70,8 +70,9 @@ func NewCORS() *CORS {
 		},
 		AllowCredentials:       false,
 		PreflightRequestMethod: fasthttp.MethodOptions,
-		PreflightMaxAgeSeconds: -1, // disable cache by default
 	}
+	cors.populatePreflightMaxAgeSeconds()
+	return cors
 }
 
 func (c *CORS) OriginAllowed(origin string) bool {
@@ -124,8 +125,12 @@ func (c *CORS) EncodeAllowCredentialsHeader() string {
 }
 
 func (c *CORS) EncodePreflightMaxAgeSeconds() string {
+
+	// defensive programing
+	c.populatePreflightMaxAgeSeconds()
+
 	if c.preflightMaxAgeSecondsStr == "" {
-		c.preflightMaxAgeSecondsStr = strconv.Itoa(c.PreflightMaxAgeSeconds)
+		c.preflightMaxAgeSecondsStr = strconv.Itoa(*c.PreflightMaxAgeSeconds)
 	}
 	return c.preflightMaxAgeSecondsStr
 }
@@ -137,4 +142,11 @@ func (c *CORS) isAllowAllOrigins() bool {
 		}
 	}
 	return false
+}
+
+func (c *CORS) populatePreflightMaxAgeSeconds() {
+	if c.PreflightMaxAgeSeconds == nil {
+		five := 5
+		c.PreflightMaxAgeSeconds = &five
+	}
 }

--- a/pkg/processor/trigger/http/cors/cors_test.go
+++ b/pkg/processor/trigger/http/cors/cors_test.go
@@ -28,6 +28,18 @@ func (suite *TestSuite) TestEncodeAllowCredentialsHeader() {
 	suite.Require().Equal(suite.cors.EncodeAllowCredentialsHeader(), "true")
 }
 
+func (suite *TestSuite) TestEncodePreflightMaxAgeSeconds() {
+
+	// 5 seconds by default
+	suite.Require().Equal(suite.cors.EncodePreflightMaxAgeSeconds(), "5")
+
+	// empty lazy-load encoded string
+	zero := 0
+	suite.cors.preflightMaxAgeSecondsStr = ""
+	suite.cors.PreflightMaxAgeSeconds = &zero
+	suite.Require().Equal(suite.cors.EncodePreflightMaxAgeSeconds(), "0")
+}
+
 func (suite *TestSuite) TestOriginAllowed() {
 	for _, testCase := range []struct {
 		allowOrigins []string

--- a/pkg/processor/trigger/http/http_test.go
+++ b/pkg/processor/trigger/http/http_test.go
@@ -81,7 +81,7 @@ func (suite *TestSuite) TestCORS() {
 			ExpectedResponseHeaders: map[string]string{
 				"Access-Control-Allow-Origin":  "foo.bar",
 				"Access-Control-Allow-Methods": "HEAD, GET, POST, PUT, DELETE, OPTIONS",
-				"Access-Control-Max-Age":       "-1",
+				"Access-Control-Max-Age":       "5",
 				"Access-Control-Allow-Headers": "Accept, Content-Length, Content-Type, Authorization, X-nuclio-log-level",
 			},
 			ExpectedEventsHandledSuccessTotal: 1,

--- a/pkg/processor/trigger/http/types.go
+++ b/pkg/processor/trigger/http/types.go
@@ -93,7 +93,9 @@ func createCORSConfiguration(CORSConfiguration *cors.CORS) *cors.CORS {
 		corsInstance.AllowCredentials = CORSConfiguration.AllowCredentials
 	}
 
-	corsInstance.PreflightMaxAgeSeconds = CORSConfiguration.PreflightMaxAgeSeconds
+	if CORSConfiguration.PreflightMaxAgeSeconds != nil {
+		corsInstance.PreflightMaxAgeSeconds = CORSConfiguration.PreflightMaxAgeSeconds
+	}
 
 	return corsInstance
 


### PR DESCRIPTION
Aligning with https://fetch.spec.whatwg.org/#http-responses