### PR TITLE
UI: Invocation URL is N/A when function is not running

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5652,9 +5652,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.28.14",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.28.14.tgz",
-      "integrity": "sha512-6XD8EJY17kAnzC+7VqL2qAWR0qAtUzxVvoIjvOnsYtlWRW/CGjdS3M5JYmmLuv0NJSkfvb1CFnseuK8repRHKA==",
+      "version": "0.28.15",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.28.15.tgz",
+      "integrity": "sha512-/QcX7KAg2xJCaaxo0w4uIPnLCG0Nqb1xquWhqb9CAu3iWcyTqR3Jr9WxTlh59nuOh1ssOroZ+7rwdu/JY4MYRw==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -49,7 +49,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.28.14",
+    "iguazio.dashboard-controls": "^0.28.15",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
- Invocation URL: Both in function list of a project and in Status tab of a function, when the function is not running display “N/A” as invocation URL. When the function is running and it is in `ClusterIP` service type, and there is no ingress for its HTTP trigger — show “N/A” plus a more-info icon explaining that an ingress can be added, with a link to Triggers tab.
  ![image](https://user-images.githubusercontent.com/13918850/102211398-381bb800-3edc-11eb-8546-4a2eb92d9e8a.png)
  ![image](https://user-images.githubusercontent.com/13918850/102211401-3b16a880-3edc-11eb-924f-ede7312d3624.png)
  ![image](https://user-images.githubusercontent.com/13918850/102211408-3d790280-3edc-11eb-865a-fbf8ed90ea32.png)
  ![image](https://user-images.githubusercontent.com/13918850/102211415-4073f300-3edc-11eb-94d9-dbbe99c3974c.png)
- Function › Triggers › HTTP › Ingresses › Host: limit the length between two periods of a DNS-1123 sub-domain to 63 maximum
  ![image](https://user-images.githubusercontent.com/13918850/101993295-0af3bd80-3cc2-11eb-8480-98f643e0cc9e.png)
- General: prevent tooltip from being obstructed by different UI elements (as a result of CSS rule `overflow: hidden`).
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/102108756-f76c6200-3e3b-11eb-9a28-a9b244713d86.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/102108773-fdfad980-3e3b-11eb-97e5-24fe2abf7e87.png)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/1161