### PR TITLE
Fix release and python onbuild - Phase 2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'nuclio/nuclio'
     strategy:
+      fail-fast: false
       matrix:
         arch: [ arm64, amd64 ]
     steps:

--- a/Makefile
+++ b/Makefile
@@ -82,12 +82,9 @@ endif
 # alpine is commonly used by controller / dlx / autoscaler
 ifeq ($(NUCLIO_ARCH), armhf)
 	NUCLIO_DOCKER_ALPINE_IMAGE ?= arm32v7/alpine:3.11
-	NUCLIO_ONBUILD_PYTHON_IMAGE ?= arm32v7/python
 else ifeq ($(NUCLIO_ARCH), arm64)
 	NUCLIO_DOCKER_ALPINE_IMAGE ?= arm64v8/alpine:3.11
-	NUCLIO_ONBUILD_PYTHON_IMAGE ?= arm64v8/python
 else
-	NUCLIO_ONBUILD_PYTHON_IMAGE ?= python
 	NUCLIO_DOCKER_ALPINE_IMAGE ?= alpine:3.11
 endif
 
@@ -296,7 +293,6 @@ PIP_REQUIRE_VIRTUALENV=false
 
 handler-builder-python-onbuild:
 	docker build \
-		--build-arg NUCLIO_ONBUILD_PYTHON_IMAGE=$(NUCLIO_ONBUILD_PYTHON_IMAGE) \
 		--build-arg NUCLIO_ARCH=$(NUCLIO_ARCH) \
 		--build-arg NUCLIO_LABEL=$(NUCLIO_LABEL) \
 		--file pkg/processor/build/runtime/python/docker/onbuild/Dockerfile \

--- a/pkg/processor/build/runtime/python/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/python/docker/onbuild/Dockerfile
@@ -14,10 +14,9 @@
 
 ARG NUCLIO_LABEL=latest
 ARG NUCLIO_ARCH=amd64
-ARG NUCLIO_ONBUILD_PYTHON_IMAGE=python
 
 # Supplies python 3.6 & common wheels
-FROM $NUCLIO_ONBUILD_PYTHON_IMAGE:3.6 as python36-builder
+FROM python:3.6 as python36-builder
 
 COPY pkg/processor/runtime/python/py/requirements /requirements
 
@@ -28,7 +27,7 @@ RUN pip download \
         --requirement /requirements/python3_6.txt
 
 # Supplies python 3.7 & common wheels
-FROM $NUCLIO_ONBUILD_PYTHON_IMAGE:3.7 as python37-builder
+FROM python:3.7 as python37-builder
 
 COPY pkg/processor/runtime/python/py/requirements /requirements
 
@@ -39,7 +38,7 @@ RUN pip download \
         --requirement /requirements/python3_7.txt
 
 # Supplies python 3.8 & common wheels
-FROM $NUCLIO_ONBUILD_PYTHON_IMAGE:3.8 as python38-builder
+FROM python:3.8 as python38-builder
 
 COPY pkg/processor/runtime/python/py/requirements /requirements
 


### PR DESCRIPTION
- [reverted, somehow](https://github.com/nuclio/nuclio/pull/2100) python onbuild image name prefix (for now, as anyway onbuild currently holds "binary" presentation of msgpack)
- marked fail-fast to false, to allow either platform to finish its release if goes OK. (that being said, if one of them has failed, once all is done, exit code would be > 0)
