### PR TITLE
Helm chart - fix indentation on new nodeSelect,tolerations,affinity [1.5.x backport]

### DIFF
--- a/hack/k8s/helm/nuclio/templates/deployment/autoscaler.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/autoscaler.yaml
@@ -65,14 +65,14 @@ spec:
       {{- end }}
       {{- with .Values.autoscaler.nodeSelector }}
       nodeSelector:
-      {{ toYaml . | indent 8 }}
+      {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.autoscaler.tolerations }}
       tolerations:
-      {{ toYaml . | indent 8 }}
+      {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.autoscaler.affinity }}
       affinity:
-      {{ toYaml . | indent 8 }}
+      {{ toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
@@ -85,14 +85,14 @@ spec:
       {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:
-      {{ toYaml . | indent 8 }}
+      {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.controller.tolerations }}
       tolerations:
-      {{ toYaml . | indent 8 }}
+      {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.controller.affinity }}
       affinity:
-      {{ toYaml . | indent 8 }}
+      {{ toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -176,14 +176,14 @@ spec:
       {{- end }}
       {{- with .Values.dashboard.nodeSelector }}
       nodeSelector:
-      {{ toYaml . | indent 8 }}
+      {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.dashboard.tolerations }}
       tolerations:
-      {{ toYaml . | indent 8 }}
+      {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.dashboard.affinity }}
       affinity:
-      {{ toYaml . | indent 8 }}
+      {{ toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/hack/k8s/helm/nuclio/templates/deployment/dlx.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dlx.yaml
@@ -65,14 +65,14 @@ spec:
       {{- end }}
       {{- with .Values.dlx.nodeSelector }}
       nodeSelector:
-      {{ toYaml . | indent 8 }}
+      {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.dlx.tolerations }}
       tolerations:
-      {{ toYaml . | indent 8 }}
+      {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.dlx.affinity }}
       affinity:
-      {{ toYaml . | indent 8 }}
+      {{ toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
Backporting #2170
No need to bump chart, re-releasing 0.7.21