### PR TITLE
Enforce trigger key and name equality

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -971,7 +971,7 @@ func (ap *Platform) validateTriggers(functionConfig *functionconfig.Config) erro
 
 		// trigger key and name must match
 		if triggerKey != triggerInstance.Name {
-			return nuclio.NewErrBadRequest(fmt.Sprintf("Trigger key and name must match (%s  %s)",
+			return nuclio.NewErrBadRequest(fmt.Sprintf("Trigger key and name mismatch (%s != %s)",
 				triggerKey, triggerInstance.Name))
 		}
 

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -83,6 +83,7 @@ func (suite *AbstractPlatformTestSuite) TestValidationFailOnMalformedIngressesSt
 		Triggers      map[string]functionconfig.Trigger
 		ExpectedError string
 	}{
+
 		// test malformed ingresses structure
 		{
 			Triggers: map[string]functionconfig.Trigger{
@@ -146,8 +147,12 @@ func (suite *AbstractPlatformTestSuite) TestValidationFailOnMalformedIngressesSt
 		// set test triggers
 		functionConfig.Spec.Triggers = testCase.Triggers
 
-		// run validations
-		err := suite.Platform.ValidateFunctionConfig(functionConfig)
+		// enrich
+		err := suite.Platform.EnrichFunctionConfig(functionConfig)
+		suite.Require().NoError(err)
+
+		// validate
+		err = suite.Platform.ValidateFunctionConfig(functionConfig)
 		if testCase.ExpectedError != "" {
 			suite.Assert().Error(err)
 			suite.Assert().Equal(testCase.ExpectedError, errors.RootCause(err).Error())
@@ -402,6 +407,17 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 			triggers: map[string]functionconfig.Trigger{
 				"": {
 					Kind: "http",
+				},
+			},
+			shouldFailValidation: true,
+		},
+
+		// mismatching trigger key and name
+		{
+			triggers: map[string]functionconfig.Trigger{
+				"a": {
+					Kind: "http",
+					Name: "b",
 				},
 			},
 			shouldFailValidation: true,

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -290,8 +290,6 @@ func (suite *TestSuite) TestModifiedRequestBodySize() {
 		createFunctionOptions.FunctionConfig.Spec.Handler = "empty:handler"
 		createFunctionOptions.FunctionConfig.Spec.Triggers["http"] = functionconfig.Trigger{
 			Kind:       "http",
-			Name:       "myHTTPTrigger",
-			MaxWorkers: 1,
 			Attributes: map[string]interface{}{
 				"maxRequestBodySize": maxRequestBodySize,
 			},

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -289,7 +289,7 @@ func (suite *TestSuite) TestModifiedRequestBodySize() {
 			path.Join(suite.GetTestFunctionsDir(), "common", "empty", "python"))
 		createFunctionOptions.FunctionConfig.Spec.Handler = "empty:handler"
 		createFunctionOptions.FunctionConfig.Spec.Triggers["http"] = functionconfig.Trigger{
-			Kind:       "http",
+			Kind: "http",
 			Attributes: map[string]interface{}{
 				"maxRequestBodySize": maxRequestBodySize,
 			},


### PR DESCRIPTION
To avoid inconsistency between trigger key and name, a validation upon function creation will take place to enforce such scenario would fail.