### PR TITLE
SecurityContext for local platform and bugfix

### DIFF
--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -182,11 +182,9 @@ func (c *ShellClient) RunContainer(imageName string, runOptions *RunOptions) (st
 		dockerArguments = append(dockerArguments, restartPolicy)
 	}
 
-	detach := "-d"
-	if runOptions.Attach {
-		detach = ""
+	if !runOptions.Attach {
+		dockerArguments = append(dockerArguments, "-d")
 	}
-	dockerArguments = append(dockerArguments, detach)
 
 	if runOptions.GPUs != "" {
 		dockerArguments = append(dockerArguments, fmt.Sprintf("--gpus %s", runOptions.GPUs))

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -241,9 +241,33 @@ func (c *ShellClient) RunContainer(imageName string, runOptions *RunOptions) (st
 		}
 	}
 
+	userArgument := ""
+	if runOptions.RunAsUser != nil || runOptions.RunAsGroup != nil {
+		userStr := ""
+		if runOptions.RunAsUser != nil && runOptions.RunAsGroup != nil {
+
+			// user and group
+			userStr = fmt.Sprintf("%d:%d", runOptions.RunAsUser, runOptions.RunAsGroup)
+		} else if runOptions.RunAsUser != nil {
+
+			// only user
+			userStr = fmt.Sprintf("%d", runOptions.RunAsUser)
+		} else {
+
+			// only group
+			userStr = fmt.Sprintf(":%d", runOptions.RunAsGroup)
+		}
+		userArgument = fmt.Sprintf("--user %s ", userStr)
+	}
+
+	groupAddArgument := ""
+	if runOptions.FSGroup != nil {
+		groupAddArgument = fmt.Sprintf("--group-add %d ", runOptions.FSGroup)
+	}
+
 	runResult, err := c.cmdRunner.Run(
 		&cmdrunner.RunOptions{LogRedactions: c.redactedValues},
-		"docker run %s %s %s %s %s %s %s %s %s %s %s %s %s",
+		"docker run %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s",
 		mountPointArguments,
 		gpus,
 		restartPolicy,
@@ -255,6 +279,8 @@ func (c *ShellClient) RunContainer(imageName string, runOptions *RunOptions) (st
 		labelArgument,
 		envArgument,
 		volumeArgument,
+		userArgument,
+		groupAddArgument,
 		imageName,
 		runOptions.Command)
 

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -239,17 +239,17 @@ func (c *ShellClient) RunContainer(imageName string, runOptions *RunOptions) (st
 	if runOptions.RunAsUser != nil || runOptions.RunAsGroup != nil {
 		userStr := ""
 		if runOptions.RunAsUser != nil {
-			userStr += fmt.Sprintf("%d", runOptions.RunAsUser)
+			userStr += fmt.Sprintf("%d", *runOptions.RunAsUser)
 		}
 		if runOptions.RunAsGroup != nil {
-			userStr += fmt.Sprintf(":%d", runOptions.RunAsGroup)
+			userStr += fmt.Sprintf(":%d", *runOptions.RunAsGroup)
 		}
 
 		dockerArguments = append(dockerArguments, fmt.Sprintf("--user %s", userStr))
 	}
 
 	if runOptions.FSGroup != nil {
-		dockerArguments = append(dockerArguments, fmt.Sprintf("--group-add %d", runOptions.FSGroup))
+		dockerArguments = append(dockerArguments, fmt.Sprintf("--group-add %d", *runOptions.FSGroup))
 	}
 
 	runResult, err := c.cmdRunner.Run(

--- a/pkg/dockerclient/types.go
+++ b/pkg/dockerclient/types.go
@@ -65,6 +65,9 @@ type RunOptions struct {
 	RestartPolicy    *RestartPolicy
 	GPUs             string
 	MountPoints      []MountPoint
+	RunAsUser        *int64
+	RunAsGroup       *int64
+	FSGroup          *int64
 }
 
 // ExecOptions are options for executing a command in a container

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1104,9 +1104,6 @@ func (suite *functionDeployTestSuite) parseEventsRecorderOutput(outputBufferStri
 
 func (suite *functionDeployTestSuite) TestDeployWithSecurityContext() {
 
-	// TODO: if we implement this feature for local platform, remove this so the test will run with docker as well
-	suite.ensureRunningOnPlatform("kube")
-
 	runAsUserID := "1000"
 	runAsGroupID := "2000"
 	fsGroup := "3000"

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -808,6 +808,7 @@ func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 		lc.populateDeploymentContainer(functionLabels, function, &deployment.Spec.Template.Spec.Containers[0])
 		deployment.Spec.Template.Spec.Volumes = volumes
 		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
+		deployment.Spec.Template.Spec.SecurityContext = function.Spec.SecurityContext
 
 		if function.Spec.ServiceAccount != "" {
 			deployment.Spec.Template.Spec.ServiceAccountName = function.Spec.ServiceAccount

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -45,6 +45,7 @@ import (
 	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/nuclio/zap"
 	"golang.org/x/sync/errgroup"
+	v1 "k8s.io/api/core/v1"
 )
 
 type Platform struct {
@@ -659,6 +660,11 @@ func (p *Platform) deployFunction(createFunctionOptions *platform.CreateFunction
 		gpus = "all"
 	}
 
+	functionSecurityContext := createFunctionOptions.FunctionConfig.Spec.SecurityContext
+	if functionSecurityContext == nil {
+		functionSecurityContext = &v1.PodSecurityContext{}
+	}
+
 	// run the docker image
 	runContainerOptions := &dockerclient.RunOptions{
 		ContainerName: p.GetContainerNameByCreateFunctionOptions(createFunctionOptions),
@@ -672,9 +678,9 @@ func (p *Platform) deployFunction(createFunctionOptions *platform.CreateFunction
 		RestartPolicy: functionPlatformConfiguration.RestartPolicy,
 		GPUs:          gpus,
 		MountPoints:   mountPoints,
-		RunAsUser:     createFunctionOptions.FunctionConfig.Spec.SecurityContext.RunAsUser,
-		RunAsGroup:    createFunctionOptions.FunctionConfig.Spec.SecurityContext.RunAsGroup,
-		FSGroup:       createFunctionOptions.FunctionConfig.Spec.SecurityContext.FSGroup,
+		RunAsUser:     functionSecurityContext.RunAsUser,
+		RunAsGroup:    functionSecurityContext.RunAsGroup,
+		FSGroup:       functionSecurityContext.FSGroup,
 	}
 
 	containerID, err := p.dockerClient.RunContainer(createFunctionOptions.FunctionConfig.Spec.Image,

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -672,6 +672,9 @@ func (p *Platform) deployFunction(createFunctionOptions *platform.CreateFunction
 		RestartPolicy: functionPlatformConfiguration.RestartPolicy,
 		GPUs:          gpus,
 		MountPoints:   mountPoints,
+		RunAsUser:     createFunctionOptions.FunctionConfig.Spec.SecurityContext.RunAsUser,
+		RunAsGroup:    createFunctionOptions.FunctionConfig.Spec.SecurityContext.RunAsGroup,
+		FSGroup:       createFunctionOptions.FunctionConfig.Spec.SecurityContext.FSGroup,
 	}
 
 	containerID, err := p.dockerClient.RunContainer(createFunctionOptions.FunctionConfig.Spec.Image,


### PR DESCRIPTION
Added SecurityContext feature for local platform using the `--user` and `--group-add` flags for `docker run`.

And fixed a bug where security context wasn't updated in kube platform if the function already existed.