### PR TITLE
[API gateways] Hide when on non-K8s platform

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5652,9 +5652,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.28.2.tgz",
-      "integrity": "sha512-guilcHVGp5Z7jI1Uw16DIB8Mw2GGyuRhyHjh6s5UXT6bzlRmY78upbvoeXAetiUa1dW6wwY3lxQOnEEtJkBdvA==",
+      "version": "0.28.4",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.28.4.tgz",
+      "integrity": "sha512-P/ep61+9vr+FgulhanZpjm7gZ/knW2Fb4drE+YpukX7XTgVGXE5t03wsa8AX67GVvEaoWY1gVOEeD36Yx16BOw==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -49,7 +49,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.28.2",
+    "iguazio.dashboard-controls": "^0.28.4",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",

--- a/pkg/dashboard/ui/src/app/app.route.js
+++ b/pkg/dashboard/ui/src/app/app.route.js
@@ -113,6 +113,16 @@
                 data: {
                     pageTitle: 'functions:API_GATEWAYS',
                     mainHeaderTitle: 'functions:API_GATEWAYS',
+                },
+                resolve: {
+                    kubePlatform: ['$state', '$timeout', 'FunctionsService',
+                        function ($state, $timeout, FunctionsService) {
+                            return $timeout(function () {
+                                if (!FunctionsService.isKubePlatform()) {
+                                    $state.go('app.projects');
+                                }
+                            });
+                        }]
                 }
             })
             .state('app.project.create-function', {

--- a/pkg/dashboard/ui/src/app/shared/services/nuclio-api-gateways-data.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/nuclio-api-gateways-data.service.js
@@ -125,7 +125,7 @@
 
             var config = {
                 method: 'put',
-                url: NuclioClientService.buildUrlWithPath('api_gateways/'),
+                url: NuclioClientService.buildUrlWithPath('api_gateways'),
                 headers: headers,
                 data: apiGateway,
                 withCredentials: false


### PR DESCRIPTION
- Project screen: hide API gateways tab when running on non-K8s platform
  - On K8s:
    ![image](https://user-images.githubusercontent.com/13918850/98702442-0b2b3100-2383-11eb-8d4b-dc7fb6afd7d2.png)
    ![image](https://user-images.githubusercontent.com/13918850/98702445-0cf4f480-2383-11eb-8b22-61769c75dcc0.png)
  - On non-K8s:
    ![image](https://user-images.githubusercontent.com/13918850/98702462-10887b80-2383-11eb-8f5c-5b182e2e0046.png)


Depends on PR https://github.com/iguazio/dashboard-controls/pull/1122