### PR TITLE
Renamed apigateway ingress resources to prefixed with nuclio

### DIFF
--- a/pkg/platform/kube/apigatewayres/lazy.go
+++ b/pkg/platform/kube/apigatewayres/lazy.go
@@ -260,7 +260,7 @@ func (lc *lazyClient) generateNginxIngress(ctx context.Context,
 		commonIngressSpec.AuthenticationMode = ingress.AuthenticationModeBasicAuth
 		commonIngressSpec.Authentication = &ingress.Authentication{
 			BasicAuth: &ingress.BasicAuth{
-				Name:     fmt.Sprintf("apigateway-%s", apiGateway.Name),
+				Name:     kube.BasicAuthNameFromAPIGatewayName(apiGateway.Name),
 				Username: apiGateway.Spec.Authentication.BasicAuth.Username,
 				Password: apiGateway.Spec.Authentication.BasicAuth.Password,
 			},

--- a/pkg/platform/kube/apigatewayres/lazy.go
+++ b/pkg/platform/kube/apigatewayres/lazy.go
@@ -278,21 +278,11 @@ func (lc *lazyClient) generateNginxIngress(ctx context.Context,
 		return nil, errors.New("Unsupported ApiGateway authentication mode provided")
 	}
 
-	// add nginx specific annotations
-	annotations := map[string]string{}
-	annotations["kubernetes.io/ingress.class"] = "nginx"
+	// if percentage is given, it is the canary deployment
+	canaryDeployment := upstream.Percentage != 0
+	commonIngressSpec.Name = kube.IngressNameFromAPIGatewayName(apiGateway.Name, canaryDeployment)
 
-	// if percentage is given, it is the canary upstream
-	if upstream.Percentage != 0 {
-		annotations["nginx.ingress.kubernetes.io/canary"] = "true"
-		annotations["nginx.ingress.kubernetes.io/canary-weight"] = strconv.FormatInt(int64(upstream.Percentage), 10)
-		commonIngressSpec.Name = kube.IngressNameFromAPIGatewayName(apiGateway.Name, true)
-	} else {
-		commonIngressSpec.Name = kube.IngressNameFromAPIGatewayName(apiGateway.Name, false)
-	}
-
-	commonIngressSpec.Annotations = annotations
-
+	commonIngressSpec.Annotations = lc.resolveCommonAnnotations(canaryDeployment, upstream.Percentage)
 	for annotationKey, annotationValue := range upstream.ExtraAnnotations {
 		commonIngressSpec.Annotations[annotationKey] = annotationValue
 	}
@@ -331,6 +321,20 @@ func (lc *lazyClient) getServiceHTTPPort(service v1.Service) (int, error) {
 	}
 
 	return 0, errors.New("Service has no http port")
+}
+
+func (lc *lazyClient) resolveCommonAnnotations(canaryDeployment bool, upstreamPercentage int) map[string]string {
+	annotations := map[string]string{}
+
+	// add nginx specific annotations
+	annotations["kubernetes.io/ingress.class"] = "nginx"
+
+	// add canary deployment specific annotations
+	if canaryDeployment {
+		annotations["nginx.ingress.kubernetes.io/canary"] = "true"
+		annotations["nginx.ingress.kubernetes.io/canary-weight"] = strconv.Itoa(upstreamPercentage)
+	}
+	return annotations
 }
 
 //

--- a/pkg/platform/kube/types.go
+++ b/pkg/platform/kube/types.go
@@ -26,11 +26,11 @@ type DeployOptions struct {
 }
 
 func IngressNameFromAPIGatewayName(apiGatewayName string, canary bool) string {
+	resourceName := fmt.Sprintf("nuclio-apigateway-%s", apiGatewayName)
 	if canary {
-		return fmt.Sprintf("apigateway-%s-canary", apiGatewayName)
+		resourceName = resourceName + "-canary"
 	}
-
-	return fmt.Sprintf("apigateway-%s", apiGatewayName)
+	return resourceName
 }
 
 func DeploymentNameFromFunctionName(functionName string) string {

--- a/pkg/platform/kube/types.go
+++ b/pkg/platform/kube/types.go
@@ -26,7 +26,7 @@ type DeployOptions struct {
 }
 
 func IngressNameFromAPIGatewayName(apiGatewayName string, canary bool) string {
-	resourceName := fmt.Sprintf("nuclio-%s", apiGatewayName)
+	resourceName := fmt.Sprintf("nuclio-agw-%s", apiGatewayName)
 	if canary {
 		resourceName = resourceName + "-canary"
 	}

--- a/pkg/platform/kube/types.go
+++ b/pkg/platform/kube/types.go
@@ -33,6 +33,10 @@ func IngressNameFromAPIGatewayName(apiGatewayName string, canary bool) string {
 	return resourceName
 }
 
+func BasicAuthNameFromAPIGatewayName(apiGatewayName string) string {
+	return fmt.Sprintf("nuclio-agw-%s", apiGatewayName)
+}
+
 func DeploymentNameFromFunctionName(functionName string) string {
 	return fmt.Sprintf("nuclio-%s", functionName)
 }

--- a/pkg/platform/kube/types.go
+++ b/pkg/platform/kube/types.go
@@ -26,7 +26,7 @@ type DeployOptions struct {
 }
 
 func IngressNameFromAPIGatewayName(apiGatewayName string, canary bool) string {
-	resourceName := fmt.Sprintf("nuclio-apigateway-%s", apiGatewayName)
+	resourceName := fmt.Sprintf("nuclio-%s", apiGatewayName)
 	if canary {
 		resourceName = resourceName + "-canary"
 	}


### PR DESCRIPTION
Prefixed apigateway to start with `nuclio` to aligned with all nuclio kubernetes managed resources
Shorthanded apigateway to `agw` to avoid name too long and kept it in to relate ingress name to apigateway feature