### PR TITLE
Allow volume mount to reuse volume

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1900,8 +1900,8 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(function *nuclioio.NuclioFuncti
 
 	// using maps to eliminate duplicates where user use the same volume to be mounted by multiple volume mounts
 	// e.g.: volume config-map X, mount it twice to different paths
-	volumeName := map[string]v1.Volume{}
-	volumeToVolumeMounts := map[string][]v1.VolumeMount{}
+	volumeNameToVolume := map[string]v1.Volume{}
+	volumeNameToVolumeMounts := map[string][]v1.VolumeMount{}
 
 	for _, configVolume := range configVolumes {
 		if configVolume.Volume.FlexVolume != nil && configVolume.Volume.FlexVolume.Driver == "v3io/fuse" {
@@ -1927,17 +1927,18 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(function *nuclioio.NuclioFuncti
 		lc.logger.DebugWith("Adding volume", "configVolume", configVolume)
 
 		// volume name is unique per its volume instance
-		volumeName[configVolume.Volume.Name] = configVolume.Volume
+		volumeNameToVolume[configVolume.Volume.Name] = configVolume.Volume
 
 		// same volume name can be shared by n volume mounts
-		volumeToVolumeMounts[configVolume.Volume.Name] = append(volumeToVolumeMounts[configVolume.Volume.Name], configVolume.VolumeMount)
+		volumeNameToVolumeMounts[configVolume.Volume.Name] = append(volumeNameToVolumeMounts[configVolume.Volume.Name],
+			configVolume.VolumeMount)
 	}
 
-	for _, volume := range volumeName {
+	for _, volume := range volumeNameToVolume {
 		volumes = append(volumes, volume)
 	}
 
-	for _, volumeVolumeMounts := range volumeToVolumeMounts {
+	for _, volumeVolumeMounts := range volumeNameToVolumeMounts {
 		volumeMounts = append(volumeMounts, volumeVolumeMounts...)
 	}
 


### PR DESCRIPTION
Bug description:

User wants to volume once, and volume mount twice. meaning, allow to "volumize" the same input to multiple locations.
Since the current function.spec requires you having tuple of volume and its volume mount, it is impossible to given partial list of `[volume, volumeMount, volumeMount] ` but requiring the user to provide a list of `[(volume, volumeMount), (volume, volumeMount)]`.
Since `volume` is unique per its name, using its "tuple" presentation forcing us to create the volume instance twice, which is not possible by Kubernetes.

Solution:
To resolve it, without changing the function spec or create a mutant of partially filled tuple (e.g.: `[(volume,), (,volumeMount), (,volumeMount)]`) - while resolving the volume / volumeMount instances to be created, I use map to filter duplicates using volume names.

Side effect:
Unintended duplicate volumes would be masked by having the _last_ volume to be used. that is minor given the fact that user never wrong 😉 
