### PR TITLE
Introducing dashboard healthcheck server

### DIFF
--- a/cmd/dashboard/app/dashboard.go
+++ b/cmd/dashboard/app/dashboard.go
@@ -18,11 +18,12 @@ package app
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"time"
 
 	commonhealthcheck "github.com/nuclio/nuclio/pkg/common/healthcheck"
-	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/dashboard"
 	"github.com/nuclio/nuclio/pkg/dashboard/functiontemplates"
 	"github.com/nuclio/nuclio/pkg/dashboard/healthcheck"
@@ -38,6 +39,68 @@ import (
 	"github.com/nuclio/logger"
 	"github.com/v3io/version-go"
 )
+
+type Dashboard struct {
+	server            restful.Server
+	healthCheckServer commonhealthcheck.Server
+	logger            logger.Logger
+
+	status status.Status
+}
+
+func (d *Dashboard) GetStatus() status.Status {
+	return d.status
+}
+
+func (d *Dashboard) SetStatus(status status.Status) {
+	if d.status != status {
+		d.logger.InfoWith("Updating server healthiness",
+			"currentStatus", d.status,
+			"desiredStatus", status)
+	}
+	d.status = status
+}
+
+func (d *Dashboard) MonitorDockerConnectivity(ctx context.Context,
+	interval time.Duration,
+	maxConsecutiveErrors int,
+	dockerClient dockerclient.Client) {
+
+	d.logger.DebugWith("Monitoring docker connectivity",
+		"interval", interval,
+		"maxConsecutiveErrors", maxConsecutiveErrors)
+
+	consecutiveErrors := 0
+	dockerConnectivityTicker := time.NewTicker(interval)
+	for {
+		select {
+		case <-ctx.Done():
+			dockerConnectivityTicker.Stop()
+			d.logger.DebugWith("Stopping docker connectivity monitor")
+			return
+		case <-dockerConnectivityTicker.C:
+			if d.GetStatus().OneOf(status.Error) {
+
+				// do not monitor while status is error
+				// let the kubelet / dockerd / user restart the process
+				continue
+			}
+
+			// get version quietly, avoid execution spamming stdout
+			if _, err := dockerClient.GetVersion(true); err == nil {
+
+				// reset counter
+				consecutiveErrors = 0
+				continue
+			}
+			consecutiveErrors++
+			if consecutiveErrors == maxConsecutiveErrors {
+				d.SetStatus(status.Error)
+				d.logger.Error("Failed to resolve docker version, connection might be unhealthy.")
+			}
+		}
+	}
+}
 
 func Run(listenAddress string,
 	dockerKeyDir string,
@@ -60,7 +123,9 @@ func Run(listenAddress string,
 	imageNamePrefixTemplate string,
 	platformAuthorizationMode string,
 	dependantImageRegistryURL string,
-	monitorDockerDeamon bool) error {
+	monitorDockerDeamon bool,
+	monitorDockerDeamonIntervalStr string,
+	monitorDockerDeamonMaxConsecutiveErrorsStr string) error {
 
 	// get platform configuration
 	platformConfiguration, err := platformconfig.NewPlatformConfig(platformConfigurationPath)
@@ -76,7 +141,7 @@ func Run(listenAddress string,
 
 	dashboardInstance := &Dashboard{
 		logger: rootLogger,
-		status: statusprovider.Initializing,
+		status: status.Initializing,
 	}
 
 	dashboardInstance.healthCheckServer, err = createAndStartHealthCheckServer(platformConfiguration,
@@ -129,17 +194,28 @@ func Run(listenAddress string,
 	// monitor docker connectivity to quickly populate any issue while connecting to docker daemon
 	if monitorDockerDeamon && platformInstance.GetContainerBuilderKind() == "docker" {
 
+		// parse docker deamon monitor max consecutive errors
+		monitorDockerDeamonMaxConsecutiveErrors, err := strconv.Atoi(monitorDockerDeamonMaxConsecutiveErrorsStr)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to parse string '%s' to integer", monitorDockerDeamonMaxConsecutiveErrorsStr)
+		}
+
+		// parse docker deamon monitor interval
+		monitorDockerDeamonInterval, err := time.ParseDuration(monitorDockerDeamonIntervalStr)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to parse string '%s' to duration", monitorDockerDeamonIntervalStr)
+		}
+
 		// create docker client
 		dockerClient, err := dockerclient.NewShellClient(rootLogger, nil)
 		if err != nil {
 			return errors.Wrap(err, "Failed to create docker shell client")
 		}
 
-		// TODO: receive from function args
 		ctx, cancel := context.WithCancel(context.Background())
 		go dashboardInstance.MonitorDockerConnectivity(ctx,
-			5*time.Second,
-			5,
+			monitorDockerDeamonInterval,
+			monitorDockerDeamonMaxConsecutiveErrors,
 			dockerClient)
 		defer cancel()
 	}
@@ -148,7 +224,7 @@ func Run(listenAddress string,
 		return errors.Wrap(err, "Failed to start server")
 	}
 
-	dashboardInstance.status = statusprovider.Ready
+	dashboardInstance.status = status.Ready
 	select {}
 }
 
@@ -287,7 +363,7 @@ func newDashboardServer(createDashboardServerOptions *CreateDashboardServerOptio
 
 func createAndStartHealthCheckServer(platformConfiguration *platformconfig.Config,
 	loggerInstance logger.Logger,
-	dashboardStatusProvider statusprovider.Provider) (commonhealthcheck.Server, error) {
+	statusProvider status.Provider) (commonhealthcheck.Server, error) {
 
 	// if enabled not passed, default to true
 	if platformConfiguration.HealthCheck.Enabled == nil {
@@ -300,7 +376,7 @@ func createAndStartHealthCheckServer(platformConfiguration *platformconfig.Confi
 	}
 
 	// create the server
-	server, err := healthcheck.NewDashboardServer(loggerInstance, dashboardStatusProvider, &platformConfiguration.HealthCheck)
+	server, err := healthcheck.NewDashboardServer(loggerInstance, statusProvider, &platformConfiguration.HealthCheck)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create health check server")
 	}

--- a/cmd/dashboard/app/dashboard.go
+++ b/cmd/dashboard/app/dashboard.go
@@ -59,7 +59,8 @@ func Run(listenAddress string,
 	defaultHTTPIngressHostTemplate string,
 	imageNamePrefixTemplate string,
 	platformAuthorizationMode string,
-	dependantImageRegistryURL string) error {
+	dependantImageRegistryURL string,
+	monitorDockerDeamon bool) error {
 
 	// get platform configuration
 	platformConfiguration, err := platformconfig.NewPlatformConfig(platformConfigurationPath)
@@ -126,7 +127,7 @@ func Run(listenAddress string,
 	}
 
 	// monitor docker connectivity to quickly populate any issue while connecting to docker daemon
-	if platformInstance.GetContainerBuilderKind() == "docker" {
+	if monitorDockerDeamon && platformInstance.GetContainerBuilderKind() == "docker" {
 
 		// create docker client
 		dockerClient, err := dockerclient.NewShellClient(rootLogger, nil)

--- a/cmd/dashboard/app/dashboard.go
+++ b/cmd/dashboard/app/dashboard.go
@@ -20,11 +20,15 @@ import (
 	"strings"
 	"time"
 
+	commonhealthcheck "github.com/nuclio/nuclio/pkg/common/healthcheck"
+	"github.com/nuclio/nuclio/pkg/common/statusprovider"
 	"github.com/nuclio/nuclio/pkg/dashboard"
 	"github.com/nuclio/nuclio/pkg/dashboard/functiontemplates"
+	"github.com/nuclio/nuclio/pkg/dashboard/healthcheck"
 	"github.com/nuclio/nuclio/pkg/loggersink"
 	"github.com/nuclio/nuclio/pkg/platform/factory"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
+	"github.com/nuclio/nuclio/pkg/restful"
 	// load all sinks
 	_ "github.com/nuclio/nuclio/pkg/sinks"
 
@@ -54,8 +58,6 @@ func Run(listenAddress string,
 	imageNamePrefixTemplate string,
 	platformAuthorizationMode string,
 	dependantImageRegistryURL string) error {
-	var functionGitTemplateFetcher *functiontemplates.GitFunctionTemplateFetcher
-	var functionZipTemplateFetcher *functiontemplates.ZipFunctionTemplateFetcher
 
 	// get platform configuration
 	platformConfiguration, err := platformconfig.NewPlatformConfig(platformConfigurationPath)
@@ -69,50 +71,111 @@ func Run(listenAddress string,
 		return errors.Wrap(err, "Failed to create logger")
 	}
 
-	// create a platform
-	platformInstance, err := factory.CreatePlatform(rootLogger, platformType, platformConfiguration, defaultNamespace)
+	dashboardInstance := &Dashboard{
+		logger: rootLogger,
+		status: statusprovider.Initializing,
+	}
+
+	dashboardInstance.healthCheckServer, err = createAndStartHealthCheckServer(platformConfiguration,
+		rootLogger,
+		dashboardInstance)
 	if err != nil {
-		return errors.Wrap(err, "Failed to create platform")
+		return errors.Wrap(err, "Failed to create and start health check server")
+	}
+
+	dashboardInstance.server, err = newDashboardServer(&CreateDashboardServerOptions{
+		logger:                dashboardInstance.logger,
+		platformConfiguration: platformConfiguration,
+
+		ListenAddress:                    listenAddress,
+		DockerKeyDir:                     dockerKeyDir,
+		DefaultRegistryURL:               defaultRegistryURL,
+		DefaultRunRegistryURL:            defaultRunRegistryURL,
+		PlatformType:                     platformType,
+		NoPullBaseImages:                 noPullBaseImages,
+		DefaultCredRefreshIntervalString: defaultCredRefreshIntervalString,
+		ExternalIPAddresses:              externalIPAddresses,
+		DefaultNamespace:                 defaultNamespace,
+		Offline:                          offline,
+		TemplatesGitRepository:           templatesGitRepository,
+		TemplatesGitRef:                  templatesGitRef,
+		TemplatesArchiveAddress:          templatesArchiveAddress,
+		TemplatesGitUsername:             templatesGitUsername,
+		TemplatesGitPassword:             templatesGitPassword,
+		TemplatesGithubAccessToken:       templatesGithubAccessToken,
+		DefaultHTTPIngressHostTemplate:   defaultHTTPIngressHostTemplate,
+		ImageNamePrefixTemplate:          imageNamePrefixTemplate,
+		PlatformAuthorizationMode:        platformAuthorizationMode,
+		DependantImageRegistryURL:        dependantImageRegistryURL,
+	})
+	if err != nil {
+		return errors.Wrap(err, "Failed to create new dashboard")
+	}
+
+	// TODO: receive from function args
+	go dashboardInstance.MonitorDockerConnectivity(10*time.Second, 5)
+
+	if err := dashboardInstance.server.Start(); err != nil {
+		return errors.Wrap(err, "Failed to start server")
+	}
+
+	dashboardInstance.status = statusprovider.Ready
+	select {}
+}
+
+func newDashboardServer(createDashboardServerOptions *CreateDashboardServerOptions) (restful.Server, error) {
+	rootLogger := createDashboardServerOptions.logger
+	var functionGitTemplateFetcher *functiontemplates.GitFunctionTemplateFetcher
+	var functionZipTemplateFetcher *functiontemplates.ZipFunctionTemplateFetcher
+
+	// create a platform
+	platformInstance, err := factory.CreatePlatform(rootLogger,
+		createDashboardServerOptions.PlatformType,
+		createDashboardServerOptions.platformConfiguration,
+		createDashboardServerOptions.DefaultNamespace)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create platform")
 	}
 
 	// create git fetcher
-	if templatesGitRepository != "" && templatesGitRef != "" {
+	if createDashboardServerOptions.TemplatesGitRepository != "" &&
+		createDashboardServerOptions.TemplatesGitRef != "" {
 		rootLogger.DebugWith("Fetching function templates from git repository",
-			"templatesGitRepository", templatesGitRepository,
-			"templatesGitRef", templatesGitRef)
+			"templatesGitRepository", createDashboardServerOptions.TemplatesGitRepository,
+			"templatesGitRef", createDashboardServerOptions.TemplatesGitRef)
 
 		// attach credentials if given
-		templatesGitRepository = attachCredentialsToGitRepository(rootLogger,
-			templatesGitRepository,
-			templatesGitUsername,
-			templatesGitPassword,
-			templatesGithubAccessToken)
+		templatesGitRepository := attachCredentialsToGitRepository(createDashboardServerOptions.logger,
+			createDashboardServerOptions.TemplatesGitRepository,
+			createDashboardServerOptions.TemplatesGitUsername,
+			createDashboardServerOptions.TemplatesGitPassword,
+			createDashboardServerOptions.TemplatesGithubAccessToken)
 
 		functionGitTemplateFetcher, err = functiontemplates.NewGitFunctionTemplateFetcher(rootLogger,
 			templatesGitRepository,
-			templatesGitRef)
+			createDashboardServerOptions.TemplatesGitRef)
 		if err != nil {
-			return errors.Wrap(err, "Failed to create git fetcher")
+			return nil, errors.Wrap(err, "Failed to create git fetcher")
 		}
 	} else {
 		rootLogger.DebugWith("Missing git fetcher configuration, templates from git won't be fetched",
-			"gitTemplateRepository", templatesGitRepository,
-			"templatesGitRef", templatesGitRef)
+			"gitTemplateRepository", createDashboardServerOptions.TemplatesGitRepository,
+			"templatesGitRef", createDashboardServerOptions.TemplatesGitRef)
 	}
 
 	// create zip fetcher
-	if templatesArchiveAddress != "" {
+	if createDashboardServerOptions.TemplatesArchiveAddress != "" {
 		functionZipTemplateFetcher, err = functiontemplates.NewZipFunctionTemplateFetcher(rootLogger,
-			templatesArchiveAddress)
+			createDashboardServerOptions.TemplatesArchiveAddress)
 		if err != nil {
-			return errors.Wrap(err, "Failed to create zip template fetcher")
+			return nil, errors.Wrap(err, "Failed to create zip template fetcher")
 		}
 	}
 
 	// create pre-generated templates fetcher
 	functionTemplatesGeneratedFetcher, err := functiontemplates.NewGeneratedFunctionTemplateFetcher(rootLogger)
 	if err != nil {
-		return errors.Wrap(err, "Failed to create pre-generated fetcher")
+		return nil, errors.Wrap(err, "Failed to create pre-generated fetcher")
 	}
 
 	// make repository for fetchers
@@ -128,83 +191,102 @@ func Run(listenAddress string,
 
 	functionTemplatesRepository, err := functiontemplates.NewRepository(rootLogger, functionTemplateFetchers)
 	if err != nil {
-		return errors.Wrap(err, "Failed to create repository out of given fetchers")
+		return nil, errors.Wrap(err, "Failed to create repository out of given fetchers")
 	}
 
 	// set external ip addresses based if user passed overriding values or not
 	var splitExternalIPAddresses []string
-	if externalIPAddresses == "" {
+	if createDashboardServerOptions.ExternalIPAddresses == "" {
 		splitExternalIPAddresses, err = platformInstance.GetDefaultInvokeIPAddresses()
 		if err != nil {
-			return errors.Wrap(err, "Failed to get default invoke ip addresses")
+			return nil, errors.Wrap(err, "Failed to get default invoke ip addresses")
 		}
 	} else {
 
 		// "10.0.0.1,10.0.0.2" -> ["10.0.0.1", "10.0.0.2"]
-		splitExternalIPAddresses = strings.Split(externalIPAddresses, ",")
+		splitExternalIPAddresses = strings.Split(createDashboardServerOptions.ExternalIPAddresses, ",")
 	}
 
-	err = platformInstance.SetExternalIPAddresses(splitExternalIPAddresses)
-	if err != nil {
-		return errors.Wrap(err, "Failed to set external ip addresses")
+	if err := platformInstance.SetExternalIPAddresses(splitExternalIPAddresses); err != nil {
+		return nil, errors.Wrap(err, "Failed to set external ip addresses")
 	}
 
-	if defaultHTTPIngressHostTemplate != "" {
-		platformInstance.SetDefaultHTTPIngressHostTemplate(defaultHTTPIngressHostTemplate)
+	if createDashboardServerOptions.DefaultHTTPIngressHostTemplate != "" {
+		platformInstance.SetDefaultHTTPIngressHostTemplate(createDashboardServerOptions.DefaultHTTPIngressHostTemplate)
 	}
 
-	if imageNamePrefixTemplate != "" {
-		platformInstance.SetImageNamePrefixTemplate(imageNamePrefixTemplate)
+	if createDashboardServerOptions.ImageNamePrefixTemplate != "" {
+		platformInstance.SetImageNamePrefixTemplate(createDashboardServerOptions.ImageNamePrefixTemplate)
 	}
 
-	rootLogger.InfoWith("Starting dashboard",
+	createDashboardServerOptions.logger.InfoWith("Starting dashboard",
 		"name", platformInstance.GetName(),
-		"noPull", noPullBaseImages,
-		"offline", offline,
-		"defaultCredRefreshInterval", defaultCredRefreshIntervalString,
-		"defaultNamespace", defaultNamespace,
+		"noPull", createDashboardServerOptions.NoPullBaseImages,
+		"offline", createDashboardServerOptions.Offline,
+		"defaultCredRefreshInterval", createDashboardServerOptions.DefaultCredRefreshIntervalString,
+		"defaultNamespace", createDashboardServerOptions.DefaultNamespace,
 		"version", version.Get(),
-		"platformConfiguration", platformConfiguration,
+		"platformConfiguration", createDashboardServerOptions.platformConfiguration,
 		"containerBuilderKind", platformInstance.GetContainerBuilderKind())
-
-	// see if the platform has anything to say about the namespace
-	defaultNamespace = platformInstance.ResolveDefaultNamespace(defaultNamespace)
 
 	// create a web server configuration
 	trueValue := true
 	webServerConfiguration := &platformconfig.WebServer{
 		Enabled:       &trueValue,
-		ListenAddress: listenAddress,
+		ListenAddress: createDashboardServerOptions.ListenAddress,
 	}
 
-	server, err := dashboard.NewServer(rootLogger,
+	dashboardServer, err := dashboard.NewServer(rootLogger,
 		platformInstance.GetContainerBuilderKind(),
-		dockerKeyDir,
-		defaultRegistryURL,
-		defaultRunRegistryURL,
+		createDashboardServerOptions.DockerKeyDir,
+		createDashboardServerOptions.DefaultRegistryURL,
+		createDashboardServerOptions.DefaultRunRegistryURL,
 		platformInstance,
-		noPullBaseImages,
+		createDashboardServerOptions.NoPullBaseImages,
 		webServerConfiguration,
-		getDefaultCredRefreshInterval(rootLogger, defaultCredRefreshIntervalString),
+		getDefaultCredRefreshInterval(rootLogger, createDashboardServerOptions.DefaultCredRefreshIntervalString),
 		splitExternalIPAddresses,
-		defaultNamespace,
-		offline,
+		platformInstance.ResolveDefaultNamespace(createDashboardServerOptions.DefaultNamespace),
+		createDashboardServerOptions.Offline,
 		functionTemplatesRepository,
-		platformConfiguration,
-		defaultHTTPIngressHostTemplate,
-		imageNamePrefixTemplate,
-		platformAuthorizationMode,
-		dependantImageRegistryURL)
+		createDashboardServerOptions.platformConfiguration,
+		createDashboardServerOptions.DefaultHTTPIngressHostTemplate,
+		createDashboardServerOptions.ImageNamePrefixTemplate,
+		createDashboardServerOptions.PlatformAuthorizationMode,
+		createDashboardServerOptions.DependantImageRegistryURL)
 	if err != nil {
-		return errors.Wrap(err, "Failed to create server")
+		return nil, errors.Wrap(err, "Failed to create server")
 	}
 
-	err = server.Start()
-	if err != nil {
-		return errors.Wrap(err, "Failed to start server")
+	return dashboardServer, nil
+}
+
+func createAndStartHealthCheckServer(platformConfiguration *platformconfig.Config,
+	loggerInstance logger.Logger,
+	dashboardInstance *Dashboard) (commonhealthcheck.Server, error) {
+
+	// if enabled not passed, default to true
+	if platformConfiguration.HealthCheck.Enabled == nil {
+		trueValue := true
+		platformConfiguration.HealthCheck.Enabled = &trueValue
 	}
 
-	select {}
+	if platformConfiguration.HealthCheck.ListenAddress == "" {
+		platformConfiguration.HealthCheck.ListenAddress = ":8082"
+	}
+
+	// create the server
+	server, err := healthcheck.NewDashboardServer(loggerInstance, dashboardInstance, &platformConfiguration.HealthCheck)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create health check server")
+	}
+
+	// start the web interface
+	if err := server.Start(); err != nil {
+		return nil, errors.Wrap(err, "Failed to start health check server")
+	}
+
+	return server, nil
 }
 
 func getDefaultCredRefreshInterval(logger logger.Logger, defaultCredRefreshIntervalString string) *time.Duration {

--- a/cmd/dashboard/app/dashboard.go
+++ b/cmd/dashboard/app/dashboard.go
@@ -281,7 +281,7 @@ func newDashboardServer(createDashboardServerOptions *CreateDashboardServerOptio
 
 func createAndStartHealthCheckServer(platformConfiguration *platformconfig.Config,
 	loggerInstance logger.Logger,
-	dashboardInstance *Dashboard) (commonhealthcheck.Server, error) {
+	dashboardStatusProvider statusprovider.Provider) (commonhealthcheck.Server, error) {
 
 	// if enabled not passed, default to true
 	if platformConfiguration.HealthCheck.Enabled == nil {
@@ -294,7 +294,7 @@ func createAndStartHealthCheckServer(platformConfiguration *platformconfig.Confi
 	}
 
 	// create the server
-	server, err := healthcheck.NewDashboardServer(loggerInstance, dashboardInstance, &platformConfiguration.HealthCheck)
+	server, err := healthcheck.NewDashboardServer(loggerInstance, dashboardStatusProvider, &platformConfiguration.HealthCheck)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create health check server")
 	}

--- a/cmd/dashboard/app/dashboard_test.go
+++ b/cmd/dashboard/app/dashboard_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/dockerclient"
+	nucliozap "github.com/nuclio/zap"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type DashboardTestSuite struct {
+	suite.Suite
+	logger    logger.Logger
+	dashboard *Dashboard
+}
+
+func (suite *DashboardTestSuite) SetupSuite() {
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
+}
+
+func (suite *DashboardTestSuite) SetupTest() {
+	suite.dashboard = &Dashboard{
+		logger: suite.logger,
+		status: statusprovider.Initializing,
+	}
+}
+
+func (suite *DashboardTestSuite) TestDashboardStatusFailed() {
+	stopChan := make(chan struct{})
+	defer close(stopChan)
+	maxConsecutiveErrors := 5
+	interval := 100 * time.Millisecond
+	dockerClient := dockerclient.NewMockDockerClient()
+	dockerClient.
+		On("GetVersion").
+		Return("", errors.New("Something bad happened")).
+		Times(maxConsecutiveErrors)
+
+	// run in the background
+	go suite.dashboard.MonitorDockerConnectivity(interval,
+		maxConsecutiveErrors,
+		dockerClient,
+		stopChan)
+
+	err := common.RetryUntilSuccessful(3*time.Second,
+		interval,
+		func() bool {
+			return suite.dashboard.GetStatus().OneOf(statusprovider.Error)
+		})
+	suite.Require().NoError(err, "Exhausted waiting for dashboard status to change")
+	dockerClient.AssertExpectations(suite.T())
+}
+
+func (suite *DashboardTestSuite) TestNoMonitorWhenDashboardStatusFailed() {
+	stopChan := make(chan struct{})
+	defer close(stopChan)
+	interval := 50 * time.Millisecond
+	suite.dashboard.SetStatus(statusprovider.Error)
+	dockerClient := dockerclient.NewMockDockerClient()
+
+	// run in the background
+	go suite.dashboard.MonitorDockerConnectivity(interval,
+		5,
+		dockerClient,
+		stopChan)
+
+	// sleep for a bit
+	time.Sleep(time.Duration(10) * interval)
+
+	// shutdown monitor
+	stopChan <- struct{}{}
+
+	dockerClient.AssertNotCalled(suite.T(), "GetVersion")
+	dockerClient.AssertExpectations(suite.T())
+}
+
+func (suite *DashboardTestSuite) TestStayReadyOnTransientFailures() {
+	stopChan := make(chan struct{})
+	defer close(stopChan)
+	maxConsecutiveErrors := 3
+	interval := 100 * time.Millisecond
+	dockerClient := dockerclient.NewMockDockerClient()
+
+	// return OK, error, error, OK, ...
+	dockerClient.
+		On("GetVersion").
+		Return("1", nil).
+		Once()
+	dockerClient.
+		On("GetVersion").
+		Return("", errors.New("Something bad happened")).
+		Twice()
+	dockerClient.
+		On("GetVersion").
+		Return("2", nil).
+		Once()
+
+	// run in the background
+	go suite.dashboard.MonitorDockerConnectivity(interval,
+		maxConsecutiveErrors,
+		dockerClient,
+		stopChan)
+
+	err := common.RetryUntilSuccessful(3*time.Second,
+		interval,
+		func() bool {
+			return len(dockerClient.Calls) >= 4
+		})
+	suite.Require().NoError(err, "Exhausted waiting for docker client to perform healthcheck validation")
+	dockerClient.AssertExpectations(suite.T())
+
+}
+
+func TestDashboardTestSuite(t *testing.T) {
+	suite.Run(t, new(DashboardTestSuite))
+}

--- a/cmd/dashboard/app/dashboard_test.go
+++ b/cmd/dashboard/app/dashboard_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
-	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/dockerclient"
 
 	"github.com/nuclio/errors"
@@ -48,7 +48,7 @@ func (suite *DashboardTestSuite) SetupTest() {
 	suite.ctx = context.TODO()
 	suite.dashboard = &Dashboard{
 		logger: suite.logger,
-		status: statusprovider.Initializing,
+		status: status.Initializing,
 	}
 	suite.dockerClient = dockerclient.NewMockDockerClient()
 }
@@ -74,14 +74,14 @@ func (suite *DashboardTestSuite) TestDashboardStatusFailed() {
 	err := common.RetryUntilSuccessful(3*time.Second,
 		interval,
 		func() bool {
-			return suite.dashboard.GetStatus().OneOf(statusprovider.Error)
+			return suite.dashboard.GetStatus().OneOf(status.Error)
 		})
 	suite.Require().NoError(err, "Exhausted waiting for dashboard status to change")
 }
 
 func (suite *DashboardTestSuite) TestNoMonitorWhenDashboardStatusFailed() {
 	interval := 50 * time.Millisecond
-	suite.dashboard.SetStatus(statusprovider.Error)
+	suite.dashboard.SetStatus(status.Error)
 
 	// run in the background
 	go suite.dashboard.MonitorDockerConnectivity(suite.ctx,

--- a/cmd/dashboard/app/dashboard_test.go
+++ b/cmd/dashboard/app/dashboard_test.go
@@ -17,15 +17,16 @@ limitations under the License.
 package app
 
 import (
-	"github.com/nuclio/errors"
-	"github.com/nuclio/logger"
-	"github.com/nuclio/nuclio/pkg/common"
-	"github.com/nuclio/nuclio/pkg/common/statusprovider"
-	"github.com/nuclio/nuclio/pkg/dockerclient"
-	nucliozap "github.com/nuclio/zap"
 	"testing"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/dockerclient"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/cmd/dashboard/app/dashboard_test.go
+++ b/cmd/dashboard/app/dashboard_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -54,7 +55,7 @@ func (suite *DashboardTestSuite) TestDashboardStatusFailed() {
 	interval := 100 * time.Millisecond
 	dockerClient := dockerclient.NewMockDockerClient()
 	dockerClient.
-		On("GetVersion").
+		On("GetVersion", true).
 		Return("", errors.New("Something bad happened")).
 		Times(maxConsecutiveErrors)
 
@@ -92,7 +93,7 @@ func (suite *DashboardTestSuite) TestNoMonitorWhenDashboardStatusFailed() {
 	// shutdown monitor
 	stopChan <- struct{}{}
 
-	dockerClient.AssertNotCalled(suite.T(), "GetVersion")
+	dockerClient.AssertNotCalled(suite.T(), "GetVersion", mock.Anything)
 	dockerClient.AssertExpectations(suite.T())
 }
 
@@ -105,15 +106,15 @@ func (suite *DashboardTestSuite) TestStayReadyOnTransientFailures() {
 
 	// return OK, error, error, OK, ...
 	dockerClient.
-		On("GetVersion").
+		On("GetVersion", true).
 		Return("1", nil).
 		Once()
 	dockerClient.
-		On("GetVersion").
+		On("GetVersion", true).
 		Return("", errors.New("Something bad happened")).
 		Twice()
 	dockerClient.
-		On("GetVersion").
+		On("GetVersion", true).
 		Return("2", nil).
 		Once()
 

--- a/cmd/dashboard/app/types.go
+++ b/cmd/dashboard/app/types.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common/healthcheck"
@@ -34,17 +35,17 @@ func (d *Dashboard) SetStatus(status statusprovider.Status) {
 	d.status = status
 }
 
-func (d *Dashboard) MonitorDockerConnectivity(interval time.Duration,
+func (d *Dashboard) MonitorDockerConnectivity(ctx context.Context,
+	interval time.Duration,
 	maxConsecutiveErrors int,
-	dockerClient dockerclient.Client,
-	stopChan <-chan struct{}) {
+	dockerClient dockerclient.Client) {
 
 	consecutiveErrors := maxConsecutiveErrors
 	dockerConnectivityTicker := time.NewTicker(interval)
 
 	for {
 		select {
-		case <-stopChan:
+		case <-ctx.Done():
 			dockerConnectivityTicker.Stop()
 			d.logger.DebugWith("Stopping docker connectivity monitor")
 			return

--- a/cmd/dashboard/app/types.go
+++ b/cmd/dashboard/app/types.go
@@ -1,77 +1,11 @@
 package app
 
 import (
-	"context"
-	"time"
-
-	"github.com/nuclio/nuclio/pkg/common/healthcheck"
-	"github.com/nuclio/nuclio/pkg/common/statusprovider"
-	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
-	"github.com/nuclio/nuclio/pkg/restful"
 
 	"github.com/nuclio/logger"
 )
-
-type Dashboard struct {
-	server            restful.Server
-	healthCheckServer healthcheck.Server
-	logger            logger.Logger
-
-	status statusprovider.Status
-}
-
-func (d *Dashboard) GetStatus() statusprovider.Status {
-	return d.status
-}
-
-func (d *Dashboard) SetStatus(status statusprovider.Status) {
-	if d.status != status {
-		d.logger.InfoWith("Updating server healthiness",
-			"currentStatus", d.status,
-			"desiredStatus", status)
-	}
-	d.status = status
-}
-
-func (d *Dashboard) MonitorDockerConnectivity(ctx context.Context,
-	interval time.Duration,
-	maxConsecutiveErrors int,
-	dockerClient dockerclient.Client) {
-
-	consecutiveErrors := maxConsecutiveErrors
-	dockerConnectivityTicker := time.NewTicker(interval)
-	d.logger.DebugWith("Monitoring docker connectivity",
-		"interval", interval,
-		"maxConsecutiveErrors", maxConsecutiveErrors)
-	for {
-		select {
-		case <-ctx.Done():
-			dockerConnectivityTicker.Stop()
-			d.logger.DebugWith("Stopping docker connectivity monitor")
-			return
-		case <-dockerConnectivityTicker.C:
-			if d.GetStatus().OneOf(statusprovider.Error) {
-
-				// do not monitor while status is error
-				// let the kubelet / dockerd / user restart the process
-				continue
-			}
-
-			// get version quietly
-			if _, err := dockerClient.GetVersion(true); err == nil {
-				consecutiveErrors = maxConsecutiveErrors
-				continue
-			}
-			consecutiveErrors--
-			if consecutiveErrors == 0 {
-				d.SetStatus(statusprovider.Error)
-				d.logger.Error("Failed to resolve docker version, connection might be unhealthy.")
-			}
-		}
-	}
-}
 
 type CreateDashboardServerOptions struct {
 	logger                logger.Logger

--- a/cmd/dashboard/app/types.go
+++ b/cmd/dashboard/app/types.go
@@ -42,7 +42,9 @@ func (d *Dashboard) MonitorDockerConnectivity(ctx context.Context,
 
 	consecutiveErrors := maxConsecutiveErrors
 	dockerConnectivityTicker := time.NewTicker(interval)
-
+	d.logger.DebugWith("Monitoring docker connectivity",
+		"interval", interval,
+		"maxConsecutiveErrors", maxConsecutiveErrors)
 	for {
 		select {
 		case <-ctx.Done():

--- a/cmd/dashboard/app/types.go
+++ b/cmd/dashboard/app/types.go
@@ -85,7 +85,6 @@ type CreateDashboardServerOptions struct {
 	externalIPAddresses              string
 	defaultNamespace                 string
 	offline                          bool
-	platformConfigurationPath        string
 	templatesGitRepository           string
 	templatesGitRef                  string
 	templatesArchiveAddress          string

--- a/cmd/dashboard/app/types.go
+++ b/cmd/dashboard/app/types.go
@@ -56,7 +56,8 @@ func (d *Dashboard) MonitorDockerConnectivity(interval time.Duration,
 				continue
 			}
 
-			if _, err := dockerClient.GetVersion(); err == nil {
+			// get version quietly
+			if _, err := dockerClient.GetVersion(true); err == nil {
 				consecutiveErrors = maxConsecutiveErrors
 				continue
 			}

--- a/cmd/dashboard/app/types.go
+++ b/cmd/dashboard/app/types.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/common/healthcheck"
+	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+	"github.com/nuclio/nuclio/pkg/restful"
+
+	"github.com/nuclio/logger"
+)
+
+type Dashboard struct {
+	server            restful.Server
+	healthCheckServer healthcheck.Server
+	logger            logger.Logger
+
+	status statusprovider.Status
+}
+
+func (d *Dashboard) GetStatus() statusprovider.Status {
+	return d.status
+}
+
+func (d *Dashboard) SetStatus(status statusprovider.Status) {
+	if d.status != status {
+		d.logger.InfoWith("Updating server healthiness",
+			"currentStatus", d.status,
+			"desiredStatus", status)
+	}
+	d.status = status
+}
+
+func (d *Dashboard) MonitorDockerConnectivity(interval time.Duration,
+	maxConsecutiveErrors int) {
+	// TODO: uncomment
+	//consecutiveErrors := maxConsecutiveErrors
+	//dockerConnectivityTicker := time.NewTicker(interval)
+	//for range dockerConnectivityTicker.C {
+	//	if _, err := d.dockerClient.GetVersion(); err != nil {
+	//		consecutiveErrors--
+	//	} else {
+	//		consecutiveErrors = maxConsecutiveErrors
+	//		continue
+	//	}
+	//	if consecutiveErrors == 0 {
+	//		d.SetStatus(statusprovider.Error)
+	//		d.logger.Error("Failed to resolve docker version, connection might be unhealthy")
+	//		break
+	//	}
+	//}
+}
+
+type CreateDashboardServerOptions struct {
+	logger                logger.Logger
+	platformConfiguration *platformconfig.Config
+
+	ListenAddress                    string
+	DockerKeyDir                     string
+	DefaultRegistryURL               string
+	DefaultRunRegistryURL            string
+	PlatformType                     string
+	NoPullBaseImages                 bool
+	DefaultCredRefreshIntervalString string
+	ExternalIPAddresses              string
+	DefaultNamespace                 string
+	Offline                          bool
+	PlatformConfigurationPath        string
+	TemplatesGitRepository           string
+	TemplatesGitRef                  string
+	TemplatesArchiveAddress          string
+	TemplatesGitUsername             string
+	TemplatesGitPassword             string
+	TemplatesGithubAccessToken       string
+	DefaultHTTPIngressHostTemplate   string
+	ImageNamePrefixTemplate          string
+	PlatformAuthorizationMode        string
+	DependantImageRegistryURL        string
+}

--- a/cmd/dashboard/docker/Dockerfile
+++ b/cmd/dashboard/docker/Dockerfile
@@ -77,4 +77,9 @@ COPY --from=build-static /home/nuclio/dashboard/src/dist /etc/nginx/static/
 # copy dashboard binary from build binary stage
 COPY --from=build-binary /nuclio/dashboard /usr/local/bin
 
+# copy a lightweight http client
+COPY --from=quay.io/nuclio/uhttpc:0.0.1-amd64 /home/nuclio/bin/uhttpc /usr/local/bin/uhttpc
+
+HEALTHCHECK --interval=1s --timeout=3s CMD /usr/local/bin/uhttpc --url http://127.0.0.1:8082/ready || exit 1
+
 CMD ["sh",  "-c", "./runner.sh"]

--- a/cmd/dashboard/docker/runner.sh
+++ b/cmd/dashboard/docker/runner.sh
@@ -5,13 +5,13 @@ _term() {
   kill -TERM "$child" 2>/dev/null
 }
 
-trap _term SIGTERM
-trap _term SIGINT
+trap _term TERM
+trap _term INT
 
 echo "Running in parallel"
 
 # citation
-# ensure each runner gets a jobslot
+# ensure each runner gets a job slot
 # buffer output on line basis
 # exit when the first job fails, kill all running jobs.
 # upon unexpected termination, signal jobs before killing (signal, timeout)

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -77,6 +77,8 @@ func main() {
 	platformAuthorizationMode := flag.String("platform-authorization-mode", defaultPlatformAuthorizationMode, "One of service-account (default) / authorization-header-oidc")
 	dependantImageRegistryURL := flag.String("dependant-image-registry", os.Getenv("NUCLIO_DASHBOARD_DEPENDANT_IMAGE_REGISTRY_URL"), "If passed, replaces base/on-build registry URLs with this value")
 	monitorDockerDeamon := flag.Bool("monitor-docker-deamon", common.GetEnvOrDefaultBool("NUCLIO_MONITOR_DOCKER_DAEMON", true), "Monitor connectivity to docker deamon (in conjunction to 'docker' as container builder kind")
+	monitorDockerDeamonIntervalStr := flag.String("monitor-docker-deamon-interval", common.GetEnvOrDefaultString("NUCLIO_MONITOR_DOCKER_DAEMON_INTERVAL", "5s"), "Docker deamon connectivity monitor interval (used in conjunction with 'monitor-docker-deamon')")
+	monitorDockerDeamonMaxConsecutiveErrorsStr := flag.String("monitor-docker-deamon-max-consecutive-errors", common.GetEnvOrDefaultString("NUCLIO_MONITOR_DOCKER_DAEMON_MAX_CONSECUTIVE_ERRORS", "5"), "Docker deamon connectivity monitor max consecutive errors before declaring docker connection is unhealthy (used in conjunction with 'monitor-docker-deamon')")
 
 	// get the namespace from args -> env -> default
 	*namespace = getNamespace(*namespace)
@@ -104,7 +106,9 @@ func main() {
 		*imageNamePrefixTemplate,
 		*platformAuthorizationMode,
 		*dependantImageRegistryURL,
-		*monitorDockerDeamon); err != nil {
+		*monitorDockerDeamon,
+		*monitorDockerDeamonIntervalStr,
+		*monitorDockerDeamonMaxConsecutiveErrorsStr); err != nil {
 
 		errors.PrintErrorStack(os.Stderr, err, 5)
 

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -76,6 +76,7 @@ func main() {
 	imageNamePrefixTemplate := flag.String("image-name-prefix-template", os.Getenv("NUCLIO_DASHBOARD_IMAGE_NAME_PREFIX_TEMPLATE"), "Go template for the image names prefix")
 	platformAuthorizationMode := flag.String("platform-authorization-mode", defaultPlatformAuthorizationMode, "One of service-account (default) / authorization-header-oidc")
 	dependantImageRegistryURL := flag.String("dependant-image-registry", os.Getenv("NUCLIO_DASHBOARD_DEPENDANT_IMAGE_REGISTRY_URL"), "If passed, replaces base/on-build registry URLs with this value")
+	monitorDockerDeamon := flag.Bool("monitor-docker-deamon", common.GetEnvOrDefaultBool("NUCLIO_MONITOR_DOCKER_DAEMON", true), "Monitor connectivity to docker deamon (in conjunction to 'docker' as container builder kind")
 
 	// get the namespace from args -> env -> default
 	*namespace = getNamespace(*namespace)
@@ -102,7 +103,8 @@ func main() {
 		*defaultHTTPIngressHostTemplate,
 		*imageNamePrefixTemplate,
 		*platformAuthorizationMode,
-		*dependantImageRegistryURL); err != nil {
+		*dependantImageRegistryURL,
+		*monitorDockerDeamon); err != nil {
 
 		errors.PrintErrorStack(os.Stderr, err, 5)
 

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	commonhealthcheck "github.com/nuclio/nuclio/pkg/common/healthcheck"
 	"github.com/nuclio/nuclio/pkg/common/statusprovider"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/loggersink"
@@ -73,7 +74,7 @@ type Processor struct {
 	functionLogger        logger.Logger
 	triggers              []trigger.Trigger
 	webAdminServer        *webadmin.Server
-	healthCheckServer     *healthcheck.Server
+	healthCheckServer     commonhealthcheck.Server
 	metricSinks           []metricsink.MetricSink
 	namedWorkerAllocators map[string]worker.Allocator
 	eventTimeoutWatcher   *timeout.EventTimeoutWatcher
@@ -375,7 +376,8 @@ func (p *Processor) createWebAdminServer(platformConfiguration *platformconfig.C
 	return webadmin.NewServer(p.logger, p, &platformConfiguration.WebAdmin)
 }
 
-func (p *Processor) createAndStartHealthCheckServer(platformConfiguration *platformconfig.Config) (*healthcheck.Server, error) {
+func (p *Processor) createAndStartHealthCheckServer(platformConfiguration *platformconfig.Config) (
+	commonhealthcheck.Server, error) {
 
 	// if enabled not passed, default to true
 	if platformConfiguration.HealthCheck.Enabled == nil {
@@ -388,7 +390,7 @@ func (p *Processor) createAndStartHealthCheckServer(platformConfiguration *platf
 	}
 
 	// create the server
-	server, err := healthcheck.NewServer(p.logger, p, &platformConfiguration.HealthCheck)
+	server, err := healthcheck.NewProcessorServer(p.logger, p, &platformConfiguration.HealthCheck)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create health check server")
 	}

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/common"
 	commonhealthcheck "github.com/nuclio/nuclio/pkg/common/healthcheck"
-	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/loggersink"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
@@ -229,23 +229,23 @@ func (p *Processor) GetWorkers() []*worker.Worker {
 }
 
 // GetStatus returns the processor's status based on its workers' readiness
-func (p *Processor) GetStatus() statusprovider.Status {
+func (p *Processor) GetStatus() status.Status {
 	workers := p.GetWorkers()
 
 	// if no workers exist yet, return initializing
 	if !p.startComplete {
-		return statusprovider.Initializing
+		return status.Initializing
 	}
 
 	// if any worker isn't ready yet, return initializing
 	for _, workerInstance := range workers {
-		if workerInstance.GetStatus() != statusprovider.Ready {
-			return statusprovider.Initializing
+		if workerInstance.GetStatus() != status.Ready {
+			return status.Initializing
 		}
 	}
 
 	// otherwise we're ready
-	return statusprovider.Ready
+	return status.Ready
 }
 
 // Stop stops the processor

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/common/statusprovider"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/loggersink"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
@@ -38,7 +39,6 @@ import (
 	_ "github.com/nuclio/nuclio/pkg/processor/runtime/python"
 	_ "github.com/nuclio/nuclio/pkg/processor/runtime/ruby"
 	_ "github.com/nuclio/nuclio/pkg/processor/runtime/shell"
-	"github.com/nuclio/nuclio/pkg/processor/status"
 	"github.com/nuclio/nuclio/pkg/processor/timeout"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
 	// load all triggers
@@ -228,23 +228,23 @@ func (p *Processor) GetWorkers() []*worker.Worker {
 }
 
 // GetStatus returns the processor's status based on its workers' readiness
-func (p *Processor) GetStatus() status.Status {
+func (p *Processor) GetStatus() statusprovider.Status {
 	workers := p.GetWorkers()
 
 	// if no workers exist yet, return initializing
 	if !p.startComplete {
-		return status.Initializing
+		return statusprovider.Initializing
 	}
 
 	// if any worker isn't ready yet, return initializing
-	for _, worker := range workers {
-		if worker.GetStatus() != status.Ready {
-			return status.Initializing
+	for _, workerInstance := range workers {
+		if workerInstance.GetStatus() != statusprovider.Ready {
+			return statusprovider.Initializing
 		}
 	}
 
 	// otherwise we're ready
-	return status.Ready
+	return statusprovider.Ready
 }
 
 // Stop stops the processor

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -140,7 +140,11 @@ spec:
           value: "nil"
         {{- end }}
         - name: NUCLIO_MONITOR_DOCKER_DAEMON
-          value: {{ .Values.dashboard.monitorDockerDeamon | quote }}
+          value: {{ .Values.dashboard.monitorDockerDeamon.enabled | quote }}
+        - name: NUCLIO_MONITOR_DOCKER_DAEMON_INTERVAL
+          value: {{ .Values.dashboard.monitorDockerDeamon.interval | quote }}
+        - name: NUCLIO_MONITOR_DOCKER_DAEMON_MAX_CONSECUTIVE_ERRORS
+          value: {{ .Values.dashboard.monitorDockerDeamon.maxConsecutiveErrors | quote }}
         - name: NUCLIO_REGISTRY_CREDENTIALS_SECRET_NAME
           value: {{ template "nuclio.registry.credentialsSecretName" . }}
         - name: NUCLIO_DASHBOARD_EXTERNAL_IP_ADDRESSES

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -47,6 +47,27 @@ spec:
         imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}
         ports:
         - containerPort: 8070
+        - name: liveness-port
+          containerPort: 8082
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: liveness-port
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: liveness-port
+          failureThreshold: 1
+          periodSeconds: 15
+          timeoutSeconds: 5
+        startupProbe:
+          httpGet:
+            path: /live
+            port: liveness-port
+          failureThreshold: 4
+          periodSeconds: 15
         volumeMounts:
         {{- if eq .Values.dashboard.containerBuilderKind "docker" }}
         - mountPath: /var/run/docker.sock

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -139,6 +139,8 @@ spec:
         - name: NUCLIO_TEMPLATES_GIT_REF
           value: "nil"
         {{- end }}
+        - name: NUCLIO_MONITOR_DOCKER_DAEMON
+          value: {{ .Values.dashboard.monitorDockerDeamon | quote }}
         - name: NUCLIO_REGISTRY_CREDENTIALS_SECRET_NAME
           value: {{ template "nuclio.registry.credentialsSecretName" . }}
         - name: NUCLIO_DASHBOARD_EXTERNAL_IP_ADDRESSES

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -54,7 +54,10 @@ dashboard:
   containerBuilderKind: "docker"
 
   # Monitor docker deamon connectivity, in conjunction with container builder kind "docker"
-  monitorDockerDeamon: true
+  monitorDockerDeamon:
+    enabled: true
+    interval: 5s
+    maxConsecutiveErrors: 5
 
   kaniko:
 

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -53,6 +53,9 @@ dashboard:
   # Supported container builders: "kaniko", "docker"
   containerBuilderKind: "docker"
 
+  # Monitor docker deamon connectivity, in conjunction with container builder kind "docker"
+  monitorDockerDeamon: true
+
   kaniko:
 
     #  Set this flag to specify a remote repository for storing cached layers

--- a/pkg/cmdrunner/shellrunner.go
+++ b/pkg/cmdrunner/shellrunner.go
@@ -52,7 +52,7 @@ func (sr *ShellRunner) Run(runOptions *RunOptions, format string, vars ...interf
 	formattedCommand := fmt.Sprintf(format, vars...)
 	redactedCommand := common.Redact(runOptions.LogRedactions, formattedCommand)
 
-	if !runOptions.SkipLoggingBeforeAfterExecute {
+	if !runOptions.LogOnlyOnFailure {
 		sr.logger.DebugWith("Executing", "command", redactedCommand)
 	}
 
@@ -96,7 +96,7 @@ func (sr *ShellRunner) Run(runOptions *RunOptions, format string, vars ...interf
 		return runResult, errors.Wrapf(err, "stdout:\n%s\nstderr:\n%s", runResult.Output, runResult.Stderr)
 	}
 
-	if !runOptions.SkipLoggingBeforeAfterExecute {
+	if !runOptions.LogOnlyOnFailure {
 		sr.logger.DebugWith("Command executed successfully",
 			"output", runResult.Output,
 			"stderr", runResult.Stderr,

--- a/pkg/cmdrunner/types.go
+++ b/pkg/cmdrunner/types.go
@@ -30,6 +30,8 @@ type RunOptions struct {
 	Env               map[string]string
 	LogRedactions     []string
 	CaptureOutputMode CaptureOutputMode
+
+	SkipLoggingBeforeAfterExecute bool
 }
 
 // RunResult holds command execution returned values

--- a/pkg/cmdrunner/types.go
+++ b/pkg/cmdrunner/types.go
@@ -31,7 +31,7 @@ type RunOptions struct {
 	LogRedactions     []string
 	CaptureOutputMode CaptureOutputMode
 
-	SkipLoggingBeforeAfterExecute bool
+	LogOnlyOnFailure bool
 }
 
 // RunResult holds command execution returned values

--- a/pkg/common/healthcheck/server.go
+++ b/pkg/common/healthcheck/server.go
@@ -19,7 +19,7 @@ package healthcheck
 import (
 	"net/http"
 
-	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
 	"github.com/heptiolabs/healthcheck"
@@ -37,12 +37,12 @@ type AbstractServer struct {
 	Enabled        bool
 	ListenAddress  string
 	Logger         logger.Logger
-	StatusProvider statusprovider.Provider
+	StatusProvider status.Provider
 	Handler        healthcheck.Handler
 }
 
 func NewAbstractServer(logger logger.Logger,
-	statusProvider statusprovider.Provider,
+	statusProvider status.Provider,
 	configuration *platformconfig.WebServer) (*AbstractServer, error) {
 	if configuration.Enabled == nil {
 		return nil, errors.New("Enabled must carry a value")

--- a/pkg/common/healthcheck/server.go
+++ b/pkg/common/healthcheck/server.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"net/http"
+
+	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+
+	"github.com/heptiolabs/healthcheck"
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+)
+
+type Server interface {
+
+	// Start the server
+	Start() error
+}
+
+type AbstractServer struct {
+	Enabled        bool
+	ListenAddress  string
+	Logger         logger.Logger
+	StatusProvider statusprovider.Provider
+	Handler        healthcheck.Handler
+}
+
+func NewAbstractServer(logger logger.Logger,
+	statusProvider statusprovider.Provider,
+	configuration *platformconfig.WebServer) (*AbstractServer, error) {
+	if configuration.Enabled == nil {
+		return nil, errors.New("Enabled must carry a value")
+	}
+
+	server := &AbstractServer{
+		Enabled:        *configuration.Enabled,
+		ListenAddress:  configuration.ListenAddress,
+		Logger:         logger.GetChild("healthcheck.server"),
+		StatusProvider: statusProvider,
+	}
+
+	// create the healthcheck handler
+	server.Handler = healthcheck.NewHandler()
+
+	// return the server
+	return server, nil
+}
+
+func (s *AbstractServer) Start() error {
+
+	// start listening
+	go http.ListenAndServe(s.ListenAddress, s.Handler) // nolint: errcheck
+
+	s.Logger.InfoWith("Listening", "listenAddress", s.ListenAddress)
+	return nil
+}

--- a/pkg/common/status/status.go
+++ b/pkg/common/status/status.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statusprovider
+package status
 
 import "fmt"
 

--- a/pkg/common/statusprovider/status.go
+++ b/pkg/common/statusprovider/status.go
@@ -14,11 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package status
+package statusprovider
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // Provider is an interface for entities that have a reportable status
 type Provider interface {
@@ -51,4 +49,13 @@ func (s Status) String() string {
 	}
 
 	return fmt.Sprintf("Unknown status - %d", s)
+}
+
+func (s Status) OneOf(statuses ...Status) bool {
+	for _, status := range statuses {
+		if s == status {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/dashboard/healthcheck/server.go
+++ b/pkg/dashboard/healthcheck/server.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"github.com/nuclio/nuclio/pkg/common/healthcheck"
+	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+)
+
+type DashboardServer struct {
+	*healthcheck.AbstractServer
+}
+
+func NewDashboardServer(logger logger.Logger,
+	statusProvider statusprovider.Provider,
+	configuration *platformconfig.WebServer) (*DashboardServer, error) {
+	var err error
+
+	newServer := &DashboardServer{}
+	newServer.AbstractServer, err = healthcheck.NewAbstractServer(logger, statusProvider, configuration)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create new abstract server")
+	}
+	return newServer, nil
+}
+
+func (s *DashboardServer) Start() error {
+
+	// if we're disabled, simply log and do nothing
+	if !s.Enabled {
+		s.Logger.Debug("Disabled, not listening")
+		return nil
+	}
+
+	// ready for incoming traffic
+	s.Handler.AddReadinessCheck("dashboard_readiness", func() error {
+		if s.StatusProvider.GetStatus() != statusprovider.Ready {
+			return errors.New("Dashboard is not ready yet")
+		}
+		return nil
+	})
+
+	// application is functioning correctly
+	s.Handler.AddLivenessCheck("dashboard_liveness", func() error {
+		if s.StatusProvider.GetStatus().OneOf(statusprovider.Error, statusprovider.Stopped) {
+			return errors.New("Dashboard is not alive or dysfunctional")
+		}
+		return nil
+	})
+
+	if err := s.AbstractServer.Start(); err != nil {
+		return errors.Wrap(err, "Failed to start healthcheck server")
+	}
+
+	return nil
+}

--- a/pkg/dashboard/healthcheck/server.go
+++ b/pkg/dashboard/healthcheck/server.go
@@ -18,7 +18,7 @@ package healthcheck
 
 import (
 	"github.com/nuclio/nuclio/pkg/common/healthcheck"
-	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
 	"github.com/nuclio/errors"
@@ -30,7 +30,7 @@ type DashboardServer struct {
 }
 
 func NewDashboardServer(logger logger.Logger,
-	statusProvider statusprovider.Provider,
+	statusProvider status.Provider,
 	configuration *platformconfig.WebServer) (*DashboardServer, error) {
 	var err error
 
@@ -52,7 +52,7 @@ func (s *DashboardServer) Start() error {
 
 	// ready for incoming traffic
 	s.Handler.AddReadinessCheck("dashboard_readiness", func() error {
-		if s.StatusProvider.GetStatus() != statusprovider.Ready {
+		if s.StatusProvider.GetStatus() != status.Ready {
 			return errors.New("Dashboard is not ready yet")
 		}
 		return nil
@@ -60,8 +60,8 @@ func (s *DashboardServer) Start() error {
 
 	// application is functioning correctly
 	s.Handler.AddLivenessCheck("dashboard_liveness", func() error {
-		if s.StatusProvider.GetStatus().OneOf(statusprovider.Error, statusprovider.Stopped) {
-			return errors.New("Dashboard is not alive or dysfunctional")
+		if s.StatusProvider.GetStatus().OneOf(status.Error, status.Stopped) {
+			return errors.New("Dashboard is unhealthy")
 		}
 		return nil
 	})

--- a/pkg/dockerclient/dockerclient.go
+++ b/pkg/dockerclient/dockerclient.go
@@ -85,4 +85,7 @@ type Client interface {
 
 	// Load loads a docker image from tar as cached image
 	Load(inPath string) error
+
+	// GetVersion returns docker client and engine versions
+	GetVersion() (string, error)
 }

--- a/pkg/dockerclient/dockerclient.go
+++ b/pkg/dockerclient/dockerclient.go
@@ -87,5 +87,5 @@ type Client interface {
 	Load(inPath string) error
 
 	// GetVersion returns docker client and engine versions
-	GetVersion() (string, error)
+	GetVersion(quiet bool) (string, error)
 }

--- a/pkg/dockerclient/mock.go
+++ b/pkg/dockerclient/mock.go
@@ -146,3 +146,8 @@ func (mdc *MockDockerClient) Load(inPath string) error {
 	args := mdc.Called(inPath)
 	return args.Error(0)
 }
+
+func (mdc *MockDockerClient) GetVersion() (string, error) {
+	args := mdc.Called()
+	return args.String(0), args.Error(1)
+}

--- a/pkg/dockerclient/mock.go
+++ b/pkg/dockerclient/mock.go
@@ -147,7 +147,7 @@ func (mdc *MockDockerClient) Load(inPath string) error {
 	return args.Error(0)
 }
 
-func (mdc *MockDockerClient) GetVersion() (string, error) {
-	args := mdc.Called()
+func (mdc *MockDockerClient) GetVersion(quiet bool) (string, error) {
+	args := mdc.Called(quiet)
 	return args.String(0), args.Error(1)
 }

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -79,8 +79,7 @@ func NewShellClient(parentLogger logger.Logger, runner cmdrunner.CmdRunner) (*Sh
 	}
 
 	// verify
-	_, err = newClient.cmdRunner.Run(nil, "docker version")
-	if err != nil {
+	if _, err := newClient.GetVersion(false); err != nil {
 		return nil, errors.Wrap(err, "No docker client found")
 	}
 
@@ -722,8 +721,11 @@ func (c *ShellClient) Load(inPath string) error {
 	return err
 }
 
-func (c *ShellClient) GetVersion() (string, error) {
-	output, err := c.runCommand(nil, `docker version --format "{{json .}}"`)
+func (c *ShellClient) GetVersion(quiet bool) (string, error) {
+	runOptions := &cmdrunner.RunOptions{
+		SkipLoggingBeforeAfterExecute: quiet,
+	}
+	output, err := c.runCommand(runOptions, `docker version --format "{{json .}}"`)
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to get docker version")
 	}

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -723,7 +723,7 @@ func (c *ShellClient) Load(inPath string) error {
 
 func (c *ShellClient) GetVersion(quiet bool) (string, error) {
 	runOptions := &cmdrunner.RunOptions{
-		SkipLoggingBeforeAfterExecute: quiet,
+		LogOnlyOnFailure: quiet,
 	}
 	output, err := c.runCommand(runOptions, `docker version --format "{{json .}}"`)
 	if err != nil {

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -722,6 +722,14 @@ func (c *ShellClient) Load(inPath string) error {
 	return err
 }
 
+func (c *ShellClient) GetVersion() (string, error) {
+	output, err := c.runCommand(nil, `docker version --format "{{json .}}"`)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to get docker version")
+	}
+	return output.Output, nil
+}
+
 func (c *ShellClient) runCommand(runOptions *cmdrunner.RunOptions, format string, vars ...interface{}) (cmdrunner.RunResult, error) {
 
 	// if user

--- a/pkg/dockerclient/shell_test.go
+++ b/pkg/dockerclient/shell_test.go
@@ -47,7 +47,7 @@ func (suite *ShellClientTestSuite) SetupTest() {
 	// create mocked cmd runner
 	suite.mockedCmdRunner = cmdrunner.NewMockRunner()
 	suite.mockedCmdRunner.
-		On("Run", mock.Anything, "docker version", mock.Anything).
+		On("Run", mock.Anything, `docker version --format "{{json .}}"`, mock.Anything).
 		Return(cmdrunner.RunResult{
 			Output: "test",
 		}, nil)

--- a/pkg/processor/healthcheck/server.go
+++ b/pkg/processor/healthcheck/server.go
@@ -18,7 +18,7 @@ package healthcheck
 
 import (
 	"github.com/nuclio/nuclio/pkg/common/healthcheck"
-	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
 	"github.com/nuclio/errors"
@@ -30,7 +30,7 @@ type ProcessorServer struct {
 }
 
 func NewProcessorServer(logger logger.Logger,
-	statusProvider statusprovider.Provider,
+	statusProvider status.Provider,
 	configuration *platformconfig.WebServer) (*ProcessorServer, error) {
 	var err error
 
@@ -52,7 +52,7 @@ func (s *ProcessorServer) Start() error {
 
 	// register the processor's status check as its readiness check
 	s.Handler.AddReadinessCheck("processor_readiness", func() error {
-		if s.StatusProvider.GetStatus() != statusprovider.Ready {
+		if s.StatusProvider.GetStatus() != status.Ready {
 			return errors.New("Processor not ready yet")
 		}
 

--- a/pkg/processor/healthcheck/server.go
+++ b/pkg/processor/healthcheck/server.go
@@ -17,11 +17,12 @@ limitations under the License.
 package healthcheck
 
 import (
-	"github.com/nuclio/errors"
-	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio/pkg/common/healthcheck"
 	"github.com/nuclio/nuclio/pkg/common/statusprovider"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
 )
 
 type ProcessorServer struct {

--- a/pkg/processor/runtime/golang/runtime.go
+++ b/pkg/processor/runtime/golang/runtime.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
-	"github.com/nuclio/nuclio/pkg/processor/status"
+	"github.com/nuclio/nuclio/pkg/common/statusprovider"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -71,7 +71,7 @@ func NewRuntime(parentLogger logger.Logger,
 		}
 	}
 
-	newGoRuntime.SetStatus(status.Ready)
+	newGoRuntime.SetStatus(statusprovider.Ready)
 
 	return newGoRuntime, nil
 }

--- a/pkg/processor/runtime/golang/runtime.go
+++ b/pkg/processor/runtime/golang/runtime.go
@@ -21,7 +21,7 @@ import (
 	"runtime/debug"
 	"time"
 
-	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 
 	"github.com/nuclio/errors"
@@ -71,7 +71,7 @@ func NewRuntime(parentLogger logger.Logger,
 		}
 	}
 
-	newGoRuntime.SetStatus(statusprovider.Ready)
+	newGoRuntime.SetStatus(status.Ready)
 
 	return newGoRuntime, nil
 }

--- a/pkg/processor/runtime/golang/runtime.go
+++ b/pkg/processor/runtime/golang/runtime.go
@@ -21,8 +21,8 @@ import (
 	"runtime/debug"
 	"time"
 
-	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/processor/runtime"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"

--- a/pkg/processor/runtime/pypy/runtime.go
+++ b/pkg/processor/runtime/pypy/runtime.go
@@ -37,12 +37,10 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/nuclio/nuclio/pkg/processor/runtime"
-	"github.com/nuclio/nuclio/pkg/processor/status"
-
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
+	"github.com/nuclio/nuclio/pkg/processor/runtime"
 )
 
 var (
@@ -94,7 +92,7 @@ func NewRuntime(parentLogger logger.Logger, configuration *runtime.Configuration
 		return nil, errors.Wrap(err, "Failed to initialize pypy runtime")
 	}
 
-	newPyPyRuntime.SetStatus(status.Ready)
+	newPyPyRuntime.SetStatus(statusprovider.Ready)
 
 	return newPyPyRuntime, nil
 }

--- a/pkg/processor/runtime/pypy/runtime.go
+++ b/pkg/processor/runtime/pypy/runtime.go
@@ -93,7 +93,7 @@ func NewRuntime(parentLogger logger.Logger, configuration *runtime.Configuration
 		return nil, errors.Wrap(err, "Failed to initialize pypy runtime")
 	}
 
-	newPyPyRuntime.SetStatus(statusprovider.Ready)
+	newPyPyRuntime.SetStatus(status.Ready)
 
 	return newPyPyRuntime, nil
 }

--- a/pkg/processor/runtime/pypy/runtime.go
+++ b/pkg/processor/runtime/pypy/runtime.go
@@ -37,10 +37,11 @@ import (
 	"sync"
 	"unsafe"
 
+	"github.com/nuclio/nuclio/pkg/processor/runtime"
+
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
-	"github.com/nuclio/nuclio/pkg/processor/runtime"
 )
 
 var (

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
-	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/processwaiter"
 
@@ -102,17 +102,17 @@ func NewAbstractRuntime(logger logger.Logger,
 
 func (r *AbstractRuntime) Start() error {
 	if err := r.startWrapper(); err != nil {
-		r.SetStatus(statusprovider.Error)
+		r.SetStatus(status.Error)
 		return errors.Wrap(err, "Failed to run wrapper")
 	}
 
-	r.SetStatus(statusprovider.Ready)
+	r.SetStatus(status.Ready)
 	return nil
 }
 
 // ProcessEvent processes an event
 func (r *AbstractRuntime) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (interface{}, error) {
-	if currentStatus := r.GetStatus(); currentStatus != statusprovider.Ready {
+	if currentStatus := r.GetStatus(); currentStatus != status.Ready {
 		return nil, errors.Errorf("Processor not ready (current status: %s)", currentStatus)
 	}
 
@@ -129,7 +129,7 @@ func (r *AbstractRuntime) ProcessEvent(event nuclio.Event, functionLogger logger
 	if !ok {
 		msg := "Client disconnected"
 		r.Logger.Error(msg)
-		r.SetStatus(statusprovider.Error)
+		r.SetStatus(status.Error)
 		r.functionLogger = nil
 		return nil, errors.New(msg)
 	}
@@ -152,14 +152,14 @@ func (r *AbstractRuntime) Stop() error {
 		}
 
 		if err := r.wrapperProcess.Kill(); err != nil {
-			r.SetStatus(statusprovider.Error)
+			r.SetStatus(status.Error)
 			return errors.Wrap(err, "Can't kill wrapper process")
 		}
 	}
 
 	r.waitForProcessTermination()
 
-	r.SetStatus(statusprovider.Stopped)
+	r.SetStatus(status.Stopped)
 	return nil
 }
 
@@ -182,11 +182,11 @@ func (r *AbstractRuntime) Restart() error {
 
 	close(r.resultChan)
 	if err := r.startWrapper(); err != nil {
-		r.SetStatus(statusprovider.Error)
+		r.SetStatus(status.Error)
 		return errors.Wrap(err, "Can't start wrapper process")
 	}
 
-	r.SetStatus(statusprovider.Ready)
+	r.SetStatus(status.Ready)
 	return nil
 }
 

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -28,8 +28,8 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/common/statusprovider"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
-	"github.com/nuclio/nuclio/pkg/processor/status"
 	"github.com/nuclio/nuclio/pkg/processwaiter"
 
 	"github.com/nuclio/errors"
@@ -102,17 +102,17 @@ func NewAbstractRuntime(logger logger.Logger,
 
 func (r *AbstractRuntime) Start() error {
 	if err := r.startWrapper(); err != nil {
-		r.SetStatus(status.Error)
+		r.SetStatus(statusprovider.Error)
 		return errors.Wrap(err, "Failed to run wrapper")
 	}
 
-	r.SetStatus(status.Ready)
+	r.SetStatus(statusprovider.Ready)
 	return nil
 }
 
 // ProcessEvent processes an event
 func (r *AbstractRuntime) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (interface{}, error) {
-	if currentStatus := r.GetStatus(); currentStatus != status.Ready {
+	if currentStatus := r.GetStatus(); currentStatus != statusprovider.Ready {
 		return nil, errors.Errorf("Processor not ready (current status: %s)", currentStatus)
 	}
 
@@ -129,7 +129,7 @@ func (r *AbstractRuntime) ProcessEvent(event nuclio.Event, functionLogger logger
 	if !ok {
 		msg := "Client disconnected"
 		r.Logger.Error(msg)
-		r.SetStatus(status.Error)
+		r.SetStatus(statusprovider.Error)
 		r.functionLogger = nil
 		return nil, errors.New(msg)
 	}
@@ -152,14 +152,14 @@ func (r *AbstractRuntime) Stop() error {
 		}
 
 		if err := r.wrapperProcess.Kill(); err != nil {
-			r.SetStatus(status.Error)
+			r.SetStatus(statusprovider.Error)
 			return errors.Wrap(err, "Can't kill wrapper process")
 		}
 	}
 
 	r.waitForProcessTermination()
 
-	r.SetStatus(status.Stopped)
+	r.SetStatus(statusprovider.Stopped)
 	return nil
 }
 
@@ -182,11 +182,11 @@ func (r *AbstractRuntime) Restart() error {
 
 	close(r.resultChan)
 	if err := r.startWrapper(); err != nil {
-		r.SetStatus(status.Error)
+		r.SetStatus(statusprovider.Error)
 		return errors.Wrap(err, "Can't start wrapper process")
 	}
 
-	r.SetStatus(status.Ready)
+	r.SetStatus(statusprovider.Ready)
 	return nil
 }
 

--- a/pkg/processor/runtime/runtime.go
+++ b/pkg/processor/runtime/runtime.go
@@ -19,8 +19,8 @@ package runtime
 import (
 	"os"
 
+	"github.com/nuclio/nuclio/pkg/common/statusprovider"
 	"github.com/nuclio/nuclio/pkg/processor/databinding"
-	"github.com/nuclio/nuclio/pkg/processor/status"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -43,10 +43,10 @@ type Runtime interface {
 	GetConfiguration() *Configuration
 
 	// SetStatus sets the runtime's reported status
-	SetStatus(newStatus status.Status)
+	SetStatus(newStatus statusprovider.Status)
 
 	// GetStatus returns the runtime's reported status
-	GetStatus() status.Status
+	GetStatus() statusprovider.Status
 
 	// Start starts the runtime, or does nothing if the runtime does not require starting (e.g. Go and shell runtimes)
 	Start() error
@@ -69,7 +69,7 @@ type AbstractRuntime struct {
 	Statistics     Statistics
 	databindings   map[string]databinding.DataBinding
 	configuration  *Configuration
-	status         status.Status
+	status         statusprovider.Status
 }
 
 // NewAbstractRuntime creates a new abstract runtime
@@ -102,7 +102,7 @@ func NewAbstractRuntime(logger logger.Logger, configuration *Configuration) (*Ab
 	}
 
 	// set the initial status
-	newAbstractRuntime.status = status.Initializing
+	newAbstractRuntime.status = statusprovider.Initializing
 
 	return &newAbstractRuntime, nil
 }
@@ -123,12 +123,12 @@ func (ar *AbstractRuntime) GetStatistics() *Statistics {
 }
 
 // SetStatus sets the runtime's reported status
-func (ar *AbstractRuntime) SetStatus(newStatus status.Status) {
+func (ar *AbstractRuntime) SetStatus(newStatus statusprovider.Status) {
 	ar.status = newStatus
 }
 
 // GetStatus returns the runtime's reported status
-func (ar *AbstractRuntime) GetStatus() status.Status {
+func (ar *AbstractRuntime) GetStatus() statusprovider.Status {
 	return ar.status
 }
 
@@ -221,6 +221,6 @@ func (ar *AbstractRuntime) createContext(parentLogger logger.Logger,
 
 // Stop stops the runtime
 func (ar *AbstractRuntime) Stop() error {
-	ar.SetStatus(status.Stopped)
+	ar.SetStatus(statusprovider.Stopped)
 	return nil
 }

--- a/pkg/processor/runtime/runtime.go
+++ b/pkg/processor/runtime/runtime.go
@@ -19,7 +19,7 @@ package runtime
 import (
 	"os"
 
-	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/databinding"
 
 	"github.com/nuclio/errors"
@@ -43,10 +43,10 @@ type Runtime interface {
 	GetConfiguration() *Configuration
 
 	// SetStatus sets the runtime's reported status
-	SetStatus(newStatus statusprovider.Status)
+	SetStatus(newStatus status.Status)
 
 	// GetStatus returns the runtime's reported status
-	GetStatus() statusprovider.Status
+	GetStatus() status.Status
 
 	// Start starts the runtime, or does nothing if the runtime does not require starting (e.g. Go and shell runtimes)
 	Start() error
@@ -69,7 +69,7 @@ type AbstractRuntime struct {
 	Statistics     Statistics
 	databindings   map[string]databinding.DataBinding
 	configuration  *Configuration
-	status         statusprovider.Status
+	status         status.Status
 }
 
 // NewAbstractRuntime creates a new abstract runtime
@@ -102,7 +102,7 @@ func NewAbstractRuntime(logger logger.Logger, configuration *Configuration) (*Ab
 	}
 
 	// set the initial status
-	newAbstractRuntime.status = statusprovider.Initializing
+	newAbstractRuntime.status = status.Initializing
 
 	return &newAbstractRuntime, nil
 }
@@ -123,12 +123,12 @@ func (ar *AbstractRuntime) GetStatistics() *Statistics {
 }
 
 // SetStatus sets the runtime's reported status
-func (ar *AbstractRuntime) SetStatus(newStatus statusprovider.Status) {
+func (ar *AbstractRuntime) SetStatus(newStatus status.Status) {
 	ar.status = newStatus
 }
 
 // GetStatus returns the runtime's reported status
-func (ar *AbstractRuntime) GetStatus() statusprovider.Status {
+func (ar *AbstractRuntime) GetStatus() status.Status {
 	return ar.status
 }
 
@@ -221,6 +221,6 @@ func (ar *AbstractRuntime) createContext(parentLogger logger.Logger,
 
 // Stop stops the runtime
 func (ar *AbstractRuntime) Stop() error {
-	ar.SetStatus(statusprovider.Stopped)
+	ar.SetStatus(status.Stopped)
 	return nil
 }

--- a/pkg/processor/runtime/shell/runtime.go
+++ b/pkg/processor/runtime/shell/runtime.go
@@ -27,9 +27,9 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/common/statusprovider"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
-	"github.com/nuclio/nuclio/pkg/processor/status"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -82,7 +82,7 @@ func NewRuntime(parentLogger logger.Logger, configuration *Configuration) (runti
 		return nil, errors.Wrap(err, "Failed checking if command is in PATH")
 	}
 
-	newShellRuntime.SetStatus(status.Ready)
+	newShellRuntime.SetStatus(statusprovider.Ready)
 
 	return newShellRuntime, nil
 }
@@ -278,7 +278,7 @@ func (s *shell) Restart() error {
 }
 
 func (s *shell) Start() error {
-	s.SetStatus(status.Ready)
+	s.SetStatus(statusprovider.Ready)
 	return nil
 }
 

--- a/pkg/processor/runtime/shell/runtime.go
+++ b/pkg/processor/runtime/shell/runtime.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
-	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 
@@ -82,7 +82,7 @@ func NewRuntime(parentLogger logger.Logger, configuration *Configuration) (runti
 		return nil, errors.Wrap(err, "Failed checking if command is in PATH")
 	}
 
-	newShellRuntime.SetStatus(statusprovider.Ready)
+	newShellRuntime.SetStatus(status.Ready)
 
 	return newShellRuntime, nil
 }
@@ -278,7 +278,7 @@ func (s *shell) Restart() error {
 }
 
 func (s *shell) Start() error {
-	s.SetStatus(statusprovider.Ready)
+	s.SetStatus(status.Ready)
 	return nil
 }
 

--- a/pkg/processor/trigger/http/http_test.go
+++ b/pkg/processor/trigger/http/http_test.go
@@ -22,7 +22,7 @@ import (
 	nethttp "net/http"
 	"testing"
 
-	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/test/suite"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/cors"
@@ -133,7 +133,7 @@ func (suite *TestSuite) TestCORS() {
 		suite.trigger.Statistics.EventsHandledFailureTotal = 0
 
 		// ensure trigger is ready
-		suite.trigger.status = statusprovider.Ready
+		suite.trigger.status = status.Ready
 
 		// create request, use OPTIONS to trigger preflight flow
 		request, err := nethttp.NewRequest(fasthttp.MethodOptions, "http://foo.bar/", nil)

--- a/pkg/processor/trigger/http/http_test.go
+++ b/pkg/processor/trigger/http/http_test.go
@@ -22,7 +22,7 @@ import (
 	nethttp "net/http"
 	"testing"
 
-	"github.com/nuclio/nuclio/pkg/processor/status"
+	"github.com/nuclio/nuclio/pkg/common/statusprovider"
 	"github.com/nuclio/nuclio/pkg/processor/test/suite"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/cors"
@@ -133,7 +133,7 @@ func (suite *TestSuite) TestCORS() {
 		suite.trigger.Statistics.EventsHandledFailureTotal = 0
 
 		// ensure trigger is ready
-		suite.trigger.status = status.Ready
+		suite.trigger.status = statusprovider.Ready
 
 		// create request, use OPTIONS to trigger preflight flow
 		request, err := nethttp.NewRequest(fasthttp.MethodOptions, "http://foo.bar/", nil)

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
-	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
 	"github.com/nuclio/nuclio/pkg/processor/worker"
@@ -47,7 +47,7 @@ type http struct {
 	configuration    *Configuration
 	events           []Event
 	bufferLoggerPool *nucliozap.BufferLoggerPool
-	status           statusprovider.Status
+	status           status.Status
 	activeContexts   []*fasthttp.RequestCtx
 	timeouts         []uint64 // flag of worker is in timeout
 	answering        []uint64 // flag the worker is answering
@@ -88,7 +88,7 @@ func newTrigger(logger logger.Logger,
 		AbstractTrigger:  abstractTrigger,
 		configuration:    configuration,
 		bufferLoggerPool: bufferLoggerPool,
-		status:           statusprovider.Initializing,
+		status:           status.Initializing,
 		activeContexts:   make([]*fasthttp.RequestCtx, numWorkers),
 		timeouts:         make([]uint64, numWorkers),
 		answering:        make([]uint64, numWorkers),
@@ -116,14 +116,14 @@ func (h *http) Start(checkpoint functionconfig.Checkpoint) error {
 	// start listening
 	go h.server.ListenAndServe(h.configuration.URL) // nolint: errcheck
 
-	h.status = statusprovider.Ready
+	h.status = status.Ready
 	return nil
 }
 
 func (h *http) Stop(force bool) (functionconfig.Checkpoint, error) {
 	h.Logger.Debug("Shutting down")
 
-	h.status = statusprovider.Stopped
+	h.status = status.Stopped
 
 	if h.server != nil {
 		err := h.server.Shutdown()
@@ -330,7 +330,7 @@ func (h *http) handlePreflightRequest(ctx *fasthttp.RequestCtx) {
 func (h *http) preHandleRequestValidation(ctx *fasthttp.RequestCtx) bool {
 
 	// ensure server is running
-	if h.status != statusprovider.Ready {
+	if h.status != status.Ready {
 		ctx.Response.SetStatusCode(nethttp.StatusServiceUnavailable)
 		msg := map[string]interface{}{
 			"error":  "Server not ready",

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -21,7 +21,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/cloudevent"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/util/clock"
@@ -103,7 +103,7 @@ func (w *Worker) GetRuntime() runtime.Runtime {
 }
 
 // GetStatus returns the status of the worker, as updated by the runtime
-func (w *Worker) GetStatus() statusprovider.Status {
+func (w *Worker) GetStatus() status.Status {
 	return w.runtime.GetStatus()
 }
 

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -21,9 +21,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/common/statusprovider"
 	"github.com/nuclio/nuclio/pkg/processor/cloudevent"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
-	"github.com/nuclio/nuclio/pkg/processor/status"
 	"github.com/nuclio/nuclio/pkg/processor/util/clock"
 
 	"github.com/nuclio/logger"
@@ -103,7 +103,7 @@ func (w *Worker) GetRuntime() runtime.Runtime {
 }
 
 // GetStatus returns the status of the worker, as updated by the runtime
-func (w *Worker) GetStatus() status.Status {
+func (w *Worker) GetStatus() statusprovider.Status {
 	return w.runtime.GetStatus()
 }
 

--- a/pkg/processor/worker/worker_test.go
+++ b/pkg/processor/worker/worker_test.go
@@ -19,8 +19,8 @@ package worker
 import (
 	"testing"
 
-	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/processor/runtime"
 
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"

--- a/pkg/processor/worker/worker_test.go
+++ b/pkg/processor/worker/worker_test.go
@@ -19,7 +19,7 @@ package worker
 import (
 	"testing"
 
-	"github.com/nuclio/nuclio/pkg/common/statusprovider"
+	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 
 	"github.com/nuclio/logger"
@@ -50,11 +50,11 @@ func (mr *MockRuntime) GetConfiguration() *runtime.Configuration {
 	return nil
 }
 
-func (mr *MockRuntime) SetStatus(newStatus statusprovider.Status) {
+func (mr *MockRuntime) SetStatus(newStatus status.Status) {
 }
 
-func (mr *MockRuntime) GetStatus() statusprovider.Status {
-	return statusprovider.Ready
+func (mr *MockRuntime) GetStatus() status.Status {
+	return status.Ready
 }
 
 func (mr *MockRuntime) Start() error {

--- a/pkg/processor/worker/worker_test.go
+++ b/pkg/processor/worker/worker_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
-	"github.com/nuclio/nuclio/pkg/processor/status"
+	"github.com/nuclio/nuclio/pkg/common/statusprovider"
 
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
@@ -50,11 +50,11 @@ func (mr *MockRuntime) GetConfiguration() *runtime.Configuration {
 	return nil
 }
 
-func (mr *MockRuntime) SetStatus(newStatus status.Status) {
+func (mr *MockRuntime) SetStatus(newStatus statusprovider.Status) {
 }
 
-func (mr *MockRuntime) GetStatus() status.Status {
-	return status.Ready
+func (mr *MockRuntime) GetStatus() statusprovider.Status {
+	return statusprovider.Ready
 }
 
 func (mr *MockRuntime) Start() error {

--- a/pkg/restful/server.go
+++ b/pkg/restful/server.go
@@ -38,6 +38,9 @@ type Server interface {
 
 	// InstallMiddleware installs middlewares on a router
 	InstallMiddleware(router chi.Router) error
+
+	// Start running the server
+	Start() error
 }
 
 type AbstractServer struct {


### PR DESCRIPTION
Docker daemon may be restarted during dashboard lifetime, that will lead to an orphaned socket being volumized to dashboard (for docker container builder).

In this PR I added healthcheck server to nuclio-dashboard, for both kubernetes & docker platforms.
This allow us to declare process healthiness while monitoring docker deamon connectivity by running `docker version` periodically.

Since most of the code was written and built for the functions / processor, I moved some code around to common to make it reusable.