### PR TITLE
Updated retry on build errors

### DIFF
--- a/pkg/cmdrunner/mock.go
+++ b/pkg/cmdrunner/mock.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmdrunner
+
+import (
+	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockRunner struct {
+	mock.Mock
+}
+
+func (m *MockRunner) Run(runOptions *RunOptions, format string, vars ...interface{}) (RunResult, error) {
+	args := m.Called(runOptions, format, vars)
+	runResults, ok := args.Get(0).(RunResult)
+	if ok && runOptions != nil {
+		runResults.Stderr = common.Redact(runOptions.LogRedactions, runResults.Stderr)
+		runResults.Output = common.Redact(runOptions.LogRedactions, runResults.Output)
+	}
+	return runResults, args.Error(1)
+}
+
+func NewMockRunner() *MockRunner {
+	return &MockRunner{}
+}

--- a/pkg/cmdrunner/mock.go
+++ b/pkg/cmdrunner/mock.go
@@ -18,6 +18,7 @@ package cmdrunner
 
 import (
 	"github.com/nuclio/nuclio/pkg/common"
+
 	"github.com/stretchr/testify/mock"
 )
 

--- a/pkg/cmdrunner/shellrunner.go
+++ b/pkg/cmdrunner/shellrunner.go
@@ -29,35 +29,6 @@ import (
 	"github.com/nuclio/logger"
 )
 
-type CaptureOutputMode int
-
-const (
-	CaptureOutputModeCombined CaptureOutputMode = iota
-	CaptureOutputModeStdout
-)
-
-// RunOptions specifies runOptions to CmdRunner.Run
-type RunOptions struct {
-	WorkingDir        *string
-	Stdin             *string
-	Env               map[string]string
-	LogRedactions     []string
-	CaptureOutputMode CaptureOutputMode
-}
-
-type RunResult struct {
-	Output   string
-	Stderr   string
-	ExitCode int
-}
-
-// CmdRunner specifies the interface to an underlying command runner
-type CmdRunner interface {
-
-	// Run runs a command, given runOptions
-	Run(runOptions *RunOptions, format string, vars ...interface{}) (RunResult, error)
-}
-
 type ShellRunner struct {
 	logger logger.Logger
 	shell  string

--- a/pkg/cmdrunner/types.go
+++ b/pkg/cmdrunner/types.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmdrunner
+
+type CaptureOutputMode int
+
+const (
+	CaptureOutputModeCombined CaptureOutputMode = iota
+	CaptureOutputModeStdout
+)
+
+// RunOptions specifies runOptions to CmdRunner.Run
+type RunOptions struct {
+	WorkingDir        *string
+	Stdin             *string
+	Env               map[string]string
+	LogRedactions     []string
+	CaptureOutputMode CaptureOutputMode
+}
+
+// RunResult holds command execution returned values
+type RunResult struct {
+	Output   string
+	Stderr   string
+	ExitCode int
+}
+
+// CmdRunner specifies the interface to an underlying command runner
+type CmdRunner interface {
+
+	// Run runs a command, given runOptions
+	Run(runOptions *RunOptions, format string, vars ...interface{}) (RunResult, error)
+}

--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -45,24 +45,19 @@ func (d *Docker) GetKind() string {
 }
 
 func (d *Docker) BuildAndPushContainerImage(buildOptions *BuildOptions, namespace string) error {
-
-	err := d.gatherArtifactsForSingleStageDockerfile(buildOptions)
-	if err != nil {
+	if err := d.gatherArtifactsForSingleStageDockerfile(buildOptions); err != nil {
 		return errors.Wrap(err, "Failed to build image artifacts")
 	}
 
-	err = d.buildContainerImage(buildOptions)
-	if err != nil {
+	if err := d.buildContainerImage(buildOptions); err != nil {
 		return errors.Wrap(err, "Failed to build docker image")
 	}
 
-	err = d.pushContainerImage(buildOptions.Image, buildOptions.RegistryURL)
-	if err != nil {
+	if err := d.pushContainerImage(buildOptions.Image, buildOptions.RegistryURL); err != nil {
 		return errors.Wrap(err, "Failed to push docker image into registry")
 	}
 
-	err = d.saveContainerImage(buildOptions)
-	if err != nil {
+	if err := d.saveContainerImage(buildOptions); err != nil {
 		return errors.Wrap(err, "Failed to save docker image")
 	}
 
@@ -210,8 +205,7 @@ ARG NUCLIO_ARCH
 `, onbuildImage)
 
 	// generate a simple Dockerfile from the onbuild image
-	err := ioutil.WriteFile(dockerfilePath, []byte(onbuildDockerfileContents), 0644)
-	if err != nil {
+	if err := ioutil.WriteFile(dockerfilePath, []byte(onbuildDockerfileContents), 0644); err != nil {
 		return errors.Wrapf(err, "Failed to write onbuild Dockerfile to %s", dockerfilePath)
 	}
 
@@ -222,13 +216,12 @@ ARG NUCLIO_ARCH
 	onbuildImageName := fmt.Sprintf("nuclio-onbuild-%s", xid.New().String())
 
 	// trigger a build
-	err = d.dockerClient.Build(&dockerclient.BuildOptions{
+	if err := d.dockerClient.Build(&dockerclient.BuildOptions{
 		Image:          onbuildImageName,
 		ContextDir:     contextDir,
 		BuildArgs:      buildArgs,
 		DockerfilePath: dockerfilePath,
-	})
-	if err != nil {
+	}); err != nil {
 		return errors.Wrap(err, "Failed to build onbuild image")
 	}
 

--- a/pkg/dockerclient/shell_test.go
+++ b/pkg/dockerclient/shell_test.go
@@ -17,64 +17,56 @@ limitations under the License.
 package dockerclient
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
-	"github.com/nuclio/nuclio/pkg/common"
 
+	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/zap"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
-type mockCmdRunner struct {
-	mock.Mock
-	expectedStdout   string
-	expectedStderr   string
-	expectedExitCode int
-}
-
-func newMockCmdRunner(expectedStdout, expectedStderr string, expectedErrorCode int) *mockCmdRunner {
-	return &mockCmdRunner{
-		expectedStdout:   expectedStdout,
-		expectedStderr:   expectedStderr,
-		expectedExitCode: expectedErrorCode,
-	}
-}
-
-func (mcr *mockCmdRunner) Run(options *cmdrunner.RunOptions, format string, vars ...interface{}) (cmdrunner.RunResult, error) {
-	if options == nil {
-		options = &cmdrunner.RunOptions{}
-	}
-
-	return cmdrunner.RunResult{
-			ExitCode: mcr.expectedExitCode,
-			Output:   common.Redact(options.LogRedactions, mcr.expectedStdout),
-			Stderr:   common.Redact(options.LogRedactions, mcr.expectedStderr)},
-		nil
-}
-
-type CmdClientTestSuite struct {
+type ShellClientTestSuite struct {
 	suite.Suite
-	logger      logger.Logger
-	shellClient ShellClient
+	logger          logger.Logger
+	mockedCmdRunner *cmdrunner.MockRunner
+	shellClient     *ShellClient
 }
 
-func (suite *CmdClientTestSuite) SetupTest() {
-	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
-	shellClient, err := NewShellClient(suite.logger, newMockCmdRunner("", "", 0))
-	if err != nil {
-		panic("Failed to create shell client")
-	}
+func (suite *ShellClientTestSuite) SetupTest() {
+	var err error
 
-	suite.shellClient = *shellClient
+	// create logger
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err, "Failed to create logger")
+
+	// create mocked cmd runner
+	suite.mockedCmdRunner = cmdrunner.NewMockRunner()
+	suite.mockedCmdRunner.
+		On("Run", mock.Anything, "docker version", mock.Anything).
+		Return(cmdrunner.RunResult{
+			Output: "test",
+		}, nil)
+
+	// create docker shell client
+	suite.shellClient, err = NewShellClient(suite.logger, suite.mockedCmdRunner)
+	suite.Require().NoError(err, "Failed to create shell client")
+
+	suite.shellClient.buildRetryInterval = 1 * time.Millisecond
 }
 
-func (suite *CmdClientTestSuite) TestShellClientRunContainerReturnsStdout() {
+func (suite *ShellClientTestSuite) TestShellClientRunContainerReturnsStdout() {
 	testPhrase := "testing"
-	suite.shellClient.cmdRunner.(*mockCmdRunner).expectedStdout = testPhrase
-
+	suite.mockedCmdRunner.
+		On("Run", mock.Anything, "docker run %s %s %s", mock.Anything).
+		Return(cmdrunner.RunResult{
+			Output: testPhrase,
+		}, nil).
+		Once()
 	output, err := suite.shellClient.RunContainer("alpine",
 		&RunOptions{
 			Ports: map[int]int{7779: 7779},
@@ -84,13 +76,18 @@ func (suite *CmdClientTestSuite) TestShellClientRunContainerReturnsStdout() {
 	suite.Equal(testPhrase, output)
 }
 
-func (suite *CmdClientTestSuite) TestShellClientRunContainerReturnsMultilineStdout() {
-	suite.shellClient.cmdRunner.(*mockCmdRunner).expectedStdout = `
+func (suite *ShellClientTestSuite) TestShellClientRunContainerReturnsMultilineStdout() {
+	suite.mockedCmdRunner.
+		On("Run", mock.Anything, "docker run %s %s %s", mock.Anything).
+		Return(cmdrunner.RunResult{
+			Output: `
 hello world
 this is another line
 and another
 andthisistheid
-`
+`,
+		}, nil).
+		Once()
 
 	containerID, err := suite.shellClient.RunContainer("alpine",
 		&RunOptions{
@@ -101,9 +98,13 @@ andthisistheid
 	suite.Require().Equal("andthisistheid", containerID)
 }
 
-func (suite *CmdClientTestSuite) TestShellClientRunContainerReturnsStderr() {
-	suite.shellClient.cmdRunner.(*mockCmdRunner).expectedStderr = "foo"
-
+func (suite *ShellClientTestSuite) TestShellClientRunContainerReturnsStderr() {
+	suite.mockedCmdRunner.
+		On("Run", mock.Anything, "docker run %s %s %s", mock.Anything).
+		Return(cmdrunner.RunResult{
+			Stderr: "foo",
+		}, nil).
+		Once()
 	_, err := suite.shellClient.RunContainer("alpine",
 		&RunOptions{
 			Ports: map[int]int{7779: 7779},
@@ -112,13 +113,17 @@ func (suite *CmdClientTestSuite) TestShellClientRunContainerReturnsStderr() {
 	suite.Require().NoError(err)
 }
 
-func (suite *CmdClientTestSuite) TestShellClientRunContainerFailsOnNonSingleStdout() {
-	suite.shellClient.cmdRunner.(*mockCmdRunner).expectedStdout = `
+func (suite *ShellClientTestSuite) TestShellClientRunContainerFailsOnNonSingleStdout() {
+	suite.mockedCmdRunner.
+		On("Run", mock.Anything, "docker run %s %s %s", mock.Anything).
+		Return(cmdrunner.RunResult{
+			Output: `
 hello world
 this is another line
 and another
-andthisistheid with a space`
-
+andthisistheid with a space`,
+		}, nil).
+		Once()
 	_, err := suite.shellClient.RunContainer("alpine",
 		&RunOptions{
 			Ports: map[int]int{7779: 7779},
@@ -127,13 +132,18 @@ andthisistheid with a space`
 	suite.Require().Error(err, "Output from docker command includes more than just ID")
 }
 
-func (suite *CmdClientTestSuite) TestShellClientRunContainerWhenImageMayNotExist() {
-	suite.shellClient.cmdRunner.(*mockCmdRunner).expectedStdout = `
+func (suite *ShellClientTestSuite) TestShellClientRunContainerWhenImageMayNotExist() {
+	suite.mockedCmdRunner.
+		On("Run", mock.Anything, "docker run %s %s %s", mock.Anything).
+		Return(cmdrunner.RunResult{
+			Output: `
 hello world
 this is another line
 and another
 therealidishere
-and this a line informing a new version of alpine was pulled. with a space`
+and this a line informing a new version of alpine was pulled. with a space`,
+		}, nil).
+		Once()
 
 	containerID, err := suite.shellClient.RunContainer("alpine",
 		&RunOptions{
@@ -145,8 +155,14 @@ and this a line informing a new version of alpine was pulled. with a space`
 	suite.Require().Equal("therealidishere", containerID)
 }
 
-func (suite *CmdClientTestSuite) TestShellClientRunContainerRedactsOutput() {
-	suite.shellClient.cmdRunner.(*mockCmdRunner).expectedStdout = `helloworldsecret`
+func (suite *ShellClientTestSuite) TestShellClientRunContainerRedactsOutput() {
+	suite.mockedCmdRunner.
+		On("Run", mock.Anything, "docker run %s %s %s", mock.Anything).
+		Return(cmdrunner.RunResult{
+			Output: "helloworldsecret",
+		}, nil).
+		Once()
+
 	suite.shellClient.redactedValues = append(suite.shellClient.redactedValues, "secret")
 	output, err := suite.shellClient.RunContainer("alpine",
 		&RunOptions{
@@ -157,6 +173,59 @@ func (suite *CmdClientTestSuite) TestShellClientRunContainerRedactsOutput() {
 	suite.Require().Equal("helloworld[redacted]", output)
 }
 
-func TestCmdRunnerTestSuite(t *testing.T) {
-	suite.Run(t, new(CmdClientTestSuite))
+func (suite *ShellClientTestSuite) TestBuildBailOnUnknownError() {
+
+	// mock failing
+	suite.mockedCmdRunner.
+		On("Run",
+			mock.Anything,
+			mock.MatchedBy(func(command string) bool {
+				return strings.Contains(command, "docker build %s")
+			}),
+			mock.Anything).
+		Return(cmdrunner.RunResult{
+			Stderr: `some bad happened`,
+		}, errors.New("unexpected error")).
+		Once()
+
+	err := suite.shellClient.Build(&BuildOptions{
+		ContextDir: "",
+	})
+	suite.Require().Error(err)
+
+	// 1 for docker version + 1 unknown build error
+	suite.mockedCmdRunner.AssertNumberOfCalls(suite.T(), "Run", 2)
+}
+
+func (suite *ShellClientTestSuite) TestBuildRetryOnErrors() {
+
+	// mock failing
+	suite.mockedCmdRunner.
+		On("Run",
+			mock.Anything,
+			mock.MatchedBy(func(command string) bool {
+				return strings.Contains(command, "docker build %s")
+			}),
+			mock.Anything).
+		Return(cmdrunner.RunResult{
+			Stderr: `Unable to find image 'nuclio-onbuild-someid:sometag' locally`,
+		}, errors.New("execution error")).
+		Twice()
+
+	// success build
+	suite.mockedCmdRunner.
+		On("Run", mock.Anything, mock.Anything, mock.Anything).
+		Return(cmdrunner.RunResult{}, nil)
+
+	err := suite.shellClient.Build(&BuildOptions{
+		ContextDir: "",
+	})
+	suite.Require().Nil(err)
+
+	// 1 for docker version + 2 failing builds + 1 success build
+	suite.mockedCmdRunner.AssertNumberOfCalls(suite.T(), "Run", 4)
+}
+
+func TestShellRunnerTestSuite(t *testing.T) {
+	suite.Run(t, new(ShellClientTestSuite))
 }


### PR DESCRIPTION
Fix a scenario when multiple concurrent deployments cause docker to reuse a specific function onbuild image as a layer cache. that is risky since once build is done, the cached layer would be saved while causing the artifact to be missing from another build in process.

A fix is simply to retry running the build command, allowing docker regenerate required docker cache layers while understanding the missing layer is not there to be used.

Add:
- Updated shell / mock unit test to use _real_ mocked cmd runner
- shorten `err if err` - proper err handling