### PR TITLE
[WIP] Default function HTTP port expose mode based on helm value

### DIFF
--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -195,3 +195,4 @@ platform: {}
 #     functions:
 #     - myPrometheusPull
 #   cronTriggerCreationMode: "kube"
+#   kubeFunctionExposureMode: nodePort

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/restful"
 
 	"github.com/nuclio/errors"
+	v1 "k8s.io/api/core/v1"
 )
 
 type frontendSpecResource struct {
@@ -94,6 +95,12 @@ func (fesr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restf
 func (fesr *frontendSpecResource) getDefaultFunctionConfig() map[string]interface{} {
 	one := 1
 	defaultWorkerAvailabilityTimeoutMilliseconds := trigger.DefaultWorkerAvailabilityTimeoutMilliseconds
+
+	var defaultServiceType v1.ServiceType = ""
+	if dashboardServer, ok := fesr.resource.GetServer().(*dashboard.Server); ok {
+		defaultServiceType = dashboardServer.GetPlatformConfiguration().GetDefaultServiceType()
+	}
+
 	defaultFunctionSpec := functionconfig.Spec{
 		MinReplicas:             &one,
 		MaxReplicas:             &one,
@@ -109,6 +116,7 @@ func (fesr *frontendSpecResource) getDefaultFunctionConfig() map[string]interfac
 				WorkerAvailabilityTimeoutMilliseconds: &defaultWorkerAvailabilityTimeoutMilliseconds,
 			},
 		},
+		ServiceType: defaultServiceType,
 	}
 
 	return map[string]interface{}{"attributes": functionconfig.Config{Spec: defaultFunctionSpec}}

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -79,7 +79,9 @@ func (suite *dashboardTestSuite) SetupTest() {
 		"",
 		true,
 		templateRepository,
-		nil,
+		&platformconfig.Config{
+			KubeFunctionExposureMode: platformconfig.KubeFunctionExposureModeNodePort,
+		},
 		"",
 		"",
 		"",
@@ -2375,6 +2377,7 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
                 "build": {},
                 "platform": {},
                 "readinessTimeoutSeconds": 60,
+                "serviceType": "NodePort",
                 "eventTimeout": ""
             }
         }

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -199,7 +199,7 @@ func (lc *lazyClient) CreateOrUpdate(ctx context.Context, function *nuclioio.Nuc
 
 	// set a default
 	if function.Spec.ServiceType == "" {
-		function.Spec.ServiceType = v1.ServiceTypeNodePort
+		function.Spec.ServiceType = platformConfig.GetDefaultServiceType()
 	}
 
 	// create or update the applicable configMap
@@ -1416,8 +1416,6 @@ func (lc *lazyClient) populateServiceSpec(functionLabels labels.Set,
 		}
 		if serviceTypeIsNodePort {
 			spec.Ports[0].NodePort = int32(functionHTTPPort)
-		} else {
-			spec.Ports[0].NodePort = 0
 		}
 		lc.logger.DebugWith("Updating service node port",
 			"functionName", function.Name,

--- a/pkg/platformconfig/reader.go
+++ b/pkg/platformconfig/reader.go
@@ -83,5 +83,6 @@ func (r *Reader) GetDefaultConfiguration() *Config {
 				{Level: "debug", Sink: "stdout"},
 			},
 		},
+		KubeFunctionExposureMode: KubeFunctionExposureModeNodePort,
 	}
 }

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -104,3 +104,10 @@ const (
 	ProcessorCronTriggerCreationMode CronTriggerCreationMode = "processor"
 	KubeCronTriggerCreationMode      CronTriggerCreationMode = "kube"
 )
+
+type KubeFunctionExposureMode string
+
+const (
+	KubeFunctionExposureModeNodePort KubeFunctionExposureMode = "nodePort"
+	KubeFunctionExposureModeNil      KubeFunctionExposureMode = "nil"
+)


### PR DESCRIPTION
- Added platform configuration `kubeFunctionExposureMode` that defaults to `"nodePort"`.
- Used configuration to determine wether to expose by default each function.
  - If `"nodePort"`, sets function's `ServiceType` to `"NodePort"`.
  - If `"nil"`, sets function's `ServiceType` to `"ClusterIP"`.
  - This can overridden by manually setting the function's `ServiceType` when creating the function.
- Added to the the frontend spec the default `ServiceType` so the UI can know what the default is and give the user an option to change it.