### PR TITLE
Configurable ServiceType for functions

### DIFF
--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -197,3 +197,4 @@ platform: {}
 #     functions:
 #     - myPrometheusPull
 #   cronTriggerCreationMode: "kube"
+#   kubeDefaultServiceType: nodePort

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -197,4 +197,4 @@ platform: {}
 #     functions:
 #     - myPrometheusPull
 #   cronTriggerCreationMode: "kube"
-#   kubeDefaultServiceType: nodePort
+#   kubeDefaultServiceType: NodePort

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -197,4 +197,5 @@ platform: {}
 #     functions:
 #     - myPrometheusPull
 #   cronTriggerCreationMode: "kube"
-#   kubeDefaultServiceType: NodePort
+#   kube:
+#     defaultServiceType: NodePort

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -118,7 +118,7 @@ func (fesr *frontendSpecResource) getDefaultFunctionConfig() map[string]interfac
 			// notice that this is a mapping between trigger kind and its default values
 			"http": {
 				WorkerAvailabilityTimeoutMilliseconds: &defaultWorkerAvailabilityTimeoutMilliseconds,
-				ServiceType: defaultServiceType,
+				ServiceType:                           defaultServiceType,
 			},
 			"cron": {
 				WorkerAvailabilityTimeoutMilliseconds: &defaultWorkerAvailabilityTimeoutMilliseconds,

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -27,7 +27,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/restful"
 
 	"github.com/nuclio/errors"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 )
 
 type frontendSpecResource struct {
@@ -96,10 +96,7 @@ func (fesr *frontendSpecResource) getDefaultFunctionConfig() map[string]interfac
 	one := 1
 	defaultWorkerAvailabilityTimeoutMilliseconds := trigger.DefaultWorkerAvailabilityTimeoutMilliseconds
 
-	var defaultServiceType v1.ServiceType = ""
-	if dashboardServer, ok := fesr.resource.GetServer().(*dashboard.Server); ok {
-		defaultServiceType = dashboardServer.GetPlatformConfiguration().KubeDefaultServiceType
-	}
+	defaultServiceType := fesr.resolveDefaultServiceType()
 	defaultHTTPTrigger := functionconfig.GetDefaultHTTPTrigger()
 	defaultHTTPTrigger.WorkerAvailabilityTimeoutMilliseconds = &defaultWorkerAvailabilityTimeoutMilliseconds
 	defaultHTTPTrigger.ServiceType = defaultServiceType
@@ -140,6 +137,14 @@ func (fesr *frontendSpecResource) GetCustomRoutes() ([]restful.CustomRoute, erro
 			RouteFunc: fesr.getFrontendSpec,
 		},
 	}, nil
+}
+
+func (fesr *frontendSpecResource) resolveDefaultServiceType() v1.ServiceType {
+	var defaultServiceType v1.ServiceType = ""
+	if dashboardServer, ok := fesr.resource.GetServer().(*dashboard.Server); ok {
+		defaultServiceType = dashboardServer.GetPlatformConfiguration().KubeDefaultServiceType
+	}
+	return defaultServiceType
 }
 
 // register the resource

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -99,7 +99,9 @@ func (fesr *frontendSpecResource) getDefaultFunctionConfig() map[string]interfac
 	defaultServiceType := fesr.resolveDefaultServiceType()
 	defaultHTTPTrigger := functionconfig.GetDefaultHTTPTrigger()
 	defaultHTTPTrigger.WorkerAvailabilityTimeoutMilliseconds = &defaultWorkerAvailabilityTimeoutMilliseconds
-	defaultHTTPTrigger.ServiceType = defaultServiceType
+	defaultHTTPTrigger.Attributes = map[string]interface{}{
+		"serviceType": defaultServiceType,
+	}
 
 	defaultFunctionSpec := functionconfig.Spec{
 		MinReplicas:             &one,
@@ -115,7 +117,9 @@ func (fesr *frontendSpecResource) getDefaultFunctionConfig() map[string]interfac
 			// notice that this is a mapping between trigger kind and its default values
 			"http": {
 				WorkerAvailabilityTimeoutMilliseconds: &defaultWorkerAvailabilityTimeoutMilliseconds,
-				ServiceType:                           defaultServiceType,
+				Attributes: map[string]interface{}{
+					"serviceType": defaultServiceType,
+				},
 			},
 			"cron": {
 				WorkerAvailabilityTimeoutMilliseconds: &defaultWorkerAvailabilityTimeoutMilliseconds,

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -146,7 +146,7 @@ func (fesr *frontendSpecResource) GetCustomRoutes() ([]restful.CustomRoute, erro
 func (fesr *frontendSpecResource) resolveDefaultServiceType() v1.ServiceType {
 	var defaultServiceType v1.ServiceType = ""
 	if dashboardServer, ok := fesr.resource.GetServer().(*dashboard.Server); ok {
-		defaultServiceType = dashboardServer.GetPlatformConfiguration().KubeConfig.DefaultServiceType
+		defaultServiceType = dashboardServer.GetPlatformConfiguration().Kube.DefaultServiceType
 	}
 	return defaultServiceType
 }

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -146,7 +146,7 @@ func (fesr *frontendSpecResource) GetCustomRoutes() ([]restful.CustomRoute, erro
 func (fesr *frontendSpecResource) resolveDefaultServiceType() v1.ServiceType {
 	var defaultServiceType v1.ServiceType = ""
 	if dashboardServer, ok := fesr.resource.GetServer().(*dashboard.Server); ok {
-		defaultServiceType = dashboardServer.GetPlatformConfiguration().KubeDefaultServiceType
+		defaultServiceType = dashboardServer.GetPlatformConfiguration().KubeConfig.DefaultServiceType
 	}
 	return defaultServiceType
 }

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -81,7 +81,9 @@ func (suite *dashboardTestSuite) SetupTest() {
 		true,
 		templateRepository,
 		&platformconfig.Config{
-			KubeDefaultServiceType: v1.ServiceTypeNodePort,
+			KubeConfig: platformconfig.PlatformKubeConfig{
+				DefaultServiceType: v1.ServiceTypeNodePort,
+			},
 		},
 		"",
 		"",

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -81,7 +81,7 @@ func (suite *dashboardTestSuite) SetupTest() {
 		true,
 		templateRepository,
 		&platformconfig.Config{
-			KubeConfig: platformconfig.PlatformKubeConfig{
+			Kube: platformconfig.PlatformKubeConfig{
 				DefaultServiceType: v1.ServiceTypeNodePort,
 			},
 		},

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/core/v1"
 )
 
 //
@@ -79,7 +80,9 @@ func (suite *dashboardTestSuite) SetupTest() {
 		"",
 		true,
 		templateRepository,
-		nil,
+		&platformconfig.Config{
+			KubeDefaultServiceType: v1.ServiceTypeNodePort,
+		},
 		"",
 		"",
 		"",
@@ -2370,13 +2373,15 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
                         "kind": "http",
                         "name": "default-http",
                         "maxWorkers": 1,
-                        "workerAvailabilityTimeoutMilliseconds": 10000
+                        "workerAvailabilityTimeoutMilliseconds": 10000,
+                        "serviceType": "NodePort"
                     },
                     "http": {
                         "class": "",
                         "kind": "",
                         "name": "",
-                        "workerAvailabilityTimeoutMilliseconds": 10000
+                        "workerAvailabilityTimeoutMilliseconds": 10000,
+                        "serviceType": "NodePort"
                     }
                 },
                 "build": {},

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 )
 
 //

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -2374,14 +2374,18 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
                         "name": "default-http",
                         "maxWorkers": 1,
                         "workerAvailabilityTimeoutMilliseconds": 10000,
-                        "serviceType": "NodePort"
+                        "attributes": {
+                            "serviceType": "NodePort"
+                        }
                     },
                     "http": {
                         "class": "",
                         "kind": "",
                         "name": "",
                         "workerAvailabilityTimeoutMilliseconds": 10000,
-                        "serviceType": "NodePort"
+                        "attributes": {
+                            "serviceType": "NodePort"
+                        }
                     }
                 },
                 "build": {},

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -73,7 +73,6 @@ type Trigger struct {
 	Annotations                           map[string]string `json:"annotations,omitempty"`
 	WorkerAvailabilityTimeoutMilliseconds *int              `json:"workerAvailabilityTimeoutMilliseconds,omitempty"`
 	WorkerAllocatorName                   string            `json:"workerAllocatorName,omitempty"`
-	ServiceType                           v1.ServiceType    `json:"serviceType,omitempty"`
 
 	// Dealer Information
 	TotalTasks        int `json:"total_tasks,omitempty"`

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -73,6 +73,7 @@ type Trigger struct {
 	Annotations                           map[string]string `json:"annotations,omitempty"`
 	WorkerAvailabilityTimeoutMilliseconds *int              `json:"workerAvailabilityTimeoutMilliseconds,omitempty"`
 	WorkerAllocatorName                   string            `json:"workerAllocatorName,omitempty"`
+	ServiceType                           v1.ServiceType    `json:"serviceType,omitempty"`
 
 	// Dealer Information
 	TotalTasks        int `json:"total_tasks,omitempty"`

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -195,9 +195,6 @@ func (lc *lazyClient) CreateOrUpdate(ctx context.Context, function *nuclioio.Nuc
 		}
 	}
 
-	// set function's service type
-	function.Spec.ServiceType = lc.resolveFunctionServiceType(function)
-
 	// create or update the applicable configMap
 	resources.configMap, err = lc.createOrUpdateConfigMap(function)
 	if err != nil {
@@ -1391,7 +1388,7 @@ func (lc *lazyClient) populateServiceSpec(functionLabels labels.Set,
 		spec.Selector = functionLabels
 	}
 
-	spec.Type = function.Spec.ServiceType
+	spec.Type = lc.resolveFunctionServiceType(function)
 	serviceTypeIsNodePort := spec.Type == v1.ServiceTypeNodePort
 	functionHTTPPort := function.Spec.GetHTTPPort()
 
@@ -2045,7 +2042,7 @@ func (lc *lazyClient) resolveFunctionServiceType(function *nuclioio.NuclioFuncti
 	}
 
 	// otherwise return platform default
-	return lc.platformConfigurationProvider.GetPlatformConfiguration().KubeConfig.DefaultServiceType
+	return lc.platformConfigurationProvider.GetPlatformConfiguration().Kube.DefaultServiceType
 }
 
 //

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2032,8 +2032,10 @@ func (lc *lazyClient) getFunctionServiceType(function *nuclioio.NuclioFunction) 
 
 	// if the http trigger has a configured service type, return that.
 	for _, trigger := range functionHTTPTriggers {
-		if trigger.ServiceType != "" {
-			return trigger.ServiceType
+		if serviceTypeInterface, serviceTypeExists := trigger.Attributes["serviceType"]; serviceTypeExists {
+			if serviceType, serviceTypeIsString := serviceTypeInterface.(string); serviceTypeIsString {
+				return v1.ServiceType(serviceType)
+			}
 		}
 	}
 

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -196,7 +196,7 @@ func (lc *lazyClient) CreateOrUpdate(ctx context.Context, function *nuclioio.Nuc
 	}
 
 	// set function's service type
-	function.Spec.ServiceType = lc.getFunctionServiceType(function)
+	function.Spec.ServiceType = lc.resolveFunctionServiceType(function)
 
 	// create or update the applicable configMap
 	resources.configMap, err = lc.createOrUpdateConfigMap(function)
@@ -2027,7 +2027,7 @@ func (lc *lazyClient) getMetricResourceByName(resourceName string) v1.ResourceNa
 	}
 }
 
-func (lc *lazyClient) getFunctionServiceType(function *nuclioio.NuclioFunction) v1.ServiceType {
+func (lc *lazyClient) resolveFunctionServiceType(function *nuclioio.NuclioFunction) v1.ServiceType {
 	functionHTTPTriggers := functionconfig.GetTriggersByKind(function.Spec.Triggers, "http")
 
 	// if the http trigger has a configured service type, return that.
@@ -2039,13 +2039,13 @@ func (lc *lazyClient) getFunctionServiceType(function *nuclioio.NuclioFunction) 
 		}
 	}
 
-	// if the function spec has a service type, return that (for backwards compatibility)
+	// otherwise, if the function spec has a service type, return that (for backwards compatibility)
 	if function.Spec.ServiceType != "" {
 		return function.Spec.ServiceType
 	}
 
 	// otherwise return platform default
-	return lc.platformConfigurationProvider.GetPlatformConfiguration().KubeDefaultServiceType
+	return lc.platformConfigurationProvider.GetPlatformConfiguration().KubeConfig.DefaultServiceType
 }
 
 //

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2033,7 +2033,7 @@ func (lc *lazyClient) getMetricResourceByName(resourceName string) v1.ResourceNa
 func (lc *lazyClient) getFunctionServiceType(function *nuclioio.NuclioFunction) (v1.ServiceType, error) {
 	functionHTTPTriggers := functionconfig.GetTriggersByKind(function.Spec.Triggers, "http")
 	if len(functionHTTPTriggers) != 1 {
-		return "", errors.Errorf("Unsupported amount of HTTP triggers: %s", len(functionHTTPTriggers))
+		return "", errors.Errorf("Unsupported amount of HTTP triggers: %d", len(functionHTTPTriggers))
 	}
 
 	// if the http trigger has a configured service type, return that.

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -206,7 +206,7 @@ func (suite *DeployFunctionTestSuite) TestDefaultHTTPTrigger() {
 func (suite *DeployFunctionTestSuite) TestHTTPTriggerServiceTypes() {
 
 	// set platform default service type to nodePort
-	suite.PlatformConfiguration.KubeDefaultServiceType = v1.ServiceTypeNodePort
+	suite.PlatformConfiguration.KubeConfig.DefaultServiceType = v1.ServiceTypeNodePort
 
 	// create function with service of type nodePort from platform default
 	defaultNodePortFunctionName := "with-default-http-trigger-node-port"
@@ -219,7 +219,7 @@ func (suite *DeployFunctionTestSuite) TestHTTPTriggerServiceTypes() {
 	})
 
 	// set platform default service type to clusterIP - the rest of the test will use this default
-	suite.PlatformConfiguration.KubeDefaultServiceType = v1.ServiceTypeClusterIP
+	suite.PlatformConfiguration.KubeConfig.DefaultServiceType = v1.ServiceTypeClusterIP
 
 	// create function with service of type clusterIP from platform default
 	defaultClusterIPFunctionName := "with-default-http-trigger-cluster-ip"

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -246,10 +246,12 @@ func (suite *DeployFunctionTestSuite) TestHTTPTriggerServiceTypes() {
 	customTriggerFunctionName := "with-default-http-trigger-cluster-ip"
 	customTriggerFunctionOptions := suite.compileCreateFunctionOptions(customTriggerFunctionName)
 	customTrigger := functionconfig.Trigger{
-		Kind:        "http",
-		Name:        "custom-trigger",
-		MaxWorkers:  1,
-		ServiceType: v1.ServiceTypeNodePort,
+		Kind:       "http",
+		Name:       "custom-trigger",
+		MaxWorkers: 1,
+		Attributes: map[string]interface{}{
+			"serviceType": v1.ServiceTypeNodePort,
+		},
 	}
 	customTriggerFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{
 		customTrigger.Name: customTrigger,

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -206,7 +206,7 @@ func (suite *DeployFunctionTestSuite) TestDefaultHTTPTrigger() {
 func (suite *DeployFunctionTestSuite) TestHTTPTriggerServiceTypes() {
 
 	// set platform default service type to nodePort
-	suite.PlatformConfiguration.KubeConfig.DefaultServiceType = v1.ServiceTypeNodePort
+	suite.PlatformConfiguration.Kube.DefaultServiceType = v1.ServiceTypeNodePort
 
 	// create function with service of type nodePort from platform default
 	defaultNodePortFunctionName := "with-default-http-trigger-node-port"
@@ -219,7 +219,7 @@ func (suite *DeployFunctionTestSuite) TestHTTPTriggerServiceTypes() {
 	})
 
 	// set platform default service type to clusterIP - the rest of the test will use this default
-	suite.PlatformConfiguration.KubeConfig.DefaultServiceType = v1.ServiceTypeClusterIP
+	suite.PlatformConfiguration.Kube.DefaultServiceType = v1.ServiceTypeClusterIP
 
 	// create function with service of type clusterIP from platform default
 	defaultClusterIPFunctionName := "with-default-http-trigger-cluster-ip"

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -203,6 +203,65 @@ func (suite *DeployFunctionTestSuite) TestDefaultHTTPTrigger() {
 	})
 }
 
+func (suite *DeployFunctionTestSuite) TestHTTPTriggerServiceTypes() {
+
+	// set platform default service type to nodePort
+	suite.PlatformConfiguration.KubeDefaultServiceType = v1.ServiceTypeNodePort
+
+	// create function with service of type nodePort from platform default
+	defaultNodePortFunctionName := "with-default-http-trigger-node-port"
+	createNodePortTriggerFunctionOptions := suite.compileCreateFunctionOptions(defaultNodePortFunctionName)
+	suite.DeployFunction(createNodePortTriggerFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+		serviceInstance := &v1.Service{}
+		suite.getResourceAndUnmarshal("service", kube.ServiceNameFromFunctionName(defaultNodePortFunctionName), serviceInstance)
+		suite.Require().Equal(v1.ServiceTypeNodePort, serviceInstance.Spec.Type)
+		return true
+	})
+
+	// set platform default service type to clusterIP - the rest of the test will use this default
+	suite.PlatformConfiguration.KubeDefaultServiceType = v1.ServiceTypeClusterIP
+
+	// create function with service of type clusterIP from platform default
+	defaultClusterIPFunctionName := "with-default-http-trigger-cluster-ip"
+	createClusterIPTriggerFunctionOptions := suite.compileCreateFunctionOptions(defaultClusterIPFunctionName)
+	suite.DeployFunction(createClusterIPTriggerFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+		serviceInstance := &v1.Service{}
+		suite.getResourceAndUnmarshal("service", kube.ServiceNameFromFunctionName(defaultClusterIPFunctionName), serviceInstance)
+		suite.Require().Equal(v1.ServiceTypeClusterIP, serviceInstance.Spec.Type)
+		return true
+	})
+
+	// override default service type in function spec (backwards compatibility)
+	customFunctionName := "custom-function"
+	customFunctionOptions := suite.compileCreateFunctionOptions(customFunctionName)
+	customFunctionOptions.FunctionConfig.Spec.ServiceType = v1.ServiceTypeNodePort
+	suite.DeployFunction(customFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+		serviceInstance := &v1.Service{}
+		suite.getResourceAndUnmarshal("service", kube.ServiceNameFromFunctionName(customFunctionName), serviceInstance)
+		suite.Require().Equal(v1.ServiceTypeNodePort, serviceInstance.Spec.Type)
+		return true
+	})
+
+	// override default service type in trigger spec
+	customTriggerFunctionName := "with-default-http-trigger-cluster-ip"
+	customTriggerFunctionOptions := suite.compileCreateFunctionOptions(customTriggerFunctionName)
+	customTrigger := functionconfig.Trigger{
+		Kind:       "http",
+		Name:       "custom-trigger",
+		MaxWorkers: 1,
+		ServiceType: v1.ServiceTypeNodePort,
+	}
+	customTriggerFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{
+		customTrigger.Name: customTrigger,
+	}
+	suite.DeployFunction(customTriggerFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+		serviceInstance := &v1.Service{}
+		suite.getResourceAndUnmarshal("service", kube.ServiceNameFromFunctionName(customTriggerFunctionName), serviceInstance)
+		suite.Require().Equal(v1.ServiceTypeNodePort, serviceInstance.Spec.Type)
+		return true
+	})
+}
+
 func (suite *DeployFunctionTestSuite) verifyCreatedTrigger(functionName string, trigger functionconfig.Trigger) bool {
 	functionInstance := &nuclioio.NuclioFunction{}
 	suite.getResourceAndUnmarshal("nucliofunction",

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -246,9 +246,9 @@ func (suite *DeployFunctionTestSuite) TestHTTPTriggerServiceTypes() {
 	customTriggerFunctionName := "with-default-http-trigger-cluster-ip"
 	customTriggerFunctionOptions := suite.compileCreateFunctionOptions(customTriggerFunctionName)
 	customTrigger := functionconfig.Trigger{
-		Kind:       "http",
-		Name:       "custom-trigger",
-		MaxWorkers: 1,
+		Kind:        "http",
+		Name:        "custom-trigger",
+		MaxWorkers:  1,
 		ServiceType: v1.ServiceTypeNodePort,
 	}
 	customTriggerFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -42,7 +42,7 @@ type Config struct {
 	CronTriggerCreationMode  CronTriggerCreationMode  `json:"cronTriggerCreationMode,omitempty"`
 	FunctionAugmentedConfigs []LabelSelectorAndConfig `json:"functionAugmentedConfigs,omitempty"`
 	IngressConfig            IngressConfig            `json:"ingressConfig,omitempty"`
-	KubeConfig               PlatformKubeConfig       `json:"kube,omitempty"`
+	Kube                     PlatformKubeConfig       `json:"kube,omitempty"`
 }
 
 func NewPlatformConfig(configurationPath string) (*Config, error) {

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 
 	"github.com/nuclio/errors"
+	"k8s.io/api/core/v1"
 )
 
 type Config struct {
@@ -35,6 +36,7 @@ type Config struct {
 	CronTriggerCreationMode  CronTriggerCreationMode  `json:"cronTriggerCreationMode,omitempty"`
 	FunctionAugmentedConfigs []LabelSelectorAndConfig `json:"functionAugmentedConfigs,omitempty"`
 	IngressConfig            IngressConfig            `json:"ingressConfig,omitempty"`
+	KubeDefaultServiceType   v1.ServiceType           `json:"kubeDefaultServiceType,omitempty"`
 }
 
 func NewPlatformConfig(configurationPath string) (*Config, error) {

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -25,6 +25,12 @@ import (
 	"k8s.io/api/core/v1"
 )
 
+type PlatformKubeConfig struct {
+
+	// TODO: Move IngressConfig here
+	DefaultServiceType v1.ServiceType `json:"defaultServiceType,omitempty"`
+}
+
 type Config struct {
 	Kind                     string                   `json:"kind,omitempty"`
 	WebAdmin                 WebServer                `json:"webAdmin,omitempty"`
@@ -36,7 +42,7 @@ type Config struct {
 	CronTriggerCreationMode  CronTriggerCreationMode  `json:"cronTriggerCreationMode,omitempty"`
 	FunctionAugmentedConfigs []LabelSelectorAndConfig `json:"functionAugmentedConfigs,omitempty"`
 	IngressConfig            IngressConfig            `json:"ingressConfig,omitempty"`
-	KubeDefaultServiceType   v1.ServiceType           `json:"kubeDefaultServiceType,omitempty"`
+	KubeConfig               PlatformKubeConfig       `json:"kube,omitempty"`
 }
 
 func NewPlatformConfig(configurationPath string) (*Config, error) {

--- a/pkg/platformconfig/reader.go
+++ b/pkg/platformconfig/reader.go
@@ -84,6 +84,8 @@ func (r *Reader) GetDefaultConfiguration() *Config {
 				{Level: "debug", Sink: "stdout"},
 			},
 		},
-		KubeDefaultServiceType: v1.ServiceTypeNodePort,
+		KubeConfig: PlatformKubeConfig{
+			DefaultServiceType: v1.ServiceTypeNodePort,
+		},
 	}
 }

--- a/pkg/platformconfig/reader.go
+++ b/pkg/platformconfig/reader.go
@@ -84,7 +84,7 @@ func (r *Reader) GetDefaultConfiguration() *Config {
 				{Level: "debug", Sink: "stdout"},
 			},
 		},
-		KubeConfig: PlatformKubeConfig{
+		Kube: PlatformKubeConfig{
 			DefaultServiceType: v1.ServiceTypeNodePort,
 		},
 	}

--- a/pkg/platformconfig/reader.go
+++ b/pkg/platformconfig/reader.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/nuclio/errors"
+	v1 "k8s.io/api/core/v1"
 )
 
 type Reader struct{}
@@ -83,5 +84,6 @@ func (r *Reader) GetDefaultConfiguration() *Config {
 				{Level: "debug", Sink: "stdout"},
 			},
 		},
+		KubeDefaultServiceType: v1.ServiceTypeNodePort,
 	}
 }


### PR DESCRIPTION
- Added `kubeDefaultServiceType` to `platformConfig` and helm values
- Added `serviceType ` to `functionconfig.Trigger.Attributes`
- Exposed the default in `frontedSpec`
- For each function, its service's ServiceType is now chosen in this order:
  - If the default/regular HTTP Trigger has a `serviceType` attribute - take that
  - If the function spec has a `ServiceType` - take that (for backwards compatibility)
  - Otherwise, take the default from `platformConfig`
- For backwards compatibility, the default is still `NodePort` but for security reasons it is recommended to change the default to `ClusterIP`
- Platform config was granted a new "kube" sub config, currently containing only `defaultServiceType`