### PR TITLE
Fix - Missing ClusterRole rule in nuclio-rbac.yaml

### DIFF
--- a/hack/k8s/resources/nuclio-rbac.yaml
+++ b/hack/k8s/resources/nuclio-rbac.yaml
@@ -68,6 +68,9 @@ rules:
 - apiGroups: ["nuclio.io"]
   resources: ["nucliofunctions", "nuclioprojects", "nucliofunctionevents", "nuclioapigateways"]
   verbs: ["*"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
 
 ---
 

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -26,7 +26,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
 	"github.com/nuclio/nuclio/pkg/restful"
 
-	"github.com/nuclio/errors"
 	"k8s.io/api/core/v1"
 )
 
@@ -37,7 +36,10 @@ type frontendSpecResource struct {
 func (fesr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restful.CustomRouteFuncResponse, error) {
 	externalIPAddresses, err := fesr.getPlatform().GetExternalIPAddresses()
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get external IP addresses")
+		externalIPAddresses = []string{"localhost"}
+		fesr.Logger.WarnWith("Failed to get external IP addresses, falling back to default",
+			"err", err,
+			"externalIPAddresses", externalIPAddresses)
 	}
 
 	// try to get platform kind

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -444,12 +444,24 @@ func (ar *AbstractResource) callCustomRouteFunc(responseWriter http.ResponseWrit
 	// see if the resource only supports a single record
 	response, err := routeFunc(request)
 
-	if err != nil || response == nil {
-		ar.Logger.ErrorWith("Custom routed handler failed",
+	if err != nil {
+		ar.Logger.WarnWith("Custom routed handler failed",
 			"err", err,
 			"routeFunc", routeFunc,
 			"request", request)
-		return
+	}
+
+	// if response object was not created, fill a placeholder
+	if response == nil {
+		response = &CustomRouteFuncResponse{
+			Single:     true,
+			StatusCode: http.StatusInternalServerError,
+			Headers:    map[string]string{"Content-Type": "application/json"},
+		}
+		ar.Logger.WarnWith("Response object not filled by handler, using placeholder",
+			"routeFunc", routeFunc,
+			"request", request,
+			"response", response)
 	}
 
 	// set headers in response
@@ -472,7 +484,6 @@ func (ar *AbstractResource) callCustomRouteFunc(responseWriter http.ResponseWrit
 				"err", err,
 				"routeFunc", routeFunc,
 				"request", request)
-			return
 		}
 
 		return

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -326,7 +326,6 @@ func (ar *AbstractResource) registerCustomRoutes() error {
 			return errors.Errorf("Invalid method %s used in custom route", customRoute.Method)
 		}
 
-
 		customRouteCopy := customRoute
 
 		ar.Logger.DebugWith("Registered custom route",

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -322,7 +322,10 @@ func (ar *AbstractResource) registerCustomRoutes() error {
 			routerFunc = ar.router.Put
 		case http.MethodDelete:
 			routerFunc = ar.router.Delete
+		default:
+			return errors.Errorf("Invalid method %s used in custom route", customRoute.Method)
 		}
+
 
 		customRouteCopy := customRoute
 
@@ -442,6 +445,14 @@ func (ar *AbstractResource) callCustomRouteFunc(responseWriter http.ResponseWrit
 	// see if the resource only supports a single record
 	response, err := routeFunc(request)
 
+	if err != nil || response == nil {
+		ar.Logger.ErrorWith("Custom routed handler failed",
+			"err", err,
+			"routeFunc", routeFunc,
+			"request", request)
+		return
+	}
+
 	// set headers in response
 	for headerKey, headerValue := range response.Headers {
 		responseWriter.Header().Set(headerKey, headerValue)
@@ -455,7 +466,15 @@ func (ar *AbstractResource) callCustomRouteFunc(responseWriter http.ResponseWrit
 	if response.Resources == nil {
 
 		// write a valid, empty JSON
-		responseWriter.Write([]byte("{}")) // nolint: errcheck
+		if _, err := responseWriter.Write([]byte("{}")); err != nil {
+
+			// should never happen
+			ar.Logger.ErrorWith("Response writer failed writing empty resources",
+				"err", err,
+				"routeFunc", routeFunc,
+				"request", request)
+			return
+		}
 
 		return
 	}


### PR DESCRIPTION
Fixing: https://github.com/nuclio/nuclio/issues/2135

## Error Flow:
- Missing ability/permisions (k8s, via RBAC) to list nodes and thus to get external addresses caused `GET /frontend_spec` to fail
- Failure in `/frontend_spec` because of the above caused a panic in dashboard, and the UI to not show the option to pick `serviceType` in the advanced section of the HTTP trigger configuration, which should always be there in k8s
- This failure and panic in dashboard probably happened when using the resource yamls for a while, but since we didn't have the `serviceType` conditioned on the response, it went unnoticed

## Fixes:
- Added missing rule to `clusterrole` in rbac yaml
- Added error handling in `resource.go:callCustomRouteFunc` to log the error correctly and avoid a panic
- Smoother handling of inability to get external IPs in `getFrontendSpec` since failling the entire request is worse than not getting external ips