### PR TITLE
UI: Bring back Host Path volume kind for local platform

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5647,9 +5647,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.32.0.tgz",
-      "integrity": "sha512-Je4YH8PwvhP70JZfgE8yWQn1/QyV8ytk+uw68ABOLyXer7g+0PxXa2JAwf9l1wH0iPQzE7ZqZOc5O+KpSipJJg==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.33.0.tgz",
+      "integrity": "sha512-4uEFDuvBhMTUuzMDmqDo5lb956TYJZNJKPvwbyEBIU9elmEZ5B9vS3VN5IdyPHOPYrRYOW7A1t5AQDL8+ZKhqw==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.32.0",
+    "iguazio.dashboard-controls": "^0.33.0",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",

--- a/pkg/dashboard/ui/src/app/app.route.js
+++ b/pkg/dashboard/ui/src/app/app.route.js
@@ -76,8 +76,8 @@
                 }
             })
             .state('app.project', {
-                abstract: true,
                 url: 'projects/:projectId',
+                redirectTo: 'app.project.functions',
                 views: {
                     main: {
                         template: '<ncl-project></ncl-project>'


### PR DESCRIPTION
- **Breadcrumbs**:
  - Widened dropdown menu to allow about 10 more characters and add a tooltip with the value in full
    Before:
    ![image](https://user-images.githubusercontent.com/13918850/107799369-fe452180-6d65-11eb-9ffb-bf55c28ab8c5.png)
    After:
    ![image](https://user-images.githubusercontent.com/13918850/107799382-01d8a880-6d66-11eb-98b1-14cd0c255e7f.png)
    ![image](https://user-images.githubusercontent.com/13918850/107799391-03a26c00-6d66-11eb-8b87-9825a9a74344.png)
  - Clicking on the project-name breadcrumb will now go to “Project” screen (URL path: `/projects/{project}`) instead of directly to “Functions” tab in “Projects” screen (URL path `/projects/{project}/functions`):
    - In Nuclio open-source it will enter the default nested tab, which is currently “Functions”, so there is no impact.
    - It allows other consumers of Nuclio UI to redirect to an external project screen.
- Function › Configuration › Volumes: brought back “Host Path” volume kind
  ![image](https://user-images.githubusercontent.com/13918850/108244233-a76d8c80-7157-11eb-8d63-fc7f00af8772.png)
  - Added read-only checkbox to host-path volumes.
    ![image](https://user-images.githubusercontent.com/13918850/108244246-ab99aa00-7157-11eb-966a-8133108e494d.png)
  - For local platform: host path is the only kind available.
    ![image](https://user-images.githubusercontent.com/13918850/108244265-b2c0b800-7157-11eb-8716-8d39d1250805.png)
  - For K8s platform: all kinds besides host path are available.
    ![image](https://user-images.githubusercontent.com/13918850/108244257-afc5c780-7157-11eb-8c5b-538394449270.png)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/1211