### PR TITLE
Fix CI transient failures on function monitoring

### DIFF
--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -20,13 +20,25 @@ import (
 
 type FunctionMonitoringTestSuite struct {
 	kubetest.KubeTestSuite
+	oldPostDeploymentMonitoringBlockingInterval time.Duration
 }
 
 func (suite *FunctionMonitoringTestSuite) SetupSuite() {
 	suite.KubeTestSuite.SetupSuite()
 
+	// keep it for suite teardown
+	suite.oldPostDeploymentMonitoringBlockingInterval = monitoring.PostDeploymentMonitoringBlockingInterval
+}
+
+func (suite *FunctionMonitoringTestSuite) TearDownSuite() {
+	monitoring.PostDeploymentMonitoringBlockingInterval = suite.oldPostDeploymentMonitoringBlockingInterval
+}
+
+func (suite *FunctionMonitoringTestSuite) SetupTest() {
+
 	// decrease blocking interval, to make test run faster
-	monitoring.PostDeploymentMonitoringBlockingInterval = time.Second
+	// give it ~10 seconds to recently deployed functions to stabilize, avoid transients
+	monitoring.PostDeploymentMonitoringBlockingInterval = 10 * time.Second
 }
 
 func (suite *FunctionMonitoringTestSuite) TestNoRecoveryAfterBuildError() {

--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -35,6 +35,7 @@ func (suite *FunctionMonitoringTestSuite) TearDownSuite() {
 }
 
 func (suite *FunctionMonitoringTestSuite) SetupTest() {
+	suite.KubeTestSuite.SetupTest()
 
 	// decrease blocking interval, to make test run faster
 	// give it ~10 seconds to recently deployed functions to stabilize, avoid transients


### PR DESCRIPTION
Caused because recently deployed functions grace period was too short causing the monitoring service to mark function as unhealthy mistakenly 