### PR TITLE
Add integration test for function brief error message

### DIFF
--- a/pkg/common/strings.go
+++ b/pkg/common/strings.go
@@ -76,8 +76,8 @@ func CompareTwoStrings(stringOne, stringTwo string) float32 {
 }
 
 func removeSpaces(stringOne, stringTwo *string) {
-	*stringOne = strings.Replace(*stringOne, " ", "", -1)
-	*stringTwo = strings.Replace(*stringTwo, " ", "", -1)
+	*stringOne = strings.ReplaceAll(*stringOne, " ", "")
+	*stringTwo = strings.ReplaceAll(*stringTwo, " ", "")
 }
 
 func returnEarlyIfPossible(stringOne, stringTwo string) float32 {

--- a/pkg/common/strings.go
+++ b/pkg/common/strings.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copied from https://github.com/fernandoporazzi/sorensen-dice-coefficient
+*/
+
+package common
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Uses Sørensen–Dice coefficient to check similarity
+func CompareTwoStrings(stringOne, stringTwo string) float32 {
+	removeSpaces(&stringOne, &stringTwo)
+
+	if value := returnEarlyIfPossible(stringOne, stringTwo); value >= 0 {
+		return value
+	}
+
+	firstBigrams := make(map[string]int)
+	for i := 0; i < len(stringOne)-1; i++ {
+		a := fmt.Sprintf("%c", stringOne[i])
+		b := fmt.Sprintf("%c", stringOne[i+1])
+
+		bigram := a + b
+
+		var count int
+
+		if value, ok := firstBigrams[bigram]; ok {
+			count = value + 1
+		} else {
+			count = 1
+		}
+
+		firstBigrams[bigram] = count
+	}
+
+	var intersectionSize float32
+	intersectionSize = 0
+
+	for i := 0; i < len(stringTwo)-1; i++ {
+		a := fmt.Sprintf("%c", stringTwo[i])
+		b := fmt.Sprintf("%c", stringTwo[i+1])
+
+		bigram := a + b
+
+		var count int
+
+		if value, ok := firstBigrams[bigram]; ok {
+			count = value
+		} else {
+			count = 0
+		}
+
+		if count > 0 {
+			firstBigrams[bigram] = count - 1
+			intersectionSize = intersectionSize + 1
+		}
+	}
+
+	return (2.0 * intersectionSize) / (float32(len(stringOne)) + float32(len(stringTwo)) - 2)
+}
+
+func removeSpaces(stringOne, stringTwo *string) {
+	*stringOne = strings.Replace(*stringOne, " ", "", -1)
+	*stringTwo = strings.Replace(*stringTwo, " ", "", -1)
+}
+
+func returnEarlyIfPossible(stringOne, stringTwo string) float32 {
+	// if both are empty strings
+	if len(stringOne) == 0 && len(stringTwo) == 0 {
+		return 1
+	}
+
+	// if only one is empty string
+	if len(stringOne) == 0 || len(stringTwo) == 0 {
+		return 0
+	}
+
+	// identical
+	if stringOne == stringTwo {
+		return 1
+	}
+
+	// both are 1-letter strings
+	if len(stringOne) == 1 && len(stringTwo) == 1 {
+		return 0
+	}
+
+	// if either is a 1-letter string
+	if len(stringOne) < 2 || len(stringTwo) < 2 {
+		return 0
+	}
+
+	return -1
+}

--- a/pkg/platform/kube/deployer.go
+++ b/pkg/platform/kube/deployer.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
@@ -358,12 +359,18 @@ func (d *deployer) getFunctionPodWarningEvents(namespace string, podName string)
 		return "", err
 	}
 
-	var podWarningEvents string
+	var podWarningEvents []string
 	for _, event := range eventList.Items {
 		if event.InvolvedObject.Name == podName && event.Type == "Warning" {
-			podWarningEvents += event.Message + "\n"
+			if !common.StringInSlice(event.Message, podWarningEvents) {
+				podWarningEvents = append(podWarningEvents, event.Message)
+			}
 		}
 	}
 
-	return podWarningEvents, nil
+	// separate each warning by a new line, and add another new line in the end
+	res := strings.Join(podWarningEvents, "\n")
+	res = res + "\n"
+
+	return res, nil
 }

--- a/pkg/platform/kube/deployer.go
+++ b/pkg/platform/kube/deployer.go
@@ -368,8 +368,5 @@ func (d *deployer) getFunctionPodWarningEvents(namespace string, podName string)
 		}
 	}
 
-	res := strings.Join(podWarningEvents, "\n")
-	res = res + "\n"
-
-	return res, nil
+	return fmt.Sprintf("%s\n", strings.Join(podWarningEvents, "\n")), nil
 }

--- a/pkg/platform/kube/deployer.go
+++ b/pkg/platform/kube/deployer.go
@@ -368,7 +368,6 @@ func (d *deployer) getFunctionPodWarningEvents(namespace string, podName string)
 		}
 	}
 
-	// separate each warning by a new line, and add another new line in the end
 	res := strings.Join(podWarningEvents, "\n")
 	res = res + "\n"
 

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -130,18 +130,15 @@ AttributeError: module 'main' has no attribute 'expected_handler'
 			_, err := suite.DeployFunctionExpectError(testCase.CreateFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
 
 				// get the function
-				functions, err := suite.Platform.GetFunctions(&platform.GetFunctionsOptions{
+				function := suite.GetFunction(&platform.GetFunctionsOptions{
 					Name:      testCase.CreateFunctionOptions.FunctionConfig.Meta.Name,
 					Namespace: testCase.CreateFunctionOptions.FunctionConfig.Meta.Namespace,
 				})
-				suite.Require().NoError(err)
-
-				message := functions[0].GetStatus().Message
 
 				// validate the brief error message in function status is at least 95% close to the expected brief error message
 				// keep it flexible for close enough messages in case small changes occur (e.g. line numbers on stack trace)
-				briefErrorMessageDiff := common.CompareTwoStrings(testCase.ExpectedBriefErrorsMessage, message)
-				suite.Require().GreaterOrEqual(briefErrorMessageDiff, 0.95)
+				briefErrorMessageDiff := common.CompareTwoStrings(testCase.ExpectedBriefErrorsMessage, function.GetStatus().Message)
+				suite.Require().GreaterOrEqual(briefErrorMessageDiff, float32(0.95))
 
 				return true
 			})

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -19,11 +19,11 @@ package test
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/nuclio/nuclio/pkg/common"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/kube"


### PR DESCRIPTION
Added integration tests to make sure `function.status.message` is filled with the expected brief error message on different function deployment failures.

- Made sure no same warning event is printed to brief error message
- Used https://github.com/fernandoporazzi/sorensen-dice-coefficient `CompareTwoStrings` to compare how close the function.status.message and the expected one are (in percent). 
Done  to allow flexibility so tests won't break when small changes happen (like different stack trace code line references)