### PR TITLE
Fix github action set-env deprecation warning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,11 +182,11 @@ jobs:
 
     - name: Export env
       run: |
-        echo ::set-env name=NUCTL_EXTERNAL_IP_ADDRESSES::$(minikube ip)
-        echo ::set-env name=NUCTL_REGISTRY::localhost:5000
-        echo ::set-env name=NUCLIO_DASHBOARD_DEFAULT_ONBUILD_REGISTRY_URL::$REPO
-        echo ::set-env name=NUCTL_NAMESPACE::$NAMESPACE
-        echo ::set-env name=KUBECONFIG::$(pwd)/kubeconfig
+        echo "NUCTL_EXTERNAL_IP_ADDRESSES=$(minikube ip)" >> $GITHUB_ENV
+        echo "NUCTL_REGISTRY=localhost:5000" >> $GITHUB_ENV
+        echo "NUCLIO_DASHBOARD_DEFAULT_ONBUILD_REGISTRY_URL=$REPO" >> $GITHUB_ENV
+        echo "NUCTL_NAMESPACE=$NAMESPACE" >> $GITHUB_ENV
+        echo "KUBECONFIG=$(pwd)/kubeconfig" >> $GITHUB_ENV
 
     - name: Install nuclio helm chart
       run: |
@@ -277,9 +277,9 @@ jobs:
 
       - name: Export env
         run: |
-          echo ::set-env name=NUCTL_EXTERNAL_IP_ADDRESSES::$(minikube ip)
-          echo ::set-env name=NUCLIO_TEST_REGISTRY_URL::localhost:5000
-          echo ::set-env name=KUBECONFIG::$(pwd)/kubeconfig
+          echo "NUCTL_EXTERNAL_IP_ADDRESSES=$(minikube ip)" >> $GITHUB_ENV
+          echo "NUCLIO_TEST_REGISTRY_URL=localhost:5000" >> $GITHUB_ENV
+          echo "KUBECONFIG=$(pwd)/kubeconfig" >> $GITHUB_ENV
 
       - name: Install nuclio helm chart
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,12 +42,12 @@ jobs:
     - name: Set NUCLIO_LABEL to unstable
       if: github.event_name == 'push' && steps.release_info.outputs.REF_BRANCH == 'development'
       run: |
-        echo "::set-env name=NUCLIO_LABEL::unstable"
+        echo "NUCLIO_LABEL=unstable" >> $GITHUB_ENV
 
     - name: Set NUCLIO_LABEL to release tag
       if: github.event_name == 'release'
       run: |
-        echo "::set-env name=NUCLIO_LABEL::${{ steps.release_info.outputs.REF_TAG }}"
+        echo "NUCLIO_LABEL=${{ steps.release_info.outputs.REF_TAG }}" >> $GITHUB_ENV
 
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
reason: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
