### PR TITLE
Fix function monitoring concurrent map writes

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -438,9 +438,9 @@ func CatchAndLogPanicWithOptions(ctx context.Context,
 	options *CatchAndLogPanicOptions) error {
 	if err := recover(); err != nil {
 		callStack := debug.Stack()
-		logPanic(ctx, loggerInstance, actionName, options.Args, callStack, err)
+		LogPanic(ctx, loggerInstance, actionName, options.Args, callStack, err)
 
-		asErr := errorFromRecoveredError(err)
+		asErr := ErrorFromRecoveredError(err)
 		if options.CustomHandler != nil {
 			options.CustomHandler(asErr)
 		}
@@ -488,7 +488,7 @@ func GetRuntimeNameAndVersion(runtime string) (string, string) {
 
 }
 
-func logPanic(ctx context.Context,
+func LogPanic(ctx context.Context,
 	loggerInstance logger.Logger,
 	actionName string,
 	args []interface{},
@@ -507,7 +507,7 @@ func logPanic(ctx context.Context,
 	loggerInstance.ErrorWithCtx(ctx, "Panic caught while "+actionName, logArgs...)
 }
 
-func errorFromRecoveredError(recoveredError interface{}) error {
+func ErrorFromRecoveredError(recoveredError interface{}) error {
 	switch typedErr := recoveredError.(type) {
 	case string:
 		return errors.New(typedErr)

--- a/pkg/errgroup/errgroup.go
+++ b/pkg/errgroup/errgroup.go
@@ -1,0 +1,58 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errgroup
+
+import (
+	"context"
+	"runtime/debug"
+
+	"github.com/nuclio/nuclio/pkg/common"
+
+	"github.com/nuclio/logger"
+	"golang.org/x/sync/errgroup"
+)
+
+type Group struct {
+	*errgroup.Group
+	logger logger.Logger
+	ctx    context.Context
+}
+
+func WithContext(ctx context.Context, loggerInstance logger.Logger) (*Group, context.Context) {
+	newBaseErrgroup, errgroupCtx := errgroup.WithContext(ctx)
+
+	return &Group{
+		Group:  newBaseErrgroup,
+		logger: loggerInstance,
+		ctx:    errgroupCtx,
+	}, errgroupCtx
+}
+
+func (g *Group) Go(actionName string, f func() error) {
+	wrapper := func() (err error) {
+		defer func() {
+			if recoveredErr := recover(); recoveredErr != nil {
+				callStack := debug.Stack()
+				common.LogPanic(g.ctx, g.logger, actionName, nil, callStack, recoveredErr)
+				err = common.ErrorFromRecoveredError(recoveredErr)
+			}
+		}()
+		err = f()
+		return
+	}
+	g.Group.Go(wrapper)
+}

--- a/pkg/platform/kube/monitoring/function.go
+++ b/pkg/platform/kube/monitoring/function.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package monitoring
 
 import (

--- a/pkg/platform/kube/monitoring/function_test.go
+++ b/pkg/platform/kube/monitoring/function_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	nuclioiofake "github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/versioned/fake"
@@ -46,9 +45,6 @@ type FunctionMonitoringTestSuite struct {
 
 func (suite *FunctionMonitoringTestSuite) SetupSuite() {
 	var err error
-
-	common.SetVersionFromEnv()
-
 	suite.Namespace = "default-namespace"
 	suite.Logger, err = nucliozap.NewNuclioZapTest("test")
 	suite.Require().NoError(err, "Failed to create logger")

--- a/pkg/platform/kube/monitoring/function_test.go
+++ b/pkg/platform/kube/monitoring/function_test.go
@@ -1,0 +1,95 @@
+// +build test_unit
+
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+	nuclioiofake "github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/versioned/fake"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type FunctionMonitoringTestSuite struct {
+	suite.Suite
+	nuclioioClientSet *nuclioiofake.Clientset
+	kubeClientSet     *fake.Clientset
+	Namespace         string
+	Logger            logger.Logger
+	functionMonitor   *FunctionMonitor
+}
+
+func (suite *FunctionMonitoringTestSuite) SetupSuite() {
+	var err error
+
+	common.SetVersionFromEnv()
+
+	suite.Namespace = "default-namespace"
+	suite.Logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err, "Failed to create logger")
+}
+
+func (suite *FunctionMonitoringTestSuite) SetupTest() {
+	var err error
+	suite.kubeClientSet = fake.NewSimpleClientset()
+	suite.nuclioioClientSet = nuclioiofake.NewSimpleClientset()
+	suite.functionMonitor, err = NewFunctionMonitor(suite.Logger,
+		suite.Namespace,
+		suite.kubeClientSet,
+		suite.nuclioioClientSet,
+		time.Second)
+	suite.Require().NoError(err)
+}
+
+func (suite *FunctionMonitoringTestSuite) TestBulkCheckFunctionStatuses() {
+
+	// create some dummy functions in provisioning mode
+	for i := 0; i < 100; i++ {
+		function, err := suite.nuclioioClientSet.NuclioV1beta1().
+			NuclioFunctions(suite.Namespace).
+			Create(&nuclioio.NuclioFunction{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("func-%d", i),
+					Namespace: suite.Namespace,
+				},
+				Spec: functionconfig.Spec{},
+				Status: functionconfig.Status{
+					State: functionconfig.FunctionStateWaitingForResourceConfiguration,
+				},
+			})
+		suite.Require().NoError(err)
+		suite.Require().NotNil(function)
+	}
+
+	err := suite.functionMonitor.checkFunctionStatuses()
+	suite.Require().NoError(err)
+}
+
+func TestFunctionMonitoringTestSuite(t *testing.T) {
+	suite.Run(t, new(FunctionMonitoringTestSuite))
+}


### PR DESCRIPTION
1. Fix max concurrent write (🤕 ) panic when bulkly update many functions using `sync.Map`
2. Added errgrup with panic recovery
3. Added unit test

Error logs

```
...controller logs...

fatal error: concurrent map read and map write
fatal error: concurrent map read and map write

goroutine 10039 [running]:
runtime.throw(0x16dce6f, 0x21)
        /usr/local/go/src/runtime/panic.go:1116 +0x72 fp=0xc0008cecb8 sp=0xc0008cec88 pc=0x433a42
runtime.mapaccess2_faststr(0x14fd6e0, 0xc00062bb00, 0xc000013670, 0xa, 0x5, 0x1)
        /usr/local/go/src/runtime/map_faststr.go:116 +0x47c fp=0xc0008ced28 sp=0xc0008cecb8 pc=0x412eec
github.com/nuclio/nuclio/pkg/platform/kube/monitoring.(*FunctionMonitor).resolveFunctionProvisionedOrRecentlyDeployed(0xc0001521e0, 0xc0006c0900, 0x4)
        /nuclio/pkg/platform/kube/monitoring/function.go:273 +0x173 fp=0xc0008cee08 sp=0xc0008ced28 pc=0x1363663
github.com/nuclio/nuclio/pkg/platform/kube/monitoring.(*FunctionMonitor).shouldSkipFunctionMonitoring(0xc0001521e0, 0xc0006c0900, 0x19a4580)
        /nuclio/pkg/platform/kube/monitoring/function.go:235 +0x3c fp=0xc0008cee80 sp=0xc0008cee08 pc=0x136300c
```