### PR TITLE
UI: Function > Build: Do not repeat image name prefix in field

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -328,11 +328,6 @@
       "resolved": "https://registry.npmjs.org/angular-ui-bootstrap/-/angular-ui-bootstrap-2.5.6.tgz",
       "integrity": "sha512-yzcHpPMLQl0232nDzm5P4iAFTFQ9dMw0QgFLuKYbDj9M0xJ62z0oudYD/Lvh1pWfRsukiytP4Xj6BHOSrSXP8A=="
     },
-    "angular-ui-layout": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/angular-ui-layout/-/angular-ui-layout-1.4.3.tgz",
-      "integrity": "sha1-WHxrRwebu76iDm338YdEwpUFMzA="
-    },
     "angularjs-slider": {
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/angularjs-slider/-/angularjs-slider-6.6.1.tgz",
@@ -5652,9 +5647,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.29.0.tgz",
-      "integrity": "sha512-hU63Viv0xEMzyrtpjyWF7XjNOSkd+ihrL3j0i+vJRH2dQU5ChUu8HaKmLPHXzjgOj2KWAFB9MzgDtfqHkD7qBw==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.29.1.tgz",
+      "integrity": "sha512-ecP+fIRNw4gBjW7eDrZxWzK5IFIsWwUepEmIWBWwUIt7EimQAVyaNtS9DeI/DFttTA6glLVFPsjloAreqjaODA==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.29.0",
+    "iguazio.dashboard-controls": "^0.29.1",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
- Function › Configuration › Build › Image: When the build image name (`spec.build.image`) includes the system's image-name prefix, split it so the prefix is only readonly to the left of the input field, and only the name itself is editable in the input field.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/102987947-dd0d4500-451b-11eb-8348-4a1b6a0aa354.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/102987937-d8e12780-451b-11eb-9451-71510836343b.png)


Depends on PR https://github.com/iguazio/dashboard-controls/pull/1172