### PR TITLE
Lock CI to go version 1.14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: "^1.14.0"
+        go-version: "1.14"
 
     - uses: actions/cache@v2
       with:
@@ -61,7 +61,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: "^1.14.0"
+        go-version: "1.14"
 
     - uses: actions/cache@v2
       with:
@@ -82,7 +82,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: "^1.14.0"
+        go-version: "1.14"
 
     - name: Build
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: "^1.14.0"
+        go-version: "1.14"
 
     # since github-actions gives us 14G only, and fill it up with some garbage
     # we will free up some space for us (~2GB)


### PR DESCRIPTION
Lock is done due to performance regression on Nuclio unit test `TestStaticAllocatorStress ` for go 1.16.

from UT and testings, it seems like it takes *more* than 30 seconds to consume messages while on 1.14 it takes ~7 seconds.
