### PR TITLE
Support releasing images and nuctl against multi architectures (arm64 / amd64)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,9 +16,12 @@ env:
 
 jobs:
   release:
-    name: Release
+    name: Release ${{ matrix.arch }}
     runs-on: ubuntu-latest
     if: github.repository == 'nuclio/nuclio'
+    strategy:
+      matrix:
+        arch: [ arm64, amd64 ]
     steps:
     - name: Dump github context
       run: echo "$GITHUB_CONTEXT"
@@ -70,29 +73,36 @@ jobs:
       run: make docker-images
       env:
         NUCLIO_DOCKER_REPO: ${{ env.REPO }}/${{ env.REPO_NAME }}
+        NUCLIO_ARCH: ${{ matrix.arch }}
 
     - name: Push images
       run: |
         make push-docker-images
       env:
         NUCLIO_DOCKER_REPO: ${{ env.REPO }}/${{ env.REPO_NAME }}
+        NUCLIO_ARCH: ${{ matrix.arch }}
 
     - name: Tag and push stable images
       if: env.NUCLIO_LABEL != 'unstable'
       run: |
-        docker tag "$NUCLIO_DOCKER_REPO/dashboard:$NUCLIO_LABEL-amd64" "$NUCLIO_DOCKER_REPO/dashboard:stable-amd64"
-        docker push "$NUCLIO_DOCKER_REPO/dashboard:stable-amd64"
+        docker tag "$NUCLIO_DOCKER_REPO/dashboard:$NUCLIO_LABEL-$NUCLIO_ARCH" "$NUCLIO_DOCKER_REPO/dashboard:stable-$NUCLIO_ARCH"
+        docker push "$NUCLIO_DOCKER_REPO/dashboard:stable-$NUCLIO_ARCH"
       env:
         NUCLIO_DOCKER_REPO: ${{ env.REPO }}/${{ env.REPO_NAME }}
+        NUCLIO_ARCH: ${{ matrix.arch }}
 
     - name: Build binaries
       run: |
-        NUCLIO_OS=linux NUCLIO_ARCH=amd64 make tools
-        NUCLIO_OS=darwin NUCLIO_ARCH=amd64 make tools
-        NUCLIO_OS=windows NUCLIO_ARCH=amd64 make tools
+        NUCLIO_OS=linux make tools
+        if [ $NUCLIO_ARCH == "amd64" ]; then \
+          NUCLIO_OS=darwin make tools; \
+          NUCLIO_OS=windows make tools; \
+        fi;
+
       env:
         NUCLIO_NUCTL_CREATE_SYMLINK: false
         GOPATH: /home/runner/go
+        NUCLIO_ARCH: ${{ matrix.arch }}
 
     - name: Upload binaries
       uses: AButler/upload-release-assets@v2.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,6 +69,17 @@ jobs:
         username: ${{ secrets.QUAYIO_DOCKER_USERNAME }}
         password: ${{ secrets.QUAYIO_DOCKER_PASSWORD }}
 
+    # for none x86_64 platforms
+    - name: Install QEMU
+      if: matrix.arch != 'amd64'
+      run: |
+
+        # install os packages
+        sudo apt update -qqy && sudo apt -qqy install qemu qemu-user-static
+
+        # enabled non arm64 docker containers executables
+        docker run --rm --privileged multiarch/qemu-user-static:latest --reset -p yes
+
     - name: Build
       run: make docker-images
       env:
@@ -106,6 +117,7 @@ jobs:
 
     - name: Upload binaries
       uses: AButler/upload-release-assets@v2.0
+      if: github.event_name == 'release'
       with:
         files: '/home/runner/go/bin/nuctl-*'
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # nuclio sdk
 pkg/processor/runtime/python/py/whl
 
+# act files (https://github.com/nektos/act)
+.github/act
+
 # general
 *.class
 *.iml


### PR DESCRIPTION
Adding `arm64` to the release artifacts (nuctl + Nuclio docker images).

Images:
 - amd64: all
 - arm64: all

nuctl:
 - amd64: linux, windows, macOS
 - arm64: linux


armhf (arm32) - In a followup PR