### PR TITLE
UI: Use DNS-1123 instead of DNS-1035 for resource name

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5647,9 +5647,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.30.0.tgz",
-      "integrity": "sha512-Fvl7kM3fHG/UQ5/ZwipWBzCGpKIeZmWNgxTF8KQ8PYKDLFt1ZrQcUhK0FQJ9Exl1rUustK/4ot/82ljUqjeWbg==",
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.30.1.tgz",
+      "integrity": "sha512-o43Hb7KQxAn4oCMlqm24qTsQ5T/Pr5W4q3tVKUJtWHYA5hKhNbnX1mhAArN5gSFCz748W1Vr+JqqT6cwN9vQyQ==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.30.0",
+    "iguazio.dashboard-controls": "^0.30.1",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",

--- a/pkg/dashboard/ui/src/app/components/projects/edit-project-dialog/edit-project-dialog.component.js
+++ b/pkg/dashboard/ui/src/app/components/projects/edit-project-dialog/edit-project-dialog.component.js
@@ -22,7 +22,7 @@
         ctrl.nameValidationRules = [];
         ctrl.serverError = '';
         ctrl.validationRules = {
-            projectName: ValidationService.getValidationRules('k8s.dns1035Label')
+            projectName: ValidationService.getValidationRules('k8s.dns1123Label')
         };
 
         ctrl.$onInit = onInit;

--- a/pkg/dashboard/ui/src/app/components/projects/new-project-dialog/new-project-dialog.component.js
+++ b/pkg/dashboard/ui/src/app/components/projects/new-project-dialog/new-project-dialog.component.js
@@ -19,10 +19,10 @@
         ctrl.isLoadingState = false;
         ctrl.nameMaxLength = null;
         ctrl.maxLengths = {
-            projectName: ValidationService.getMaxLength('k8s.dns1035Label')
+            projectName: ValidationService.getMaxLength('k8s.dns1123Label')
         };
         ctrl.validationRules = {
-            projectName: ValidationService.getValidationRules('k8s.dns1035Label')
+            projectName: ValidationService.getValidationRules('k8s.dns1123Label')
         };
         ctrl.serverError = '';
 


### PR DESCRIPTION
- Changed restrictions for function and API gateway names from DNS-1035 label to DNS-1123 label. The only difference between a DNS-1123 label and a DNS-1035 label is that DNS-123 label can being with a digit while DNS-1035 cannot.
  ![image](https://user-images.githubusercontent.com/13918850/103240333-b9516100-4958-11eb-9722-50b65e7c3ffd.png)
    ![image](https://user-images.githubusercontent.com/13918850/103239241-9f624f00-4955-11eb-82a3-ef9b139bf82e.png)
    ![image](https://user-images.githubusercontent.com/13918850/103239243-a12c1280-4955-11eb-9960-0df91f74a36a.png)
- Function:
  - Code › Test pane: enable the Test button when the function is scaled-to-zero and update its tooltip text accordingly
    ![image](https://user-images.githubusercontent.com/13918850/103218756-a4f37100-4924-11eb-81b4-89653a759af8.png)
  - Configuration › Volumes:
    - Removed the uniqueness restriction on the volume name
      ![image](https://user-images.githubusercontent.com/13918850/103232573-7cc73a80-4943-11eb-9541-9833f7785116.png)
    - Turned “Container name” field of V3IO volume type optional
      ![image](https://user-images.githubusercontent.com/13918850/103239627-d08f4f00-4956-11eb-8a8a-f074feda01b5.png)