### PR TITLE
Shell: return stderr upon execution error 

### DIFF
--- a/pkg/processor/runtime/shell/runtime.go
+++ b/pkg/processor/runtime/shell/runtime.go
@@ -38,11 +38,12 @@ import (
 
 type shell struct {
 	*runtime.AbstractRuntime
-	configuration *Configuration
-	command       string
-	env           []string
-	commandInPath bool
-	ctx           context.Context
+	configuration  *Configuration
+	command        string
+	env            []string
+	commandInPath  bool
+	ctx            context.Context
+	restartChannel chan struct{}
 }
 
 // NewRuntime returns a new shell runtime
@@ -69,6 +70,7 @@ func NewRuntime(parentLogger logger.Logger, configuration *Configuration) (runti
 	}
 
 	newShellRuntime.env = newShellRuntime.getEnvFromConfiguration()
+	newShellRuntime.restartChannel = make(chan struct{}, 1)
 
 	newShellRuntime.commandInPath, err = newShellRuntime.commandIsInPath()
 	if err != nil {
@@ -90,7 +92,7 @@ func (s *shell) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (
 	command = append(command, s.getCommandArguments(event)...)
 
 	// create a timeout context
-	ctx, cancel := context.WithTimeout(s.ctx, *s.configuration.DefaultTimeout)
+	ctx, cancel := context.WithCancel(s.ctx)
 	defer cancel()
 
 	s.Logger.DebugWith("Executing shell",
@@ -98,19 +100,55 @@ func (s *shell) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (
 		"eventID", event.GetID(),
 		"bodyLen", len(event.GetBody()),
 		"command", command,
-		"timeout", *s.configuration.DefaultTimeout)
+		"eventTimeout", s.configuration.Spec.EventTimeout)
+
+	responseChan := make(chan nuclio.Response, 1)
+
+	// process event in background
+	go s.processEvent(ctx, command, event, responseChan)
+
+	// wait for event response, return once it is done (or errored)
+	for {
+		select {
+		case response := <-responseChan:
+			return response, nil
+
+		case <-ctx.Done():
+			return nil, nuclio.NewErrRequestTimeout("Failed waiting for function execution")
+
+		case <-s.restartChannel:
+			s.Logger.Warn("Cancelling execution due to an ongoing restart")
+			cancel()
+		}
+	}
+}
+
+func (s *shell) processEvent(context context.Context,
+	command []string,
+	event nuclio.Event,
+	responseChan chan nuclio.Response) {
+
+	response := nuclio.Response{
+		StatusCode: http.StatusInternalServerError,
+		Headers:    s.configuration.ResponseHeaders,
+	}
+
+	// write response upon finishing
+	defer func() {
+		responseChan <- response
+	}()
 
 	var cmd *exec.Cmd
 
 	if s.commandInPath {
 
 		// if the command is an executable, run it as a command with sh -c.
-		cmd = exec.CommandContext(ctx, "sh", "-c", strings.Join(command, " "))
+		cmd = exec.CommandContext(context, "sh", "-c", strings.Join(command, " "))
 	} else {
 
 		// if the command is a shell script run it with sh(without -c). this will make sh
 		// read the script and run it as shell script and run it.
-		cmd = exec.CommandContext(ctx, "sh", command...)
+		cmd = exec.CommandContext(context, "sh", command...)
 	}
 
 	cmd.Stdin = strings.NewReader(string(event.GetBody()))
@@ -134,11 +172,8 @@ func (s *shell) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (
 			"bodyLen", len(event.GetBody()),
 			"command", command,
 			"err", err)
-		return nuclio.Response{
-			StatusCode: http.StatusInternalServerError,
-			Headers:    s.configuration.ResponseHeaders,
-			Body:       []byte(fmt.Sprintf(ResponseErrorFormat, err, out)),
-		}, nil
+		response.Body = []byte(fmt.Sprintf(ResponseErrorFormat, err, out))
+		return
 	}
 
 	// calculate call duration
@@ -151,12 +186,8 @@ func (s *shell) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (
 	s.Logger.DebugWith("Shell executed",
 		"eventID", event.GetID(),
 		"callDuration", callDuration)
-
-	return nuclio.Response{
-		StatusCode: http.StatusOK,
-		Headers:    s.configuration.ResponseHeaders,
-		Body:       out,
-	}, nil
+	response.StatusCode = http.StatusOK
+	response.Body = out
 }
 
 func (s *shell) getCommand() (string, error) {
@@ -235,6 +266,24 @@ func (s *shell) getEnvFromEvent(event nuclio.Event) []string {
 		fmt.Sprintf("NUCLIO_EVENT_TYPE_VERSION=%s", event.GetTypeVersion()),
 		fmt.Sprintf("NUCLIO_EVENT_VERSION=%s", event.GetVersion()),
 	}
+}
+
+func (s *shell) Restart() error {
+	if err := s.Stop(); err != nil {
+		return errors.Wrap(err, "Failed to stop runtime")
+	}
+	s.Logger.Warn("Restarting")
+	s.restartChannel <- struct{}{}
+	return s.Start()
+}
+
+func (s *shell) Start() error {
+	s.SetStatus(status.Ready)
+	return nil
+}
+
+func (s *shell) SupportsRestart() bool {
+	return true
 }
 
 func (s *shell) commandIsInPath() (bool, error) {

--- a/pkg/processor/runtime/shell/runtime_test.go
+++ b/pkg/processor/runtime/shell/runtime_test.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2017 The Nuclio Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package shell
 
 import (

--- a/pkg/processor/runtime/shell/runtime_test.go
+++ b/pkg/processor/runtime/shell/runtime_test.go
@@ -1,0 +1,109 @@
+package shell
+
+import (
+	"net/http"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+	"github.com/nuclio/nuclio/pkg/processor"
+	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/test/suite"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/nuclio-sdk-go"
+	"github.com/stretchr/testify/suite"
+)
+
+// nuclio.TriggerInfoProvider interface
+type TestTriggerInfoProvider struct{}
+
+func (ti *TestTriggerInfoProvider) GetClass() string { return "test class" }
+func (ti *TestTriggerInfoProvider) GetKind() string  { return "test kind" }
+func (ti *TestTriggerInfoProvider) GetName() string  { return "test name" }
+
+type ShellRuntimeSuite struct {
+	processorsuite.TestSuite
+	runtimeInstance runtime.Runtime
+
+	tempRuntimeHandlerDir string
+}
+
+func (suite *ShellRuntimeSuite) SetupSuite() {
+	suite.TestSuite.SetupSuite()
+	suite.Runtime = "shell"
+	configuration, err := NewConfiguration(suite.resolveRuntimeConfiguration(suite.Logger))
+	suite.Require().NoError(err, "Failed to create new configuration")
+
+	suite.tempRuntimeHandlerDir = os.Getenv("NUCLIO_SHELL_HANDLER_DIR")
+	err = os.Setenv("NUCLIO_SHELL_HANDLER_DIR", path.Join(suite.GetTestFunctionsDir(),
+		suite.Runtime, "timeout"))
+	suite.Require().NoError(err, "Failed to set NUCLIO_SHELL_HANDLER_DIR env")
+
+	configuration.Spec.Handler = "timeout.sh:main"
+
+	suite.runtimeInstance, err = NewRuntime(suite.Logger, configuration)
+	suite.Require().NoError(err, "Failed to create new shell runtime")
+}
+
+func (suite *ShellRuntimeSuite) TearDownSuite() {
+	suite.Require().NoError(os.Setenv("NUCLIO_SHELL_HANDLER_DIR", suite.tempRuntimeHandlerDir))
+}
+
+func (suite *ShellRuntimeSuite) TestExecute() {
+	eventInstance := &nuclio.MemoryEvent{
+		Body: []byte("sleep 0.1"),
+	}
+	eventInstance.SetTriggerInfoProvider(&TestTriggerInfoProvider{})
+	response, err := suite.runtimeInstance.ProcessEvent(eventInstance, suite.Logger)
+	suite.Require().NotNil(response)
+	suite.Require().NoError(err)
+
+	nuclioResponse := response.(nuclio.Response)
+	suite.Require().Equal(http.StatusOK, nuclioResponse.StatusCode)
+
+}
+
+func (suite *ShellRuntimeSuite) TestTimeout() {
+
+	// restart runtime after waiting a bit
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+
+		// restart runtime
+		err := suite.runtimeInstance.Restart()
+		suite.Require().NoError(err)
+	}()
+
+	// compile event
+	eventInstance := &nuclio.MemoryEvent{}
+	eventInstance.SetTriggerInfoProvider(&TestTriggerInfoProvider{})
+
+	// process event
+	_, err := suite.runtimeInstance.ProcessEvent(eventInstance, suite.Logger)
+	suite.Require().Error(err)
+
+	// error should be with status, to inform user his request has timed out
+	responseError := err.(*nuclio.ErrorWithStatusCode)
+	suite.Require().Equal(http.StatusRequestTimeout, responseError.StatusCode())
+}
+
+func (suite *ShellRuntimeSuite) resolveRuntimeConfiguration(loggerInstance logger.Logger) *runtime.Configuration {
+	return &runtime.Configuration{
+		FunctionLogger: loggerInstance,
+		Configuration: &processor.Configuration{
+			Config: functionconfig.Config{
+				Meta: functionconfig.Meta{},
+				Spec: functionconfig.Spec{},
+			},
+			PlatformConfig: &platformconfig.Config{},
+		},
+	}
+}
+
+func TestShellRuntimeSuite(t *testing.T) {
+	suite.Run(t, new(ShellRuntimeSuite))
+}

--- a/pkg/processor/runtime/shell/test/outputter/outputter.sh
+++ b/pkg/processor/runtime/shell/test/outputter/outputter.sh
@@ -24,6 +24,15 @@ elif [ "${EVENT_BODY}" == "return_env" ]; then
 	echo ${ENV1}-${ENV2}
 elif [ "${EVENT_BODY}" == "return_error" ]; then
 	exit 1
+elif [ "${EVENT_BODY}" == "return_error_with_message" ]; then
+  echo ${EVENT_BODY}
+  >&2 echo "some_error"
+	exit 1
 elif [ "${EVENT_BODY}" == "return_arguments" ]; then
 	echo $1-$2
+elif [ "$(echo ${EVENT_BODY} | cut -d' ' -f1)" == "sleep" ]; then
+  export sleepTimeout=$(echo ${EVENT_BODY} | cut -d' ' -f2)
+  echo "sleeping ${sleepTimeout}"
+	sleep ${sleepTimeout}
+	echo "done"
 fi

--- a/pkg/processor/runtime/shell/test/outputter/outputter.sh
+++ b/pkg/processor/runtime/shell/test/outputter/outputter.sh
@@ -30,9 +30,4 @@ elif [ "${EVENT_BODY}" == "return_error_with_message" ]; then
 	exit 1
 elif [ "${EVENT_BODY}" == "return_arguments" ]; then
 	echo $1-$2
-elif [ "$(echo ${EVENT_BODY} | cut -d' ' -f1)" == "sleep" ]; then
-  export sleepTimeout=$(echo ${EVENT_BODY} | cut -d' ' -f2)
-  echo "sleeping ${sleepTimeout}"
-	sleep ${sleepTimeout}
-	echo "done"
 fi

--- a/pkg/processor/runtime/shell/test/outputter/outputter.sh
+++ b/pkg/processor/runtime/shell/test/outputter/outputter.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/sh
-
 export EVENT_BODY=$(cat)
 
 if [ "${EVENT_BODY}" == "return_body" ]; then

--- a/pkg/processor/runtime/shell/test/timeout_test.go
+++ b/pkg/processor/runtime/shell/test/timeout_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2017 The Nuclio Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	"net/http"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// TimeoutTestSuite is a shell timeout test suite
+type TimeoutTestSuite struct {
+	httpsuite.TestSuite
+}
+
+// SetupTest sets up the test
+func (suite *TimeoutTestSuite) SetupTest() {
+	suite.TestSuite.SetupTest()
+
+	suite.Runtime = "shell"
+	suite.FunctionDir = path.Join(suite.GetNuclioSourceDir(), "test", "_functions", "shell")
+}
+
+func (suite *TimeoutTestSuite) TestTimeout() {
+	eventTimeout := 1 * time.Second
+	createFunctionOptions := suite.GetDeployOptions("timeout",
+		suite.GetFunctionPath("timeout"))
+
+	createFunctionOptions.FunctionConfig.Spec.EventTimeout = eventTimeout.String()
+	createFunctionOptions.FunctionConfig.Spec.Handler = "timeout.sh:main"
+	okStatusCode := http.StatusOK
+	timeoutStatusCode := http.StatusRequestTimeout
+	suite.DeployFunctionAndRequests(createFunctionOptions, []*httpsuite.Request{
+		{
+			Name:                       "handler timeout",
+			RequestBody:                "",
+			ExpectedResponseBody:       "Failed waiting for function execution",
+			ExpectedResponseStatusCode: &timeoutStatusCode,
+		},
+		{
+			Name:                       "do not timeout",
+			RequestBody:                fmt.Sprintf("sleep %f", (eventTimeout / 2).Seconds()),
+			ExpectedResponseStatusCode: &okStatusCode,
+		},
+	})
+}
+
+func TestTimeout(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	suite.Run(t, new(TimeoutTestSuite))
+}

--- a/pkg/processor/runtime/shell/types.go
+++ b/pkg/processor/runtime/shell/types.go
@@ -1,21 +1,28 @@
 package shell
 
 import (
+	"time"
+
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/nuclio/errors"
 )
 
+const ResponseErrorFormat = "Failed to run shell command.\nError: %s\nOutput:%s"
+
 type Configuration struct {
 	*runtime.Configuration
 	Arguments       string
 	ResponseHeaders map[string]interface{}
+	DefaultTimeout  *time.Duration
 }
 
 func NewConfiguration(runtimeConfiguration *runtime.Configuration) (*Configuration, error) {
+	minute := time.Minute
 	newConfiguration := Configuration{
-		Configuration: runtimeConfiguration,
+		Configuration:  runtimeConfiguration,
+		DefaultTimeout: &minute,
 	}
 
 	// parse attributes

--- a/pkg/processor/runtime/shell/types.go
+++ b/pkg/processor/runtime/shell/types.go
@@ -1,8 +1,6 @@
 package shell
 
 import (
-	"time"
-
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 
 	"github.com/mitchellh/mapstructure"
@@ -15,14 +13,11 @@ type Configuration struct {
 	*runtime.Configuration
 	Arguments       string
 	ResponseHeaders map[string]interface{}
-	DefaultTimeout  *time.Duration
 }
 
 func NewConfiguration(runtimeConfiguration *runtime.Configuration) (*Configuration, error) {
-	minute := time.Minute
 	newConfiguration := Configuration{
-		Configuration:  runtimeConfiguration,
-		DefaultTimeout: &minute,
+		Configuration: runtimeConfiguration,
 	}
 
 	// parse attributes

--- a/test/_functions/shell/timeout/timeout.sh
+++ b/test/_functions/shell/timeout/timeout.sh
@@ -1,0 +1,12 @@
+export EVENT_BODY=$(cat)
+
+if [ "$(echo ${EVENT_BODY} | cut -d' ' -f1)" == "sleep" ]; then
+  export sleepTimeout=$(echo ${EVENT_BODY} | cut -d' ' -f2)
+	sleep ${sleepTimeout}
+	exit 0
+fi
+
+# doing nothing while waiting for processor to kill me
+while true; do
+  read
+done < /dev/stdin

--- a/test/_functions/shell/timeout/timeout.sh
+++ b/test/_functions/shell/timeout/timeout.sh
@@ -1,12 +1,37 @@
-export EVENT_BODY=$(cat)
+#!/bin/sh
 
-if [ "$(echo ${EVENT_BODY} | cut -d' ' -f1)" == "sleep" ]; then
-  export sleepTimeout=$(echo ${EVENT_BODY} | cut -d' ' -f2)
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+EVENTBODY=$(cat)
+
+sleep_and_exit() {
+  sleepTimeout=$(echo ${EVENTBODY} | cut -d' ' -f2)
 	sleep ${sleepTimeout}
 	exit 0
-fi
+}
 
-# doing nothing while waiting for processor to kill me
-while true; do
-  read
-done < /dev/stdin
+wait_infinitely() {
+
+  # doing nothing while waiting for processor to kill me
+  while true; do
+    sleep 0.1
+    read
+  done < /dev/stdin
+}
+
+case $EVENTBODY in
+  "sleep"*) sleep_and_exit ;;
+  *)        wait_infinitely ;;
+esac


### PR DESCRIPTION
When an execution fail, the response body is empty. To fix that, I added both _error_, _stderr_  and  _stdout_ to response output.

In addition to that, I made the execution timeout configurable on the runtime attributes level.
if your shell runtime execution should last more than a minute, override its `runtimeAttributes` with
`DefaultTimeout: 10m`.