### PR TITLE
Enforce function resource version validation upon deletion

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -330,8 +330,7 @@ func (fr *functionResource) deleteFunction(request *http.Request) (*restful.Cust
 
 	deleteFunctionOptions.FunctionConfig.Meta = *functionInfo.Meta
 
-	err = fr.getPlatform().DeleteFunction(&deleteFunctionOptions)
-	if err != nil {
+	if err := fr.getPlatform().DeleteFunction(&deleteFunctionOptions); err != nil {
 		return &restful.CustomRouteFuncResponse{
 			Single:     true,
 			StatusCode: common.ResolveErrorStatusCodeOrDefault(err, http.StatusInternalServerError),
@@ -342,7 +341,7 @@ func (fr *functionResource) deleteFunction(request *http.Request) (*restful.Cust
 		ResourceType: "function",
 		Single:       true,
 		StatusCode:   http.StatusNoContent,
-	}, err
+	}, nil
 }
 
 func (fr *functionResource) functionToAttributes(function platform.Function) restful.Attributes {
@@ -377,8 +376,7 @@ func (fr *functionResource) getFunctionInfoFromRequest(request *http.Request) (*
 	}
 
 	functionInfoInstance := functionInfo{}
-	err = json.Unmarshal(body, &functionInfoInstance)
-	if err != nil {
+	if err := json.Unmarshal(body, &functionInfoInstance); err != nil {
 		return nil, nuclio.WrapErrBadRequest(errors.Wrap(err, "Failed to parse JSON body"))
 	}
 
@@ -406,6 +404,7 @@ func (fr *functionResource) validateUpdateInfo(functionInfo *functionInfo, funct
 }
 
 func (fr *functionResource) processFunctionInfo(functionInfoInstance *functionInfo, projectName string) (*functionInfo, error) {
+
 	// override namespace if applicable
 	if functionInfoInstance.Meta != nil {
 		functionInfoInstance.Meta.Namespace = fr.getNamespaceOrDefault(functionInfoInstance.Meta.Namespace)

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -283,7 +283,7 @@ func (ap *Platform) ValidateResourceVersion(functionConfigWithStatus *functionco
 	// when requestResourceVersion is empty, the existing one will be overridden
 	if requestResourceVersion != "" &&
 		requestResourceVersion != existingResourceVersion {
-		ap.Logger.ErrorWith("Create function resource version is stale",
+		ap.Logger.WarnWith("Create function resource version is stale",
 			"requestResourceVersion", requestResourceVersion,
 			"existingResourceVersion", existingResourceVersion)
 		return errors.New("Function resource version is stale")

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -260,30 +260,30 @@ func (ap *Platform) ValidateCreateFunctionOptionsAgainstExistingFunctionConfig(
 	}
 
 	// validate resource version
-	if err := ap.ValidateResourceVersion(existingFunctionConfig, createFunctionOptions); err != nil {
+	if err := ap.ValidateResourceVersion(existingFunctionConfig, &createFunctionOptions.FunctionConfig); err != nil {
 		return nuclio.WrapErrConflict(err)
 	}
 	return nil
 }
 
 // Validate existing and new create function options resource version
-func (ap *Platform) ValidateResourceVersion(existingFunctionConfig *functionconfig.ConfigWithStatus,
-	createFunctionOptions *platform.CreateFunctionOptions) error {
+func (ap *Platform) ValidateResourceVersion(functionConfigWithStatus *functionconfig.ConfigWithStatus,
+	requestFunctionConfig *functionconfig.Config) error {
 
 	// if function has no existing instance, resource version validation is irrelevant.
-	if existingFunctionConfig == nil {
+	if functionConfigWithStatus == nil {
 		return nil
 	}
 
 	// existing function should always be the latest
 	// reason: the way we `GET` nuclio function ensures we retrieve the latest copy.
-	existingResourceVersion := existingFunctionConfig.Meta.ResourceVersion
-	requestResourceVersion := createFunctionOptions.FunctionConfig.Meta.ResourceVersion
+	existingResourceVersion := functionConfigWithStatus.Meta.ResourceVersion
+	requestResourceVersion := requestFunctionConfig.Meta.ResourceVersion
 
 	// when requestResourceVersion is empty, the existing one will be overridden
 	if requestResourceVersion != "" &&
 		requestResourceVersion != existingResourceVersion {
-		ap.Logger.WarnWith("Create function resource version is stale",
+		ap.Logger.ErrorWith("Create function resource version is stale",
 			"requestResourceVersion", requestResourceVersion,
 			"existingResourceVersion", existingResourceVersion)
 		return errors.New("Function resource version is stale")
@@ -325,7 +325,7 @@ func (ap *Platform) ValidateCreateFunctionOptions(createFunctionOptions *platfor
 	return nil
 }
 
-// Validation and enforcement of required function deletion logic
+// Validation and enforcement of required project deletion logic
 func (ap *Platform) ValidateDeleteProjectOptions(deleteProjectOptions *platform.DeleteProjectOptions) error {
 	projectName := deleteProjectOptions.Meta.Name
 
@@ -335,6 +335,35 @@ func (ap *Platform) ValidateDeleteProjectOptions(deleteProjectOptions *platform.
 
 	if err := ap.validateProjectIsEmpty(deleteProjectOptions.Meta.Namespace, projectName); err != nil {
 		return errors.Wrap(err, "Cannot delete non-empty project")
+	}
+
+	return nil
+}
+
+// Validation and enforcement of required function deletion logic
+func (ap *Platform) ValidateDeleteFunctionOptions(deleteFunctionOptions *platform.DeleteFunctionOptions) error {
+	functionName := deleteFunctionOptions.FunctionConfig.Meta.Name
+	functionNamespace := deleteFunctionOptions.FunctionConfig.Meta.Namespace
+	functions, err := ap.platform.GetFunctions(&platform.GetFunctionsOptions{
+		Name:      functionName,
+		Namespace: functionNamespace,
+	})
+	if err != nil {
+		return errors.Wrap(err, "Failed to get functions")
+	}
+
+	// function does not exists and hence nothing to validate (that might happen, delete method can be idempotent)
+	if len(functions) == 0 {
+		ap.Logger.DebugWith("Function is already deleted", "functionName", functionName)
+		return nil
+	}
+
+	functionToDelete := functions[0]
+
+	// validate resource version
+	if err := ap.ValidateResourceVersion(functionToDelete.GetConfigWithStatus(),
+		&deleteFunctionOptions.FunctionConfig); err != nil {
+		return nuclio.WrapErrConflict(err)
 	}
 
 	return nil

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -12,20 +12,14 @@ import (
 	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platform/mock"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
 	"github.com/nuclio/logger"
 	"github.com/nuclio/zap"
 	"github.com/rs/xid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
-
-type TestPlatform struct {
-	platform.Platform
-	logger         logger.Logger
-	suiteAssertion *assert.Assertions
-}
 
 const (
 	MultiWorkerFunctionLogsFilePath          = "test/logs_examples/multi_worker"
@@ -38,17 +32,10 @@ const (
 	BriefErrorsMessageFile                   = "brief_errors_message.txt"
 )
 
-// GetProjects will list existing projects
-func (mp *TestPlatform) GetProjects(getProjectsOptions *platform.GetProjectsOptions) ([]platform.Project, error) {
-	project, err := platform.NewAbstractProject(mp.logger, nil, platform.ProjectConfig{})
-	mp.suiteAssertion.NoError(err, "Failed to create new abstract project")
-	return []platform.Project{
-		project,
-	}, nil
-}
-
 type AbstractPlatformTestSuite struct {
 	suite.Suite
+	mockedPlatform *mock.Platform
+
 	Logger           logger.Logger
 	DockerClient     dockerclient.Client
 	Platform         *Platform
@@ -71,11 +58,8 @@ func (suite *AbstractPlatformTestSuite) SetupSuite() {
 	suite.Logger, err = nucliozap.NewNuclioZapTest("test")
 	suite.Require().NoError(err, "Logger should create successfully")
 
-	testPlatform := &TestPlatform{
-		logger:         suite.Logger,
-		suiteAssertion: suite.Assert(),
-	}
-	suite.Platform, err = NewPlatform(suite.Logger, testPlatform, &platformconfig.Config{})
+	suite.mockedPlatform = &mock.Platform{}
+	suite.Platform, err = NewPlatform(suite.Logger, suite.mockedPlatform, &platformconfig.Config{})
 	suite.Require().NoError(err, "Could not create platform")
 
 	suite.Platform.ContainerBuilder, err = containerimagebuilderpusher.NewNop(suite.Logger, nil)
@@ -84,6 +68,112 @@ func (suite *AbstractPlatformTestSuite) SetupSuite() {
 
 func (suite *AbstractPlatformTestSuite) SetupTest() {
 	suite.TestID = xid.New().String()
+}
+
+func (suite *AbstractPlatformTestSuite) TestValidateDeleteFunctionOptions() {
+	for _, testCase := range []struct {
+		existingFunctions     []platform.Function
+		deleteFunctionOptions *platform.DeleteFunctionOptions
+		shouldFailValidation  bool
+	}{
+
+		// happy flow
+		{
+			existingFunctions: []platform.Function{
+				&platform.AbstractFunction{
+					Logger:   suite.Logger,
+					Platform: suite.Platform.platform,
+					Config: functionconfig.Config{
+						Meta: functionconfig.Meta{
+							Name: "existing",
+						},
+					},
+				},
+			},
+			deleteFunctionOptions: &platform.DeleteFunctionOptions{
+				FunctionConfig: functionconfig.Config{
+					Meta: functionconfig.Meta{
+						Name: "existing",
+					},
+				},
+			},
+		},
+
+		// function may not be existing, validation should pass (delete is idempotent)
+		{
+			deleteFunctionOptions: &platform.DeleteFunctionOptions{
+				FunctionConfig: functionconfig.Config{
+					Meta: functionconfig.Meta{
+						Name:            "not-existing",
+						ResourceVersion: "",
+					},
+					Spec: functionconfig.Spec{},
+				},
+			},
+		},
+
+		// matching resourceVersion
+		{
+			existingFunctions: []platform.Function{
+				&platform.AbstractFunction{
+					Logger:   suite.Logger,
+					Platform: suite.Platform.platform,
+					Config: functionconfig.Config{
+						Meta: functionconfig.Meta{
+							Name:            "existing",
+							ResourceVersion: "1",
+						},
+					},
+				},
+			},
+			deleteFunctionOptions: &platform.DeleteFunctionOptions{
+				FunctionConfig: functionconfig.Config{
+					Meta: functionconfig.Meta{
+						Name:            "existing",
+						ResourceVersion: "1",
+					},
+				},
+			},
+		},
+
+		// fail: stale resourceVersion
+		{
+			existingFunctions: []platform.Function{
+				&platform.AbstractFunction{
+					Logger:   suite.Logger,
+					Platform: suite.Platform.platform,
+					Config: functionconfig.Config{
+						Meta: functionconfig.Meta{
+							Name:            "existing",
+							ResourceVersion: "2",
+						},
+					},
+				},
+			},
+			deleteFunctionOptions: &platform.DeleteFunctionOptions{
+				FunctionConfig: functionconfig.Config{
+					Meta: functionconfig.Meta{
+						Name:            "existing",
+						ResourceVersion: "1",
+					},
+				},
+			},
+			shouldFailValidation: true,
+		},
+	} {
+
+		suite.mockedPlatform.On("GetFunctions", &platform.GetFunctionsOptions{
+			Name:      testCase.deleteFunctionOptions.FunctionConfig.Meta.Name,
+			Namespace: testCase.deleteFunctionOptions.FunctionConfig.Meta.Namespace,
+		}).Return(testCase.existingFunctions, nil).Once()
+
+		err := suite.Platform.ValidateDeleteFunctionOptions(testCase.deleteFunctionOptions)
+		if testCase.shouldFailValidation {
+			suite.Require().Error(err)
+		} else {
+			suite.Require().NoError(err)
+		}
+	}
 }
 
 // Test function with invalid min max replicas
@@ -118,6 +208,15 @@ func (suite *AbstractPlatformTestSuite) TestMinMaxReplicas() {
 		{MinReplicas: &two, MaxReplicas: &one, shouldFailValidation: true},
 		{MinReplicas: &two, MaxReplicas: &two, ExpectedMinReplicas: &two, ExpectedMaxReplicas: &two, shouldFailValidation: false},
 	} {
+
+		suite.mockedPlatform.On("GetProjects", &platform.GetProjectsOptions{
+			Meta: platform.ProjectMeta{
+				Name:      platform.DefaultProjectName,
+				Namespace: "default",
+			},
+		}).Return([]platform.Project{
+			&platform.AbstractProject{},
+		}, nil).Once()
 
 		// name it with index and shift with 65 to get A as first letter
 		functionName := string(rune(idx + 65))
@@ -221,6 +320,16 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 			shouldFailValidation: true,
 		},
 	} {
+
+		suite.mockedPlatform.On("GetProjects", &platform.GetProjectsOptions{
+			Meta: platform.ProjectMeta{
+				Name:      platform.DefaultProjectName,
+				Namespace: "default",
+			},
+		}).Return([]platform.Project{
+			&platform.AbstractProject{},
+		}, nil).Once()
+
 		// name it with index and shift with 65 to get A as first letter
 		functionName := string(rune(idx + 65))
 		functionConfig := *functionconfig.NewConfig()

--- a/pkg/platform/function.go
+++ b/pkg/platform/function.go
@@ -36,7 +36,7 @@ type Function interface {
 	// GetConfig will return the configuration of the function
 	GetConfig() *functionconfig.Config
 
-	// GetState returns the state of the function
+	// GetStatus returns the state of the function
 	GetStatus() *functionconfig.Status
 
 	// GetInvokeURL returns the URL on which the function can be invoked
@@ -50,6 +50,9 @@ type Function interface {
 
 	// GetVersion returns a string representing the version
 	GetVersion() string
+
+	// GetConfigWithStatus returns configuration and state of the function
+	GetConfigWithStatus() *functionconfig.ConfigWithStatus
 }
 
 type AbstractFunction struct {
@@ -82,6 +85,7 @@ func (af *AbstractFunction) Initialize([]string) error {
 	return nil
 }
 
+// GetConfig will return the configuration of the function
 func (af *AbstractFunction) GetConfig() *functionconfig.Config {
 	return &af.Config
 }
@@ -110,7 +114,7 @@ func (af *AbstractFunction) GetReplicas() (int, int) {
 	return 0, 0
 }
 
-// GetState returns the state of the function
+// GetStatus returns the state of the function
 func (af *AbstractFunction) GetStatus() *functionconfig.Status {
 	return &af.Status
 }

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -377,6 +377,15 @@ func (p *Platform) UpdateFunction(updateFunctionOptions *platform.UpdateFunction
 
 // DeleteFunction will delete a previously deployed function
 func (p *Platform) DeleteFunction(deleteFunctionOptions *platform.DeleteFunctionOptions) error {
+	p.Logger.DebugWith("Deleting function",
+		"functionConfig", deleteFunctionOptions.FunctionConfig)
+
+	// pre delete validation
+	if err := p.ValidateDeleteFunctionOptions(deleteFunctionOptions); err != nil {
+		return errors.Wrap(err, "Failed while validating function deletion options")
+	}
+
+	// user must clean api gateway before deleting the function
 	if err := p.validateFunctionHasNoAPIGateways(deleteFunctionOptions); err != nil {
 		return errors.Wrap(err, "Failed while validating function has no api gateways")
 	}

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -8,32 +8,18 @@ import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/abstract"
+	"github.com/nuclio/nuclio/pkg/platform/mock"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
 	"github.com/nuclio/logger"
 	"github.com/nuclio/zap"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/api/core/v1"
 )
 
-type TestPlatform struct {
-	platform.Platform
-	logger         logger.Logger
-	suiteAssertion *assert.Assertions
-}
-
-// GetProjects will list existing projects
-func (mp *TestPlatform) GetProjects(getProjectsOptions *platform.GetProjectsOptions) ([]platform.Project, error) {
-	project, err := platform.NewAbstractProject(mp.logger, nil, platform.ProjectConfig{})
-	mp.suiteAssertion.NoError(err, "Failed to create new abstract project")
-	return []platform.Project{
-		project,
-	}, nil
-}
-
 type KubePlatformTestSuite struct {
 	suite.Suite
+	mockedPlatform     *mock.Platform
 	Logger             logger.Logger
 	Platform           *Platform
 	PlatformKubeConfig *platformconfig.PlatformKubeConfig
@@ -50,10 +36,8 @@ func (suite *KubePlatformTestSuite) SetupSuite() {
 	suite.PlatformKubeConfig = &platformconfig.PlatformKubeConfig{
 		DefaultServiceType: v1.ServiceTypeClusterIP,
 	}
-	abstractPlatform, err := abstract.NewPlatform(suite.Logger, &TestPlatform{
-		logger:         suite.Logger,
-		suiteAssertion: suite.Assert(),
-	}, &platformconfig.Config{
+	suite.mockedPlatform = &mock.Platform{}
+	abstractPlatform, err := abstract.NewPlatform(suite.Logger, suite.mockedPlatform, &platformconfig.Config{
 		Kube: *suite.PlatformKubeConfig,
 	})
 	suite.Require().NoError(err, "Could not create platform")
@@ -88,6 +72,15 @@ func (suite *KubePlatformTestSuite) TestFunctionTriggersEnriched() {
 			}(),
 		},
 	} {
+		suite.mockedPlatform.On("GetProjects", &platform.GetProjectsOptions{
+			Meta: platform.ProjectMeta{
+				Name:      platform.DefaultProjectName,
+				Namespace: suite.Platform.ResolveDefaultNamespace(""),
+			},
+		}).Return([]platform.Project{
+			&platform.AbstractProject{},
+		}, nil).Once()
+
 		// name it with index and shift with 65 to get A as first letter
 		functionName := string(rune(idx + 65))
 		functionConfig := *functionconfig.NewConfig()

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -325,79 +325,13 @@ func (p *Platform) UpdateFunction(updateFunctionOptions *platform.UpdateFunction
 // DeleteFunction will delete a previously deployed function
 func (p *Platform) DeleteFunction(deleteFunctionOptions *platform.DeleteFunctionOptions) error {
 
-	// delete the function from the local store
-	err := p.localStore.deleteFunction(&deleteFunctionOptions.FunctionConfig.Meta)
-	if err != nil && err != nuclio.ErrNotFound {
-		p.Logger.WarnWith("Failed to delete function from local store", "err", err.Error())
+	// delete function options validation
+	if err := p.ValidateDeleteFunctionOptions(deleteFunctionOptions); err != nil {
+		return errors.Wrap(err, "Failed while validating function deletion options")
 	}
 
-	getFunctionEventsOptions := &platform.FunctionEventMeta{
-		Labels: map[string]string{
-			"nuclio.io/function-name": deleteFunctionOptions.FunctionConfig.Meta.Name,
-		},
-		Namespace: deleteFunctionOptions.FunctionConfig.Meta.Namespace,
-	}
-	functionEvents, err := p.localStore.getFunctionEvents(getFunctionEventsOptions)
-	if err != nil {
-		return errors.Wrap(err, "Failed to get function events")
-	}
-
-	p.Logger.InfoWith("Got function events", "num", len(functionEvents))
-
-	errGroup, _ := errgroup.WithContext(context.TODO())
-	for _, functionEvent := range functionEvents {
-
-		errGroup.Go(func() error {
-			err = p.localStore.deleteFunctionEvent(&functionEvent.GetConfig().Meta)
-			if err != nil {
-				return errors.Wrap(err, "Failed to delete function event")
-			}
-			return nil
-		})
-	}
-
-	// wait for all errgroup goroutines
-	if err := errGroup.Wait(); err != nil {
-		return errors.Wrap(err, "Failed to delete function events")
-	}
-
-	getContainerOptions := &dockerclient.GetContainerOptions{
-		Labels: map[string]string{
-			"nuclio.io/platform":      "local",
-			"nuclio.io/namespace":     deleteFunctionOptions.FunctionConfig.Meta.Namespace,
-			"nuclio.io/function-name": deleteFunctionOptions.FunctionConfig.Meta.Name,
-		},
-	}
-
-	containersInfo, err := p.dockerClient.GetContainers(getContainerOptions)
-	if err != nil {
-		return errors.Wrap(err, "Failed to get containers")
-	}
-
-	// iterate over contains and delete them. It's possible that under some weird circumstances
-	// there are a few instances of this function in the namespace
-	for _, containerInfo := range containersInfo {
-		if err := p.dockerClient.RemoveContainer(containerInfo.ID); err != nil {
-			return err
-		}
-	}
-
-	// get function platform specific configuration
-	functionPlatformConfiguration, err := newFunctionPlatformConfiguration(&deleteFunctionOptions.FunctionConfig)
-	if err != nil {
-		return errors.Wrap(err, "Failed to create function platform configuration")
-	}
-
-	if functionPlatformConfiguration.ProcessorMountMode == ProcessorMountModeVolume {
-
-		// delete function volumes after containers are deleted
-		if err := p.dockerClient.DeleteVolume(p.GetProcessorMountVolumeName(&deleteFunctionOptions.FunctionConfig)); err != nil {
-			return errors.Wrapf(err, "Failed to delete function volume")
-		}
-	}
-
-	p.Logger.InfoWith("Function deleted", "name", deleteFunctionOptions.FunctionConfig.Meta.Name)
-	return nil
+	// actual function and its resources deletion
+	return p.delete(deleteFunctionOptions)
 }
 
 // GetHealthCheckMode returns the healthcheck mode the platform requires
@@ -708,6 +642,83 @@ func (p *Platform) deployFunction(createFunctionOptions *platform.CreateFunction
 		Port:        functionExternalHTTPPort,
 		ContainerID: containerID,
 	}, nil
+}
+
+func (p *Platform) delete(deleteFunctionOptions *platform.DeleteFunctionOptions) error {
+
+	// delete the function from the local store
+	err := p.localStore.deleteFunction(&deleteFunctionOptions.FunctionConfig.Meta)
+	if err != nil && err != nuclio.ErrNotFound {
+		p.Logger.WarnWith("Failed to delete function from local store", "err", err.Error())
+	}
+
+	getFunctionEventsOptions := &platform.FunctionEventMeta{
+		Labels: map[string]string{
+			"nuclio.io/function-name": deleteFunctionOptions.FunctionConfig.Meta.Name,
+		},
+		Namespace: deleteFunctionOptions.FunctionConfig.Meta.Namespace,
+	}
+	functionEvents, err := p.localStore.getFunctionEvents(getFunctionEventsOptions)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get function events")
+	}
+
+	p.Logger.InfoWith("Got function events", "num", len(functionEvents))
+
+	errGroup, _ := errgroup.WithContext(context.TODO())
+	for _, functionEvent := range functionEvents {
+
+		errGroup.Go(func() error {
+			err = p.localStore.deleteFunctionEvent(&functionEvent.GetConfig().Meta)
+			if err != nil {
+				return errors.Wrap(err, "Failed to delete function event")
+			}
+			return nil
+		})
+	}
+
+	// wait for all errgroup goroutines
+	if err := errGroup.Wait(); err != nil {
+		return errors.Wrap(err, "Failed to delete function events")
+	}
+
+	getContainerOptions := &dockerclient.GetContainerOptions{
+		Labels: map[string]string{
+			"nuclio.io/platform":      "local",
+			"nuclio.io/namespace":     deleteFunctionOptions.FunctionConfig.Meta.Namespace,
+			"nuclio.io/function-name": deleteFunctionOptions.FunctionConfig.Meta.Name,
+		},
+	}
+
+	containersInfo, err := p.dockerClient.GetContainers(getContainerOptions)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get containers")
+	}
+
+	// iterate over contains and delete them. It's possible that under some weird circumstances
+	// there are a few instances of this function in the namespace
+	for _, containerInfo := range containersInfo {
+		if err := p.dockerClient.RemoveContainer(containerInfo.ID); err != nil {
+			return err
+		}
+	}
+
+	// get function platform specific configuration
+	functionPlatformConfiguration, err := newFunctionPlatformConfiguration(&deleteFunctionOptions.FunctionConfig)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create function platform configuration")
+	}
+
+	if functionPlatformConfiguration.ProcessorMountMode == ProcessorMountModeVolume {
+
+		// delete function volumes after containers are deleted
+		if err := p.dockerClient.DeleteVolume(p.GetProcessorMountVolumeName(&deleteFunctionOptions.FunctionConfig)); err != nil {
+			return errors.Wrapf(err, "Failed to delete function volume")
+		}
+	}
+
+	p.Logger.InfoWith("Function deleted", "name", deleteFunctionOptions.FunctionConfig.Meta.Name)
+	return nil
 }
 
 func (p *Platform) resolveAndCreateFunctionMounts(createFunctionOptions *platform.CreateFunctionOptions,


### PR DESCRIPTION
Following https://github.com/nuclio/nuclio/pull/1697,
Enforce resourceVersion for `DELETE /api/function/:id` as well