### PR TITLE
Enrich trigger name from its map key

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -928,7 +928,7 @@ func (ap *Platform) validateProjectExists(createFunctionOptions *platform.Create
 func (ap *Platform) validateTriggers(createFunctionOptions *platform.CreateFunctionOptions) error {
 
 	var httpTriggerExists bool
-	for triggerName, _trigger := range createFunctionOptions.FunctionConfig.Spec.Triggers {
+	for triggerName, triggerInstance := range createFunctionOptions.FunctionConfig.Spec.Triggers {
 
 		// do not allow trigger with empty name
 		if triggerName == "" {
@@ -936,15 +936,15 @@ func (ap *Platform) validateTriggers(createFunctionOptions *platform.CreateFunct
 		}
 
 		// no more workers than limitation allows
-		if _trigger.MaxWorkers > trigger.MaxWorkersLimit {
+		if triggerInstance.MaxWorkers > trigger.MaxWorkersLimit {
 			return errors.Errorf("MaxWorkers value for %s trigger (%d) exceeds the limit of %d",
 				triggerName,
-				_trigger.MaxWorkers,
+				triggerInstance.MaxWorkers,
 				trigger.MaxWorkersLimit)
 		}
 
 		// no more than one http trigger is allowed
-		if _trigger.Kind == "http" {
+		if triggerInstance.Kind == "http" {
 			if !httpTriggerExists {
 				httpTriggerExists = true
 				continue
@@ -1017,6 +1017,11 @@ func (ap *Platform) enrichTriggers(createFunctionOptions *platform.CreateFunctio
 	ap.enrichDefaultHTTPTrigger(createFunctionOptions)
 
 	for triggerName, triggerInstance := range createFunctionOptions.FunctionConfig.Spec.Triggers {
+
+		// if name was not given, inherit its key
+		if triggerInstance.Name == "" {
+			triggerInstance.Name = triggerName
+		}
 
 		// ensure having max workers
 		if common.StringInSlice(triggerInstance.Kind, []string{"http", "v3ioStream"}) {

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -163,7 +163,7 @@ func (suite *AbstractPlatformTestSuite) TestMinMaxReplicas() {
 	}
 }
 
-func (suite *AbstractPlatformTestSuite) TestFunctionTriggersEnriched() {
+func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() {
 	for idx, testCase := range []struct {
 		triggers                 map[string]functionconfig.Trigger
 		expectedEnrichedTriggers map[string]functionconfig.Trigger
@@ -171,6 +171,7 @@ func (suite *AbstractPlatformTestSuite) TestFunctionTriggersEnriched() {
 	}{
 
 		// enrich maxWorkers to 1
+		// enrich name from key
 		{
 			triggers: map[string]functionconfig.Trigger{
 				"some-trigger": {
@@ -181,6 +182,7 @@ func (suite *AbstractPlatformTestSuite) TestFunctionTriggersEnriched() {
 				"some-trigger": {
 					Kind:       "http",
 					MaxWorkers: 1,
+					Name:       "some-trigger",
 				},
 			},
 		},


### PR DESCRIPTION
To avoid weird behavior in UI where trigger name is empty while its key is filled.
