### PR TITLE
Function monitoring: enhancing the way deployment is detected as available

### DIFF
--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -72,10 +72,10 @@ func (suite *FunctionMonitoringTestSuite) TestRecoverFromPodsHardLimit() {
 		suite.Require().NoError(err)
 
 		// clean leftovers
-		defer suite.KubeClientSet. // nolint: errcheck
-						CoreV1().
-						ResourceQuotas(suite.Namespace).
-						Delete(resourceQuota.Name, &metav1.DeleteOptions{})
+		defer suite.KubeClientSet.
+			CoreV1().
+			ResourceQuotas(suite.Namespace).
+			Delete(resourceQuota.Name, &metav1.DeleteOptions{}) // nolint: errcheck
 
 		// delete function single pod
 		pods := suite.GetFunctionPods(getFunctionOptions.Name)


### PR DESCRIPTION
This change came after noticing many CI failures, caused by a race condition between the function monitoring and the resync process.

Disclaimer:
- the post deployment block call is _up_ to 60 seconds, once deployment is ready it might check it immediately.
- while function is deployed, is has a "minimum available replicas" which allow the function to become "ready".
- during second deploy of a function, there is a transient state in which a deployment has replicas set for old function + new function rollout. e.g.: for function with 1 replica, during deployment, a deployment would have 2 replicas set.

CI Failure logs

```
21.01.06 17:21:06.211                      test (I) Function deploy complete {"functionName": "function-deploy-fail", "httpPort": 32053}
21.01.06 17:21:06.277          test.functionres (D) Deployment not available yet {"reason": "MinimumReplicasAvailable", "unavailableReplicas": 1, "deploymentName": "nuclio-function-deploy-fail"}
21.01.06 17:21:06.780          test.functionres (D) Deployment not available yet {"reason": "MinimumReplicasAvailable", "unavailableReplicas": 1, "deploymentName": "nuclio-function-deploy-fail"}
21.01.06 17:21:06.856     test.function_monitor (D) Function was recently deployed {"functionName": "function-deploy-fail", "lastProvisioningTimestamp": "21.01.06 17:21:01.854"}
21.01.06 17:21:06.856     test.function_monitor (D) Function is being provisioned or recently deployed, skipping {"functionName": "function-deploy-fail", "functionState": "ready"}
21.01.06 17:21:07.783          test.functionres (D) Deployment not available yet {"reason": "MinimumReplicasAvailable", "unavailableReplicas": 1, "deploymentName": "nuclio-function-deploy-fail"}
1 => 21.01.06 17:21:09.791          test.functionres (D) Deployment is available {"reason": "MinimumReplicasAvailable", "deploymentName": "nuclio-function-deploy-fail"}
21.01.06 17:21:09.815          test.functionres (D) Waiting for deployment to be available {"namespace": "default", "functionName": "function-deploy-fail", "deploymentName": "nuclio-function-deploy-fail"}
2 => 21.01.06 17:21:10.069          test.functionres (D) Deployment is available {"reason": "MinimumReplicasAvailable", "deploymentName": "nuclio-function-deploy-fail"}
21.01.06 17:21:11.215          test.functionres (D) Waiting for deployment to be available {"namespace": "default", "functionName": "function-deploy-fail", "deploymentName": "nuclio-function-deploy-fail"}
21.01.06 17:21:11.467          test.functionres (D) Deployment not available yet {"reason": "MinimumReplicasAvailable", "unavailableReplicas": 1, "deploymentName": "nuclio-function-deploy-fail"}
21.01.06 17:21:11.860     test.function_monitor (D) Getting function deployment function {"functionName": "function-deploy-fail", "functionNamespace": "default"}
21.01.06 17:21:11.864     test.function_monitor (I) Function state has changed, updating 
{
    "functionName": "function-deploy-fail",
    "functionStatus": {
        "state": "unhealthy",
        "message": "Function is not healthy",
        "httpPort": 32053,
        "scaleToZero": {
            "lastScaleEvent": "resourceUpdated",
            "lastScaleEventTime": "2021-01-06T17:21:05.990333996Z"
        }
    },
    "functionNamespace": "default",
    "functionDeploymentStatus": {
        "observedGeneration": 5,
        "replicas": 2,
        "updatedReplicas": 1,
        "readyReplicas": 1,
        "availableReplicas": 1,
        "unavailableReplicas": 1,
        "conditions": [
            {
                "type": "Available",
                "status": "True",
                "lastUpdateTime": "2021-01-06T17:20:38Z",
                "lastTransitionTime": "2021-01-06T17:20:38Z",
                "reason": "MinimumReplicasAvailable",
                "message": "Deployment has minimum availability."
            },
            {
                "type": "Progressing",
                "status": "True",
                "lastUpdateTime": "2021-01-06T17:21:11Z",
                "lastTransitionTime": "2021-01-06T17:19:31Z",
                "reason": "ReplicaSetUpdated",
                "message": "ReplicaSet \"nuclio-function-deploy-fail-7bb9b45cbd\" is progressing."
            }
        ]
    },
    "functionIsAvailable": false
}
```

What we can see here, is that
- function second deploy has finished successfully
- function has minimum availability, and so it is marked as ready
- there are some "resync" waiting for deployment to become "ready" (since there are unavailable replicas)
- function monitoring runs, detect that function has 1 unavailable replicas and immediately mark function as unhealthy

This would happen on _slow_ machines, such as CI.

To fix it, I set the function monitoring to mark functions as unhealthy according to https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#failed-deployment