### PR TITLE
[API Gateway] Condition sign in annotation

### DIFF
--- a/pkg/platform/kube/apigatewayres/lazy.go
+++ b/pkg/platform/kube/apigatewayres/lazy.go
@@ -267,6 +267,11 @@ func (lc *lazyClient) generateNginxIngress(ctx context.Context,
 		}
 	case ingress.AuthenticationModeOauth2:
 		commonIngressSpec.AuthenticationMode = ingress.AuthenticationModeOauth2
+		if apiGateway.Spec.Authentication != nil && apiGateway.Spec.Authentication.DexAuth != nil {
+			commonIngressSpec.Authentication = &ingress.Authentication{
+				DexAuth: apiGateway.Spec.Authentication.DexAuth,
+			}
+		}
 	case ingress.AuthenticationModeAccessKey:
 		commonIngressSpec.AuthenticationMode = ingress.AuthenticationModeAccessKey
 	default:

--- a/pkg/platform/kube/apigatewayres/lazy.go
+++ b/pkg/platform/kube/apigatewayres/lazy.go
@@ -269,7 +269,9 @@ func (lc *lazyClient) generateNginxIngress(ctx context.Context,
 		commonIngressSpec.AuthenticationMode = ingress.AuthenticationModeOauth2
 		if apiGateway.Spec.Authentication != nil && apiGateway.Spec.Authentication.DexAuth != nil {
 			commonIngressSpec.Authentication = &ingress.Authentication{
-				DexAuth: apiGateway.Spec.Authentication.DexAuth,
+				DexAuth: &ingress.DexAuth{
+					RedirectUnauthorizedToSignIn: apiGateway.Spec.Authentication.DexAuth.RedirectUnauthorizedToSignIn,
+				},
 			}
 		}
 	case ingress.AuthenticationModeAccessKey:

--- a/pkg/platform/kube/apigatewayres/lazy.go
+++ b/pkg/platform/kube/apigatewayres/lazy.go
@@ -269,9 +269,7 @@ func (lc *lazyClient) generateNginxIngress(ctx context.Context,
 		commonIngressSpec.AuthenticationMode = ingress.AuthenticationModeOauth2
 		if apiGateway.Spec.Authentication != nil && apiGateway.Spec.Authentication.DexAuth != nil {
 			commonIngressSpec.Authentication = &ingress.Authentication{
-				DexAuth: &ingress.DexAuth{
-					RedirectUnauthorizedToSignIn: apiGateway.Spec.Authentication.DexAuth.RedirectUnauthorizedToSignIn,
-				},
+				DexAuth: apiGateway.Spec.Authentication.DexAuth,
 			}
 		}
 	case ingress.AuthenticationModeAccessKey:

--- a/pkg/platform/kube/ingress/types.go
+++ b/pkg/platform/kube/ingress/types.go
@@ -34,7 +34,8 @@ type BasicAuth struct {
 }
 
 type DexAuth struct {
-	Oauth2ProxyURL string `json:"oauth2ProxyUrl,omitempty"`
+	Oauth2ProxyURL               string `json:"oauth2ProxyUrl,omitempty"`
+	RedirectUnauthorizedToSignIn bool   `json:"redirectUnauthorizedToSignIn,omitempty"`
 }
 
 type AuthenticationMode string

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -265,13 +265,17 @@ func (agc *APIGatewayConfig) scrubAPIGatewayData() {
 }
 
 type APIGatewayAuthenticationSpec struct {
-	BasicAuth *BasicAuth       `json:"basicAuth,omitempty"`
-	DexAuth   *ingress.DexAuth `json:"dexAuth,omitempty"`
+	BasicAuth *BasicAuth `json:"basicAuth,omitempty"`
+	DexAuth   *DexAuth   `json:"dexAuth,omitempty"`
 }
 
 type BasicAuth struct {
 	Username string `json:"username"`
 	Password string `json:"password,omitempty"`
+}
+
+type DexAuth struct {
+	RedirectUnauthorizedToSignIn bool `json:"redirectUnauthorizedToSignIn,omitempty"`
 }
 
 type APIGatewayUpstreamKind string

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -265,17 +265,13 @@ func (agc *APIGatewayConfig) scrubAPIGatewayData() {
 }
 
 type APIGatewayAuthenticationSpec struct {
-	BasicAuth *BasicAuth `json:"basicAuth,omitempty"`
-	DexAuth   *DexAuth   `json:"dexAuth,omitempty"`
+	BasicAuth *BasicAuth       `json:"basicAuth,omitempty"`
+	DexAuth   *ingress.DexAuth `json:"dexAuth,omitempty"`
 }
 
 type BasicAuth struct {
 	Username string `json:"username"`
 	Password string `json:"password,omitempty"`
-}
-
-type DexAuth struct {
-	RedirectUnauthorizedToSignIn bool `json:"redirectUnauthorizedToSignIn,omitempty"`
 }
 
 type APIGatewayUpstreamKind string


### PR DESCRIPTION
Added new `RedirectUnauthorizedToSignIn` bool to `DexAuth` inside `APIGatewayAuthenticationSpec`
When this is true, the `"nginx.ingress.kubernetes.io/auth-signin"` annotation is added to the underlying ingress.
The effect - when the ingress gets a request it tries to authorize it by sending request to the `"nginx.ingress.kubernetes.io/auth-url"`, if it fail, if the `auth-signin` is defined it returns a redirect to it, if it's not defined it returns 401.
The bad side of defining the `auth-signin` is that it will mostly be some UI login screen, so a script sending request to the ingress and being redirected to the login screen might mistakenly think the request passed successfully, while it just got a 200 response with html body (the login screen).
Bottomline, setting the `auth-signin` is only suggested for API gateways that are purposed to be used from some GUI (like a browser)
The default for `RedirectUnauthorizedToSignIn` is false -> `auth-signin` won't be set

Also separated API gateways' `DexAuth` from `ingress.DexAuth` cause they are different now