### PR TITLE
Add skip importing projects by label selectors

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -477,7 +477,7 @@ func CatchAndLogPanicWithOptions(ctx context.Context,
 	return nil
 }
 
-// MapStringToStringMatchByLabelSelectorStr return whether labelsMap matched by encoded label selector
+// LabelsMapMatchByLabelSelector returns whether a labelsMap is matched by an encoded label selector
 // corresponding to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 //
 // Example:
@@ -486,8 +486,7 @@ func CatchAndLogPanicWithOptions(ctx context.Context,
 //     c: d
 //   encodedLabelSelector: a=b
 // returns true
-func MapStringToStringMatchByLabelSelectorStr(labelSelector string,
-	mapStringToString map[string]string) (bool, error) {
+func LabelsMapMatchByLabelSelector(labelSelector string, labelsMap map[string]string) (bool, error) {
 
 	parsedLabelSelector, err := metav1.ParseToLabelSelector(labelSelector)
 	if err != nil {
@@ -497,7 +496,7 @@ func MapStringToStringMatchByLabelSelectorStr(labelSelector string,
 	if err != nil {
 		return false, errors.Wrap(err, "Failed to get selector from label selector")
 	}
-	return selector.Matches(labels.Set(mapStringToString)), nil
+	return selector.Matches(labels.Set(labelsMap)), nil
 }
 
 func logPanic(ctx context.Context,

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -39,6 +39,8 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 var LettersAndNumbers = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
@@ -473,6 +475,29 @@ func CatchAndLogPanicWithOptions(ctx context.Context,
 		return asErr
 	}
 	return nil
+}
+
+// MapStringToStringMatchByLabelSelectorStr return whether labelsMap matched by encoded label selector
+// corresponding to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+//
+// Example:
+//   labelsMap:
+//     a: b
+//     c: d
+//   encodedLabelSelector: a=b
+// returns true
+func MapStringToStringMatchByLabelSelectorStr(labelSelector string,
+	mapStringToString map[string]string) (bool, error) {
+
+	parsedLabelSelector, err := metav1.ParseToLabelSelector(labelSelector)
+	if err != nil {
+		return false, errors.Wrap(err, "Failed to parse label selector")
+	}
+	selector, err := metav1.LabelSelectorAsSelector(parsedLabelSelector)
+	if err != nil {
+		return false, errors.Wrap(err, "Failed to get selector from label selector")
+	}
+	return selector.Matches(labels.Set(mapStringToString)), nil
 }
 
 func logPanic(ctx context.Context,

--- a/pkg/common/helper_test.go
+++ b/pkg/common/helper_test.go
@@ -353,119 +353,69 @@ func (suite *StripPrefixesTestSuite) TestPositive() {
 	suite.Require().Equal("prefix_something_1", stripped)
 }
 
-type MapStringToStringMatchByLabelSelectorTestSuite struct {
+type LabelsMapMatcherTestSuite struct {
 	suite.Suite
 }
 
-func (suite *MapStringToStringMatchByLabelSelectorTestSuite) Test() {
+func (suite *LabelsMapMatcherTestSuite) Test() {
 	for _, testCase := range []struct {
 		name                 string
-		mapStringToString    map[string]string
+		labelsMap            map[string]string
 		encodedLabelSelector string
 		matching             bool
 		expectedError        bool
 	}{
 		{
-			name: "SingleLabel",
-			mapStringToString: map[string]string{
+			name: "Sanity",
+			labelsMap: map[string]string{
 				"c": "d",
 			},
 			encodedLabelSelector: "c=d",
 			matching:             true,
 		},
 		{
-			name: "PartialLabels",
-			mapStringToString: map[string]string{
-				"a": "b",
-				"c": "d",
-			},
-			encodedLabelSelector: "a=b",
-			matching:             true,
-		},
-		{
-			name: "AllLabels",
-			mapStringToString: map[string]string{
-				"a": "b",
-				"c": "d",
-			},
-
-			encodedLabelSelector: "a=b,c=d",
-			matching:             true,
-		},
-		{
-			name: "EmptyEncodedLabel",
-			mapStringToString: map[string]string{
+			name: "EmptyLabelSelectorsMatchAll",
+			labelsMap: map[string]string{
 				"a": "b",
 			},
-
 			encodedLabelSelector: "",
 			matching:             true,
 		},
 		{
-			name:                 "EmptyEncodedLabelEmptyLabels",
-			mapStringToString:    map[string]string{},
-			encodedLabelSelector: "",
-			matching:             true,
-		},
-		{
-			name:              "EmptyEncodedLabelNilLabels",
-			mapStringToString: nil,
-
+			name:                 "NillableLabelMaps",
+			labelsMap:            nil,
 			encodedLabelSelector: "",
 			matching:             true,
 		},
 
 		// miss match
 		{
-			name: "EncodedLabelNotInLabels",
-			mapStringToString: map[string]string{
+			name: "EncodedLabelSelectorsNotInLabels",
+			labelsMap: map[string]string{
 				"a": "b",
 				"c": "d",
 			},
-
 			encodedLabelSelector: "z=w",
 			matching:             false,
 		},
 		{
-			name:              "EncodedLabelNilLabels",
-			mapStringToString: nil,
+			name:      "EncodedLabelSelectorsNilLabels",
+			labelsMap: nil,
 
 			encodedLabelSelector: "a=b",
-			matching:             false,
-		},
-		{
-			name:                 "EncodedLabelNoLabels",
-			mapStringToString:    map[string]string{},
-			encodedLabelSelector: "z=w",
-			matching:             false,
-		},
-		{
-			name: "ValueMatchKeyNot",
-			mapStringToString: map[string]string{
-				"c": "d",
-			},
-			encodedLabelSelector: "a=d",
-			matching:             false,
-		},
-		{
-			name: "KeyMatchValueNot",
-			mapStringToString: map[string]string{
-				"c": "d",
-			},
-			encodedLabelSelector: "c=a",
 			matching:             false,
 		},
 
 		// explode
 		{
 			name:                 "InvalidEncodedLabelSelector",
-			mapStringToString:    nil,
+			labelsMap:            nil,
 			encodedLabelSelector: "!@#$",
 			expectedError:        true,
 		},
 	} {
 		suite.Run(testCase.name, func() {
-			matching, err := MapStringToStringMatchByLabelSelectorStr(testCase.encodedLabelSelector, testCase.mapStringToString)
+			matching, err := LabelsMapMatchByLabelSelector(testCase.encodedLabelSelector, testCase.labelsMap)
 			if testCase.expectedError {
 				suite.Require().Error(err)
 				return
@@ -485,5 +435,5 @@ func TestHelperTestSuite(t *testing.T) {
 	suite.Run(t, new(IsDirTestSuite))
 	suite.Run(t, new(IsFileTestSuite))
 	suite.Run(t, new(StripPrefixesTestSuite))
-	suite.Run(t, new(MapStringToStringMatchByLabelSelectorTestSuite))
+	suite.Run(t, new(LabelsMapMatcherTestSuite))
 }

--- a/pkg/common/helper_test.go
+++ b/pkg/common/helper_test.go
@@ -353,6 +353,130 @@ func (suite *StripPrefixesTestSuite) TestPositive() {
 	suite.Require().Equal("prefix_something_1", stripped)
 }
 
+type MapStringToStringMatchByLabelSelectorTestSuite struct {
+	suite.Suite
+}
+
+func (suite *MapStringToStringMatchByLabelSelectorTestSuite) Test() {
+	for _, testCase := range []struct {
+		name                 string
+		mapStringToString    map[string]string
+		encodedLabelSelector string
+		matching             bool
+		expectedError        bool
+	}{
+		{
+			name: "SingleLabel",
+			mapStringToString: map[string]string{
+				"c": "d",
+			},
+			encodedLabelSelector: "c=d",
+			matching:             true,
+		},
+		{
+			name: "PartialLabels",
+			mapStringToString: map[string]string{
+				"a": "b",
+				"c": "d",
+			},
+			encodedLabelSelector: "a=b",
+			matching:             true,
+		},
+		{
+			name: "AllLabels",
+			mapStringToString: map[string]string{
+				"a": "b",
+				"c": "d",
+			},
+
+			encodedLabelSelector: "a=b,c=d",
+			matching:             true,
+		},
+		{
+			name: "EmptyEncodedLabel",
+			mapStringToString: map[string]string{
+				"a": "b",
+			},
+
+			encodedLabelSelector: "",
+			matching:             true,
+		},
+		{
+			name:                 "EmptyEncodedLabelEmptyLabels",
+			mapStringToString:    map[string]string{},
+			encodedLabelSelector: "",
+			matching:             true,
+		},
+		{
+			name:              "EmptyEncodedLabelNilLabels",
+			mapStringToString: nil,
+
+			encodedLabelSelector: "",
+			matching:             true,
+		},
+
+		// miss match
+		{
+			name: "EncodedLabelNotInLabels",
+			mapStringToString: map[string]string{
+				"a": "b",
+				"c": "d",
+			},
+
+			encodedLabelSelector: "z=w",
+			matching:             false,
+		},
+		{
+			name:              "EncodedLabelNilLabels",
+			mapStringToString: nil,
+
+			encodedLabelSelector: "a=b",
+			matching:             false,
+		},
+		{
+			name:                 "EncodedLabelNoLabels",
+			mapStringToString:    map[string]string{},
+			encodedLabelSelector: "z=w",
+			matching:             false,
+		},
+		{
+			name: "ValueMatchKeyNot",
+			mapStringToString: map[string]string{
+				"c": "d",
+			},
+			encodedLabelSelector: "a=d",
+			matching:             false,
+		},
+		{
+			name: "KeyMatchValueNot",
+			mapStringToString: map[string]string{
+				"c": "d",
+			},
+			encodedLabelSelector: "c=a",
+			matching:             false,
+		},
+
+		// explode
+		{
+			name:                 "InvalidEncodedLabelSelector",
+			mapStringToString:    nil,
+			encodedLabelSelector: "!@#$",
+			expectedError:        true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			matching, err := MapStringToStringMatchByLabelSelectorStr(testCase.encodedLabelSelector, testCase.mapStringToString)
+			if testCase.expectedError {
+				suite.Require().Error(err)
+				return
+			}
+			suite.Require().NoError(err)
+			suite.Require().Equal(testCase.matching, matching)
+		})
+
+	}
+}
+
 func TestHelperTestSuite(t *testing.T) {
 	suite.Run(t, new(RetryUntilSuccessfulTestSuite))
 	suite.Run(t, new(RetryUntilSuccessfulOnErrorPatternsTestSuite))
@@ -361,4 +485,5 @@ func TestHelperTestSuite(t *testing.T) {
 	suite.Run(t, new(IsDirTestSuite))
 	suite.Run(t, new(IsFileTestSuite))
 	suite.Run(t, new(StripPrefixesTestSuite))
+	suite.Run(t, new(MapStringToStringMatchByLabelSelectorTestSuite))
 }

--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -202,7 +202,7 @@ func (i *importFunctionCommandeer) resolveFunctionImportConfigs(functionBody []b
 type importProjectCommandeer struct {
 	*importCommandeer
 	skipProjectNames         []string
-	skipProjectSelectors     string
+	skipLabelSelectors       string
 	skipTransformDisplayName bool
 }
 
@@ -258,7 +258,7 @@ Use --help for more information`)
 	}
 
 	cmd.Flags().StringSliceVar(&commandeer.skipProjectNames, "skip", []string{}, "Names of projects to skip (don't import), as a comma-separated list")
-	cmd.Flags().StringVar(&commandeer.skipProjectSelectors, "skip-selectors", "", "Selectors (label query) to filter projects on")
+	cmd.Flags().StringVar(&commandeer.skipLabelSelectors, "skip-label-selectors", "", "Label selectors to filter projects on")
 	cmd.Flags().BoolVar(&commandeer.skipTransformDisplayName, "skip-transform-display-name", false, "Skip transforming display name into project name if the latter is missing or in form of UUID")
 	commandeer.cmd = cmd
 
@@ -398,7 +398,7 @@ func (i *importProjectCommandeer) importProject(projectImportOptions *ProjectImp
 func (i *importProjectCommandeer) importProjects(projectsImportOptions map[string]*ProjectImportOptions) error {
 	i.rootCommandeer.loggerInstance.DebugWith("Importing projects",
 		"projectsImportOptions", projectsImportOptions,
-		"skipProjectSelectors", i.skipProjectSelectors,
+		"skipLabelSelectors", i.skipLabelSelectors,
 		"skipProjectNames", i.skipProjectNames,
 		"skipTransformDisplayName", i.skipTransformDisplayName)
 
@@ -484,11 +484,11 @@ func (i *importProjectCommandeer) shouldSkipProject(projectImportConfig *Project
 
 	// empty by default
 	// if we match by empty selectors, it will match all projects and will simply cause to skip all projects
-	if i.skipProjectSelectors != "" {
-		match, err := common.MapStringToStringMatchByLabelSelectorStr(i.skipProjectSelectors,
+	if i.skipLabelSelectors != "" {
+		match, err := common.LabelsMapMatchByLabelSelector(i.skipLabelSelectors,
 			projectImportConfig.Project.Meta.Labels)
 		if err != nil {
-			return false, errors.Wrap(err, "Failed to match project by given label")
+			return false, errors.Wrap(err, "Failed to match project labels")
 		}
 		return match, nil
 

--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -201,9 +201,9 @@ func (i *importFunctionCommandeer) resolveFunctionImportConfigs(functionBody []b
 
 type importProjectCommandeer struct {
 	*importCommandeer
-	skipProjectNames          []string
-	skipProjectLabelSelectors string
-	skipTransformDisplayName  bool
+	skipProjectNames         []string
+	skipProjectSelectors     string
+	skipTransformDisplayName bool
 }
 
 func newImportProjectCommandeer(importCommandeer *importCommandeer) *importProjectCommandeer {
@@ -258,7 +258,7 @@ Use --help for more information`)
 	}
 
 	cmd.Flags().StringSliceVar(&commandeer.skipProjectNames, "skip", []string{}, "Names of projects to skip (don't import), as a comma-separated list")
-	cmd.Flags().StringVar(&commandeer.skipProjectLabelSelectors, "skip-labels", "", "Labels of projects to skip (don't import), as a key=value pairs")
+	cmd.Flags().StringVar(&commandeer.skipProjectSelectors, "skip-selectors", "", "Selectors (label query) to filter projects on")
 	cmd.Flags().BoolVar(&commandeer.skipTransformDisplayName, "skip-transform-display-name", false, "Skip transforming display name into project name if the latter is missing or in form of UUID")
 	commandeer.cmd = cmd
 
@@ -398,7 +398,7 @@ func (i *importProjectCommandeer) importProject(projectImportOptions *ProjectImp
 func (i *importProjectCommandeer) importProjects(projectsImportOptions map[string]*ProjectImportOptions) error {
 	i.rootCommandeer.loggerInstance.DebugWith("Importing projects",
 		"projectsImportOptions", projectsImportOptions,
-		"skipProjectLabelSelectors", i.skipProjectLabelSelectors,
+		"skipProjectSelectors", i.skipProjectSelectors,
 		"skipProjectNames", i.skipProjectNames,
 		"skipTransformDisplayName", i.skipTransformDisplayName)
 
@@ -484,8 +484,8 @@ func (i *importProjectCommandeer) shouldSkipProject(projectImportConfig *Project
 
 	// empty by default
 	// if we match by empty selectors, it will match all projects and will simply cause to skip all projects
-	if i.skipProjectLabelSelectors != "" {
-		match, err := common.MapStringToStringMatchByLabelSelectorStr(i.skipProjectLabelSelectors,
+	if i.skipProjectSelectors != "" {
+		match, err := common.MapStringToStringMatchByLabelSelectorStr(i.skipProjectSelectors,
 			projectImportConfig.Project.Meta.Labels)
 		if err != nil {
 			return false, errors.Wrap(err, "Failed to match project by given label")

--- a/pkg/nuctl/test/project_test.go
+++ b/pkg/nuctl/test/project_test.go
@@ -413,7 +413,7 @@ func (suite *projectExportImportTestSuite) TestImportProjectSkipBySelectors() {
 
 			// import
 			err = suite.ExecuteNuctl([]string{"import", "project", "--verbose"}, map[string]string{
-				"skip-selectors": testCase.encodedSkipLabelSelectors,
+				"skip-label-selectors": testCase.encodedSkipLabelSelectors,
 			})
 
 			// delete leftovers

--- a/pkg/nuctl/test/project_test.go
+++ b/pkg/nuctl/test/project_test.go
@@ -293,6 +293,136 @@ func (suite *projectExportImportTestSuite) TestImportProjectWithDisplayName() {
 	}
 }
 
+func (suite *projectExportImportTestSuite) TestImportProjectSkipByLabel() {
+	for _, testCase := range []struct {
+		name                      string
+		projectImportConfig       *command.ProjectImportConfig
+		encodedSkipLabelSelectors string
+		skipImportingProject      bool
+		expectedFailure           bool
+	}{
+
+		// skip import
+		{
+			name: "SkipImportSanity",
+			projectImportConfig: &command.ProjectImportConfig{
+				Project: &platform.ProjectConfig{
+					Meta: platform.ProjectMeta{
+						Name:      "test-project-" + xid.New().String(),
+						Namespace: suite.namespace,
+						Labels: map[string]string{
+							"skip": "me",
+						},
+					},
+				},
+			},
+			encodedSkipLabelSelectors: "skip=me",
+			skipImportingProject:      true,
+		},
+		{
+			name: "ComplexLabelNameValue",
+			projectImportConfig: &command.ProjectImportConfig{
+				Project: &platform.ProjectConfig{
+					Meta: platform.ProjectMeta{
+						Name:      "test-project-" + xid.New().String(),
+						Namespace: suite.namespace,
+						Labels: map[string]string{
+							"app.kubernetes.io/part-of": "nuclio-test",
+						},
+					},
+				},
+			},
+			encodedSkipLabelSelectors: "app.kubernetes.io/part-of=nuclio-test",
+			skipImportingProject:      true,
+		},
+
+		// import
+		{
+			name: "ImportSanity",
+			projectImportConfig: &command.ProjectImportConfig{
+				Project: &platform.ProjectConfig{
+					Meta: platform.ProjectMeta{
+						Name:      "test-project-" + xid.New().String(),
+						Namespace: suite.namespace,
+						Labels: map[string]string{
+							"whatever": "ishere",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ImportLabelSelectorsMissMatch",
+			projectImportConfig: &command.ProjectImportConfig{
+				Project: &platform.ProjectConfig{
+					Meta: platform.ProjectMeta{
+						Name:      "test-project-" + xid.New().String(),
+						Namespace: suite.namespace,
+						Labels: map[string]string{
+							"donot-skip": "me",
+						},
+					},
+				},
+			},
+			encodedSkipLabelSelectors: "skip=me",
+		},
+
+		// export failure
+		{
+			name: "InvalidLabelSelectorInput",
+			projectImportConfig: &command.ProjectImportConfig{
+				Project: &platform.ProjectConfig{
+					Meta: platform.ProjectMeta{
+						Name:      "test-project-" + xid.New().String(),
+						Namespace: suite.namespace,
+						Labels: map[string]string{
+							"whatever": "ishere",
+						},
+					},
+				},
+			},
+			encodedSkipLabelSelectors: "invalid@label^selector!",
+			expectedFailure:           true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			projectName := testCase.projectImportConfig.Project.Meta.Name
+
+			var encodedProjectImportConfig []byte
+			encodedProjectImportConfig, err := yaml.Marshal(testCase.projectImportConfig)
+			suite.Require().NoError(err)
+
+			// import project from stdin
+			suite.inputBuffer = *bytes.NewBuffer(encodedProjectImportConfig)
+
+			// import
+			err = suite.ExecuteNuctl([]string{"import", "project", "--verbose"}, map[string]string{
+				"skip-labels": testCase.encodedSkipLabelSelectors,
+			})
+
+			// delete leftovers
+			defer suite.ExecuteNuctl([]string{"delete", "project", projectName}, nil) // nolint: errcheck
+
+			if testCase.expectedFailure {
+				suite.Require().Error(err)
+				return
+			}
+
+			// assertions
+			suite.Require().NoError(err)
+
+			if testCase.skipImportingProject {
+				err = suite.ExecuteNuctl([]string{"get", "project", projectName}, nil)
+				suite.Require().Error(err)
+				suite.Require().EqualError(err, "No projects found")
+
+			} else {
+				suite.assertProjectImported(projectName)
+			}
+		})
+	}
+}
+
 func (suite *projectExportImportTestSuite) TestExportProjectWithDisplayName() {
 	suite.ensureRunningOnPlatform("kube")
 

--- a/pkg/nuctl/test/project_test.go
+++ b/pkg/nuctl/test/project_test.go
@@ -304,7 +304,7 @@ func (suite *projectExportImportTestSuite) TestImportProjectSkipByLabel() {
 
 		// skip import
 		{
-			name: "SkipImportSanity",
+			name: "SkipImportLabelSelectorsSanity",
 			projectImportConfig: &command.ProjectImportConfig{
 				Project: &platform.ProjectConfig{
 					Meta: platform.ProjectMeta{
@@ -317,6 +317,22 @@ func (suite *projectExportImportTestSuite) TestImportProjectSkipByLabel() {
 				},
 			},
 			encodedSkipLabelSelectors: "skip=me",
+			skipImportingProject:      true,
+		},
+		{
+			name: "SkipImportInLabelSelectors",
+			projectImportConfig: &command.ProjectImportConfig{
+				Project: &platform.ProjectConfig{
+					Meta: platform.ProjectMeta{
+						Name:      "test-project-" + xid.New().String(),
+						Namespace: suite.namespace,
+						Labels: map[string]string{
+							"skip": "b",
+						},
+					},
+				},
+			},
+			encodedSkipLabelSelectors: "skip in (a,b,c)",
 			skipImportingProject:      true,
 		},
 		{

--- a/pkg/nuctl/test/project_test.go
+++ b/pkg/nuctl/test/project_test.go
@@ -293,7 +293,7 @@ func (suite *projectExportImportTestSuite) TestImportProjectWithDisplayName() {
 	}
 }
 
-func (suite *projectExportImportTestSuite) TestImportProjectSkipByLabel() {
+func (suite *projectExportImportTestSuite) TestImportProjectSkipBySelectors() {
 	for _, testCase := range []struct {
 		name                      string
 		projectImportConfig       *command.ProjectImportConfig
@@ -413,7 +413,7 @@ func (suite *projectExportImportTestSuite) TestImportProjectSkipByLabel() {
 
 			// import
 			err = suite.ExecuteNuctl([]string{"import", "project", "--verbose"}, map[string]string{
-				"skip-labels": testCase.encodedSkipLabelSelectors,
+				"skip-selectors": testCase.encodedSkipLabelSelectors,
 			})
 
 			// delete leftovers


### PR DESCRIPTION
To provide a [Kubernetes-like](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) way to skip importing projects by a label selector - Ive added a `--skip-selectors` flag to `nuctl import` command, to ensure projects matched by the given label selectors, would be skipped during import process.

E.g.:
For exported projects
```
project-a:
  meta:
    name: project-a
    labels:
      some-key: some-value
...
```

when invoking 
> cat exportedProjects.yaml |  nuctl import project --skip-selectors some-key=some-value

Project `project-a` would be skipped.

