### PR TITLE
[Nuclio] Layout breaks on window resize with closed test pane

### DIFF
--- a/pkg/dashboard/ui/build.config.js
+++ b/pkg/dashboard/ui/build.config.js
@@ -135,7 +135,6 @@ module.exports = {
             'node_modules/angular/angular.js',
             'node_modules/angular-ui-bootstrap/dist/ui-bootstrap-tpls.js',
             'node_modules/@uirouter/angularjs/release/angular-ui-router.min.js',
-            'node_modules/angular-ui-layout/src/ui-layout.js',
             'node_modules/jquery-ui/ui/widget.js',
             'node_modules/jquery-ui/ui/widgets/mouse.js',
             'node_modules/jquery-ui/ui/widgets/sortable.js',
@@ -172,7 +171,6 @@ module.exports = {
         css: [
             'node_modules/jquery-ui/themes/themes/theme.css',
             'node_modules/ng-dialog/css/ngDialog.css',
-            'node_modules/angular-ui-layout/src/ui-layout.css',
             'node_modules/angularjs-slider/dist/rzslider.css',
             'node_modules/angular-cron-jobs/dist/angular-cron-jobs.css'
         ]

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -13,7 +13,6 @@
     "angular-money-directive": "~1.2.5",
     "angular-sanitize": "^1.7.9",
     "angular-ui-bootstrap": "~2.5.6",
-    "angular-ui-layout": "~1.4.3",
     "angularjs-slider": "~6.6.1",
     "ansi-colors": "4.1.1",
     "babel-core": "^6.26.0",


### PR DESCRIPTION
https://trello.com/c/s4qGK3k0/640-nuclio-layout-breaks-on-window-resize-with-closed-test-pane

- Function › Code: [bugfix] layout breaks on window resize while the test pane is closed
![nuclio-function-code_bug_layout_breakage](https://user-images.githubusercontent.com/13918850/102979897-666a4a80-450f-11eb-92d8-eb80392d7517.gif)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/1169