### PR TITLE
chore: Upgrade actions-setup-minikube to v2.3.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,7 +156,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
 
-    - uses: manusa/actions-setup-minikube@v2.1.0
+    - uses: manusa/actions-setup-minikube@v2.3.0
       with:
         minikube version: "v1.15.1"
         kubernetes version: "v1.17.9"
@@ -263,7 +263,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - uses: manusa/actions-setup-minikube@v2.1.0
+      - uses: manusa/actions-setup-minikube@v2.3.0
         with:
           minikube version: "v1.15.1"
           kubernetes version: "v1.17.9"


### PR DESCRIPTION
Upgrade `manusa/actions-setup-minikube` to use the latest version.

GitHub is rolling out Ubuntu 20.04 as the default environment. GitHub actions workflows using `ubuntu-latest` will [soon ](https://github.com/actions/virtual-environments/issues/1816) start an Ubuntu 20,04 instance instead of 18.04.

Prior versions of `manusa/actions-setup-minikube` have a check which won't allow the workflow job to run. Starting on `2.2.0`, Ubuntu 20.04 is supported too (https://github.com/manusa/actions-setup-minikube/issues/26).