### PR TITLE
Deprecate local platform functions attribute processorMountMode in favor of mountMode

### DIFF
--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -67,7 +67,6 @@ The `spec` section contains the requirements and attributes and has the followin
 | minReplicas | int | The minimum number of replicas |
 | platform.attributes.restartPolicy.name | string | The name of the restart policy for the function-image container; applicable only to Docker platforms |
 | platform.attributes.restartPolicy.maximumRetryCount | int | The maximum retries for restarting the function-image container; applicable only to Docker platforms |
-| platform.attributes.processorMountMode | string | (DEPRECATED, use MountMode instead)
 | platform.attributes.mountMode | string | Function mount mode, which determines how Docker mounts the function configurations - `bind` \| `volume` (default: `bind`); applicable only to Docker platforms |
 | maxReplicas | int | The maximum number of replicas |
 | targetCPU | int | Target CPU when auto scaling, as a percentage (default: 75%) |

--- a/pkg/platform/local/types.go
+++ b/pkg/platform/local/types.go
@@ -28,9 +28,6 @@ type functionPlatformConfiguration struct {
 	Network       string
 	RestartPolicy *dockerclient.RestartPolicy
 	MountMode     FunctionMountMode
-
-	// Deprecated. Will be removed in the next minor (1.6.x) version release
-	ProcessorMountMode FunctionMountMode
 }
 
 func newFunctionPlatformConfiguration(functionConfig *functionconfig.Config) (*functionPlatformConfiguration, error) {
@@ -40,14 +37,6 @@ func newFunctionPlatformConfiguration(functionConfig *functionconfig.Config) (*f
 	if err := mapstructure.Decode(functionConfig.Spec.Platform.Attributes, &newConfiguration); err != nil {
 		return nil, errors.Wrap(err, "Failed to decode attributes")
 	}
-
-	// if mount mode field is not set, shove deprecated field value to it, it might contain a value
-	if newConfiguration.MountMode == "" {
-		newConfiguration.MountMode = newConfiguration.ProcessorMountMode
-	}
-
-	// anyway, empty out value
-	newConfiguration.ProcessorMountMode = ""
 
 	return &newConfiguration, nil
 }


### PR DESCRIPTION
On <=1.5.x versions, `processorMountMode` was used for functions running with local platform to allow them override the way the (processor) configuration was shoved into the function container.

Since its name has changed to `mountMode` and `processorMountMode`  and was deprecated on 1.5.16 - it is now safe to simply remove this field completely.