### PR TITLE
Reducing log level for create project

### DIFF
--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -440,7 +440,7 @@ func (p *Platform) CreateProject(createProjectOptions *platform.CreateProjectOpt
 	p.platformProjectToProject(createProjectOptions.ProjectConfig, &newProject)
 
 	// create
-	p.Logger.InfoWith("Creating project",
+	p.Logger.DebugWith("Creating project",
 		"projectName", createProjectOptions.ProjectConfig.Meta.Name)
 	if _, err := p.consumer.nuclioClientSet.NuclioV1beta1().
 		NuclioProjects(createProjectOptions.ProjectConfig.Meta.Namespace).

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -346,7 +346,7 @@ func (p *Platform) CreateProject(createProjectOptions *platform.CreateProjectOpt
 	}
 
 	// create
-	p.Logger.InfoWith("Creating project",
+	p.Logger.DebugWith("Creating project",
 		"projectName", createProjectOptions.ProjectConfig.Meta.Name)
 	return p.localStore.createOrUpdateProject(createProjectOptions.ProjectConfig)
 }


### PR DESCRIPTION
Since log lines are added to export/import, it screws the produced artifact.
Reducing log level for now, on next version a better logger mechanism would be introduced.