### PR TITLE
Labeler - use pull_request_target instead of cron

### DIFF
--- a/.github/workflows/pr_label.yaml
+++ b/.github/workflows/pr_label.yaml
@@ -1,13 +1,12 @@
 name: "Label PRs"
-on:
-  schedule:
-    - cron: "*/30 * * * *"
+
+on: pull_request_target
 
 jobs:
-  execute:
+  label:
     runs-on: ubuntu-latest
     steps:
-      - uses: jpmcb/prow-github-actions@v1.0.0
+      - uses: actions/labeler@v2
         with:
-          jobs: 'pr-labeler'
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: ".github/labels.yaml"


### PR DESCRIPTION
Now that `pull_request_target` can be used, this PR can provide a better way to use the label-er action (as oppose to a cron that ran every 30 minutes)