### PR TITLE
UI: No invocation URL when HTTP trigger has ingresses

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5652,9 +5652,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.28.0.tgz",
-      "integrity": "sha512-hm1/KzI+jgrMu84T/YrgVonV4NBCJwqTxVbo73CEzgJpndVePcvuVGVR8R9W84JjAAMeAWfJ0Ydq93BmVOOvXA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.28.2.tgz",
+      "integrity": "sha512-guilcHVGp5Z7jI1Uw16DIB8Mw2GGyuRhyHjh6s5UXT6bzlRmY78upbvoeXAetiUa1dW6wwY3lxQOnEEtJkBdvA==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -49,7 +49,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.28.0",
+    "iguazio.dashboard-controls": "^0.28.2",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
The issue originated in the wrong assumption that triggers on backend model are a list (array), while actually they are a dictionary (object).

Depends on PR https://github.com/iguazio/dashboard-controls/pull/1118