### PR TITLE
Use docker volume to mount the processor config to function container

### DIFF
--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -65,8 +65,9 @@ The `spec` section contains the requirements and attributes and has the followin
 | volumes | map | A map in an architecture similar to Kubernetes volumes, for Docker deployment |
 | replicas | int | The number of desired instances; 0 for auto-scaling. |
 | minReplicas | int | The minimum number of replicas |
-| platform.attributes.restartPolicy.name | string | function image container restart policy name (applied for docker platform only) |
-| platform.attributes.restartPolicy.maximumRetryCount | int | restart maximum counter before exhausted |
+| platform.attributes.restartPolicy.name | string | Function image container restart policy name (applied for docker platform only) |
+| platform.attributes.restartPolicy.maximumRetryCount | int | Restart maximum counter before exhausted |
+| platform.attributes.processorMountMode | string | How to mount the processor config (options: bind, volume; default: bind) | 
 | maxReplicas | int | The maximum number of replicas |
 | targetCPU | int | Target CPU when auto scaling, as a percentage (default: 75%) |
 | dataBindings | See reference | A map of data sources used by the function ("data bindings") |
@@ -111,6 +112,10 @@ spec:
       restartPolicy:
         name: on-failure
         maximumRetryCount: 3
+
+      # will use `volume` to mount the processor into function
+      # more info @ https://docs.docker.com/storage/volumes
+      processorMountMode: volume
   env:
   - name: SOME_ENV
     value: abc

--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -67,7 +67,7 @@ The `spec` section contains the requirements and attributes and has the followin
 | minReplicas | int | The minimum number of replicas |
 | platform.attributes.restartPolicy.name | string | Function image container restart policy name (applied for docker platform only) |
 | platform.attributes.restartPolicy.maximumRetryCount | int | Restart maximum counter before exhausted |
-| platform.attributes.processorMountMode | string | How to mount the processor config (options: bind, volume; default: bind) | 
+| platform.attributes.processorMountMode | string | The way docker would mount the processor config (options: bind, volume; default: bind) |
 | maxReplicas | int | The maximum number of replicas |
 | targetCPU | int | Target CPU when auto scaling, as a percentage (default: 75%) |
 | dataBindings | See reference | A map of data sources used by the function ("data bindings") |

--- a/pkg/dockerclient/dockerclient.go
+++ b/pkg/dockerclient/dockerclient.go
@@ -74,6 +74,12 @@ type Client interface {
 	// DeleteNetwork deletes a docker network
 	DeleteNetwork(networkName string) error
 
+	// CreateVolume create a docker volume
+	CreateVolume(*CreateVolumeOptions) error
+
+	// DeleteVolume delete a docker volume
+	DeleteVolume(volumeName string) error
+
 	// Save saves a docker image as tar in specified path
 	Save(imageName string, outPath string) error
 

--- a/pkg/dockerclient/mock.go
+++ b/pkg/dockerclient/mock.go
@@ -123,6 +123,18 @@ func (mdc *MockDockerClient) DeleteNetwork(networkName string) error {
 	return args.Error(0)
 }
 
+// CreateVolume creates a docker volume
+func (mdc *MockDockerClient) CreateVolume(options *CreateVolumeOptions) error {
+	args := mdc.Called(options)
+	return args.Error(0)
+}
+
+// DeleteVolume deletes a docker volume
+func (mdc *MockDockerClient) DeleteVolume(volumeName string) error {
+	args := mdc.Called(volumeName)
+	return args.Error(0)
+}
+
 // Save saves a docker image in path
 func (mdc *MockDockerClient) Save(imageName string, outPath string) error {
 	args := mdc.Called(imageName, outPath)

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -228,9 +228,23 @@ func (c *ShellClient) RunContainer(imageName string, runOptions *RunOptions) (st
 		}
 	}
 
+	mountPointArguments := ""
+	if len(runOptions.MountPoints) > 0 {
+		for _, mountPoint := range runOptions.MountPoints {
+			mountPointArguments += fmt.Sprintf("--mount source=%s,destination=%s",
+				mountPoint.Source,
+				mountPoint.Destination)
+			if !mountPoint.RW {
+				mountPointArguments += ",readonly"
+			}
+			mountPointArguments += " "
+		}
+	}
+
 	runResult, err := c.cmdRunner.Run(
 		&cmdrunner.RunOptions{LogRedactions: c.redactedValues},
-		"docker run %s %s %s %s %s %s %s %s %s %s %s %s",
+		"docker run %s %s %s %s %s %s %s %s %s %s %s %s %s",
+		mountPointArguments,
 		gpus,
 		restartPolicy,
 		detach,
@@ -537,6 +551,20 @@ func (c *ShellClient) CreateNetwork(options *CreateNetworkOptions) error {
 // DeleteNetwork deletes a docker network
 func (c *ShellClient) DeleteNetwork(networkName string) error {
 	_, err := c.runCommand(nil, `docker network rm %s`, networkName)
+
+	return err
+}
+
+// CreateVolume creates a docker volume
+func (c *ShellClient) CreateVolume(options *CreateVolumeOptions) error {
+	_, err := c.runCommand(nil, `docker volume create %s`, options.Name)
+
+	return err
+}
+
+// DeleteVolume deletes a docker volume
+func (c *ShellClient) DeleteVolume(volumeName string) error {
+	_, err := c.runCommand(nil, `docker volume rm %s`, volumeName)
 
 	return err
 }

--- a/pkg/dockerclient/types.go
+++ b/pkg/dockerclient/types.go
@@ -64,6 +64,7 @@ type RunOptions struct {
 	Network          string
 	RestartPolicy    *RestartPolicy
 	GPUs             string
+	MountPoints      []MountPoint
 }
 
 // ExecOptions are options for executing a command in a container
@@ -340,5 +341,10 @@ type Address struct {
 
 // CreateNetworkOptions are options for creating a network
 type CreateNetworkOptions struct {
+	Name string
+}
+
+// CreateVolumeOptions are options for creating a volume
+type CreateVolumeOptions struct {
 	Name string
 }

--- a/pkg/dockerclient/types.go
+++ b/pkg/dockerclient/types.go
@@ -149,6 +149,9 @@ type MountPoint struct {
 	Destination string
 	Mode        string
 	RW          bool
+	Type        string
+	Driver      string
+	Name        string
 }
 
 // HostConfig the non-portable Config structure of a container.

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -1017,7 +1017,7 @@ func (p *Platform) prepareFunctionVolumeMount(createFunctionOptions *platform.Cr
 				RW:          true,
 			},
 		},
-		Command: fmt.Sprintf(`sh -c 'echo "%s" | base64 -d > %s'`,
+		Command: fmt.Sprintf(`sh -c 'echo "%s" | base64 -d | install -m 777 /dev/stdin %s'`,
 			base64.StdEncoding.EncodeToString(processorConfigBody),
 			path.Join(FunctionProcessorContainerDirPath, "processor.yaml")),
 	}); err != nil {

--- a/pkg/platform/local/test/platform_test.go
+++ b/pkg/platform/local/test/platform_test.go
@@ -169,6 +169,21 @@ func (suite *TestSuite) TestImportFunctionFlow() {
 		})
 }
 
+func (suite *TestSuite) TestDeployFunctionVolumeMount() {
+	createFunctionOptions := suite.getDeployOptions("volume-mount")
+	createFunctionOptions.FunctionConfig.Meta.Namespace = suite.namespace
+	suite.Platform.(*local.Platform).SetFunctionProcessorMountMode(local.FunctionProcessorMountModeVolume)
+	suite.DeployFunctionAndRedeploy(createFunctionOptions,
+
+		// sanity
+		func(deployResult *platform.CreateFunctionResult) bool {
+			return true
+		},
+		func(deployResult *platform.CreateFunctionResult) bool {
+			return true
+		})
+}
+
 func (suite *TestSuite) getDeployOptions(functionName string) *platform.CreateFunctionOptions {
 	functionPath := []string{suite.GetTestFunctionsDir(), "common", "reverser", "python", "reverser.py"}
 	createFunctionOptions := suite.TestSuite.GetDeployOptions(functionName, filepath.Join(functionPath...))

--- a/pkg/platform/local/test/platform_test.go
+++ b/pkg/platform/local/test/platform_test.go
@@ -181,7 +181,7 @@ func (suite *TestSuite) TestDeployFunctionVolumeMount() {
 		// sanity
 		func(deployResult *platform.CreateFunctionResult) bool {
 			containers, err := suite.DockerClient.GetContainers(&dockerclient.GetContainerOptions{
-				Name:    localPlatform.GetContainerNameByCreateFunctionOptions(createFunctionOptions),
+				Name: localPlatform.GetContainerNameByCreateFunctionOptions(createFunctionOptions),
 			})
 			suite.Require().NoError(err, "Failed to get containers")
 

--- a/pkg/platform/local/types.go
+++ b/pkg/platform/local/types.go
@@ -39,3 +39,10 @@ func newFunctionPlatformConfiguration(functionConfig *functionconfig.Config) (*f
 
 	return &newConfiguration, nil
 }
+
+type functionProcessorMountMode string
+
+const (
+	FunctionProcessorMountModeBidMount functionProcessorMountMode = "BindMount"
+	FunctionProcessorMountModeVolume   functionProcessorMountMode = "Volume"
+)

--- a/pkg/platform/local/types.go
+++ b/pkg/platform/local/types.go
@@ -25,8 +25,9 @@ import (
 )
 
 type functionPlatformConfiguration struct {
-	Network       string
-	RestartPolicy *dockerclient.RestartPolicy
+	Network            string
+	RestartPolicy      *dockerclient.RestartPolicy
+	ProcessorMountMode ProcessorMountMode
 }
 
 func newFunctionPlatformConfiguration(functionConfig *functionconfig.Config) (*functionPlatformConfiguration, error) {
@@ -40,9 +41,9 @@ func newFunctionPlatformConfiguration(functionConfig *functionconfig.Config) (*f
 	return &newConfiguration, nil
 }
 
-type functionProcessorMountMode string
+type ProcessorMountMode string
 
 const (
-	FunctionProcessorMountModeBidMount functionProcessorMountMode = "BindMount"
-	FunctionProcessorMountModeVolume   functionProcessorMountMode = "Volume"
+	ProcessorMountModeBind   ProcessorMountMode = "bind"
+	ProcessorMountModeVolume ProcessorMountMode = "volume"
 )


### PR DESCRIPTION
Nuclio deploy a function while dumping its processor configuration to host `/tmp`, this allow us to share configuration between containers  (dashboard & deployed function) and nuctl (running from host).

Since `tmp` might get wiped every now and then, it result with errors when 
1. docker daemon tries to restart function
2. tmp dir is getting wiped during deploy
3. file permission changes

To use this feature, you would require to edit your function spec and set the platform attributes as follow

```
meta:
  name: no-mount-binding-function
spec:
   ..my other spec fields..
  platform:
    attributes:
      processorMountMode: volume
```

This should resolve 
- https://github.com/nuclio/nuclio/issues/1806
- https://github.com/nuclio/nuclio/issues/1812
- https://github.com/nuclio/nuclio/issues/1782
- https://github.com/nuclio/nuclio/issues/1768