### PR TITLE
Return created apigateway resource upon create request

### DIFF
--- a/pkg/dashboard/resource/apigateway.go
+++ b/pkg/dashboard/resource/apigateway.go
@@ -139,7 +139,7 @@ func (agr *apiGatewayResource) updateAPIGateway(request *http.Request) (*restful
 		}, err
 	}
 
-	apiGatewayConfig := platform.APIGatewayConfig{
+	apiGatewayConfig := &platform.APIGatewayConfig{
 		Meta:   *apiGatewayInfo.Meta,
 		Spec:   *apiGatewayInfo.Spec,
 		Status: *apiGatewayInfo.Status,
@@ -216,7 +216,7 @@ func (agr *apiGatewayResource) createAPIGateway(apiGatewayInfoInstance *apiGatew
 	// just deploy. the status is async through polling
 	agr.Logger.DebugWith("Creating api gateway", "newAPIGateway", newAPIGateway)
 	if err = agr.getPlatform().CreateAPIGateway(&platform.CreateAPIGatewayOptions{
-		APIGatewayConfig: *newAPIGateway.GetConfig(),
+		APIGatewayConfig: newAPIGateway.GetConfig(),
 	}); err != nil {
 		if strings.Contains(errors.Cause(err).Error(), "already exists") {
 			err = nuclio.WrapErrConflict(err)

--- a/pkg/nuctl/command/create.go
+++ b/pkg/nuctl/command/create.go
@@ -219,7 +219,7 @@ func newCreateAPIGatewayCommandeer(createCommandeer *createCommandeer) *createAP
 			commandeer.apiGatewayConfig.Status.State = platform.APIGatewayStateWaitingForProvisioning
 
 			return createCommandeer.rootCommandeer.platform.CreateAPIGateway(&platform.CreateAPIGatewayOptions{
-				APIGatewayConfig: commandeer.apiGatewayConfig,
+				APIGatewayConfig: &commandeer.apiGatewayConfig,
 			})
 		},
 	}

--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -278,7 +278,7 @@ func (i *importProjectCommandeer) importAPIGateway(apiGateway *platform.APIGatew
 
 	// just create. the status is async through polling
 	return i.rootCommandeer.platform.CreateAPIGateway(&platform.CreateAPIGatewayOptions{
-		APIGatewayConfig: platform.APIGatewayConfig{
+		APIGatewayConfig: &platform.APIGatewayConfig{
 			Meta: apiGateway.Meta,
 			Spec: apiGateway.Spec,
 		},

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -553,14 +553,14 @@ func (p *Platform) CreateAPIGateway(createAPIGatewayOptions *platform.CreateAPIG
 	newAPIGateway := nuclioio.NuclioAPIGateway{}
 
 	// enrich
-	p.EnrichAPIGatewayConfig(&createAPIGatewayOptions.APIGatewayConfig)
+	p.EnrichAPIGatewayConfig(createAPIGatewayOptions.APIGatewayConfig)
 
 	// validate
-	if err := p.ValidateAPIGatewayConfig(&createAPIGatewayOptions.APIGatewayConfig); err != nil {
+	if err := p.ValidateAPIGatewayConfig(createAPIGatewayOptions.APIGatewayConfig); err != nil {
 		return errors.Wrap(err, "Failed to validate and enrich api gateway name")
 	}
 
-	p.platformAPIGatewayToAPIGateway(&createAPIGatewayOptions.APIGatewayConfig, &newAPIGateway)
+	p.platformAPIGatewayToAPIGateway(createAPIGatewayOptions.APIGatewayConfig, &newAPIGateway)
 
 	// create
 	_, err := p.consumer.nuclioClientSet.NuclioV1beta1().
@@ -583,10 +583,10 @@ func (p *Platform) UpdateAPIGateway(updateAPIGatewayOptions *platform.UpdateAPIG
 	}
 
 	// enrich
-	p.EnrichAPIGatewayConfig(&updateAPIGatewayOptions.APIGatewayConfig)
+	p.EnrichAPIGatewayConfig(updateAPIGatewayOptions.APIGatewayConfig)
 
 	// validate
-	if err := p.ValidateAPIGatewayConfig(&updateAPIGatewayOptions.APIGatewayConfig); err != nil {
+	if err := p.ValidateAPIGatewayConfig(updateAPIGatewayOptions.APIGatewayConfig); err != nil {
 		return errors.Wrap(err, "Failed to validate and enrich api gateway name")
 	}
 

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -440,7 +440,7 @@ func (suite *KubeTestSuite) compileCreateAPIGatewayOptions(apiGatewayName string
 	functionName string) *platform.CreateAPIGatewayOptions {
 
 	return &platform.CreateAPIGatewayOptions{
-		APIGatewayConfig: platform.APIGatewayConfig{
+		APIGatewayConfig: &platform.APIGatewayConfig{
 			Meta: platform.APIGatewayMeta{
 				Name:      apiGatewayName,
 				Namespace: suite.Namespace,

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -327,11 +327,11 @@ type APIGatewayStatus struct {
 }
 
 type CreateAPIGatewayOptions struct {
-	APIGatewayConfig APIGatewayConfig
+	APIGatewayConfig *APIGatewayConfig
 }
 
 type UpdateAPIGatewayOptions struct {
-	APIGatewayConfig APIGatewayConfig
+	APIGatewayConfig *APIGatewayConfig
 }
 
 type DeleteAPIGatewayOptions struct {


### PR DESCRIPTION
Since the previous structure that holds the apigateway configuration was passed by value, it caused the enrichment function within the `.CreateAPIGateway` not to enrich the callee object that is later being respond to the user.

Changing the `CreateAPIGatewayOptions` and `UpdateAPIGatewayOptions` to hold a point to the config resolves this issue, as it would passed by reference and hence enrichment would ensure the response body is enriched as well.