### PR TITLE
Fix CI tests - go 1.15 compatibility [backport 1.4.x]

### DIFF
--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -123,7 +123,7 @@ func (suite *TestAbstractSuite) TestMinMaxReplicas() {
 	} {
 
 		// name it with index and shift with 65 to get A as first letter
-		functionName := string(idx + 65)
+		functionName := string(rune(idx + 65))
 		functionConfig := *functionconfig.NewConfig()
 
 		createFunctionOptions := &platform.CreateFunctionOptions{


### PR DESCRIPTION
Backports #1799 to ensure ci tests passes for prs open against `1.4.x` branch