### PR TITLE
Fix CI tests - go 1.15 compatibility

### DIFF
--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -123,7 +123,7 @@ func (suite *TestAbstractSuite) TestMinMaxReplicas() {
 	} {
 
 		// name it with index and shift with 65 to get A as first letter
-		functionName := string(idx + 65)
+		functionName := string(rune(idx + 65))
 		functionConfig := *functionconfig.NewConfig()
 
 		createFunctionOptions := &platform.CreateFunctionOptions{


### PR DESCRIPTION
As per go 1.15 you can't do `string(i)` for `i` an `int` - it now has to go through a `rune`
See: https://github.com/golang/go/issues/3939
See also: https://github.com/golang/go/issues/32479
Now this issues a warning in go vet.
## How did this break nuclio CI
While in nuclio we use go1.14.2, the CI (GH actions) cache picked up go 1.15:
https://github.com/nuclio/nuclio/runs/1003538254?check_suite_focus=true
Notice: 
![Screen Shot 2020-08-19 at 19 41 55](https://user-images.githubusercontent.com/18181802/90664978-1115e800-e254-11ea-9568-2768d2670253.png)

Because we pick up latest with ^1.14.0 which will pick up 1.15.x if available.