### PR TITLE
Update CI minikube version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -242,7 +242,7 @@ jobs:
 
       - uses: azure/setup-helm@v1
         with:
-          version: "v3.2.4"
+          version: "v3.3.4"
 
       - uses: actions/cache@v2
         with:
@@ -253,17 +253,19 @@ jobs:
 
       - uses: manusa/actions-setup-minikube@v2.0.1
         with:
-          minikube version: "v1.12.1"
+          minikube version: "v1.14.0"
           kubernetes version: "v1.17.9"
           github token: ${{ github.token }}
-          start args: '--addons=registry --insecure-registry="10.1.0.0/24"'
+          driver: docker
+          start args: '--addons registry ingress metrics-server --insecure-registry "10.1.0.0/24" "10.96.0.0/24"'
 
       - name: Post minikube setup
         run: |
 
           # redirect $(minikube ip):5000 -> localhost:5000
           docker run --rm --detach --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"
-          kubectl config view --flatten >> kubeconfig
+          minikube kubectl -- config view --flatten > kubeconfig_flatten
+          minikube kubectl -- get service
 
       - name: Fetch nuclio docker images
         uses: actions/download-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,7 @@ jobs:
 
     - uses: azure/setup-helm@v1
       with:
-        version: "v3.2.4"
+        version: "v3.3.4"
 
     - uses: actions/cache@v2
       with:
@@ -158,17 +158,22 @@ jobs:
 
     - uses: manusa/actions-setup-minikube@v2.0.1
       with:
-        minikube version: "v1.12.1"
+        minikube version: "v1.14.0"
         kubernetes version: "v1.17.9"
+        driver: docker
         github token: ${{ github.token }}
-        start args: '--addons=registry --insecure-registry="10.1.0.0/24"'
+        start args: '--addons registry --addons ingress'
 
     - name: Post minikube setup
       run: |
 
+        # activate minikube docker
+        eval $(minikube -p minikube docker-env)
+
+
         # redirect $(minikube ip):5000 -> localhost:5000
         docker run --rm --detach --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"
-        kubectl config view --flatten >> kubeconfig
+        kubectl config view --flatten > kubeconfig_flatten
 
     - name: Fetch nuclio docker images
       uses: actions/download-artifact@v2
@@ -186,7 +191,8 @@ jobs:
         echo "NUCTL_REGISTRY=localhost:5000" >> $GITHUB_ENV
         echo "NUCLIO_DASHBOARD_DEFAULT_ONBUILD_REGISTRY_URL=$REPO" >> $GITHUB_ENV
         echo "NUCTL_NAMESPACE=$NAMESPACE" >> $GITHUB_ENV
-        echo "KUBECONFIG=$(pwd)/kubeconfig" >> $GITHUB_ENV
+        echo "KUBECONFIG=$(pwd)/kubeconfig_flatten" >> $GITHUB_ENV
+        echo "NUCTL_TEST_DEFAULT_APIGATEWAY_HOST=nuclio-test-function-host.info" >> $GITHUB_ENV
 
     - name: Install nuclio helm chart
       run: |
@@ -195,12 +201,13 @@ jobs:
           | envsubst \
           | helm install --debug --wait --namespace ${NAMESPACE} -f - nuclio hack/k8s/helm/nuclio/
 
-    - name: Install nginx ingress controller
-      run: |
-        ./test/k8s/ci_assets/install_nginx_ingress_controller.sh
-
     - name: Run nuctl k8s tests
       run: |
+
+        # write function host to /etc/hosts
+        echo "${NUCTL_EXTERNAL_IP_ADDRESSES} ${NUCTL_TEST_DEFAULT_APIGATEWAY_HOST}" | sudo tee -a /etc/hosts
+
+        # run test
         make test-k8s-nuctl
 
   test_docker_nuctl:
@@ -255,17 +262,19 @@ jobs:
         with:
           minikube version: "v1.14.0"
           kubernetes version: "v1.17.9"
-          github token: ${{ github.token }}
           driver: docker
-          start args: '--addons registry ingress metrics-server --insecure-registry "10.1.0.0/24" "10.96.0.0/24"'
+          github token: ${{ github.token }}
+          start args: '--addons registry --addons ingress'
 
       - name: Post minikube setup
         run: |
 
+          # activate minikube docker
+          eval $(minikube -p minikube docker-env)
+
           # redirect $(minikube ip):5000 -> localhost:5000
           docker run --rm --detach --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"
-          minikube kubectl -- config view --flatten > kubeconfig_flatten
-          minikube kubectl -- get service
+          kubectl config view --flatten > kubeconfig_flatten
 
       - name: Fetch nuclio docker images
         uses: actions/download-artifact@v2
@@ -281,10 +290,11 @@ jobs:
         run: |
           echo "NUCTL_EXTERNAL_IP_ADDRESSES=$(minikube ip)" >> $GITHUB_ENV
           echo "NUCLIO_TEST_REGISTRY_URL=localhost:5000" >> $GITHUB_ENV
-          echo "KUBECONFIG=$(pwd)/kubeconfig" >> $GITHUB_ENV
+          echo "KUBECONFIG=$(pwd)/kubeconfig_flatten" >> $GITHUB_ENV
 
       - name: Install nuclio helm chart
         run: |
+
           # create namespace
           kubectl create namespace ${NAMESPACE}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,8 +176,17 @@ jobs:
       with:
         name: nuclio-docker-images
 
-    - name: Load nuclio docker images
+    - name: Load nuclio docker images to host (for helm)
       run: |
+
+        docker load -i nuclio_docker_images.tar.gz
+        rm nuclio_docker_images.tar.gz
+
+    - name: Load nuclio docker images to minikube (for nuclio itself)
+      run: |
+
+        # activate minikube docker
+        eval $(minikube -p minikube docker-env)
         docker load -i nuclio_docker_images.tar.gz
         rm nuclio_docker_images.tar.gz
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -178,9 +178,6 @@ jobs:
 
     - name: Load nuclio docker images
       run: |
-
-        # activate minikube docker
-        eval $(minikube -p minikube docker-env)
         docker load -i nuclio_docker_images.tar.gz
         rm nuclio_docker_images.tar.gz
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,10 +167,6 @@ jobs:
     - name: Post minikube setup
       run: |
 
-        # activate minikube docker
-        eval $(minikube -p minikube docker-env)
-
-
         # redirect $(minikube ip):5000 -> localhost:5000
         docker run --rm --detach --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"
         kubectl config view --flatten > kubeconfig_flatten
@@ -271,9 +267,6 @@ jobs:
 
       - name: Post minikube setup
         run: |
-
-          # activate minikube docker
-          eval $(minikube -p minikube docker-env)
 
           # redirect $(minikube ip):5000 -> localhost:5000
           docker run --rm --detach --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,6 +182,9 @@ jobs:
 
     - name: Load nuclio docker images
       run: |
+
+        # activate minikube docker
+        eval $(minikube -p minikube docker-env)
         docker load -i nuclio_docker_images.tar.gz
         rm nuclio_docker_images.tar.gz
 
@@ -290,7 +293,7 @@ jobs:
         run: |
           echo "NUCTL_EXTERNAL_IP_ADDRESSES=$(minikube ip)" >> $GITHUB_ENV
           echo "NUCLIO_TEST_REGISTRY_URL=localhost:5000" >> $GITHUB_ENV
-          echo "KUBECONFIG=$(pwd)/kubeconfig_flatten" >> $GITHUB_ENV
+          echo "NUCLIO_TEST_KUBECONFIG=$(pwd)/kubeconfig_flatten" >> $GITHUB_ENV
 
       - name: Install nuclio helm chart
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,17 +176,16 @@ jobs:
       with:
         name: nuclio-docker-images
 
-    - name: Load nuclio docker images to host (for helm)
+    - name: Load nuclio docker images
       run: |
 
+        # load nuclio docker images to host docker
         docker load -i nuclio_docker_images.tar.gz
-        rm nuclio_docker_images.tar.gz
-
-    - name: Load nuclio docker images to minikube (for nuclio itself)
-      run: |
 
         # activate minikube docker
         eval $(minikube -p minikube docker-env)
+
+        # load nuclio docker images to minikube
         docker load -i nuclio_docker_images.tar.gz
         rm nuclio_docker_images.tar.gz
 

--- a/Makefile
+++ b/Makefile
@@ -425,6 +425,7 @@ test: build-test
 test-k8s: build-test
 	docker run \
 		--rm \
+		--network host \
 		--volume /var/run/docker.sock:/var/run/docker.sock \
 		--volume $(GOPATH)/bin:/go/bin \
 		--volume $(shell pwd):$(GO_BUILD_TOOL_WORKDIR) \
@@ -435,7 +436,9 @@ test-k8s: build-test
 		--env NUCLIO_VERSION_GIT_COMMIT=$(NUCLIO_VERSION_GIT_COMMIT) \
 		--env NUCLIO_LABEL=$(NUCLIO_LABEL) \
 		--env NUCLIO_ARCH=$(NUCLIO_ARCH) \
+		--env NUCLIO_TEST_REGISTRY_URL=$(NUCLIO_TEST_REGISTRY_URL) \
 		--env NUCLIO_OS=$(NUCLIO_OS) \
+		--env MINIKUBE_HOME=$(MINIKUBE_HOME) \
 		--env NUCLIO_GO_TEST_TIMEOUT=$(NUCLIO_GO_TEST_TIMEOUT) \
 		--env KUBECONFIG=/kubeconfig \
 		$(NUCLIO_DOCKER_TEST_TAG) \

--- a/Makefile
+++ b/Makefile
@@ -423,6 +423,7 @@ test: build-test
 
 .PHONY: test-k8s
 test-k8s: build-test
+	NUCLIO_TEST_KUBECONFIG=$(if $(NUCLIO_TEST_KUBECONFIG),$(NUCLIO_TEST_KUBECONFIG),$(KUBECONFIG)) \
 	docker run \
 		--rm \
 		--network host \
@@ -430,7 +431,7 @@ test-k8s: build-test
 		--volume $(GOPATH)/bin:/go/bin \
 		--volume $(shell pwd):$(GO_BUILD_TOOL_WORKDIR) \
 		--volume /tmp:/tmp \
-		--volume $(KUBECONFIG)/:/kubeconfig \
+		--volume $(NUCLIO_TEST_KUBECONFIG)/:/kubeconfig \
 		--workdir $(GO_BUILD_TOOL_WORKDIR) \
 		--env NUCLIO_TEST_HOST=$(NUCLIO_TEST_HOST) \
 		--env NUCLIO_VERSION_GIT_COMMIT=$(NUCLIO_VERSION_GIT_COMMIT) \

--- a/pkg/nuctl/test/apigagteway_test.go
+++ b/pkg/nuctl/test/apigagteway_test.go
@@ -172,6 +172,10 @@ func (suite *apiGatewayInvokeTestSuite) testInvoke(authenticationMode ingress.Au
 }
 
 func (suite *apiGatewayInvokeTestSuite) getAPIGatewayDefaultHost() string {
+	defaultTestAPIGatewayHost := common.GetEnvOrDefaultString("NUCTL_TEST_DEFAULT_APIGATEWAY_HOST", "")
+	if defaultTestAPIGatewayHost != "" {
+		return defaultTestAPIGatewayHost
+	}
 
 	// select host address according to system's kubernetes runner (minikube / docker-for-mac)
 	if common.GetEnvOrDefaultString("MINIKUBE_HOME", "") != "" {

--- a/pkg/nuctl/test/apigagteway_test.go
+++ b/pkg/nuctl/test/apigagteway_test.go
@@ -150,12 +150,15 @@ func (suite *apiGatewayInvokeTestSuite) testInvoke(authenticationMode ingress.Au
 	}
 
 	// invoke the api-gateway URL to make sure it works (we get the expected function response)
+	responseBody := ""
 	err = common.RetryUntilSuccessful(20*time.Second, 1*time.Second, func() bool {
-		responseBody, err := suite.invokeHTTPRequest(request, &expectedResponseBody)
-		suite.Require().NoError(err)
-		suite.Require().Equal(expectedResponseBody, responseBody)
+		responseBody, err = suite.invokeHTTPRequest(request, &expectedResponseBody)
+		if err != nil {
+			return false
+		}
 		return true
 	})
+	suite.Require().Equal(expectedResponseBody, responseBody)
 	suite.Require().NoError(err)
 
 	if authenticationMode != ingress.AuthenticationModeNone {
@@ -243,7 +246,7 @@ func (suite *apiGatewayInvokeTestSuite) invokeHTTPRequest(request *http.Request,
 
 	if expectedBody != nil {
 		if string(body) != *expectedBody {
-			suite.logger.WarnWith("Got unexpected response from api gateway",
+			suite.logger.WarnWith("Got unexpected response body",
 				"requestURL", request.URL,
 				"requestMethod", request.Method,
 				"body", string(body))

--- a/pkg/nuctl/test/apigagteway_test.go
+++ b/pkg/nuctl/test/apigagteway_test.go
@@ -241,7 +241,7 @@ func (suite *apiGatewayInvokeTestSuite) invokeApiGateURL(request *http.Request,
 				"requestURL", request.URL,
 				"body", string(body))
 			return string(body), errors.Errorf("Unexpected body response. received: %s expected %s",
-				body, expectedBody)
+				body, *expectedBody)
 		}
 	}
 


### PR DESCRIPTION
Updated minikube version to 1.14.0 that allows us to:

1. use docker driver
2. enable ingress addon
3. enable api gateway nuctl tests
