### PR TITLE
Configurable http trigger annotation

### DIFF
--- a/pkg/platform/kube/controller/nucliofunction_test.go
+++ b/pkg/platform/kube/controller/nucliofunction_test.go
@@ -112,6 +112,10 @@ func (suite *NuclioFunctionTestSuite) TestCreateOrUpdateWithScaleToZeroLabel() {
 					continue
 				}
 
+				if _, found := deployment.Labels[kube.FunctionScaleToZeroLabelKey]; found {
+					suite.Require().FailNow("Key should have been omitted from deployment resource")
+				}
+
 				suite.logger.DebugWith("Marking function deployment as available",
 					"functionDeploymentName", functionDeploymentName)
 				_, err = kubeFakeClient.AppsV1().Deployments(suite.namespace).Update(&appsv1.Deployment{

--- a/pkg/platform/kube/controller/nucliofunction_test.go
+++ b/pkg/platform/kube/controller/nucliofunction_test.go
@@ -91,6 +91,7 @@ func (suite *NuclioFunctionTestSuite) TestCreateOrUpdateWithScaleToZeroLabel() {
 		suite.logger,
 		kubeFakeClient,
 		suite.nuclioioInterfaceMock)
+	suite.Require().NoError(err)
 
 	go func() {
 		functionDeploymentName := "nuclio-func-name"

--- a/pkg/platform/kube/controller/nucliofunction_test.go
+++ b/pkg/platform/kube/controller/nucliofunction_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/mocks"
 	"github.com/nuclio/nuclio/pkg/platform/kube/functionres"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
@@ -35,6 +34,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 

--- a/pkg/platform/kube/controller/nucliofunction_test.go
+++ b/pkg/platform/kube/controller/nucliofunction_test.go
@@ -22,14 +22,20 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platform/kube"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	"github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/mocks"
 	"github.com/nuclio/nuclio/pkg/platform/kube/functionres"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 type NuclioFunctionTestSuite struct {
@@ -76,6 +82,102 @@ func (suite *NuclioFunctionTestSuite) SetupTest() {
 		Return(suite.nuclioFunctionInterfaceMock)
 
 	suite.functionOperatorInstance.controller.nuclioClientSet = suite.nuclioioInterfaceMock
+}
+
+func (suite *NuclioFunctionTestSuite) TestCreateOrUpdateWithScaleToZeroLabel() {
+	var err error
+	kubeFakeClient := fake.NewSimpleClientset()
+	suite.functionOperatorInstance.functionresClient, err = functionres.NewLazyClient(
+		suite.logger,
+		kubeFakeClient,
+		suite.nuclioioInterfaceMock)
+
+	go func() {
+		functionDeploymentName := "nuclio-func-name"
+		for {
+			select {
+			case <-time.After(5 * time.Second):
+				suite.Require().Fail("Took too much time to mark deployment as ready")
+			default:
+				suite.logger.DebugWith("Getting function deployment",
+					"functionDeploymentName", functionDeploymentName)
+				deployment, err := kubeFakeClient.AppsV1().Deployments(suite.namespace).Get(functionDeploymentName,
+					metav1.GetOptions{})
+
+				if err != nil || deployment == nil {
+					suite.logger.DebugWith("Function deployment does not exists yet",
+						"functionDeploymentName", functionDeploymentName,
+						"err", err)
+					time.Sleep(250 * time.Millisecond)
+					continue
+				}
+
+				suite.logger.DebugWith("Marking function deployment as available",
+					"functionDeploymentName", functionDeploymentName)
+				_, err = kubeFakeClient.AppsV1().Deployments(suite.namespace).Update(&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "nuclio-func-name",
+						Namespace: suite.namespace,
+					},
+					Status: appsv1.DeploymentStatus{
+						Conditions: []appsv1.DeploymentCondition{
+							{
+								Type:   appsv1.DeploymentAvailable,
+								Status: v1.ConditionTrue,
+								Reason: "manually-changed-by-nuclio-test",
+							},
+						},
+					},
+				})
+				suite.Require().NoError(err)
+
+				// done
+				return
+			}
+		}
+	}()
+
+	mockedPlatformConfig := &functionres.MockedPlatformConfigurationProvider{}
+	mockedPlatformConfig.
+		On("GetPlatformConfiguration").
+		Return(&platformconfig.Config{
+			FunctionAugmentedConfigs: []platformconfig.LabelSelectorAndConfig{
+				{
+					LabelSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							kube.FunctionScaleToZeroLabelKey: "true",
+						},
+					},
+					HTTPTrigger: functionconfig.Trigger{
+						Annotations: map[string]string{
+							"do": "it",
+						},
+					},
+				},
+			},
+		})
+	mockedPlatformConfig.
+		On("GetPlatformConfigurationName").
+		Return("something")
+
+	suite.functionOperatorInstance.functionresClient.SetPlatformConfigurationProvider(mockedPlatformConfig)
+	functionInstance := &nuclioio.NuclioFunction{}
+	functionInstance.Name = "func-name"
+	functionInstance.Namespace = suite.namespace
+	functionInstance.Status.State = functionconfig.FunctionStateReady
+	functionInstance.Labels = map[string]string{
+		kube.FunctionScaleToZeroLabelKey: "true",
+	}
+	functionInstance.Spec.Triggers = map[string]functionconfig.Trigger{
+		"default-http": functionconfig.GetDefaultHTTPTrigger(),
+	}
+	ctx := context.TODO()
+	err = suite.functionOperatorInstance.CreateOrUpdate(ctx, functionInstance)
+	suite.Require().NoError(err)
+
+	// nothing override it accidentally
+	suite.Require().Equal("true", functionInstance.Labels[kube.FunctionScaleToZeroLabelKey])
+	suite.Require().Equal("it", functionInstance.Spec.Triggers["default-http"].Annotations["do"])
 }
 
 func (suite *NuclioFunctionTestSuite) TestRecoverFromPanic() {

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -79,7 +79,7 @@ func (suite *lazyTestSuite) TestNoChanges() {
 			Replicas: &one,
 		},
 	}
-	functionLabels := suite.client.getFunctionLabels(&function)
+	functionLabels := suite.client.getFunctionLabels(&function, true)
 	functionLabels["nuclio.io/function-name"] = function.Name
 
 	// logs are spammy, let them

--- a/pkg/platform/kube/functionres/mock.go
+++ b/pkg/platform/kube/functionres/mock.go
@@ -20,9 +20,24 @@ import (
 	"context"
 
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
 
 	"github.com/stretchr/testify/mock"
 )
+
+type MockedPlatformConfigurationProvider struct {
+	mock.Mock
+}
+
+func (m *MockedPlatformConfigurationProvider) GetPlatformConfiguration() *platformconfig.Config {
+	args := m.Called()
+	return args.Get(0).(*platformconfig.Config)
+}
+
+func (m *MockedPlatformConfigurationProvider) GetPlatformConfigurationName() string {
+	args := m.Called()
+	return args.String(0)
+}
 
 type MockedFunctionRes struct {
 	mock.Mock

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -340,8 +340,7 @@ func (p Platform) EnrichFunctionConfig(functionConfig *functionconfig.Config) er
 		return err
 	}
 
-	p.enrichHTTPTriggersWithServiceType(functionConfig)
-
+	p.enrichHTTPTriggers(functionConfig)
 	return nil
 }
 
@@ -1216,6 +1215,11 @@ func (p *Platform) enrichAndValidateFunctionConfig(functionConfig *functionconfi
 	}
 
 	return nil
+}
+
+func (p *Platform) enrichHTTPTriggers(functionConfig *functionconfig.Config) {
+	p.enrichHTTPTriggersWithServiceType(functionConfig)
+
 }
 
 func (p *Platform) enrichHTTPTriggersWithServiceType(functionConfig *functionconfig.Config) {

--- a/pkg/platform/kube/types.go
+++ b/pkg/platform/kube/types.go
@@ -22,6 +22,8 @@ import (
 	"github.com/rs/xid"
 )
 
+const FunctionScaleToZeroLabelKey = "nuclio.io/function-scale-to-zero"
+
 type DeployOptions struct {
 }
 

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -472,13 +472,13 @@ functionAugmentedConfigs:
 		{
 
 			// all function matches `nuclio.io/class: function` should have deployment spec of MinReadySeconds: 90
-			v1.LabelSelector{
+			LabelSelector: v1.LabelSelector{
 				MatchLabels: map[string]string{
 					"nuclio.io/class": "function",
 				},
 			},
-			functionconfig.Config{},
-			Kubernetes{
+			FunctionConfig: functionconfig.Config{},
+			Kubernetes: Kubernetes{
 				Deployment: &appsv1.Deployment{
 					Spec: appsv1.DeploymentSpec{
 						MinReadySeconds: 90,
@@ -489,11 +489,11 @@ functionAugmentedConfigs:
 		{
 
 			// set min replicas to 0 and max replicas to 10 for all functions
-			v1.LabelSelector{},
-			functionconfig.Config{
+			LabelSelector: v1.LabelSelector{},
+			FunctionConfig: functionconfig.Config{
 				Spec: functionconfig.Spec{MinReplicas: &zero, MaxReplicas: &ten},
 			},
-			Kubernetes{},
+			Kubernetes: Kubernetes{},
 		},
 	}
 

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -93,6 +93,7 @@ type LabelSelectorAndConfig struct {
 	LabelSelector  machinarymetav1.LabelSelector `json:"labelSelector,omitempty"`
 	FunctionConfig functionconfig.Config         `json:"functionConfig,omitempty"`
 	Kubernetes     Kubernetes                    `json:"kubernetes,omitempty"`
+	HTTPTrigger    functionconfig.Trigger        `json:"httpTrigger,omitempty"`
 }
 
 type Kubernetes struct {


### PR DESCRIPTION
Some changes to allow HTTP trigger specifics by applying augmented config

- Added `functionHTTPTrigger` augmented config structure to allow HTTP Trigger specific augmented configurations
- Added `nuclio.io/function-scale-to-zero` label to scale-to-zero candidate functions
- Added UTs

This will allow us to have augmented config applied on the HTTP Trigger for scale to zero functions. E.x:

```
functionAugmentedConfigs:
  - labelSelector:
      matchLabels:
        nuclio.io/scale-to-zero: true
    httpTrigger:
      annotations:
        nginx.ingress.kubernetes.io/service-upstream: true
```
