### PR TITLE
Make event path normalization mode configurable

### DIFF
--- a/docs/reference/triggers/http.md
+++ b/docs/reference/triggers/http.md
@@ -15,8 +15,10 @@ The HTTP trigger is the only trigger created by default if not configured (by de
 | cors.allowOrigins | list of strings | Indicates that the CORS response can be shared with requesting code from the specified origin (`Access-Control-Allow-Origin` response header); (default: `['*']` to allow sharing with any origin, for requests without credentials). |
 | cors.allowMethods | list of strings | The allowed HTTP methods, which can be used when accessing the resource (`Access-Control-Allow-Methods` response header); (default: `"HEAD, GET, POST, PUT, DELETE, OPTIONS"`). |
 | cors.allowHeaders | list of strings | The allowed HTTP headers, which can be used when accessing the resource (`Access-Control-Allow-Headers` response header); (default: `"Accept, Content-Length, Content-Type, X-nuclio-log-level"`). |
+| cors.exposeHeaders | list of strings | The exposed HTTP Headers, which can be accessed by the user (`Access-Control-Expose-Headers` response header); (default: empty). |
 | cors.allowCredentials | bool | `true` to allow user credentials in the actual request (`Access-Control-Allow-Credentials` response header); (default: `false`). |
 | cors.preflightMaxAgeSeconds | int | The number of seconds in which the results of a preflight request can be cached in a preflight result cache (`Access-Control-Max-Age` response header); (default: `-1` to indicate no preflight results caching). |
+| disablePathNormalizing | bool | `true` to disable urldecoding and normalizing of the event path; (default: `false`). |
 | serviceType | string | (k8s only) ServiceType for the k8s service created for exposing the trigger. **Important Note:** As of nuclio version 1.5.2 the default ServiceType is `ClusterIP` as opposed to `NodePort`. This means by default the function will not be exposed outside the cluster without configuring a proper ingress or manually changing the ServiceType to `NodePort` |
 
 ### Examples

--- a/pkg/processor/trigger/http/event.go
+++ b/pkg/processor/trigger/http/event.go
@@ -26,7 +26,8 @@ import (
 // allows accessing fasthttp.RequestCtx as a event.Sync
 type Event struct {
 	nuclio.AbstractEvent
-	ctx *fasthttp.RequestCtx
+	ctx                    *fasthttp.RequestCtx
+	disablePathNormalizing bool
 }
 
 // GetContentType returns the content type of the body
@@ -73,6 +74,11 @@ func (e *Event) GetMethod() string {
 
 // GetPath returns the path of the event
 func (e *Event) GetPath() string {
+	if e.disablePathNormalizing {
+
+		// return non urldecoded or normalized path
+		return string(e.ctx.Request.URI().PathOriginal())
+	}
 	return string(e.ctx.Request.URI().Path())
 }
 

--- a/pkg/processor/trigger/http/event_test.go
+++ b/pkg/processor/trigger/http/event_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package http
+
+import (
+	"github.com/valyala/fasthttp"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type EventTestSuite struct {
+	suite.Suite
+	event Event
+}
+
+func (suite *EventTestSuite) SetupTest() {
+	suite.event = Event{}
+}
+
+func (suite *EventTestSuite) TestGetEventPathDisablePathNormalization() {
+	ctx := &fasthttp.RequestCtx{
+		Request: fasthttp.Request{},
+	}
+	requestPath := "/../../am%20here"
+	ctx.Request.URI().SetPath(requestPath)
+	suite.event.ctx = ctx
+	suite.event.disablePathNormalizing = true
+	suite.Require().Equal(requestPath, suite.event.GetPath())
+}
+
+func (suite *EventTestSuite) TestGetEventPath() {
+	ctx := &fasthttp.RequestCtx{
+		Request: fasthttp.Request{},
+	}
+	requestPath := "/../../am%20here"
+	ctx.Request.URI().SetPath(requestPath)
+	suite.event.ctx = ctx
+	suite.event.disablePathNormalizing = false
+	suite.Require().Equal("/am here", suite.event.GetPath())
+}
+
+func TestEvent(t *testing.T) {
+	suite.Run(t, new(EventTestSuite))
+}

--- a/pkg/processor/trigger/http/event_test.go
+++ b/pkg/processor/trigger/http/event_test.go
@@ -14,14 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
 package http
 
 import (
-	"github.com/valyala/fasthttp"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"github.com/valyala/fasthttp"
 )
 
 type EventTestSuite struct {

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -199,6 +199,7 @@ func (h *http) AllocateWorkerAndSubmitEvent(ctx *fasthttp.RequestCtx,
 	h.answering[workerIndex] = 0
 	event := &h.events[workerIndex]
 	event.ctx = ctx
+	event.disablePathNormalizing = h.configuration.DisablePathNormalizing
 
 	// submit to worker
 	response, processError = h.SubmitEventToWorker(functionLogger, workerInstance, event)

--- a/pkg/processor/trigger/http/types.go
+++ b/pkg/processor/trigger/http/types.go
@@ -36,8 +36,9 @@ type Configuration struct {
 	// NOTE: Modifying the max request body size affect with gradually memory consumption increasing
 	// as the entire request being read into the memory
 	// https://github.com/valyala/fasthttp/issues/667#issuecomment-540965683
-	MaxRequestBodySize int
-	CORS               *cors.CORS
+	MaxRequestBodySize     int
+	CORS                   *cors.CORS
+	DisablePathNormalizing bool
 }
 
 func NewConfiguration(ID string,


### PR DESCRIPTION
Event path, by default, is being normalized (and urldecoded) - that means, once processor receives event from endpoint
`<function-url>/../some%20thing`, that url is being normalized and decoded to `/some thing`.

Since that might lead to unexpected input on the function side where user would rely on the original url, I added a way to allow user specify on their function yaml to disable path normalizing.

Example:

```yaml
triggers:
  myHttpTrigger:
    kind: "http"
    attributes:
      disablePathNormalizing: true
```
