### PR TITLE
Preserve function unhealthiness when deployment failed

### DIFF
--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -263,7 +263,7 @@ func (fo *functionOperator) setFunctionError(function *nuclioio.NuclioFunction,
 		State:   functionErrorState,
 		Message: errors.GetErrorStackString(err, 10),
 	}); setStatusErr != nil {
-		fo.logger.Warn("Failed to update function on error",
+		fo.logger.WarnWith("Failed to update function on error",
 			"setStatusErr", errors.Cause(setStatusErr))
 	}
 

--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -216,8 +216,8 @@ def handler(context, event):
 			// wait for monitoring
 			time.Sleep(postDeploymentSleepInterval)
 
-			// ensure function is still in error state (due to deploy error of missing configmap)
-			suite.GetFunctionAndExpectState(getFunctionOptions, functionconfig.FunctionStateError)
+			// function would become unhealthy as its function deployment is missing the mentioned configmap
+			suite.GetFunctionAndExpectState(getFunctionOptions, functionconfig.FunctionStateUnhealthy)
 
 			// create the missing configmap
 			configMap, err = suite.KubeClientSet.CoreV1().ConfigMaps(suite.Namespace).Create(configMap)

--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -155,8 +155,8 @@ func (suite *FunctionMonitoringTestSuite) TestNoRecoveryAfterBuildError() {
 		})
 }
 
-func (suite *FunctionMonitoringTestSuite) TestNoRecoveryAfterDeployError() {
-	functionName := "function-deploy-fail"
+func (suite *FunctionMonitoringTestSuite) TestRecoveryAfterDeployError() {
+	functionName := "function-recover-after-deploy-fail"
 	createFunctionOptions := suite.CompileCreateFunctionOptions(functionName)
 	getFunctionOptions := &platform.GetFunctionsOptions{
 		Name:      createFunctionOptions.FunctionConfig.Meta.Name,
@@ -209,7 +209,7 @@ def handler(context, event):
 	postDeploymentSleepInterval := 2*suite.Controller.GetFunctionMonitoringInterval() +
 		monitoring.PostDeploymentMonitoringBlockingInterval
 
-	suite.DeployFunctionExpectErrorAndRedeploy(createFunctionOptions,
+	_, err := suite.DeployFunctionExpectError(createFunctionOptions,
 		func(deployResult *platform.CreateFunctionResult) bool {
 			var err error
 
@@ -237,19 +237,48 @@ def handler(context, event):
 			// wait for monitoring
 			time.Sleep(postDeploymentSleepInterval)
 
-			// ensure function monitoring did not recover the function from its recent deploy error
-			suite.GetFunctionAndExpectState(getFunctionOptions, functionconfig.FunctionStateError)
-
-			return true
-		}, func(deployResult *platform.CreateFunctionResult) bool {
-
-			// let interval occur at least once
-			time.Sleep(postDeploymentSleepInterval)
-
-			// ensure function in ready state, deploy passes
+			// function should be recovered by function monitoring
 			suite.GetFunctionAndExpectState(getFunctionOptions, functionconfig.FunctionStateReady)
+
 			return true
 		})
+	suite.Require().Error(err)
+}
+
+func (suite *FunctionMonitoringTestSuite) TestNoRecoveryAfterDeployError() {
+	functionName := "function-no-recover-after-deploy-fail"
+	createFunctionOptions := suite.CompileCreateFunctionOptions(functionName)
+	getFunctionOptions := &platform.GetFunctionsOptions{
+		Name:      createFunctionOptions.FunctionConfig.Meta.Name,
+		Namespace: createFunctionOptions.FunctionConfig.Meta.Namespace,
+	}
+	createFunctionOptions.FunctionConfig.Spec.ReadinessTimeoutSeconds = 10
+
+	// function deploy would fail trying to run, leaving the function in error state forever
+	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = base64.StdEncoding.
+		EncodeToString([]byte(`def invalidhandler(context, event):return ""`))
+
+	// wait for at least one monitor + post deployment blocking intervals
+	postDeploymentSleepInterval := 2*suite.Controller.GetFunctionMonitoringInterval() +
+		monitoring.PostDeploymentMonitoringBlockingInterval
+
+	_, err := suite.DeployFunctionExpectError(createFunctionOptions,
+		func(deployResult *platform.CreateFunctionResult) bool {
+
+			// wait for monitoring
+			time.Sleep(postDeploymentSleepInterval)
+
+			// ensure function is still in error state (due to deploy error of missing configmap)
+			suite.GetFunctionAndExpectState(getFunctionOptions, functionconfig.FunctionStateError)
+
+			// let function monitoring run for a while
+			time.Sleep(postDeploymentSleepInterval)
+
+			// function should be remained in error state
+			suite.GetFunctionAndExpectState(getFunctionOptions, functionconfig.FunctionStateError)
+			return true
+		})
+	suite.Require().Error(err)
 }
 
 func (suite *FunctionMonitoringTestSuite) TestRecoverErrorStateFunctionWhenResourcesAvailable() {


### PR DESCRIPTION
Scenario:

1. Kubernetes being slow on reporting function pods readiness
2. Deploy function(s)
3. Nuclio-controller gives up on waiting for function readiness, marking function state as `unhealthy`
4. While that happened, the context used to create/update the function gets timedout (deadline due to readiness timeout)
5. The Worker (Kubernets workers) gets the function, see its context got timeout and re-queue it
6. Nuclio-controller being triggered again, this time function has "unhealthy" state but does nothing
7. In the meantime, Nuclio-dashboard is waiting for the function deployment to finish
8. Nuclio-dashboard identify the deployment has finished with state != ready and report error by setting function state back to error.
9. Function pods are up and serving while function being left in error state

This PR solves the issue raised on 8 & 9 by

8. Nuclio-dashboard preserve the deployment unhealthy state
9. Function pods are up, controller function monitoring recover its state from unhealthy to healthy
