### PR TITLE
Add git code entry type (not including Azure Devops)

### DIFF
--- a/docs/reference/function-configuration/code-entry-types.md
+++ b/docs/reference/function-configuration/code-entry-types.md
@@ -158,12 +158,12 @@ Set the [`spec.build.codeEntryType`](/docs/reference/function-configuration/func
   - `codeEntryAttributes` &mdash;
 
       // must use one of the following as git reference
-      - `gitBranch` (dashboard: **Branch**) &mdash; the Git repository branch from which to download the function code.
-      - `gitTag` (dashboard: **Tag**) &mdash; the Git repository tag from which to download the function code.
-      - `gitReference` (dashboard: **Reference**) &mdash; the Git repository reference from which to download the function code.
+      - `branch` (dashboard: **Branch**) &mdash; the Git repository branch from which to download the function code.
+      - `tag` (dashboard: **Tag**) &mdash; the Git repository tag from which to download the function code.
+      - `reference` (dashboard: **Reference**) &mdash; the Git repository reference from which to download the function code.
 
-      - `gitUsername` (dashboard: **Username**) (Optional) Git username
-      - `gitPassword` (dashboard: **Password**) (Optional) Git password
+      - `username` (dashboard: **Username**) (Optional) Git username
+      - `password` (dashboard: **Password**) (Optional) Git password
       - `workDir` (dashboard: **Work directory**) (Optional) &mdash; the relative path to the function-code directory within the configured repository.
       The default work directory is the root directory of the git repository (`"/"`).
 
@@ -178,16 +178,15 @@ spec:
   runtime: golang
   build:
     codeEntryType: "git"
-    path: "https://bitbucket.org/saharel/test-nuclio-cet.git"
+    path: "https://bitbucket.org/<my-user>/<my-repo>"
     codeEntryAttributes:
       workDir: "/go-function"
-      gitBranch: "go-func"
+      branch: "go-func"
 
       # Uncomment in case of a private repository
       #
-      # gitCredentials:
-      #  accessKey: "myaccesskey"
       #  username: "myusername"
+      #  password: "mypassword"
 ```
 
 Using Tag:
@@ -198,10 +197,10 @@ spec:
   runtime: golang
   build:
     codeEntryType: "git"
-    path: "https://bitbucket.org/saharel/test-nuclio-cet.git"
+    path: "https://bitbucket.org/<my-user>/<my-repo>"
     codeEntryAttributes:
       workDir: "/go-function"
-      gitTag: "0.0.1"
+      tag: "0.0.1"
 ```
 
 Using Full Reference:
@@ -212,10 +211,10 @@ spec:
   runtime: golang
   build:
     codeEntryType: "git"
-    path: "https://bitbucket.org/saharel/test-nuclio-cet.git"
+    path: "https://bitbucket.org/<my-user>/<my-repo>"
     codeEntryAttributes:
       workDir: "/go-function"
-      gitReference: "refs/heads/go-func"
+      reference: "refs/heads/go-func"
 ```
 
 <a id="code-entry-type-github"></a>

--- a/docs/reference/function-configuration/code-entry-types.md
+++ b/docs/reference/function-configuration/code-entry-types.md
@@ -43,7 +43,7 @@ The code-entry type is determined by using the following processing logic:
 
 2. If [`spec.build.functionSourceCode`](/docs/reference/function-configuration.md#spec.build.functionSourceCode) is set (and `spec.image` isn't set), the implied code-entry type is [encoded source-code string](#code-entry-type-sourcecode) (`sourceCode`) and the function is built from the configured source code. The `spec.build.codeEntryType` and `spec.build.path` fields are ignored.
 
-3. If [`spec.build.codeEntryType`](/docs/reference/function-configuration.md#spec.build.codeEntryType) is set (and `spec.image` and `spec.build.functionSourceCode` aren't set), the value of the code-entry field determines the [external function-code code-entry type](#external-func-code-entry-types) (`archive`, `github`, or `s3`).
+3. If [`spec.build.codeEntryType`](/docs/reference/function-configuration/function-configuration-reference.md#spec.build.codeEntryType) is set (and `spec.image` and `spec.build.functionSourceCode` aren't set), the value of the code-entry field determines the [external function-code code-entry type](#external-func-code-entry-types) (`archive`, `github`, or `s3`).
 
 4. If [`spec.build.path`](/docs/reference/function-configuration.md#spec.build.path) is set (and `spec.image`, `spec.build.functionSourceCode`, and `spec.build.codeEntryType` aren't set), the implied code-entry type is [source-code-file](#code-entry-type-codefile) and the function is built from the configured source code.
 
@@ -127,7 +127,7 @@ spec:
 <a id="external-func-code-entry-types"></a>
 ## External function-code entry types
 
-Set the [`spec.build.codeEntryType`](/docs/reference/function-configuration.md#spec.build.codeEntryType) function-configuration field to one of the following code-entry types to download the function code from the respective external source:
+Set the [`spec.build.codeEntryType`](/docs/reference/function-configuration/function-configuration-reference.md#spec.build.codeEntryType) function-configuration field to one of the following code-entry types to download the function code from the respective external source:
 
 - `github` &mdash; download the code from a GitHub repository. See [GitHub code-entry type (`github`)](#code-entry-type-github).
 - `archive` &mdash; download the code as an archive file from an Iguazio Data Science Platform data container (authenticated) or from any URL that doesn't require download authentication. See [Archive-file code-entry type (`archive`)](#code-entry-type-archive).
@@ -140,7 +140,7 @@ Additional information for performing the download &mdash; such as the download 
 > - <a id="archive-file-formats"></a>The `archive` and `s3` code-entry types support the following archive-file formats: **\*.jar**, **\*.rar**, **\*.tar**, **\*.tar.bz2**, **\*.tar.lz4**, **\*.tar.gz**, **\*.tar.sz**, **\*.tar.xz**, **\*.zip**
 > - The downloaded code files are saved and can be used by the function handler.
 
-> **Dashboard Note:** To configure an external function-code source from the dashboard, select the relevant code-entry type &mdash; `Archive`, `GitHub`, or `S3` &mdash; from the **Code entry type** list.
+> **Dashboard Note:** To configure an external function-code source from the dashboard, select the relevant code-entry type &mdash; `Archive`, `Git`, `GitHub`, or `S3` &mdash; from the **Code entry type** list.
 
 The downloaded function code can optionally contain a **function.yaml** file with function configuration for enriching the original configuration (in the configuration file that sets the code-entry type) according to the following merge strategy:
 
@@ -148,15 +148,85 @@ The downloaded function code can optionally contain a **function.yaml** file wit
 - List and map field values &mdash; such as `meta.labels` and `spec.env` &mdash;are merged by adding any values that are set only in the downloaded configuration to the values that are set in the original configuration.
 - In case of a conflict &mdash; i.e., if the original and downloaded configurations set different values for the same element &mdash; the original configuration takes precedence and the value in the downloaded configuration is ignored.
 
+<a id="code-entry-type-git"></a>
+### Git code-entry type (`git`)
+
+Set the [`spec.build.codeEntryType`](/docs/reference/function-configuration/function-configuration-reference.md#spec.build.codeEntryType) function-configuration field to `git` (dashboard: **Code entry type** = `Git`) to clone the function code from a Git repository. The following configuration fields provide additional information for performing the cloning:
+
+- `spec.build` &mdash;
+  - `path` (dashboard: **URL**) (Required) &mdash; the URL of the Git repository that contains the function code.
+  - `codeEntryAttributes` &mdash;
+
+      // must use one of the following as git reference
+      - `gitBranch` (dashboard: **Branch**) &mdash; the Git repository branch from which to download the function code.
+      - `gitTag` (dashboard: **Tag**) &mdash; the Git repository tag from which to download the function code.
+      - `gitReference` (dashboard: **Reference**) &mdash; the Git repository reference from which to download the function code.
+
+      - `gitUsername` (dashboard: **Username**) (Optional) Git username
+      - `gitPassword` (dashboard: **Password**) (Optional) Git password
+      - `workDir` (dashboard: **Work directory**) (Optional) &mdash; the relative path to the function-code directory within the configured repository.
+      The default work directory is the root directory of the git repository (`"/"`).
+
+<a id="code-entry-type-git-example"></a>
+#### Examples
+
+Using Branch:
+```yaml
+spec:
+  description: my Go function
+  handler: main:Handler
+  runtime: golang
+  build:
+    codeEntryType: "git"
+    path: "https://bitbucket.org/saharel/test-nuclio-cet.git"
+    codeEntryAttributes:
+      workDir: "/go-function"
+      gitBranch: "go-func"
+
+      # Uncomment in case of a private repository
+      #
+      # gitCredentials:
+      #  accessKey: "myaccesskey"
+      #  username: "myusername"
+```
+
+Using Tag:
+```yaml
+spec:
+  description: my Go function
+  handler: main:Handler
+  runtime: golang
+  build:
+    codeEntryType: "git"
+    path: "https://bitbucket.org/saharel/test-nuclio-cet.git"
+    codeEntryAttributes:
+      workDir: "/go-function"
+      gitTag: "0.0.1"
+```
+
+Using Full Reference:
+```yaml
+spec:
+  description: my Go function
+  handler: main:Handler
+  runtime: golang
+  build:
+    codeEntryType: "git"
+    path: "https://bitbucket.org/saharel/test-nuclio-cet.git"
+    codeEntryAttributes:
+      workDir: "/go-function"
+      gitReference: "refs/heads/go-func"
+```
+
 <a id="code-entry-type-github"></a>
 ### GitHub code-entry type (`github`)
 
-Set the [`spec.build.codeEntryType`](/docs/reference/function-configuration.md#spec.build.codeEntryType) function-configuration field to `github` (dashboard: **Code entry type** = `GitHub`) to download the function code from a GitHub repository. The following configuration fields provide additional information for performing the download:
+Set the [`spec.build.codeEntryType`](/docs/reference/function-configuration/function-configuration-reference.md#spec.build.codeEntryType) function-configuration field to `github` (dashboard: **Code entry type** = `GitHub`) to download the function code from a GitHub repository. The following configuration fields provide additional information for performing the download:
 
 - `spec.build` &mdash;
   - `path` (dashboard: **URL**) (Required) &mdash; the URL of the GitHub repository that contains the function code.
   - `codeEntryAttributes` &mdash;
-      -  `branch` (dashboard: **Branch**) (Required) &mdash; the GitHub repository branch from which to download the function code.
+      - `branch` (dashboard: **Branch**) (Required) &mdash; the GitHub repository branch from which to download the function code.
       - `headers.Authorization` (dashboard: **Token**) (Optional) &mdash; a GitHub access token for download authentication.
       - `workDir` (dashboard: **Work directory**) (Optional) &mdash; the relative path to the function-code directory within the configured repository branch.
       The default work directory is the root directory of the GitHub repository (`"/"`).
@@ -182,7 +252,7 @@ spec:
 <a id="code-entry-type-archive"></a>
 ### Archive-file code-entry type (`archive`)
 
-Set the [`spec.build.codeEntryType`](/docs/reference/function-configuration.md#spec.build.codeEntryType) function-configuration field to `archive` (dashboard: **Code entry type** = `Archive`) to download [an archive file](#archive-file-formats) of the function code from one of the following sources:
+Set the [`spec.build.codeEntryType`](/docs/reference/function-configuration/function-configuration-reference.md#spec.build.codeEntryType) function-configuration field to `archive` (dashboard: **Code entry type** = `Archive`) to download [an archive file](#archive-file-formats) of the function code from one of the following sources:
 
 - An [Iguazio Data Science Platform](https://www.iguazio.com) ("platform") data container. Downloads from this source require user authentication.
 - Any URL that doesn't require user authentication to perform the download.
@@ -217,7 +287,7 @@ spec:
 <a id="code-entry-type-s3"></a>
 ### AWS S3 code-entry type (`s3`)
 
-Set the [`spec.build.codeEntryType`](/docs/reference/function-configuration.md#spec.build.codeEntryType) function-configuration field to `s3` (dashboard: **Code entry type** = `S3`) to download [an archive file](#archive-file-formats) of the function code from an Amazon Simple Storage Service (AWS S3) bucket. The following configuration fields provide additional information for performing the download:
+Set the [`spec.build.codeEntryType`](/docs/reference/function-configuration/function-configuration-reference.md#spec.build.codeEntryType) function-configuration field to `s3` (dashboard: **Code entry type** = `S3`) to download [an archive file](#archive-file-formats) of the function code from an Amazon Simple Storage Service (AWS S3) bucket. The following configuration fields provide additional information for performing the download:
 
 - `spec.build.codeEntryAttributes` &mdash;
   - `s3Bucket` (dashboard: **Bucket**) (Required) &mdash; the name of the S3 bucket that contains the archive file.

--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -77,7 +77,7 @@ The `spec` section contains the requirements and attributes and has the followin
 | triggers.(name).annotations | list of strings | Annotations to be assigned to the trigger, if applicable |
 | triggers.(name).workerAvailabilityTimeoutMilliseconds | int | The number of milliseconds to wait for a worker if one is not available. 0 = never wait (default: 10000, which is 10 seconds)|
 | triggers.(name).attributes | See [reference](/docs/reference/triggers) | The per-trigger attributes |
-| <a id="spec.build.path"></a>build.path | string | The URL of a GitHub repository or an archive-file that contains the function code &mdash; for the `github` or `archive` [code-entry type](#spec.build.codeEntryType) &mdash; or the URL of a function source-code file; see [Code-Entry Types](/docs/reference/function-configuration/code-entry-types.md) |
+| <a id="spec.build.path"></a>build.path | string | The URL of a GitHub repository or an archive-file that contains the function code &mdash; for the `git`, `github` or `archive` [code-entry type](#spec.build.codeEntryType) &mdash; or the URL of a function source-code file; see [Code-Entry Types](/docs/reference/function-configuration/code-entry-types.md) |
 | <a id="spec.build.functionSourceCode"></a>build.functionSourceCode | string | Base-64 encoded function source code for the `sourceCode` [code-entry type](#spec.build.codeEntryType); see [Code-Entry Types](/docs/reference/function-configuration/code-entry-types.md#code-entry-type-sourcecode) |
 | build.registry | string | The container image repository to which the built image will be pushed |
 | build.noBaseImagePull | string | Do not pull any base images when building, use local images only |
@@ -86,7 +86,7 @@ The `spec` section contains the requirements and attributes and has the followin
 | build.Commands | list of string | Commands run opaquely as part of container image build |
 | build.onbuildImage | string | The name of an "onbuild" container image from which to build the function's processor image; the name can include `{{ .Label }}` and `{{ .Arch }}` for formatting |
 | build.image | string | The name of the built container image (default: the function name) |
-| <a id="spec.build.codeEntryType"></a>build.codeEntryType | string | The function's code-entry type - `archive` \| `github` \| `image` \| `s3` \| `sourceCode`; see [Code-Entry Types](/docs/reference/function-configuration/code-entry-types.md) |
+| <a id="spec.build.codeEntryType"></a>build.codeEntryType | string | The function's code-entry type - `archive` \| `git` \| `github` \| `image` \| `s3` \| `sourceCode`; see [Code-Entry Types](/docs/reference/function-configuration/code-entry-types.md) |
 | <a id="spec.build.codeEntryAttributes"></a>build.codeEntryAttributes | See [reference](/docs/reference/function-configuration/code-entry-types.md#external-func-code-entry-types) | Code-entry attributes, which provide information for downloading the function when using the `github`, `s3`, or `archive` [code-entry type](#spec.build.codeEntryType) |
 | runRegistry | string | The container image repository from which the platform will pull the image |
 | runtimeAttributes | See [reference](/docs/reference/runtimes/) | Runtime-specific attributes |

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1580,13 +1580,13 @@ func (b *Builder) resolveGitReference() (string, error) {
 
 func (b *Builder) resolveCodeEntryAttributeAsString(attribute string) string {
 	if value, found := b.options.FunctionConfig.Spec.Build.CodeEntryAttributes[attribute]; found {
-		switch value.(type) {
+		switch typedValue := value.(type) {
 		case string:
-			return value.(string)
+			return typedValue
 		case int, int8, int16, int32, int64:
-			return fmt.Sprintf("%d", value)
-		case float64, float32:
-			return fmt.Sprintf("%f", value)
+			return fmt.Sprintf("%d", typedValue)
+		case float32, float64:
+			return fmt.Sprintf("%f", typedValue)
 		}
 	}
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1509,7 +1509,6 @@ func (b *Builder) resolveFunctionPathFromURL(functionPath string, codeEntryType 
 			return "", errors.Wrapf(err, "Failed to create temporary dir for download: %s", tempDir)
 		}
 
-		// in case this is git entry type - clone folder into tempDir
 		if codeEntryType == GitEntryType {
 			if err = b.cloneFunctionFromGit(tempDir, functionPath); err != nil {
 				return "", errors.Wrap(err, "Failed to download function from git")

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1518,8 +1518,8 @@ func (b *Builder) resolveFunctionPathFromURL(functionPath string, codeEntryType 
 		}
 
 		isArchive := codeEntryType == S3EntryType ||
-		codeEntryType == GithubEntryType ||
-		codeEntryType == ArchiveEntryType
+			codeEntryType == GithubEntryType ||
+			codeEntryType == ArchiveEntryType
 
 		// jar is an exception - we want it to remain compressed, as our java runtime processor expects to get it
 		isArchive = isArchive && !util.IsJar(functionPath)

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1566,13 +1566,13 @@ func (b *Builder) getS3FunctionItemKey() (string, error) {
 }
 
 func (b *Builder) resolveGitReference() (string, error) {
-	if b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["gitBranch"] != "" {
+	if b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["gitBranch"] != nil {
 		return fmt.Sprintf("refs/heads/%s", b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["gitBranch"]), nil
 	}
-	if b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["gitTag"] != "" {
+	if b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["gitTag"] != nil {
 		return fmt.Sprintf("refs/tags/%s", b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["gitTag"]), nil
 	}
-	if b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["gitReference"] != "" {
+	if b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["gitReference"] != nil {
 		return b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["gitReference"].(string), nil
 	}
 

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -616,7 +616,7 @@ func (suite *testSuite) TestResolveFunctionPathS3CodeEntry() {
 
 func (suite *testSuite) TestResolveFunctionPathGitCodeEntry() {
 	for _, testCase := range []struct {
-		Name string
+		Name               string
 		BuildConfiguration functionconfig.Build
 	}{
 
@@ -649,8 +649,8 @@ func (suite *testSuite) TestResolveFunctionPathGitCodeEntry() {
 				CodeEntryType: GitEntryType,
 				Path:          "https://github.com/sahare92/test-nuclio-cet.git",
 				CodeEntryAttributes: map[string]interface{}{
-					"workDir": "go-function",
-					"gitReference":  "refs/heads/go-func",
+					"workDir":      "go-function",
+					"gitReference": "refs/heads/go-func",
 				},
 			},
 		},

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -614,7 +614,7 @@ func (suite *testSuite) TestResolveFunctionPathS3CodeEntry() {
 	suite.testResolveFunctionPathArchive(buildConfiguration, "")
 }
 
-func (suite *testSuite) TestResolveFurnctionPathGitCodeEntry() {
+func (suite *testSuite) TestResolveFunctionPathGitCodeEntry() {
 	for _, testCase := range []struct {
 		Name string
 		BuildConfiguration functionconfig.Build
@@ -660,7 +660,7 @@ func (suite *testSuite) TestResolveFurnctionPathGitCodeEntry() {
 			Name: "BitBucketBranch",
 			BuildConfiguration: functionconfig.Build{
 				CodeEntryType: GitEntryType,
-				Path:          "https://github.com/sahare92/test-nuclio-cet.git",
+				Path:          "https://bitbucket.org/saharel/test-nuclio-cet.git",
 				CodeEntryAttributes: map[string]interface{}{
 					"workDir":   "go-function",
 					"gitBranch": "go-func",
@@ -671,7 +671,7 @@ func (suite *testSuite) TestResolveFurnctionPathGitCodeEntry() {
 			Name: "BitBucketTag",
 			BuildConfiguration: functionconfig.Build{
 				CodeEntryType: GitEntryType,
-				Path:          "https://github.com/sahare92/test-nuclio-cet.git",
+				Path:          "https://bitbucket.org/saharel/test-nuclio-cet.git",
 				CodeEntryAttributes: map[string]interface{}{
 					"workDir": "go-function",
 					"gitTag":  "0.0.1",

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -614,6 +614,108 @@ func (suite *testSuite) TestResolveFunctionPathS3CodeEntry() {
 	suite.testResolveFunctionPathArchive(buildConfiguration, "")
 }
 
+func (suite *testSuite) TestResolveFurnctionPathGitCodeEntry() {
+	for _, testCase := range []struct {
+		Name string
+		BuildConfiguration functionconfig.Build
+	}{
+
+		// Github
+		{
+			Name: "GithubBranch",
+			BuildConfiguration: functionconfig.Build{
+				CodeEntryType: GitEntryType,
+				Path:          "https://github.com/sahare92/test-nuclio-cet.git",
+				CodeEntryAttributes: map[string]interface{}{
+					"workDir":   "go-function",
+					"gitBranch": "go-func",
+				},
+			},
+		},
+		{
+			Name: "GithubTag",
+			BuildConfiguration: functionconfig.Build{
+				CodeEntryType: GitEntryType,
+				Path:          "https://github.com/sahare92/test-nuclio-cet.git",
+				CodeEntryAttributes: map[string]interface{}{
+					"workDir": "go-function",
+					"gitTag":  "0.0.1",
+				},
+			},
+		},
+		{
+			Name: "GithubReference",
+			BuildConfiguration: functionconfig.Build{
+				CodeEntryType: GitEntryType,
+				Path:          "https://github.com/sahare92/test-nuclio-cet.git",
+				CodeEntryAttributes: map[string]interface{}{
+					"workDir": "go-function",
+					"gitReference":  "refs/heads/go-func",
+				},
+			},
+		},
+
+		// BitBucket
+		{
+			Name: "BitBucketBranch",
+			BuildConfiguration: functionconfig.Build{
+				CodeEntryType: GitEntryType,
+				Path:          "https://github.com/sahare92/test-nuclio-cet.git",
+				CodeEntryAttributes: map[string]interface{}{
+					"workDir":   "go-function",
+					"gitBranch": "go-func",
+				},
+			},
+		},
+		{
+			Name: "BitBucketTag",
+			BuildConfiguration: functionconfig.Build{
+				CodeEntryType: GitEntryType,
+				Path:          "https://github.com/sahare92/test-nuclio-cet.git",
+				CodeEntryAttributes: map[string]interface{}{
+					"workDir": "go-function",
+					"gitTag":  "0.0.1",
+				},
+			},
+		},
+	} {
+		suite.Run(testCase.Name, func() {
+			err := suite.builder.createTempDir()
+			suite.Require().NoError(err)
+
+			suite.builder.options.FunctionConfig.Spec.Build = testCase.BuildConfiguration
+
+			path, _, err := suite.builder.resolveFunctionPath(testCase.BuildConfiguration.Path)
+			suite.Require().NoError(err)
+
+			// make sure the path is set to the work dir inside the downloaded folder
+			destinationWorkDir := filepath.Join("/download", testCase.BuildConfiguration.CodeEntryAttributes["workDir"].(string))
+			suite.Require().Equal(suite.builder.tempDir+destinationWorkDir, path)
+
+			// get git reference as it was planted on the code inside the remote git repository
+			referenceName, err := suite.builder.resolveGitReference()
+			suite.Require().NoError(err)
+
+			// make sure our test file was downloaded correctly
+			handlerFileContents, err := ioutil.ReadFile(filepath.Join(path, "/main.go"))
+			suite.Require().Equal(fmt.Sprintf(`package main
+
+import (
+    "github.com/nuclio/nuclio-sdk-go"
+)
+
+func Handler(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
+    return "Hello from reference: %s", nil
+}
+
+`, referenceName), string(handlerFileContents))
+			suite.Require().NoError(err)
+
+			suite.builder.cleanupTempDir() // nolint: errcheck
+		})
+	}
+}
+
 // test that when `spec.build.image` is given, it is enriched correctly
 func (suite *testSuite) TestImageNameConfigurationEnrichment() {
 	suite.builder.options.FunctionConfig.Meta.Name = "name"

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -627,8 +627,8 @@ func (suite *testSuite) TestResolveFunctionPathGitCodeEntry() {
 				CodeEntryType: GitEntryType,
 				Path:          "https://github.com/sahare92/test-nuclio-cet.git",
 				CodeEntryAttributes: map[string]interface{}{
-					"workDir":   "go-function",
-					"gitBranch": "go-func",
+					"workDir": "go-function",
+					"branch":  "go-func",
 				},
 			},
 		},
@@ -639,7 +639,7 @@ func (suite *testSuite) TestResolveFunctionPathGitCodeEntry() {
 				Path:          "https://github.com/sahare92/test-nuclio-cet.git",
 				CodeEntryAttributes: map[string]interface{}{
 					"workDir": "go-function",
-					"gitTag":  "0.0.1",
+					"tag":     "0.0.1",
 				},
 			},
 		},
@@ -649,8 +649,8 @@ func (suite *testSuite) TestResolveFunctionPathGitCodeEntry() {
 				CodeEntryType: GitEntryType,
 				Path:          "https://github.com/sahare92/test-nuclio-cet.git",
 				CodeEntryAttributes: map[string]interface{}{
-					"workDir":      "go-function",
-					"gitReference": "refs/heads/go-func",
+					"workDir":   "go-function",
+					"reference": "refs/heads/go-func",
 				},
 			},
 		},
@@ -662,8 +662,8 @@ func (suite *testSuite) TestResolveFunctionPathGitCodeEntry() {
 				CodeEntryType: GitEntryType,
 				Path:          "https://bitbucket.org/saharel/test-nuclio-cet.git",
 				CodeEntryAttributes: map[string]interface{}{
-					"workDir":   "go-function",
-					"gitBranch": "go-func",
+					"workDir": "go-function",
+					"branch":  "go-func",
 				},
 			},
 		},
@@ -674,10 +674,12 @@ func (suite *testSuite) TestResolveFunctionPathGitCodeEntry() {
 				Path:          "https://bitbucket.org/saharel/test-nuclio-cet.git",
 				CodeEntryAttributes: map[string]interface{}{
 					"workDir": "go-function",
-					"gitTag":  "0.0.1",
+					"tag":     "0.0.1",
 				},
 			},
 		},
+
+		// TODO: add a test for azure-devops when it's added
 	} {
 		suite.Run(testCase.Name, func() {
 			err := suite.builder.createTempDir()


### PR DESCRIPTION
This PR introduces GitEntryType ("git") to be used as a new Code Entry Type.

New CET structure:
```
- `spec.build`
  - path - (Required) the URL of the Git repository that contains the function code
  - codeEntryAttributes

      // must use one of the following as git reference
      - gitBranch -  the Git repository branch from which to download the function code.
      - gitTag - the Git repository tag from which to download the function code.
      - gitReference - the Git repository reference from which to download the function code.

      - gitUsername - (Optional) Git username
      - gitPassword - (Optional) Git password
      - workDir - the relative path to the function-code directory within the configured repository.
      The default work directory is the root directory of the git repository (`"/"`).
```

Replacing #2104 (separated new git CET and deprecation of old GitHub CET)