### PR TITLE
Fix function image name is enriched needlessly upon build failures

### DIFF
--- a/pkg/platform/kube/deployer.go
+++ b/pkg/platform/kube/deployer.go
@@ -130,7 +130,7 @@ func (d *deployer) populateFunction(functionConfig *functionconfig.Config,
 	//    name:tag (e.g. foo:latest) and we need to prepend run registry
 
 	// if, for some reason, the run registry is specified, prepend that
-	if functionConfig.Spec.RunRegistry != "" {
+	if functionConfig.Spec.RunRegistry != "" && functionInstance.Spec.Image != "" {
 
 		// check if the run registry is part of the image already first
 		if !strings.HasPrefix(functionInstance.Spec.Image, fmt.Sprintf("%s/", functionConfig.Spec.RunRegistry)) {


### PR DESCRIPTION
When function build fail before image is getting built, the field is left empty. once it updates the function record with the failure, it enriches the image with the run-registry prefix. in such case, the function record is getting enriched with the prefix only and left with `image: some-registry/`, which is itself a bad image name.