### PR TITLE
Log internal/external invocation urls upon successfull deployment

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -195,10 +195,11 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 	}
 
 	// indicate that we're done
-	// TODO: print function.Status.Invocation and not just `HTTPPort`
 	createFunctionOptions.Logger.InfoWith("Function deploy complete",
 		"functionName", deployResult.UpdatedFunctionConfig.Meta.Name,
-		"httpPort", deployResult.Port)
+		"httpPort", deployResult.Port,
+		"internalInvocationURLs", deployResult.FunctionStatus.InternalInvocationURLs,
+		"externalInvocationURLs", deployResult.FunctionStatus.ExternalInvocationURLs)
 	return deployResult, nil
 }
 

--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -144,7 +144,8 @@ func (d *Deployer) Deploy(functionInstance *nuclioio.NuclioFunction,
 	}
 
 	return &platform.CreateFunctionResult{
-		Port: updatedFunctionInstance.Status.HTTPPort,
+		Port:           updatedFunctionInstance.Status.HTTPPort,
+		FunctionStatus: updatedFunctionInstance.Status,
 	}, updatedFunctionInstance, "", nil
 }
 

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -302,6 +302,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 			return nil, errors.Wrap(err, "Failed to update a function with state")
 		}
 
+		createFunctionResult.FunctionStatus = functionStatus
 		return createFunctionResult, nil
 	}
 
@@ -1128,7 +1129,12 @@ func (p *Platform) populateFunctionInvocationStatus(functionInvocation *function
 	}
 
 	functionInvocation.InternalInvocationURLs = addresses
-	functionInvocation.ExternalInvocationURLs = append(functionInvocation.ExternalInvocationURLs,
-		fmt.Sprintf("%s:%d", externalIPAddresses[0], createFunctionResults.Port))
+	functionInvocation.ExternalInvocationURLs = []string{}
+	for _, externalIPAddress := range externalIPAddresses {
+		if externalIPAddress != "" {
+			functionInvocation.ExternalInvocationURLs = append(functionInvocation.ExternalInvocationURLs,
+				fmt.Sprintf("%s:%d", externalIPAddress, createFunctionResults.Port))
+		}
+	}
 	return nil
 }

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -81,8 +81,9 @@ type CreateFunctionBuildResult struct {
 // CreateFunctionResult holds the results of a deploy
 type CreateFunctionResult struct {
 	CreateFunctionBuildResult
-	Port        int
-	ContainerID string
+	FunctionStatus functionconfig.Status
+	Port           int
+	ContainerID    string
 }
 
 // GetFunctionsOptions is the base for all platform get options


### PR DESCRIPTION
Currently, once a function has been deployed with clusterIP, the troublesome log line includes `httpPort: 0` only without explaining how to invoke the function

This PR, continuing the effort made on https://github.com/nuclio/nuclio/pull/2163 by includes the internal/external invocations urls

Exampels:

NodePort + Ingress

<img width="1240" alt="Screen Shot 2021-04-27 at 11 31 44" src="https://user-images.githubusercontent.com/6547459/116269383-2e3c7800-a74c-11eb-8faa-d6e39ced0e4c.png">


With a clusterIP
```
[11:23:44.883]  (I)  Function deploy complete   [externalInvocationURLs: [], functionName: "helloworld", httpPort: 0, internalInvocationURLs: ["nuclio-helloworld.default.svc.cluster.local:8080"]] 
```

With a nodePort
```
[11:21:44.949]  (I)  Function deploy complete   [externalInvocationURLs: ["192.168.65.4:32366"], functionName: "helloworld", httpPort: 32366, internalInvocationURLs: ["nuclio-helloworld.default.svc.cluster.local:8080"]] 
```

With an Ingress
```
[11:23:17.683]  (I)  Function deploy complete   [externalInvocationURLs: ["somewhere.com/"], functionName: "helloworld", httpPort: 0, internalInvocationURLs: ["nuclio-helloworld.default.svc.cluster.local:8080"]] 
```
