### PR TITLE
nuctl docs updates - Explaining function exposure and nodePorts

### DIFF
--- a/docs/concepts/k8s/function-ingress.md
+++ b/docs/concepts/k8s/function-ingress.md
@@ -9,11 +9,15 @@
 
 ## Overview
 
-If you followed the [Getting Started with Nuclio on Kubernetes](/docs/setup/k8s/getting-started-k8s.md) or [Getting Started with Nuclio on Google Kubernetes Engine (GKE)](/docs/setup/gke/getting-started-gke.md) guide, you invoked functions using their HTTP interface with `nuctl` and the Nuclio dashboard. By default, each function deployed to Kubernetes declares a [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/) that is responsible for routing requests to the functions' HTTP trigger port. It does this using a [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport), which is a unique cluster-wide port that is assigned to the function.
+If you followed the [Getting Started with Nuclio on Kubernetes](/docs/setup/k8s/getting-started-k8s.md) or [Getting Started with Nuclio on Google Kubernetes Engine (GKE)](/docs/setup/gke/getting-started-gke.md) guide, you invoked functions using their HTTP interface with `nuctl` and the Nuclio dashboard.
+By default, each function deployed to Kubernetes declares a [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/) that is responsible for routing requests to the functions' HTTP trigger port.
+To invoke the function externally, using `nuctl`, you probably exposed your function by using a [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport), which is a unique cluster-wide port that is assigned to the function.
 
-This means that an underlying HTTP client calls `http://<your cluster IP>:<some unique port>`. You can try this out yourself: first, find out the NodePort assigned to your function, by using the `nuctl get function` command of the `nuctl` CLI or the `kubectl get svc` command of the Kubernetes CLI. Then, use curl to send an HTTP request to this port.
+This means that, if your function's HTTP trigger is configured with a [NodePort](/docs/referece/triggers/http.md#attribues.serviceType), any underlying HTTP client can call `http://<your cluster IP>:<some unique port>` to reach it.
+You can try this out yourself: first, find out the NodePort assigned to your function, by using the `nuctl get function` command of the `nuctl` CLI or the `kubectl get svc` command of the Kubernetes CLI. Then, use curl to send an HTTP request to this port.
 
-In addition to configuring a service, Nuclio creates a [Kubernetes ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for your function's HTTP trigger, with the path specified as `<function name>/latest`. However, without an ingress controller running on your cluster, this will have no effect. An Ingress controller will listen for changed ingresses and reconfigure some type of reverse proxy to route requests based on rules specified in the ingress.
+In addition to configuring a service, Nuclio can create a [Kubernetes ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for your function's HTTP trigger, with the path specified as `<function name>/latest`.
+However, without an ingress controller running on your cluster, this will have no effect. An Ingress controller will listen for changed ingresses and reconfigure some type of reverse proxy to route requests based on rules specified in the ingress resource.
 
 ## Setting up an ingress controller
 

--- a/docs/concepts/k8s/function-ingress.md
+++ b/docs/concepts/k8s/function-ingress.md
@@ -13,7 +13,7 @@ If you followed the [Getting Started with Nuclio on Kubernetes](/docs/setup/k8s/
 By default, each function deployed to Kubernetes declares a [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/) that is responsible for routing requests to the functions' HTTP trigger port.
 To invoke the function externally, using `nuctl`, you probably exposed your function by using a [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport), which is a unique cluster-wide port that is assigned to the function.
 
-This means that, if your function's HTTP trigger is configured with a [NodePort](/docs/referece/triggers/http.md#attribues.serviceType), any underlying HTTP client can call `http://<your cluster IP>:<some unique port>` to reach it.
+This means that, if your function's HTTP trigger is configured with a [NodePort](/docs/referece/triggers/http.md#attributes.serviceType), any underlying HTTP client can call `http://<your cluster IP>:<some unique port>` to reach it.
 You can try this out yourself: first, find out the NodePort assigned to your function, by using the `nuctl get function` command of the `nuctl` CLI or the `kubectl get svc` command of the Kubernetes CLI. Then, use curl to send an HTTP request to this port.
 
 In addition to configuring a service, Nuclio can create a [Kubernetes ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for your function's HTTP trigger, with the path specified as `<function name>/latest`.

--- a/docs/concepts/k8s/function-ingress.md
+++ b/docs/concepts/k8s/function-ingress.md
@@ -13,8 +13,8 @@ If you followed the [Getting Started with Nuclio on Kubernetes](/docs/setup/k8s/
 By default, each function deployed to Kubernetes declares a [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/) that is responsible for routing requests to the functions' HTTP trigger port.
 To invoke the function externally, using `nuctl`, you probably exposed your function by using a [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport), which is a unique cluster-wide port that is assigned to the function.
 
-This means that, if your function's HTTP trigger is configured with a [NodePort](/docs/referece/triggers/http.md#attributes.serviceType), any underlying HTTP client can call `http://<your cluster IP>:<some unique port>` to reach it.
-You can try this out yourself: first, find out the NodePort assigned to your function, by using the `nuctl get function` command of the `nuctl` CLI or the `kubectl get svc` command of the Kubernetes CLI. Then, use curl to send an HTTP request to this port.
+This means that if your function's HTTP trigger is configured with a `NodePort`, any underlying HTTP client can call `http://<your cluster IP>:<some unique port>` to reach it.
+You can try this out yourself: first, find out the NodePort assigned to your function, by using the `nuctl get function` command of the `nuctl` CLI or the `kubectl get svc` command of the Kubernetes CLI. Then, use `curl` to send an HTTP request to this port.
 
 In addition to configuring a service, Nuclio can create a [Kubernetes ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for your function's HTTP trigger, with the path specified as `<function name>/latest`.
 However, without an ingress controller running on your cluster, this will have no effect. An Ingress controller will listen for changed ingresses and reconfigure some type of reverse proxy to route requests based on rules specified in the ingress resource.

--- a/docs/devel/coding-conventions.md
+++ b/docs/devel/coding-conventions.md
@@ -4,7 +4,7 @@
     - Follow the latest kubernetes coding conventions: https://github.com/kubernetes/kubernetes/blob/release-1.1/docs/devel/coding-conventions.md
   - Go
     - Functions should be short and call out to other short functions
-    - Choose verbose, descriptive, human readable names (`handler` not `hdlr`, `handleFunctioncrAdd` not `add`). The only exception is with receivers (`func (c *Client) foo()`)
+    - Choose verbose, descriptive, human-readable names (`handler` not `hdlr`, `handleFunctionAdd` not `add`). The only exception is with receivers (`func (c *Client) foo()`)
     - Insert newlines before comments and after blocks of code (e.g., a non-nested `}` within a function)
     - Functionality and state must be contained within instantiatable objects. Package level state variables are discouraged
     - Within a struct, exported methods go first, followed by non-exported methods. This holds true to methods conceptually belonging to a struct (e.g., "static" methods without receivers)

--- a/docs/reference/nuctl/nuctl.md
+++ b/docs/reference/nuctl/nuctl.md
@@ -61,3 +61,14 @@ When running on Kubernetes, `nuctl` requires a running registry on your Kubernet
 
 For an example of function deployment using `nuctl` against a Kubernetes cluster, see the Nuclio [Kubernetes getting-started guide](/docs/setup/k8s/getting-started-k8s.md#deploy-a-function-with-the-nuclio-cli).
 
+#### Invoking a function using nuctl on Kubernetes
+
+While in most cases using `nuctl` on the [Local Docker](#docker) platform enables you to invoke your function by running the
+`nuctl invoke` command on the host, in Kubernetes platform this is a bit trickier - and will most likely not work
+by default for some configurations. This means, for example, that `nuctl invoke` command will not be able to work
+unless your function is explicitly exposed or reachable from wherever you run `nuctl invoke`.
+
+See [Exposing a function](/docs/tasks/deploying-functions.md#exposing-a-function) for more details.
+
+For your convenience, when deploying a function using `nuctl`, exposing it via a `NodePort` can be easily done by using the
+CLI arg `--http-trigger-service-type=nodePort`.

--- a/docs/reference/nuctl/nuctl.md
+++ b/docs/reference/nuctl/nuctl.md
@@ -68,7 +68,7 @@ While in most cases using `nuctl` on the [Local Docker](#docker) platform enable
 by default for some configurations. This means, for example, that `nuctl invoke` command will not be able to work
 unless your function is explicitly exposed or reachable from wherever you run `nuctl invoke`.
 
-See [Exposing a function](/docs/tasks/deploying-functions.md#exposing-a-function) for more details.
+See [exposing a function](/docs/tasks/deploying-functions.md#exposing-a-function) for more details.
 
 For your convenience, when deploying a function using `nuctl`, exposing it via a `NodePort` can be easily done by using the
 CLI arg `--http-trigger-service-type=nodePort`.

--- a/docs/reference/triggers/cron.md
+++ b/docs/reference/triggers/cron.md
@@ -1,7 +1,16 @@
 # cron: Cron Trigger
 
+**In This Document**
+- [Overview](#overview)
+- [Attributes](#attributes)
+- [Examples](#examples)
+
+<a id="overview"></a>
+## Overview
+
 Triggers the function according to a schedule or interval, with an optional body.
 
+<a id="attributes"></a>
 ## Attributes
 
 | **Path** | **Type** | **Description** |
@@ -25,6 +34,7 @@ Triggers the function according to a schedule or interval, with an optional body
 >    - The `wget` request is sent with the header `"x-nuclio-invoke-trigger: cron"`.
 >    - You can use the [`concurrencyPolicy`](#attr-concurrencyPolicy) and [`jobBackoffLimit`](#attr-jobBackoffLimit) attributes to configure the CronJobs.
 
+<a id="examples"></a>
 ### Examples
 
 ```yaml

--- a/docs/reference/triggers/http.md
+++ b/docs/reference/triggers/http.md
@@ -17,7 +17,7 @@ The HTTP trigger is the only trigger created by default if not configured (by de
 | cors.allowHeaders | list of strings | The allowed HTTP headers, which can be used when accessing the resource (`Access-Control-Allow-Headers` response header); (default: `"Accept, Content-Length, Content-Type, X-nuclio-log-level"`). |
 | cors.allowCredentials | bool | `true` to allow user credentials in the actual request (`Access-Control-Allow-Credentials` response header); (default: `false`). |
 | cors.preflightMaxAgeSeconds | int | The number of seconds in which the results of a preflight request can be cached in a preflight result cache (`Access-Control-Max-Age` response header); (default: `-1` to indicate no preflight results caching). |
-| serviceType | string | (Kubernetes only) Kubernetes `ServiceType`, used by the Kubernetes service to expose the trigger. The default `ServiceType` is `ClusterIP`, which means that by default the trigger won't be exposed outside of the cluster unless you configure a proper ingress or manually change the `ServiceType` to `NodePort`. |
+| <a id="attribues.serviceType"></a>serviceType | string | (Kubernetes only) Kubernetes `ServiceType`, used by the Kubernetes service to expose the trigger. The default `ServiceType` is `ClusterIP`, which means that by default the trigger won't be exposed outside of the cluster unless you configure a proper ingress or manually change the `ServiceType` to `NodePort`. |
 
 ### Examples
 

--- a/docs/reference/triggers/http.md
+++ b/docs/reference/triggers/http.md
@@ -1,13 +1,24 @@
 # http: HTTP Trigger
 
-The HTTP trigger is the only trigger created by default if not configured (by default, it has 1 worker). This trigger handles incoming HTTP requests at container port 8080, assigning workers to incoming requests. If a worker is not available, a `503` error is returned.
+**In This Document**
+- [Overview](#overview)
+- [Attributes](#attributes)
+- [Examples](#examples)
 
+<a id="overview"></a>
+## Overview
+
+The HTTP trigger is the only trigger created by default if not configured (by default, it has 1 worker).
+This trigger handles incoming HTTP requests at container port 8080, assigning workers to incoming requests.
+If a worker is not available, a `503` error is returned.
+
+<a id="attributes"></a>
 ## Attributes
 
 | **Path** | **Type** | **Description** |
 | :--- | :--- | :--- |
 | port | int | The NodePort (or equivalent) on which the function will serve HTTP requests. If empty, chooses a random port within the platform range. |
-| ingresses.(name).host | string | The host to which the ingress maps. |
+| <a id="attributes.ingresses"></a>ingresses.(name).host | string | The host to which the ingress maps. |
 | ingresses.(name).paths | list of strings | The paths that the ingress handles. Variables of the form `{{.<NAME>}}` can be specified using `.Name`, `.Namespace`, and `.Version`. For example, `/{{.Namespace}}-{{.Name}}/{{.Version}}` will result in a default ingress of `/namespace-name/version`. |
 | readBufferSize | int | Per-connection buffer size for reading requests. |
 | maxRequestBodySize | int | Maximum request body size. |
@@ -17,9 +28,10 @@ The HTTP trigger is the only trigger created by default if not configured (by de
 | cors.allowHeaders | list of strings | The allowed HTTP headers, which can be used when accessing the resource (`Access-Control-Allow-Headers` response header); (default: `"Accept, Content-Length, Content-Type, X-nuclio-log-level"`). |
 | cors.allowCredentials | bool | `true` to allow user credentials in the actual request (`Access-Control-Allow-Credentials` response header); (default: `false`). |
 | cors.preflightMaxAgeSeconds | int | The number of seconds in which the results of a preflight request can be cached in a preflight result cache (`Access-Control-Max-Age` response header); (default: `-1` to indicate no preflight results caching). |
-| <a id="attribues.serviceType"></a>serviceType | string | (Kubernetes only) Kubernetes `ServiceType`, used by the Kubernetes service to expose the trigger. The default `ServiceType` is `ClusterIP`, which means that by default the trigger won't be exposed outside of the cluster unless you configure a proper ingress or manually change the `ServiceType` to `NodePort`. |
+| <a id="attributes.serviceType"></a>serviceType | string | (Kubernetes only) Kubernetes `ServiceType`, used by the Kubernetes service to expose the trigger. The default `ServiceType` is `ClusterIP`, which means that by default the trigger won't be exposed outside of the cluster unless you configure a proper ingress or manually change the `ServiceType` to `NodePort`. |
 
-### Examples
+<a id="examples"></a>
+## Examples
 
 With 4 workers and a maximum body size of 1 KB -
 
@@ -42,7 +54,7 @@ triggers:
       port: 32001
 ```
 
-With ingresseses -
+With ingresses -
 
 ```yaml
 triggers:

--- a/docs/reference/triggers/kafka.md
+++ b/docs/reference/triggers/kafka.md
@@ -14,6 +14,7 @@
   - [Rebalancing notes](#rebalancing-notes)
 - [Configuration example](#config-example)
 
+<a id="overview"></a>
 ## Overview
 
 The Nuclio Kafka trigger allows users to process messages sent to Kafka. To simplify, you send messages to a Kafka stream (across topics and partitions), tell Nuclio to read from this stream, and your function handler is then called once for every stream message.

--- a/docs/setup/gke/getting-started-gke.md
+++ b/docs/setup/gke/getting-started-gke.md
@@ -92,7 +92,8 @@ kubectl create namespace nuclio
 **Create a Kubernetes Docker-registry secret** from service-key file that you created as part of the [Kubernetes cluster setup](#set-up-a-kubernetes-cluster-and-a-local-environment), and delete this file:
 
 ```sh
-kubectl create secret docker-registry registry-credentials --namespace nuclio \
+kubectl create secret docker-registry registry-credentials \
+    --namespace nuclio \
     --docker-username _json_key \
     --docker-password "$(cat credentials.json)" \
     --docker-server gcr.io \
@@ -114,7 +115,7 @@ kubectl create configmap --namespace nuclio nuclio-registry --from-literal=regis
 kubectl apply -f https://raw.githubusercontent.com/nuclio/nuclio/master/hack/k8s/resources/nuclio-rbac.yaml
 ```
 
-**Deploy Nuclio to the cluster:** the cluster. The following command deploys the Nuclio controller and dashboard, among other resources:
+**Deploy Nuclio to the cluster:** The following command deploys the Nuclio controller and dashboard, among other resources:
 
 ```sh
 kubectl apply -f https://raw.githubusercontent.com/nuclio/nuclio/master/hack/gke/resources/nuclio.yaml
@@ -144,25 +145,38 @@ Replace the `<URL>` placeholder with the URL of your Docker registry.
 If you're using Docker Hub, the URL should include your username - `docker.io/<username>` - and you might also need to log into your Docker Hub account (`docker login`) on the installation machine before running the deployment command.
 You can add the `--verbose` flag if you want to peek under the hood.
 ```sh
-nuctl deploy helloworld -n nuclio -p https://raw.githubusercontent.com/nuclio/nuclio/master/hack/examples/golang/helloworld/helloworld.go --registry <URL>
+nuctl deploy helloworld \
+    --namespace nuclio \
+    --path https://raw.githubusercontent.com/nuclio/nuclio/master/hack/examples/golang/helloworld/helloworld.go \
+    --http-trigger-service-type nodePort \
+    --registry <URL>
 ```
+>**Note:** The command above exposes the function externally using a `nodePort`. This is done for demonstration
+> purposes only. Please read more [about exposing your function](/docs/tasks/deploying-functions.md#exposing-a-function)
+> for more information
 
 When the function deployment completes, you can get the function information by running the following CLI command:
+
 ```sh
 nuctl get function helloworld
 ```
+
 Sample output -
+
 ```sh
   NAMESPACE | NAME        | PROJECT | STATE | NODE PORT | REPLICAS  
   nuclio    | helloworld  | default | ready |     42089 | 1/1   
 ```
 You can see from the sample output that the deployed function `helloworld` is running and using port `42089`.
 
-Run the following CLI command to invoke the function:
+Since the function is exposed using a `nodePort`, you can run the following CLI command to invoke it:
+
 ```sh
 nuctl invoke helloworld --method POST --body '{"hello":"world"}' --content-type "application/json"
 ```
+
 Sample output -
+
 ```sh
 > Response headers:
 Server = nuclio

--- a/docs/setup/gke/getting-started-gke.md
+++ b/docs/setup/gke/getting-started-gke.md
@@ -152,8 +152,8 @@ nuctl deploy helloworld \
     --registry <URL>
 ```
 >**Note:** The command above exposes the function externally using a `nodePort`. This is done for demonstration
-> purposes only. Please read more [about exposing your function](/docs/tasks/deploying-functions.md#exposing-a-function)
-> for more information
+> purposes only. Please read more about [exposing your function](/docs/tasks/deploying-functions.md#exposing-a-function)
+> for more information.
 
 When the function deployment completes, you can get the function information by running the following CLI command:
 

--- a/docs/setup/k8s/getting-started-k8s.md
+++ b/docs/setup/k8s/getting-started-k8s.md
@@ -98,8 +98,9 @@ nuctl deploy helloworld \
     --registry <URL>
 ```
 >**Note:** The command above exposes the function externally using a `nodePort`. This is done for demonstration
-> purposes only. Please read more [about exposing your function](/docs/tasks/deploying-functions.md#exposing-a-function)
-> for more information
+> purposes only. Please read more about [exposing your function](/docs/tasks/deploying-functions.md#exposing-a-function)
+> for more information.
+
 When the function deployment completes, you can get the function information by running the following CLI command:
 
 ```sh

--- a/docs/setup/k8s/getting-started-k8s.md
+++ b/docs/setup/k8s/getting-started-k8s.md
@@ -41,7 +41,8 @@ Replace the `<...>` placeholders in the following commands with your username, p
 read -s mypassword
 <enter your password>
 
-kubectl create secret docker-registry registry-credentials --namespace nuclio \
+kubectl create secret docker-registry registry-credentials \
+    --namespace nuclio \
     --docker-username <username> \
     --docker-password $mypassword \
     --docker-server <URL> \
@@ -68,6 +69,7 @@ kubectl apply -f https://raw.githubusercontent.com/nuclio/nuclio/master/hack/k8s
 Use the command `kubectl get pods --namespace nuclio` to verify both the controller and dashboard are running.
 
 **Forward the Nuclio dashboard port:** the Nuclio dashboard publishes a service at port 8070. To use the dashboard, you first need to forward this port to your local IP address:
+
 ```sh
 kubectl port-forward -n nuclio $(kubectl get pods -n nuclio -l nuclio.io/app=dashboard -o jsonpath='{.items[0].metadata.name}') 8070:8070
 ```
@@ -87,22 +89,34 @@ When the function deployment completes, you can select **Test** to invoke the fu
 Run the following Nuclio CLI (`nuctl`) command from a command-line shell to deploy the example [`helloworld`](/hack/examples/golang/helloworld/helloworld.go) Go function.
 If you're using Docker Hub, the URL should include your username - `docker.io/<username>` - and you might also need to log into your Docker Hub account (`docker login`) on the installation machine before running the deployment command.
 You can add the `--verbose` flag if you want to peek under the hood.
-```sh
-nuctl deploy helloworld -n nuclio -p https://raw.githubusercontent.com/nuclio/nuclio/master/hack/examples/golang/helloworld/helloworld.go --registry <URL>
-```
 
+```sh
+nuctl deploy helloworld \
+    --namespace nuclio \
+    --http-trigger-service-type nodePort \
+    --path https://raw.githubusercontent.com/nuclio/nuclio/master/hack/examples/golang/helloworld/helloworld.go \
+    --registry <URL>
+```
+>**Note:** The command above exposes the function externally using a `nodePort`. This is done for demonstration
+> purposes only. Please read more [about exposing your function](/docs/tasks/deploying-functions.md#exposing-a-function)
+> for more information
 When the function deployment completes, you can get the function information by running the following CLI command:
+
 ```sh
 nuctl get function helloworld
 ```
+
 Sample output -
+
 ```sh
   NAMESPACE | NAME        | PROJECT | STATE | NODE PORT | REPLICAS  
   nuclio    | helloworld  | default | ready |     42089 | 1/1   
 ```
+
 You can see from the sample output that the deployed function `helloworld` is running and using port `42089`.
 
-Run the following CLI command to invoke the function:
+Since the function is exposed using a `nodePort`, you can run the following CLI command to invoke it:
+
 ```sh
 nuctl invoke helloworld --method POST --body '{"hello":"world"}' --content-type "application/json"
 ```

--- a/docs/setup/minikube/getting-started-minikube.md
+++ b/docs/setup/minikube/getting-started-minikube.md
@@ -33,27 +33,35 @@ Before starting the set-up procedure, ensure that the following prerequisites ar
 Note that the following command also enables role-based access control (RBAC) so that you can get more comfortable working with an RBAC-enabled Kubernetes cluster:
 
 ```sh
-minikube start --kubernetes-version v1.17.9 --driver docker --extra-config=apiserver.authorization-mode=RBAC --addons ingress
+minikube start --kubernetes-version v1.17.9 --driver docker --extra-config=apiserver.authorization-mode=RBAC
 ```
 
 > **Note:** You may want to
 > - Change the Kubernetes version. Currently, the recommended version is 1.17.9.
-> - Add `--addons ingress` to your `minikube start` command to support creating function ingresses.
+> - Change the minikube driver according to your environment and needs
+> - Add `--addons ingress` to your `minikube start` command to support creating function ingresses to flexibly
+> [expose your function](/docs/tasks/deploying-functions.md#exposing-a-function).
 >     Ensure that your function ingress appears on your hosts file (**/etc/hosts**).
 >     You can do this by running this command:
 >     ```sh
 >     echo "$(minikube ip) my-function.info" | sudo tee -a /etc/hosts
 >     ```
 
-**Bring up a Docker registry inside Minikube.** You'll later push your functions to this registry:
+**Bring up a Docker registry inside Minikube.** You'll later push your functions to this registry.
 
-> **Note:** You can skip this step if you're a more advanced user and would like to use another type of registry, such as [Docker Hub](https://hub.docker.com/), [Azure Container Registry (ACR)](https://azure.microsoft.com/services/container-registry/), or [Google Container Registry (GCR)](https://cloud.google.com/container-registry/). See [Getting started with Kubernetes](/docs/setup/k8s/getting-started-k8s.md) for instructions. 
+> **Note:** We are bringing up a local, simple, insecure docker registry. Instead, you can skip this step, 
+> and use any other docker registry, such as [Docker Hub](https://hub.docker.com/), [Azure Container Registry (ACR)](https://azure.microsoft.com/services/container-registry/),
+> or [Google Container Registry (GCR)](https://cloud.google.com/container-registry/).
+> See [Getting started with Kubernetes](/docs/setup/k8s/getting-started-k8s.md) for instructions. 
+
+SSH into the minikube machine, and run the registry using `docker`:
 
 ```sh
 minikube ssh -- docker run -d -p 5000:5000 registry:2
 ```
 
-Before container images can be pushed to your built-in registry, you need to add its address (`$(minikube ip):5000`) to the list of insecure registries:
+Before Docker container images can be pushed to your newly created, insecure registry, you need to add its
+address (`$(minikube ip):5000`) to the list of insecure registries to instruct Docker to accept working against it:
 
 - **Docker for Mac OS** -  you can add it under **Preferences | Daemon**.
 - **Linux** - follow the instructions in the [Docker documentation](https://docs.docker.com/registry/insecure/#deploy-a-plain-http-registry).
@@ -103,9 +111,18 @@ When the function deployment completes, you can select **Test** to invoke the fu
 Run the following Nuclio CLI (`nuctl`) command from a command-line shell to deploy the example [`helloworld`](/hack/examples/golang/helloworld/helloworld.go) Go function.
 You can add the `--verbose` flag if you want to peek under the hood.
 ```sh
-nuctl deploy helloworld -n nuclio -p https://raw.githubusercontent.com/nuclio/nuclio/master/hack/examples/golang/helloworld/helloworld.go --registry $(minikube ip):5000 --run-registry localhost:5000
+nuctl deploy helloworld \
+    --namespace nuclio \
+    --http-trigger-service-type nodePort \
+    --path https://raw.githubusercontent.com/nuclio/nuclio/master/hack/examples/golang/helloworld/helloworld.go \
+    --registry $(minikube ip):5000 \
+    --run-registry localhost:5000
 ```
-> **Note:** The difference between the two registries specified in this command and the reason for their addresses being different is as follows:
+>**Note:** The command above exposes the function externally using a `nodePort`. This is done for demonstration
+> purposes only. Please read more [about exposing your function](/docs/tasks/deploying-functions.md#exposing-a-function)
+> for more information
+
+>**Note:** The difference between the two registries specified in this command, and the reason for their addresses being different is as follows:
 >
 > - The `--registry` option defines the Docker registry onto which the function images that you build will be pushed. This is the registry that you previously brought up on your Minikube VM.
 > - The `--registry-run` option defines the registry from which the [`kubelet`](https://kubernetes.io/docs/reference/generated/kubelet/) Kubernetes "node agent" will pull the function images. Because this operation occurs in the Minikube VM, the command specifies `localhost` instead of the VM's IP address.
@@ -121,11 +138,14 @@ Sample output -
 ```
 You can see from the sample output that the deployed function `helloworld` is running and using port `42089`.
 
-Run the following CLI command to invoke the function:
+Since the function is exposed using a `nodePort`, you can run the following CLI command to invoke it:
+
 ```sh
 nuctl invoke helloworld --method POST --body '{"hello":"world"}' --content-type "application/json"
 ```
+
 Sample output -
+
 ```sh
 > Response headers:
 Server = nuclio

--- a/docs/setup/minikube/getting-started-minikube.md
+++ b/docs/setup/minikube/getting-started-minikube.md
@@ -119,8 +119,8 @@ nuctl deploy helloworld \
     --run-registry localhost:5000
 ```
 >**Note:** The command above exposes the function externally using a `nodePort`. This is done for demonstration
-> purposes only. Please read more [about exposing your function](/docs/tasks/deploying-functions.md#exposing-a-function)
-> for more information
+> purposes only. Please read more about [exposing your function](/docs/tasks/deploying-functions.md#exposing-a-function)
+> for more information.
 
 >**Note:** The difference between the two registries specified in this command, and the reason for their addresses being different is as follows:
 >

--- a/docs/tasks/deploying-functions.md
+++ b/docs/tasks/deploying-functions.md
@@ -6,8 +6,10 @@ This tutorial guides you through the process of deploying functions and specifyi
 - [Writing a simple function](#writing-a-simple-function)
 - [Deploying a simple function](#deploying-a-simple-function)
 - [Providing function configuration](#providing-function-configuration)
+- [Exposing a function](#exposing-a-function)
 - [What's next](#whats-next)
 
+<a id="writing-a-simple-function"></a>
 ## Writing a simple function
 
 After successfully installing Nuclio, you can start writing functions and deploying them to your cluster. All supported runtimes (such as Go, Python, or NodeJS) have an entry point that receives two arguments:
@@ -46,16 +48,18 @@ def my_entry_point(context, event):
 		# return a response
 		return 'A string response'
 ```
-
+<a id="deploying-a-simple-function"></a>
 ## Deploying a simple function
 
-To convert source code to a running function, you must first _deploy_ the function. A deploy process has three stages:
+To convert source code to a running function, you must first _deploy_ the function. A deployment process has three stages:
 
 1. The source code is built to a container image and pushed to a Docker registry
 2. A function object is created in Nuclio (i.e., in Kubernetes, this is a function CRD)
 3. A controller creates the appropriate function resources on the cluster (i.e., in Kubernetes this is the deployment, service, ingress, etc.)
 
-This process can be triggered through `nuctl deploy` which you will use throughout this tutorial. You will now write the function that you wrote in the previous step to a `/tmp/nuclio/my_function.py` file. Before you do anything, verify with `nuctl` that everything is properly configured by getting all functions deployed in the "nuclio" namespace:
+This process can be triggered through `nuctl deploy` which you will use throughout this tutorial. You will now write
+the function that you wrote in the previous step to a `/tmp/nuclio/my_function.py` file. Before you do anything,
+verify with `nuctl` that everything is properly configured by getting all functions deployed in the "nuclio" namespace:
 
 ```sh
 nuctl get function --namespace nuclio
@@ -67,16 +71,19 @@ Now deploy your function, specifying the function name, the path, the "nuclio" n
 
 ```sh
 nuctl deploy my-function \
+	--namespace nuclio \
 	--path /tmp/nuclio/my_function.py \
 	--runtime python \
 	--handler my_function:my_entry_point \
-	--namespace nuclio \
+	--http-trigger-service-type nodePort \
 	--registry $(minikube ip):5000 --run-registry localhost:5000
 ```
 
-> **Note:**
-> 1. `--path` can also hold a URL
-> 2. See the applicable setup guide to get registry informatiom
+> **Notes:**
+> 1. `--path` can also hold a URL.
+> 2. See the applicable setup guide to get registry information.
+> 3. Notice we used a `nodePort` to Expose the function and make it reachable externally. This
+> is for demonstration purposes only! See [Exposing a function](#exposing-a-function) to learn more about why this is here. 
 
 Once the function deploys, you should see `Function deploy complete` and an HTTP port through which you can invoke it. If there's a problem, invoke the above with `--verbose` and try to understand what went wrong. You can see your function through `nuctl get`:
 
@@ -88,7 +95,8 @@ nuctl get function --namespace nuclio
 
 ```
 
-To illustrate that the function is indeed accessible via HTTP, you'll use [httpie](https://httpie.org) to invoke the function at the port specified by the deploy log:
+To illustrate that the function is indeed accessible via HTTP, you'll use [httpie](https://httpie.org) to invoke
+the function at the port specified by the deployment log:
 
 ```sh
 http $(minikube ip):<port from log>
@@ -123,6 +131,7 @@ Content-Length = 17
 A string response
 ```
 
+<a id="providing-function-configuration"></a>
 ## Providing function configuration
 
 There are often cases in which providing code is not enough to deploy a function. For example, if
@@ -178,10 +187,11 @@ With `nuctl`, you simply pass `--env` and a JSON encoding of the trigger configu
 
 ```sh
 nuctl deploy my-function \
+    --namespace nuclio \
 	--path /tmp/nuclio/my_function.py \
 	--runtime python \
 	--handler my_function:my_entry_point \
-	--namespace nuclio \
+	--http-trigger-service-type nodePort \
 	--registry $(minikube ip):5000 --run-registry localhost:5000 \
 	--env MY_ENV_VALUE='my value' \
 	--triggers '{"periodic": {"kind": "cron", "attributes": {"interval": "3s"}}}'
@@ -204,6 +214,10 @@ spec:
   handler: my_function:my_entry_point
   runtime: python
   triggers:
+    http:
+      kind: http
+      attributes:
+        serviceType: NodePort
     periodic:
       attributes:
         interval: 3s
@@ -214,8 +228,10 @@ spec:
 With all the information in the `function.yaml`, you can pass the _directory_ of the source and configuration to `nuctl`. The name, namespace, trigger, env are all taken from the configuration file:
 
 ```sh
-nuctl deploy --path /tmp/nuclio \
-	--registry $(minikube ip):5000 --run-registry localhost:5000
+nuctl deploy \
+    --path /tmp/nuclio \
+	--registry $(minikube ip):5000 \
+	--run-registry localhost:5000
 ```
 
 ### Providing configuration via inline configuration
@@ -241,6 +257,10 @@ import os
 #     handler: my_function_with_config:my_entry_point
 #     runtime: python
 #     triggers:
+#       http:
+#         kind: http
+#         attributes:
+#           serviceType: NodePort
 #       periodic:
 #         attributes:
 #           interval: 3s
@@ -270,10 +290,38 @@ def my_entry_point(context, event):
 Now deploy this function:
 
 ```sh
-nuctl deploy --path /tmp/nuclio/my_function_with_config.py \
-        --registry $(minikube ip):5000 --run-registry localhost:5000
+nuctl deploy \
+    --path /tmp/nuclio/my_function_with_config.py \
+    --registry $(minikube ip):5000 \
+    --run-registry localhost:5000
 ```
 
+<a id="exposing-a-function"></a>
+## Exposing a function
+
+>**Security note:** Exposing your functions outside your Kubernetes cluster network has dire security implications.
+> Please make sure you understand the risks involved before deciding to expose any function externally. Always control
+> on which networks your functions are exposed, and use proper authentication to protect them, as well as the rest of your pipeline and data.
+
+When deploying a function on a Kubernetes cluster, the function is not exposed by default for external communication,
+but only on the kubernetes cluster network, using a `ClusterIP` [Service Type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types).
+In most network topologies this makes the function only available inside the cluster network, and [Kubernetes network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+can be used to further limit and control communications. The function will be unavailable for invocations
+over HTTP from entities running outside the cluster, like `nuctl`, `curl` or any other HTTP client.
+
+To understand whether a function is reachable to your HTTP client (this can be `curl`, `httpie`, `nuctl invoke` or any
+other HTTP client), consider where it is running from and the network path. An unexposed (default) function will not be
+reachable from your client unless you're running the client from inside a pod in your cluster.
+
+If you wish to expose your function externally, for example, to be able to run `nuctl invoke` from outside the
+Kubernetes network, you can do so in one of 2 ways during deployment, both controlled via the [HTTP trigger spec](/docs/reference/triggers/http.md):
+1. Configure the function with a reachable [HTTP ingress](/docs/reference/triggers/http.md#attributes.ingresses)
+1. Configure the function to use [serviceType](/docs/reference/triggers/http.md#attributes.serviceType) of type `nodePort`.
+
+If you are deploying the function using [nuctl](/docs/reference/nuctl/nuctl.md) CLI, you can also configure a `NodePort` easily by using the
+`--http-trigger-service-type=nodePort` CLI arg.
+
+<a id="whats-next"></a>
 ## What's next?
 
 - Check out how to [build functions once and deploy them many times](/docs/tasks/deploying-pre-built-functions.md).

--- a/docs/tasks/deploying-functions.md
+++ b/docs/tasks/deploying-functions.md
@@ -188,13 +188,13 @@ With `nuctl`, you simply pass `--env` and a JSON encoding of the trigger configu
 ```sh
 nuctl deploy my-function \
     --namespace nuclio \
-	--path /tmp/nuclio/my_function.py \
-	--runtime python \
-	--handler my_function:my_entry_point \
-	--http-trigger-service-type nodePort \
-	--registry $(minikube ip):5000 --run-registry localhost:5000 \
-	--env MY_ENV_VALUE='my value' \
-	--triggers '{"periodic": {"kind": "cron", "attributes": {"interval": "3s"}}}'
+    --path /tmp/nuclio/my_function.py \
+    --runtime python \
+    --handler my_function:my_entry_point \
+    --http-trigger-service-type nodePort \
+    --registry $(minikube ip):5000 --run-registry localhost:5000 \
+    --env MY_ENV_VALUE='my value' \
+    --triggers '{"periodic": {"kind": "cron", "attributes": {"interval": "3s"}}}'
 ```
 
 ### Providing configuration via function.yaml
@@ -230,8 +230,8 @@ With all the information in the `function.yaml`, you can pass the _directory_ of
 ```sh
 nuctl deploy \
     --path /tmp/nuclio \
-	--registry $(minikube ip):5000 \
-	--run-registry localhost:5000
+    --registry $(minikube ip):5000 \
+    --run-registry localhost:5000
 ```
 
 ### Providing configuration via inline configuration

--- a/docs/tasks/deploying-functions.md
+++ b/docs/tasks/deploying-functions.md
@@ -82,8 +82,8 @@ nuctl deploy my-function \
 > **Notes:**
 > 1. `--path` can also hold a URL.
 > 2. See the applicable setup guide to get registry information.
-> 3. Notice we used a `nodePort` to Expose the function and make it reachable externally. This
-> is for demonstration purposes only! See [Exposing a function](#exposing-a-function) to learn more about why this is here. 
+> 3. Notice we used a `nodePort` to expose the function and make it reachable externally. This
+> is for demonstration purposes only. See [exposing a function](#exposing-a-function) to learn more about why this is here.
 
 Once the function deploys, you should see `Function deploy complete` and an HTTP port through which you can invoke it. If there's a problem, invoke the above with `--verbose` and try to understand what went wrong. You can see your function through `nuctl get`:
 
@@ -316,11 +316,11 @@ reachable from your client unless you're running the client from inside a pod in
 If you wish to expose your function externally, for example, to be able to run `nuctl invoke` from outside the
 Kubernetes network, you can do so in one of 2 ways during deployment, both controlled via the [HTTP trigger spec](/docs/reference/triggers/http.md):
 1. Configure the function with a reachable [HTTP ingress](/docs/reference/triggers/http.md#attributes.ingresses). For
-   this to work you'll need to install an ingress controller on your cluster. See [function ingress doc](/docs/concepts/k8s/function-ingress.md)
+   this to work you'll need to install an ingress controller on your cluster. See [function ingress document](/docs/concepts/k8s/function-ingress.md)
    for more details.
 2. Configure the function to use [serviceType](/docs/reference/triggers/http.md#attributes.serviceType) of type `nodePort`.
 
-If you are deploying the function using [nuctl](/docs/reference/nuctl/nuctl.md) CLI, you can also configure a `NodePort` easily by using the
+If you are deploying the function using [nuctl](/docs/reference/nuctl/nuctl.md) CLI, you can also configure a `nodePort` easily by using the
 `--http-trigger-service-type=nodePort` CLI arg.
 
 <a id="whats-next"></a>

--- a/docs/tasks/deploying-functions.md
+++ b/docs/tasks/deploying-functions.md
@@ -315,8 +315,10 @@ reachable from your client unless you're running the client from inside a pod in
 
 If you wish to expose your function externally, for example, to be able to run `nuctl invoke` from outside the
 Kubernetes network, you can do so in one of 2 ways during deployment, both controlled via the [HTTP trigger spec](/docs/reference/triggers/http.md):
-1. Configure the function with a reachable [HTTP ingress](/docs/reference/triggers/http.md#attributes.ingresses)
-1. Configure the function to use [serviceType](/docs/reference/triggers/http.md#attributes.serviceType) of type `nodePort`.
+1. Configure the function with a reachable [HTTP ingress](/docs/reference/triggers/http.md#attributes.ingresses). For
+   this to work you'll need to install an ingress controller on your cluster. See [function ingress doc](/docs/concepts/k8s/function-ingress.md)
+   for more details.
+2. Configure the function to use [serviceType](/docs/reference/triggers/http.md#attributes.serviceType) of type `nodePort`.
 
 If you are deploying the function using [nuctl](/docs/reference/nuctl/nuctl.md) CLI, you can also configure a `NodePort` easily by using the
 `--http-trigger-service-type=nodePort` CLI arg.


### PR DESCRIPTION
- New section `Exposing a function` section added to `/docs/tasks/deploying-functions.md`
- References and clarifications in various nuctl notes
- Various other small fixes