### PR TITLE
Fix function ingress host and path validations

### DIFF
--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -249,6 +249,14 @@ func (suite *KubeTestSuite) GetAPIGatewayIngress(apiGatewayName string, canary b
 	return ingressInstance
 }
 
+func (suite *KubeTestSuite) GetFunctionIngress(functionName string) *extensionsv1beta1.Ingress {
+	ingressInstance := &extensionsv1beta1.Ingress{}
+	suite.GetResourceAndUnmarshal("ingress",
+		kube.IngressNameFromFunctionName(functionName),
+		ingressInstance)
+	return ingressInstance
+}
+
 func (suite *KubeTestSuite) GetFunctionPods(functionName string) []v1.Pod {
 	pods, err := suite.KubeClientSet.CoreV1().Pods(suite.Namespace).List(metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("nuclio.io/function-name=%s", functionName),


### PR DESCRIPTION
Bug description:
Following [PR](https://github.com/nuclio/nuclio/pull/1997), When creating a function it validates whether there is an ingress existing with the same one desired by the function to be created. if there is one, it returns with a conflicting error saying an ingress is already existing. The issue is that, it **should** not fail if the ingress was created for that specific function.