### PR TITLE
Bugfix - nil pointer dereference when running in local/docker platform

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1034,7 +1034,10 @@ func (ap *Platform) enrichTriggers(createFunctionOptions *platform.CreateFunctio
 func (ap *Platform) getBaseImagesOverrides() (map[string]string, error) {
 	switch configType := ap.Config.(type) {
 	case *platformconfig.Config:
-		return configType.ImageRegistryOverrides.BaseImageRegistries, nil
+		if configType != nil {
+			return configType.ImageRegistryOverrides.BaseImageRegistries, nil
+		}
+		return nil, nil
 
 	// FIXME: When deploying using nuctl in a kubernetes environment, it will be a kube platform, but the configuration
 	// will be of type *config.Configuration which is lacking
@@ -1051,7 +1054,10 @@ func (ap *Platform) getBaseImagesOverrides() (map[string]string, error) {
 func (ap *Platform) getOnbuildImagesOverrides() (map[string]string, error) {
 	switch configType := ap.Config.(type) {
 	case *platformconfig.Config:
-		return configType.ImageRegistryOverrides.OnbuildImageRegistries, nil
+		if configType != nil {
+			return configType.ImageRegistryOverrides.OnbuildImageRegistries, nil
+		}
+		return nil, nil
 
 	// FIXME: When deploying using nuctl in a kubernetes environment, it will be a kube platform, but the configuration
 	// will be of type *config.Configuration which is lacking


### PR DESCRIPTION
```
    suite.go:63: test panicked: runtime error: invalid memory address or nil pointer dereference
        goroutine 24 [running]:
        runtime/debug.Stack(0xc00044ae48, 0x227b380, 0x33cc5c0)
        	/usr/local/Cellar/go@1.14/1.14.9/libexec/go1.14.9/src/runtime/debug/stack.go:24 +0x9d
        github.com/stretchr/testify/suite.failOnPanic(0xc000187680)
        	/Users/liranbg/go/pkg/mod/github.com/stretchr/testify@v1.6.1/suite/suite.go:63 +0x57
        panic(0x227b380, 0x33cc5c0)
        	/usr/local/Cellar/go@1.14/1.14.9/libexec/go1.14.9/src/runtime/panic.go:969 +0x166
        github.com/nuclio/nuclio/pkg/platform/abstract.(*Platform).getBaseImagesOverrides(0xc000230120, 0xb1deb0784f84352, 0xc00044b080, 0x100fc9d)
        	/Users/liranbg/iguazio/nuclio/nuclio/pkg/platform/abstract/platform.go:1037 +0xf1
        github.com/nuclio/nuclio/pkg/platform/abstract.(*Platform).GetBaseImageRegistry(0xc000230120, 0x0, 0x0, 0x27d0500, 0xc0000bc008, 0x0, 0x0, 0x0, 0x0)
        	/Users/liranbg/iguazio/nuclio/nuclio/pkg/platform/abstract/platform.go:501 +0x2f
        github.com/nuclio/nuclio/pkg/processor/build.(*Builder).buildProcessorImage(0xc000222400, 0x0, 0x0, 0x0, 0x0)
```

This, apparently can only happen in tests (config=nil).
@liranbg - please decide if you still want to be defensive on-access there or not