### PR TITLE
Dashboard - avoid writing body on NoContent code

### DIFF
--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -476,14 +476,23 @@ func (ar *AbstractResource) callCustomRouteFunc(responseWriter http.ResponseWrit
 
 	if response.Resources == nil {
 
-		// write a valid, empty JSON
-		if _, err := responseWriter.Write([]byte("{}")); err != nil {
+		switch response.StatusCode {
+		case http.StatusNoContent:
 
-			// should never happen
-			ar.Logger.ErrorWith("Response writer failed writing empty resources",
-				"err", err,
-				"routeFunc", routeFunc,
-				"request", request)
+			// nothing to do
+			break
+		default:
+
+			// write a valid, empty JSON
+			if _, err := responseWriter.Write([]byte("{}")); err != nil {
+
+				// should never happen
+				ar.Logger.ErrorWith("Response writer failed writing empty resources",
+					"err", err,
+					"routeFunc", routeFunc,
+					"request", request)
+			}
+
 		}
 
 		return


### PR DESCRIPTION
Dashboard log an error when removing a function

```
21.05.03 12:42:06.481 oard.server.api/functions (E) Response writer failed writing empty resources {"err": "http: request method or response status code does not allow body", "routeFuncError": "json: unsupported type: restful.CustomRouteFunc", "requestError": "json: unsupported type: func() (io.ReadCloser, error)"}
```

This does not interfere with the response, but hurting the logs