### PR TITLE
Bump chart version to 0.7.0

### DIFF
--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.6.18
+version: 0.7.0
 appVersion: 1.4.15
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io


### PR DESCRIPTION
bumping minor to 0.7.x, as 0.6.x is here to track any nuclio 1.4.x changes/releases
