### PR TITLE
[Nuclio] Triggers are not saved while switching tabs

### DIFF
--- a/pkg/dashboard/ui/src/app/app.route.js
+++ b/pkg/dashboard/ui/src/app/app.route.js
@@ -207,7 +207,7 @@
                 url: '/triggers',
                 views: {
                     version: {
-                        template: '<ncl-version-triggers data-version="ctrl.version"' +
+                        template: '<ncl-version-triggers data-version="$ctrl.version"' +
                             'data-containers="$ctrl.containers"></ncl-version-triggers>'
                     }
                 },


### PR DESCRIPTION
https://trello.com/c/YJsl2kNB/505-nuclio-triggers-are-not-saved-while-switching-tabs

![nuclio_triggers-disappear](https://user-images.githubusercontent.com/13918850/89777854-2af95180-db15-11ea-8d5b-2d5c758ee7f1.gif)

