### PR TITLE
Fix building java onbuild image

### DIFF
--- a/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
@@ -20,8 +20,8 @@ FROM quay.io/nuclio/processor:${NUCLIO_LABEL}-${NUCLIO_ARCH} as processor
 
 FROM openjdk:9-slim as user-handler-builder
 
-RUN apt-get update \
-    && apt-get install -y curl \
+RUN apt-get update -qqy \
+    && apt-get install -o APT::Immediate-Configure=false -qqy curl \
     && curl -LO https://services.gradle.org/distributions/gradle-4.5.1-bin.zip \
     && unzip gradle-4.5.1-bin.zip \
     && rm gradle-4.5.1-bin.zip \


### PR DESCRIPTION
To resolve the issue of 

```
E: Could not configure 'libc6:amd64'.
E: Could not perform immediate configuration on 'libnss-nis:amd64'. Please see man 5 apt.conf under APT::Immediate-Configure for details. (2)
```

Note that curl is being used during image creation, nothing else afterwards is using it