### PR TITLE
Remove api gateways authentication mode validation

### DIFF
--- a/pkg/platform/kube/ingress/ingress.go
+++ b/pkg/platform/kube/ingress/ingress.go
@@ -402,6 +402,13 @@ func (m *Manager) compileDexAuthAnnotations(spec Spec) (map[string]string, error
 }
 
 func (m *Manager) compileIguazioSessionVerificationAnnotations(sessionVerificationEndpoint string) (map[string]string, error) {
+	if m.platformConfiguration.IngressConfig.IguazioAuthURL == "" {
+		return nil, errors.New("No iguazio auth URL configured")
+	}
+
+	if m.platformConfiguration.IngressConfig.IguazioSignInURL == "" {
+		return nil, errors.New("No iguazio sign in URL configured")
+	}
 
 	return map[string]string{
 		"nginx.ingress.kubernetes.io/auth-method":           "POST",

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1095,7 +1095,9 @@ func (p *Platform) validateAPIGatewayAuthMode(apiGateway *nuclioio.NuclioAPIGate
 	if err != nil {
 		return errors.Wrap(err, "Failed getting allowed authentication modes")
 	}
-	if common.StringInSlice(string(apiGateway.Spec.AuthenticationMode), allowedAuthenticationModes) {
+
+	// validate the authentication mode is allowed
+	if !common.StringInSlice(string(apiGateway.Spec.AuthenticationMode), allowedAuthenticationModes) {
 		return nuclio.NewErrBadRequest("Api gateway authentication mode not allowed")
 	}
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
@@ -519,10 +518,6 @@ func (p *Platform) CreateAPIGateway(createAPIGatewayOptions *platform.CreateAPIG
 		return errors.Wrap(err, "Failed to validate and enrich api gateway name")
 	}
 
-	if err := p.validateAPIGatewayAuthMode(&newAPIGateway); err != nil {
-		return errors.Wrap(err, "Failed to validate api gateway auth mode")
-	}
-
 	// set state to waiting for provisioning
 	createAPIGatewayOptions.APIGatewayConfig.Status = platform.APIGatewayStatus{
 		State: platform.APIGatewayStateWaitingForProvisioning,
@@ -553,10 +548,6 @@ func (p *Platform) UpdateAPIGateway(updateAPIGatewayOptions *platform.UpdateAPIG
 
 	if err := p.enrichAndValidateAPIGatewayName(&updatedAPIGateway); err != nil {
 		return errors.Wrap(err, "Failed to validate and enrich api gateway name")
-	}
-
-	if err := p.validateAPIGatewayAuthMode(&updatedAPIGateway); err != nil {
-		return errors.Wrap(err, "Failed to validate api gateway auth mode")
 	}
 
 	// set api gateway state to "waitingForProvisioning", so the controller will know to update this resource
@@ -1085,20 +1076,6 @@ func (p *Platform) enrichAndValidateAPIGatewayName(apiGateway *nuclioio.NuclioAP
 	}
 	if apiGateway.Spec.Name != apiGateway.Name {
 		return nuclio.NewErrBadRequest("Api gateway metadata.name must match api gateway spec.name")
-	}
-
-	return nil
-}
-
-func (p *Platform) validateAPIGatewayAuthMode(apiGateway *nuclioio.NuclioAPIGateway) error {
-	allowedAuthenticationModes, err := p.GetAllowedAuthenticationModes()
-	if err != nil {
-		return errors.Wrap(err, "Failed getting allowed authentication modes")
-	}
-
-	// validate the authentication mode is allowed
-	if !common.StringInSlice(string(apiGateway.Spec.AuthenticationMode), allowedAuthenticationModes) {
-		return nuclio.NewErrBadRequest("Api gateway authentication mode not allowed")
 	}
 
 	return nil

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1096,7 +1096,7 @@ func (p *Platform) validateAPIGatewayAuthMode(apiGateway *nuclioio.NuclioAPIGate
 		return errors.Wrap(err, "Failed getting allowed authentication modes")
 	}
 	if common.StringInSlice(string(apiGateway.Spec.AuthenticationMode), allowedAuthenticationModes) {
-		return nuclio.NewErrBadRequest("Api gateway authnetication mode not allowed")
+		return nuclio.NewErrBadRequest("Api gateway authentication mode not allowed")
 	}
 
 	return nil


### PR DESCRIPTION
Removed api gateway authentication mode validation on api gateway creation/update.
Done to allow nuctl create/update api gateways (couldn't before, because its platform config wasn't configured accordingly)