### PR TITLE
Fix dashboard logging for GET /api/functions requests

### DIFF
--- a/pkg/restful/server.go
+++ b/pkg/restful/server.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
@@ -164,9 +165,9 @@ func (s *AbstractServer) requestResponseLogger() func(next http.Handler) http.Ha
 			// when request processing is done, log the request / response
 			defer func() {
 				if common.StringSliceContainsStringPrefix([]string{
-					"/api/functions/",
+					"/api/functions",
 					"/api/function_templates",
-				}, request.URL.Path) {
+				}, strings.TrimSuffix(request.URL.Path, "/")) {
 					return
 				}
 				s.Logger.DebugWith("Handled request",


### PR DESCRIPTION
Considering the fact the resource can be called w/out a suffix of `/`, the check should trim it and ensure it correspondingly 