### PR TITLE
Introducing Python 3.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -598,7 +598,7 @@ test-nodejs:
 .PHONY: test-python
 test-python:
 	@set -e; \
-	for runtime in 3.8 3.7 3.6; do \
+	for runtime in 3.9 3.8 3.7 3.6; do \
 		docker build \
 			--build-arg PYTHON_IMAGE_TAG=$$runtime \
 			--build-arg CACHEBUST=$(shell date +%s) \

--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -59,7 +59,7 @@ The `spec` section contains the requirements and attributes and has the followin
 | :--- | :--- | :--- |
 | description | string | A textual description of the function |
 | handler | string | The entry point to the function, in the form of `package:entrypoint`; varies slightly between runtimes, see the appropriate runtime documentation for specifics |
-| runtime | string | The name of the language runtime - `golang` \| `python:3.6` \| `python:3.7` \| `python:3.8` \| `shell` \| `java` \| `nodejs` | 
+| runtime | string | The name of the language runtime - `golang` \| `python:3.6` \| `python:3.7` \| `python:3.8` \| `python:3.9` \| `shell` \| `java` \| `nodejs` | 
 | <a id="spec.image"></a>image | string | The name of the function's container image &mdash; used for the `image` [code-entry type](#spec.build.codeEntryType); see [Code-Entry Types](/docs/reference/function-configuration/code-entry-types.md#code-entry-type-image) |
 | env | map | A name-value environment-variables tuple; it's also possible to reference secrets from the map elements, as demonstrated in the [specifcation example](#spec-example) |
 | volumes | map | A map in an architecture similar to Kubernetes volumes, for Docker deployment |

--- a/docs/reference/runtimes/python/python-reference.md
+++ b/docs/reference/runtimes/python/python-reference.md
@@ -7,7 +7,7 @@ This document describes the specific Python build and deploy configurations.
 - [Function and handler](#function-and-handler)
 - [Dockerfile](#dockerfile)
 - [Python runtime 2.7 EOL](#python-runtime-27-eol)
-- [Introducing Python runtime 3.7 and 3.8](#introducing-python-runtime-37-and-38)
+- [Introducing Python runtimes 3.7, 3.8 and 3.9](#introducing-python-runtimes-37-38-and-39)
 - [Function configuration](#function-configuration)
 - [Build and execution](#build-and-execution)
 
@@ -75,19 +75,19 @@ releases. Starting from [Nuclio 1.6.0](https://github.com/nuclio/nuclio/releases
 deploy any Nuclio function using Python 2.7 runtime.
 
 To keep using latest Nuclio, and reach better performance and message throughput, we strongly suggest migrating your
-code to the newer [Python 3.7 and 3.8 runtimes](#introducing-python-runtime-37-and-38), if you haven't already.
+code to the newer [Python 3.7, 3.8 and 3.9 runtimes](#introducing-python-runtimes-37-38-and-39), if you haven't already.
 
-<a id="introducing-python-runtime-37-and-38"></a>
-## Introducing Python runtime 3.7 and 3.8
+<a id="introducing-python-runtimes-37-38-and-39"></a>
+## Introducing Python runtimes 3.7, 3.8 and 3.9
 
-Nuclio officially supports python 3.7 and python 3.8 (along with good-old python 3.6) as stand-alone runtimes. Along
+Nuclio officially supports python 3.7, 3.8 and python 3.9 (along with good-old python 3.6) as stand-alone runtimes. Along
 with simply bumping the python versions, some changes to the internal function processor were made, to take advantage of
 new language features and newer packages.
 
 Key differences and changes:
 
-- Python 3.8 is 5%-8% faster than Python 3.6 for small sized event messages.
-- Python 3.7 and 3.8 base images are `python:3.7` and `python:3.8`, respectively.
+- Python 3.8+ is 5%-8% faster than Python 3.6 for small sized event messages.
+- Python 3.7, 3.8 and 3.9 base images are `python:3.7`, `python:3.8` and `python:3.9`, respectively.
 - Events metadata, such as headers, path, method, etc are now byte-strings. This may incur changes in your code to refer
   to the various (now) byte-string event properties correctly in the new runtimes. e.g.: Simple code snipped which
   worked on python 2.7 and 3.6, using some event metadata, such as `event.path` -
@@ -98,7 +98,7 @@ Key differences and changes:
       return "I'm doing something..."
   ```
 
-  In the new 3.7 and 3.8 runtimes, the matching `event.path` property is now a `byte-string` instead of an old `string`,
+  In Python 3.7+ runtimes, the matching `event.path` property is now a `byte-string` instead of an old `string`,
   The new snippet will look like this:
 
   ```python

--- a/hack/scripts/benchmark/benchmark.py
+++ b/hack/scripts/benchmark/benchmark.py
@@ -64,6 +64,7 @@ class Runtimes(object):
     python36 = "python:3.6"
     python37 = "python:3.7"
     python38 = "python:3.8"
+    python39 = "python:3.9"
 
     # NOTE: python is just an alias to python3.6
     python = "python"

--- a/pkg/dashboard/functiontemplates/generated.go
+++ b/pkg/dashboard/functiontemplates/generated.go
@@ -1013,6 +1013,44 @@ def handler(context, event):
 `,
 	},
 	{
+		Name: "helloworld:python-39",
+		Configuration: unmarshalConfig(`metadata: {}
+spec:
+  build: {}
+  description: Showcases unstructured logging and a structured response.
+  eventTimeout: ""
+  handler: helloworld:handler
+  maxReplicas: 1
+  minReplicas: 1
+  platform: {}
+  resources: {}
+  runtime: python:3.9
+`),
+		SourceCode: `# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def handler(context, event):
+    context.logger.info('This is an unstructured log')
+
+    return context.Response(body='Hello, from nuclio :]',
+                            headers={},
+                            content_type='text/plain',
+                            status_code=200)
+`,
+	},
+	{
 		Name: "sentiments:python-36",
 		Configuration: unmarshalConfig(`metadata: {}
 spec:

--- a/pkg/dashboard/functiontemplates/generator/generator.go
+++ b/pkg/dashboard/functiontemplates/generator/generator.go
@@ -258,14 +258,14 @@ func (g *Generator) buildFunctionTemplates(functionDirs []string) ([]*functionte
 			"runtime", configuration.Spec.Runtime)
 		functionTemplates = append(functionTemplates, functionTemplate)
 
-		// HACK: allow python 3.6, 3.7, 3.8 share the same functions to avoid specific examples per runtime version
+		// HACK: allow python 3.6, 3.7, 3.8, 3.9 share the same functions to avoid specific examples per runtime version
 		runtimeName, runtimeVersion := common.GetRuntimeNameAndVersion(configuration.Spec.Runtime)
 		if runtimeName == "python" &&
 			runtimeVersion == "3.6" &&
 			functionName == "helloworld" {
 
-			// add helloworld function example to python 3.7 and 3.8
-			for _, runtimeCopy := range []string{"python:3.7", "python:3.8"} {
+			// add helloworld function example to python 3.7+
+			for _, runtimeCopy := range []string{"python:3.7", "python:3.8", "python:3.9"} {
 				configurationCopy := *configuration
 				configurationCopy.Spec.Runtime = runtimeCopy
 

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -139,6 +139,11 @@ func (suite *functionDeployTestSuite) TestDeploy() {
 			filename: "empty.py",
 		},
 		{
+			runtime:  "python:3.9",
+			handler:  "empty:handler",
+			filename: "empty.py",
+		},
+		{
 			runtime:  "ruby",
 			handler:  "empty:main",
 			filename: "empty.rb",

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -426,6 +426,7 @@ func (b *Builder) initializeSupportedRuntimes() {
 	b.runtimeInfo["python:3.6"] = runtimeInfo{"py", poundParser, 5}
 	b.runtimeInfo["python:3.7"] = runtimeInfo{"py", poundParser, 5}
 	b.runtimeInfo["python:3.8"] = runtimeInfo{"py", poundParser, 5}
+	b.runtimeInfo["python:3.9"] = runtimeInfo{"py", poundParser, 5}
 	b.runtimeInfo["nodejs"] = runtimeInfo{"js", slashSlashParser, 0}
 	b.runtimeInfo["java"] = runtimeInfo{"java", slashSlashParser, 0}
 	b.runtimeInfo["ruby"] = runtimeInfo{"rb", poundParser, 0}

--- a/pkg/processor/build/runtime/python/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/python/docker/onbuild/Dockerfile
@@ -48,6 +48,17 @@ RUN pip download \
         --exists-action i \
         --requirement /requirements/python3_8.txt
 
+# Supplies python 3.9 & common wheels
+FROM python:3.9 as python39-builder
+
+COPY pkg/processor/runtime/python/py/requirements /requirements
+
+# Python 3.9 wheels
+RUN pip download \
+        --dest /whl \
+        --exists-action i \
+        --requirement /requirements/python3_9.txt
+
 # Supplies processor
 FROM quay.io/nuclio/processor:${NUCLIO_LABEL}-${NUCLIO_ARCH} as processor
 
@@ -63,3 +74,4 @@ COPY --from=processor /home/nuclio/bin/processor /home/nuclio/bin/processor
 COPY --from=python36-builder /whl /home/nuclio/bin/py-whl
 COPY --from=python37-builder /whl /home/nuclio/bin/py3.7-whl
 COPY --from=python38-builder /whl /home/nuclio/bin/py3.8-whl
+COPY --from=python39-builder /whl /home/nuclio/bin/py3.9-whl

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -55,7 +55,7 @@ func (p *python) GetProcessorDockerfileInfo(onbuildImageRegistry string) (*runti
 	_, runtimeVersion := common.GetRuntimeNameAndVersion(p.FunctionConfig.Spec.Runtime)
 
 	switch runtimeVersion {
-	case "3.8", "3.7":
+	case "3.9", "3.8", "3.7":
 		baseImage = fmt.Sprintf("python:%s", runtimeVersion)
 
 		// use specific wheel files path

--- a/pkg/processor/build/runtime/python/test/python_test.go
+++ b/pkg/processor/build/runtime/python/test/python_test.go
@@ -169,6 +169,7 @@ func TestIntegrationSuite(t *testing.T) {
 		{runtimeName: "python:3.6"},
 		{runtimeName: "python:3.7"},
 		{runtimeName: "python:3.8"},
+		{runtimeName: "python:3.9"},
 	} {
 		t.Run(testCase.runtimeName, func(t *testing.T) {
 			testSuite := new(TestSuite)

--- a/pkg/processor/runtime/python/py/requirements/python3_9.txt
+++ b/pkg/processor/runtime/python/py/requirements/python3_9.txt
@@ -1,0 +1,3 @@
+-r common.txt
+pip==21.0
+msgpack==1.0.2 --no-binary=msgpack

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -448,6 +448,7 @@ func TestIntegrationSuite(t *testing.T) {
 		{runtimeName: "python:3.6"},
 		{runtimeName: "python:3.7"},
 		{runtimeName: "python:3.8"},
+		{runtimeName: "python:3.9"},
 	} {
 		t.Run(testCase.runtimeName, func(t *testing.T) {
 			testSuite := new(TestSuite)


### PR DESCRIPTION
## Python 3.9

Introducing python 3.9 as officially OOB runtime.

Continuing the work effort made on https://github.com/nuclio/nuclio/pull/2072