### PR TITLE
Helm chart - support dashboard nodePort from global for mlrun-kit [1.5.x backport]

### DIFF
--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.7.20
+version: 0.7.21
 appVersion: 1.5.17
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.7.21
+version: 0.7.20
 appVersion: 1.5.17
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/templates/_helpers.tpl
+++ b/hack/k8s/helm/nuclio/templates/_helpers.tpl
@@ -89,3 +89,13 @@ NOTE: make sure to not quote here, because an empty string is false, but a quote
 {{- define "nuclio.platformConfigName" -}}
 {{- printf "%s-platform-config" (include "nuclio.fullName" .) | trunc 63 -}}
 {{- end -}}
+
+{{- define "nuclio.dashboard.nodePort" -}}
+{{- if .Values.dashboard.nodePort -}}
+{{- .Values.dashboard.nodePort -}}
+{{- else if .Values.global.nuclio.dashboard.nodePort -}}
+{{- .Values.global.nuclio.dashboard.nodePort -}}
+{{- else -}}
+{{- print "" -}}
+{{- end -}}
+{{- end -}}

--- a/hack/k8s/helm/nuclio/templates/service/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/service/dashboard.yaml
@@ -26,14 +26,14 @@ metadata:
 spec:
   selector:
     nuclio.io/name: {{ template "nuclio.dashboardName" . }}
-{{- if .Values.dashboard.nodePort }}
+{{- if (include "nuclio.dashboard.nodePort" .) }}
   type: NodePort
 {{- end }}
   ports:
   - name: admin
     port: 8070
     protocol: TCP
-{{- if .Values.dashboard.nodePort }}
-    nodePort: {{ .Values.dashboard.nodePort }}
+{{- if (include "nuclio.dashboard.nodePort" .) }}
+    nodePort: {{ template "nuclio.dashboard.nodePort" . }}
 {{- end }}
 {{- end }}

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -229,6 +229,10 @@ platform: {}
 
 # global is a stanza that is used if this is used as a subchart. Ignore otherwise
 global:
+  externalHostAddress:
   registry:
     url:
     secretName:
+  nuclio:
+    dashboard:
+      nodePort:


### PR DESCRIPTION
Backporting https://github.com/nuclio/nuclio/pull/2103 to 1.5.x (part of 0.7.19 chart)
This Change will be followed by re-releasing 0.7.20 chart (current 0.7.20 missing contents from 0.7.19)