### PR TITLE
Deprecated local platform old function unhealthy status message

### DIFF
--- a/pkg/common/consts.go
+++ b/pkg/common/consts.go
@@ -12,9 +12,5 @@ const (
 type FunctionStateMessage string
 
 const (
-	FunctionStateMessageUnhealthy = "Function is not healthy"
-
-	// TODO: deprecated. (used by local platform)
-	// TODO: remove on >= 1.6.0
-	DeprecatedFunctionStateMessage = "Container is not healthy (detected by nuclio platform)"
+	FunctionStateMessageUnhealthy FunctionStateMessage = "Function is not healthy"
 )

--- a/pkg/platform/kube/monitoring/function.go
+++ b/pkg/platform/kube/monitoring/function.go
@@ -147,7 +147,7 @@ func (fm *FunctionMonitor) updateFunctionStatus(function *nuclioio.NuclioFunctio
 		stateChanged = true
 	} else if !functionIsAvailable && function.Status.State == functionconfig.FunctionStateReady {
 		function.Status.State = functionconfig.FunctionStateUnhealthy
-		function.Status.Message = common.FunctionStateMessageUnhealthy
+		function.Status.Message = string(common.FunctionStateMessageUnhealthy)
 		stateChanged = true
 	}
 

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -520,10 +520,7 @@ func (p *Platform) ValidateFunctionContainersHealthiness() {
 				[]functionconfig.FunctionState{
 					functionconfig.FunctionStateError,
 					functionconfig.FunctionStateUnhealthy,
-				}) && common.StringInSlice(functionStatus.Message, []string{
-				common.FunctionStateMessageUnhealthy,
-				common.DeprecatedFunctionStateMessage,
-			})
+				}) && functionStatus.Message == string(common.FunctionStateMessageUnhealthy)
 
 			if !(functionIsReady || functionWasSetAsUnhealthy) {
 
@@ -939,7 +936,7 @@ func (p *Platform) setFunctionUnhealthy(function platform.Function) error {
 	functionStatus.State = functionconfig.FunctionStateUnhealthy
 
 	// set unhealthy error message
-	functionStatus.Message = common.FunctionStateMessageUnhealthy
+	functionStatus.Message = string(common.FunctionStateMessageUnhealthy)
 
 	p.Logger.WarnWith("Setting function state as unhealthy",
 		"functionName", function.GetConfig().Meta.Name,


### PR DESCRIPTION
Aligned behavior with kube platform on 1.5.x and now status message has been deprecated. 
Remove its appearance for good. 