### PR TITLE
Add function mount mode on local platform

### DIFF
--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -67,7 +67,8 @@ The `spec` section contains the requirements and attributes and has the followin
 | minReplicas | int | The minimum number of replicas |
 | platform.attributes.restartPolicy.name | string | The name of the restart policy for the function-image container; applicable only to Docker platforms |
 | platform.attributes.restartPolicy.maximumRetryCount | int | The maximum retries for restarting the function-image container; applicable only to Docker platforms |
-| platform.attributes.processorMountMode | string | Processor mount mode, which determines how Docker mounts the processor configuration - `bind` \| `volume` (default: `bind`); applicable only to Docker platforms |
+| platform.attributes.processorMountMode | string | (DEPRECATED, use MountMode instead)
+| platform.attributes.mountMode | string | Function mount mode, which determines how Docker mounts the function configurations - `bind` \| `volume` (default: `bind`); applicable only to Docker platforms |
 | maxReplicas | int | The maximum number of replicas |
 | targetCPU | int | Target CPU when auto scaling, as a percentage (default: 75%) |
 | dataBindings | See reference | A map of data sources used by the function ("data bindings") |
@@ -118,7 +119,7 @@ spec:
 
       # Use `volume` to mount the processor into the function.
       # For more information, see https://docs.docker.com/storage/volumes.
-      processorMountMode: volume
+      mountMode: volume
   env:
   - name: SOME_ENV
     value: abc

--- a/pkg/common/consts.go
+++ b/pkg/common/consts.go
@@ -15,5 +15,6 @@ const (
 	FunctionStateMessageUnhealthy = "Function is not healthy"
 
 	// TODO: deprecated. (used by local platform)
+	// TODO: remove on >= 1.6.0
 	DeprecatedFunctionStateMessage = "Container is not healthy (detected by nuclio platform)"
 )

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -698,8 +698,7 @@ func (c *ShellClient) DeleteVolume(volumeName string) error {
 		return errors.New("Invalid volume name to delete")
 	}
 
-	_, err := c.runCommand(nil, `docker volume rm %s`, volumeName)
-
+	_, err := c.runCommand(nil, `docker volume rm --force %s`, volumeName)
 	return err
 }
 

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -704,6 +704,9 @@ func (p *Platform) delete(deleteFunctionOptions *platform.DeleteFunctionOptions)
 
 	// get function platform specific configuration
 	functionPlatformConfiguration, err := newFunctionPlatformConfiguration(&deleteFunctionOptions.FunctionConfig)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create a function's platform configuration")
+	}
 
 	// get function processor mount mode
 	functionMountMode, err := p.resolveFunctionMountMode(functionPlatformConfiguration)

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -751,7 +751,7 @@ func (p *Platform) resolveAndCreateFunctionMounts(createFunctionOptions *platfor
 			return nil, nil, errors.Wrap(err, "Failed to prepare a function's volume mount")
 		}
 		mountPoints = append(mountPoints, dockerclient.MountPoint{
-			Source:      p.GetFunctionMountVolumeName(&createFunctionOptions.FunctionConfig),
+			Source:      p.GetFunctionVolumeMountName(&createFunctionOptions.FunctionConfig),
 			Destination: FunctionProcessorContainerDirPath,
 
 			// read only mode
@@ -846,7 +846,7 @@ func (p *Platform) GetContainerNameByCreateFunctionOptions(createFunctionOptions
 		createFunctionOptions.FunctionConfig.Meta.Name)
 }
 
-func (p *Platform) GetFunctionMountVolumeName(functionConfig *functionconfig.Config) string {
+func (p *Platform) GetFunctionVolumeMountName(functionConfig *functionconfig.Config) string {
 	return fmt.Sprintf("nuclio-%s-%s",
 		functionConfig.Meta.Namespace,
 		functionConfig.Meta.Name)
@@ -1033,7 +1033,7 @@ func (p *Platform) prepareFunctionVolumeMount(createFunctionOptions *platform.Cr
 
 	// create docker volume
 	if err := p.dockerClient.CreateVolume(&dockerclient.CreateVolumeOptions{
-		Name: p.GetFunctionMountVolumeName(&createFunctionOptions.FunctionConfig),
+		Name: p.GetFunctionVolumeMountName(&createFunctionOptions.FunctionConfig),
 	}); err != nil {
 		return errors.Wrapf(err, "Failed to create a volume for function %s",
 			createFunctionOptions.FunctionConfig.Meta.Name)
@@ -1052,7 +1052,7 @@ func (p *Platform) prepareFunctionVolumeMount(createFunctionOptions *platform.Cr
 		Remove: true,
 		MountPoints: []dockerclient.MountPoint{
 			{
-				Source:      p.GetFunctionMountVolumeName(&createFunctionOptions.FunctionConfig),
+				Source:      p.GetFunctionVolumeMountName(&createFunctionOptions.FunctionConfig),
 				Destination: FunctionProcessorContainerDirPath,
 				RW:          true,
 			},

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -702,24 +702,10 @@ func (p *Platform) delete(deleteFunctionOptions *platform.DeleteFunctionOptions)
 		}
 	}
 
-	// get function platform specific configuration
-	functionPlatformConfiguration, err := newFunctionPlatformConfiguration(&deleteFunctionOptions.FunctionConfig)
-	if err != nil {
-		return errors.Wrap(err, "Failed to create a function's platform configuration")
-	}
-
-	// get function processor mount mode
-	functionMountMode, err := p.resolveFunctionMountMode(functionPlatformConfiguration)
-	if err != nil {
-		return errors.Wrap(err, "Failed to resolve processor mount mode")
-	}
-
-	if functionMountMode == FunctionMountModeVolume {
-
-		// delete function volumes after containers are deleted
-		if err := p.dockerClient.DeleteVolume(p.GetFunctionMountVolumeName(&deleteFunctionOptions.FunctionConfig)); err != nil {
-			return errors.Wrapf(err, "Failed to delete a function volume")
-		}
+	// delete function volume mount after containers are deleted
+	functionVolumeMountName := p.GetFunctionVolumeMountName(&deleteFunctionOptions.FunctionConfig)
+	if err := p.dockerClient.DeleteVolume(functionVolumeMountName); err != nil {
+		return errors.Wrapf(err, "Failed to delete a function volume")
 	}
 
 	p.Logger.InfoWith("Successfully deleted function",

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -950,7 +950,7 @@ func (p *Platform) setFunctionUnhealthy(function platform.Function) error {
 	functionStatus := function.GetStatus()
 
 	// set function state to error
-	functionStatus.State = functionconfig.FunctionStateError
+	functionStatus.State = functionconfig.FunctionStateUnhealthy
 
 	// set unhealthy error message
 	functionStatus.Message = common.FunctionStateMessageUnhealthy

--- a/pkg/platform/local/test/platform_test.go
+++ b/pkg/platform/local/test/platform_test.go
@@ -180,7 +180,7 @@ func (suite *TestSuite) TestDeployFunctionVolumeMount() {
 	createFunctionOptions := suite.getDeployOptions("volume-mount")
 	createFunctionOptions.FunctionConfig.Meta.Namespace = suite.namespace
 	createFunctionOptions.FunctionConfig.Spec.Platform.Attributes = map[string]interface{}{
-		"processorMountMode": local.ProcessorMountModeVolume,
+		"mountMode": local.FunctionMountModeVolume,
 	}
 	localPlatform := suite.Platform.(*local.Platform)
 	suite.DeployFunctionAndRedeploy(createFunctionOptions,
@@ -192,11 +192,11 @@ func (suite *TestSuite) TestDeployFunctionVolumeMount() {
 			})
 			suite.Require().NoError(err, "Failed to get containers")
 
-			containerProcessorMount := containers[0].Mounts[0]
-			suite.Require().Equal(string(local.ProcessorMountModeVolume), containerProcessorMount.Type)
-			suite.Require().Equal(localPlatform.GetProcessorMountVolumeName(&createFunctionOptions.FunctionConfig), containerProcessorMount.Name)
-			suite.Require().Equal(local.FunctionProcessorContainerDirPath, containerProcessorMount.Destination)
-			suite.Require().Equal(false, containerProcessorMount.RW)
+			containerMount := containers[0].Mounts[0]
+			suite.Require().Equal(string(local.FunctionMountModeVolume), containerMount.Type)
+			suite.Require().Equal(localPlatform.GetFunctionMountVolumeName(&createFunctionOptions.FunctionConfig), containerMount.Name)
+			suite.Require().Equal(local.FunctionProcessorContainerDirPath, containerMount.Destination)
+			suite.Require().Equal(false, containerMount.RW)
 			return true
 		},
 		func(deployResult *platform.CreateFunctionResult) bool {

--- a/pkg/platform/local/test/platform_test.go
+++ b/pkg/platform/local/test/platform_test.go
@@ -110,11 +110,11 @@ func (suite *TestSuite) TestValidateFunctionContainersHealthiness() {
 			// Trigger function containers healthiness validation
 			go suite.Platform.(*local.Platform).ValidateFunctionContainersHealthiness()
 
-			// Wait for function to get into error state
+			// Wait for function to become unhealthy
 			suite.WaitForFunctionState(&platform.GetFunctionsOptions{
 				Name:      functionName,
 				Namespace: suite.namespace,
-			}, functionconfig.FunctionStateError, time.Minute)
+			}, functionconfig.FunctionStateUnhealthy, time.Minute)
 
 			// Start the container
 			err = suite.DockerClient.StartContainer(deployResult.ContainerID)

--- a/pkg/platform/local/types.go
+++ b/pkg/platform/local/types.go
@@ -25,9 +25,12 @@ import (
 )
 
 type functionPlatformConfiguration struct {
-	Network            string
-	RestartPolicy      *dockerclient.RestartPolicy
-	ProcessorMountMode ProcessorMountMode
+	Network       string
+	RestartPolicy *dockerclient.RestartPolicy
+	MountMode     FunctionMountMode
+
+	// Deprecated. Will be removed in the next minor (1.6.x) version release
+	ProcessorMountMode FunctionMountMode
 }
 
 func newFunctionPlatformConfiguration(functionConfig *functionconfig.Config) (*functionPlatformConfiguration, error) {
@@ -38,12 +41,24 @@ func newFunctionPlatformConfiguration(functionConfig *functionconfig.Config) (*f
 		return nil, errors.Wrap(err, "Failed to decode attributes")
 	}
 
+	// if mount mode field is not set, shove deprecated field value to it, it might contain a value
+	if newConfiguration.MountMode == "" {
+		newConfiguration.MountMode = newConfiguration.ProcessorMountMode
+	}
+
+	// anyway, empty out value
+	newConfiguration.ProcessorMountMode = ""
+
 	return &newConfiguration, nil
 }
 
-type ProcessorMountMode string
+type FunctionMountMode string
 
 const (
-	ProcessorMountModeBind   ProcessorMountMode = "bind"
-	ProcessorMountModeVolume ProcessorMountMode = "volume"
+
+	// use `/tmp` host path directory and bind mount
+	FunctionMountModeBind FunctionMountMode = "bind"
+
+	// create a docker volume and mount it
+	FunctionMountModeVolume FunctionMountMode = "volume"
 )


### PR DESCRIPTION
To allow deploying function with configuration being volume mounted (and not bind mounted) for all functions being deployed, I aded `NUCLIO_DASHBOARD_DEFAULT_FUNCTION_MOUNT_MODE` env to local platform. that will ensure function mount mode on all functions without an explicit mount mode. 

continuing #1820 which introduced the option.

Deprecation note: `processorMountMode` in favor of `mountMode` for naming correctness as not only the processor is being mounted.
That being said, the value is still accepted and if `mountMode` isn't set, the deprecated value is being shoved onto `mountMode`.
