### PR TITLE
Added CI build + deploy for all runtimes

### DIFF
--- a/hack/examples/ruby/empty/empty.rb
+++ b/hack/examples/ruby/empty/empty.rb
@@ -1,0 +1,19 @@
+#
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+def main(context, event)
+  ''
+end

--- a/hack/examples/shell/empty/empty.sh
+++ b/hack/examples/shell/empty/empty.sh
@@ -1,0 +1,16 @@
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+echo ""

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -486,6 +486,23 @@ func LabelsMapMatchByLabelSelector(labelSelector string, labelsMap map[string]st
 	return selector.Matches(labels.Set(labelsMap)), nil
 }
 
+// GetRuntimeNameAndVersion return runtime name and version.
+// e.g. go:1.8 -> go, 1.8
+func GetRuntimeNameAndVersion(runtime string) (string, string) {
+
+	switch runtimeAndVersion := strings.Split(runtime, ":"); len(runtimeAndVersion) {
+
+	// if both are passed (e.g. python:3.6) - return them both
+	case 2:
+		return runtimeAndVersion[0], runtimeAndVersion[1]
+
+	// otherwise - return the first element (e.g. go -> go)
+	default:
+		return runtimeAndVersion[0], ""
+	}
+
+}
+
 func logPanic(ctx context.Context,
 	loggerInstance logger.Logger,
 	actionName string,

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -19,7 +19,6 @@ package functionconfig
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/v3io/scaler-types"
@@ -286,20 +285,6 @@ func (s *Spec) DeepCopyInto(out *Spec) {
 
 	// TODO: proper deep copy
 	*out = *s
-}
-
-// GetRuntimeNameAndVersion return runtime and version
-func (s *Spec) GetRuntimeNameAndVersion() (string, string) {
-	runtimeAndVersion := strings.Split(s.Runtime, ":")
-
-	switch len(runtimeAndVersion) {
-	case 1:
-		return runtimeAndVersion[0], ""
-	case 2:
-		return runtimeAndVersion[0], runtimeAndVersion[1]
-	default:
-		return "", ""
-	}
 }
 
 // GetHTTPPort returns the HTTP port

--- a/pkg/nuctl/test/suite.go
+++ b/pkg/nuctl/test/suite.go
@@ -51,7 +51,6 @@ type Suite struct {
 	suite.Suite
 	origPlatformKind    string
 	logger              logger.Logger
-	rootCommandeer      *command.RootCommandeer
 	dockerClient        dockerclient.Client
 	shellClient         *cmdrunner.ShellRunner
 	outputBuffer        bytes.Buffer
@@ -110,13 +109,13 @@ func (suite *Suite) TearDownSuite() {
 func (suite *Suite) ExecuteNuctl(positionalArgs []string,
 	namedArgs map[string]string) error {
 
-	suite.rootCommandeer = command.NewRootCommandeer()
+	rootCommandeer := command.NewRootCommandeer()
 
 	// set the output so we can capture it (but also output to stdout)
-	suite.rootCommandeer.GetCmd().SetOut(io.MultiWriter(os.Stdout, &suite.outputBuffer))
+	rootCommandeer.GetCmd().SetOut(io.MultiWriter(os.Stdout, &suite.outputBuffer))
 
 	// set the input so we can write to stdin
-	suite.rootCommandeer.GetCmd().SetIn(&suite.inputBuffer)
+	rootCommandeer.GetCmd().SetIn(&suite.inputBuffer)
 
 	// since args[0] is the executable name, just shove something there
 	argsStringSlice := []string{
@@ -136,7 +135,7 @@ func (suite *Suite) ExecuteNuctl(positionalArgs []string,
 	suite.logger.DebugWith("Executing nuctl", "args", argsStringSlice)
 
 	// execute
-	return suite.rootCommandeer.Execute()
+	return rootCommandeer.Execute()
 }
 
 // RetryExecuteNuctlUntilSuccessful executes nuctl until expectFailure is met
@@ -169,6 +168,10 @@ func (suite *Suite) GetFunctionsDir() string {
 
 func (suite *Suite) GetFunctionConfigsDir() string {
 	return path.Join(suite.GetNuclioSourceDir(), "test", "_function_configs")
+}
+
+func (suite *Suite) GetExamples() string {
+	return path.Join(suite.GetNuclioSourceDir(), "hack", "examples")
 }
 
 func (suite *Suite) GetImportsDir() string {

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -134,23 +134,6 @@ func (ar *AbstractRuntime) GetFunctionDir() string {
 	return path.Dir(ar.FunctionConfig.Spec.Build.Path)
 }
 
-// GetRuntimeNameAndVersion returns name and version of runtime from runtime.
-// e.g. go:1.8 -> go, 1.8
-func (ar *AbstractRuntime) GetRuntimeNameAndVersion() (string, string) {
-	nameAndVersion := strings.Split(ar.FunctionConfig.Spec.Runtime, ":")
-
-	switch len(nameAndVersion) {
-
-	// if both are passed (e.g. python:3.6) - return them both
-	case 2:
-		return nameAndVersion[0], nameAndVersion[1]
-
-	// otherwise - return the first element (e.g. go -> go)
-	default:
-		return nameAndVersion[0], ""
-	}
-}
-
 // GetProcessorImageObjectPaths returns the paths of all objects that should reside in the handler
 // directory
 func (ar *AbstractRuntime) GetHandlerDirObjectPaths() []string {
@@ -171,7 +154,7 @@ func (ar *AbstractRuntime) DetectFunctionHandlers(functionPath string) ([]string
 }
 
 func (ar *AbstractRuntime) GetOverrideImageRegistryFromMap(imagesOverrideMap map[string]string) string {
-	runtimeName, runtimeVersion := ar.GetRuntimeNameAndVersion()
+	runtimeName, runtimeVersion := common.GetRuntimeNameAndVersion(ar.FunctionConfig.Spec.Runtime)
 
 	// supports both overrides per runtimeName and per runtimeName + runtimeVersion
 	if runtimeVersion != "" {


### PR DESCRIPTION
Each function would be built, deployed and invoked to provide more confidence for cross runtime changes.

- Added "empty" example for both shell / ruby to align with other runtimes.
- Moved `GetRuntimeNameAndVersion` to common, as it is being used by various places around (code-dup).
- Remove `rootCommandeer` as suite property, to allow test parallelism (doing so locally for now, not CI)