### PR TITLE
Helm chart - upgrade CRD version for new k8s compatibility

### DIFF
--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.7.8
+version: 0.7.9
 appVersion: 1.5.6
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/templates/crd/api-gateway.yaml
+++ b/hack/k8s/helm/nuclio/templates/crd/api-gateway.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- if and .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: nuclioapigateways.nuclio.io
@@ -27,5 +27,8 @@ spec:
     plural: nuclioapigateways
     singular: nuclioapigateway
   scope: Namespaced
-  version: v1beta1
+  versions:
+    - name: v1
+      served: true
+      storage: true
 {{- end }}

--- a/hack/k8s/helm/nuclio/templates/crd/function-event.yaml
+++ b/hack/k8s/helm/nuclio/templates/crd/function-event.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: nucliofunctionevents.nuclio.io
@@ -27,5 +27,8 @@ spec:
     plural: nucliofunctionevents
     singular: nucliofunctionevent
   scope: Namespaced
-  version: v1beta1
+  versions:
+  - name: v1
+    served: true
+    storage: true
 {{- end }}

--- a/hack/k8s/helm/nuclio/templates/crd/function.yaml
+++ b/hack/k8s/helm/nuclio/templates/crd/function.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: nucliofunctions.nuclio.io
@@ -27,5 +27,8 @@ spec:
     plural: nucliofunctions
     singular: nucliofunction
   scope: Namespaced
-  version: v1beta1
+  versions:
+  - name: v1
+    served: true
+    storage: true
 {{- end }}

--- a/hack/k8s/helm/nuclio/templates/crd/project.yaml
+++ b/hack/k8s/helm/nuclio/templates/crd/project.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: nuclioprojects.nuclio.io
@@ -27,5 +27,8 @@ spec:
     plural: nuclioprojects
     singular: nuclioproject
   scope: Namespaced
-  version: v1beta1
+  versions:
+  - name: v1
+    served: true
+    storage: true
 {{- end }}


### PR DESCRIPTION
This will remove deprecation warnings when installing the chart on v1.16+ k8s versions and prevent it from failing on this check when v1.22 comes along (it hasn't yet):
```
W1126 23:09:53.706837   15704 warnings.go:67] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
```