### PR TITLE
chore: Upgrade actions-setup-minikube to v2.0.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,7 +156,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
 
-    - uses: manusa/actions-setup-minikube@v1.1.0
+    - uses: manusa/actions-setup-minikube@v2.0.1
       with:
         minikube version: "v1.12.1"
         kubernetes version: "v1.17.9"
@@ -251,7 +251,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - uses: manusa/actions-setup-minikube@v1.1.0
+      - uses: manusa/actions-setup-minikube@v2.0.1
         with:
           minikube version: "v1.12.1"
           kubernetes version: "v1.17.9"


### PR DESCRIPTION
Upgrade `manusa/actions-setup-minikube` to the latest version.

Removes the following warnings caused by [CVE-2020-15228](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w):
```
Warning: The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Warning: The `add-path` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

Relates to:
- https://github.com/manusa/actions-setup-minikube/issues/22
- https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/