### PR TITLE
Update status code errors returned on validation failure

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -342,7 +342,7 @@ func (ap *Platform) ValidateDeleteProjectOptions(deleteProjectOptions *platform.
 
 	switch projectName {
 	case platform.DefaultProjectName:
-		return nuclio.NewErrConflict("Cannot delete the default project")
+		return nuclio.NewErrPreconditionFailed("Cannot delete the default project")
 	case "":
 		return nuclio.NewErrBadRequest("Project name cannot be empty")
 	}

--- a/pkg/platform/errors.go
+++ b/pkg/platform/errors.go
@@ -24,8 +24,8 @@ import (
 var ErrProjectContainsFunctions = nuclio.NewErrPreconditionFailed("Project contains functions")
 var ErrProjectContainsAPIGateways = nuclio.NewErrPreconditionFailed("Project contains api gateways")
 
-var ErrFunctionIsUsedByAPIGateways = nuclio.NewErrConflict("Function is used by api gateways")
+var ErrFunctionIsUsedByAPIGateways = nuclio.NewErrPreconditionFailed("Function is used by api gateways")
 
-var ErrIngressHostPathInUse = nuclio.NewErrConflict("Ingress host and path are already in use")
+var ErrIngressHostPathInUse = nuclio.NewErrPreconditionFailed("Ingress host and path are already in use")
 
 var ErrUnsupportedMethod = nuclio.NewErrNotImplemented("Unsupported method")

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1383,7 +1383,7 @@ func (p *Platform) validateAPIGatewayFunctionsHaveNoIngresses(apiGatewayConfig *
 
 			ingresses := functionconfig.GetIngressesFromTriggers(function[0].GetConfig().Spec.Triggers)
 			if len(ingresses) > 0 {
-				return nuclio.NewErrConflict(fmt.Sprintf("Api gateway upstream function: %s must not have an ingress", upstream.Nucliofunction.Name))
+				return nuclio.NewErrPreconditionFailed(fmt.Sprintf("Api gateway upstream function: %s must not have an ingress", upstream.Nucliofunction.Name))
 			}
 
 			return nil


### PR DESCRIPTION
To allow better error handling on the client side, it is required to differentiate between _conflict_ and _validation_ error. and hence we group them the following way

Conflict:
  - upon resource create (e.g. POST): means another resource exists
  - upon resource update (e.g. PUT): means resource version requested is stale (`resourceVersion` applied to k8s only)

PreCondition:
  - upon resource create/update: request does not adhere to a specific rule, validation failed
