### PR TITLE
Configurable base/onbuild images by runtime

### DIFF
--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.7.6
+version: 0.7.7
 appVersion: 1.5.4
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.7.7
+version: 0.7.6
 appVersion: 1.5.4
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -207,10 +207,10 @@ platform: {}
 #   cronTriggerCreationMode: "kube"
 #   kube:
 #     defaultServiceType: NodePort
-#   image_registries_overrides:
-#     base_image_registries:
+#   imageRegistryOverrides:
+#     baseImageRegistries:
 #       "python:3.6": "myregistry"
-#     onbuild_image_registries:
+#     onbuildImageRegistries:
 #       "golang": "myregistry"
 
 # global is a stanza that is used if this is used as a subchart. Ignore otherwise

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -207,6 +207,11 @@ platform: {}
 #   cronTriggerCreationMode: "kube"
 #   kube:
 #     defaultServiceType: NodePort
+#   image_registries_overrides:
+#     base_image_registries:
+#       "python:3.6": "myregistry"
+#     onbuild_image_registries:
+#       "golang": "myregistry"
 
 # global is a stanza that is used if this is used as a subchart. Ignore otherwise
 global:

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1034,7 +1034,7 @@ func (ap *Platform) enrichTriggers(createFunctionOptions *platform.CreateFunctio
 func (ap *Platform) getBaseImagesOverrides() (*map[string]string, error) {
 	switch configType := ap.Config.(type) {
 	case *platformconfig.Config:
-		return configType.ImageRegistriesOverrides.BaseImageRegistries, nil
+		return configType.ImageRegistryOverrides.BaseImageRegistries, nil
 
 	// FIXME: When deploying using nuctl in a kubernetes environment, it will be a kube platform, but the configuration
 	// will be of type *config.Configuration which is lacking
@@ -1051,7 +1051,7 @@ func (ap *Platform) getBaseImagesOverrides() (*map[string]string, error) {
 func (ap *Platform) getOnbuildImagesOverrides() (*map[string]string, error) {
 	switch configType := ap.Config.(type) {
 	case *platformconfig.Config:
-		return configType.ImageRegistriesOverrides.OnbuildImageRegistries, nil
+		return configType.ImageRegistryOverrides.OnbuildImageRegistries, nil
 
 	// FIXME: When deploying using nuctl in a kubernetes environment, it will be a kube platform, but the configuration
 	// will be of type *config.Configuration which is lacking

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -504,10 +504,10 @@ func (ap *Platform) GetBaseImageRegistry(registry string, runtime runtime.Runtim
 	}
 
 	if baseImagesOverrides == nil {
-		baseImagesOverrides = new(map[string]string)
+		baseImagesOverrides = map[string]string{}
 	}
 
-	imageRegistryRuntimeOverride := runtime.GetOverrideImageRegistryFromMap(*baseImagesOverrides)
+	imageRegistryRuntimeOverride := runtime.GetOverrideImageRegistryFromMap(baseImagesOverrides)
 	if imageRegistryRuntimeOverride != "" {
 		return imageRegistryRuntimeOverride, nil
 	}
@@ -521,10 +521,10 @@ func (ap *Platform) GetOnbuildImageRegistry(registry string, runtime runtime.Run
 		return "", errors.Wrap(err, "Failed to get onbuild images override from platform")
 	}
 	if onbuildImagesOverrides == nil {
-		onbuildImagesOverrides = new(map[string]string)
+		onbuildImagesOverrides = map[string]string{}
 	}
 
-	imageRegistryRuntimeOverride := runtime.GetOverrideImageRegistryFromMap(*onbuildImagesOverrides)
+	imageRegistryRuntimeOverride := runtime.GetOverrideImageRegistryFromMap(onbuildImagesOverrides)
 	if imageRegistryRuntimeOverride != "" {
 		return imageRegistryRuntimeOverride, nil
 	}
@@ -1031,7 +1031,7 @@ func (ap *Platform) enrichTriggers(createFunctionOptions *platform.CreateFunctio
 }
 
 // returns overrides for base images per runtime
-func (ap *Platform) getBaseImagesOverrides() (*map[string]string, error) {
+func (ap *Platform) getBaseImagesOverrides() (map[string]string, error) {
 	switch configType := ap.Config.(type) {
 	case *platformconfig.Config:
 		return configType.ImageRegistryOverrides.BaseImageRegistries, nil
@@ -1048,7 +1048,7 @@ func (ap *Platform) getBaseImagesOverrides() (*map[string]string, error) {
 }
 
 // returns overrides for base images per runtime
-func (ap *Platform) getOnbuildImagesOverrides() (*map[string]string, error) {
+func (ap *Platform) getOnbuildImagesOverrides() (map[string]string, error) {
 	switch configType := ap.Config.(type) {
 	case *platformconfig.Config:
 		return configType.ImageRegistryOverrides.OnbuildImageRegistries, nil

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -30,6 +30,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platform/config"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/processor/build"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
@@ -464,10 +465,12 @@ func (ap *Platform) GetExternalIPAddresses() ([]string, error) {
 	return ap.ExternalIPAddresses, nil
 }
 
+// GetScaleToZeroConfiguration returns scale to zero configuration
 func (ap *Platform) GetScaleToZeroConfiguration() (*platformconfig.ScaleToZero, error) {
 	return nil, nil
 }
 
+// GetAllowedAuthenticationModes returns allowed authentication modes
 func (ap *Platform) GetAllowedAuthenticationModes() ([]string, error) {
 	return nil, nil
 }
@@ -479,7 +482,8 @@ func (ap *Platform) ResolveDefaultNamespace(defaultNamespace string) string {
 
 // BuildAndPushContainerImage builds container image and pushes it into docker registry
 func (ap *Platform) BuildAndPushContainerImage(buildOptions *containerimagebuilderpusher.BuildOptions) error {
-	return ap.ContainerBuilder.BuildAndPushContainerImage(buildOptions, ap.platform.ResolveDefaultNamespace("@nuclio.selfNamespace"))
+	return ap.ContainerBuilder.BuildAndPushContainerImage(buildOptions,
+		ap.platform.ResolveDefaultNamespace("@nuclio.selfNamespace"))
 }
 
 // Get Onbuild stage for multistage builds
@@ -493,13 +497,38 @@ func (ap *Platform) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Art
 }
 
 // GetBaseImageRegistry returns base image registry
-func (ap *Platform) GetBaseImageRegistry(registry string) string {
-	return ap.ContainerBuilder.GetBaseImageRegistry(registry)
+func (ap *Platform) GetBaseImageRegistry(registry string, runtime runtime.Runtime) (string, error) {
+	baseImagesOverrides, err := ap.getBaseImagesOverrides()
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to get base images override from platform")
+	}
+
+	if baseImagesOverrides == nil {
+		baseImagesOverrides = new(map[string]string)
+	}
+
+	imageRegistryRuntimeOverride := runtime.GetOverrideImageRegistryFromMap(*baseImagesOverrides)
+	if imageRegistryRuntimeOverride != "" {
+		return imageRegistryRuntimeOverride, nil
+	}
+	return ap.ContainerBuilder.GetBaseImageRegistry(registry), nil
 }
 
 // GetOnbuildImageRegistry returns onbuild image registry
-func (ap *Platform) GetOnbuildImageRegistry(registry string) string {
-	return ap.ContainerBuilder.GetOnbuildImageRegistry(registry)
+func (ap *Platform) GetOnbuildImageRegistry(registry string, runtime runtime.Runtime) (string, error) {
+	onbuildImagesOverrides, err := ap.getOnbuildImagesOverrides()
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to get onbuild images override from platform")
+	}
+	if onbuildImagesOverrides == nil {
+		onbuildImagesOverrides = new(map[string]string)
+	}
+
+	imageRegistryRuntimeOverride := runtime.GetOverrideImageRegistryFromMap(*onbuildImagesOverrides)
+	if imageRegistryRuntimeOverride != "" {
+		return imageRegistryRuntimeOverride, nil
+	}
+	return ap.ContainerBuilder.GetOnbuildImageRegistry(registry), nil
 }
 
 // GetDefaultRegistryCredentialsSecretName returns secret with credentials to push/pull from docker registry
@@ -999,4 +1028,38 @@ func (ap *Platform) enrichTriggers(createFunctionOptions *platform.CreateFunctio
 		createFunctionOptions.FunctionConfig.Spec.Triggers[triggerName] = triggerInstance
 	}
 	return nil
+}
+
+// returns overrides for base images per runtime
+func (ap *Platform) getBaseImagesOverrides() (*map[string]string, error) {
+	switch configType := ap.Config.(type) {
+	case *platformconfig.Config:
+		return configType.ImageRegistriesOverrides.BaseImageRegistries, nil
+
+	// FIXME: When deploying using nuctl in a kubernetes environment, it will be a kube platform, but the configuration
+	// will be of type *config.Configuration which is lacking
+	// we need to fix the platform config (p.Config) to always be of the same type (*platformconfig.Config) and not
+	// passing interface{} everywhere
+	case *config.Configuration:
+		return nil, nil
+	default:
+		return nil, errors.New("Not a valid configuration instance")
+	}
+}
+
+// returns overrides for base images per runtime
+func (ap *Platform) getOnbuildImagesOverrides() (*map[string]string, error) {
+	switch configType := ap.Config.(type) {
+	case *platformconfig.Config:
+		return configType.ImageRegistriesOverrides.OnbuildImageRegistries, nil
+
+	// FIXME: When deploying using nuctl in a kubernetes environment, it will be a kube platform, but the configuration
+	// will be of type *config.Configuration which is lacking
+	// we need to fix the platform config (p.Config) to always be of the same type (*platformconfig.Config) and not
+	// passing interface{} everywhere
+	case *config.Configuration:
+		return nil, nil
+	default:
+		return nil, errors.New("Not a valid configuration instance")
+	}
 }

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -257,12 +257,12 @@ func (mp *Platform) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Art
 	return map[string]string{}, nil
 }
 
-func (mp *Platform) GetBaseImageRegistry(registry string) string {
-	return "quay.io"
+func (mp *Platform) GetBaseImageRegistry(registry string, runtime runtime.Runtime) (string, error) {
+	return "quay.io", nil
 }
 
-func (mp *Platform) GetOnbuildImageRegistry(registry string) string {
-	return ""
+func (mp *Platform) GetOnbuildImageRegistry(registry string, runtime runtime.Runtime) (string, error) {
+	return "", nil
 }
 
 func (mp *Platform) GetDefaultRegistryCredentialsSecretName() string {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -134,10 +134,10 @@ type Platform interface {
 
 	RenderImageNamePrefixTemplate(projectName string, functionName string) (string, error)
 
-	// Get scale to zero configuration
+	// GetScaleToZeroConfiguration returns scale to zero configuration
 	GetScaleToZeroConfiguration() (*platformconfig.ScaleToZero, error)
 
-	// Get allowed authentication modes
+	// GetAllowedAuthenticationModes returns allowed authentication modes
 	GetAllowedAuthenticationModes() ([]string, error)
 
 	// GetNamespaces returns all the namespaces in the platform
@@ -165,10 +165,10 @@ type Platform interface {
 	TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifact) (map[string]string, error)
 
 	// GetOnbuildImageRegistry returns onbuild base registry
-	GetOnbuildImageRegistry(registry string) string
+	GetOnbuildImageRegistry(registry string, runtime runtime.Runtime) (string, error)
 
 	// GetBaseImageRegistry returns base image registry
-	GetBaseImageRegistry(registry string) string
+	GetBaseImageRegistry(registry string, runtime runtime.Runtime) (string, error)
 
 	// GetDefaultRegistryCredentialsSecretName returns secret with credentials to push/pull from docker registry
 	GetDefaultRegistryCredentialsSecretName() string

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -22,27 +22,21 @@ import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 
 	"github.com/nuclio/errors"
-	"k8s.io/api/core/v1"
 )
 
-type PlatformKubeConfig struct {
-
-	// TODO: Move IngressConfig here
-	DefaultServiceType v1.ServiceType `json:"defaultServiceType,omitempty"`
-}
-
 type Config struct {
-	Kind                     string                   `json:"kind,omitempty"`
-	WebAdmin                 WebServer                `json:"webAdmin,omitempty"`
-	HealthCheck              WebServer                `json:"healthCheck,omitempty"`
-	Logger                   Logger                   `json:"logger,omitempty"`
-	Metrics                  Metrics                  `json:"metrics,omitempty"`
-	ScaleToZero              ScaleToZero              `json:"scaleToZero,omitempty"`
-	AutoScale                AutoScale                `json:"autoScale,omitempty"`
-	CronTriggerCreationMode  CronTriggerCreationMode  `json:"cronTriggerCreationMode,omitempty"`
-	FunctionAugmentedConfigs []LabelSelectorAndConfig `json:"functionAugmentedConfigs,omitempty"`
-	IngressConfig            IngressConfig            `json:"ingressConfig,omitempty"`
-	Kube                     PlatformKubeConfig       `json:"kube,omitempty"`
+	Kind                     string                         `json:"kind,omitempty"`
+	WebAdmin                 WebServer                      `json:"webAdmin,omitempty"`
+	HealthCheck              WebServer                      `json:"healthCheck,omitempty"`
+	Logger                   Logger                         `json:"logger,omitempty"`
+	Metrics                  Metrics                        `json:"metrics,omitempty"`
+	ScaleToZero              ScaleToZero                    `json:"scaleToZero,omitempty"`
+	AutoScale                AutoScale                      `json:"autoScale,omitempty"`
+	CronTriggerCreationMode  CronTriggerCreationMode        `json:"cronTriggerCreationMode,omitempty"`
+	FunctionAugmentedConfigs []LabelSelectorAndConfig       `json:"functionAugmentedConfigs,omitempty"`
+	IngressConfig            IngressConfig                  `json:"ingressConfig,omitempty"`
+	Kube                     PlatformKubeConfig             `json:"kube,omitempty"`
+	ImageRegistriesOverrides ImageRegistriesOverridesConfig `json:"image_registries_overrides,omitempty"`
 }
 
 func NewPlatformConfig(configurationPath string) (*Config, error) {

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -25,18 +25,18 @@ import (
 )
 
 type Config struct {
-	Kind                     string                         `json:"kind,omitempty"`
-	WebAdmin                 WebServer                      `json:"webAdmin,omitempty"`
-	HealthCheck              WebServer                      `json:"healthCheck,omitempty"`
-	Logger                   Logger                         `json:"logger,omitempty"`
-	Metrics                  Metrics                        `json:"metrics,omitempty"`
-	ScaleToZero              ScaleToZero                    `json:"scaleToZero,omitempty"`
-	AutoScale                AutoScale                      `json:"autoScale,omitempty"`
-	CronTriggerCreationMode  CronTriggerCreationMode        `json:"cronTriggerCreationMode,omitempty"`
-	FunctionAugmentedConfigs []LabelSelectorAndConfig       `json:"functionAugmentedConfigs,omitempty"`
-	IngressConfig            IngressConfig                  `json:"ingressConfig,omitempty"`
-	Kube                     PlatformKubeConfig             `json:"kube,omitempty"`
-	ImageRegistriesOverrides ImageRegistriesOverridesConfig `json:"image_registries_overrides,omitempty"`
+	Kind                     string                       `json:"kind,omitempty"`
+	WebAdmin                 WebServer                    `json:"webAdmin,omitempty"`
+	HealthCheck              WebServer                    `json:"healthCheck,omitempty"`
+	Logger                   Logger                       `json:"logger,omitempty"`
+	Metrics                  Metrics                      `json:"metrics,omitempty"`
+	ScaleToZero              ScaleToZero                  `json:"scaleToZero,omitempty"`
+	AutoScale                AutoScale                    `json:"autoScale,omitempty"`
+	CronTriggerCreationMode  CronTriggerCreationMode      `json:"cronTriggerCreationMode,omitempty"`
+	FunctionAugmentedConfigs []LabelSelectorAndConfig     `json:"functionAugmentedConfigs,omitempty"`
+	IngressConfig            IngressConfig                `json:"ingressConfig,omitempty"`
+	Kube                     PlatformKubeConfig           `json:"kube,omitempty"`
+	ImageRegistryOverrides   ImageRegistryOverridesConfig `json:"imageRegistryOverrides,omitempty"`
 }
 
 func NewPlatformConfig(configurationPath string) (*Config, error) {

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -105,11 +105,11 @@ type PlatformKubeConfig struct {
 	DefaultServiceType corev1.ServiceType `json:"defaultServiceType,omitempty"`
 }
 
-type ImageRegistriesOverridesConfig struct {
+type ImageRegistryOverridesConfig struct {
 
-	// maps are [runtime -> image-ref]
-	BaseImageRegistries    *map[string]string `json:"base_image_registries,omitempty"`
-	OnbuildImageRegistries *map[string]string `json:"onbuild_image_registries,omitempty"`
+	// maps are [runtime -> registry]
+	BaseImageRegistries    *map[string]string `json:"baseImageRegistries,omitempty"`
+	OnbuildImageRegistries *map[string]string `json:"onbuildImageRegistries,omitempty"`
 }
 
 // default values for created ingresses

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -21,7 +21,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	machinarymetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type LoggerSink struct {
@@ -90,13 +90,26 @@ type Metrics struct {
 }
 
 type LabelSelectorAndConfig struct {
-	LabelSelector  v1.LabelSelector      `json:"labelSelector,omitempty"`
-	FunctionConfig functionconfig.Config `json:"functionConfig,omitempty"`
-	Kubernetes     Kubernetes            `json:"kubernetes,omitempty"`
+	LabelSelector  machinarymetav1.LabelSelector `json:"labelSelector,omitempty"`
+	FunctionConfig functionconfig.Config         `json:"functionConfig,omitempty"`
+	Kubernetes     Kubernetes                    `json:"kubernetes,omitempty"`
 }
 
 type Kubernetes struct {
 	Deployment *appsv1.Deployment `json:"deployment,omitempty"`
+}
+
+type PlatformKubeConfig struct {
+
+	// TODO: Move IngressConfig here
+	DefaultServiceType corev1.ServiceType `json:"defaultServiceType,omitempty"`
+}
+
+type ImageRegistriesOverridesConfig struct {
+
+	// maps are [runtime -> image-ref]
+	BaseImageRegistries    *map[string]string `json:"base_image_registries,omitempty"`
+	OnbuildImageRegistries *map[string]string `json:"onbuild_image_registries,omitempty"`
 }
 
 // default values for created ingresses

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -108,8 +108,8 @@ type PlatformKubeConfig struct {
 type ImageRegistryOverridesConfig struct {
 
 	// maps are [runtime -> registry]
-	BaseImageRegistries    *map[string]string `json:"baseImageRegistries,omitempty"`
-	OnbuildImageRegistries *map[string]string `json:"onbuildImageRegistries,omitempty"`
+	BaseImageRegistries    map[string]string `json:"baseImageRegistries,omitempty"`
+	OnbuildImageRegistries map[string]string `json:"onbuildImageRegistries,omitempty"`
 }
 
 // default values for created ingresses


### PR DESCRIPTION
A new section in platform config can receive per-runtime registry override for base and onbuild images for finer grained control over dark-site compatibility