### PR TITLE
Bump dashboard image node version

### DIFF
--- a/cmd/dashboard/docker/Dockerfile
+++ b/cmd/dashboard/docker/Dockerfile
@@ -17,7 +17,7 @@
 #
 ARG NUCLIO_LABEL
 
-FROM node:8 as build-static
+FROM node:10.21.0 as build-static
 
 # copy source tree
 COPY ./pkg/dashboard/ui /home/nuclio/dashboard/src


### PR DESCRIPTION
We've been using this version lately for our dashboard image. after discussion with @eran-nussbaum we considered this bump safe.