### PR TITLE
Support runtime specific build arguments

### DIFF
--- a/docs/tasks/configuring-a-platform.md
+++ b/docs/tasks/configuring-a-platform.md
@@ -192,3 +192,14 @@ cronTriggerCreationMode: "kube"
 
 For more information, see the [Cron-trigger reference](/docs/reference/triggers/cron.md).
 
+<a id="runtime"></a>
+### Runtime (`runtime`)
+
+The `runtime` sections allows you to configure various runtime related parameters. 
+For example to define custom PyPI repository, add the following section:
+```yaml
+  runtime:
+    python:
+      buildArgs:
+        PIP_INDEX_URL: "https://test.pypi.org/simple"
+```

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -195,6 +195,10 @@ crd:
   create: true
 
 platform: {}
+#  runtime:
+#    python:
+#      buildArgs:
+#        PIP_INDEX_URL: "https://test.pypi.org/simple"
 #   logger:
 #     sinks:
 #       myHumanReadableStdout:

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -221,6 +221,7 @@ type Build struct {
 	Timestamp           int64                  `json:"timestamp,omitempty"`
 	BuildTimeoutSeconds *int64                 `json:"buildTimeoutSeconds,omitempty"`
 	Mode                BuildMode              `json:"mode,omitempty"`
+	Args                map[string]string      `json:"args,omitempty"`
 }
 
 // Spec holds all parameters related to a function's configuration

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -633,6 +633,11 @@ func (ap *Platform) GetContainerBuilderKind() string {
 	return ap.ContainerBuilder.GetKind()
 }
 
+// GetRuntimeBuildArgs returns the runtime specific build arguments
+func (ap *Platform) GetRuntimeBuildArgs(runtime runtime.Runtime) map[string]string {
+	return runtime.GetRuntimeBuildArgs(ap.Config.Runtime)
+}
+
 func (ap *Platform) functionBuildRequired(functionConfig *functionconfig.Config) (bool, error) {
 
 	// if neverBuild was passed explicitly don't build

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -108,6 +108,11 @@ func (mp *Platform) GetProjects(getProjectsOptions *platform.GetProjectsOptions)
 	return args.Get(0).([]platform.Project), args.Error(1)
 }
 
+func (mp *Platform) GetRuntimeBuildArgs(runtime runtime.Runtime) map[string]string {
+	args := mp.Called()
+	return args.Get(0).(map[string]string)
+}
+
 //
 // API Gateway
 //

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -182,4 +182,7 @@ type Platform interface {
 
 	// GetContainerBuilderKind returns the container-builder kind
 	GetContainerBuilderKind() string
+
+	// GetRuntimeBuildArgs returns the runtime specific build arguments
+	GetRuntimeBuildArgs(runtime runtime.Runtime) map[string]string
 }

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/runtimeconfig"
 
 	"github.com/nuclio/errors"
 )
@@ -41,6 +42,7 @@ type Config struct {
 	Kube                     PlatformKubeConfig           `json:"kube,omitempty"`
 	Local                    PlatformLocalConfig          `json:"local,omitempty"`
 	ImageRegistryOverrides   ImageRegistryOverridesConfig `json:"imageRegistryOverrides,omitempty"`
+	Runtime                  *runtimeconfig.Config        `json:"runtime,omitempty"`
 
 	ContainerBuilderConfiguration *containerimagebuilderpusher.ContainerBuilderConfiguration `json:"containerBuilderConfiguration,omitempty"`
 }

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -310,7 +310,8 @@ func (b *Builder) GenerateDockerfileContents(baseImage string,
 	onbuildArtifacts []runtime.Artifact,
 	imageArtifactPaths map[string]string,
 	directives map[string][]functionconfig.Directive,
-	healthCheckRequired bool) (string, error) {
+	healthCheckRequired bool,
+	buildArgs map[string]string) (string, error) {
 
 	// now that all artifacts are in the artifacts directory, we can craft a Dockerfile
 	dockerfileTemplateContents := `# Multistage builds
@@ -321,6 +322,10 @@ func (b *Builder) GenerateDockerfileContents(baseImage string,
 
 # From the base image
 FROM {{ .BaseImage }}
+
+{{ range $key, $value := .BuildArgs }}
+ARG {{ $key }}={{ $value }}
+{{ end }}
 
 # Old(er) Docker support - must use all build args
 ARG NUCLIO_LABEL
@@ -383,6 +388,7 @@ CMD [ "processor" ]
 		"PreCopyDirectives":    directives["preCopy"],
 		"PostCopyDirectives":   directives["postCopy"],
 		"HealthcheckRequired":  healthCheckRequired,
+		"BuildArgs":            buildArgs,
 	})
 
 	if err != nil {
@@ -1197,6 +1203,9 @@ func (b *Builder) getRuntimeProcessorDockerfileInfo(baseImageRegistry string, on
 		return nil, errors.Wrap(err, "Failed to get processor Dockerfile info")
 	}
 
+	// get docker file building arguments
+	processorDockerfileInfo.BuildArgs = b.getDockerFileBuildArgs()
+
 	// get directives
 	directives := b.options.FunctionConfig.Spec.Build.Directives
 
@@ -1220,7 +1229,8 @@ func (b *Builder) getRuntimeProcessorDockerfileInfo(baseImageRegistry string, on
 		processorDockerfileInfo.OnbuildArtifacts,
 		processorDockerfileInfo.ImageArtifactPaths,
 		directives,
-		b.platform.GetHealthCheckMode() == platform.HealthCheckModeInternalClient)
+		b.platform.GetHealthCheckMode() == platform.HealthCheckModeInternalClient,
+		processorDockerfileInfo.BuildArgs)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to generate docker file content")
@@ -1339,6 +1349,25 @@ func (b *Builder) getProcessorDockerfileOnbuildImage(runtimeDefaultOnbuildImage 
 	}
 
 	return runtimeDefaultOnbuildImage, nil
+}
+
+func (b *Builder) getDockerFileBuildArgs() map[string]string {
+
+	// Get platform build args for our runtime
+	buildArgs := b.platform.GetRuntimeBuildArgs(b.runtime)
+
+	// Enrich build args with function specific args
+	for key, value := range b.options.FunctionConfig.Spec.Build.Args {
+		if len(value) > 0 {
+			buildArgs[key] = value
+		} else {
+
+			// value is empty, remote this arg
+			delete(buildArgs, key)
+		}
+	}
+
+	return buildArgs
 }
 
 func (b *Builder) getBuildArgs() map[string]string {

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
+	"github.com/nuclio/nuclio/pkg/runtimeconfig"
 )
 
 type python struct {
@@ -119,4 +120,12 @@ func (p *python) GetProcessorDockerfileInfo(onbuildImageRegistry string) (*runti
 	}
 
 	return &processorDockerfileInfo, nil
+}
+
+// GetBuildArgs returns building arguments
+func (p *python) GetRuntimeBuildArgs(runtimeConfig *runtimeconfig.Config) map[string]string {
+	if runtimeConfig != nil && runtimeConfig.Python != nil {
+		return runtimeConfig.Python.BuildArgs
+	}
+	return p.AbstractRuntime.GetRuntimeBuildArgs(runtimeConfig)
 }

--- a/pkg/processor/build/runtime/python/test/python_test.go
+++ b/pkg/processor/build/runtime/python/test/python_test.go
@@ -20,10 +20,16 @@ limitations under the License.
 package test
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
+	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime/test/suite"
+	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
+	"github.com/nuclio/nuclio/pkg/runtimeconfig"
 
+	"github.com/nuclio/errors"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -38,6 +44,83 @@ func (suite *TestSuite) SetupSuite() {
 	suite.TestSuite.RuntimeSuite = suite
 	suite.TestSuite.ArchivePattern = "python"
 	suite.Runtime = suite.runtime
+}
+
+func (suite *TestSuite) TestBuildWithBuildArgs() {
+	createFunctionOptions := suite.GetDeployOptions("func-with-build-args",
+		suite.GetFunctionPath(suite.GetTestFunctionsDir(), "common", "empty", "python"))
+	createFunctionOptions.FunctionConfig.Spec.Handler = "empty:handler"
+
+	// Configure custom pypi repository
+	pypiRepositoryURL := "https://test.pypi.org/simple"
+	runtimePlatformConfigurationCopy := suite.PlatformConfiguration.Runtime
+	suite.PlatformConfiguration.Runtime = &runtimeconfig.Config{
+		Python: &runtimeconfig.Python{
+			BuildArgs: map[string]string{
+				"PIP_INDEX_URL": pypiRepositoryURL,
+			},
+		},
+	}
+	defer func() {
+
+		// HACK - reset runtime platform configuration
+		// to avoid platform configuration effecting following tests
+		// NOTE: on >= 1.6.0 platform configuration would be re-initiated per test case and not per suite.
+		suite.PlatformConfiguration.Runtime = runtimePlatformConfigurationCopy
+	}()
+
+	// Try to deploy some non-existing package.
+	// The deployment will fail but if custom PyPI configuration is successful
+	// we should see "Looking in indexes: XXX" message in the logs
+	createFunctionOptions.FunctionConfig.Spec.Build.Commands = []string{"pip install non-existing-package"}
+	suite.PopulateDeployOptions(createFunctionOptions)
+	_, err := suite.Platform.CreateFunction(createFunctionOptions)
+	suite.Assert().NotNil(err)
+
+	// delete leftovers
+	defer suite.Platform.DeleteFunction(&platform.DeleteFunctionOptions{ // nolint: errcheck
+		FunctionConfig: createFunctionOptions.FunctionConfig,
+	})
+	stackTrace := errors.GetErrorStackString(err, 10)
+	suite.Assert().Contains(stackTrace, fmt.Sprintf("Looking in indexes: %s", pypiRepositoryURL))
+}
+
+func (suite *TestSuite) TestBuildWithBuildArgsExtended() {
+	createFunctionOptions := suite.GetDeployOptions("func-with-build-args-extended",
+		suite.GetFunctionPath(suite.GetTestFunctionsDir(), "common", "empty", "python"))
+	createFunctionOptions.FunctionConfig.Spec.Handler = "empty:handler"
+	createFunctionOptions.FunctionConfig.Spec.Build.Commands = []string{"pip install adbuzdugan"}
+
+	// Create a copy of function options since it's modified during deployment
+	createFunctionOptionsOriginal := *createFunctionOptions
+
+	// Sanity, verify deployment attempt without custom pypi repository fails
+	suite.DeployFunctionAndExpectError(createFunctionOptions, "Failed to deploy function")
+
+	// Configure custom pypi repository and re-deploy (should succeed)
+	runtimePlatformConfigurationCopy := suite.PlatformConfiguration.Runtime
+	suite.PlatformConfiguration.Runtime = &runtimeconfig.Config{
+		Python: &runtimeconfig.Python{
+			BuildArgs: map[string]string{
+				"PIP_INDEX_URL": "https://test.pypi.org/simple",
+			},
+		},
+	}
+
+	defer func() {
+
+		// HACK - reset runtime platform configuration
+		// to avoid platform configuration effecting following tests
+		// NOTE: on >= 1.6.0 platform configuration would be re-initiated per test case and not per suite.
+		suite.PlatformConfiguration.Runtime = runtimePlatformConfigurationCopy
+	}()
+
+	expectedStatusCode := http.StatusOK
+	suite.DeployFunctionAndRequest(&createFunctionOptionsOriginal,
+		&httpsuite.Request{
+			RequestMethod:              "POST",
+			ExpectedResponseStatusCode: &expectedStatusCode,
+		})
 }
 
 func (suite *TestSuite) GetFunctionInfo(functionName string) buildsuite.FunctionInfo {

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/runtimeconfig"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -38,6 +39,7 @@ type ProcessorDockerfileInfo struct {
 	Directives         map[string][]functionconfig.Directive
 	DockerfileContents string
 	DockerfilePath     string
+	BuildArgs          map[string]string
 }
 
 type Artifact struct {
@@ -68,6 +70,9 @@ type Runtime interface {
 
 	// GetOverrideImageRegistryFromMap returns an override image for the runtime from the given map
 	GetOverrideImageRegistryFromMap(map[string]string) string
+
+	// GetRuntimeBuildArgs returns building arguments
+	GetRuntimeBuildArgs(runtimeConfig *runtimeconfig.Config) map[string]string
 }
 
 type Factory interface {
@@ -171,4 +176,8 @@ func (ar *AbstractRuntime) GetOverrideImageRegistryFromMap(imagesOverrideMap map
 
 	// no override found
 	return ""
+}
+
+func (ar *AbstractRuntime) GetRuntimeBuildArgs(runtimeConfig *runtimeconfig.Config) map[string]string {
+	return map[string]string{}
 }

--- a/pkg/processor/build/test/build_test.go
+++ b/pkg/processor/build/test/build_test.go
@@ -861,7 +861,8 @@ func (suite *testSuite) generateDockerfileAndVerify(builder *build.Builder,
 		dockerfileInfo.OnbuildArtifacts,
 		dockerfileInfo.ImageArtifactPaths,
 		dockerfileInfo.Directives,
-		healthCheckRequired)
+		healthCheckRequired,
+		dockerfileInfo.BuildArgs)
 
 	dockerfileContents = common.RemoveEmptyLines(dockerfileContents)
 

--- a/pkg/processor/trigger/http/test/suite/suite.go
+++ b/pkg/processor/trigger/http/test/suite/suite.go
@@ -131,6 +131,7 @@ func (suite *TestSuite) DeployFunctionAndRequests(createFunctionOptions *platfor
 	requests []*Request) *platform.CreateFunctionResult {
 
 	return suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+		suite.Require().NotNil(deployResult)
 		for _, request := range requests {
 			request.Enrich(deployResult)
 			if !suite.SendRequestVerifyResponse(request) {

--- a/pkg/runtimeconfig/runtimeconfig.go
+++ b/pkg/runtimeconfig/runtimeconfig.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtimeconfig
+
+type Config struct {
+	Python *Python `json:"python,omitempty"`
+}
+
+type Python struct {
+	BuildArgs map[string]string `json:"buildArgs,omitempty"`
+}


### PR DESCRIPTION
Forward porting #2109  to development (, >=1.6.x)

Allowing us to add per-runtime platform configuration which sets build arguments during function image creations.

E.g.: to ensure all python functions are using pre-defined pypi server, simply pass the following platform configuration


```
platformConfiguration:
  ...
  runtime:
    python:
      buildArgs:
        PIP_INDEX_URL: "https://my-pypi-server.com"
```

