### PR TITLE
Python runtime to recover from msgpack decoding exceptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -494,14 +494,13 @@ test-nodejs:
 
 .PHONY: test-python
 test-python:
-	docker build \
-		--build-arg CACHEBUST=$(shell date +%s) \
-		--build-arg PYTHON_IMAGE_TAG=3.6-slim-stretch \
-		-f pkg/processor/runtime/python/test/Dockerfile .
-	docker build \
-		--build-arg CACHEBUST=$(shell date +%s) \
-		--build-arg PYTHON_IMAGE_TAG=2.7-slim-stretch \
-		-f pkg/processor/runtime/python/test/Dockerfile .
+	@$(eval PYTHON_IMAGE_TAGS ?= 3.9 3.8 3.7 3.6 2.7)
+	@$(eval TEST_BUILD_COMMANDS := $(foreach PYTHON_IMAGE_TAG,$(PYTHON_IMAGE_TAGS), docker build \
+	  --build-arg PYTHON_IMAGE_TAG=$(PYTHON_IMAGE_TAG) \
+	  --build-arg CACHEBUST=$(shell date +%s) \
+	  --file pkg/processor/runtime/python/test/Dockerfile \
+	  .;))
+	@$(foreach TEST_BUILD_COMMAND,$(TEST_BUILD_COMMANDS), $(TEST_BUILD_COMMAND))
 
 .PHONY: test-short
 test-short: modules ensure-gopath

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -116,7 +116,7 @@ class Wrapper(object):
 
             except UnicodeDecodeError as exc:
 
-                # in case of an unpacking error, reset unpacker to avoid consecutive errors
+                # reset unpacker to avoid consecutive errors
                 self._unpacker = self._resolve_unpacker()
                 self._on_serving_error(exc)
 

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -61,10 +61,8 @@ class Wrapper(object):
         # make a writeable file from processor
         self._processor_sock_wfile = self._processor_sock.makefile('w')
 
-        # since this wrapper is behind the nuclio processor, in which pre-handle the traffic & request
-        # it is not mandatory to provide security over max buffer size.
-        # the request limit should be handled on the processor level.
-        self._unpacker = msgpack.Unpacker(raw=False, max_buffer_size=2 ** 32 - 1)
+        # create msgpack unpacker
+        self._unpacker = self._resolve_unpacker()
 
         # get handler module
         entrypoint_module = sys.modules[self._entrypoint.__module__]
@@ -95,6 +93,7 @@ class Wrapper(object):
         while True:
 
             try:
+
                 # resolve event message length
                 event_message_length = self._resolve_event_message_length()
 
@@ -106,21 +105,23 @@ class Wrapper(object):
 
                 try:
                     self._handle_event(event)
-
                 except BaseException as exc:
-                    self._handle_serving_error('Exception caught in handler "{0}": {1}'.format(exc,
-                                                                                               traceback.format_exc()))
+                    self._on_handle_event_error(exc)
 
             except WrapperFatalException as exc:
-                self._handle_serving_error('Fatal error: "{0}": {1}'.format(exc,
-                                                                            traceback.format_exc()))
+                self._on_serving_error(exc)
 
                 # explode
                 self._shutdown(error_code=1)
 
+            except UnicodeDecodeError as exc:
+
+                # in case of an unpacking error, reset unpacker to avoid consecutive errors
+                self._unpacker = self._resolve_unpacker()
+                self._on_serving_error(exc)
+
             except Exception as exc:
-                self._handle_serving_error('Exception caught while serving "{0}": {1}'.format(exc,
-                                                                                              traceback.format_exc()))
+                self._on_serving_error(exc)
 
             # for testing, we can ask wrapper to only read a set number of requests
             if num_requests is not None and num_requests != 0:
@@ -128,6 +129,14 @@ class Wrapper(object):
 
             if num_requests == 0:
                 break
+
+    def _resolve_unpacker(self):
+        """
+        Since this wrapper is behind the nuclio processor, in which pre-handle the traffic & request
+        it is not mandatory to provide security over max buffer size.
+        the request limit should be handled on the processor level.
+        """
+        return msgpack.Unpacker(raw=False, max_buffer_size=2 ** 32 - 1)
 
     def _load_entrypoint_from_handler(self, handler):
         """
@@ -173,15 +182,6 @@ class Wrapper(object):
         self._processor_sock_wfile.write(body + '\n')
         self._processor_sock_wfile.flush()
 
-    def _log_and_encode_exception(self, formatted_exception, log_level='warn'):
-        getattr(self._logger, log_level)(formatted_exception)
-        return self._json_encoder.encode({
-            'body': formatted_exception,
-            'body_encoding': 'text',
-            'content_type': 'text/plain',
-            'status_code': 500,
-        })
-
     def _resolve_event_message_length(self):
 
         # used for the first message, to determine the body size
@@ -218,9 +218,28 @@ class Wrapper(object):
 
         return next(self._unpacker)
 
-    def _handle_serving_error(self, formatted_exception):
+    def _on_serving_error(self, exc):
+        self._log_and_response_error(exc, 'Exception caught while serving')
+
+    def _on_handle_event_error(self, exc):
+        error_message = 'Exception caught in handler'
+        formatted_response_error = '{0} - "{1}": {2}'.format(error_message,
+                                                             exc,
+                                                             traceback.format_exc())
+        self._log_and_response_error(exc, error_message, formatted_response_error)
+
+    def _log_and_response_error(self, exc, error_message, overridden_response_error=''):
+        self._logger.error_with(error_message, exc=str(exc), traceback=traceback.format_exc())
+        self._write_response_error(overridden_response_error or error_message)
+
+    def _write_response_error(self, body):
         try:
-            encoded_response = self._log_and_encode_exception(formatted_exception)
+            encoded_response = self._json_encoder.encode({
+                'body': body,
+                'body_encoding': 'text',
+                'content_type': 'text/plain',
+                'status_code': 500,
+            })
 
             # try write the formatted exception back to processor
             self._write_packet_to_processor('r' + encoded_response)

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -222,15 +222,14 @@ class Wrapper(object):
         self._log_and_response_error(exc, 'Exception caught while serving')
 
     def _on_handle_event_error(self, exc):
-        error_message = 'Exception caught in handler'
-        formatted_response_error = '{0} - "{1}": {2}'.format(error_message,
-                                                             exc,
-                                                             traceback.format_exc())
-        self._log_and_response_error(exc, error_message, formatted_response_error)
+        self._log_and_response_error(exc, 'Exception caught in handler')
 
-    def _log_and_response_error(self, exc, error_message, overridden_response_error=''):
+    def _log_and_response_error(self, exc, error_message):
+        encoded_error_response = '{0} - "{1}": {2}'.format(error_message,
+                                                           exc,
+                                                           traceback.format_exc())
         self._logger.error_with(error_message, exc=str(exc), traceback=traceback.format_exc())
-        self._write_response_error(overridden_response_error or error_message)
+        self._write_response_error(encoded_error_response or error_message)
 
     def _write_response_error(self, body):
         try:

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -72,7 +72,7 @@ class TestSubmitEvents(unittest.TestCase):
         self._unix_stream_server.shutdown()
         self._unix_stream_server_thread.join()
 
-    def test_nonutf8_message(self):
+    def test_non_utf8_headers(self):
         self._wait_for_socket_creation()
         self._wrapper._entrypoint = lambda context, event: event.body
 
@@ -82,7 +82,7 @@ class TestSubmitEvents(unittest.TestCase):
         ]
 
         # middle event is malformed
-        events[len(events) // 2]['path'] = b'\xda'
+        events[len(events) // 2]['headers']['x-nuclio'] = b'\xda'
 
         # send events
         t = threading.Thread(target=self._send_events, args=(events,))

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -34,9 +34,11 @@ import nuclio_sdk
 if sys.version_info[:2] >= (3, 0):
     from socketserver import UnixStreamServer, BaseRequestHandler
     from unittest import mock
+    import http.client as httpclient
 else:
     from SocketServer import UnixStreamServer, BaseRequestHandler
     import mock
+    import httplib as httpclient
 
 
 class TestSubmitEvents(unittest.TestCase):
@@ -69,6 +71,42 @@ class TestSubmitEvents(unittest.TestCase):
         self._unix_stream_server.server_close()
         self._unix_stream_server.shutdown()
         self._unix_stream_server_thread.join()
+
+    def test_nonutf8_message(self):
+        self._wait_for_socket_creation()
+        self._wrapper._entrypoint = lambda context, event: event.body
+
+        events = [
+            json.loads(nuclio_sdk.Event(_id=str(i), body='e{0}'.format(i)).to_json())
+            for i in range(3)
+        ]
+
+        # middle event is malformed
+        events[len(events) // 2]['path'] = b'\xda'
+
+        # send events
+        t = threading.Thread(target=self._send_events, args=(events,))
+        t.start()
+
+        self._wrapper.serve_requests(num_requests=len(events))
+        t.join()
+
+        # processor start
+        # duration
+        # function response
+        # malformed log line (wrapper)
+        # malformed response
+        # duration
+        # function response
+        self._wait_until_received_messages(7)
+
+        malformed_response = self._unix_stream_server._messages[4]['body']
+        self.assertEqual(httpclient.INTERNAL_SERVER_ERROR, malformed_response['status_code'])
+
+        # ensure messages coming after malformed request are still valid
+        last_function_response = self._unix_stream_server._messages[-1]['body']
+        self.assertEqual(httpclient.OK, last_function_response['status_code'])
+        self.assertEqual(events[-1]['body'], last_function_response['body'])
 
     def test_bad_function_code(self):
         def raise_exception(ctx, event):
@@ -140,7 +178,12 @@ class TestSubmitEvents(unittest.TestCase):
         recorded_event_ids = set()
         expected_events_length = 10000
 
-        t = threading.Thread(target=self._send_events, args=(expected_events_length,))
+        events = (
+            nuclio_sdk.Event(_id=i, body='e{}'.format(i))
+            for i in range(expected_events_length)
+        )
+
+        t = threading.Thread(target=self._send_events, args=(events,))
         t.start()
 
         self._wrapper._entrypoint = functools.partial(record_event, recorded_event_ids)
@@ -159,7 +202,11 @@ class TestSubmitEvents(unittest.TestCase):
             return 'OK'
 
         num_of_events = 10
-        self._send_events(num_of_events)
+        events = (
+            nuclio_sdk.Event(_id=i, body='e{}'.format(i))
+            for i in range(num_of_events)
+        )
+        self._send_events(events)
         self._wrapper._entrypoint = event_recorder
         self._wrapper.serve_requests(num_of_events)
         self.assertEqual(num_of_events, len(recorded_events), 'wrong number of events')
@@ -203,9 +250,11 @@ class TestSubmitEvents(unittest.TestCase):
     #     self.assertEqual(num_of_events, self._wrapper._entrypoint.call_count, 'Received unexpected number of events')
 
     def _send_event(self, event):
+        if not isinstance(event, dict):
+            event = self._event_to_dict(event)
 
         # pack exactly as processor or wrapper explodes
-        body = msgpack.Packer().pack(self._event_to_dict(event))
+        body = msgpack.Packer().pack(event)
 
         # big endian body len
         body_len = struct.pack(">I", len(body))
@@ -222,10 +271,10 @@ class TestSubmitEvents(unittest.TestCase):
     def _event_to_dict(self, event):
         return json.loads(event.to_json())
 
-    def _send_events(self, num_of_events):
+    def _send_events(self, events):
         self._wait_for_socket_creation()
-        for i in range(num_of_events):
-            self._send_event(nuclio_sdk.Event(_id=i, body='e{}'.format(i)))
+        for event in events:
+            self._send_event(event)
 
     def _wait_for_socket_creation(self, timeout=10, interval=0.1):
 
@@ -239,11 +288,12 @@ class TestSubmitEvents(unittest.TestCase):
             time.sleep(interval)
             current_messages_length = len(self._unix_stream_server._messages)
             if current_messages_length >= minimum_messages_length:
-                break
+                return
             self._logger.debug_with('Waiting for messages to arrive',
                                     current_messages_length=current_messages_length,
                                     minimum_messages_length=minimum_messages_length)
             timeout -= interval
+        raise RuntimeError('Failed waiting for messages')
 
     def _create_unix_stream_server(self, socket_path):
         unix_stream_server = _SingleConnectionUnixStreamServer(socket_path, _Connection)
@@ -329,7 +379,7 @@ class TestCallFunction(unittest.TestCase):
 
         # prepare a responder
         connection_response = mock.MagicMock()
-        connection_response.status = 204
+        connection_response.status = httpclient.NO_CONTENT
         connection_response.getheaders = lambda: [('Content-Type', 'application/json')]
         connection_response.read = mock.MagicMock(return_value='{"b": "some_response"}')
 
@@ -349,7 +399,7 @@ class TestCallFunction(unittest.TestCase):
 
         self.assertEqual({'b': 'some_response'}, response.body)
         self.assertEqual('application/json', response.content_type)
-        self.assertEqual(204, response.status_code)
+        self.assertEqual(httpclient.NO_CONTENT, response.status_code)
 
     def test_get_function_url(self):
         self.assertEqual(nuclio_sdk.Platform('local', 'ns')._get_function_url('function-name'),

--- a/pkg/processor/runtime/python/test/Dockerfile
+++ b/pkg/processor/runtime/python/test/Dockerfile
@@ -12,15 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PYTHON_IMAGE_TAG=3.6-slim-stretch
-
+ARG PYTHON_IMAGE_TAG=3.6
 FROM python:$PYTHON_IMAGE_TAG
 
 WORKDIR /nuclio
 
-RUN apt-get update && apt-get install gcc -y
+# copy common/dev requirements file
+COPY pkg/processor/runtime/python/py/requirements/dev.txt py/requirements/dev.txt
+COPY pkg/processor/runtime/python/py/requirements/common.txt py/requirements/common.txt
 
+# install common / dev
+RUN python -m pip install \
+    --requirement py/requirements/common.txt \
+    --requirement py/requirements/dev.txt
+
+# copy files
 COPY pkg/processor/runtime/python .
+
+# determine runtime version and install its packages (if exists)
+ARG PYTHON_IMAGE_TAG=3.6
+RUN RUNTIME_REQUIREMENTS_SPECIFIC_FILE="py/requirements/python$(echo "$PYTHON_IMAGE_TAG" | tr '.' '_').txt" \
+    && (test -f ${RUNTIME_REQUIREMENTS_SPECIFIC_FILE} \
+        && python -m pip install -r ${RUNTIME_REQUIREMENTS_SPECIFIC_FILE}) \
+        || true
 
 ARG CACHEBUST=1
 RUN ./test/test.sh

--- a/pkg/processor/runtime/python/test/test.sh
+++ b/pkg/processor/runtime/python/test/test.sh
@@ -20,19 +20,6 @@ set -o errexit
 # show command before execute
 set -o xtrace
 
-# shared
-python -m pip install -r py/requirements/common.txt
-
-# dev
-python -m pip install -r py/requirements/dev.txt
-
-# determine runtime version and install its packages
-if [[ $(python -V 2>&1) =~ 2\.7 ]]; then
-    python -m pip install -r py/requirements/python2.txt
-else
-    python -m pip install -r py/requirements/python3_6.txt
-fi
-
 # remove python cached
 find ./py \
     -name ".pytest_cache" -type d \


### PR DESCRIPTION
_msgpack_, our json binary encoder/decoder, use `utf8` to decode incoming events. When an incoming event contains, for an instance, a non `utf8` header value, it raises a decode exception and its internal buffer never get cleaned. This immediately put the function in bad shape as it is being able to respond to any consecutive incoming events.

In this PR:
1. reset unpacker upon decoding failures
2. avoid sending server exception traceback in response (unless raised within function handler)
3. Enhanced python wrapper tests (test on 2.7 and 3.6 to 3.9)
4. Fix python runtime integration test to be run from IDE