### PR TITLE
UI: Hide annotations with key prefix of `nuclio.io`

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5647,9 +5647,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.29.1.tgz",
-      "integrity": "sha512-ecP+fIRNw4gBjW7eDrZxWzK5IFIsWwUepEmIWBWwUIt7EimQAVyaNtS9DeI/DFttTA6glLVFPsjloAreqjaODA==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.29.2.tgz",
+      "integrity": "sha512-i75q1BjwIFN+GLvMmuFUNKE9nR2iXym7RikMf5Npgsk9fGzH+cdK0Qk/Gii97nK+zwGPhLNOsxBjEPShXwUA1g==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.29.1",
+    "iguazio.dashboard-controls": "^0.29.2",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
- Function › Configuration › Annotations: Hide from the list the annotations with key prefix of `nuclio.io`. You can still see them via “View YAML” action.
- Function: [bugfix] breadcrumbs are incorrect
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/103100563-d6fe8d80-461b-11eb-91a5-2e19e161f451.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/103100601-01e8e180-461c-11eb-8b4d-499428c439b7.png)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/1175