### PR TITLE
Optimize delete projects endpoint

### DIFF
--- a/pkg/common/map.go
+++ b/pkg/common/map.go
@@ -25,8 +25,8 @@ func StringToStringMap(source string, separator string) map[string]string {
 	separatedString := strings.Split(source, ",")
 	result := map[string]string{}
 
-	for _, keyAndValie := range separatedString {
-		kv := strings.Split(keyAndValie, separator)
+	for _, keyAndValue := range separatedString {
+		kv := strings.Split(keyAndValue, separator)
 
 		if len(kv) > 1 {
 			result[kv[0]] = kv[1]

--- a/pkg/nuctl/test/project_test.go
+++ b/pkg/nuctl/test/project_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/nuclio/nuclio-sdk-go"
+	"github.com/nuclio/errors"
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/suite"
 )
@@ -181,7 +181,7 @@ func (suite *projectExportImportTestSuite) TestDeleteProject() {
 			name:            "FailDeleteProjectWithFunctions",
 			importFunctions: true,
 			strategy:        platform.DeleteProjectStrategyRestricted,
-			expectedError:   nuclio.NewErrPreconditionFailed(platform.ErrProjectContainsFunctions.Error()),
+			expectedError:   platform.ErrProjectContainsFunctions,
 		},
 	} {
 		suite.Run(testCase.name, func() {
@@ -216,7 +216,7 @@ func (suite *projectExportImportTestSuite) TestDeleteProject() {
 				"strategy": string(testCase.strategy),
 			})
 			if testCase.expectedError != nil {
-				suite.Require().EqualError(err, testCase.expectedError.Error())
+				suite.Require().EqualError(errors.RootCause(err), testCase.expectedError.Error())
 				suite.Require().Error(err)
 				return
 			}

--- a/pkg/platform/errors.go
+++ b/pkg/platform/errors.go
@@ -21,8 +21,8 @@ import (
 )
 
 // A project containing resources(functions/api gateways), cannot be deleted
-var ErrProjectContainsFunctions = nuclio.NewErrConflict("Project contains functions")
-var ErrProjectContainsAPIGateways = nuclio.NewErrConflict("Project contains api gateways")
+var ErrProjectContainsFunctions = nuclio.NewErrPreconditionFailed("Project contains functions")
+var ErrProjectContainsAPIGateways = nuclio.NewErrPreconditionFailed("Project contains api gateways")
 
 var ErrFunctionIsUsedByAPIGateways = nuclio.NewErrConflict("Function is used by api gateways")
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -354,11 +354,7 @@ func (p *Platform) GetFunctions(getFunctionsOptions *platform.GetFunctionsOption
 	p.EnrichFunctionsWithDeployLogStream(functions)
 
 	if !getFunctionsOptions.SkipEnrichingAPIGateways {
-		if err = p.enrichFunctionsWithAPIGateways(functions, &platform.GetAPIGatewaysOptions{
-			Name:      getFunctionsOptions.Name,
-			Labels:    getFunctionsOptions.Labels,
-			Namespace: getFunctionsOptions.Namespace,
-		}); err != nil {
+		if err = p.enrichFunctionsWithAPIGateways(functions, getFunctionsOptions.Namespace); err != nil {
 
 			// relevant when upgrading nuclio from a version that didn't have api-gateways to one that has
 			if !strings.Contains(errors.RootCause(err).Error(),

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -486,6 +486,8 @@ func (p *Platform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOpt
 		return errors.Wrap(err, "Failed to validate delete project options")
 	}
 
+	p.Logger.DebugWith("Deleting project",
+		"projectMeta", deleteProjectOptions.Meta)
 	if err := p.consumer.nuclioClientSet.NuclioV1beta1().
 		NuclioProjects(deleteProjectOptions.Meta.Namespace).
 		Delete(deleteProjectOptions.Meta.Name, &metav1.DeleteOptions{}); err != nil {

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -489,6 +489,10 @@ func (p *Platform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOpt
 	if err := p.consumer.nuclioClientSet.NuclioV1beta1().
 		NuclioProjects(deleteProjectOptions.Meta.Namespace).
 		Delete(deleteProjectOptions.Meta.Name, &metav1.DeleteOptions{}); err != nil {
+
+		if apierrors.IsNotFound(err) {
+			return nuclio.NewErrNotFound(fmt.Sprintf("Project %s not found", deleteProjectOptions.Meta.Name))
+		}
 		return errors.Wrapf(err,
 			"Failed to delete project %s from namespace %s",
 			deleteProjectOptions.Meta.Name,

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/nuclio/errors"
+	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
@@ -530,7 +531,8 @@ func (suite *DeployAPIGatewayTestSuite) TestUpdateFunctionWithIngressWhenHasAPIG
 			_, err := suite.DeployFunctionExpectError(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
 				return true
 			})
-			suite.Require().Equal("Function can't expose ingresses while it is being exposed by an api gateway", errors.RootCause(err).Error())
+			suite.Require().Error(err)
+			suite.Require().IsType(&nuclio.ErrBadRequest, errors.RootCause(err))
 		})
 		suite.Require().NoError(err)
 

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -362,7 +362,7 @@ func (p *Platform) UpdateProject(updateProjectOptions *platform.UpdateProjectOpt
 // DeleteProject will delete an existing project
 func (p *Platform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOptions) error {
 	if err := p.Platform.ValidateDeleteProjectOptions(deleteProjectOptions); err != nil {
-		return err
+		return errors.Wrap(err, "Failed to validate delete project options")
 	}
 
 	if err := p.localStore.deleteProject(&deleteProjectOptions.Meta); err != nil {
@@ -404,6 +404,11 @@ func (p *Platform) DeleteFunctionEvent(deleteFunctionEventOptions *platform.Dele
 // GetFunctionEvents will list existing function events
 func (p *Platform) GetFunctionEvents(getFunctionEventsOptions *platform.GetFunctionEventsOptions) ([]platform.FunctionEvent, error) {
 	return p.localStore.getFunctionEvents(getFunctionEventsOptions)
+}
+
+// GetAPIGateways not supported on this platform
+func (p *Platform) GetAPIGateways(getAPIGatewaysOptions *platform.GetAPIGatewaysOptions) ([]platform.APIGateway, error) {
+	return nil, nil
 }
 
 // GetExternalIPAddresses returns the external IP addresses invocations will use, if "via" is set to "external-ip".

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -365,6 +365,8 @@ func (p *Platform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOpt
 		return errors.Wrap(err, "Failed to validate delete project options")
 	}
 
+	p.Logger.DebugWith("Deleting project",
+		"projectMeta", deleteProjectOptions.Meta)
 	if err := p.localStore.deleteProject(&deleteProjectOptions.Meta); err != nil {
 		return errors.Wrapf(err,
 			"Failed to delete project %s from namespace %s",

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -91,6 +91,9 @@ type GetFunctionsOptions struct {
 	Namespace  string
 	Labels     string
 	AuthConfig *AuthConfig
+
+	// allow skipping getting api gateways for the returned functions list
+	SkipEnrichingAPIGateways bool
 }
 
 // InvokeViaType defines via which mechanism the function will be invoked


### PR DESCRIPTION
#### `DELETE /api/projects` optimization

- if `restricted`, it gets functions and api gateways for the given project name, thought it might be a non-existing project.
> Added get on project, to ensure it exists before proceeding with more excessive API calls

-  When getting project related resources, it fetches both functions and api gateways sequently and not concurrently
> changed to use error group to allow concurrency

- When getting project resources, functions are being enriched with api gateways
> this is not needed. projects fetches api gateways anyway