### PR TITLE
Support Azure-Devops repositories on Git code entry type

### DIFF
--- a/pkg/cmdrunner/mock.go
+++ b/pkg/cmdrunner/mock.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cmdrunner
 
 import (
-	"github.com/nuclio/nuclio/pkg/common"
-
 	"github.com/stretchr/testify/mock"
 )
 
@@ -30,8 +28,8 @@ func (m *MockRunner) Run(runOptions *RunOptions, format string, vars ...interfac
 	args := m.Called(runOptions, format, vars)
 	runResults, ok := args.Get(0).(RunResult)
 	if ok && runOptions != nil {
-		runResults.Stderr = common.Redact(runOptions.LogRedactions, runResults.Stderr)
-		runResults.Output = common.Redact(runOptions.LogRedactions, runResults.Output)
+		runResults.Stderr = Redact(runOptions.LogRedactions, runResults.Stderr)
+		runResults.Output = Redact(runOptions.LogRedactions, runResults.Output)
 	}
 	return runResults, args.Error(1)
 }

--- a/pkg/common/git.go
+++ b/pkg/common/git.go
@@ -1,0 +1,167 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+	"github.com/nuclio/nuclio/pkg/cmdrunner"
+
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	githttp "gopkg.in/src-d/go-git.v4/plumbing/transport/http"
+)
+
+type GitAttributes struct {
+	Branch    string `json:"branch,omitempty"`
+	Tag       string `json:"tag,omitempty"`
+	Reference string `json:"reference,omitempty"`
+	Username  string `json:"username,omitempty"`
+	Password  string `json:"password,omitempty"`
+}
+
+type GitClient interface {
+	Clone(outputDir, repositoryURL string, gitAttributes *GitAttributes) error
+}
+
+type AbstractGitClient struct {
+	GitClient
+
+	cmdRunner cmdrunner.CmdRunner
+}
+
+func NewGitClient(parentLogger logger.Logger) (GitClient, error) {
+	var err error
+
+	abstractGitClient := AbstractGitClient{}
+
+	// create cmd runner
+	abstractGitClient.cmdRunner, err = cmdrunner.NewShellRunner(parentLogger)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create cmd runner")
+	}
+
+	return abstractGitClient, nil
+}
+
+func (agc AbstractGitClient) Clone(outputDir, repositoryURL string, gitAttributes *GitAttributes) error {
+	var referenceName string
+	var gitAuth *githttp.BasicAuth
+	var err error
+
+	// resolve full git reference name
+	referenceName, err = ResolveGitReference(repositoryURL, gitAttributes)
+	if err != nil {
+		return errors.Wrap(err, "Failed to resolve git reference")
+	}
+
+	// resolve git credentials when given
+	gitAuth = agc.parseFunctionGitCredentials(gitAttributes)
+
+	// if it's Azure Devops repo - clone differently (the normal go-git client doesn't support it yet)
+	if isAzureDevopsRepositoryURL(repositoryURL) {
+		return agc.cloneFromAzureDevops(outputDir, repositoryURL, referenceName, gitAuth, agc.cmdRunner)
+	}
+
+	if _, err = git.PlainClone(outputDir, false, &git.CloneOptions{
+		URL:           repositoryURL,
+		ReferenceName: plumbing.ReferenceName(referenceName),
+		Depth:         1,
+		Auth:          gitAuth,
+	}); err != nil {
+		return errors.Wrap(err, "Failed to clone git repository")
+	}
+
+	return nil
+}
+
+func (agc AbstractGitClient) cloneFromAzureDevops(outputDir string,
+	repositoryURL string,
+	referenceName string,
+	gitAuth *githttp.BasicAuth,
+	cmdRunner cmdrunner.CmdRunner) error {
+
+	// if auth is passed, transplant username:password into repository URL
+	if gitAuth != nil {
+		splitFunctionPath := strings.Split(repositoryURL, "://")
+		repositoryURL = fmt.Sprintf("%s://%s:%s@%s",
+			splitFunctionPath[0],
+			gitAuth.Username,
+			gitAuth.Password,
+			splitFunctionPath[1])
+	}
+
+	// generate a git clone command
+	cloneCommand := fmt.Sprintf("git clone %s --depth 1 -q %s",
+		Quote(repositoryURL),
+		outputDir)
+
+	// attach git reference name when given (use - as it works both for branch/tag)
+	if referenceName != "" {
+		cloneCommand = fmt.Sprintf("%s -b %s", cloneCommand, referenceName)
+	}
+
+	// run the above git clone command
+	res, err := cmdRunner.Run(nil, cloneCommand)
+	if err != nil {
+		return errors.Wrap(err, "Failed to run clone command on azure repository")
+	}
+
+	if res.ExitCode != 0 {
+		return errors.Errorf("Failed to clone azure devops git repository. Reason: %s", res.Output)
+	}
+
+	return nil
+}
+
+func (agc AbstractGitClient) parseFunctionGitCredentials(gitAttributes *GitAttributes) *githttp.BasicAuth {
+	username := gitAttributes.Username
+	password := gitAttributes.Password
+
+	if username != "" || password != "" {
+
+		// username must not be empty when password is given (doesn't matter what's the user as long as it's not empty)
+		if username == "" {
+			username = "defaultuser"
+		}
+
+		return &githttp.BasicAuth{
+			Username: username,
+			Password: password,
+		}
+	}
+
+	return nil
+}
+
+func ResolveGitReference(repositoryURL string, gitAttributes *GitAttributes) (string, error) {
+	addReferencePrefix := !isAzureDevopsRepositoryURL(repositoryURL)
+
+	// branch
+	if ref := gitAttributes.Branch; ref != "" {
+		if addReferencePrefix {
+			ref = fmt.Sprintf("refs/heads/%s", ref)
+		}
+		return ref, nil
+	}
+
+	// tag
+	if ref := gitAttributes.Tag; ref != "" {
+		if addReferencePrefix {
+			ref = fmt.Sprintf("refs/tags/%s", ref)
+		}
+		return ref, nil
+	}
+
+	// reference
+	if ref := gitAttributes.Reference; ref != "" {
+		return ref, nil
+	}
+
+	return "", errors.New("No git reference was specified. (must specify branch/tag/reference)")
+}
+
+func isAzureDevopsRepositoryURL(repositoryURL string) bool {
+	return strings.Contains(repositoryURL, "dev.azure.com")
+}

--- a/pkg/common/git.go
+++ b/pkg/common/git.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/nuclio/errors"
-	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
 
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	githttp "gopkg.in/src-d/go-git.v4/plumbing/transport/http"

--- a/pkg/common/git.go
+++ b/pkg/common/git.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nuclio/logger"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 	githttp "gopkg.in/src-d/go-git.v4/plumbing/transport/http"
 )
 
@@ -43,10 +44,10 @@ func NewGitClient(parentLogger logger.Logger) (GitClient, error) {
 		return nil, errors.Wrap(err, "Failed to create cmd runner")
 	}
 
-	return abstractGitClient, nil
+	return &abstractGitClient, nil
 }
 
-func (agc AbstractGitClient) Clone(outputDir, repositoryURL string, gitAttributes *GitAttributes) error {
+func (agc *AbstractGitClient) Clone(outputDir, repositoryURL string, gitAttributes *GitAttributes) error {
 	var referenceName string
 	var gitAuth *githttp.BasicAuth
 	var err error
@@ -69,7 +70,7 @@ func (agc AbstractGitClient) Clone(outputDir, repositoryURL string, gitAttribute
 	return agc.clone(outputDir, repositoryURL, referenceName, gitAuth)
 }
 
-func (agc AbstractGitClient) clone(outputDir, repositoryURL, referenceName string, gitAuth *githttp.BasicAuth) error {
+func (agc *AbstractGitClient) clone(outputDir, repositoryURL, referenceName string, gitAuth transport.AuthMethod) error {
 	if _, err := git.PlainClone(outputDir, false, &git.CloneOptions{
 		URL:           repositoryURL,
 		ReferenceName: plumbing.ReferenceName(referenceName),
@@ -84,7 +85,7 @@ func (agc AbstractGitClient) clone(outputDir, repositoryURL, referenceName strin
 	return nil
 }
 
-func (agc AbstractGitClient) logCurrentCommitSHA(gitDir, repositoryURL, referenceName string) {
+func (agc *AbstractGitClient) logCurrentCommitSHA(gitDir, repositoryURL, referenceName string) {
 	res, err := agc.cmdRunner.Run(nil, fmt.Sprintf("cd %s;git rev-parse HEAD", Quote(gitDir)))
 	if err != nil || res.ExitCode != 0 {
 		agc.logger.WarnWith("Failed to get commit SHA", "err", err)
@@ -104,7 +105,7 @@ func (agc AbstractGitClient) logCurrentCommitSHA(gitDir, repositoryURL, referenc
 		"commitSHA", commitSHA)
 }
 
-func (agc AbstractGitClient) cloneFromAzureDevops(outputDir string,
+func (agc *AbstractGitClient) cloneFromAzureDevops(outputDir string,
 	repositoryURL string,
 	referenceName string,
 	gitAuth *githttp.BasicAuth,
@@ -152,7 +153,7 @@ func (agc AbstractGitClient) cloneFromAzureDevops(outputDir string,
 	return nil
 }
 
-func (agc AbstractGitClient) parseFunctionGitCredentials(gitAttributes *GitAttributes) *githttp.BasicAuth {
+func (agc *AbstractGitClient) parseFunctionGitCredentials(gitAttributes *GitAttributes) *githttp.BasicAuth {
 	username := gitAttributes.Username
 	password := gitAttributes.Password
 

--- a/pkg/common/git.go
+++ b/pkg/common/git.go
@@ -127,7 +127,7 @@ func (agc AbstractGitClient) cloneFromAzureDevops(outputDir string,
 
 	// attach git reference name when given (use - as it works both for branch/tag)
 	if referenceName != "" {
-		cloneCommand = fmt.Sprintf("%s -b %s", cloneCommand, referenceName)
+		cloneCommand = fmt.Sprintf("%s -b %s", cloneCommand, Quote(referenceName))
 	}
 
 	// run the above git clone command

--- a/pkg/common/git.go
+++ b/pkg/common/git.go
@@ -79,7 +79,7 @@ func (agc AbstractGitClient) Clone(outputDir, repositoryURL string, gitAttribute
 	return nil
 }
 
-func (agc AbstractGitClient) printCurrentCommitSHA(gitDir, referenceName, repositoryURL string) {
+func (agc AbstractGitClient) printCurrentCommitSHA(gitDir, repositoryURL, referenceName string) {
 	res, err := agc.cmdRunner.Run(nil, fmt.Sprintf("cd %s;git rev-parse HEAD", Quote(gitDir)))
 	if err != nil || res.ExitCode != 0 {
 		agc.logger.WarnWith("Failed to get commit SHA", "err", err)

--- a/pkg/common/git/git.go
+++ b/pkg/common/git/git.go
@@ -15,7 +15,6 @@ import (
 	githttp "gopkg.in/src-d/go-git.v4/plumbing/transport/http"
 )
 
-
 type Client interface {
 	Clone(outputDir, repositoryURL string, attributes *Attributes) error
 }

--- a/pkg/common/git/types.go
+++ b/pkg/common/git/types.go
@@ -1,0 +1,9 @@
+package git
+
+type Attributes struct {
+	Branch    string `json:"branch,omitempty"`
+	Tag       string `json:"tag,omitempty"`
+	Reference string `json:"reference,omitempty"`
+	Username  string `json:"username,omitempty"`
+	Password  string `json:"password,omitempty"`
+}

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -198,21 +198,6 @@ func RunningInContainer() bool {
 	return FileExists("/.dockerenv")
 }
 
-func Redact(redactions []string, runOutput string) string {
-	if redactions == nil {
-		return runOutput
-	}
-
-	var replacements []string
-
-	for _, redactionField := range redactions {
-		replacements = append(replacements, redactionField, "[redacted]")
-	}
-
-	replacer := strings.NewReplacer(replacements...)
-	return replacer.Replace(runOutput)
-}
-
 func StripPrefixes(input string, prefixes []string) string {
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(input, prefix) {

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -747,7 +747,7 @@ func (c *ShellClient) runCommand(runOptions *cmdrunner.RunOptions, format string
 	if runOptions.CaptureOutputMode == cmdrunner.CaptureOutputModeStdout && runResult.Stderr != "" {
 		c.logger.WarnWith("Docker command outputted to stderr - this may result in errors",
 			"workingDir", runOptions.WorkingDir,
-			"cmd", common.Redact(runOptions.LogRedactions, fmt.Sprintf(format, vars...)),
+			"cmd", cmdrunner.Redact(runOptions.LogRedactions, fmt.Sprintf(format, vars...)),
 			"stderr", runResult.Stderr)
 	}
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	gitcommon "github.com/nuclio/nuclio/pkg/common/git"
 	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
@@ -121,7 +122,7 @@ type Builder struct {
 
 	versionInfo *version.Info
 
-	gitClient common.GitClient
+	gitClient gitcommon.Client
 }
 
 // NewBuilder returns a new builder
@@ -137,7 +138,7 @@ func NewBuilder(parentLogger logger.Logger, platform platform.Platform, s3Client
 
 	newBuilder.initializeSupportedRuntimes()
 
-	newBuilder.gitClient, err = common.NewGitClient(newBuilder.logger)
+	newBuilder.gitClient, err = gitcommon.NewClient(newBuilder.logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create git client")
 	}
@@ -1616,8 +1617,8 @@ func (b *Builder) resolveCodeEntryAttributeAsString(attribute string) string {
 	return ""
 }
 
-func (b *Builder) parseGitAttributes() (*common.GitAttributes, error) {
-	var gitAttributes common.GitAttributes
+func (b *Builder) parseGitAttributes() (*gitcommon.Attributes, error) {
+	var gitAttributes gitcommon.Attributes
 
 	// get branch reference and authorization when given
 	if b.options.FunctionConfig.Spec.Build.CodeEntryAttributes == nil {

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -717,7 +717,9 @@ func (suite *testSuite) TestResolveFunctionPathGitCodeEntry() {
 			suite.Require().Equal(suite.builder.tempDir+destinationWorkDir, path)
 
 			// get git reference as it was planted on the code inside the remote git repository
-			referenceName, err := suite.builder.resolveGitReference(testCase.BuildConfiguration.Path)
+			gitAttributes, err := suite.builder.parseGitAttributes()
+			suite.Require().NoError(err)
+			referenceName, err := common.ResolveGitReference(suite.builder.options.FunctionConfig.Spec.Build.Path, gitAttributes)
 			suite.Require().NoError(err)
 
 			// make sure our test file was downloaded correctly

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -679,7 +679,29 @@ func (suite *testSuite) TestResolveFunctionPathGitCodeEntry() {
 			},
 		},
 
-		// TODO: add a test for azure-devops when it's added
+		// Azure Devops
+		{
+			Name: "AzureDevopsBranch",
+			BuildConfiguration: functionconfig.Build{
+				CodeEntryType: GitEntryType,
+				Path:          "https://dev.azure.com/sahar920089/test-nuclio-cet/_git/test-nuclio-cet",
+				CodeEntryAttributes: map[string]interface{}{
+					"workDir": "go-function",
+					"branch":  "go-func",
+				},
+			},
+		},
+		{
+			Name: "AzureDevopsTag",
+			BuildConfiguration: functionconfig.Build{
+				CodeEntryType: GitEntryType,
+				Path:          "https://dev.azure.com/sahar920089/test-nuclio-cet/_git/test-nuclio-cet",
+				CodeEntryAttributes: map[string]interface{}{
+					"workDir": "go-function",
+					"tag":     "0.0.1",
+				},
+			},
+		},
 	} {
 		suite.Run(testCase.Name, func() {
 			err := suite.builder.createTempDir()
@@ -695,7 +717,7 @@ func (suite *testSuite) TestResolveFunctionPathGitCodeEntry() {
 			suite.Require().Equal(suite.builder.tempDir+destinationWorkDir, path)
 
 			// get git reference as it was planted on the code inside the remote git repository
-			referenceName, err := suite.builder.resolveGitReference()
+			referenceName, err := suite.builder.resolveGitReference(testCase.BuildConfiguration.Path)
 			suite.Require().NoError(err)
 
 			// make sure our test file was downloaded correctly

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	gitcommon "github.com/nuclio/nuclio/pkg/common/git"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 	mockplatform "github.com/nuclio/nuclio/pkg/platform/mock"
@@ -719,7 +720,7 @@ func (suite *testSuite) TestResolveFunctionPathGitCodeEntry() {
 			// get git reference as it was planted on the code inside the remote git repository
 			gitAttributes, err := suite.builder.parseGitAttributes()
 			suite.Require().NoError(err)
-			referenceName, err := common.ResolveGitReference(suite.builder.options.FunctionConfig.Spec.Build.Path, gitAttributes)
+			referenceName, err := gitcommon.ResolveReference(suite.builder.options.FunctionConfig.Spec.Build.Path, gitAttributes)
 			suite.Require().NoError(err)
 
 			// make sure our test file was downloaded correctly


### PR DESCRIPTION
Changes:
- Support Azure Devops repositories (use git cli, as it is not supported by go-git) + tests on `builder_tests`
- Print current commit SHA when cloning from git repos
- Refactored builder's git logic into common/git.go
- Moved `common.Redact()` function to `cmdRunner.Redact()` (to prevent circular dependencies when using cmdRunner on git client)