### PR TITLE
Fix integration test

### DIFF
--- a/pkg/processor/trigger/http/test/suite/http_test.go
+++ b/pkg/processor/trigger/http/test/suite/http_test.go
@@ -70,10 +70,10 @@ func (suite *HTTPTestSuite) TestCORS() {
 				},
 				ExpectedResponseStatusCode: &validPreflightResponseStatusCode,
 				ExpectedResponseHeadersValues: map[string][]string{
-					"Access-Control-Allow-Methods":  {allowMethods},
-					"Access-Control-Allow-Headers":  {allowHeaders},
-					"Access-Control-Allow-Origin":   {origin},
-					"Access-Control-Max-Age":        {strconv.Itoa(preflightMaxAgeSeconds)},
+					"Access-Control-Allow-Methods": {allowMethods},
+					"Access-Control-Allow-Headers": {allowHeaders},
+					"Access-Control-Allow-Origin":  {origin},
+					"Access-Control-Max-Age":       {strconv.Itoa(preflightMaxAgeSeconds)},
 				},
 			},
 			{

--- a/pkg/processor/trigger/http/test/suite/http_test.go
+++ b/pkg/processor/trigger/http/test/suite/http_test.go
@@ -70,7 +70,6 @@ func (suite *HTTPTestSuite) TestCORS() {
 				},
 				ExpectedResponseStatusCode: &validPreflightResponseStatusCode,
 				ExpectedResponseHeadersValues: map[string][]string{
-					"Access-Control-Expose-Headers": {exposeHeaders},
 					"Access-Control-Allow-Methods":  {allowMethods},
 					"Access-Control-Allow-Headers":  {allowHeaders},
 					"Access-Control-Allow-Origin":   {origin},


### PR DESCRIPTION
`Access-Control-Expose-Headers` is not part of CORS preflight response