### PR TITLE
UI: Remove "Python 2.7" and add "Python 3.7" and "Python 3.8"

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5647,9 +5647,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.31.1.tgz",
-      "integrity": "sha512-3R56evleeUR2vXRSVclRROXRQcTMvmaqn97Kw4Q77FwGc8HNERP+8j4IpEkgZzRQbyHskf+Cgm2x1RcRVGeZWg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.32.0.tgz",
+      "integrity": "sha512-Je4YH8PwvhP70JZfgE8yWQn1/QyV8ytk+uw68ABOLyXer7g+0PxXa2JAwf9l1wH0iPQzE7ZqZOc5O+KpSipJJg==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.31.1",
+    "iguazio.dashboard-controls": "^0.32.0",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
- Remove runtime “Python 2.7” and add runtimes “Python 3.7” and “Python 3.8”:
  - Create function › From template › Runtime filter
    ![image](https://user-images.githubusercontent.com/13918850/107384097-52e46480-6afa-11eb-89d0-cb6f8693e88f.png)
  - Create function › From scratch › Runtime field
    ![image](https://user-images.githubusercontent.com/13918850/107384166-5ed02680-6afa-11eb-90d3-9df8bc2309cd.png)
  - Function › Code › Runtime field
    ![image](https://user-images.githubusercontent.com/13918850/107384223-6c85ac00-6afa-11eb-869a-fc8fde94d899.png)
    ![image](https://user-images.githubusercontent.com/13918850/107384233-70193300-6afa-11eb-8089-f71d6c35af26.png)
  - Project › Functions (list) › Runtime (column)
    ![image](https://user-images.githubusercontent.com/13918850/107384363-8e7f2e80-6afa-11eb-9c8f-f74c74eac80f.png)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/1206