### PR TITLE
UI: Fix falsely showing transient states of functions and API GWs

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5647,9 +5647,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.31.0.tgz",
-      "integrity": "sha512-hRgAE4urGibcpipl9JxhUgtBEtt5tKId/h6pEH+Af4P33VDIv+NqcilHRcDws9ierLNLvk1uVfhM0uplQ+O0Jg==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.31.1.tgz",
+      "integrity": "sha512-3R56evleeUR2vXRSVclRROXRQcTMvmaqn97Kw4Q77FwGc8HNERP+8j4IpEkgZzRQbyHskf+Cgm2x1RcRVGeZWg==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.31.0",
+    "iguazio.dashboard-controls": "^0.31.1",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
-  API Gateways: [bugfixed] Transient states were sometimes shown on “Status” column instead of the (existing) loader.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/106390875-3017c900-63f3-11eb-8e45-5b08f452db9d.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/106391157-951fee80-63f4-11eb-9727-0a8dc8cbbdf9.png)
  ![image](https://user-images.githubusercontent.com/13918850/106391136-846f7880-63f4-11eb-88b0-802804eb26ba.png)
- API Gateways › Wizard › Function list:
  Instead of merely capitalizing the `status.state` of the function, such as:
  ![image](https://user-images.githubusercontent.com/13918850/106388079-7cf4a300-63e5-11eb-8a98-93a539215103.png)
  ![image](https://user-images.githubusercontent.com/13918850/106388074-78c88580-63e5-11eb-9876-8c0a01d8cd7e.png)
  be consistent with the same set of values that is used throughout Nuclio for function status:
  ![image](https://user-images.githubusercontent.com/13918850/106388098-985fae00-63e5-11eb-8c95-6ebce37436f4.png)
  ![image](https://user-images.githubusercontent.com/13918850/106388115-a57c9d00-63e5-11eb-8454-78f2c5c80a94.png)
  ![image](https://user-images.githubusercontent.com/13918850/106388116-a7def700-63e5-11eb-9d41-84cb0b264237.png)
  ![image](https://user-images.githubusercontent.com/13918850/106388119-aad9e780-63e5-11eb-93ef-ea8e21cde5ab.png)
  ![image](https://user-images.githubusercontent.com/13918850/106388123-b0373200-63e5-11eb-9a6a-df3b126b251e.png)
  ![image](https://user-images.githubusercontent.com/13918850/106388126-b62d1300-63e5-11eb-93c4-66ba9226e22a.png)
  ![image](https://user-images.githubusercontent.com/13918850/106388127-b9c09a00-63e5-11eb-9dc8-4e30055448ca.png)