### PR TITLE
UI: Add host field to API gateway wizard when no template

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5652,9 +5652,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.28.4",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.28.4.tgz",
-      "integrity": "sha512-P/ep61+9vr+FgulhanZpjm7gZ/knW2Fb4drE+YpukX7XTgVGXE5t03wsa8AX67GVvEaoWY1gVOEeD36Yx16BOw==",
+      "version": "0.28.5",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.28.5.tgz",
+      "integrity": "sha512-8hOxlMHlyqCenNeA3iz0pEDImyjnrSlJg3EiJqL7M3LIdvfakvYNxQHwabAYjp3iZD6x77Sphhzv9mrq20hlKg==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -49,7 +49,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.28.4",
+    "iguazio.dashboard-controls": "^0.28.5",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
- Project › API gateways › wizard › Basic Settings: when on non-K8s platform, when there is no default HTTP host-ingress template from backend, added a new “Host” field, which, together with “Path” field, constructs “Endpoint” (when “Host” is empty “Enter host to see endpoint” message appears and the copy-to-clipboard icon button is hidden):
  ![image](https://user-images.githubusercontent.com/13918850/99179844-ed1a5380-2729-11eb-9867-af7254da1331.png)
  ![image](https://user-images.githubusercontent.com/13918850/99179848-f2779e00-2729-11eb-9129-432bbc15eaa6.png)
- Function › Configuration › Labels: disabled on edit only for K8s platform
  - On K8s platform:
    ![image](https://user-images.githubusercontent.com/13918850/98818833-c19b1e80-2434-11eb-988a-12870c247baa.png)
  - On non-K8s platform:
    ![image](https://user-images.githubusercontent.com/13918850/98818850-c8299600-2434-11eb-8a09-a28834fbaba8.png)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/1125