### PR TITLE
UI: HTTP trigger tweaks; Disallow naming after reserved words

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5652,9 +5652,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.27.0.tgz",
-      "integrity": "sha512-SFbB7L6EjxP+ks01thnR1sv32nngIAXKVw+G3ObI/APLk3FNnRVvyCqbXz/PrgqFmGzSGmV4vlAVtFeQqEXYrw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.28.0.tgz",
+      "integrity": "sha512-hm1/KzI+jgrMu84T/YrgVonV4NBCJwqTxVbo73CEzgJpndVePcvuVGVR8R9W84JjAAMeAWfJ0Ydq93BmVOOvXA==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -49,7 +49,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.27.0",
+    "iguazio.dashboard-controls": "^0.28.0",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
- Function › Triggers › HTTP:
  - Reword message when no HTTP trigger exists
    ![image](https://user-images.githubusercontent.com/13918850/98348656-b3f32c80-2021-11eb-908b-22ba32cd4043.png)
  - Fix: HTTP trigger name's more-info tooltip missing on init and appears only after trigger item is expanded then collapsed.
    ![image](https://user-images.githubusercontent.com/13918850/98348680-bd7c9480-2021-11eb-99fc-8dc015e7b610.png)
    ![image](https://user-images.githubusercontent.com/13918850/98348695-c2414880-2021-11eb-85d0-bc6773635216.png)
  - When using the link in the above message to add a new HTTP trigger:
    - Set its name `http` instead of value from backend (`default-http`).
    - Start in edit mode of trigger (expanded with input fields).
    - Disable the Deploy button (until trigger item is applied validly).
    ![image](https://user-images.githubusercontent.com/13918850/98348738-cec5a100-2021-11eb-9339-39a92667587b.png)
- Function › Configuration › Labels: added 'nuclio.io' as an invalid prefix:
  ![image](https://user-images.githubusercontent.com/13918850/98027521-7a4dd600-1e15-11eb-89c3-f3982ead7ff8.png)
- API gateways › Wizard › Authentication › OAuth2: added “Redirect unauthorized requests” checkbox field
  ![image](https://user-images.githubusercontent.com/13918850/98248713-fbc07800-1f7d-11eb-9c37-c6e255303ae4.png)
- Disallow naming functions and API gateways after the following reserved words: `dashboard`, `controller`, `dlx`, `scaler`
  - Create new function:
    - From template:
      ![image](https://user-images.githubusercontent.com/13918850/98006696-3fd73f80-1dfb-11eb-9e32-5ccdef55ccf6.png)
    - From scratch:
      ![image](https://user-images.githubusercontent.com/13918850/98006730-48c81100-1dfb-11eb-88d1-b732a4f56bb4.png)
  - Duplicate function pop-up:
    ![image](https://user-images.githubusercontent.com/13918850/98006763-51204c00-1dfb-11eb-912e-7bad055ce829.png)
  - API gateways wizard:
    ![image](https://user-images.githubusercontent.com/13918850/98006810-5a111d80-1dfb-11eb-89c1-7ae6f78d5ba6.png)