### PR TITLE
Added function invocation timeout

### DIFF
--- a/cmd/dashboard/README.md
+++ b/cmd/dashboard/README.md
@@ -196,6 +196,7 @@ The HTTP method you apply to this endpoint is the one with which dashboard will 
   * `x-nuclio-path`: The path to invoke the function with (can be empty to invoke with `/`)
   * `x-nuclio-invoke-via`: One of `external-ip`, `loadbalancer` and `domain-name`
   * `x-nuclio-invoke-url`: Function invocation url to use (if provided, overrides `x-nuclio-invoke-via` header)
+  * `x-nuclio-invoke-timeout`: Function invocation request timeout (e.g.: `1s`)
   * Any other header is passed transparently to the function
 * Body: Raw body passed as is to the function
 

--- a/pkg/dashboard/resource/invocation.go
+++ b/pkg/dashboard/resource/invocation.go
@@ -18,7 +18,6 @@ package resource
 
 import (
 	"fmt"
-	"github.com/nuclio/nuclio-sdk-go"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -31,6 +30,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/restful"
 
 	"github.com/nuclio/errors"
+	"github.com/nuclio/nuclio-sdk-go"
 )
 
 type invocationResource struct {

--- a/pkg/dashboard/resource/invocation.go
+++ b/pkg/dashboard/resource/invocation.go
@@ -18,10 +18,12 @@ package resource
 
 import (
 	"fmt"
+	"github.com/nuclio/nuclio-sdk-go"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/dashboard"
@@ -78,6 +80,12 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 		return
 	}
 
+	invokeTimeout, err := tr.resolveInvokeTimeout(request.Header.Get("x-nuclio-invoke-timeout"))
+	if err != nil {
+		tr.writeErrorHeader(responseWriter, http.StatusBadRequest)
+		tr.writeErrorMessage(responseWriter, errors.RootCause(err).Error())
+	}
+
 	// resolve the function host
 	invocationResult, err := tr.getPlatform().CreateFunctionInvocation(&platform.CreateFunctionInvocationOptions{
 		Name:      functionName,
@@ -88,6 +96,7 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 		Body:      requestBody,
 		Via:       invokeVia,
 		URL:       invokeURL,
+		Timeout:   invokeTimeout,
 	})
 
 	if err != nil {
@@ -133,6 +142,17 @@ func (tr *invocationResource) writeErrorHeader(responseWriter http.ResponseWrite
 func (tr *invocationResource) writeErrorMessage(responseWriter io.Writer, message string) {
 	formattedMessage := fmt.Sprintf(`{"error": "%s"}`, message)
 	responseWriter.Write([]byte(formattedMessage)) // nolint: errcheck
+}
+
+func (tr *invocationResource) resolveInvokeTimeout(invokeTimeout string) (time.Duration, error) {
+	if invokeTimeout == "" {
+		return platform.FunctionInvocationDefaultTimeout, nil
+	}
+	parsedDuration, err := time.ParseDuration(invokeTimeout)
+	if err != nil {
+		return 0, nuclio.NewErrBadRequest("Invalid invoke timeout")
+	}
+	return parsedDuration, nil
 }
 
 // register the resource

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -213,6 +213,7 @@ func (s *Server) InstallMiddleware(router chi.Router) error {
 			"X-nuclio-wait-function-action",
 			"X-nuclio-api-gateway-name",
 			"X-nuclio-api-gateway-namespace",
+			"X-nuclio-invoke-timeout",
 			"X-nuclio-invoke-via",
 			"X-nuclio-invoke-url",
 			"X-nuclio-project-name",

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -32,6 +32,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nuclio/nuclio/pkg/dashboard"
 	"github.com/nuclio/nuclio/pkg/dashboard/functiontemplates"
@@ -632,6 +633,7 @@ func (suite *functionTestSuite) TestInvokeSuccessful() {
 		"x-nuclio-function-namespace": functionNamespace,
 		"x-nuclio-invoke-via":         "external-ip",
 		"x-nuclio-invoke-url":         "something",
+		"x-nuclio-invoke-timeout":     "5m",
 	}
 
 	// add functionRequestHeaders to requestHeaders so that dashboard will invoke the functions with them
@@ -657,6 +659,7 @@ func (suite *functionTestSuite) TestInvokeSuccessful() {
 		suite.Require().Equal(requestMethod, createFunctionInvocationOptions.Method)
 		suite.Require().Equal(platform.InvokeViaAny, createFunctionInvocationOptions.Via)
 		suite.Require().Equal("something", createFunctionInvocationOptions.URL)
+		suite.Require().Equal(5*time.Minute, createFunctionInvocationOptions.Timeout)
 
 		// dashboard will trim the first "/"
 		suite.Require().Equal(requestPath[1:], createFunctionInvocationOptions.Path)

--- a/pkg/platform/abstract/invoker.go
+++ b/pkg/platform/abstract/invoker.go
@@ -86,7 +86,9 @@ func (i *invoker) invoke(createFunctionInvocationOptions *platform.CreateFunctio
 		fullpath += "/" + createFunctionInvocationOptions.Path
 	}
 
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: createFunctionInvocationOptions.Timeout,
+	}
 	var req *http.Request
 	var body io.Reader = http.NoBody
 

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -116,9 +116,12 @@ type CreateFunctionInvocationOptions struct {
 	Body         []byte
 	Headers      http.Header
 	LogLevelName string
+	Timeout      time.Duration
 	Via          InvokeViaType
 	URL          string
 }
+
+const FunctionInvocationDefaultTimeout = time.Minute
 
 // CreateFunctionInvocationResult holds the result of a single invocation
 type CreateFunctionInvocationResult struct {


### PR DESCRIPTION
Golang HTTP Client timeout is not set by default. That may _potentially_ lead to function invocations waiting forever for a response.

To avoid such scenarios, the invocation timeout default is set to `1m`. to override it, and set an unlimited timeout, the user may provide `--timeout 0s`  from nuctl or set `x-nuclio-invoke-timeout: 0s` using the RESTful resource `/api/function_invocations`