### PR TITLE
UI: Config>Build: Fix missing image name prefix after deploy

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5652,9 +5652,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.28.12",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.28.12.tgz",
-      "integrity": "sha512-HgKKaXxwNncKsRlDxrVuqFXrJErnI1iaxsFjzxrgHX/YzKOp6GMWzCN2dXkInOj5VFhWzubtWBWoC2UOdaNmww==",
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.28.13.tgz",
+      "integrity": "sha512-IsdkD/c2wMeBwedELhonGu5eJfpMqBDGcDWYMf+pVi3J9MYNogHghi2U8dGF/cux4icYxVWZcck/BeqnVg9d4Q==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -49,7 +49,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.28.12",
+    "iguazio.dashboard-controls": "^0.28.13",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
- Function › Configuration › Build › Image name: [bugfix] the read-only prefix that precedes the image name field disappeared after deploying the function.

Depends on PR https://github.com/iguazio/dashboard-controls/pull/1151