### PR TITLE
[BugFix]: DefaultServiceType enrichment

### DIFF
--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -70,6 +70,10 @@ func NewPlatformConfig(configurationPath string) (*Config, error) {
 		config.CronTriggerCreationMode = ProcessorCronTriggerCreationMode
 	}
 
+	if config.Kube.DefaultServiceType == "" {
+		config.Kube.DefaultServiceType = DefaultServiceType
+	}
+
 	return config, nil
 }
 

--- a/pkg/platformconfig/reader.go
+++ b/pkg/platformconfig/reader.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/nuclio/errors"
-	v1 "k8s.io/api/core/v1"
 )
 
 type Reader struct{}
@@ -83,9 +82,6 @@ func (r *Reader) GetDefaultConfiguration() *Config {
 			Functions: []LoggerSinkBinding{
 				{Level: "debug", Sink: "stdout"},
 			},
-		},
-		Kube: PlatformKubeConfig{
-			DefaultServiceType: v1.ServiceTypeNodePort,
 		},
 	}
 }

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -113,4 +114,6 @@ type CronTriggerCreationMode string
 const (
 	ProcessorCronTriggerCreationMode CronTriggerCreationMode = "processor"
 	KubeCronTriggerCreationMode      CronTriggerCreationMode = "kube"
+
+	DefaultServiceType = corev1.ServiceTypeNodePort
 )


### PR DESCRIPTION
If platform config was given, the default service type wasn't included.
Fixed the enrichment, so it happens after reading the file, adding the DefaultServiceType if it wasn't given.