### PR TITLE
Fix unordered list of volumes causing deployment spec to be reconfigured

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -1941,6 +1942,15 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(function *nuclioio.NuclioFuncti
 	for _, volumeVolumeMounts := range volumeNameToVolumeMounts {
 		volumeMounts = append(volumeMounts, volumeVolumeMounts...)
 	}
+
+	// kubernetes is sensitive to list order.
+	// avoid deployment from being re-applied by order volumes and volume mounts by name
+	sort.Slice(volumes, func(i, j int) bool {
+		return volumes[i].Name < volumes[j].Name
+	})
+	sort.Slice(volumeMounts, func(i, j int) bool {
+		return volumeMounts[i].Name < volumeMounts[j].Name
+	})
 
 	// flatten and return as list of instances
 	return volumes, volumeMounts

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -49,9 +49,8 @@ func (c *mockedPlatformConfigurationProvider) GetPlatformConfiguration() *platfo
 
 type lazyTestSuite struct {
 	suite.Suite
-	logger        logger.Logger
-	client        lazyClient
-	kubeClientSet *fake.Clientset
+	logger logger.Logger
+	client lazyClient
 }
 
 func (suite *lazyTestSuite) SetupTest() {

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -88,6 +88,7 @@ func (suite *lazyTestSuite) TestNoChanges() {
 	suite.client.logger.(*nucliozap.NuclioZap).SetLevel(nucliozap.InfoLevel)
 	defer suite.client.logger.(*nucliozap.NuclioZap).SetLevel(prevLevel)
 
+	// "create" the deployment
 	deploymentInstance, err := suite.client.createOrUpdateDeployment(functionLabels,
 		"image-pull-secret-str",
 		&function)
@@ -96,12 +97,15 @@ func (suite *lazyTestSuite) TestNoChanges() {
 
 	// make sure no changes were applied for 1000 times of re-apply deployment.
 	for i := 0; i < 1000; i++ {
+
+		// "update" the deployment
 		updatedDeploymentInstance, err := suite.client.createOrUpdateDeployment(functionLabels,
 			"image-pull-secret-str",
 			&function)
 		suite.Require().NoError(err)
 		suite.Require().NotNil(deploymentInstance)
 
+		// ensure no changes
 		suite.Require().Empty(cmp.Diff(deploymentInstance, updatedDeploymentInstance))
 	}
 }

--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -31,8 +31,8 @@ func (suite *FunctionMonitoringTestSuite) SetupSuite() {
 	suite.oldPostDeploymentMonitoringBlockingInterval = monitoring.PostDeploymentMonitoringBlockingInterval
 
 	// decrease blocking interval, to make test run faster
-	// give it ~10 seconds to recently deployed functions to stabilize, avoid transients
-	monitoring.PostDeploymentMonitoringBlockingInterval = 10 * time.Second
+	// give it ~5 seconds to recently deployed functions to stabilize, avoid transients
+	monitoring.PostDeploymentMonitoringBlockingInterval = 5 * time.Second
 }
 
 func (suite *FunctionMonitoringTestSuite) TearDownSuite() {
@@ -246,7 +246,8 @@ func (suite *FunctionMonitoringTestSuite) TestRecoverErrorStateFunctionWhenResou
 		Namespace: createFunctionOptions.FunctionConfig.Meta.Namespace,
 	}
 
-	functionMonitoringSleepTimeout := 2 * suite.Controller.GetFunctionMonitoringInterval()
+	functionMonitoringSleepTimeout := 2*suite.Controller.GetFunctionMonitoringInterval() +
+		monitoring.PostDeploymentMonitoringBlockingInterval
 	suite.DeployFunction(createFunctionOptions, func(deployResults *platform.CreateFunctionResult) bool {
 
 		// get the function

--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -46,11 +46,9 @@ func (suite *FunctionMonitoringTestSuite) TestRecoverFromPodsHardLimit() {
 		Name:      createFunctionOptions.FunctionConfig.Meta.Name,
 		Namespace: createFunctionOptions.FunctionConfig.Meta.Namespace,
 	}
-	one := 1
+	two := 2
 	three := 3
-	createFunctionOptions.FunctionConfig.Spec.MinReplicas = &one
-	createFunctionOptions.FunctionConfig.Spec.MaxReplicas = &three
-
+	createFunctionOptions.FunctionConfig.Spec.Replicas = &three
 	_ = suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
 
 		// limit pod to one
@@ -64,7 +62,7 @@ func (suite *FunctionMonitoringTestSuite) TestRecoverFromPodsHardLimit() {
 				},
 				Spec: v1.ResourceQuotaSpec{
 					Hard: v1.ResourceList{
-						v1.ResourcePods: resource.MustParse(strconv.Itoa(one)),
+						v1.ResourcePods: resource.MustParse(strconv.Itoa(two)),
 					},
 				},
 				Status: v1.ResourceQuotaStatus{},


### PR DESCRIPTION
Function were re-deployed transiently due to deployment spec change on the list of volume / volume mounts, causing the pod to restart each X controller intervals.