### PR TITLE
CI - tweaks and updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,7 +155,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
 
-    - uses: manusa/actions-setup-minikube@v2.3.0
+    - uses: manusa/actions-setup-minikube@v2.4.0
       with:
         minikube version: "v1.15.1"
         kubernetes version: "v1.17.9"
@@ -262,7 +262,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - uses: manusa/actions-setup-minikube@v2.3.0
+      - uses: manusa/actions-setup-minikube@v2.4.0
         with:
           minikube version: "v1.15.1"
           kubernetes version: "v1.17.9"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,10 +111,12 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    # since github-actions gives us 14G only, and fill it up with some garbage
+    # since github-actions gives us 14G only, and fills it up with some garbage
     # we will free up some space for us (~2GB)
-    - name: Freeing some disk space
-      run: docker system prune --all --force
+    - name: Freeing up disk space
+      run: |
+        chmod +x "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
+        "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
 
     - name: Build
       run: make docker-images

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,22 +128,13 @@ jobs:
       run: docker system prune --force
 
     - name: Save
-      run: |
-        # list built images
-        # join with " "
-        # save docker images
-        # compress using pigz (use fast, the difference is insignificant)
-        docker images \
-            --filter="reference=${REPO}/${REPO_NAME}/*:${NUCLIO_LABEL}*" \
-            --format "{{ .Repository }}:{{ .Tag }}" \
-          | xargs docker save \
-          | pigz --fast > nuclio_docker_images.tar.gz
+      run: make save-docker-images
 
     - name: Upload
       uses: actions/upload-artifact@v2
       with:
         name: nuclio-docker-images
-        path: nuclio_docker_images.tar.gz
+        path: nuclio-docker-images-*.tar.gz
 
   test_k8s_nuctl:
     name: Test Kubernetes nuctl
@@ -188,14 +179,14 @@ jobs:
       run: |
 
         # load nuclio docker images to host docker
-        docker load -i nuclio_docker_images.tar.gz
+        make load-docker-images
 
         # activate minikube docker
         eval $(minikube -p minikube docker-env)
 
         # load nuclio docker images to minikube
-        docker load -i nuclio_docker_images.tar.gz
-        rm nuclio_docker_images.tar.gz
+        make load-docker-images
+        rm nuclio-docker-images*.tar.gz
 
     - name: Export env
       run: |
@@ -245,8 +236,8 @@ jobs:
 
     - name: Load nuclio docker images
       run: |
-        docker load -i nuclio_docker_images.tar.gz
-        rm nuclio_docker_images.tar.gz
+        make load-docker-images
+        rm nuclio-docker-images*.tar.gz
 
     - name: Run nuctl docker tests
       run: |
@@ -293,8 +284,8 @@ jobs:
 
       - name: Load nuclio docker images
         run: |
-          docker load -i nuclio_docker_images.tar.gz
-          rm nuclio_docker_images.tar.gz
+          make load-docker-images
+          rm nuclio-docker-images*.tar.gz
 
       - name: Export env
         run: |

--- a/.github/workflows/long_ci.yaml
+++ b/.github/workflows/long_ci.yaml
@@ -38,18 +38,8 @@ jobs:
       # we will free up some space for us (~2GB)
       - name: Freeing up disk space
         run: |
-          df --human-readable
-          sudo apt-get remove --yes '^dotnet-.*' 'php.*' azure-cli google-cloud-sdk google-chrome-stable firefox powershell
-          sudo apt-get autoremove --yes
-          sudo apt clean
-          docker system prune --all --force
-          sudo rm --recursive --force \
-            /usr/share/dotnet \
-            /usr/share/miniconda \
-            /usr/share/dotnet \
-            /usr/local/lib/android \
-            /usr/share/swift
-          df --human-readable
+          chmod +x "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
+          "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
 
       - name: Set labels
         uses: actions/github-script@v3

--- a/.github/workflows/long_ci.yaml
+++ b/.github/workflows/long_ci.yaml
@@ -37,7 +37,17 @@ jobs:
       # since github-actions gives us 14G only, and fills it up with some garbage
       # we will free up some space for us (~2GB)
       - name: Freeing up disk space
-        run: docker system prune --all --force
+        run: |
+          df --human-readable
+          sudo apt-get remove --yes '^ghc-8.*' '^dotnet-.*' 'php.*' azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell
+          sudo apt-get autoremove --yes
+          sudo apt clean
+          docker system prune --all --force
+          sudo rm --recursive --force \
+            /usr/share/dotnet \
+            /usr/share/miniconda \
+            /usr/share/swift
+          df --human-readable
 
       - name: Set labels
         uses: actions/github-script@v3

--- a/.github/workflows/long_ci.yaml
+++ b/.github/workflows/long_ci.yaml
@@ -39,13 +39,15 @@ jobs:
       - name: Freeing up disk space
         run: |
           df --human-readable
-          sudo apt-get remove --yes '^ghc-8.*' '^dotnet-.*' 'php.*' azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell
+          sudo apt-get remove --yes '^dotnet-.*' 'php.*' azure-cli google-cloud-sdk google-chrome-stable firefox powershell
           sudo apt-get autoremove --yes
           sudo apt clean
           docker system prune --all --force
           sudo rm --recursive --force \
             /usr/share/dotnet \
             /usr/share/miniconda \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
             /usr/share/swift
           df --human-readable
 

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -5,7 +5,7 @@ on:
   - cron:  '0 */12 * * *'
 
 jobs:
-  build:
+  periodic:
     name: Periodic Regression
     runs-on: ubuntu-latest
 
@@ -28,7 +28,9 @@ jobs:
     # since github-actions gives us 14G only, and fills it up with some garbage
     # we will free up some space for us (~2GB)
     - name: Freeing up disk space
-      run: docker system prune --all --force
+      run: |
+        chmod +x "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
+        "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
 
     - name: Build
       run: make build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,10 +59,12 @@ jobs:
       with:
         go-version: "1.14"
 
-    # since github-actions gives us 14G only, and fill it up with some garbage
+    # since github-actions gives us 14G only, and fills it up with some garbage
     # we will free up some space for us (~2GB)
-    - name: Freeing some disk space
-      run: docker system prune --all --force
+    - name: Freeing up disk space
+      run: |
+        chmod +x "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
+        "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
 
     - uses: azure/docker-login@v1
       with:

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,10 @@ save-docker-images: print-docker-images
 	@echo "Saving Nuclio docker images"
 	docker save $(IMAGES_TO_PUSH) | pigz --fast > nuclio-docker-images-$(NUCLIO_LABEL)-$(NUCLIO_ARCH).tar.gz
 
+load-docker-images: print-docker-images
+	@echo "Load Nuclio docker images"
+	docker load -i nuclio-docker-images-$(NUCLIO_LABEL)-$(NUCLIO_ARCH).tar.gz
+
 print-docker-images:
 	@echo "Nuclio Docker images:"
 	@for image in $(IMAGES_TO_PUSH); do \

--- a/hack/scripts/ci/free-space.sh
+++ b/hack/scripts/ci/free-space.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+
+print_free_space() {
+  df --human-readable
+}
+
+# before cleanup
+print_free_space
+
+# clean unneeded os packages and misc
+sudo apt-get remove --yes '^dotnet-.*' 'php.*' azure-cli google-cloud-sdk google-chrome-stable firefox powershell
+sudo apt-get autoremove --yes
+sudo apt clean
+
+# cleanup unneeded share dirs ~30GB
+sudo rm --recursive --force \
+    /usr/local/lib/android \
+    /usr/share/dotnet \
+    /usr/share/miniconda \
+    /usr/share/dotnet \
+    /usr/share/swift \
+
+# clean unneeded docker images
+docker system prune --all --force
+
+# post cleanup
+print_free_space

--- a/hack/scripts/ci/free-space.sh
+++ b/hack/scripts/ci/free-space.sh
@@ -18,7 +18,7 @@ sudo rm --recursive --force \
     /usr/share/dotnet \
     /usr/share/miniconda \
     /usr/share/dotnet \
-    /usr/share/swift \
+    /usr/share/swift
 
 # clean unneeded docker images
 docker system prune --all --force


### PR DESCRIPTION
Updates - 

1. Free more disk space (from 2gb cleanup to more than 40GB!)
2. Use makefile `save-docker-images` and `load-docker-images`
3. Update minikube installation script

w.r.t (1):


Free disk space before cleanup:
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   64G   20G  77% /
devtmpfs        3.4G     0  3.4G   0% /dev
tmpfs           3.4G   12K  3.4G   1% /dev/shm
tmpfs           696M  1.1M  695M   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           3.4G     0  3.4G   0% /sys/fs/cgroup
/dev/loop0       33M   33M     0 100% /snap/snapd/11588
/dev/loop1       71M   71M     0 100% /snap/lxd/19647
/dev/loop2       56M   56M     0 100% /snap/core18/1997
/dev/sdb15      105M  7.8M   97M   8% /boot/efi
/dev/sda1        14G  4.1G  9.0G  32% /mnt
```

After cleanup:
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   23G   62G  27% /
devtmpfs        3.4G     0  3.4G   0% /dev
tmpfs           3.4G   12K  3.4G   1% /dev/shm
tmpfs           696M  1.1M  695M   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           3.4G     0  3.4G   0% /sys/fs/cgroup
/dev/loop0       33M   33M     0 100% /snap/snapd/11588
/dev/loop1       71M   71M     0 100% /snap/lxd/19647
/dev/loop2       56M   56M     0 100% /snap/core18/1997
/dev/sdb15      105M  7.8M   97M   8% /boot/efi
/dev/sda1        14G  4.1G  9.0G  32% /mnt
```