### PR TITLE
Resolve top-down status code on error

### DIFF
--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -22,10 +22,11 @@ func ResolveErrorStatusCodeOrDefault(err error, defaultStatusCode int) int {
 			return typedError.StatusCode()
 		}
 
+		// in case the previous level didn't have a status code - get the next cause in the error stack
 		cause := errors.Cause(currentErr)
 
 		// if there's no cause, we're done
-		// if the cause is not comparabile, it's not an Error and we're done
+		// if the cause is not comparable, it's not an Error and we're done
 		// if the cause == the error, we're done since that's what Cause() returns
 		if cause == nil || !reflect.TypeOf(cause).Comparable() || cause == currentErr {
 			break

--- a/pkg/common/errors_test.go
+++ b/pkg/common/errors_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/nuclio-sdk-go"
+	"github.com/stretchr/testify/suite"
+)
+
+type ErrorsTestSuite struct {
+	suite.Suite
+}
+
+func (ets *ErrorsTestSuite) TestResolveErrorStatusCodeOrDefault() {
+	for _, testCase := range []struct {
+		inputError         error
+		expectedStatusCode int
+		defaultStatusCode  int
+	}{
+
+		// test get status code from deepest error cause
+		{
+			inputError:         errors.Wrap(errors.Wrap(nuclio.NewErrBadRequest("err"), "err"), "err"),
+			expectedStatusCode: http.StatusBadRequest,
+		},
+
+		// test get status code from middle error cause
+		{
+			inputError:         errors.Wrap(errors.Wrap(nuclio.WrapErrConflict(nuclio.NewErrBadRequest("err")), "err"), "err"),
+			expectedStatusCode: http.StatusConflict,
+		},
+
+		// test get status code from the top
+		{
+			inputError:         nuclio.WrapErrMethodNotAllowed(errors.Wrap(nuclio.WrapErrConflict(nuclio.NewErrBadRequest("err")), "err")),
+			expectedStatusCode: http.StatusMethodNotAllowed,
+		},
+
+		// test get general internal status code when error has no status code
+		{
+			inputError:         errors.Wrap(errors.Wrap(errors.New("err"), "err"), "err"),
+			expectedStatusCode: http.StatusInternalServerError,
+			defaultStatusCode:  http.StatusOK,
+		},
+
+		// test get default status code when error is nil
+		{
+			inputError:         nil,
+			expectedStatusCode: http.StatusOK,
+			defaultStatusCode:  http.StatusOK,
+		},
+	} {
+
+		// set default status code
+		defaultStatusCode := http.StatusInternalServerError
+		if testCase.defaultStatusCode != 0 {
+			defaultStatusCode = testCase.defaultStatusCode
+		}
+
+		// run the tested function
+		statusCode := ResolveErrorStatusCodeOrDefault(testCase.inputError, defaultStatusCode)
+
+		// validate we got the expected status code
+		ets.Require().Equal(testCase.expectedStatusCode, statusCode)
+	}
+}
+
+func TestErrorsTestSuite(t *testing.T) {
+	suite.Run(t, new(ErrorsTestSuite))
+}

--- a/pkg/dashboard/resource/apigateway.go
+++ b/pkg/dashboard/resource/apigateway.go
@@ -326,11 +326,6 @@ func (agr *apiGatewayResource) enrichAPIGatewayInfo(apiGatewayInfoInstance *apiG
 	}
 }
 
-func (agr *apiGatewayResource) processAPIGatewayInfo(apiGatewayInfoInstance *apiGatewayInfo, projectName string) error {
-
-	return nil
-}
-
 // register the resource
 var apiGatewayResourceInstance = &apiGatewayResource{
 	resource: newResource("api/api_gateways", []restful.ResourceMethod{


### PR DESCRIPTION
Whenever there's an error, `ResolveErrorStatusCodeOrDefault` will iterate top-down on the error stack and return the first status code it finds