### PR TITLE
Enable function container healthiness check by default for local platform

### DIFF
--- a/pkg/nuctl/command/nuctl.go
+++ b/pkg/nuctl/command/nuctl.go
@@ -116,6 +116,10 @@ func (rc *RootCommandeer) initialize() error {
 
 	rc.platformConfiguration.Kube.KubeConfigPath = rc.KubeconfigPath
 
+	// do not let nuctl monitor function containers
+	// nuctl is a CLI tool, to enable function container healthiness, use Nuclio dashboard
+	rc.platformConfiguration.Local.FunctionContainersHealthinessEnabled = false
+
 	// ask the factory to create the appropriate platform
 	// TODO: as more platforms are supported, i imagine the last argument will be to some
 	// sort of configuration provider interface

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -47,13 +47,10 @@ import (
 
 type Platform struct {
 	*abstract.Platform
-	cmdRunner                             cmdrunner.CmdRunner
-	dockerClient                          dockerclient.Client
-	localStore                            *store
-	defaultFunctionMountMode              FunctionMountMode
-	functionContainersHealthinessEnabled  bool
-	functionContainersHealthinessTimeout  time.Duration
-	functionContainersHealthinessInterval time.Duration
+	cmdRunner                cmdrunner.CmdRunner
+	dockerClient             dockerclient.Client
+	localStore               *store
+	defaultFunctionMountMode FunctionMountMode
 }
 
 const Mib = 1048576
@@ -72,11 +69,6 @@ func NewPlatform(parentLogger logger.Logger,
 
 	// init platform
 	newPlatform.Platform = newAbstractPlatform
-
-	// function containers healthiness check is disabled by default
-	newPlatform.functionContainersHealthinessEnabled = common.GetEnvOrDefaultBool("NUCLIO_CHECK_FUNCTION_CONTAINERS_HEALTHINESS", true)
-	newPlatform.functionContainersHealthinessTimeout = time.Second * 5
-	newPlatform.functionContainersHealthinessInterval = time.Second * 30
 
 	// create a command runner
 	if newPlatform.cmdRunner, err = cmdrunner.NewShellRunner(newPlatform.Logger); err != nil {
@@ -99,10 +91,10 @@ func NewPlatform(parentLogger logger.Logger,
 	}
 
 	// ignite goroutine to check function container healthiness
-	if newPlatform.functionContainersHealthinessEnabled {
+	if newPlatform.Config.Local.FunctionContainersHealthinessEnabled {
 		newPlatform.Logger.DebugWith("Igniting container healthiness validator")
 		go func(newPlatform *Platform) {
-			uptimeTicker := time.NewTicker(newPlatform.functionContainersHealthinessInterval)
+			uptimeTicker := time.NewTicker(newPlatform.Config.Local.FunctionContainersHealthinessInterval)
 			for range uptimeTicker.C {
 				newPlatform.ValidateFunctionContainersHealthiness()
 			}
@@ -923,7 +915,7 @@ func (p *Platform) deletePreviousContainers(createFunctionOptions *platform.Crea
 
 func (p *Platform) checkAndSetFunctionUnhealthy(containerID string, function platform.Function) error {
 	if err := p.dockerClient.AwaitContainerHealth(containerID,
-		&p.functionContainersHealthinessTimeout); err != nil {
+		&p.Config.Local.FunctionContainersHealthinessTimeout); err != nil {
 		return p.setFunctionUnhealthy(function)
 	}
 	return nil
@@ -951,7 +943,7 @@ func (p *Platform) setFunctionUnhealthy(function platform.Function) error {
 
 func (p *Platform) checkAndSetFunctionHealthy(containerID string, function platform.Function) error {
 	if err := p.dockerClient.AwaitContainerHealth(containerID,
-		&p.functionContainersHealthinessTimeout); err != nil {
+		&p.Config.Local.FunctionContainersHealthinessTimeout); err != nil {
 		return errors.Wrapf(err, "Failed to ensure the health of container ID %s", containerID)
 	}
 	functionStatus := function.GetStatus()

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -74,7 +74,7 @@ func NewPlatform(parentLogger logger.Logger,
 	newPlatform.Platform = newAbstractPlatform
 
 	// function containers healthiness check is disabled by default
-	newPlatform.functionContainersHealthinessEnabled = common.GetEnvOrDefaultBool("NUCLIO_CHECK_FUNCTION_CONTAINERS_HEALTHINESS", false)
+	newPlatform.functionContainersHealthinessEnabled = common.GetEnvOrDefaultBool("NUCLIO_CHECK_FUNCTION_CONTAINERS_HEALTHINESS", true)
 	newPlatform.functionContainersHealthinessTimeout = time.Second * 5
 	newPlatform.functionContainersHealthinessInterval = time.Second * 30
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -18,7 +18,6 @@ package platformconfig
 
 import (
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -166,16 +165,6 @@ func (config *Config) enrichLocalPlatform() {
 	case "false":
 		config.Local.FunctionContainersHealthinessEnabled = false
 	case "true":
-		config.Local.FunctionContainersHealthinessEnabled = true
-	}
-
-	// if set via envvar, override given configuration
-	switch value := strings.ToLower(os.Getenv("NUCLIO_CHECK_FUNCTION_CONTAINERS_HEALTHINESS")); value {
-	case "false", "true":
-		config.Local.FunctionContainersHealthinessEnabled, _ = strconv.ParseBool(value)
-	default:
-
-		// enable by default
 		config.Local.FunctionContainersHealthinessEnabled = true
 	}
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -18,6 +18,9 @@ package platformconfig
 
 import (
 	"os"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
@@ -37,6 +40,7 @@ type Config struct {
 	FunctionAugmentedConfigs []LabelSelectorAndConfig     `json:"functionAugmentedConfigs,omitempty"`
 	IngressConfig            IngressConfig                `json:"ingressConfig,omitempty"`
 	Kube                     PlatformKubeConfig           `json:"kube,omitempty"`
+	Local                    PlatformLocalConfig          `json:"local,omitempty"`
 	ImageRegistryOverrides   ImageRegistryOverridesConfig `json:"imageRegistryOverrides,omitempty"`
 
 	ContainerBuilderConfiguration *containerimagebuilderpusher.ContainerBuilderConfiguration `json:"containerBuilderConfiguration,omitempty"`
@@ -62,7 +66,11 @@ func NewPlatformConfig(configurationPath string) (*Config, error) {
 		config.Kind = "local"
 	}
 
+	// enrich local platform configuration
+	config.enrichLocalPlatform()
+
 	// default cron trigger creation mode to processor
+	// TODO: move under `config.Kube`
 	if config.CronTriggerCreationMode == "" {
 		config.CronTriggerCreationMode = ProcessorCronTriggerCreationMode
 	}
@@ -149,4 +157,33 @@ func (config *Config) getLoggerSinksWithLevel(loggerSinkBindings []LoggerSinkBin
 	}
 
 	return result, nil
+}
+
+func (config *Config) enrichLocalPlatform() {
+
+	// if set via envvar, override given configuration
+	switch strings.ToLower(os.Getenv("NUCLIO_CHECK_FUNCTION_CONTAINERS_HEALTHINESS")) {
+	case "false":
+		config.Local.FunctionContainersHealthinessEnabled = false
+	case "true":
+		config.Local.FunctionContainersHealthinessEnabled = true
+	}
+
+	// if set via envvar, override given configuration
+	switch value := strings.ToLower(os.Getenv("NUCLIO_CHECK_FUNCTION_CONTAINERS_HEALTHINESS")); value {
+	case "false", "true":
+		config.Local.FunctionContainersHealthinessEnabled, _ = strconv.ParseBool(value)
+	default:
+
+		// enable by default
+		config.Local.FunctionContainersHealthinessEnabled = true
+	}
+
+	if config.Local.FunctionContainersHealthinessInterval == 0 {
+		config.Local.FunctionContainersHealthinessInterval = time.Second * 30
+	}
+
+	if config.Local.FunctionContainersHealthinessTimeout == 0 {
+		config.Local.FunctionContainersHealthinessTimeout = time.Second * 5
+	}
 }

--- a/pkg/platformconfig/reader.go
+++ b/pkg/platformconfig/reader.go
@@ -49,6 +49,9 @@ func (r *Reader) ReadFileOrDefault(configurationPath string) (*Config, error) {
 		return r.GetDefaultConfiguration(), nil
 	}
 
+	// close after
+	defer platformConfigurationFile.Close() // nolint: errcheck
+
 	if err := r.Read(platformConfigurationFile, "yaml", &platformConfiguration); err != nil {
 		return nil, errors.Wrap(err, "Failed to read configuration file")
 	}

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package platformconfig
 
 import (
+	"time"
+
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -104,6 +106,12 @@ type PlatformKubeConfig struct {
 
 	// TODO: Move IngressConfig here
 	DefaultServiceType corev1.ServiceType `json:"defaultServiceType,omitempty"`
+}
+
+type PlatformLocalConfig struct {
+	FunctionContainersHealthinessEnabled  bool
+	FunctionContainersHealthinessTimeout  time.Duration
+	FunctionContainersHealthinessInterval time.Duration
 }
 
 type ImageRegistryOverridesConfig struct {


### PR DESCRIPTION
It has been asked a lot by the open-source community and there is no good reason why not to allow it by default.
The result of this change would help reflecting whether a function is healthy or not.
