### PR TITLE
Switch ServiceType Default to ClusterIP

### DIFF
--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -115,5 +115,5 @@ const (
 	ProcessorCronTriggerCreationMode CronTriggerCreationMode = "processor"
 	KubeCronTriggerCreationMode      CronTriggerCreationMode = "kube"
 
-	DefaultServiceType = corev1.ServiceTypeNodePort
+	DefaultServiceType = corev1.ServiceTypeClusterIP
 )


### PR DESCRIPTION
From now on,
Functions will be created with ClusterIP ServiceType by default.
This means functions will not be exposed outside the k8s cluster, unless:
 - Either an ingress is created to expose the http trigger
 - Or the ServiceType of the http trigger is specified as NodePort