### PR TITLE
Add deprecation warnings when deploying a function with python 2.7

### DIFF
--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -59,7 +59,7 @@ The `spec` section contains the requirements and attributes and has the followin
 | :--- | :--- | :--- |
 | description | string | A textual description of the function |
 | handler | string | The entry point to the function, in the form of `package:entrypoint`. Varies slightly between runtimes, see the appropriate runtime documentation for specifics |
-| runtime | string | The name of the language runtime. One of: `golang`, `python:2.7`, `python:3.6`, `shell`, `java`, `nodejs`, `pypy` | 
+| runtime | string | The name of the language runtime. One of: `golang`, `python`, `shell`, `java`, `nodejs`, `pypy` | 
 | <a id="spec.image"></a>image | string | The name of the function's container image &mdash; used for the `image` [code-entry type](#spec.build.codeEntryType); see [Code-Entry Types](/docs/reference/function-configuration/code-entry-types.md#code-entry-type-image) |
 | env | map | A name-value environment-variables tuple; it's also possible to reference secrets from the map elements, as demonstrated in the [specifcation example](#spec-example) |
 | volumes | map | A map in an architecture similar to Kubernetes volumes, for Docker deployment |

--- a/docs/tasks/benchmarking.md
+++ b/docs/tasks/benchmarking.md
@@ -45,7 +45,7 @@ Transfer/sec:     33.36MB
 
 Deploy an empty Python function with 36 workers:
 ```sh
-nuctl deploy helloworld-py -n nuclio -p https://raw.githubusercontent.com/nuclio/nuclio/development/hack/examples/python/empty/empty.py --platform local --triggers '{"mh": {"kind": "http", "maxWorkers": 36}}' --runtime python:2.7 --handler empty:handler
+nuctl deploy helloworld-py -n nuclio -p https://raw.githubusercontent.com/nuclio/nuclio/development/hack/examples/python/empty/empty.py --platform local --triggers '{"mh": {"kind": "http", "maxWorkers": 36}}' --runtime python --handler empty:handler
 ```
 
 Run the benchmark:

--- a/docs/tasks/deploying-functions.md
+++ b/docs/tasks/deploying-functions.md
@@ -68,7 +68,7 @@ Now deploy your function, specifying the function name, the path, the "nuclio" n
 ```sh
 nuctl deploy my-function \
 	--path /tmp/nuclio/my_function.py \
-	--runtime python:2.7 \
+	--runtime python \
 	--handler my_function:my_entry_point \
 	--namespace nuclio \
 	--registry $(minikube ip):5000 --run-registry localhost:5000
@@ -179,7 +179,7 @@ With `nuctl`, you simply pass `--env` and a JSON encoding of the trigger configu
 ```sh
 nuctl deploy my-function \
 	--path /tmp/nuclio/my_function.py \
-	--runtime python:2.7 \
+	--runtime python \
 	--handler my_function:my_entry_point \
 	--namespace nuclio \
 	--registry $(minikube ip):5000 --run-registry localhost:5000 \
@@ -202,7 +202,7 @@ spec:
   - name: MY_ENV_VALUE
     value: my value
   handler: my_function:my_entry_point
-  runtime: python:2.7
+  runtime: python
   triggers:
     periodic:
       attributes:
@@ -239,7 +239,7 @@ import os
 #     - name: MY_ENV_VALUE
 #       value: my value
 #     handler: my_function_with_config:my_entry_point
-#     runtime: python:2.7
+#     runtime: python
 #     triggers:
 #       periodic:
 #         attributes:

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -43,7 +43,9 @@ func (p *python) GetProcessorDockerfileInfo(onbuildImageRegistry string) (*runti
 	}
 
 	if p.FunctionConfig.Spec.Runtime == "python:2.7" {
-		p.Logger.Warn("Nuclio will drop support for Python 2.7 within the next minor version")
+		p.Logger.Warn("Python 2.7 runtime is deprecated. " +
+			"Nuclio will drop support for Python 2.7 runtime as of version 1.6.0. " +
+			"Please migrate your code to Python 3.6")
 		processorDockerfileInfo.BaseImage = "python:2.7-alpine"
 	} else {
 		processorDockerfileInfo.BaseImage = "python:3.6"

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -43,7 +43,7 @@ func (p *python) GetProcessorDockerfileInfo(onbuildImageRegistry string) (*runti
 	}
 
 	if p.FunctionConfig.Spec.Runtime == "python:2.7" {
-		p.Logger.Warn("A future version of nuclio python will drop support for Python 2.7.")
+		p.Logger.Warn("Nuclio will drop support for Python 2.7 within the next minor version")
 		processorDockerfileInfo.BaseImage = "python:2.7-alpine"
 	} else {
 		processorDockerfileInfo.BaseImage = "python:3.6"

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -43,6 +43,7 @@ func (p *python) GetProcessorDockerfileInfo(onbuildImageRegistry string) (*runti
 	}
 
 	if p.FunctionConfig.Spec.Runtime == "python:2.7" {
+		p.Logger.Warn("A future version of nuclio python will drop support for Python 2.7.")
 		processorDockerfileInfo.BaseImage = "python:2.7-alpine"
 	} else {
 		processorDockerfileInfo.BaseImage = "python:3.6"

--- a/pkg/processor/build/runtime/python/test/python_test.go
+++ b/pkg/processor/build/runtime/python/test/python_test.go
@@ -25,18 +25,12 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type testSuite struct {
+type TestSuite struct {
 	buildsuite.TestSuite
 	runtime string
 }
 
-func newTestSuite(runtime string) *testSuite {
-	return &testSuite{
-		runtime: runtime,
-	}
-}
-
-func (suite *testSuite) SetupSuite() {
+func (suite *TestSuite) SetupSuite() {
 	suite.TestSuite.SetupSuite()
 
 	suite.TestSuite.RuntimeSuite = suite
@@ -44,7 +38,7 @@ func (suite *testSuite) SetupSuite() {
 	suite.Runtime = suite.runtime
 }
 
-func (suite *testSuite) TestBuildPy2() {
+func (suite *TestSuite) TestBuildPy2() {
 	if suite.Runtime != "python:2.7" {
 		suite.T().Skip("This should only run when runtime is python 2.7")
 	}
@@ -63,7 +57,7 @@ func (suite *testSuite) TestBuildPy2() {
 		})
 }
 
-func (suite *testSuite) GetFunctionInfo(functionName string) buildsuite.FunctionInfo {
+func (suite *TestSuite) GetFunctionInfo(functionName string) buildsuite.FunctionInfo {
 	functionInfo := buildsuite.FunctionInfo{
 		Runtime: suite.runtime,
 	}
@@ -103,7 +97,13 @@ func TestIntegrationSuite(t *testing.T) {
 		return
 	}
 
-	suite.Run(t, newTestSuite("python"))
-	suite.Run(t, newTestSuite("python:2.7"))
-	suite.Run(t, newTestSuite("python:3.6"))
+	for _, runtime := range []string{
+		"python",
+		"python:2.7",
+		"python:3.6",
+	} {
+		TestSuite := new(TestSuite)
+		TestSuite.runtime = runtime
+		suite.Run(t, TestSuite)
+	}
 }

--- a/pkg/processor/build/test/build_test.go
+++ b/pkg/processor/build/test/build_test.go
@@ -226,7 +226,7 @@ func (suite *testSuite) TestBuildFunctionFromFileExpectSourceCodePopulated() {
 	createFunctionOptions := suite.GetDeployOptions("reverser",
 		path.Join(suite.GetNuclioSourceDir(), "test", "_functions", "common", "reverser", "python", "reverser.py"))
 
-	createFunctionOptions.FunctionConfig.Spec.Runtime = "python:2.7"
+	createFunctionOptions.FunctionConfig.Spec.Runtime = "python"
 	createFunctionOptions.FunctionConfig.Spec.Handler = "reverser:handler"
 
 	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
@@ -269,9 +269,9 @@ func (suite *testSuite) TestBuildJessiePassesNonInteractiveFlag() {
 	createFunctionOptions := suite.GetDeployOptions("printer",
 		path.Join(suite.GetNuclioSourceDir(), "test", "_functions", "python", "py2-printer"))
 
-	createFunctionOptions.FunctionConfig.Spec.Runtime = "python:2.7"
+	createFunctionOptions.FunctionConfig.Spec.Runtime = "python"
 	createFunctionOptions.FunctionConfig.Spec.Handler = "printer:handler"
-	createFunctionOptions.FunctionConfig.Spec.Build.BaseImage = "python:2.7-jessie"
+	createFunctionOptions.FunctionConfig.Spec.Build.BaseImage = "python:3.6-jessie"
 
 	createFunctionOptions.FunctionConfig.Spec.Build.Commands = append(createFunctionOptions.FunctionConfig.Spec.Build.Commands, "apt-get -qq update")
 	createFunctionOptions.FunctionConfig.Spec.Build.Commands = append(createFunctionOptions.FunctionConfig.Spec.Build.Commands, "apt-get -qq install curl")

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -87,6 +87,10 @@ class Wrapper(object):
         # indicate that we're ready
         self._write_packet_to_processor('s')
 
+        # log deprecation warning
+        if sys.version_info[:2] == (2, 7):
+            self._logger.warn('A future version of nuclio python will drop support for Python 2.7.')
+
     def serve_requests(self, num_requests=None):
         """Read event from socket, send out reply"""
 

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -89,7 +89,7 @@ class Wrapper(object):
 
         # log deprecation warning
         if sys.version_info[:2] == (2, 7):
-            self._logger.warn('A future version of nuclio python will drop support for Python 2.7.')
+            self._logger.warn('Nuclio will drop support for Python 2.7 within the next minor version')
 
     def serve_requests(self, num_requests=None):
         """Read event from socket, send out reply"""

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -23,6 +23,7 @@ import traceback
 
 import msgpack
 import nuclio_sdk
+import nuclio_sdk.helpers
 import nuclio_sdk.json_encoder
 import nuclio_sdk.logger
 
@@ -88,8 +89,10 @@ class Wrapper(object):
         self._write_packet_to_processor('s')
 
         # log deprecation warning
-        if sys.version_info[:2] == (2, 7):
-            self._logger.warn('Nuclio will drop support for Python 2.7 within the next minor version')
+        if nuclio_sdk.helpers.PYTHON2:
+            self._logger.warn('Python 2.7 runtime is deprecated. '
+                              'Nuclio will drop support for Python 2.7 runtime as of version 1.6.0. '
+                              'Please migrate your code to Python 3.6')
 
     def serve_requests(self, num_requests=None):
         """Read event from socket, send out reply"""

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -104,7 +104,6 @@ class TestSubmitEvents(unittest.TestCase):
             expected_messages += 1
 
         self._wait_until_received_messages(expected_messages)
-        print(self._unix_stream_server._messages)
 
         malformed_response = self._unix_stream_server._messages[-3]['body']
         self.assertEqual(httpclient.INTERNAL_SERVER_ERROR, malformed_response['status_code'])

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -29,9 +29,9 @@ import unittest
 import _nuclio_wrapper as wrapper
 import msgpack
 import nuclio_sdk
+import nuclio_sdk.helpers
 
-# python2/3 differences
-if sys.version_info[:2] >= (3, 0):
+if nuclio_sdk.helpers.PYTHON3:
     from socketserver import UnixStreamServer, BaseRequestHandler
     from unittest import mock
     import http.client as httpclient
@@ -92,15 +92,21 @@ class TestSubmitEvents(unittest.TestCase):
         t.join()
 
         # processor start
+        # if python 2 then: deprecation note
         # duration
         # function response
         # malformed log line (wrapper)
         # malformed response
         # duration
         # function response
-        self._wait_until_received_messages(7)
+        expected_messages = 7
+        if nuclio_sdk.helpers.PYTHON2:
+            expected_messages += 1
 
-        malformed_response = self._unix_stream_server._messages[4]['body']
+        self._wait_until_received_messages(expected_messages)
+        print(self._unix_stream_server._messages)
+
+        malformed_response = self._unix_stream_server._messages[-3]['body']
         self.assertEqual(httpclient.INTERNAL_SERVER_ERROR, malformed_response['status_code'])
 
         # ensure messages coming after malformed request are still valid


### PR DESCRIPTION
Python 2.7 has gone deprecated and unmaintained a while ago.

To allow ourselves add great features, fix encoding decoding bugs and improve python performance, it is require for us to deprecate python 2.7 to allow using 3rd party packages which drop support for python 2.7.

This change would happen incrementally, while all versions up until today will continue deploying python 2.7.

Starting next minor release, we will drop support for python 2.7 functions.

To update your functions, you simply update your `function.yaml` runtime from `python:2.7` to `python` (which would be resolve to the default python runtime, which is currently 3.6).