### PR TITLE
Resolve error status code from top level error or root cause

### DIFF
--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -1,0 +1,22 @@
+package common
+
+import (
+	"github.com/nuclio/errors"
+	"github.com/nuclio/nuclio-sdk-go"
+)
+
+func ResolveErrorStatusCodeOrDefault(err error, defaultStatusCode int) int {
+
+	// resolve from top level
+	if errWithStatus, ok := err.(*nuclio.ErrorWithStatusCode); ok {
+		return errWithStatus.StatusCode()
+	}
+
+	// resolve from root cause
+	if rootCauseWithStatus, ok := errors.RootCause(err).(*nuclio.ErrorWithStatusCode); ok {
+		return rootCauseWithStatus.StatusCode()
+	}
+
+	// unable to resolve, returning default
+	return defaultStatusCode
+}

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/dashboard"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
@@ -317,18 +318,9 @@ func (fr *functionResource) deleteFunction(request *http.Request) (*restful.Cust
 	// get the authentication configuration for the request
 	authConfig, err := fr.getRequestAuthConfig(request)
 	if err != nil {
-
-		// get error
-		if errWithStatus, ok := err.(*nuclio.ErrorWithStatusCode); ok {
-			return &restful.CustomRouteFuncResponse{
-				Single:     true,
-				StatusCode: errWithStatus.StatusCode(),
-			}, err
-		}
-
 		return &restful.CustomRouteFuncResponse{
 			Single:     true,
-			StatusCode: http.StatusInternalServerError,
+			StatusCode: common.ResolveErrorStatusCodeOrDefault(err, http.StatusInternalServerError),
 		}, err
 	}
 

--- a/pkg/dashboard/resource/functionevent.go
+++ b/pkg/dashboard/resource/functionevent.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/dashboard"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/restful"
@@ -243,19 +244,11 @@ func (fer *functionEventResource) updateFunctionEvent(request *http.Request) (*r
 		Spec: *functionEventInfo.Spec,
 	}
 
-	err = fer.getPlatform().UpdateFunctionEvent(&platform.UpdateFunctionEventOptions{
+	if err = fer.getPlatform().UpdateFunctionEvent(&platform.UpdateFunctionEventOptions{
 		FunctionEventConfig: functionEventConfig,
-	})
-
-	if err != nil {
+	}); err != nil {
 		fer.Logger.WarnWith("Failed to update function event", "err", err)
-	}
-
-	// if there was an error, try to get the status code
-	if err != nil {
-		if errWithStatusCode, ok := err.(nuclio.ErrorWithStatusCode); ok {
-			statusCode = errWithStatusCode.StatusCode()
-		}
+		statusCode = common.ResolveErrorStatusCodeOrDefault(err, http.StatusInternalServerError)
 	}
 
 	// return the stuff

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -314,7 +314,7 @@ func (ap *Platform) ValidateDeleteProjectOptions(deleteProjectOptions *platform.
 	projectName := deleteProjectOptions.Meta.Name
 
 	if projectName == platform.DefaultProjectName {
-		return errors.New("Cannot delete the default project")
+		return nuclio.NewErrConflict("Cannot delete the default project")
 	}
 
 	if err := ap.validateProjectIsEmpty(deleteProjectOptions.Meta.Namespace, projectName); err != nil {


### PR DESCRIPTION
To avoid cases where the root cause, containing the desired error status code get ignored when trying to resolve the status from the top level error.

This pr ensure that errors hidden on the root cause would be populated (unless the user intentionally override it on the top level error)