### PR TITLE
Helm chart - node selector, affinity and tolerations support [1.5.x backport]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ all:
 #
 
 helm-publish:
-	$(eval HELM_PUBLISH_COMMIT_MESSAGE := "Releasing chart $(shell helm inspect chart hack/k8s/helm/nuclio | yq r - version)")
+	$(eval HELM_PUBLISH_COMMIT_MESSAGE := "Releasing chart $(shell helm inspect chart hack/k8s/helm/nuclio | yq eval '.version' -)")
 	@echo Fetching branch
 	@rm -rf /tmp/nuclio-helm
 	@git clone -b gh-pages --single-branch git@github.com:nuclio/nuclio.git /tmp/nuclio-helm

--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.7.20
+version: 0.7.21
 appVersion: 1.5.17
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/templates/deployment/autoscaler.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/autoscaler.yaml
@@ -63,4 +63,16 @@ spec:
         configMap:
           name: {{ template "nuclio.platformConfigName" . }}
       {{- end }}
+      {{- with .Values.autoscaler.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.autoscaler.tolerations }}
+      tolerations:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.autoscaler.affinity }}
+      affinity:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
 {{- end }}

--- a/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
@@ -83,4 +83,16 @@ spec:
         configMap:
           name: {{ template "nuclio.platformConfigName" . }}
       {{- end }}
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.controller.affinity }}
+      affinity:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
 {{- end }}

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -174,4 +174,16 @@ spec:
         configMap:
           name: {{ template "nuclio.platformConfigName" . }}
       {{- end }}
+      {{- with .Values.dashboard.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.tolerations }}
+      tolerations:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.affinity }}
+      affinity:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
 {{- end }}

--- a/hack/k8s/helm/nuclio/templates/deployment/dlx.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dlx.yaml
@@ -63,4 +63,16 @@ spec:
         configMap:
           name: {{ template "nuclio.platformConfigName" . }}
       {{- end }}
+      {{- with .Values.dlx.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.dlx.tolerations }}
+      tolerations:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.dlx.affinity }}
+      affinity:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
 {{- end }}

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -14,6 +14,22 @@ controller:
     pullPolicy: IfNotPresent  
   resources: {}
 
+  ## Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## List of node taints to tolerate (requires Kubernetes >= 1.6)
+  tolerations: []
+  #  - key: "key"
+  #    operator: "Equal|Exists"
+  #    value: "value"
+  #    effect: "NoSchedule|PreferNoSchedule|NoExecute"
+
+  ## Affinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+
   # Uncomment to have the controller to listen only the namespace's events, 
   # change to listen on other specific namespace
   # namespace: "@nuclio.selfNamespace"
@@ -47,6 +63,23 @@ dashboard:
     tag: 1.5.17-amd64
     pullPolicy: IfNotPresent
   resources: {}
+
+  ## Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## List of node taints to tolerate (requires Kubernetes >= 1.6)
+  tolerations: []
+  #  - key: "key"
+  #    operator: "Equal|Exists"
+  #    value: "value"
+  #    effect: "NoSchedule|PreferNoSchedule|NoExecute"
+
+  ## Affinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+
   baseImagePullPolicy: IfNotPresent
   externalIPAddresses: []
   httpIngressHostTemplate: ""
@@ -107,6 +140,22 @@ autoscaler:
     pullPolicy: IfNotPresent
   resources: {}
 
+  ## Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## List of node taints to tolerate (requires Kubernetes >= 1.6)
+  tolerations: []
+  #  - key: "key"
+  #    operator: "Equal|Exists"
+  #    value: "value"
+  #    effect: "NoSchedule|PreferNoSchedule|NoExecute"
+
+  ## Affinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+
 dlx:
   enabled: false
   replicas: 1
@@ -115,6 +164,22 @@ dlx:
     tag: 1.5.17-amd64
     pullPolicy: IfNotPresent
   resources: {}
+
+  ## Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## List of node taints to tolerate (requires Kubernetes >= 1.6)
+  tolerations: []
+  #  - key: "key"
+  #    operator: "Equal|Exists"
+  #    value: "value"
+  #    effect: "NoSchedule|PreferNoSchedule|NoExecute"
+
+  ## Affinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
 
 registry:
 


### PR DESCRIPTION
- Backporting #2168, #2168
- Bump chart to 0.7.21 (will be released manually)