### PR TITLE
Enable python 3.7 & 3.8 CI tests + add to benchmarking script

### DIFF
--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -126,6 +126,16 @@ func (suite *functionDeployTestSuite) TestDeploy() {
 			filename: "empty.py",
 		},
 		{
+			runtime:  "python:3.7",
+			handler:  "empty:handler",
+			filename: "empty.py",
+		},
+		{
+			runtime:  "python:3.8",
+			handler:  "empty:handler",
+			filename: "empty.py",
+		},
+		{
 			runtime:  "ruby",
 			handler:  "empty:main",
 			filename: "empty.rb",
@@ -135,17 +145,6 @@ func (suite *functionDeployTestSuite) TestDeploy() {
 			handler:  "empty.sh:main",
 			filename: "empty.sh",
 		},
-		// TODO: Enable when python 3.7 + 3.8 merged
-		//{
-		//	runtime:  "python:3.7",
-		//	handler:  "empty:handler",
-		//	filename: "empty.py",
-		//},
-		//{
-		//	runtime:  "python:3.8",
-		//	handler:  "empty:handler",
-		//	filename: "empty.py",
-		//},
 	} {
 		suite.Run(runtimeInfo.runtime, func() {
 			runtimeName, _ := common.GetRuntimeNameAndVersion(runtimeInfo.runtime)


### PR DESCRIPTION
Update / enable ci tests for python 3.7 and 3.8:

- Deploy "sanity" function (using examples/empty) for both python 3.7 and 3.8 as part of CI integration tests
- Add both python 3.7 and 3.8 runtimes to benchmarking (e.g.: `python benchmark.py --runtimes golang,python:3.7,python:3.8`)
