### PR TITLE
[Projects] Do not omit `spec.displayName` on create

### DIFF
--- a/pkg/dashboard/ui/src/app/components/projects/new-project-dialog/new-project-dialog.component.js
+++ b/pkg/dashboard/ui/src/app/components/projects/new-project-dialog/new-project-dialog.component.js
@@ -72,7 +72,8 @@
                     }
 
                     // use data from dialog to create a new project
-                    NuclioProjectsDataService.createProject(ctrl.data)
+                    var projectData = lodash.omit(ctrl.data, 'spec.displayName');
+                    NuclioProjectsDataService.createProject(projectData)
                         .then(function () {
                             ctrl.closeDialog({ project: ctrl.data });
                         })

--- a/pkg/dashboard/ui/src/app/components/projects/new-project-dialog/new-project-dialog.component.js
+++ b/pkg/dashboard/ui/src/app/components/projects/new-project-dialog/new-project-dialog.component.js
@@ -72,8 +72,7 @@
                     }
 
                     // use data from dialog to create a new project
-                    var projectData = lodash.omit(ctrl.data, 'spec.displayName');
-                    NuclioProjectsDataService.createProject(projectData)
+                    NuclioProjectsDataService.createProject(ctrl.data)
                         .then(function () {
                             ctrl.closeDialog({ project: ctrl.data });
                         })

--- a/pkg/dashboard/ui/src/app/shared/services/import.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/import.service.js
@@ -84,8 +84,9 @@
          */
         function importProject(project, onFailure) {
             var projectData = lodash.omit(project, 'spec.functions');
+            var importProcess = true;
 
-            return NuclioProjectsDataService.createProject(projectData)
+            return NuclioProjectsDataService.createProject(projectData, importProcess)
                 .catch(function (error) {
 
                     // swallow "409 Conflict" errors
@@ -103,7 +104,7 @@
                     var functions = lodash.get(project, 'spec.functions');
 
                     var checkedFunctionList = lodash.map(functions, function (func) {
-                        return NuclioFunctionsDataService.createFunction(func, projectName)
+                        return NuclioFunctionsDataService.createFunction(func, projectName, importProcess)
                             .catch(function (error) {
                                 if (error.status === 409) {
                                     if (lodash.has(conflictProjectsData, projectName)) {

--- a/pkg/dashboard/ui/src/app/shared/services/nuclio-functions-data.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/nuclio-functions-data.service.js
@@ -23,10 +23,10 @@
          * Update existing function with new data
          * @param {Object} functionDetails
          * @param {string} projectName - the name of the project containing the function
-         * @param {boolean} importProcess - "true" if importing process
+         * @param {boolean} [importProcess=null] - `true` if importing process
          * @returns {Promise}
          */
-        function createFunction(functionDetails, projectName, importProcess = false) {
+        function createFunction(functionDetails, projectName, importProcess) {
             var headers = {
                 'Content-Type': 'application/json',
                 'x-nuclio-project-name': projectName
@@ -41,7 +41,10 @@
 
             var config = {
                 method: 'post',
-                url: NuclioClientService.buildUrlWithPath('functions', importProcess ? '?import=true' : ''),
+                url: NuclioClientService.buildUrlWithPath('functions'),
+                params: {
+                    import: lodash.defaultTo(importProcess, null)
+                },
                 headers: headers,
                 data: functionDetails,
                 withCredentials: false

--- a/pkg/dashboard/ui/src/app/shared/services/nuclio-functions-data.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/nuclio-functions-data.service.js
@@ -23,7 +23,7 @@
          * Update existing function with new data
          * @param {Object} functionDetails
          * @param {string} projectName - the name of the project containing the function
-         * @param {boolean} [importProcess=null] - `true` if importing process
+         * @param {boolean} [importProcess] - `true` if importing process
          * @returns {Promise}
          */
         function createFunction(functionDetails, projectName, importProcess) {
@@ -43,7 +43,7 @@
                 method: 'post',
                 url: NuclioClientService.buildUrlWithPath('functions'),
                 params: {
-                    import: lodash.defaultTo(importProcess, null)
+                    import: importProcess
                 },
                 headers: headers,
                 data: functionDetails,

--- a/pkg/dashboard/ui/src/app/shared/services/nuclio-functions-data.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/nuclio-functions-data.service.js
@@ -23,9 +23,10 @@
          * Update existing function with new data
          * @param {Object} functionDetails
          * @param {string} projectName - the name of the project containing the function
+         * @param {boolean} importProcess - "true" if importing process
          * @returns {Promise}
          */
-        function createFunction(functionDetails, projectName) {
+        function createFunction(functionDetails, projectName, importProcess = false) {
             var headers = {
                 'Content-Type': 'application/json',
                 'x-nuclio-project-name': projectName
@@ -40,7 +41,7 @@
 
             var config = {
                 method: 'post',
-                url: NuclioClientService.buildUrlWithPath('functions'),
+                url: NuclioClientService.buildUrlWithPath('functions', importProcess ? '?import=true' : ''),
                 headers: headers,
                 data: functionDetails,
                 withCredentials: false

--- a/pkg/dashboard/ui/src/app/shared/services/nuclio-projects-data.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/nuclio-projects-data.service.js
@@ -21,7 +21,7 @@
         /**
          * Creates a new project
          * @param {Promise} project - the project to create
-         * @param {boolean} [importProcess=null] - `true` if importing process
+         * @param {boolean} [importProcess] - `true` if importing process
          */
         function createProject(project, importProcess) {
             var headers = {
@@ -38,7 +38,7 @@
                 method: 'POST',
                 url: NuclioClientService.buildUrlWithPath('projects'),
                 params: {
-                    import: lodash.defaultTo(importProcess, null)
+                    import: importProcess
                 },
                 headers: headers,
                 data: data,

--- a/pkg/dashboard/ui/src/app/shared/services/nuclio-projects-data.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/nuclio-projects-data.service.js
@@ -21,9 +21,9 @@
         /**
          * Creates a new project
          * @param {Promise} project - the project to create
-         * @param {boolean} importProcess - "true" if importing process
+         * @param {boolean} [importProcess=null] - `true` if importing process
          */
-        function createProject(project, importProcess = false) {
+        function createProject(project, importProcess) {
             var headers = {
                 'Content-Type': 'application/json'
             };
@@ -36,7 +36,10 @@
 
             return NuclioClientService.makeRequest({
                 method: 'POST',
-                url: NuclioClientService.buildUrlWithPath('projects', importProcess ? '?import=true' : ''),
+                url: NuclioClientService.buildUrlWithPath('projects'),
+                params: {
+                    import: lodash.defaultTo(importProcess, null)
+                },
                 headers: headers,
                 data: data,
                 withCredentials: false

--- a/pkg/dashboard/ui/src/app/shared/services/nuclio-projects-data.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/nuclio-projects-data.service.js
@@ -21,8 +21,9 @@
         /**
          * Creates a new project
          * @param {Promise} project - the project to create
+         * @param {boolean} importProcess - "true" if importing process
          */
-        function createProject(project) {
+        function createProject(project, importProcess = false) {
             var headers = {
                 'Content-Type': 'application/json'
             };
@@ -35,7 +36,7 @@
 
             return NuclioClientService.makeRequest({
                 method: 'POST',
-                url: NuclioClientService.buildUrlWithPath('projects', ''),
+                url: NuclioClientService.buildUrlWithPath('projects', importProcess ? '?import=true' : ''),
                 headers: headers,
                 data: data,
                 withCredentials: false

--- a/pkg/dashboard/ui/src/app/shared/services/nuclio-projects-data.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/nuclio-projects-data.service.js
@@ -26,10 +26,7 @@
             var headers = {
                 'Content-Type': 'application/json'
             };
-            var data = lodash.chain(project)
-                .pick(['metadata', 'spec'])
-                .omit('spec.displayName')
-                .value();
+            var data = lodash.pick(project, ['metadata', 'spec']);
             var namespace = NuclioNamespacesDataService.getNamespace();
 
             if (!lodash.isNil(namespace)) {


### PR DESCRIPTION
https://trello.com/c/7pD5pfgG/661-projects-import-do-not-omit-specdisplayname-during-import

Also add `import=true` on `POST` requests as part of import process.

Reverts PR https://github.com/nuclio/nuclio/pull/1990