### PR TITLE
UI: Allow to overwrite newer function version with stale (+ more)

### DIFF
--- a/pkg/dashboard/ui/gulpfile.js
+++ b/pkg/dashboard/ui/gulpfile.js
@@ -191,7 +191,8 @@ gulp.task('app.js', function () {
         .pipe(minifyHtml({
             removeComments: true,
             collapseWhitespace: true,
-            collapseInlineTagWhitespace: true
+            collapseInlineTagWhitespace: true,
+            conservativeCollapse: true
         }))
         .pipe(ngHtml2Js({
             moduleName: config.app_files.templates_module_name
@@ -542,7 +543,8 @@ function buildIndexHtml(isVersionForTests) {
         .pipe(gulpIf(!state.isDevMode, minifyHtml({
             removeComments: true,
             collapseWhitespace: true,
-            collapseInlineTagWhitespace: true
+            collapseInlineTagWhitespace: true,
+            conservativeCollapse: true
         })))
         .pipe(gulp.dest(config.build_dir));
 
@@ -688,7 +690,8 @@ gulp.task('app.js_shared', function () {
         .pipe(minifyHtml({
             removeComments: true,
             collapseWhitespace: true,
-            collapseInlineTagWhitespace: true
+            collapseInlineTagWhitespace: true,
+            conservativeCollapse: true
         }))
         .pipe(ngHtml2Js({
             moduleName: config.shared_files.templates_module_name

--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5652,9 +5652,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.28.9",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.28.9.tgz",
-      "integrity": "sha512-A38JqGaic1XFMq7dkA/Fm0lLIj8QfNFYu2ESuoZmhZoOyW34QVjlFrBRdHhEcGG00kfH+FCMcukr8vCUnJiUsA==",
+      "version": "0.28.10",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.28.10.tgz",
+      "integrity": "sha512-nUYQcdDbPVtXWzYyXI1CVrUMQ5u3vwRA0rC0Ah4REYY+Cy8atbFRDbMVXFmF8nZY6CgODvF8kypG/iGWqEHAWQ==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -49,7 +49,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.28.9",
+    "iguazio.dashboard-controls": "^0.28.10",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",

--- a/pkg/dashboard/ui/src/app/components/projects/edit-project-dialog/edit-project-dialog.tpl.html
+++ b/pkg/dashboard/ui/src/app/components/projects/edit-project-dialog/edit-project-dialog.tpl.html
@@ -70,5 +70,5 @@
 
 <div class="error-text text-centered error-relative"
      data-ng-show="$ctrl.isServerError()">
-    {{ 'common:ERROR' | i18next }}:&nbsp;{{$ctrl.serverError}}
+    {{ 'common:ERROR' | i18next }}: {{$ctrl.serverError}}
 </div>

--- a/pkg/dashboard/ui/src/app/components/projects/new-project-dialog/new-project-dialog.tpl.html
+++ b/pkg/dashboard/ui/src/app/components/projects/new-project-dialog/new-project-dialog.tpl.html
@@ -71,5 +71,5 @@
 
 <div class="error-text text-centered error-relative"
      data-ng-show="$ctrl.isServerError()">
-    {{ 'common:ERROR' | i18next }}:&nbsp;{{$ctrl.serverError}}
+    {{ 'common:ERROR' | i18next }}: {{$ctrl.serverError}}
 </div>


### PR DESCRIPTION
- Create new function › From Template: [bugfix] when filtering templates the pagination was not working.
- Function:
  - On deploying a function, in case there is already a newer version deployed, show a pop-up explaining the situation and suggest to overwrite the newer version with the current stale one (“Cancel” button is focused by default):
    ![image](https://user-images.githubusercontent.com/13918850/100546614-ff88a700-326a-11eb-950f-ddb4f1b38bed.png)
  - [bugfix] Refresh and Actions remained disabled after the “Deploy” button was click and deploy was canceled or failed
  ![image](https://user-images.githubusercontent.com/13918850/100740107-d427c880-33e0-11eb-878e-17550094ce7d.png)
- Build: The HTML minifier used to collapsed sequences of whitespace characters between HTML elements and remove them altogether. Now they would be collapsed into a single space character instead. For example, the source code
  ```html
  <foo>   
    <bar>
  ```
  would turn to
  ```html
  <foo> <bar>
  ```
  instead of
  ```html
  <foo><bar>
  ```