### PR TITLE
[DOC REVIEW] K8s cron-triggers config; NATS trigger unify doc format

### DIFF
--- a/docs/reference/triggers/cron.md
+++ b/docs/reference/triggers/cron.md
@@ -8,8 +8,8 @@ Triggers the function according to a schedule or interval, with an optional body
 | :--- | :--- | :--- |
 | <a id="attr-schedule"></a>schedule | string | A cron-like schedule (for example, `*/5 * * * *`). |
 | <a id="attr-interval"></a>interval | string | An interval (for example, `1s`, `30m`). |
-| concurrencyPolicy | string | Concurrency policy - `"Allow"`, `"Forbid"`, or `"Replace"`; (default: `"Forbid"`). Applicable only to Kubernetes platforms. |
-| jobBackoffLimit | int32 | The number of retries before failing a job; (default: `2`). Applicable only to Kubernetes platforms. |
+| <a id="attr-concurrencyPolicy"></a>concurrencyPolicy | string | Concurrency policy - `"Allow"`, `"Forbid"`, or `"Replace"`; (default: `"Forbid"`). Applicable only when using CronJobs on Kubernetes platforms (see the [Kubernetes notes](#k8s-notes)). |
+| <a id="attr-jobBackoffLimit"></a>jobBackoffLimit | int32 | The number of retries before failing a job; (default: `2`). Applicable only when using CronJobs on Kubernetes platforms (see the [Kubernetes notes](#k8s-notes)). |
 | event.body | string | The body passed in the event. |
 | event.headers | map of string/int | The headers passed in the event. |
 
@@ -17,13 +17,13 @@ Triggers the function according to a schedule or interval, with an optional body
 > **Note:**
 > 1. <a id="schedule-or-interval-attr-set-note"></a>You must set either the [`schedule`](#attr-schedule) or [`interval`](#attr-interval) mutually-exclusive attributes.
 > 2. <a id="event-attrs-note"></a>The `event.*` attributes are optional.
-> 3. <a id="k8s-notes"></a>On Kubernetes platforms, the Cron trigger is implemented as a Kubernetes CronJob (instead of the standard implementation, which runs the trigger within the processor).
->    Note:
->    - On Kubernetes, you must set the `cronTriggerCreationMode` platform-configuration field to `"kube"`, to implement Cron triggers as CronJobs.
+> 3. <a id="k8s-notes"></a>**[Tech Preview]** On Kubernetes platforms, you can set the `cronTriggerCreationMode` platform-configuration field to `"kube"` to run the triggers as Kubernetes CronJobs instead of the default implementation of running Cron triggers from the Nuclio processor.
 >        For more information, see [Configuring a Platform](/docs/tasks/configuring-a-platform.md#cronTriggerCreationMode).
+>        When running Cron triggers as CronJobs &mdash;
 >    - The created CronJob uses `wget` to call the default HTTP trigger of the function according to the configured interval or schedule.
 >        (This means that worker-related attributes are irrelevant.)
 >    - The `wget` request is sent with the header `"x-nuclio-invoke-trigger: cron"`.
+>    - You can use the [`concurrencyPolicy`](#attr-concurrencyPolicy) and [`jobBackoffLimit`](#attr-jobBackoffLimit) attributes to configure the CronJobs.
 
 ### Examples
 
@@ -35,8 +35,9 @@ triggers:
       interval: 3s
 ```
 
-The following example is specific to Kubernetes platforms, as it sets the Kubernetes-specific `concurrencyPolicy` and `jobBackoffLimit` attributes.
-Remember that when running on Kubernetes, you also need to set the `cronTriggerCreationMode` platform-configuration field to `"kube"` (see the [Kubernetes notes](#k8s-notes)).
+The following example is demonstrates a configuration for running Cron triggers as Kubernetes CronJobs, as it sets the `concurrencyPolicy` and `jobBackoffLimit` attributes.
+Remember that this implementation requires setting the `cronTriggerCreationMode` platform-configuration field to `"kube"`.
+See the [Kubernetes notes](#k8s-notes).
 ```yaml
 triggers:
   myCronTrigger:
@@ -46,3 +47,4 @@ triggers:
       concurrencyPolicy: "Allow"
       jobBackoffLimit: 2
 ```
+

--- a/docs/reference/triggers/cron.md
+++ b/docs/reference/triggers/cron.md
@@ -6,22 +6,26 @@ Triggers the function according to a schedule or interval, with an optional body
 
 | **Path** | **Type** | **Description** |
 | :--- | :--- | :--- |
-| schedule | string | A cron-like schedule (for example, `*/5 * * * *`) |
-| interval | string | An interval (for example, `1s`, `30m`) |
-| concurrencyPolicy | string | Concurrency policy [Allow, Forbid, Replace]. (optional, defaults to "Forbid". Relevant only for k8s platform)
-| jobBackoffLimit | int32 | The number of retries before failing a job. (optional, defaults to 2. Relevant only for k8s platform)
-| event.body | string | The body passed in the event |
-| event.headers | map of string/int | The headers passed in the event |
+| <a id="attr-schedule"></a>schedule | string | A cron-like schedule (for example, `*/5 * * * *`). |
+| <a id="attr-interval"></a>interval | string | An interval (for example, `1s`, `30m`). |
+| concurrencyPolicy | string | Concurrency policy - `"Allow"`, `"Forbid"`, or `"Replace"`; (default: `"Forbid"`). Applicable only to Kubernetes platforms. |
+| jobBackoffLimit | int32 | The number of retries before failing a job; (default: `2`). Applicable only to Kubernetes platforms. |
+| event.body | string | The body passed in the event. |
+| event.headers | map of string/int | The headers passed in the event. |
 
+<a id="attr-notes"></a>
 > **Note:**
-> 1. Either `schedule` or `interval` must be passed.
-> 2. The `event.*` attributes are optional.
-> 3. When running on k8s platform, this trigger will be implemented as k8s CronJob. (instead of running inside the processor like a regular trigger)
->    1. The created CronJob uses "wget" to call the default http trigger of the function every interval/schedule. (That means that worker related attributes are irrelevant)
->    2. The "wget" request will be sent with the header "x-nuclio-invoke-trigger"="cron".
+> 1. <a id="schedule-or-interval-attr-set-note"></a>You must set either the [`schedule`](#attr-schedule) or [`interval`](#attr-interval) mutually-exclusive attributes.
+> 2. <a id="event-attrs-note"></a>The `event.*` attributes are optional.
+> 3. <a id="k8s-notes"></a>On Kubernetes platforms, the Cron trigger is implemented as a Kubernetes CronJob (instead of the standard implementation, which runs the trigger within the processor).
+>    Note:
+>    - On Kubernetes, you must set the `cronTriggerCreationMode` platform-configuration field to `"kube"`, to implement Cron triggers as CronJobs.
+>        For more information, see [Configuring a Platform](/docs/tasks/configuring-a-platform.md#cronTriggerCreationMode).
+>    - The created CronJob uses `wget` to call the default HTTP trigger of the function according to the configured interval or schedule.
+>        (This means that worker-related attributes are irrelevant.)
+>    - The `wget` request is sent with the header `"x-nuclio-invoke-trigger: cron"`.
 
-### Example
-
+### Examples
 
 ```yaml
 triggers:
@@ -31,7 +35,8 @@ triggers:
       interval: 3s
 ```
 
-On K8s platform (it also requires setting cronTriggerCreationMode=="kube" on platform config, Reference: [Platform Config](/docs/tasks/configuring-a-platform.md)):
+The following example is specific to Kubernetes platforms, as it sets the Kubernetes-specific `concurrencyPolicy` and `jobBackoffLimit` attributes.
+Remember that when running on Kubernetes, you also need to set the `cronTriggerCreationMode` platform-configuration field to `"kube"` (see the [Kubernetes notes](#k8s-notes)).
 ```yaml
 triggers:
   myCronTrigger:

--- a/docs/reference/triggers/nats.md
+++ b/docs/reference/triggers/nats.md
@@ -16,8 +16,8 @@ The queue name may be a Go template, which may include any of the following fiel
 
 | **Path** | **Type** | **Description** |
 | :--- | :--- | :--- |
-| topic | string | The topic on which to listen |
-| queueName | string | The name of a shared worker queue to join; (defaults to an auto-generated name per trigger) |
+| topic | string | The topic on which to listen. |
+| queueName | string | The name of a shared worker queue to join; (default: an auto-generated name per trigger). |
 
 ### Example
 

--- a/docs/tasks/configuring-a-platform.md
+++ b/docs/tasks/configuring-a-platform.md
@@ -2,7 +2,7 @@
 
 #### In This Document
 - [Overview](#overview)
-- [Creating a platform configuration in Kubernetes](#creating-a-platform-configuration-in-kubernetes)
+- [Creating a platform configuration in Kubernetes](#k8s-platform-config-create)
 - [Configuration elements](#configuration-elements)
 
 ## Overview
@@ -13,15 +13,18 @@ While this could theoretically be passed in the function configuration, it would
 
 > **Note:** A "platform" could be a cluster or any sub resource of that cluster like a namespace. If, for example, you have a namespace per tenant, you configure logging, metrics, etc. differently for each tenant
 
+<a id="k8s-platform-config-create"></a>
 ## Creating a platform configuration in Kubernetes
 
-In Kubernetes, a platform configuration is stored as a ConfigMap named `platform-config` in the namespace of the function. For example, to create a ConfigMap in the "nuclio" namespace from a local file called `platform.yaml`, run:
+In Kubernetes, a platform configuration is stored as a ConfigMap named `platform-config` in the namespace of the function. For example, to create a ConfigMap in the "nuclio" namespace from a local file called `platform.yaml`, run the following from a command line:
 ```sh
 kubectl create configmap platform-config  --namespace nuclio --from-file platform.yaml
 ```
 
+<a id="config-elements"></a>
 ## Configuration elements
 
+<a id="logger-supported-log-sinks"></a>
 ### Log sinks (`logger`)
 
 Configuring where a function logs to is a two step process. First, you create a named logger sink and provide it with configuration. Then, you reference this logger sink at the desired scope with a given log level. Scopes include the following:
@@ -55,6 +58,7 @@ logger:
 
 First, you declared the two sinks: `myStdoutLogger` and `myAppInsightsLogger`. Then, you bound `system:debug` (which catches all logs at the severity level and higher) to `myStdoutLogger`, and `system:warning`, `functions:debug` to `myAppInsightsLogger`.
 
+<a id="supported-log-sinks"></a>
 #### Supported log sinks
 
 All log sinks support the following fields:
@@ -63,16 +67,19 @@ All log sinks support the following fields:
 - `url`: The URL at which the sink resides
 - `attributes`: Kind specific attributes
 
+<a id="log-sink-stdout"></a>
 ##### Standard output (`stdout`)
 
 The standard output sink currently does not support any specific attributes.
 
+<a id="log-sink-appinsights"></a>
 ##### Azure Application Insights (`appinsights`)
 
 - `attributes.instrumentationKey`: The instrumentation key from Azure
 - `attributes.maxBatchSize`: Max number of records to batch together before sending to Azure (defaults to 1024)
 - `attributes.maxBatchInterval`: Time to wait for maxBatchSize records (valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"), after which whatever's gathered will be sent towards Azure (defaults to 3s)
 
+<a id="metrics"></a>
 ### Metric sinks (`metrics`)
 
 Metric sinks behave similarly to logger sinks in that first you declare a sink and then bind a scope to it. To illustrate with an example, if you would (for some reason) want all of your system metrics to be pulled by Prometheus whereas all function metrics pushed to a Prometheus push proxy, your `metrics` section in the `platform.yaml` would look like this:
@@ -105,8 +112,9 @@ metrics:
   - myAppInsights
   functions:
   - myPromPush
-``` 
+```
 
+<a id="supported-metric-sinks"></a>
 #### Supported metric sinks
 
 All metric sinks support the following fields:
@@ -115,6 +123,7 @@ All metric sinks support the following fields:
 - `url`: The URL at which the sink resides
 - `attributes`: Kind specific attributes
 
+<a id="metric-sink-prometheusPush"></a>
 ##### Prometheus push (`prometheusPush`)
 
 - `url`: The URL at which the push proxy resides
@@ -122,12 +131,14 @@ All metric sinks support the following fields:
 - `attributes.instanceName`: The Prometheus instance name
 - `attributes.interval`: A string holding the interval to which the push occurs such as "10s", "1h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
 
+<a id="metric-sink-prometheusPull"></a>
 ##### Prometheus pull (`prometheusPull`)
 
 - `url`: The URL at which the HTTP listener serves pull requests
 - `attributes.jobName`: The Prometheus job name
 - `attributes.instanceName`: The Prometheus instance name
 
+<a id="metric-sink-appinsights"></a>
 ##### Azure Application Insights (`appinsights`)
 
 - `attributes.interval`: A string holding the interval to which the push occurs such as "10s", "1h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
@@ -135,6 +146,7 @@ All metric sinks support the following fields:
 - `attributes.maxBatchSize`: Max number of records to batch together before sending to Azure (defaults to 1024)
 - `attributes.maxBatchInterval`: Time to wait for maxBatchSize records (valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"), after which whatever's gathered will be sent towards Azure (defaults to 3s)
 
+<a id="webAdmin"></a>
 ### Webadmin (`webAdmin`)
 
 Functions can optionally serve requests to get and update their configuration via HTTP. By default this is enabled at address `:8081` but can be overridden by the configuration:
@@ -149,6 +161,7 @@ webAdmin:
   listenAddress: :10000
 ```
 
+<a id="healthCheck"></a>
 ### Health check (`healthCheck`)
 
 An important part of the function life cycle is to verify its health via HTTP. By default this is enabled at address `:8082` but can be overridden by the configuration:
@@ -163,16 +176,20 @@ healthCheck:
   enabled: false
 ```
 
-### Cron trigger creation mode (`cronTriggerCreationMode`)
+<a id="cronTriggerCreationMode"></a>
+### Cron-trigger creation mode (`cronTriggerCreationMode`)
 
-A function can run cron triggers as k8s CronJobs or creating the cron logic inside the processor.
+The `cronTriggerCreationMode` configuration field determines how to run cron triggers:
 
-For more information - [Cron Trigger](/docs/reference/triggers/cron.md)
+- `"kube"` - run Cron triggers as Kubernetes CronJobs.
+    <br/>
+    This value is applicable only to Kubernetes platforms and must be set on such platforms.
+- `"processor"` (default)] - run Cron triggers within the processor.
 
-- `cronTriggerCreationMode`: Which way to implement cron triggers. ["kube", "processor" (default)]
-
-For example, the following will configure the system to implement cron triggers as k8s CronJobs:
-
+For example, the following configuration implements Cron triggers as Kubernetes CronJobs on a Kubernetes platform:
 ```yaml
 cronTriggerCreationMode: "kube"
 ```
+
+For more information, see the [Cron-trigger reference](/docs/reference/triggers/cron.md).
+

--- a/docs/tasks/configuring-a-platform.md
+++ b/docs/tasks/configuring-a-platform.md
@@ -63,9 +63,9 @@ First, you declared the two sinks: `myStdoutLogger` and `myAppInsightsLogger`. T
 
 All log sinks support the following fields:
 
-- `kind`: The kind of output
-- `url`: The URL at which the sink resides
-- `attributes`: Kind specific attributes
+- `kind` - The kind of output
+- `url` - The URL at which the sink resides
+- `attributes` - Kind specific attributes
 
 <a id="log-sink-stdout"></a>
 ##### Standard output (`stdout`)
@@ -75,9 +75,9 @@ The standard output sink currently does not support any specific attributes.
 <a id="log-sink-appinsights"></a>
 ##### Azure Application Insights (`appinsights`)
 
-- `attributes.instrumentationKey`: The instrumentation key from Azure
-- `attributes.maxBatchSize`: Max number of records to batch together before sending to Azure (defaults to 1024)
-- `attributes.maxBatchInterval`: Time to wait for maxBatchSize records (valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"), after which whatever's gathered will be sent towards Azure (defaults to 3s)
+- `attributes.instrumentationKey` - The instrumentation key from Azure
+- `attributes.maxBatchSize` - Max number of records to batch together before sending to Azure (defaults to 1024)
+- `attributes.maxBatchInterval` - Time to wait for maxBatchSize records (valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"), after which whatever's gathered will be sent towards Azure (defaults to 3s)
 
 <a id="metrics"></a>
 ### Metric sinks (`metrics`)
@@ -119,40 +119,41 @@ metrics:
 
 All metric sinks support the following fields:
 
-- `kind`: The kind of output
-- `url`: The URL at which the sink resides
-- `attributes`: Kind specific attributes
+- `kind` - The kind of output
+- `url` - The URL at which the sink resides
+- `attributes` - Kind specific attributes
 
 <a id="metric-sink-prometheusPush"></a>
 ##### Prometheus push (`prometheusPush`)
 
-- `url`: The URL at which the push proxy resides
-- `attributes.jobName`: The Prometheus job name
-- `attributes.instanceName`: The Prometheus instance name
-- `attributes.interval`: A string holding the interval to which the push occurs such as "10s", "1h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+- `url` - The URL at which the push proxy resides
+- `attributes.jobName` - The Prometheus job name
+- `attributes.instanceName` - The Prometheus instance name
+- `attributes.interval` - A string holding the interval to which the push occurs such as "10s", "1h" or "2h45m".
+    Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
 
 <a id="metric-sink-prometheusPull"></a>
 ##### Prometheus pull (`prometheusPull`)
 
-- `url`: The URL at which the HTTP listener serves pull requests
-- `attributes.jobName`: The Prometheus job name
-- `attributes.instanceName`: The Prometheus instance name
+- `url` - The URL at which the HTTP listener serves pull requests
+- `attributes.jobName` - The Prometheus job name
+- `attributes.instanceName` - The Prometheus instance name
 
 <a id="metric-sink-appinsights"></a>
 ##### Azure Application Insights (`appinsights`)
 
-- `attributes.interval`: A string holding the interval to which the push occurs such as "10s", "1h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
-- `attributes.instrumentationKey`: The instrumentation key from Azure
-- `attributes.maxBatchSize`: Max number of records to batch together before sending to Azure (defaults to 1024)
-- `attributes.maxBatchInterval`: Time to wait for maxBatchSize records (valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"), after which whatever's gathered will be sent towards Azure (defaults to 3s)
+- `attributes.interval` - A string holding the interval to which the push occurs such as "10s", "1h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+- `attributes.instrumentationKey` - The instrumentation key from Azure
+- `attributes.maxBatchSize` - Max number of records to batch together before sending to Azure (defaults to 1024)
+- `attributes.maxBatchInterval` - Time to wait for maxBatchSize records (valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"), after which whatever's gathered will be sent towards Azure (defaults to 3s)
 
 <a id="webAdmin"></a>
 ### Webadmin (`webAdmin`)
 
 Functions can optionally serve requests to get and update their configuration via HTTP. By default this is enabled at address `:8081` but can be overridden by the configuration:
 
-- `enabled`: Whether or not to listen to requests. `true`, by default
-- `listenAddress`: The address to listen on. `:8081`, by default
+- `enabled` - Whether or not to listen to requests. `true`, by default
+- `listenAddress` - The address to listen on. `:8081`, by default
 
 For example, the following configuration can be used listen on port `:10000`:
 
@@ -166,8 +167,8 @@ webAdmin:
 
 An important part of the function life cycle is to verify its health via HTTP. By default this is enabled at address `:8082` but can be overridden by the configuration:
 
-- `enabled`: Whether or not to listen to requests. `true`, by default
-- `listenAddress`: The address to listen on. `:8082`, by default
+- `enabled` - Whether or not to listen to requests. `true`, by default
+- `listenAddress` - The address to listen on. `:8082`, by default
 
 For example, the following configuration disables responses to health checks:
 
@@ -181,10 +182,8 @@ healthCheck:
 
 The `cronTriggerCreationMode` configuration field determines how to run cron triggers:
 
-- `"kube"` - run Cron triggers as Kubernetes CronJobs.
-    <br/>
-    This value is applicable only to Kubernetes platforms and must be set on such platforms.
-- `"processor"` (default)] - run Cron triggers within the processor.
+- `"processor"` (default)] - Run Cron triggers from the Nuclio processor.
+- `"kube"` - **[Tech Preview]** Run Cron triggers as Kubernetes CronJobs; applicable only on Kubernetes platforms.
 
 For example, the following configuration implements Cron triggers as Kubernetes CronJobs on a Kubernetes platform:
 ```yaml

--- a/docs/tasks/configuring-a-platform.md
+++ b/docs/tasks/configuring-a-platform.md
@@ -180,7 +180,7 @@ healthCheck:
 <a id="cronTriggerCreationMode"></a>
 ### Cron-trigger creation mode (`cronTriggerCreationMode`)
 
-The `cronTriggerCreationMode` configuration field determines how to run cron triggers:
+The `cronTriggerCreationMode` configuration field determines how to run Cron triggers:
 
 - `"processor"` (default)] - Run Cron triggers from the Nuclio processor.
 - `"kube"` - **[Tech Preview]** Run Cron triggers as Kubernetes CronJobs; applicable only on Kubernetes platforms.

--- a/docs/tasks/configuring-a-platform.md
+++ b/docs/tasks/configuring-a-platform.md
@@ -182,7 +182,7 @@ healthCheck:
 
 The `cronTriggerCreationMode` configuration field determines how to run Cron triggers:
 
-- `"processor"` (default)] - Run Cron triggers from the Nuclio processor.
+- `"processor"` (default) - Run Cron triggers from the Nuclio processor.
 - `"kube"` - **[Tech Preview]** Run Cron triggers as Kubernetes CronJobs; applicable only on Kubernetes platforms.
 
 For example, the following configuration implements Cron triggers as Kubernetes CronJobs on a Kubernetes platform:


### PR DESCRIPTION
Doc review for PR 1628, PR 1735, PR 1748, and PR 1755 (Cron trigger reference & platform-configuration task) + minor rephrasing in the NATS-trigger attributes doc for cross-triggers doc consistency

@liranbg / @omesser please merge.