### PR TITLE
Apigateways - renaming authentication mode (dex -> oauth2)

### DIFF
--- a/pkg/platform/kube/apigatewayres/lazy.go
+++ b/pkg/platform/kube/apigatewayres/lazy.go
@@ -265,8 +265,8 @@ func (lc *lazyClient) generateNginxIngress(ctx context.Context,
 				Password: apiGateway.Spec.Authentication.BasicAuth.Password,
 			},
 		}
-	case ingress.AuthenticationModeDex:
-		commonIngressSpec.AuthenticationMode = ingress.AuthenticationModeDex
+	case ingress.AuthenticationModeOauth2:
+		commonIngressSpec.AuthenticationMode = ingress.AuthenticationModeOauth2
 	case ingress.AuthenticationModeAccessKey:
 		commonIngressSpec.AuthenticationMode = ingress.AuthenticationModeAccessKey
 	default:

--- a/pkg/platform/kube/ingress/ingress.go
+++ b/pkg/platform/kube/ingress/ingress.go
@@ -361,7 +361,7 @@ func (m *Manager) compileAuthAnnotations(ctx context.Context, spec Spec) (map[st
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "Failed to get access key auth mode annotations")
 		}
-	case AuthenticationModeDex:
+	case AuthenticationModeOauth2:
 		authIngressAnnotations, err = m.compileDexAuthAnnotations(spec)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "Failed to get dex auth annotations")

--- a/pkg/platform/kube/ingress/types.go
+++ b/pkg/platform/kube/ingress/types.go
@@ -43,5 +43,5 @@ const (
 	AuthenticationModeNone      AuthenticationMode = "none"
 	AuthenticationModeBasicAuth AuthenticationMode = "basicAuth"
 	AuthenticationModeAccessKey AuthenticationMode = "accessKey"
-	AuthenticationModeDex       AuthenticationMode = "dex"
+	AuthenticationModeOauth2    AuthenticationMode = "oauth2"
 )


### PR DESCRIPTION
More familiar and generic as a "mode" name, even though the implementation is dex specific today