### PR TITLE
Python 3.7, 3.8: Do not decode event strings to utf8 by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -588,13 +588,14 @@ test-nodejs:
 
 .PHONY: test-python
 test-python:
-	@$(eval PYTHON_IMAGE_TAGS ?= 3.9 3.8 3.7 3.6)
-	@$(eval TEST_BUILD_COMMANDS := $(foreach PYTHON_IMAGE_TAG,$(PYTHON_IMAGE_TAGS), docker build \
-	  --build-arg PYTHON_IMAGE_TAG=$(PYTHON_IMAGE_TAG) \
-	  --build-arg CACHEBUST=$(shell date +%s) \
-	  --file pkg/processor/runtime/python/test/Dockerfile \
-	  .;))
-	@$(foreach TEST_BUILD_COMMAND,$(TEST_BUILD_COMMANDS), $(TEST_BUILD_COMMAND))
+	@set -e; \
+	for runtime in 3.8 3.7 3.6; do \
+		docker build \
+			--build-arg PYTHON_IMAGE_TAG=$$runtime \
+			--build-arg CACHEBUST=$(shell date +%s) \
+			--file pkg/processor/runtime/python/test/Dockerfile \
+			. ;\
+	done
 
 
 #

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/v3io/v3io-go-http v0.0.1
 	github.com/v3io/version-go v0.0.2
 	github.com/valyala/fasthttp v1.14.0
-	github.com/vmihailenco/msgpack/v5 v5.2.0
+	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/v3io/v3io-go-http v0.0.1
 	github.com/v3io/version-go v0.0.2
 	github.com/valyala/fasthttp v1.14.0
-	github.com/vmihailenco/msgpack v4.0.4+incompatible
+	github.com/vmihailenco/msgpack/v5 v5.2.0
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/v3io/v3io-go-http v0.0.1
 	github.com/v3io/version-go v0.0.2
 	github.com/valyala/fasthttp v1.14.0
-	github.com/vmihailenco/msgpack v4.0.4+incompatible
+	github.com/vmihailenco/msgpack/v4 v4.3.12
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1

--- a/go.sum
+++ b/go.sum
@@ -433,10 +433,8 @@ github.com/valyala/fasthttp v1.2.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk
 github.com/valyala/fasthttp v1.14.0 h1:67bfuW9azCMwW/Jlq/C+VeihNpAuJMWkYPBig1gdi3A=
 github.com/valyala/fasthttp v1.14.0/go.mod h1:ol1PCaL0dX20wC0htZ7sYCsvCYmrouYra0zHzaclZhE=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
-github.com/vmihailenco/msgpack/v5 v5.2.0 h1:ZhIAtVUP1mme8GIlpiAnmTzjSWMexA/uNF2We85DR0w=
-github.com/vmihailenco/msgpack/v5 v5.2.0/go.mod h1:fEM7KuHcnm0GvDCztRpw9hV0PuoO2ciTismP6vjggcM=
-github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
-github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
+github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=

--- a/go.sum
+++ b/go.sum
@@ -433,8 +433,10 @@ github.com/valyala/fasthttp v1.2.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk
 github.com/valyala/fasthttp v1.14.0 h1:67bfuW9azCMwW/Jlq/C+VeihNpAuJMWkYPBig1gdi3A=
 github.com/valyala/fasthttp v1.14.0/go.mod h1:ol1PCaL0dX20wC0htZ7sYCsvCYmrouYra0zHzaclZhE=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
-github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
-github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vmihailenco/msgpack/v5 v5.2.0 h1:ZhIAtVUP1mme8GIlpiAnmTzjSWMexA/uNF2We85DR0w=
+github.com/vmihailenco/msgpack/v5 v5.2.0/go.mod h1:fEM7KuHcnm0GvDCztRpw9hV0PuoO2ciTismP6vjggcM=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
+github.com/golang/protobuf v1.3.4 h1:87PNWwrRvUSnqS4dlcBU/ftvOIBep4sYuBLlh6rX2wk=
+github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/gonum/blas v0.0.0-20181208220705-f22b278b28ac h1:Q0Jsdxl5jbxouNs1TQYt0gxesYMU4VXRbsTlgDloZ50=
@@ -433,8 +435,10 @@ github.com/valyala/fasthttp v1.2.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk
 github.com/valyala/fasthttp v1.14.0 h1:67bfuW9azCMwW/Jlq/C+VeihNpAuJMWkYPBig1gdi3A=
 github.com/valyala/fasthttp v1.14.0/go.mod h1:ol1PCaL0dX20wC0htZ7sYCsvCYmrouYra0zHzaclZhE=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
-github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
-github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvCazn8G65U=
+github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
+github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
+github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
@@ -519,6 +523,7 @@ golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/pkg/processor/build/runtime/python/test/python_test.go
+++ b/pkg/processor/build/runtime/python/test/python_test.go
@@ -80,14 +80,15 @@ func TestIntegrationSuite(t *testing.T) {
 		return
 	}
 
-	for _, runtime := range []string{
-		"python",
+	for _, runtimeName := range []string{
 		"python:3.6",
 		"python:3.7",
 		"python:3.8",
 	} {
-		TestSuite := new(TestSuite)
-		TestSuite.runtime = runtime
-		suite.Run(t, TestSuite)
+		t.Run(runtimeName, func(t *testing.T) {
+			testSuite := new(TestSuite)
+			testSuite.runtime = runtimeName
+			suite.Run(t, testSuite)
+		})
 	}
 }

--- a/pkg/processor/build/runtime/python/test/python_test.go
+++ b/pkg/processor/build/runtime/python/test/python_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime/test/suite"
@@ -80,14 +81,16 @@ func TestIntegrationSuite(t *testing.T) {
 		return
 	}
 
-	for _, runtimeName := range []string{
-		"python:3.6",
-		"python:3.7",
-		"python:3.8",
+	for _, testCase := range []struct {
+		runtimeVersion string
+	}{
+		{runtimeVersion: "3.6"},
+		{runtimeVersion: "3.7"},
+		{runtimeVersion: "3.8"},
 	} {
-		t.Run(runtimeName, func(t *testing.T) {
+		t.Run(fmt.Sprintf("python:%s", testCase.runtimeVersion), func(t *testing.T) {
 			testSuite := new(TestSuite)
-			testSuite.runtime = runtimeName
+			testSuite.runtime = testCase.runtimeVersion
 			suite.Run(t, testSuite)
 		})
 	}

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -70,6 +70,9 @@ class Wrapper(object):
         # create msgpack unpacker
         self._unpacker = self._resolve_unpacker()
 
+        # event serializer
+        self._event_serializer = nuclio_sdk.EventSerializerFactory.create('msgpack', self._runtime_version)
+
         # get handler module
         entrypoint_module = sys.modules[self._entrypoint.__module__]
 
@@ -107,7 +110,7 @@ class Wrapper(object):
                 event_message = self._resolve_event(event_message_length)
 
                 # instantiate event message
-                event = nuclio_sdk.Event.from_msgpack(event_message)
+                event = self._event_serializer.serialize(event_message)
 
                 try:
                     self._handle_event(event)

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -141,8 +141,13 @@ class Wrapper(object):
         Since this wrapper is behind the nuclio processor, in which pre-handle the traffic & request
         it is not mandatory to provide security over max buffer size.
         the request limit should be handled on the processor level.
+
+        use raw to unpack event contents to python bytes without decoding to utf8.
         """
-        return msgpack.Unpacker(raw=False, max_buffer_size=self._max_buffer_size)
+
+        # on runtime python 3.6 we use raw = False
+        raw = self._runtime_version != '3.6'
+        return msgpack.Unpacker(raw=raw, max_buffer_size=self._max_buffer_size)
 
     def _load_entrypoint_from_handler(self, handler):
         """

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -42,6 +42,7 @@ class Wrapper(object):
                  handler,
                  socket_path,
                  platform_kind,
+                 runtime_version,
                  namespace=None,
                  worker_id=None,
                  trigger_kind=None,
@@ -52,6 +53,7 @@ class Wrapper(object):
         self._entrypoint = None
         self._processor_sock = None
         self._platform = nuclio_sdk.Platform(platform_kind, namespace=namespace)
+        self._runtime_version = runtime_version
 
         # 1gb
         self._max_buffer_size = 1024 * 1024 * 1024
@@ -292,6 +294,11 @@ def create_logger(level):
 def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
 
+    parser.add_argument('--runtime-version',
+                        choices=['3.6', '3.7', '3.8'],
+                        default='3.6',
+                        help='Indicating the runtime version used by processor to run this wrapper')
+
     parser.add_argument('--handler',
                         help='handler (module.sub:handler)',
                         required=True)
@@ -341,6 +348,7 @@ def run_wrapper():
                                    args.handler,
                                    args.socket_path,
                                    args.platform_kind,
+                                   args.runtime_version,
                                    args.namespace,
                                    args.worker_id,
                                    args.trigger_kind,

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -70,8 +70,8 @@ class Wrapper(object):
         # create msgpack unpacker
         self._unpacker = self._resolve_unpacker()
 
-        # event serializer
-        self._event_serializer = self._resolve_event_serializer()
+        # event deserializer (event message to event instance)
+        self._event_deserializer = self._resolve_event_deserializer()
 
         # get handler module
         entrypoint_module = sys.modules[self._entrypoint.__module__]
@@ -110,7 +110,7 @@ class Wrapper(object):
                 event_message = self._resolve_event(event_message_length)
 
                 # instantiate event message
-                event = self._event_serializer.serialize(event_message)
+                event = self._event_deserializer.deserialize(event_message)
 
                 try:
                     self._handle_event(event)
@@ -149,12 +149,12 @@ class Wrapper(object):
         """
         return msgpack.Unpacker(raw=not self._decode_events, max_buffer_size=self._max_buffer_size)
 
-    def _resolve_event_serializer(self):
+    def _resolve_event_deserializer(self):
         """
         Event serializer to use when serializing incoming events
         """
-        serializer = 'msgpack' if self._decode_events else 'msgpack_raw'
-        return nuclio_sdk.EventSerializerFactory.create(serializer)
+        deserializer_kind = 'msgpack' if self._decode_events else 'msgpack_raw'
+        return nuclio_sdk.EventDeserializerFactory.create(deserializer_kind)
 
     def _load_entrypoint_from_handler(self, handler):
         """

--- a/pkg/processor/runtime/python/py/requirements/common.txt
+++ b/pkg/processor/runtime/python/py/requirements/common.txt
@@ -1,3 +1,2 @@
 mock==2.0.0
-nuclio-sdk==0.2.0
-msgpack==0.6.1
+

--- a/pkg/processor/runtime/python/py/requirements/common.txt
+++ b/pkg/processor/runtime/python/py/requirements/common.txt
@@ -1,2 +1,7 @@
 mock==2.0.0
-nuclio-sdk==0.3.0
+
+# TODO: uncomment
+#nuclio-sdk==0.3.0
+
+# TODO: remove
+git+https://github.com/liranbg/nuclio-sdk-py.git@msgpack102

--- a/pkg/processor/runtime/python/py/requirements/common.txt
+++ b/pkg/processor/runtime/python/py/requirements/common.txt
@@ -1,2 +1,2 @@
 mock==2.0.0
-
+nuclio-sdk==0.3.0

--- a/pkg/processor/runtime/python/py/requirements/common.txt
+++ b/pkg/processor/runtime/python/py/requirements/common.txt
@@ -1,7 +1,2 @@
 mock==2.0.0
-
-# TODO: uncomment
-#nuclio-sdk==0.3.0
-
-# TODO: remove
-git+https://github.com/liranbg/nuclio-sdk-py.git@msgpack102
+nuclio-sdk==0.3.0

--- a/pkg/processor/runtime/python/py/requirements/dev.txt
+++ b/pkg/processor/runtime/python/py/requirements/dev.txt
@@ -1,3 +1,4 @@
 pytest
 matplotlib
 memory_profiler
+six

--- a/pkg/processor/runtime/python/py/requirements/python3_6.txt
+++ b/pkg/processor/runtime/python/py/requirements/python3_6.txt
@@ -1,0 +1,2 @@
+msgpack==0.6.1
+nuclio-sdk==0.2.0

--- a/pkg/processor/runtime/python/py/requirements/python3_6.txt
+++ b/pkg/processor/runtime/python/py/requirements/python3_6.txt
@@ -1,2 +1,1 @@
 msgpack==0.6.1
-nuclio-sdk==0.2.0

--- a/pkg/processor/runtime/python/py/requirements/python3_7.txt
+++ b/pkg/processor/runtime/python/py/requirements/python3_7.txt
@@ -1,1 +1,3 @@
 pip==21.0
+msgpack==1.0.2
+nuclio-sdk==0.3.0

--- a/pkg/processor/runtime/python/py/requirements/python3_7.txt
+++ b/pkg/processor/runtime/python/py/requirements/python3_7.txt
@@ -1,3 +1,2 @@
 pip==21.0
 msgpack==1.0.2
-nuclio-sdk==0.3.0

--- a/pkg/processor/runtime/python/py/requirements/python3_8.txt
+++ b/pkg/processor/runtime/python/py/requirements/python3_8.txt
@@ -1,1 +1,3 @@
 pip==21.0
+msgpack==1.0.2
+nuclio-sdk==0.3.0

--- a/pkg/processor/runtime/python/py/requirements/python3_8.txt
+++ b/pkg/processor/runtime/python/py/requirements/python3_8.txt
@@ -1,3 +1,2 @@
 pip==21.0
 msgpack==1.0.2
-nuclio-sdk==0.3.0

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -40,7 +40,7 @@ class TestSubmitEvents(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls._decode_incoming_event_messages = False
+        cls._decode_events = False
 
     def setUp(self):
         self._temp_path = tempfile.mkdtemp(prefix='nuclio-test-py-wrapper')
@@ -69,7 +69,7 @@ class TestSubmitEvents(unittest.TestCase):
                                         self._default_test_handler,
                                         self._socket_path,
                                         self._platform_kind,
-                                        decode_incoming_event_messages=self._decode_incoming_event_messages)
+                                        decode_events=self._decode_events)
 
     def tearDown(self):
         sys.path.remove(self._temp_path)
@@ -113,7 +113,7 @@ class TestSubmitEvents(unittest.TestCase):
 
         # when using raw, the "malformed" is actually considered valid, as msgpack
         # being able to deserialize non utf-8 event messages.
-        if self._decode_incoming_event_messages:
+        if self._decode_events:
             self.assertEqual(http.client.INTERNAL_SERVER_ERROR, malformed_response['status_code'])
         else:
             self.assertEqual(http.client.OK, malformed_response['status_code'])

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -38,7 +38,7 @@ class TestSubmitEvents(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls._decode_events = False
+        cls._decode_event_strings = False
 
     def setUp(self):
         self._temp_path = tempfile.mkdtemp(prefix='nuclio-test-py-wrapper')
@@ -67,7 +67,7 @@ class TestSubmitEvents(unittest.TestCase):
                                         self._default_test_handler,
                                         self._socket_path,
                                         self._platform_kind,
-                                        decode_events=self._decode_events)
+                                        decode_event_strings=self._decode_event_strings)
 
     def tearDown(self):
         sys.path.remove(self._temp_path)
@@ -115,8 +115,9 @@ class TestSubmitEvents(unittest.TestCase):
 
         malformed_response = self._unix_stream_server._messages[-3]['body']
 
-        # when trying to decode, an error status code is expected
-        if self._decode_events:
+        if self._decode_event_strings:
+
+            # msgpack would fail decoding a non utf8 string when deserializing the event
             self.assertEqual(http.client.INTERNAL_SERVER_ERROR, malformed_response['status_code'])
         else:
             self.assertEqual(http.client.OK, malformed_response['status_code'])

--- a/pkg/processor/runtime/python/runtime.go
+++ b/pkg/processor/runtime/python/runtime.go
@@ -184,7 +184,7 @@ func (py *python) resolveDecodeEvents() bool {
 
 	// switch case for explicitness
 	// do not resolve empty or null-able values as false/true for forward/backwards compatibility
-	switch os.Getenv("NUCLIO_PYTHON_DECODE_EVENTS") {
+	switch strings.ToLower(os.Getenv("NUCLIO_PYTHON_DECODE_EVENTS")) {
 	case "true":
 		return true
 	case "false":
@@ -194,7 +194,7 @@ func (py *python) resolveDecodeEvents() bool {
 	// resolve by runtime version
 	switch _, runtimeVersion := common.GetRuntimeNameAndVersion(py.configuration.Spec.Runtime); runtimeVersion {
 
-	// python is an alias to 3.6 and hence, versionless runtime is currently considered python3.6
+	// python is an alias to 3.6 and hence, versionless runtime is assumed to be python3.6
 	case "", "3.6":
 
 		// backwards compatibility

--- a/pkg/processor/runtime/python/runtime.go
+++ b/pkg/processor/runtime/python/runtime.go
@@ -181,20 +181,25 @@ func (py *python) GetEventEncoder(writer io.Writer) rpc.EventEncoder {
 }
 
 func (py *python) resolveDecodeEvents() bool {
-	var decodeIncomingEventMessages bool
+
+	// switch case for explicitness
+	// do not resolve empty or null-able values as false/true for forward/backwards compatibility
+	switch os.Getenv("NUCLIO_PYTHON_DECODE_EVENTS") {
+	case "true":
+		return true
+	case "false":
+		return false
+	}
+
+	// resolve by runtime version
 	switch _, runtimeVersion := common.GetRuntimeNameAndVersion(py.configuration.Spec.Runtime); runtimeVersion {
 
 	// python is an alias to 3.6 and hence, versionless runtime is currently considered python3.6
 	case "", "3.6":
 
 		// backwards compatibility
-		decodeIncomingEventMessages = true
+		return true
 	default:
-
-		// events are byte strings, allow overriding using env
-		if common.GetEnvOrDefaultBool("NUCLIO_PYTHON_DECODE_EVENTS", false) {
-			decodeIncomingEventMessages = true
-		}
+		return false
 	}
-	return decodeIncomingEventMessages
 }

--- a/pkg/processor/runtime/python/runtime.go
+++ b/pkg/processor/runtime/python/runtime.go
@@ -82,6 +82,13 @@ func (py *python) RunWrapper(socketPath string) (*os.Process, error) {
 	py.Logger.DebugWith("Setting PYTHONPATH", "value", envPath)
 	env = append(env, envPath)
 
+	// explicitly state runtime version
+	// to provide runtime version features oriented, it is required to explicitly
+	// pass the version as argument rather than inferring it from the interpreter.
+	// reason: some python:3.6 functions out there using python 3.7 as a base image,
+	// to avoid non-backward compatibility changes, we explicitly pass the runtime version.
+	_, runtimeVersion := common.GetRuntimeNameAndVersion(py.configuration.Config.Spec.Runtime)
+
 	args := []string{
 		pythonExePath, "-u", wrapperScriptPath,
 		"--handler", handler,
@@ -91,6 +98,7 @@ func (py *python) RunWrapper(socketPath string) (*os.Process, error) {
 		"--worker-id", strconv.Itoa(py.configuration.WorkerID),
 		"--trigger-kind", py.configuration.TriggerKind,
 		"--trigger-name", py.configuration.TriggerName,
+		"--runtime-version", runtimeVersion,
 	}
 
 	py.Logger.DebugWith("Running wrapper", "command", strings.Join(args, " "))

--- a/pkg/processor/runtime/python/runtime.go
+++ b/pkg/processor/runtime/python/runtime.go
@@ -95,7 +95,7 @@ func (py *python) RunWrapper(socketPath string) (*os.Process, error) {
 
 	// whether to decode incoming event messages
 	if py.resolveDecodeEvents() {
-		args = append(args, "--decode-events")
+		args = append(args, "--decode-event-strings")
 	}
 
 	py.Logger.DebugWith("Running wrapper", "command", strings.Join(args, " "))
@@ -184,7 +184,7 @@ func (py *python) resolveDecodeEvents() bool {
 
 	// switch case for explicitness
 	// do not resolve empty or null-able values as false/true for forward/backwards compatibility
-	switch strings.ToLower(os.Getenv("NUCLIO_PYTHON_DECODE_EVENTS")) {
+	switch strings.ToLower(os.Getenv("NUCLIO_PYTHON_DECODE_EVENT_STRINGS")) {
 	case "true":
 		return true
 	case "false":

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -97,11 +97,12 @@ func (suite *TestSuite) TestOutputs() {
 		suite.GetFunctionPath("outputter"))
 
 	createFunctionOptions.FunctionConfig.Spec.Handler = "outputter:handler"
-	createFunctionOptions.FunctionConfig.Spec.Env = append(createFunctionOptions.FunctionConfig.Spec.Env,
-		v1.EnvVar{
-			Value: "true",
+	createFunctionOptions.FunctionConfig.Spec.Env = []v1.EnvVar{
+		{
 			Name:  "NUCLIO_PYTHON_DECODE_EVENTS",
-		})
+			Value: "true",
+		},
+	}
 
 	testRequests := []*httpsuite.Request{
 		{
@@ -335,6 +336,9 @@ func (suite *TestSuite) TestNonUTF8Headers() {
 	}
 	suite.DeployFunctionAndRequests(createFunctionOptions, []*httpsuite.Request{
 		{
+
+			// event body is []bytes and hence would always be a python bytestring
+			// and hence no utf8 decoding is applied by msgpack
 			RequestMethod:              http.MethodPost,
 			RequestBody:                nonUTF8String,
 			ExpectedResponseStatusCode: &okStatus,

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -99,7 +99,7 @@ func (suite *TestSuite) TestOutputs() {
 	createFunctionOptions.FunctionConfig.Spec.Handler = "outputter:handler"
 	createFunctionOptions.FunctionConfig.Spec.Env = []v1.EnvVar{
 		{
-			Name:  "NUCLIO_PYTHON_DECODE_EVENTS",
+			Name:  "NUCLIO_PYTHON_DECODE_EVENT_STRINGS",
 			Value: "true",
 		},
 	}
@@ -332,7 +332,7 @@ func (suite *TestSuite) TestNonUTF8Headers() {
 	nonUTF8String := string([]byte{192, 175})
 
 	createFunctionOptions.FunctionConfig.Spec.Env = []v1.EnvVar{
-		{Name: "NUCLIO_PYTHON_DECODE_EVENTS", Value: "true"},
+		{Name: "NUCLIO_PYTHON_DECODE_EVENT_STRINGS", Value: "true"},
 	}
 	suite.DeployFunctionAndRequests(createFunctionOptions, []*httpsuite.Request{
 		{
@@ -361,7 +361,7 @@ func (suite *TestSuite) TestNonUTF8Headers() {
 
 	// do not decode to utf8, allow incoming event messages to be byte string and not utf8 encoded.
 	createFunctionOptions.FunctionConfig.Spec.Env = []v1.EnvVar{
-		{Name: "NUCLIO_PYTHON_DECODE_EVENTS", Value: "false"},
+		{Name: "NUCLIO_PYTHON_DECODE_EVENT_STRINGS", Value: "false"},
 	}
 	suite.DeployFunctionAndRequests(createFunctionOptions, []*httpsuite.Request{
 		{
@@ -442,14 +442,16 @@ func TestIntegrationSuite(t *testing.T) {
 		return
 	}
 
-	for _, runtimeName := range []string{
-		"python:3.6",
-		"python:3.7",
-		"python:3.8",
+	for _, testCase := range []struct {
+		runtimeVersion string
+	}{
+		{runtimeVersion: "3.6"},
+		{runtimeVersion: "3.7"},
+		{runtimeVersion: "3.8"},
 	} {
-		t.Run(runtimeName, func(t *testing.T) {
+		t.Run(fmt.Sprintf("python:%s", testCase.runtimeVersion), func(t *testing.T) {
 			testSuite := new(TestSuite)
-			testSuite.runtime = runtimeName
+			testSuite.runtime = testCase.runtimeVersion
 			suite.Run(t, testSuite)
 		})
 	}

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -350,8 +350,8 @@ func (suite *TestSuite) TestNonUTF8Headers() {
 	// do not decode to utf8, allow incoming event messages to be byte string and not utf8 encoded.
 	createFunctionOptions.FunctionConfig.Spec.Env = append(createFunctionOptions.FunctionConfig.Spec.Env,
 		v1.EnvVar{
-			Name:  "NUCLIO_PYTHON_SKIP_DECODING_INCOMING_EVENT_MESSAGES",
-			Value: "true",
+			Name:  "NUCLIO_PYTHON_DECODE_EVENTS",
+			Value: "false",
 		})
 	suite.DeployFunctionAndRequests(createFunctionOptions, []*httpsuite.Request{
 		{

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -97,6 +97,11 @@ func (suite *TestSuite) TestOutputs() {
 		suite.GetFunctionPath("outputter"))
 
 	createFunctionOptions.FunctionConfig.Spec.Handler = "outputter:handler"
+	createFunctionOptions.FunctionConfig.Spec.Env = append(createFunctionOptions.FunctionConfig.Spec.Env,
+		v1.EnvVar{
+			Value: "true",
+			Name:  "NUCLIO_PYTHON_DECODE_EVENTS",
+		})
 
 	testRequests := []*httpsuite.Request{
 		{
@@ -325,6 +330,9 @@ func (suite *TestSuite) TestNonUTF8Headers() {
 
 	nonUTF8String := string([]byte{192, 175})
 
+	createFunctionOptions.FunctionConfig.Spec.Env = []v1.EnvVar{
+		{Name: "NUCLIO_PYTHON_DECODE_EVENTS", Value: "true"},
+	}
 	suite.DeployFunctionAndRequests(createFunctionOptions, []*httpsuite.Request{
 		{
 			RequestMethod:              http.MethodPost,
@@ -348,11 +356,9 @@ func (suite *TestSuite) TestNonUTF8Headers() {
 	})
 
 	// do not decode to utf8, allow incoming event messages to be byte string and not utf8 encoded.
-	createFunctionOptions.FunctionConfig.Spec.Env = append(createFunctionOptions.FunctionConfig.Spec.Env,
-		v1.EnvVar{
-			Name:  "NUCLIO_PYTHON_DECODE_EVENTS",
-			Value: "false",
-		})
+	createFunctionOptions.FunctionConfig.Spec.Env = []v1.EnvVar{
+		{Name: "NUCLIO_PYTHON_DECODE_EVENTS", Value: "false"},
+	}
 	suite.DeployFunctionAndRequests(createFunctionOptions, []*httpsuite.Request{
 		{
 			RequestMethod:              http.MethodPost,
@@ -437,8 +443,10 @@ func TestIntegrationSuite(t *testing.T) {
 		"python:3.7",
 		"python:3.8",
 	} {
-		testSuite := new(TestSuite)
-		testSuite.runtime = runtimeName
-		suite.Run(t, testSuite)
+		t.Run(runtimeName, func(t *testing.T) {
+			testSuite := new(TestSuite)
+			testSuite.runtime = runtimeName
+			suite.Run(t, testSuite)
+		})
 	}
 }

--- a/pkg/processor/runtime/python/test/test.sh
+++ b/pkg/processor/runtime/python/test/test.sh
@@ -26,7 +26,7 @@ find ./py \
     -o -name "*.pyc" \
     -o -name "__pycache__" -type d \
     -print0 \
-    | xargs rm -rf
+    | xargs --null rm -rf
 
 # run tests
 python -m pytest -v .

--- a/pkg/processor/runtime/rpc/encode_msgpack.go
+++ b/pkg/processor/runtime/rpc/encode_msgpack.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
-	"github.com/vmihailenco/msgpack"
+	"github.com/vmihailenco/msgpack/v5"
 )
 
 // EventMsgPackEncoder encodes nuclio events as MsgPack

--- a/pkg/processor/runtime/rpc/encode_msgpack.go
+++ b/pkg/processor/runtime/rpc/encode_msgpack.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
-	"github.com/vmihailenco/msgpack"
+	"github.com/vmihailenco/msgpack/v4"
 )
 
 // EventMsgPackEncoder encodes nuclio events as MsgPack

--- a/pkg/processor/runtime/rpc/encode_msgpack.go
+++ b/pkg/processor/runtime/rpc/encode_msgpack.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
-	"github.com/vmihailenco/msgpack/v5"
+	"github.com/vmihailenco/msgpack"
 )
 
 // EventMsgPackEncoder encodes nuclio events as MsgPack

--- a/test/_functions/common/event-recorder/python/event_recorder.py
+++ b/test/_functions/common/event-recorder/python/event_recorder.py
@@ -62,9 +62,11 @@ def _invoked_by_cron(event):
            or event.get_header(b'x-nuclio-invoke-trigger') == b'cron'
 
 
-def _ensure_str(s):
+def _ensure_str(s, encoding='utf-8', errors='strict'):
+
+    # Optimization: Fast return for the common case.
     if type(s) is str:
         return s
     if isinstance(s, bytes):
-        return s.decode()
-    return s
+        return s.decode(encoding, errors)
+    raise TypeError(f"not expecting type '{type(s)}'")

--- a/test/_functions/common/event-recorder/python/event_recorder.py
+++ b/test/_functions/common/event-recorder/python/event_recorder.py
@@ -14,7 +14,8 @@
 
 import datetime
 import json
-import tempfile
+
+events_log_file_path = '/tmp/events.json'
 
 
 def handler(context, event):
@@ -35,14 +36,14 @@ def handler(context, event):
         })
 
         # store in log file
-        with open(context.user_data['events_log_file_path'], 'a') as events_log_file:
+        with open(events_log_file_path, 'a') as events_log_file:
             events_log_file.write(serialized_record + ', ')
 
     else:
 
         # read the log file
         try:
-            with open(context.user_data['events_log_file_path'], 'r') as events_log_file:
+            with open(events_log_file_path, 'r') as events_log_file:
                 events_log_file_contents = events_log_file.read()
         except IOError:
             events_log_file_contents = ''
@@ -56,15 +57,9 @@ def handler(context, event):
         return encoded_event_log
 
 
-def init_context(context):
-    context.user_data = {
-        'events_log_file_path': tempfile.mktemp(suffix='.json'),
-    }
-
-
 def _invoked_by_cron(event):
-    return event.get_header('x-nuclio-invoke-trigger') == _ensure_str('cron') \
-           or event.get_header(b'x-nuclio-invoke-trigger') == _ensure_str('cron')
+    return event.get_header('x-nuclio-invoke-trigger') == 'cron' \
+           or event.get_header(b'x-nuclio-invoke-trigger') == b'cron'
 
 
 def _ensure_str(s):

--- a/test/_functions/common/event-returner/python/eventreturner.py
+++ b/test/_functions/common/event-returner/python/eventreturner.py
@@ -14,6 +14,7 @@
 
 import json
 
+
 def handler(context, event):
 
     # for object bodies, just take it as is. otherwise decode
@@ -22,11 +23,16 @@ def handler(context, event):
     else:
         body = event.body
 
+    headers = {
+        _ensure_str(header): _ensure_str(value)
+        for header, value in event.headers.items()
+    }
+
     return json.dumps({
         'id': event.id,
         'eventType': event.trigger.kind,
         'contentType': event.content_type,
-        'headers': dict(event.headers),
+        'headers': headers,
         'timestamp': event.timestamp.isoformat('T') + 'Z',
         'path': event.path,
         'url': event.url,
@@ -35,4 +41,12 @@ def handler(context, event):
         'typeVersion': event.type_version,
         'version': event.version,
         'body': body
-    })
+    }, default=_ensure_str)
+
+
+def _ensure_str(s):
+    if type(s) is str:
+        return s
+    if isinstance(s, bytes):
+        return s.decode()
+    return s

--- a/test/_functions/common/event-returner/python/eventreturner.py
+++ b/test/_functions/common/event-returner/python/eventreturner.py
@@ -41,12 +41,20 @@ def handler(context, event):
         'typeVersion': event.type_version,
         'version': event.version,
         'body': body
-    }, default=_ensure_str)
+    }, default=_json_default)
 
 
-def _ensure_str(s):
+def _json_default(s):
+    if type(s) is bytes:
+        return _ensure_str(s)
+    return s
+
+
+def _ensure_str(s, encoding='utf-8', errors='strict'):
+
+    # Optimization: Fast return for the common case.
     if type(s) is str:
         return s
     if isinstance(s, bytes):
-        return s.decode()
-    return s
+        return s.decode(encoding, errors)
+    raise TypeError(f"not expecting type '{type(s)}'")

--- a/test/_functions/common/json-parser-with-function-config/python/parser.py
+++ b/test/_functions/common/json-parser-with-function-config/python/parser.py
@@ -17,4 +17,4 @@ import simplejson
 def handler(context, event):
     """Return a field from within a json"""
 
-    return event.body['return_this']
+    return event.body.get('return_this') or event.body.get(b'return_this')

--- a/test/_functions/common/json-parser-with-function-config/python/parser.py
+++ b/test/_functions/common/json-parser-with-function-config/python/parser.py
@@ -14,7 +14,8 @@
 
 import simplejson
 
+
 def handler(context, event):
     """Return a field from within a json"""
 
-    return event.body.get('return_this') or event.body.get(b'return_this')
+    return event.body['return_this']

--- a/test/_functions/common/json-parser-with-inline-function-config/python/parser.py
+++ b/test/_functions/common/json-parser-with-inline-function-config/python/parser.py
@@ -29,4 +29,4 @@ import simplejson
 def handler(context, event):
     """Return a field from within a json"""
 
-    return event.body.get('return_this') or event.body.get(b'return_this')
+    return event.body['return_this']

--- a/test/_functions/common/json-parser-with-inline-function-config/python/parser.py
+++ b/test/_functions/common/json-parser-with-inline-function-config/python/parser.py
@@ -25,7 +25,8 @@
 
 import simplejson
 
+
 def handler(context, event):
     """Return a field from within a json"""
 
-    return event.body['return_this']
+    return event.body.get('return_this') or event.body.get(b'return_this')


### PR DESCRIPTION
## Disable event strings utf-8 encoding (for python runtimes 3.7, 3.8)

Event fields type would be byte strings and not encoded to strings.
e.g.:

> $> type(event.path)
> <class 'bytes'>

## Changes

- by default, do not encode event strings to utf8 for runtimes 3.7, 3.8
- bumped msgpack on python wrapper / sdk to 1.0.2 for runtimes > 3.6, python 3.6 remains in its current constellation
- bumped `nuclio-sdk-py` version [related pr](https://github.com/nuclio/nuclio-sdk-py/pull/24) to 0.3.0
- bumped processor msgpack to latest v4 to include all bug fixes
- Allow explicitly decoding events to utf8 if running any python runtime with env `NUCLIO_PYTHON_DECODE_EVENT_STRINGS` set to true.
  - setting it to false would would force the opposite. empty for default behavior.
- Fixed Makefile python test command to fail fast
- Updated few python test functions to work against decoded and undecoded events

## Throughput benchmarking

Tested against: Linux, 8 cores, 8 workers

tl;dr; ~5% improvement for small size messages


Below is benchmarking results, on the left - message size, on the right - total requests made within time frame (10s)

Python 3.6 w decoding:
 - 0k - 158224
 - 12kb - 140186
 - 64kb - 92074
 - 128kb - 55081
 
Python 3.8 w/0 decoding:
 - 0k - 166141
 - 12kb - 146766
 - 64kb - 93594
 - 128kb - 55979

<details><summary>Python 3.6 w decoding</summary>

```
> benchmark  (I)  Benchmarking function - python-36-bm @ http://localhost:33069, size: 0kb
Requests      [total, rate, throughput]         158224, 15822.44, 15821.96
Duration      [total, attack, wait]             10s, 10s, 306.033µs
Latencies     [min, mean, 50, 90, 95, 99, max]  220.939µs, 468.558µs, 433.079µs, 613.848µs, 712.672µs, 1.082ms, 11.082ms
Bytes In      [total, mean]                     0, 0.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:158224
```

```
> benchmark  (I)  Benchmarking function - python-36-bm @ http://localhost:33069, size: 12kb
Requests      [total, rate, throughput]         140186, 14018.66, 14018.21
Duration      [total, attack, wait]             10s, 10s, 320.299µs
Latencies     [min, mean, 50, 90, 95, 99, max]  247.288µs, 530.165µs, 491.196µs, 703.289µs, 812.006µs, 1.193ms, 19.62ms
Bytes In      [total, mean]                     0, 0.00
Bytes Out     [total, mean]                     1722605568, 12288.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:140186
```

```
> benchmark  (I)  Benchmarking function - python-36-bm @ http://localhost:33069, size: 64kb
Requests      [total, rate, throughput]         92074, 9207.46, 9207.00
Duration      [total, attack, wait]             10s, 10s, 498.581µs
Latencies     [min, mean, 50, 90, 95, 99, max]  321.31µs, 815.65µs, 755.703µs, 1.119ms, 1.294ms, 1.809ms, 14.545ms
Bytes In      [total, mean]                     0, 0.00
Bytes Out     [total, mean]                     6034161664, 65536.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:92074
```

```
> benchmark  (I)  Benchmarking function - python-36-bm @ http://localhost:33069, size: 128kb
Requests      [total, rate, throughput]         55081, 5508.18, 5507.90
Duration      [total, attack, wait]             10s, 10s, 511.099µs
Latencies     [min, mean, 50, 90, 95, 99, max]  490.537µs, 1.369ms, 1.286ms, 1.882ms, 2.15ms, 2.928ms, 17.703ms
Bytes In      [total, mean]                     0, 0.00
Bytes Out     [total, mean]                     7219576832, 131072.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:55081
```

</details>

<details><summary>Python 3.8 w/o decoding</summary>

```
> benchmark  (I)  Benchmarking function - python-38-bm @ http://localhost:33070, size: 0kb
Requests      [total, rate, throughput]         166141, 16613.99, 16613.56
Duration      [total, attack, wait]             10s, 10s, 260.831µs
Latencies     [min, mean, 50, 90, 95, 99, max]  198.874µs, 444.433µs, 411.494µs, 582.798µs, 676.924µs, 1.05ms, 22.266ms
Bytes In      [total, mean]                     0, 0.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:166141
```

```
Benchmarking function - python-38-bm @ http://localhost:33070, size: 12kb
Requests      [total, rate, throughput]         146766, 14676.64, 14675.54
Duration      [total, attack, wait]             10.001s, 10s, 750.752µs
Latencies     [min, mean, 50, 90, 95, 99, max]  221.365µs, 504.482µs, 467.036µs, 668.088µs, 776.269µs, 1.176ms, 12.598ms
Bytes In      [total, mean]                     0, 0.00
Bytes Out     [total, mean]                     1803460608, 12288.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:146766
```

```
> benchmark  (I)  Benchmarking function - python-38-bm @ http://localhost:33070, size: 64kb
Requests      [total, rate, throughput]         93594, 9359.49, 9359.06
Duration      [total, attack, wait]             10s, 10s, 452.068µs
Latencies     [min, mean, 50, 90, 95, 99, max]  317.549µs, 799.671µs, 741.162µs, 1.093ms, 1.263ms, 1.786ms, 14.602ms
Bytes In      [total, mean]                     0, 0.00
Bytes Out     [total, mean]                     6133776384, 65536.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:93594
```

```
> benchmark  (I)  Benchmarking function - python-38-bm @ http://localhost:33070, size: 128kb
Requests      [total, rate, throughput]         55979, 5597.65, 5596.98
Duration      [total, attack, wait]             10.002s, 10s, 1.198ms
Latencies     [min, mean, 50, 90, 95, 99, max]  455.23µs, 1.346ms, 1.264ms, 1.849ms, 2.121ms, 2.899ms, 13.96ms
Bytes In      [total, mean]                     0, 0.00
Bytes Out     [total, mean]                     7337279488, 131072.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:55979
```
</details>
