### PR TITLE
UI: Function: Inform about UI precedence over external + reword

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5652,9 +5652,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.28.8",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.28.8.tgz",
-      "integrity": "sha512-JH2rQKYOp4hXP1uGZJxg06NUdee+eizf8VCGANxmihGbf/Iywdkvbabh6UJ4ptbtrLBrsZhb/48+NKOyuE30WQ==",
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.28.9.tgz",
+      "integrity": "sha512-A38JqGaic1XFMq7dkA/Fm0lLIj8QfNFYu2ESuoZmhZoOyW34QVjlFrBRdHhEcGG00kfH+FCMcukr8vCUnJiUsA==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -49,7 +49,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.28.8",
+    "iguazio.dashboard-controls": "^0.28.9",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
- Function › Code › Code Entry Type: when any option is selected other than “Source code (edit online)” a message is displayed to inform the user that the configuration in UI has precedence over the configuration in the external code source.
  ![image](https://user-images.githubusercontent.com/13918850/100009791-fbc2d380-2dd7-11eb-83a5-03c5aaf03ac1.png)
- Create function: reworded the text messages in the pop-up dialogs when attempting to create a function with a name that is already in use by an existing function
  - For a function on the same project, or on another project when running on a non-K8s platform:
    ![image](https://user-images.githubusercontent.com/13918850/100098042-1f345f80-2e66-11eb-9a6b-5af50283b5df.png)
  - For a function on another project when running on a K8s platform
    ![image](https://user-images.githubusercontent.com/13918850/100098071-29eef480-2e66-11eb-9d32-af6eb1219fd7.png)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/1137