### PR TITLE
Reduce spammy log lines on controller

### DIFF
--- a/pkg/platform/kube/controller/functionevent.go
+++ b/pkg/platform/kube/controller/functionevent.go
@@ -71,8 +71,12 @@ func newFunctionEventOperator(parentLogger logger.Logger,
 
 // CreateOrUpdate handles creation/update of an object
 func (feo *functionEventOperator) CreateOrUpdate(ctx context.Context, object runtime.Object) error {
-	feo.logger.DebugWith("Created/updated", "object", object)
+	functionEvent, objectIsFunctionEvent := object.(*nuclioio.NuclioFunctionEvent)
+	if !objectIsFunctionEvent {
+		return errors.New("Received unexpected object, expected function event")
+	}
 
+	feo.logger.DebugWith("Created/updated", "functionEventName", functionEvent.Name)
 	return nil
 }
 

--- a/pkg/platform/kube/controller/project.go
+++ b/pkg/platform/kube/controller/project.go
@@ -71,8 +71,12 @@ func newProjectOperator(parentLogger logger.Logger,
 
 // CreateOrUpdate handles creation/update of an object
 func (po *projectOperator) CreateOrUpdate(ctx context.Context, object runtime.Object) error {
-	po.logger.DebugWith("Created/updated", "object", object)
+	project, objectIsProject := object.(*nuclioio.NuclioProject)
+	if !objectIsProject {
+		return errors.New("Received unexpected object, expected project")
+	}
 
+	po.logger.DebugWith("Created/updated", "projectName", project.Name)
 	return nil
 }
 


### PR DESCRIPTION
When having multiple projects/function events, controller become too spammy as it logs the entire object - tho it doesnt do anything with it.