### PR TITLE
UI: Wrong conditions for Invocation URL, Test button, invoke-via

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5652,9 +5652,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.25.7.tgz",
-      "integrity": "sha512-bbhMVa3rQ/XnSoD+Z8K77JkG9eUfMd/gFCFkP4b1vy5x2pzarpYP1k2npgm3e3YoyAbbbQ3StUPdFS+rRVhpUQ==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.26.0.tgz",
+      "integrity": "sha512-OHbCvkAhY//+ykgxQ+b9O1jwn2cESYjlrxQ39ExcCsVsg2nDuQdqCdGX6gwuPoDNoBYhGD/Jup2/E4yEMZVD6g==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -49,7 +49,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.25.7",
+    "iguazio.dashboard-controls": "^0.26.0",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",

--- a/pkg/dashboard/ui/src/app/components/data-wrappers/function-events-data-wrapper/function-events-data-wrapper.component.js
+++ b/pkg/dashboard/ui/src/app/components/data-wrappers/function-events-data-wrapper/function-events-data-wrapper.component.js
@@ -53,11 +53,12 @@
         /**
          * Invoke function event
          * @param {Object} eventData
+         * @param {string} invokeVia
          * @param {Promise} canceller
          * @returns {Promise}
          */
-        function invokeFunction(eventData, canceller) {
-            return NuclioEventDataService.invokeFunction(eventData, canceller);
+        function invokeFunction(eventData, invokeVia, canceller) {
+            return NuclioEventDataService.invokeFunction(eventData, invokeVia, canceller);
         }
     }
 }());

--- a/pkg/dashboard/ui/src/app/components/data-wrappers/function-events-data-wrapper/function-events-data-wrapper.tpl.html
+++ b/pkg/dashboard/ui/src/app/components/data-wrappers/function-events-data-wrapper/function-events-data-wrapper.tpl.html
@@ -2,5 +2,5 @@
                          data-delete-function-event="$ctrl.deleteFunctionEvent(eventData)"
                          data-get-function-events="$ctrl.getFunctionEvents(functionData)"
                          data-create-function-event="$ctrl.createFunctionEvent(eventData, isNewEvent)"
-                         data-invoke-function="$ctrl.invokeFunction(eventData, canceler)">
+                         data-invoke-function="$ctrl.invokeFunction(eventData, invokeVia, canceler)">
 </ncl-function-event-pane>

--- a/pkg/dashboard/ui/src/app/shared/services/nuclio-event-data.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/nuclio-event-data.service.js
@@ -94,14 +94,16 @@
         /**
          * Invokes the function.
          * @param {Object} eventData - the function event to invoke function with.
+         * @param {string} [invokeVia='external-ip'] - via which mechanism to invoke the function, 'domain-name' or
+         *     'external-ip'.
          * @param {Promise} [canceler] - if provided, function invocation is canceled on resolving this promise.
          * @returns {Promise}
          */
-        function invokeFunction(eventData, canceler) {
+        function invokeFunction(eventData, invokeVia, canceler) {
             var userDefinedHeaders = lodash.get(eventData, 'spec.attributes.headers', {});
             var headers = lodash.assign({}, userDefinedHeaders, {
                 'x-nuclio-function-name': eventData.metadata.labels['nuclio.io/function-name'],
-                'x-nuclio-invoke-via': 'external-ip',
+                'x-nuclio-invoke-via': lodash.defaultTo(invokeVia, 'external-ip'),
                 'x-nuclio-path': eventData.spec.attributes.path,
                 'x-nuclio-log-level': eventData.spec.attributes.logLevel
             });


### PR DESCRIPTION
After fix:
- On K8s platform with `ClusterIP` service type:
  - Invocation URL: always "URL not exposed"
  - Test button: always enabled (unless function is not running, etc.)
  - `x-nuclio-invoke-via` request header: `domain-name`
- On K8s platform with `NodePort` service type and on non-K8s platform:
  - Invocation URL:
    - comprises of external IP address and port number in case they are valid
    - "URL not exposed" otherwise
  - Test button:
    - enabled in case external IP address and port number are valid
    - disabled otherwise (and when function is not running, etc.)
  - `x-nuclio-invoke-via` request header: `external-ip`