### PR TITLE
Enhanced create function enrichment + validation

### DIFF
--- a/pkg/containerimagebuilderpusher/nop.go
+++ b/pkg/containerimagebuilderpusher/nop.go
@@ -1,0 +1,46 @@
+package containerimagebuilderpusher
+
+import (
+	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
+
+	"github.com/nuclio/logger"
+)
+
+type Nop struct {
+	logger logger.Logger
+}
+
+func NewNop(logger logger.Logger, builderConfiguration *ContainerBuilderConfiguration) (BuilderPusher, error) {
+	nop := Nop{
+		logger: logger,
+	}
+	return nop, nil
+}
+
+func (n Nop) GetKind() string {
+	return ""
+}
+
+func (n Nop) BuildAndPushContainerImage(buildOptions *BuildOptions, namespace string) error {
+	return nil
+}
+
+func (n Nop) GetOnbuildStages(onbuildArtifacts []runtime.Artifact) ([]string, error) {
+	return nil, nil
+}
+
+func (n Nop) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifact) (map[string]string, error) {
+	return nil, nil
+}
+
+func (n Nop) GetBaseImageRegistry(registry string) string {
+	return ""
+}
+
+func (n Nop) GetOnbuildImageRegistry(registry string) string {
+	return ""
+}
+
+func (n Nop) GetDefaultRegistryCredentialsSecretName() string {
+	return ""
+}

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -901,6 +901,11 @@ func (ap *Platform) validateTriggers(createFunctionOptions *platform.CreateFunct
 	var httpTriggerExists bool
 	for triggerName, _trigger := range createFunctionOptions.FunctionConfig.Spec.Triggers {
 
+		// do not allow trigger with empty name
+		if triggerName == "" {
+			return errors.Errorf("Trigger name cannot be empty")
+		}
+
 		// no more workers than limitation allows
 		if _trigger.MaxWorkers > trigger.MaxWorkersLimit {
 			return errors.Errorf("MaxWorkers value for %s trigger (%d) exceeds the limit of %d",

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -208,6 +208,16 @@ func (suite *TestAbstractSuite) TestFunctionTriggersEnriched() {
 			},
 			shouldFailValidation: true,
 		},
+
+		// do not allow empty name triggers
+		{
+			triggers: map[string]functionconfig.Trigger{
+				"": {
+					Kind: "http",
+				},
+			},
+			shouldFailValidation: true,
+		},
 	} {
 		// name it with index and shift with 65 to get A as first letter
 		functionName := string(rune(idx + 65))

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -47,7 +47,7 @@ func (mp *TestPlatform) GetProjects(getProjectsOptions *platform.GetProjectsOpti
 	}, nil
 }
 
-type TestAbstractSuite struct {
+type AbstractPlatformTestSuite struct {
 	suite.Suite
 	Logger           logger.Logger
 	DockerClient     dockerclient.Client
@@ -61,7 +61,7 @@ type TestAbstractSuite struct {
 	DefaultNamespace string
 }
 
-func (suite *TestAbstractSuite) SetupSuite() {
+func (suite *AbstractPlatformTestSuite) SetupSuite() {
 	var err error
 
 	common.SetVersionFromEnv()
@@ -82,12 +82,12 @@ func (suite *TestAbstractSuite) SetupSuite() {
 	suite.Require().NoError(err)
 }
 
-func (suite *TestAbstractSuite) SetupTest() {
+func (suite *AbstractPlatformTestSuite) SetupTest() {
 	suite.TestID = xid.New().String()
 }
 
 // Test function with invalid min max replicas
-func (suite *TestAbstractSuite) TestMinMaxReplicas() {
+func (suite *AbstractPlatformTestSuite) TestMinMaxReplicas() {
 	zero := 0
 	one := 1
 	two := 2
@@ -163,7 +163,7 @@ func (suite *TestAbstractSuite) TestMinMaxReplicas() {
 	}
 }
 
-func (suite *TestAbstractSuite) TestFunctionTriggersEnriched() {
+func (suite *AbstractPlatformTestSuite) TestFunctionTriggersEnriched() {
 	for idx, testCase := range []struct {
 		triggers                 map[string]functionconfig.Trigger
 		expectedEnrichedTriggers map[string]functionconfig.Trigger
@@ -249,23 +249,23 @@ func (suite *TestAbstractSuite) TestFunctionTriggersEnriched() {
 	}
 }
 
-func (suite *TestAbstractSuite) TestGetProcessorLogsOnMultiWorker() {
+func (suite *AbstractPlatformTestSuite) TestGetProcessorLogsOnMultiWorker() {
 	suite.testGetProcessorLogsTestFromFile(MultiWorkerFunctionLogsFilePath)
 }
 
-func (suite *TestAbstractSuite) TestGetProcessorLogsOnPanic() {
+func (suite *AbstractPlatformTestSuite) TestGetProcessorLogsOnPanic() {
 	suite.testGetProcessorLogsTestFromFile(PanicFunctionLogsFilePath)
 }
 
-func (suite *TestAbstractSuite) TestGetProcessorLogsOnGoWithCallStack() {
+func (suite *AbstractPlatformTestSuite) TestGetProcessorLogsOnGoWithCallStack() {
 	suite.testGetProcessorLogsTestFromFile(GoWithCallStackFunctionLogsFilePath)
 }
 
-func (suite *TestAbstractSuite) TestGetProcessorLogsWithSpecialSubstrings() {
+func (suite *AbstractPlatformTestSuite) TestGetProcessorLogsWithSpecialSubstrings() {
 	suite.testGetProcessorLogsTestFromFile(SpecialSubstringsFunctionLogsFilePath)
 }
 
-func (suite *TestAbstractSuite) TestGetProcessorLogsWithConsecutiveDuplicateMessages() {
+func (suite *AbstractPlatformTestSuite) TestGetProcessorLogsWithConsecutiveDuplicateMessages() {
 	suite.testGetProcessorLogsTestFromFile(ConsecutiveDuplicateFunctionLogsFilePath)
 }
 
@@ -274,7 +274,7 @@ func (suite *TestAbstractSuite) TestGetProcessorLogsWithConsecutiveDuplicateMess
 // - FunctionLogsFile
 // - FormattedFunctionLogsFile
 // - BriefErrorsMessageFile
-func (suite *TestAbstractSuite) testGetProcessorLogsTestFromFile(functionLogsFilePath string) {
+func (suite *AbstractPlatformTestSuite) testGetProcessorLogsTestFromFile(functionLogsFilePath string) {
 	functionLogsFile, err := os.Open(path.Join(functionLogsFilePath, FunctionLogsFile))
 	suite.Require().NoError(err, "Failed to read function logs file")
 
@@ -292,5 +292,5 @@ func (suite *TestAbstractSuite) testGetProcessorLogsTestFromFile(functionLogsFil
 }
 
 func TestAbstractPlatformTestSuite(t *testing.T) {
-	suite.Run(t, new(TestAbstractSuite))
+	suite.Run(t, new(AbstractPlatformTestSuite))
 }

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -144,10 +144,6 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 		return nil, errors.Wrap(err, "Create function options enrichment failed")
 	}
 
-	if err := p.enrichHTTPTriggersWithServiceType(createFunctionOptions); err != nil {
-		return nil, errors.Wrap(err, "Failed to enrich HTTP triggers with service type")
-	}
-
 	if err := p.ValidateCreateFunctionOptions(createFunctionOptions); err != nil {
 		return nil, errors.Wrap(err, "Create function options validation failed")
 	}
@@ -335,6 +331,18 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 
 	// do the deploy in the abstract base class
 	return p.HandleDeployFunction(existingFunctionConfig, createFunctionOptions, onAfterConfigUpdated, onAfterBuild)
+}
+
+func (p Platform) EnrichCreateFunctionOptions(createFunctionOptions *platform.CreateFunctionOptions) error {
+	if err := p.Platform.EnrichCreateFunctionOptions(createFunctionOptions); err != nil {
+		return err
+	}
+
+	if err := p.enrichHTTPTriggersWithServiceType(createFunctionOptions); err != nil {
+		return errors.Wrap(err, "Failed to enrich HTTP triggers with service type")
+	}
+
+	return nil
 }
 
 // GetFunctions will return deployed functions

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -1,0 +1,123 @@
+package kube
+
+import (
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platform/abstract"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/api/core/v1"
+)
+
+type TestPlatform struct {
+	platform.Platform
+	logger         logger.Logger
+	suiteAssertion *assert.Assertions
+}
+
+// GetProjects will list existing projects
+func (mp *TestPlatform) GetProjects(getProjectsOptions *platform.GetProjectsOptions) ([]platform.Project, error) {
+	project, err := platform.NewAbstractProject(mp.logger, nil, platform.ProjectConfig{})
+	mp.suiteAssertion.NoError(err, "Failed to create new abstract project")
+	return []platform.Project{
+		project,
+	}, nil
+}
+
+type TestAbstractSuite struct {
+	suite.Suite
+	Logger             logger.Logger
+	Platform           *Platform
+	PlatformKubeConfig *platformconfig.PlatformKubeConfig
+}
+
+func (suite *TestAbstractSuite) SetupSuite() {
+	var err error
+
+	common.SetVersionFromEnv()
+
+	suite.Logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err, "Logger should create successfully")
+
+	suite.PlatformKubeConfig = &platformconfig.PlatformKubeConfig{
+		DefaultServiceType: v1.ServiceTypeClusterIP,
+	}
+	abstractPlatform, err := abstract.NewPlatform(suite.Logger, &TestPlatform{
+		logger:         suite.Logger,
+		suiteAssertion: suite.Assert(),
+	}, &platformconfig.Config{
+		Kube: *suite.PlatformKubeConfig,
+	})
+	suite.Require().NoError(err, "Could not create platform")
+
+	abstractPlatform.ContainerBuilder, err = containerimagebuilderpusher.NewNop(suite.Logger, nil)
+	suite.Require().NoError(err)
+
+	suite.Platform = &Platform{
+		Platform: abstractPlatform,
+	}
+}
+
+func (suite *TestAbstractSuite) TestFunctionTriggersEnriched() {
+	for idx, testCase := range []struct {
+		triggers                 map[string]functionconfig.Trigger
+		expectedEnrichedTriggers map[string]functionconfig.Trigger
+		shouldFailValidation     bool
+	}{
+
+		// enrich with default http trigger
+		{
+			triggers: nil,
+			expectedEnrichedTriggers: func() map[string]functionconfig.Trigger {
+				defaultHTTPTrigger := functionconfig.GetDefaultHTTPTrigger()
+				defaultHTTPTrigger.Attributes = map[string]interface{}{
+					"serviceType": suite.PlatformKubeConfig.DefaultServiceType,
+				}
+				return map[string]functionconfig.Trigger{
+					defaultHTTPTrigger.Name: defaultHTTPTrigger,
+				}
+
+			}(),
+		},
+	} {
+		// name it with index and shift with 65 to get A as first letter
+		functionName := string(rune(idx + 65))
+		functionConfig := *functionconfig.NewConfig()
+
+		createFunctionOptions := &platform.CreateFunctionOptions{
+			Logger:         suite.Logger,
+			FunctionConfig: functionConfig,
+		}
+		createFunctionOptions.FunctionConfig.Meta.Name = functionName
+		createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
+			"nuclio.io/project-name": platform.DefaultProjectName,
+		}
+		createFunctionOptions.FunctionConfig.Spec.Triggers = testCase.triggers
+		suite.Logger.DebugWith("Checking function ", "functionName", functionName)
+
+		err := suite.Platform.EnrichCreateFunctionOptions(createFunctionOptions)
+		suite.Require().NoError(err, "Failed to enrich function")
+
+		err = suite.Platform.ValidateCreateFunctionOptions(createFunctionOptions)
+		if testCase.shouldFailValidation {
+			suite.Require().Error(err, "Validation passed unexpectedly")
+			continue
+		}
+
+		suite.Require().NoError(err, "Validation failed unexpectedly")
+		suite.Equal(testCase.expectedEnrichedTriggers,
+			createFunctionOptions.FunctionConfig.Spec.Triggers)
+	}
+}
+
+func TestKubePlatformTestSuite(t *testing.T) {
+	suite.Run(t, new(TestAbstractSuite))
+}

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -32,14 +32,14 @@ func (mp *TestPlatform) GetProjects(getProjectsOptions *platform.GetProjectsOpti
 	}, nil
 }
 
-type TestAbstractSuite struct {
+type KubePlatformTestSuite struct {
 	suite.Suite
 	Logger             logger.Logger
 	Platform           *Platform
 	PlatformKubeConfig *platformconfig.PlatformKubeConfig
 }
 
-func (suite *TestAbstractSuite) SetupSuite() {
+func (suite *KubePlatformTestSuite) SetupSuite() {
 	var err error
 
 	common.SetVersionFromEnv()
@@ -66,7 +66,7 @@ func (suite *TestAbstractSuite) SetupSuite() {
 	}
 }
 
-func (suite *TestAbstractSuite) TestFunctionTriggersEnriched() {
+func (suite *KubePlatformTestSuite) TestFunctionTriggersEnriched() {
 	for idx, testCase := range []struct {
 		triggers                 map[string]functionconfig.Trigger
 		expectedEnrichedTriggers map[string]functionconfig.Trigger
@@ -119,5 +119,5 @@ func (suite *TestAbstractSuite) TestFunctionTriggersEnriched() {
 }
 
 func TestKubePlatformTestSuite(t *testing.T) {
-	suite.Run(t, new(TestAbstractSuite))
+	suite.Run(t, new(KubePlatformTestSuite))
 }

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -45,6 +45,11 @@ func (mp *Platform) CreateFunction(createFunctionOptions *platform.CreateFunctio
 	return args.Get(0).(*platform.CreateFunctionResult), args.Error(1)
 }
 
+func (mp *Platform) EnrichCreateFunctionOptions(createFunctionBuildOptions *platform.CreateFunctionOptions) error {
+	args := mp.Called(createFunctionBuildOptions)
+	return args.Error(0)
+}
+
 // UpdateFunction will update a previously deployed function
 func (mp *Platform) UpdateFunction(updateFunctionOptions *platform.UpdateFunctionOptions) error {
 	args := mp.Called(updateFunctionOptions)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -45,6 +45,9 @@ type Platform interface {
 	// Deploy will deploy a processor image to the platform (optionally building it, if source is provided)
 	CreateFunction(createFunctionOptions *CreateFunctionOptions) (*CreateFunctionResult, error)
 
+	// Enrich create function options upon creating function
+	EnrichCreateFunctionOptions(*CreateFunctionOptions) error
+
 	// UpdateFunction will update a previously deployed function
 	UpdateFunction(updateFunctionOptions *UpdateFunctionOptions) error
 

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -468,7 +468,7 @@ functionAugmentedConfigs:
 	err := suite.reader.Read(bytes.NewBufferString(configurationContents), "yaml", &readConfiguration)
 	suite.Require().NoError(err)
 
-	expectedFunctionAugumentedConfigs := []LabelSelectorAndConfig{
+	expectedFunctionAugmentedConfigs := []LabelSelectorAndConfig{
 		{
 
 			// all function matches `nuclio.io/class: function` should have deployment spec of MinReadySeconds: 90
@@ -497,7 +497,7 @@ functionAugmentedConfigs:
 		},
 	}
 
-	suite.Require().True(compare.NoOrder(expectedFunctionAugumentedConfigs,
+	suite.Require().True(compare.NoOrder(expectedFunctionAugmentedConfigs,
 		readConfiguration.FunctionAugmentedConfigs))
 }
 


### PR DESCRIPTION
- Max workers is set to 1 for http / v3ioStream
- Do not allow empty name triggers
- Added kube platform unit test (+ test to ensure serviceType is added for http triggers)


Fixes:
- Do not create docker clients and etc for short platform (abstract / kube) tests
