### PR TITLE
UI: Omit project name from error message on single project action

### DIFF
--- a/pkg/dashboard/ui/src/app/components/projects/projects.component.js
+++ b/pkg/dashboard/ui/src/app/components/projects/projects.component.js
@@ -153,14 +153,18 @@
                         }
                     })
                     .catch(function (errorMessage) {
-                        errorMessages.push(projectName + ': ' + errorMessage);
+                        errorMessages.push({ name: projectName, message: errorMessage });
                     });
             });
 
             return $q.all(promises)
                 .then(function () {
                     if (lodash.isNonEmpty(errorMessages)) {
-                        return DialogsService.alert(errorMessages);
+                        var messages = errorMessages.length === 1 ? errorMessages[0].message :
+                            _.map(errorMessages, function (errorMessage) {
+                                return errorMessage.name + ': ' + errorMessage.message;
+                            });
+                        return DialogsService.alert(messages);
                     }
                 });
         }


### PR DESCRIPTION
- Projects: When multiple projects are selected and a single action is taken upon all of them it makes sense to have each project's name before its corresponding error message so the user knows which error message is relevant to which project.
  When an action is taken on a single project the project name is superfluous.
  Multiple:
  ![image](https://user-images.githubusercontent.com/13918850/103147787-3dd98f00-4761-11eb-8df5-3f21cccb53bc.png)
  Single — before:
  ![image](https://user-images.githubusercontent.com/13918850/103147808-5a75c700-4761-11eb-9709-15be065905a5.png)
  Single — after:
  ![image](https://user-images.githubusercontent.com/13918850/103147792-4762f700-4761-11eb-88f6-35a517d7954a.png)
