### PR TITLE
Followup - reserved resource name

### DIFF
--- a/pkg/nuctl/test/apigagteway_test.go
+++ b/pkg/nuctl/test/apigagteway_test.go
@@ -86,6 +86,33 @@ func (suite *apiGatewayCreateGetAndDeleteTestSuite) TestCreateGetAndDelete() {
 	}
 }
 
+func (suite *apiGatewayCreateGetAndDeleteTestSuite) TestCreateFailsOnReservedResourceName() {
+	suite.ensureRunningOnPlatform("kube")
+	apiGatewayName := "dashboard"
+
+	namedArgs := map[string]string{
+		"host":                "some-host",
+		"description":         "some-description",
+		"path":                "some-path",
+		"authentication-mode": "basicAuth",
+		"basic-auth-username": "basic-username",
+		"basic-auth-password": "basic-password",
+		"function":            "function",
+		"canary-function":     "canary-function",
+		"canary-percentage":   "25",
+	}
+
+	// remove leftovers in case test failed for any reason
+	defer suite.ExecuteNuctl([]string{"delete", "apigateway", apiGatewayName}, nil) // nolint: errcheck
+
+	err := suite.ExecuteNuctl([]string{
+		"create",
+		"apigateway",
+		apiGatewayName,
+	}, namedArgs)
+	suite.Require().Error(err, "Resource name is reserved and its creation should be failed")
+}
+
 type apiGatewayInvokeTestSuite struct {
 	Suite
 }

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -918,7 +918,7 @@ func (suite *functionDeployTestSuite) TestDeployAndRedeployHTTPTriggerPortChange
 	suite.Require().Equal(desiredHTTPPort, deployedFunctionConfig.Status.HTTPPort)
 }
 
-func (suite *functionDeployTestSuite) TestDeployFailsOnPreservedFunctionName() {
+func (suite *functionDeployTestSuite) TestDeployFailsOnReservedFunctionName() {
 	functionName := "dashboard"
 	imageName := "nuclio/processor-" + functionName
 

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -294,8 +294,8 @@ func (ap *Platform) EnrichFunctionsWithDeployLogStream(functions []platform.Func
 // Validation and enforcement of required function creation logic
 func (ap *Platform) ValidateCreateFunctionOptions(createFunctionOptions *platform.CreateFunctionOptions) error {
 
-	if common.StringInSlice(createFunctionOptions.FunctionConfig.Meta.Name, ap.resolvePreservedFunctionNames()) {
-		return nuclio.NewErrPreconditionFailed(fmt.Sprintf("Function name %s is preserved and cannot be used.",
+	if common.StringInSlice(createFunctionOptions.FunctionConfig.Meta.Name, ap.ResolveReservedResourceNames()) {
+		return nuclio.NewErrPreconditionFailed(fmt.Sprintf("Function name %s is reserved and cannot be used.",
 			createFunctionOptions.FunctionConfig.Meta.Name))
 	}
 
@@ -329,45 +329,16 @@ func (ap *Platform) ValidateDeleteProjectOptions(deleteProjectOptions *platform.
 	return nil
 }
 
-func (ap *Platform) validateProjectIsEmpty(namespace, projectName string) error {
+// ResolveReservedFunctionNames returns a list of reserved resource names
+func (ap *Platform) ResolveReservedResourceNames() []string {
 
-	// validate the project has no functions
-	getFunctionsOptions := &platform.GetFunctionsOptions{
-		Namespace: namespace,
-		Labels:    fmt.Sprintf("nuclio.io/project-name=%s", projectName),
+	// these names are reserved for Nuclio internal purposes and to avoid collisions with nuclio internal resources
+	return []string{
+		"dashboard",
+		"controller",
+		"dlx",
+		"scaler",
 	}
-
-	functions, err := ap.platform.GetFunctions(getFunctionsOptions)
-	if err != nil {
-		return errors.Wrap(err, "Failed to get functions")
-	}
-
-	if len(functions) != 0 {
-		return platform.ErrProjectContainsFunctions
-	}
-
-	// validate the project has no api gateways
-	getAPIGatewaysOptions := &platform.GetAPIGatewaysOptions{
-		Namespace: namespace,
-		Labels:    fmt.Sprintf("nuclio.io/project-name=%s", projectName),
-	}
-
-	apiGateways, err := ap.platform.GetAPIGateways(getAPIGatewaysOptions)
-	if err != nil {
-
-		// if api gateways are not supported on this platform, just ignore this validation
-		if err == platform.ErrUnsupportedMethod {
-			return nil
-		}
-
-		return errors.Wrap(err, "Failed to get api gateways")
-	}
-
-	if len(apiGateways) != 0 {
-		return platform.ErrProjectContainsAPIGateways
-	}
-
-	return nil
 }
 
 // CreateFunctionInvocation will invoke a previously deployed function
@@ -952,13 +923,43 @@ func (ap *Platform) enrichMinMaxReplicas(createFunctionOptions *platform.CreateF
 	}
 }
 
-func (ap *Platform) resolvePreservedFunctionNames() []string {
+func (ap *Platform) validateProjectIsEmpty(namespace, projectName string) error {
 
-	// these names are preserved for Nuclio internal purposes and to avoid collisions with nuclio internal resources
-	return []string{
-		"dashboard",
-		"controller",
-		"dlx",
-		"scaler",
+	// validate the project has no functions
+	getFunctionsOptions := &platform.GetFunctionsOptions{
+		Namespace: namespace,
+		Labels:    fmt.Sprintf("nuclio.io/project-name=%s", projectName),
 	}
+
+	functions, err := ap.platform.GetFunctions(getFunctionsOptions)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get functions")
+	}
+
+	if len(functions) != 0 {
+		return platform.ErrProjectContainsFunctions
+	}
+
+	// validate the project has no api gateways
+	getAPIGatewaysOptions := &platform.GetAPIGatewaysOptions{
+		Namespace: namespace,
+		Labels:    fmt.Sprintf("nuclio.io/project-name=%s", projectName),
+	}
+
+	apiGateways, err := ap.platform.GetAPIGateways(getAPIGatewaysOptions)
+	if err != nil {
+
+		// if api gateways are not supported on this platform, just ignore this validation
+		if err == platform.ErrUnsupportedMethod {
+			return nil
+		}
+
+		return errors.Wrap(err, "Failed to get api gateways")
+	}
+
+	if len(apiGateways) != 0 {
+		return platform.ErrProjectContainsAPIGateways
+	}
+
+	return nil
 }

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
@@ -1085,6 +1086,11 @@ func (p *Platform) enrichAndValidateAPIGatewayName(apiGateway *nuclioio.NuclioAP
 	}
 	if apiGateway.Spec.Name != apiGateway.Name {
 		return nuclio.NewErrBadRequest("Api gateway metadata.name must match api gateway spec.name")
+	}
+
+	if common.StringInSlice(apiGateway.Spec.Name, p.ResolveReservedResourceNames()) {
+		return nuclio.NewErrPreconditionFailed(fmt.Sprintf("APIGateway name %s is reserved and cannot be used.",
+			apiGateway.Spec.Name))
 	}
 
 	return nil


### PR DESCRIPTION
Following up with #1884 to fix typo of *preserved* -> *reserved* 
and added validation on api gateway as well