### PR TITLE
Added controller integration test suite

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,7 @@ run:
 
   skip-dirs:
     - docs
+    - vendor
 
 linters-settings:
   gocritic:

--- a/hack/scripts/generate-crds/update-codegen.sh
+++ b/hack/scripts/generate-crds/update-codegen.sh
@@ -37,7 +37,10 @@ bash "${CODEGEN_PKG}"/generate-groups.sh \
   --go-header-file "${SCRIPT_ROOT}"/boilerplate.go.txt
 
 # merge outputs with current source code
-rsync --remove-source-files --ignore-times "${PROJECT_ROOT}/github.com/nuclio/nuclio/pkg" "${PROJECT_ROOT}"
+rsync --recursive \
+ --remove-source-files \
+ --ignore-times \
+ "${PROJECT_ROOT}/github.com/nuclio/nuclio/pkg" "${PROJECT_ROOT}"
 
 # delete generated code
 rm -rf "${PROJECT_ROOT}/github.com"

--- a/pkg/platform/kube/controller/controller.go
+++ b/pkg/platform/kube/controller/controller.go
@@ -165,12 +165,12 @@ func (c *Controller) Start() error {
 
 	// start operators
 	if err := c.startOperators(); err != nil {
-		return err
+		return errors.Wrap(err, "Failed to start operators")
 	}
 
 	// start monitors
 	if err := c.startMonitors(); err != nil {
-		return err
+		return errors.Wrap(err, "Failed to start monitors")
 	}
 
 	c.logger.InfoWith("Controller has successfully started", "namespace", c.namespace)

--- a/pkg/platform/kube/controller/nucliofunction_test.go
+++ b/pkg/platform/kube/controller/nucliofunction_test.go
@@ -65,6 +65,7 @@ func (suite *NuclioFunctionTestSuite) SetupTest() {
 	functionresClient, err := functionres.NewLazyClient(suite.logger,
 		suite.k8sClientSet,
 		suite.functionClientSet)
+	suite.Require().NoError(err)
 
 	suite.controller, err = NewController(suite.logger, suite.namespace,
 		"",

--- a/pkg/platform/kube/controller/nucliofunction_test.go
+++ b/pkg/platform/kube/controller/nucliofunction_test.go
@@ -25,59 +25,63 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
-	"github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/mocks"
+	"github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/versioned/fake"
 	"github.com/nuclio/nuclio/pkg/platform/kube/functionres"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
 
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 type NuclioFunctionTestSuite struct {
 	suite.Suite
-	logger                       logger.Logger
-	namespace                    string
-	nuclioioV1beta1InterfaceMock *mocks.NuclioV1beta1Interface
-	nuclioFunctionInterfaceMock  *mocks.NuclioFunctionInterface
-	nuclioioInterfaceMock        *mocks.Interface
-	functionresClientMock        *functionres.MockedFunctionRes
-	functionOperatorInstance     *functionOperator
+	logger            logger.Logger
+	namespace         string
+	functionClientSet *fake.Clientset
+	k8sClientSet      *k8sfake.Clientset
+	controller        *Controller
 }
 
 func (suite *NuclioFunctionTestSuite) SetupTest() {
 	var err error
-	resyncInterval := 1 * time.Hour
+	resyncInterval := 0 * time.Second
+	functionMonitoringInterval := 10 * time.Second
+	cronJobInterval := 10 * time.Second
+	defaultNumWorkers := 1
 
 	suite.logger, err = nucliozap.NewNuclioZapTest("test")
 	suite.Require().NoError(err)
 
-	suite.functionresClientMock = &functionres.MockedFunctionRes{}
-
-	suite.functionOperatorInstance, err = newFunctionOperator(suite.logger,
-		&Controller{
-			namespace: suite.namespace,
-		},
-		&resyncInterval,
-		"",
-		suite.functionresClientMock,
-		0)
+	platformConfig, err := platformconfig.NewPlatformConfig("")
 	suite.Require().NoError(err)
 
-	// mock it all the way down
-	suite.nuclioioInterfaceMock = &mocks.Interface{}
-	suite.nuclioioV1beta1InterfaceMock = &mocks.NuclioV1beta1Interface{}
-	suite.nuclioFunctionInterfaceMock = &mocks.NuclioFunctionInterface{}
+	suite.k8sClientSet = k8sfake.NewSimpleClientset()
+	suite.functionClientSet = fake.NewSimpleClientset()
 
-	suite.nuclioioInterfaceMock.
-		On("NuclioV1beta1").
-		Return(suite.nuclioioV1beta1InterfaceMock)
+	functionresClient, err := functionres.NewLazyClient(suite.logger,
+		suite.k8sClientSet,
+		suite.functionClientSet)
 
-	suite.nuclioioV1beta1InterfaceMock.
-		On("NuclioFunctions", suite.namespace).
-		Return(suite.nuclioFunctionInterfaceMock)
-
-	suite.functionOperatorInstance.controller.nuclioClientSet = suite.nuclioioInterfaceMock
+	suite.controller, err = NewController(suite.logger, suite.namespace,
+		"",
+		suite.k8sClientSet,
+		suite.functionClientSet,
+		functionresClient,
+		nil,
+		resyncInterval,
+		functionMonitoringInterval,
+		cronJobInterval,
+		platformConfig,
+		"configuration-name",
+		defaultNumWorkers,
+		defaultNumWorkers,
+		defaultNumWorkers,
+		defaultNumWorkers)
+	suite.Require().NoError(err)
 }
 
 func (suite *NuclioFunctionTestSuite) TestRecoverFromPanic() {
@@ -85,16 +89,15 @@ func (suite *NuclioFunctionTestSuite) TestRecoverFromPanic() {
 	functionInstance.Name = "func-name"
 	functionInstance.Status.State = functionconfig.FunctionStateReady
 
-	suite.functionresClientMock.
-		On("CreateOrUpdate", mock.Anything, functionInstance, mock.Anything).
-		Panic("something bad happened")
+	suite.k8sClientSet.PrependReactor("create",
+		"configmaps",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
 
-	suite.nuclioFunctionInterfaceMock.
-		On("Update", functionInstance).
-		Return(nil, nil).
-		Once()
+			// simulating a panic being thrown during function creation
+			panic("Oh nooo")
+		})
 
-	err := suite.functionOperatorInstance.CreateOrUpdate(context.TODO(), functionInstance)
+	err := suite.controller.functionOperator.CreateOrUpdate(context.TODO(), functionInstance)
 	suite.Require().NoError(err)
 
 	// function state must be change to error after panicking during its create/update

--- a/pkg/platform/kube/controller/test/controller_test.go
+++ b/pkg/platform/kube/controller/test/controller_test.go
@@ -1,0 +1,103 @@
+// +build test_integration
+// +build test_kube
+
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platform"
+	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+	"github.com/nuclio/nuclio/pkg/platform/kube/test"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+	"time"
+)
+
+type ControllerTestSuite struct {
+	test.KubeTestSuite
+}
+
+func (suite *ControllerTestSuite) SetupSuite() {
+	suite.KubeTestSuite.DisableControllerStart = true
+	suite.KubeTestSuite.SetupSuite()
+}
+
+func (suite *ControllerTestSuite) TestStaleResourceVersion() {
+
+	// build function
+	function := suite.buildTestFunction()
+
+	// creating function CRD record
+	functionCRDRecord, err := suite.FunctionClientSet.
+		NuclioV1beta1().
+		NuclioFunctions(suite.Namespace).
+		Create(&nuclioio.NuclioFunction{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        function.Meta.Name,
+				Namespace:   function.Meta.Namespace,
+				Labels:      function.Meta.Labels,
+				Annotations: function.Meta.Annotations,
+			},
+			Spec: function.Spec,
+			Status: functionconfig.Status{
+				State: functionconfig.FunctionStateWaitingForResourceConfiguration,
+			},
+		})
+	suite.Require().NoError(err)
+	suite.Require().NotEmpty(functionCRDRecord.ResourceVersion)
+
+	// ensure no resync interval (sanity)
+	suite.Require().Equal(0, int(suite.Controller.GetResyncInterval()))
+
+	// start controller
+	err = suite.Controller.Start()
+	suite.Require().NoError(err)
+
+	suite.WaitForFunctionState(&platform.GetFunctionsOptions{
+		Namespace: functionCRDRecord.Namespace,
+		Name:      functionCRDRecord.Name,
+	}, functionconfig.FunctionStateReady, 5*time.Minute)
+}
+
+func (suite *ControllerTestSuite) buildTestFunction() *functionconfig.Config {
+
+	// build a function
+	createFunctionOptions := suite.CompileCreateFunctionOptions(fmt.Sprintf("test-%s", suite.TestID))
+	buildFunctionResults, err := suite.Platform.CreateFunctionBuild(&platform.CreateFunctionBuildOptions{
+		Logger:              suite.Logger,
+		FunctionConfig:      createFunctionOptions.FunctionConfig,
+		PlatformName:        suite.Platform.GetName(),
+		OnAfterConfigUpdate: nil,
+	})
+	suite.Require().NoError(err)
+	suite.Require().NotEmpty(buildFunctionResults.Image)
+	buildFunctionResults.UpdatedFunctionConfig.Spec.Image = fmt.Sprintf("%s/%s",
+		suite.RegistryURL,
+		buildFunctionResults.Image)
+	return &buildFunctionResults.UpdatedFunctionConfig
+}
+
+func TestControllerTestSuite(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+	suite.Run(t, new(ControllerTestSuite))
+}


### PR DESCRIPTION
 - Added an integration test to ensure restarted controller syncs function during start up (while resync interval is disabled)
that means, if function CRD was created while controller is being restarted due to a reason, the controller would then start and pick up that function waiting for resources creation.

- Updated controller unit test with new fake clientset

