### PR TITLE
Remove nuctl redundant platform config

### DIFF
--- a/.run/(test_kube) nuctl.run.xml
+++ b/.run/(test_kube) nuctl.run.xml
@@ -10,6 +10,7 @@
       <env name="NUCTL_REGISTRY" value="localhost:5000" />
       <env name="NUCTL_PLATFORM" value="kube" />
       <env name="NUCTL_EXTERNAL_IP_ADDRESSES" value="localhost" />
+      <env name="NUCTL_DEFAULT_SERVICE_TYPE" value="NodePort" />
     </envs>
     <framework value="gotest" />
     <kind value="PACKAGE" />

--- a/pkg/common/k8s.go
+++ b/pkg/common/k8s.go
@@ -24,6 +24,7 @@ func GetKubeconfigPath(kubeconfigPath string) string {
 	if kubeconfigPath == "" {
 		return GetEnvOrDefaultString("KUBECONFIG", getKubeconfigFromHomeDir())
 	}
+
 	return kubeconfigPath
 }
 

--- a/pkg/common/k8s.go
+++ b/pkg/common/k8s.go
@@ -24,7 +24,6 @@ func GetKubeconfigPath(kubeconfigPath string) string {
 	if kubeconfigPath == "" {
 		return GetEnvOrDefaultString("KUBECONFIG", getKubeconfigFromHomeDir())
 	}
-
 	return kubeconfigPath
 }
 

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -1,6 +1,9 @@
 package containerimagebuilderpusher
 
-import "github.com/nuclio/nuclio/pkg/processor/build/runtime"
+import (
+	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
+)
 
 // BuildOptions are options for building a container image
 type BuildOptions struct {
@@ -29,4 +32,53 @@ type ContainerBuilderConfiguration struct {
 	CacheRepo                            string
 	InsecurePushRegistry                 bool
 	InsecurePullRegistry                 bool
+}
+
+func NewContainerBuilderConfiguration() *ContainerBuilderConfiguration {
+	containerBuilderConfiguration := ContainerBuilderConfiguration{}
+
+	// if some of the parameters are undefined, try environment variables
+	if containerBuilderConfiguration.Kind == "" {
+		containerBuilderConfiguration.Kind = common.GetEnvOrDefaultString("NUCLIO_CONTAINER_BUILDER_KIND",
+			"docker")
+	}
+	if containerBuilderConfiguration.BusyBoxImage == "" {
+		containerBuilderConfiguration.BusyBoxImage = common.GetEnvOrDefaultString("NUCLIO_BUSYBOX_CONTAINER_IMAGE",
+			"busybox:1.31")
+	}
+	if containerBuilderConfiguration.KanikoImage == "" {
+		containerBuilderConfiguration.KanikoImage = common.GetEnvOrDefaultString("NUCLIO_KANIKO_CONTAINER_IMAGE",
+			"gcr.io/kaniko-project/executor:v0.17.1")
+	}
+	if containerBuilderConfiguration.KanikoImagePullPolicy == "" {
+		containerBuilderConfiguration.KanikoImagePullPolicy = common.GetEnvOrDefaultString(
+			"NUCLIO_KANIKO_CONTAINER_IMAGE_PULL_POLICY", "IfNotPresent")
+	}
+	if containerBuilderConfiguration.JobPrefix == "" {
+		containerBuilderConfiguration.JobPrefix = common.GetEnvOrDefaultString("NUCLIO_DASHBOARD_JOB_NAME_PREFIX",
+			"kanikojob")
+	}
+
+	containerBuilderConfiguration.InsecurePushRegistry =
+		common.GetEnvOrDefaultBool("NUCLIO_KANIKO_INSECURE_PUSH_REGISTRY", false)
+	containerBuilderConfiguration.InsecurePullRegistry =
+		common.GetEnvOrDefaultBool("NUCLIO_KANIKO_INSECURE_PULL_REGISTRY", false)
+
+	containerBuilderConfiguration.DefaultRegistryCredentialsSecretName =
+		common.GetEnvOrDefaultString("NUCLIO_REGISTRY_CREDENTIALS_SECRET_NAME", "")
+
+	if containerBuilderConfiguration.DefaultBaseRegistryURL == "" {
+		containerBuilderConfiguration.DefaultBaseRegistryURL =
+			common.GetEnvOrDefaultString("NUCLIO_DASHBOARD_DEFAULT_BASE_REGISTRY_URL", "")
+	}
+
+	if containerBuilderConfiguration.DefaultOnbuildRegistryURL == "" {
+		containerBuilderConfiguration.DefaultOnbuildRegistryURL =
+			common.GetEnvOrDefaultString("NUCLIO_DASHBOARD_DEFAULT_ONBUILD_REGISTRY_URL", "quay.io")
+	}
+
+	containerBuilderConfiguration.CacheRepo =
+		common.GetEnvOrDefaultString("NUCLIO_DASHBOARD_KANIKO_CACHE_REPO", "")
+
+	return &containerBuilderConfiguration
 }

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -49,15 +49,9 @@ func (fesr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restf
 		}
 	}
 
-	scaleToZeroConfiguration, err := fesr.getPlatform().GetScaleToZeroConfiguration()
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed getting scale to zero configuration")
-	}
+	scaleToZeroConfiguration := fesr.getPlatform().GetScaleToZeroConfiguration()
 
-	allowedAuthenticationModes, err := fesr.getPlatform().GetAllowedAuthenticationModes()
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed getting allowed authentication modes")
-	}
+	allowedAuthenticationModes := fesr.getPlatform().GetAllowedAuthenticationModes()
 
 	scaleToZeroMode := platformconfig.DisabledScaleToZeroMode
 	var inactivityWindowPresets []string

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -2972,12 +2972,12 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
 
 	suite.mockPlatform.
 		On("GetScaleToZeroConfiguration").
-		Return(&scaleToZeroConfiguration, nil).
+		Return(&scaleToZeroConfiguration).
 		Once()
 
 	suite.mockPlatform.
 		On("GetAllowedAuthenticationModes").
-		Return(allowedAuthenticationModes, nil).
+		Return(allowedAuthenticationModes).
 		Once()
 
 	expectedStatusCode := http.StatusOK

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -547,8 +547,12 @@ func (d *deployCommandeer) overrideFunctionConfig(functionConfig *functionconfig
 
 	// kube platform specific overrides
 	if _, ok := d.rootCommandeer.platform.(*kube.Platform); ok {
+		overridingHTTPServiceType := v1.ServiceType(common.GetEnvOrDefaultString("NUCTL_DEFAULT_SERVICE_TYPE", ""))
+		if d.overrideHTTPTriggerServiceType != "" {
+			overridingHTTPServiceType = v1.ServiceType(d.overrideHTTPTriggerServiceType)
+		}
 
-		if err := d.overrideHTTPTrigger(functionConfig, v1.ServiceType(d.overrideHTTPTriggerServiceType)); err != nil {
+		if err := d.overrideHTTPTrigger(functionConfig, overridingHTTPServiceType); err != nil {
 			return errors.Wrap(err, "Failed overriding function http trigger service type")
 		}
 	}

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -138,6 +138,9 @@ func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
 			// if the spec was brought from a file or from an already imported function.
 			commandeer.populateDeploymentDefaults()
 
+			// Populate HTTP Service type
+			commandeer.populateHTTPServiceType()
+
 			// Override basic fields from the config
 			commandeer.functionConfig.Meta.Name = commandeer.functionName
 			commandeer.functionConfig.Meta.Namespace = rootCommandeer.namespace
@@ -159,8 +162,7 @@ func newDeployCommandeer(rootCommandeer *RootCommandeer) *deployCommandeer {
 			commandeer.functionConfig.Meta.RemoveSkipBuildAnnotation()
 			commandeer.functionConfig.Meta.RemoveSkipDeployAnnotation()
 
-			commandeer.rootCommandeer.loggerInstance.DebugWith("Deploying function",
-				"functionConfig", commandeer.functionConfig)
+			commandeer.rootCommandeer.loggerInstance.DebugWith("Deploying function", "functionConfig", commandeer.functionConfig)
 			_, deployErr := rootCommandeer.platform.CreateFunction(&platform.CreateFunctionOptions{
 				Logger:         rootCommandeer.loggerInstance,
 				FunctionConfig: commandeer.functionConfig,
@@ -344,7 +346,9 @@ func (d *deployCommandeer) populateDeploymentDefaults() {
 	if d.functionConfig.Spec.RuntimeAttributes == nil {
 		d.functionConfig.Spec.RuntimeAttributes = map[string]interface{}{}
 	}
+}
 
+func (d *deployCommandeer) populateHTTPServiceType() {
 	overridingHTTPServiceType := v1.ServiceType(common.GetEnvOrDefaultString("NUCTL_DEFAULT_SERVICE_TYPE", ""))
 	if d.overrideHTTPTriggerServiceType != "" {
 		overridingHTTPServiceType = v1.ServiceType(d.overrideHTTPTriggerServiceType)

--- a/pkg/nuctl/command/nuctl.go
+++ b/pkg/nuctl/command/nuctl.go
@@ -108,6 +108,12 @@ func (rc *RootCommandeer) initialize() error {
 		return errors.Wrap(err, "Failed to create logger")
 	}
 
+	// TODO: accept platform config path as arg
+	rc.platformConfiguration, err = platformconfig.NewPlatformConfig("")
+	if err != nil {
+		return errors.Wrap(err, "Failed to create platform config")
+	}
+
 	rc.platformConfiguration.Kube.KubeConfigPath = rc.KubeconfigPath
 
 	// ask the factory to create the appropriate platform

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -30,7 +30,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
-	"github.com/nuclio/nuclio/pkg/platform/config"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/processor/build"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
@@ -56,7 +55,7 @@ type Platform struct {
 	Logger                         logger.Logger
 	platform                       platform.Platform
 	invoker                        *invoker
-	Config                         interface{}
+	Config                         *platformconfig.Config
 	ExternalIPAddresses            []string
 	DeployLogStreams               *sync.Map
 	ContainerBuilder               containerimagebuilderpusher.BuilderPusher
@@ -64,7 +63,9 @@ type Platform struct {
 	ImageNamePrefixTemplate        string
 }
 
-func NewPlatform(parentLogger logger.Logger, platform platform.Platform, platformConfiguration interface{}) (*Platform, error) {
+func NewPlatform(parentLogger logger.Logger,
+	platform platform.Platform,
+	platformConfiguration *platformconfig.Config) (*Platform, error) {
 	var err error
 
 	newPlatform := &Platform{
@@ -495,13 +496,13 @@ func (ap *Platform) GetExternalIPAddresses() ([]string, error) {
 }
 
 // GetScaleToZeroConfiguration returns scale to zero configuration
-func (ap *Platform) GetScaleToZeroConfiguration() (*platformconfig.ScaleToZero, error) {
-	return nil, nil
+func (ap *Platform) GetScaleToZeroConfiguration() *platformconfig.ScaleToZero {
+	return nil
 }
 
 // GetAllowedAuthenticationModes returns allowed authentication modes
-func (ap *Platform) GetAllowedAuthenticationModes() ([]string, error) {
-	return nil, nil
+func (ap *Platform) GetAllowedAuthenticationModes() []string {
+	return nil
 }
 
 // ResolveDefaultNamespace returns the proper default resource namespace, given the current default namespace
@@ -527,10 +528,7 @@ func (ap *Platform) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Art
 
 // GetBaseImageRegistry returns base image registry
 func (ap *Platform) GetBaseImageRegistry(registry string, runtime runtime.Runtime) (string, error) {
-	baseImagesOverrides, err := ap.getBaseImagesOverrides()
-	if err != nil {
-		return "", errors.Wrap(err, "Failed to get base images override from platform")
-	}
+	baseImagesOverrides := ap.getBaseImagesOverrides()
 
 	if baseImagesOverrides == nil {
 		baseImagesOverrides = map[string]string{}
@@ -545,10 +543,7 @@ func (ap *Platform) GetBaseImageRegistry(registry string, runtime runtime.Runtim
 
 // GetOnbuildImageRegistry returns onbuild image registry
 func (ap *Platform) GetOnbuildImageRegistry(registry string, runtime runtime.Runtime) (string, error) {
-	onbuildImagesOverrides, err := ap.getOnbuildImagesOverrides()
-	if err != nil {
-		return "", errors.Wrap(err, "Failed to get onbuild images override from platform")
-	}
+	onbuildImagesOverrides := ap.getOnbuildImagesOverrides()
 	if onbuildImagesOverrides == nil {
 		onbuildImagesOverrides = map[string]string{}
 	}
@@ -1103,41 +1098,11 @@ func (ap *Platform) enrichTriggers(functionConfig *functionconfig.Config) error 
 }
 
 // returns overrides for base images per runtime
-func (ap *Platform) getBaseImagesOverrides() (map[string]string, error) {
-	switch configType := ap.Config.(type) {
-	case *platformconfig.Config:
-		if configType != nil {
-			return configType.ImageRegistryOverrides.BaseImageRegistries, nil
-		}
-		return nil, nil
-
-	// FIXME: When deploying using nuctl in a kubernetes environment, it will be a kube platform, but the configuration
-	// will be of type *config.Configuration which is lacking
-	// we need to fix the platform config (p.Config) to always be of the same type (*platformconfig.Config) and not
-	// passing interface{} everywhere
-	case *config.Configuration:
-		return nil, nil
-	default:
-		return nil, errors.New("Not a valid configuration instance")
-	}
+func (ap *Platform) getBaseImagesOverrides() map[string]string {
+	return ap.Config.ImageRegistryOverrides.BaseImageRegistries
 }
 
 // returns overrides for base images per runtime
-func (ap *Platform) getOnbuildImagesOverrides() (map[string]string, error) {
-	switch configType := ap.Config.(type) {
-	case *platformconfig.Config:
-		if configType != nil {
-			return configType.ImageRegistryOverrides.OnbuildImageRegistries, nil
-		}
-		return nil, nil
-
-	// FIXME: When deploying using nuctl in a kubernetes environment, it will be a kube platform, but the configuration
-	// will be of type *config.Configuration which is lacking
-	// we need to fix the platform config (p.Config) to always be of the same type (*platformconfig.Config) and not
-	// passing interface{} everywhere
-	case *config.Configuration:
-		return nil, nil
-	default:
-		return nil, errors.New("Not a valid configuration instance")
-	}
+func (ap *Platform) getOnbuildImagesOverrides() map[string]string {
+	return ap.Config.ImageRegistryOverrides.OnbuildImageRegistries
 }

--- a/pkg/platform/config/types.go
+++ b/pkg/platform/config/types.go
@@ -1,8 +1,0 @@
-package config
-
-import "github.com/nuclio/nuclio/pkg/containerimagebuilderpusher"
-
-type Configuration struct {
-	KubeconfigPath                string
-	ContainerBuilderConfiguration containerimagebuilderpusher.ContainerBuilderConfiguration
-}

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -29,7 +29,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/abstract"
-	"github.com/nuclio/nuclio/pkg/platform/config"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
@@ -57,9 +56,7 @@ const Mib = 1048576
 
 // NewPlatform instantiates a new kubernetes platform
 func NewPlatform(parentLogger logger.Logger,
-	kubeconfigPath string,
-	containerBuilderConfiguration *containerimagebuilderpusher.ContainerBuilderConfiguration,
-	platformConfiguration interface{}) (*Platform, error) {
+	platformConfiguration *platformconfig.Config) (*Platform, error) {
 	newPlatform := &Platform{}
 
 	// create base
@@ -70,10 +67,10 @@ func NewPlatform(parentLogger logger.Logger,
 
 	// init platform
 	newPlatform.Platform = newAbstractPlatform
-	newPlatform.kubeconfigPath = kubeconfigPath
+	newPlatform.kubeconfigPath = common.GetKubeconfigPath(platformConfiguration.Kube.KubeConfigPath)
 
 	// create consumer
-	newPlatform.consumer, err = newConsumer(newPlatform.Logger, kubeconfigPath)
+	newPlatform.consumer, err = newConsumer(newPlatform.Logger, newPlatform.kubeconfigPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create consumer")
 	}
@@ -103,16 +100,17 @@ func NewPlatform(parentLogger logger.Logger,
 	}
 
 	// create container builder
-	if containerBuilderConfiguration != nil && containerBuilderConfiguration.Kind == "kaniko" {
+	if platformConfiguration.ContainerBuilderConfiguration.Kind == "kaniko" {
 		newPlatform.ContainerBuilder, err = containerimagebuilderpusher.NewKaniko(newPlatform.Logger,
-			newPlatform.consumer.kubeClientSet, containerBuilderConfiguration)
+			newPlatform.consumer.kubeClientSet, platformConfiguration.ContainerBuilderConfiguration)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to create kaniko builder")
 		}
 	} else {
 
 		// Default container image builder
-		newPlatform.ContainerBuilder, err = containerimagebuilderpusher.NewDocker(newPlatform.Logger, containerBuilderConfiguration)
+		newPlatform.ContainerBuilder, err = containerimagebuilderpusher.NewDocker(newPlatform.Logger,
+			platformConfiguration.ContainerBuilderConfiguration)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to create docker builder")
 		}
@@ -339,9 +337,7 @@ func (p Platform) EnrichFunctionConfig(functionConfig *functionconfig.Config) er
 		return err
 	}
 
-	if err := p.enrichHTTPTriggersWithServiceType(functionConfig); err != nil {
-		return errors.Wrap(err, "Failed to enrich HTTP triggers with service type")
-	}
+	p.enrichHTTPTriggersWithServiceType(functionConfig)
 
 	return nil
 }
@@ -918,37 +914,16 @@ func (p *Platform) GetDefaultInvokeIPAddresses() ([]string, error) {
 	return []string{}, nil
 }
 
-func (p *Platform) GetScaleToZeroConfiguration() (*platformconfig.ScaleToZero, error) {
-	switch configType := p.Config.(type) {
-	case *platformconfig.Config:
-		return &configType.ScaleToZero, nil
-
-	// FIXME: When deploying using nuctl in a kubernetes environment, it will be a kube platform, but the configuration
-	// will be of type *config.Configuration which has no scale to zero configuration
-	// we need to fix the platform config (p.Config) to always be of the same type (*platformconfig.Config) and not
-	// passing interface{} everywhere
-	case *config.Configuration:
-		return nil, nil
-	default:
-		return nil, errors.New("Not a valid configuration instance")
-	}
+func (p *Platform) GetScaleToZeroConfiguration() *platformconfig.ScaleToZero {
+	return &p.Config.ScaleToZero
 }
 
-func (p *Platform) GetAllowedAuthenticationModes() ([]string, error) {
-	switch configType := p.Config.(type) {
-	case *platformconfig.Config:
-		allowedAuthenticationModes := []string{string(ingress.AuthenticationModeNone), string(ingress.AuthenticationModeBasicAuth)}
-		if len(configType.IngressConfig.AllowedAuthenticationModes) > 0 {
-			allowedAuthenticationModes = configType.IngressConfig.AllowedAuthenticationModes
-		}
-		return allowedAuthenticationModes, nil
-
-	// FIXME: see comment in GetScaleToZeroConfiguration
-	case *config.Configuration:
-		return nil, nil
-	default:
-		return nil, errors.New("Not a valid configuration instance")
+func (p *Platform) GetAllowedAuthenticationModes() []string {
+	allowedAuthenticationModes := []string{string(ingress.AuthenticationModeNone), string(ingress.AuthenticationModeBasicAuth)}
+	if len(p.Config.IngressConfig.AllowedAuthenticationModes) > 0 {
+		allowedAuthenticationModes = p.Config.IngressConfig.AllowedAuthenticationModes
 	}
+	return allowedAuthenticationModes
 }
 
 func (p *Platform) SaveFunctionDeployLogs(functionName, namespace string) error {
@@ -1030,18 +1005,9 @@ func (p *Platform) setScaleToZeroSpec(functionSpec *functionconfig.Spec) error {
 		return nil
 	}
 
-	scaleToZeroConfiguration, err := p.GetScaleToZeroConfiguration()
-	if err != nil {
-		return errors.Wrap(err, "Failed getting scale to zero configuration")
-	}
-
-	if scaleToZeroConfiguration == nil {
-		return nil
-	}
-
-	if scaleToZeroConfiguration.Mode == platformconfig.EnabledScaleToZeroMode {
+	if p.Config.ScaleToZero.Mode == platformconfig.EnabledScaleToZeroMode {
 		functionSpec.ScaleToZero = &functionconfig.ScaleToZeroSpec{
-			ScaleResources: scaleToZeroConfiguration.ScaleResources,
+			ScaleResources: p.Config.ScaleToZero.ScaleResources,
 		}
 	}
 
@@ -1183,16 +1149,12 @@ func (p *Platform) enrichAndValidateFunctionConfig(functionConfig *functionconfi
 	return nil
 }
 
-func (p *Platform) enrichHTTPTriggersWithServiceType(functionConfig *functionconfig.Config) error {
-
-	var err error
+func (p *Platform) enrichHTTPTriggersWithServiceType(functionConfig *functionconfig.Config) {
 
 	// for backwards compatibility
 	serviceType := functionConfig.Spec.ServiceType
 	if serviceType == "" {
-		if serviceType, err = p.getDefaultServiceType(); err != nil {
-			return errors.Wrap(err, "Failed getting default service type")
-		}
+		serviceType = p.Config.Kube.DefaultServiceType
 	}
 
 	for triggerName, trigger := range functionconfig.GetTriggersByKind(functionConfig.Spec.Triggers, "http") {
@@ -1200,8 +1162,6 @@ func (p *Platform) enrichHTTPTriggersWithServiceType(functionConfig *functioncon
 			trigger,
 			serviceType)
 	}
-
-	return nil
 }
 
 func (p *Platform) validateFunctionHasNoAPIGateways(deleteFunctionOptions *platform.DeleteFunctionOptions) error {
@@ -1238,25 +1198,4 @@ func (p *Platform) enrichTriggerWithServiceType(functionConfig *functionconfig.C
 	}
 
 	return trigger
-}
-
-func (p *Platform) getDefaultServiceType() (v1.ServiceType, error) {
-	switch configType := p.Config.(type) {
-	case *platformconfig.Config:
-		return configType.Kube.DefaultServiceType, nil
-
-	// FIXME: see comment in GetScaleToZeroConfiguration
-	// for now, if nuctl - return the constant default
-	case *config.Configuration:
-		nuctlDefaultServiceType := v1.ServiceType(
-			common.GetEnvOrDefaultString("NUCTL_DEFAULT_SERVICE_TYPE", ""))
-
-		if nuctlDefaultServiceType == "" {
-			nuctlDefaultServiceType = platformconfig.DefaultServiceType
-		}
-
-		return nuctlDefaultServiceType, nil
-	default:
-		return "", errors.New("Not a valid configuration instance")
-	}
 }

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -35,6 +35,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/abstract"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/processor"
 	"github.com/nuclio/nuclio/pkg/processor/config"
 
@@ -62,8 +63,7 @@ const FunctionProcessorContainerDirPath = "/etc/nuclio/config/processor"
 
 // NewPlatform instantiates a new local platform
 func NewPlatform(parentLogger logger.Logger,
-	containerBuilderConfiguration *containerimagebuilderpusher.ContainerBuilderConfiguration,
-	platformConfiguration interface{}) (*Platform, error) {
+	platformConfiguration *platformconfig.Config) (*Platform, error) {
 	newPlatform := &Platform{}
 
 	// create base
@@ -86,7 +86,7 @@ func NewPlatform(parentLogger logger.Logger,
 	}
 
 	if newPlatform.ContainerBuilder, err = containerimagebuilderpusher.NewDocker(newPlatform.Logger,
-		containerBuilderConfiguration); err != nil {
+		platformConfiguration.ContainerBuilderConfiguration); err != nil {
 		return nil, errors.Wrap(err, "Failed to create containerimagebuilderpusher")
 	}
 

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -206,14 +206,14 @@ func (mp *Platform) GetExternalIPAddresses() ([]string, error) {
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (mp *Platform) GetScaleToZeroConfiguration() (*platformconfig.ScaleToZero, error) {
+func (mp *Platform) GetScaleToZeroConfiguration() *platformconfig.ScaleToZero {
 	args := mp.Called()
-	return args.Get(0).(*platformconfig.ScaleToZero), args.Error(1)
+	return args.Get(0).(*platformconfig.ScaleToZero)
 }
 
-func (mp *Platform) GetAllowedAuthenticationModes() ([]string, error) {
+func (mp *Platform) GetAllowedAuthenticationModes() []string {
 	args := mp.Called()
-	return args.Get(0).([]string), args.Error(1)
+	return args.Get(0).([]string)
 }
 
 // GetHealthCheckMode returns the healthcheck mode the platform requires

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -139,10 +139,10 @@ type Platform interface {
 	RenderImageNamePrefixTemplate(projectName string, functionName string) (string, error)
 
 	// GetScaleToZeroConfiguration returns scale to zero configuration
-	GetScaleToZeroConfiguration() (*platformconfig.ScaleToZero, error)
+	GetScaleToZeroConfiguration() *platformconfig.ScaleToZero
 
 	// GetAllowedAuthenticationModes returns allowed authentication modes
-	GetAllowedAuthenticationModes() ([]string, error)
+	GetAllowedAuthenticationModes() []string
 
 	// GetNamespaces returns all the namespaces in the platform
 	GetNamespaces() ([]string, error)

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -19,24 +19,26 @@ package platformconfig
 import (
 	"os"
 
+	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 
 	"github.com/nuclio/errors"
 )
 
 type Config struct {
-	Kind                     string                       `json:"kind,omitempty"`
-	WebAdmin                 WebServer                    `json:"webAdmin,omitempty"`
-	HealthCheck              WebServer                    `json:"healthCheck,omitempty"`
-	Logger                   Logger                       `json:"logger,omitempty"`
-	Metrics                  Metrics                      `json:"metrics,omitempty"`
-	ScaleToZero              ScaleToZero                  `json:"scaleToZero,omitempty"`
-	AutoScale                AutoScale                    `json:"autoScale,omitempty"`
-	CronTriggerCreationMode  CronTriggerCreationMode      `json:"cronTriggerCreationMode,omitempty"`
-	FunctionAugmentedConfigs []LabelSelectorAndConfig     `json:"functionAugmentedConfigs,omitempty"`
-	IngressConfig            IngressConfig                `json:"ingressConfig,omitempty"`
-	Kube                     PlatformKubeConfig           `json:"kube,omitempty"`
-	ImageRegistryOverrides   ImageRegistryOverridesConfig `json:"imageRegistryOverrides,omitempty"`
+	Kind                          string                       `json:"kind,omitempty"`
+	WebAdmin                      WebServer                    `json:"webAdmin,omitempty"`
+	HealthCheck                   WebServer                    `json:"healthCheck,omitempty"`
+	Logger                        Logger                       `json:"logger,omitempty"`
+	Metrics                       Metrics                      `json:"metrics,omitempty"`
+	ScaleToZero                   ScaleToZero                  `json:"scaleToZero,omitempty"`
+	AutoScale                     AutoScale                    `json:"autoScale,omitempty"`
+	CronTriggerCreationMode       CronTriggerCreationMode      `json:"cronTriggerCreationMode,omitempty"`
+	FunctionAugmentedConfigs      []LabelSelectorAndConfig     `json:"functionAugmentedConfigs,omitempty"`
+	IngressConfig                 IngressConfig                `json:"ingressConfig,omitempty"`
+	Kube                          PlatformKubeConfig           `json:"kube,omitempty"`
+	ImageRegistryOverrides        ImageRegistryOverridesConfig `json:"imageRegistryOverrides,omitempty"`
+	ContainerBuilderConfiguration *containerimagebuilderpusher.ContainerBuilderConfiguration
 }
 
 func NewPlatformConfig(configurationPath string) (*Config, error) {

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -26,19 +26,20 @@ import (
 )
 
 type Config struct {
-	Kind                          string                       `json:"kind,omitempty"`
-	WebAdmin                      WebServer                    `json:"webAdmin,omitempty"`
-	HealthCheck                   WebServer                    `json:"healthCheck,omitempty"`
-	Logger                        Logger                       `json:"logger,omitempty"`
-	Metrics                       Metrics                      `json:"metrics,omitempty"`
-	ScaleToZero                   ScaleToZero                  `json:"scaleToZero,omitempty"`
-	AutoScale                     AutoScale                    `json:"autoScale,omitempty"`
-	CronTriggerCreationMode       CronTriggerCreationMode      `json:"cronTriggerCreationMode,omitempty"`
-	FunctionAugmentedConfigs      []LabelSelectorAndConfig     `json:"functionAugmentedConfigs,omitempty"`
-	IngressConfig                 IngressConfig                `json:"ingressConfig,omitempty"`
-	Kube                          PlatformKubeConfig           `json:"kube,omitempty"`
-	ImageRegistryOverrides        ImageRegistryOverridesConfig `json:"imageRegistryOverrides,omitempty"`
-	ContainerBuilderConfiguration *containerimagebuilderpusher.ContainerBuilderConfiguration
+	Kind                     string                       `json:"kind,omitempty"`
+	WebAdmin                 WebServer                    `json:"webAdmin,omitempty"`
+	HealthCheck              WebServer                    `json:"healthCheck,omitempty"`
+	Logger                   Logger                       `json:"logger,omitempty"`
+	Metrics                  Metrics                      `json:"metrics,omitempty"`
+	ScaleToZero              ScaleToZero                  `json:"scaleToZero,omitempty"`
+	AutoScale                AutoScale                    `json:"autoScale,omitempty"`
+	CronTriggerCreationMode  CronTriggerCreationMode      `json:"cronTriggerCreationMode,omitempty"`
+	FunctionAugmentedConfigs []LabelSelectorAndConfig     `json:"functionAugmentedConfigs,omitempty"`
+	IngressConfig            IngressConfig                `json:"ingressConfig,omitempty"`
+	Kube                     PlatformKubeConfig           `json:"kube,omitempty"`
+	ImageRegistryOverrides   ImageRegistryOverridesConfig `json:"imageRegistryOverrides,omitempty"`
+
+	ContainerBuilderConfiguration *containerimagebuilderpusher.ContainerBuilderConfiguration `json:"containerBuilderConfiguration,omitempty"`
 }
 
 func NewPlatformConfig(configurationPath string) (*Config, error) {

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -100,6 +100,7 @@ type Kubernetes struct {
 }
 
 type PlatformKubeConfig struct {
+	KubeConfigPath string `json:"kube_config_path,omitempty"`
 
 	// TODO: Move IngressConfig here
 	DefaultServiceType corev1.ServiceType `json:"defaultServiceType,omitempty"`

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -100,7 +100,7 @@ type Kubernetes struct {
 }
 
 type PlatformKubeConfig struct {
-	KubeConfigPath string `json:"kube_config_path,omitempty"`
+	KubeConfigPath string `json:"kubeConfigPath,omitempty"`
 
 	// TODO: Move IngressConfig here
 	DefaultServiceType corev1.ServiceType `json:"defaultServiceType,omitempty"`

--- a/pkg/processor/build/test/build_test.go
+++ b/pkg/processor/build/test/build_test.go
@@ -598,7 +598,7 @@ func (suite *testSuite) TestBuildFuncFromLocalArchiveRedeployUsesSameImage() {
 }
 
 func (suite *testSuite) TestGenerateProcessorDockerfile() {
-	newPlatform, err := local.NewPlatform(suite.Logger, nil, nil)
+	newPlatform, err := local.NewPlatform(suite.Logger, nil)
 	suite.Require().NoErrorf(err, "Instantiating Platform failed: %s", err)
 
 	builder, err := build.NewBuilder(suite.Logger, newPlatform, nil)

--- a/pkg/processor/build/test/build_test.go
+++ b/pkg/processor/build/test/build_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform/abstract"
 	"github.com/nuclio/nuclio/pkg/platform/kube"
 	"github.com/nuclio/nuclio/pkg/platform/local"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/processor/build"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
@@ -598,7 +599,7 @@ func (suite *testSuite) TestBuildFuncFromLocalArchiveRedeployUsesSameImage() {
 }
 
 func (suite *testSuite) TestGenerateProcessorDockerfile() {
-	newPlatform, err := local.NewPlatform(suite.Logger, nil)
+	newPlatform, err := local.NewPlatform(suite.Logger, &platformconfig.Config{})
 	suite.Require().NoErrorf(err, "Instantiating Platform failed: %s", err)
 
 	builder, err := build.NewBuilder(suite.Logger, newPlatform, nil)


### PR DESCRIPTION
Currently, nuctl holds a degraded version of platform config, unlike dashboard, which is lack of many functionality that cannot be introduced without adding many hacks and workarounds - this make both code maintaining hard

In this PR, I removed `platform/config` internal pkg (so called nuctl platform config) and ensure nuctl uses `platformconfig.Config` - which is the object being used by dashboard.
That brings unity between both components while reducing noise of code duplication / less workarounds and much more clarity.

Future note: it would allow us to pass a command arg of platform config path, that can be used during deployment.