### PR TITLE
Allow passing security context via function config

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -418,3 +418,12 @@ func MatchStringPatterns(patterns []string, s string) bool {
 func CompileImageName(registryURL string, imageName string) string {
 	return strings.TrimSuffix(registryURL, "/") + "/" + imageName
 }
+
+func AnyPositiveInSliceInt64(numbers []int64) bool {
+	for _, number := range numbers {
+		if number >= 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -254,6 +254,7 @@ type Spec struct {
 	Avatar                  string                  `json:"avatar,omitempty"`
 	ServiceType             v1.ServiceType          `json:"serviceType,omitempty"`
 	ImagePullPolicy         v1.PullPolicy           `json:"imagePullPolicy,omitempty"`
+	SecurityContext         *v1.PodSecurityContext  `json:"security_context,omitempty"`
 	ServiceAccount          string                  `json:"serviceAccount,omitempty"`
 	ScaleToZero             *ScaleToZeroSpec        `json:"scaleToZero,omitempty"`
 

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -409,9 +409,9 @@ func (d *deployCommandeer) enrichConfigWithIntArgs() {
 		d.functionConfig.Spec.ReadinessTimeoutSeconds = d.readinessTimeoutSeconds
 	}
 
-    // fill security context
+	// fill security context
 
-    // initialize struct if at least one flag is provided
+	// initialize struct if at least one flag is provided
 	if common.AnyPositiveInSliceInt64([]int64{d.runAsUser, d.runAsGroup, d.fsGroup}) {
 		d.functionConfig.Spec.SecurityContext = &v1.PodSecurityContext{}
 	}
@@ -421,7 +421,7 @@ func (d *deployCommandeer) enrichConfigWithIntArgs() {
 		d.functionConfig.Spec.SecurityContext.RunAsUser = &d.runAsUser
 	}
 
-    // group id
+	// group id
 	if d.runAsGroup >= 0 {
 		d.functionConfig.Spec.SecurityContext.RunAsGroup = &d.runAsGroup
 	}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -753,6 +753,7 @@ func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 					},
 					Volumes:            volumes,
 					ServiceAccountName: function.Spec.ServiceAccount,
+					SecurityContext:    function.Spec.SecurityContext,
 				},
 			},
 		}

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -18,6 +18,8 @@ package test
 
 import (
 	"encoding/base64"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
@@ -104,7 +106,7 @@ func (suite *DeployFunctionTestSuite) TestSecurityContext() {
 	runAsUserID := int64(1000)
 	runAsGroupID := int64(2000)
 	fsGroup := int64(3000)
-	functionName := "security-context-config"
+	functionName := "security-context"
 	createFunctionOptions := suite.compileCreateFunctionOptions(functionName)
 	createFunctionOptions.FunctionConfig.Spec.SecurityContext = &v1.PodSecurityContext{
 		RunAsUser:  &runAsUserID,
@@ -122,10 +124,21 @@ func (suite *DeployFunctionTestSuite) TestSecurityContext() {
 		suite.Require().NotNil(deploymentInstance.Spec.Template.Spec.SecurityContext.RunAsGroup)
 		suite.Require().NotNil(deploymentInstance.Spec.Template.Spec.SecurityContext.FSGroup)
 
-		// verify security context values
+		// verify deployment spec security context values
 		suite.Require().Equal(runAsUserID, *deploymentInstance.Spec.Template.Spec.SecurityContext.RunAsUser)
 		suite.Require().Equal(runAsGroupID, *deploymentInstance.Spec.Template.Spec.SecurityContext.RunAsGroup)
 		suite.Require().Equal(fsGroup, *deploymentInstance.Spec.Template.Spec.SecurityContext.FSGroup)
+
+		// verify running function indeed using the right uid / gid / groups
+		podName := fmt.Sprintf("deployment/%s", kube.DeploymentNameFromFunctionName(functionName))
+		results, err := suite.executeKubectl([]string{"exec", podName, "--", "id"}, nil)
+		suite.Require().NoError(err, "Failed to execute `id` command on function pod")
+		suite.Require().Equal(fmt.Sprintf(`uid=%d gid=%d groups=%d,%d`,
+			runAsUserID,
+			runAsGroupID,
+			runAsGroupID,
+			fsGroup),
+			strings.TrimSpace(results.Output))
 		return true
 	})
 }


### PR DESCRIPTION
Security context is the Kubernetes way to define the access control to the running pod

Adding `SecurityContext` field to the function spec allowing us to ensure the running function has the correct privileges.

TODO:
- [ ] Update docs
- [ ] Add nuctl test for flags
- [ ] E2E with UI (another pr, not blocking)
