### PR TITLE
Fix transient error on restarting process

### DIFF
--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -469,8 +469,14 @@ func (r *AbstractRuntime) waitForProcessTermination() {
 	for {
 		select {
 		case <-r.stopChan:
+			r.Logger.DebugWith("Process terminated",
+				"wid", r.Context.WorkerID,
+				"process", r.wrapperProcess)
 			return
 		case <-time.After(10 * time.Second):
+			r.Logger.DebugWith("Timeout waiting for process termination, assuming closed",
+				"wid", r.Context.WorkerID,
+				"process", r.wrapperProcess)
 			return
 		}
 	}

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -18,7 +18,6 @@ package rpc
 
 import (
 	"bufio"
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -467,13 +466,11 @@ func (r *AbstractRuntime) watchWrapperProcess() {
 
 // waitForProcessTermination will best effort wait few seconds to stop channel, if timeout - assume closed
 func (r *AbstractRuntime) waitForProcessTermination() {
-	ctx, cancel := context.WithDeadline(context.TODO(), time.Now().Add(10*time.Second))
-	defer cancel()
 	for {
 		select {
 		case <-r.stopChan:
 			return
-		case <-ctx.Done():
+		case <-time.After(10 * time.Second):
 			return
 		}
 	}

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -18,6 +18,7 @@ package rpc
 
 import (
 	"bufio"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -65,6 +66,7 @@ type AbstractRuntime struct {
 	functionLogger logger.Logger
 	runtime        Runtime
 	startChan      chan struct{}
+	stopChan       chan struct{}
 	socketType     SocketType
 	processWaiter  *processwaiter.ProcessWaiter
 }
@@ -92,6 +94,7 @@ func NewAbstractRuntime(logger logger.Logger,
 		configuration:   configuration,
 		runtime:         runtimeInstance,
 		startChan:       make(chan struct{}, 1),
+		stopChan:        make(chan struct{}, 1),
 		socketType:      UnixSocket,
 	}
 
@@ -149,12 +152,13 @@ func (r *AbstractRuntime) Stop() error {
 			r.Logger.WarnWith("Failed to cancel process waiting")
 		}
 
-		err := r.wrapperProcess.Kill()
-		if err != nil {
+		if err := r.wrapperProcess.Kill(); err != nil {
 			r.SetStatus(status.Error)
 			return errors.Wrap(err, "Can't kill wrapper process")
 		}
 	}
+
+	r.waitForProcessTermination()
 
 	r.SetStatus(status.Stopped)
 	return nil
@@ -237,7 +241,9 @@ func (r *AbstractRuntime) startWrapper() error {
 		return errors.Wrap(err, "Can't get connection from wrapper")
 	}
 
-	r.Logger.InfoWith("Wrapper connected", "wid", r.Context.WorkerID)
+	r.Logger.InfoWith("Wrapper connected",
+		"wid", r.Context.WorkerID,
+		"pid", r.wrapperProcess.Pid)
 
 	r.eventEncoder = r.runtime.GetEventEncoder(conn)
 	r.resultChan = make(chan *result)
@@ -423,14 +429,19 @@ func (r *AbstractRuntime) newResultChan() {
 func (r *AbstractRuntime) watchWrapperProcess() {
 
 	// whatever happens, clear wrapper process
-	defer func() { r.wrapperProcess = nil }()
+	defer func() {
+		r.wrapperProcess = nil
+		r.stopChan <- struct{}{}
+	}()
 
 	// wait for the process
 	processWaitResult := <-r.processWaiter.Wait(r.wrapperProcess, nil)
 
 	// if we were simply canceled, do nothing
 	if processWaitResult.Err == processwaiter.ErrCancelled {
-		r.Logger.DebugWith("Process watch cancelled. Returning", "wid", r.Context.WorkerID)
+		r.Logger.DebugWith("Process watch cancelled. Returning",
+			"pid", r.wrapperProcess.Pid,
+			"wid", r.Context.WorkerID)
 		return
 	}
 
@@ -452,4 +463,18 @@ func (r *AbstractRuntime) watchWrapperProcess() {
 	}
 
 	panic(fmt.Sprintf("Wrapper process for worker %d exited unexpectedly with: %s", r.Context.WorkerID, panicMessage))
+}
+
+// waitForProcessTermination will best effort wait few seconds to stop channel, if timeout - assume closed
+func (r *AbstractRuntime) waitForProcessTermination() {
+	ctx, cancel := context.WithDeadline(context.TODO(), time.Now().Add(10*time.Second))
+	defer cancel()
+	for {
+		select {
+		case <-r.stopChan:
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
 }


### PR DESCRIPTION
CI logs:
```
20.12.14 06:51:37.456 [0;37m  rpc-runtime-test.logger[0m [0;32m(D)[0m Creating listener socket {"path": "/tmp/nuclio-rpc-bvbgmu8a53hfknchbhu0.sock"}
20.12.14 06:51:37.456 [0;37m  rpc-runtime-test.logger[0m [0;34m(I)[0m Wrapper connected {"wid": 0}
20.12.14 06:51:37.456 [0;37m  rpc-runtime-test.logger[0m [0;32m(D)[0m Started
20.12.14 06:51:38.457 [0;37m  rpc-runtime-test.logger[0m [0;33m(W)[0m Nothing waiting on result channel during restart. Continuing
20.12.14 06:51:38.457 [0;37m  rpc-runtime-test.logger[0m [0;32m(D)[0m Creating listener socket {"path": "/tmp/nuclio-rpc-bvbgmuga53hfknchbhug.sock"}
20.12.14 06:51:38.457 [0;37m  rpc-runtime-test.logger[0m [0;34m(I)[0m Wrapper connected {"wid": 0}
20.12.14 06:51:38.457 [0;37m  rpc-runtime-test.logger[0m [0;32m(D)[0m Started
20.12.14 06:51:38.457 [0;37m  rpc-runtime-test.logger[0m [0;32m(D)[0m Process watch cancelled. Returning {"wid": 0}
20.12.14 06:51:38.458 [0;37m  rpc-runtime-test.logger[0m [0;32m(D)[0m Process watch cancelled. Returning {"wid": 0}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4a1e96]

goroutine 8 [running]:
os.(*Process).wait(0x0, 0x0, 0x0, 0x0)
	/usr/local/go/src/os/exec_unix.go:17 +0x26
os.(*Process).Wait(...)
	/usr/local/go/src/os/exec.go:125
github.com/nuclio/nuclio/pkg/processwaiter.(*ProcessWaiter).waitForProcess(0xc0003b59b0, 0x0, 0xc000046120)
	/nuclio/pkg/processwaiter/processwaiter.go:75 +0x2b
created by github.com/nuclio/nuclio/pkg/processwaiter.(*ProcessWaiter).Wait.func1
	/nuclio/pkg/processwaiter/processwaiter.go:41 +0x6e
```

The reason for the error is that the goroutine responsible to cancel the running process, is delayed while the struct is being nullified causing panic.

To fix it, I added a `stopChan` to communicate the process termination to callee so it would "best effort" wait for process to exit before continue the stop flow.