### PR TITLE
[Bugfix]: Shell runtime execution with security context

### DIFF
--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1153,9 +1153,9 @@ func (suite *functionDeployTestSuite) TestDeployWithSecurityContext() {
 
 	err = suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"},
 		map[string]string{
-			"image":        imageName,
-			"runtime":      "shell",
-			"handler":      "main.sh",
+			"image":   imageName,
+			"runtime": "shell",
+			"handler": "main.sh",
 
 			// the `id` command
 			"source":       "aWQ=",

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1110,6 +1110,8 @@ func (suite *functionDeployTestSuite) TestDeployWithSecurityContext() {
 	runAsUserID := "1000"
 	runAsGroupID := "2000"
 	fsGroup := "3000"
+
+	// with executable handler
 	uniqueSuffix := "-" + xid.New().String()
 	functionName := "security-context" + uniqueSuffix
 	imageName := "nuclio/processor-" + functionName
@@ -1119,6 +1121,44 @@ func (suite *functionDeployTestSuite) TestDeployWithSecurityContext() {
 			"image":        imageName,
 			"runtime":      "shell",
 			"handler":      "id",
+			"run-as-user":  runAsUserID,
+			"run-as-group": runAsGroupID,
+			"fsgroup":      fsGroup,
+		})
+
+	suite.Require().NoError(err)
+
+	// make sure to clean up after the test
+	defer suite.dockerClient.RemoveImage(imageName) // nolint: errcheck
+
+	// use nuctl to delete the function when we're done
+	defer suite.ExecuteNuctl([]string{"delete", "fu", functionName}, nil) // nolint: errcheck
+
+	// try a few times to invoke, until it succeeds
+	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"invoke", functionName},
+		map[string]string{"method": "POST"},
+		false)
+	suite.Require().NoError(err)
+
+	// make sure the id command from the handler, returns the correct uid and gids
+	suite.Require().Contains(suite.outputBuffer.String(), fmt.Sprintf(`uid=%s gid=%s groups=%s`,
+		runAsUserID,
+		runAsGroupID,
+		fsGroup))
+
+	// with script handler
+	uniqueSuffix = "-" + xid.New().String()
+	functionName = "security-context" + uniqueSuffix
+	imageName = "nuclio/processor-" + functionName
+
+	err = suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"},
+		map[string]string{
+			"image":        imageName,
+			"runtime":      "shell",
+			"handler":      "main.sh",
+
+			// the `id` command
+			"source":       "aWQ=",
 			"run-as-user":  runAsUserID,
 			"run-as-group": runAsGroupID,
 			"fsgroup":      fsGroup,

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -808,6 +808,7 @@ func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 		lc.populateDeploymentContainer(functionLabels, function, &deployment.Spec.Template.Spec.Containers[0])
 		deployment.Spec.Template.Spec.Volumes = volumes
 		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
+		deployment.Spec.Template.Spec.SecurityContext = function.Spec.SecurityContext
 
 		if function.Spec.ServiceAccount != "" {
 			deployment.Spec.Template.Spec.ServiceAccountName = function.Spec.ServiceAccount

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -808,7 +808,6 @@ func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 		lc.populateDeploymentContainer(functionLabels, function, &deployment.Spec.Template.Spec.Containers[0])
 		deployment.Spec.Template.Spec.Volumes = volumes
 		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
-		deployment.Spec.Template.Spec.SecurityContext = function.Spec.SecurityContext
 
 		if function.Spec.ServiceAccount != "" {
 			deployment.Spec.Template.Spec.ServiceAccountName = function.Spec.ServiceAccount

--- a/pkg/processor/runtime/shell/runtime.go
+++ b/pkg/processor/runtime/shell/runtime.go
@@ -105,7 +105,7 @@ func (s *shell) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (
 	// run the command
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		s.Logger.WarnWith("Failed Executing shell",
+		s.Logger.ErrorWith("Failed Executing shell",
 			"name", s.configuration.Meta.Name,
 			"version", s.configuration.Spec.Version,
 			"eventID", event.GetID(),
@@ -156,11 +156,6 @@ func (s *shell) getCommand() (string, error) {
 
 	// is there really a file there? could be user set module to something on the path
 	if common.FileExists(shellHandlerPath) {
-
-		// set permissions of handler such that if it wasn't executable before, it's executable now
-		//if err := os.Chmod(shellHandlerPath, 0755); err != nil {
-		//	return "", errors.Wrapf(err, "Failed to change mode for %s", shellHandlerPath)
-		//}
 
 		command = shellHandlerPath
 	} else {


### PR DESCRIPTION
Shell runtime would need to `chmod` the run script to give it execute permissions.
If a security context is given, this fails.

Added a check to see if the handler is a script in the current working directory or a command from the PATH.
If it is a command, it is run with `sh -c`
If not, it is run with `sh` (without `-c`) which results in `sh` reading the file as a script and running it, so there's no need to `chmod` the file.

Benchmarked the changes in the event processing function to ensure no large loss of performance happens because of the string manipulations. The performance change is negligible.