### PR TITLE
Allow passing security context via function config - Part 2

### DIFF
--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -94,6 +94,9 @@ The `spec` section contains the requirements and attributes and has the followin
 | readinessTimeoutSeconds | int | Number of seconds that the controller will wait for the function to become ready before declaring failure (default: 60) |
 | avatar | string | Base64 representation of an icon to be shown in UI for the function |
 | eventTimeout | string | Global event timeout, in the format supported for the `Duration` parameter of the [`time.ParseDuration`](https://golang.org/pkg/time/#ParseDuration) Go function |
+| securityContext.runAsUser | int | The UID to run the entrypoint of the container process. (k8s only) |
+| securityContext.runAsGroup | int | The GID to run the entrypoint of the container process. (k8s only) |
+| securityContext.fsGroup | int | A supplemental group added to the groups to run the entrypoint of the container process. (k8s only) |
 
 <a id="spec-example"></a>
 ### Example
@@ -146,7 +149,11 @@ spec:
       memory: 128M
     limits:
       cpu: 2
-      memory: 256M  
+      memory: 256M
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 2000
+    fsGroup: 3000
 ```
 
 ## See also

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1130,13 +1130,11 @@ func (suite *functionDeployTestSuite) TestDeployWithSecurityContext() {
 
 	// try a few times to invoke, until it succeeds
 	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"invoke", functionName},
-		map[string]string{
-			"method": "POST",
-		},
+		map[string]string{"method": "POST"},
 		false)
 	suite.Require().NoError(err)
 
-	// make sure reverser worked
+	// make sure the id command from the handler, returns the correct uid and gids
 	suite.Require().Contains(suite.outputBuffer.String(), fmt.Sprintf(`uid=%s gid=%s groups=%s`,
 		runAsUserID,
 		runAsGroupID,

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1103,6 +1103,10 @@ func (suite *functionDeployTestSuite) parseEventsRecorderOutput(outputBufferStri
 }
 
 func (suite *functionDeployTestSuite) TestDeployWithSecurityContext() {
+
+	// TODO: if we implement this feature for local platform, remove this so the test will run with docker as well
+	suite.ensureRunningOnPlatform("kube")
+
 	runAsUserID := "1000"
 	runAsGroupID := "2000"
 	fsGroup := "3000"


### PR DESCRIPTION
Part 1 - https://github.com/nuclio/nuclio/pull/1819

- Added nuctl test for security context
- Added docs for security context in function spec
