### PR TITLE
Enrich get functions requests with API Gateways only when needed

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -56,9 +56,11 @@ func (fr *functionResource) GetAll(request *http.Request) (map[string]restful.At
 		return nil, nuclio.NewErrBadRequest("Namespace must exist")
 	}
 
+	// TODO: enrich with api gateways only if given by header
 	getFunctionsOptions := &platform.GetFunctionsOptions{
-		Name:      request.Header.Get("x-nuclio-function-name"),
-		Namespace: fr.getNamespaceFromRequest(request),
+		Name:                  request.Header.Get("x-nuclio-function-name"),
+		Namespace:             fr.getNamespaceFromRequest(request),
+		EnrichWithAPIGateways: true,
 	}
 
 	// if the user wants to filter by project, do that
@@ -68,7 +70,6 @@ func (fr *functionResource) GetAll(request *http.Request) (map[string]restful.At
 	}
 
 	functions, err := fr.getPlatform().GetFunctions(getFunctionsOptions)
-
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get functions")
 	}
@@ -96,9 +97,11 @@ func (fr *functionResource) GetByID(request *http.Request, id string) (restful.A
 		return nil, nuclio.NewErrBadRequest("Namespace must exist")
 	}
 
+	// TODO: enrich with api gateways only if given by header
 	functions, err := fr.getPlatform().GetFunctions(&platform.GetFunctionsOptions{
-		Namespace: fr.getNamespaceFromRequest(request),
-		Name:      id,
+		Namespace:             fr.getNamespaceFromRequest(request),
+		Name:                  id,
+		EnrichWithAPIGateways: true,
 	})
 
 	if err != nil {

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -764,9 +764,8 @@ func (ap *Platform) GetProjectResources(projectMeta *platform.ProjectMeta) ([]pl
 	// get functions
 	errGroup.Go(func() error {
 		functions, err = ap.platform.GetFunctions(&platform.GetFunctionsOptions{
-			Namespace:                projectMeta.Namespace,
-			Labels:                   fmt.Sprintf("nuclio.io/project-name=%s", projectMeta.Name),
-			SkipEnrichingAPIGateways: true,
+			Namespace: projectMeta.Namespace,
+			Labels:    fmt.Sprintf("nuclio.io/project-name=%s", projectMeta.Name),
 		})
 		if err != nil {
 			return errors.Wrap(err, "Failed to get project functions")

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -495,9 +495,8 @@ func (suite *AbstractPlatformTestSuite) TestValidateDeleteProjectOptions() {
 			if len(testCase.existingProjects) > 0 {
 				suite.mockedPlatform.
 					On("GetFunctions", &platform.GetFunctionsOptions{
-						Namespace:                suite.DefaultNamespace,
-						Labels:                   fmt.Sprintf("nuclio.io/project-name=%s", testCase.deleteProjectOptions.Meta.Name),
-						SkipEnrichingAPIGateways: true,
+						Namespace: suite.DefaultNamespace,
+						Labels:    fmt.Sprintf("nuclio.io/project-name=%s", testCase.deleteProjectOptions.Meta.Name),
 					}).
 					Return(testCase.existingFunctions, nil).
 					Once()

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -353,7 +353,7 @@ func (p *Platform) GetFunctions(getFunctionsOptions *platform.GetFunctionsOption
 
 	p.EnrichFunctionsWithDeployLogStream(functions)
 
-	if !getFunctionsOptions.SkipEnrichingAPIGateways {
+	if getFunctionsOptions.EnrichWithAPIGateways {
 		if err = p.enrichFunctionsWithAPIGateways(functions, getFunctionsOptions.Namespace); err != nil {
 
 			// relevant when upgrading nuclio from a version that didn't have api-gateways to one that has

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -219,14 +219,6 @@ func (suite *KubeTestSuite) GetFunctionAndExpectState(getFunctionOptions *platfo
 	return function
 }
 
-func (suite *KubeTestSuite) GetFunction(getFunctionOptions *platform.GetFunctionsOptions) platform.Function {
-
-	// get the function
-	functions, err := suite.Platform.GetFunctions(getFunctionOptions)
-	suite.Require().NoError(err)
-	return functions[0]
-}
-
 func (suite *KubeTestSuite) GetAPIGateway(getAPIGatewayOptions *platform.GetAPIGatewaysOptions) platform.APIGateway {
 
 	// get the function
@@ -298,22 +290,6 @@ func (suite *KubeTestSuite) WaitForFunctionDeployment(functionName string,
 			return callback(suite.GetFunctionDeployment(functionName))
 		})
 	suite.Require().NoError(err, "Failed to wait on deployment callback")
-}
-
-func (suite *KubeTestSuite) WaitForFunctionState(getFunctionOptions *platform.GetFunctionsOptions,
-	desiredFunctionState functionconfig.FunctionState,
-	duration time.Duration) {
-
-	err := common.RetryUntilSuccessful(duration,
-		1*time.Second,
-		func() bool {
-			function := suite.GetFunction(getFunctionOptions)
-			suite.Logger.InfoWith("Waiting for function state",
-				"currentFunctionState", function.GetStatus().State,
-				"desiredFunctionState", desiredFunctionState)
-			return function.GetStatus().State == desiredFunctionState
-		})
-	suite.Require().NoError(err, "Function did not reach its desired state")
 }
 
 func (suite *KubeTestSuite) WaitForAPIGatewayState(getAPIGatewayOptions *platform.GetAPIGatewaysOptions,

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -92,8 +92,8 @@ type GetFunctionsOptions struct {
 	Labels     string
 	AuthConfig *AuthConfig
 
-	// allow skipping getting api gateways for the returned functions list
-	SkipEnrichingAPIGateways bool
+	// Enrich functions with their api gateways
+	EnrichWithAPIGateways bool
 }
 
 // InvokeViaType defines via which mechanism the function will be invoked


### PR DESCRIPTION
Enriching get functions with api gateways makes UI life's better, but that is too excessive while making needlessly enrichments that cost many IO/s.

+ eliminated code dup on local/kube test suite.