### PR TITLE
Project Sync - Add leader polling/synchronization loop

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -517,3 +517,7 @@ func ErrorFromRecoveredError(recoveredError interface{}) error {
 		return errors.New(fmt.Sprintf("Unknown error type: %s", reflect.TypeOf(typedErr)))
 	}
 }
+
+func TimeToTimePointer(t time.Time) *time.Time {
+	return &t
+}

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -517,7 +517,3 @@ func ErrorFromRecoveredError(recoveredError interface{}) error {
 		return errors.New(fmt.Sprintf("Unknown error type: %s", reflect.TypeOf(typedErr)))
 	}
 }
-
-func TimeToTimePointer(t time.Time) *time.Time {
-	return &t
-}

--- a/pkg/common/map.go
+++ b/pkg/common/map.go
@@ -126,3 +126,12 @@ func CreateKeyValuePairs(m map[string]string) string {
 	}
 	return generatedString
 }
+
+// returns string to string map if it's not nil. otherwise, return an empty one
+func GetStringStringMapOrEmpty(m map[string]string) map[string]string {
+	if m == nil {
+		return map[string]string{}
+	}
+
+	return m
+}

--- a/pkg/common/map.go
+++ b/pkg/common/map.go
@@ -128,7 +128,7 @@ func CreateKeyValuePairs(m map[string]string) string {
 }
 
 // returns string to string map if it's not nil. otherwise, return an empty one
-func GetStringStringMapOrEmpty(m map[string]string) map[string]string {
+func GetStringToStringMapOrEmpty(m map[string]string) map[string]string {
 	if m == nil {
 		return map[string]string{}
 	}

--- a/pkg/common/url.go
+++ b/pkg/common/url.go
@@ -142,7 +142,9 @@ func SendHTTPRequest(method string,
 
 	// attach cookies
 	for _, cookie := range cookies {
-		req.AddCookie(cookie)
+		if cookie != nil {
+			req.AddCookie(cookie)
+		}
 	}
 
 	// attach headers

--- a/pkg/common/url.go
+++ b/pkg/common/url.go
@@ -142,9 +142,7 @@ func SendHTTPRequest(method string,
 
 	// attach cookies
 	for _, cookie := range cookies {
-		if cookie != nil {
-			req.AddCookie(cookie)
-		}
+		req.AddCookie(cookie)
 	}
 
 	// attach headers

--- a/pkg/nuctl/test/project_test.go
+++ b/pkg/nuctl/test/project_test.go
@@ -538,7 +538,6 @@ func (suite *projectExportImportTestSuite) TestImportProject() {
 		uniqueSuffix,
 		[]string{function1Name, function2Name},
 		[]string{function1EventDisplayName, function2EventDisplayName},
-		//[]string{apiGateway1Name})
 		[]string{apiGateway1Name, apiGateway2Name})
 	defer os.Remove(uniqueProjectConfigPath) // nolint: errcheck
 

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -786,7 +786,7 @@ func (ap *Platform) EnsureDefaultProjectExistence() error {
 		}); err != nil {
 
 			// if project already exists, return
-			if apierrors.IsAlreadyExists(err) {
+			if apierrors.IsAlreadyExists(errors.RootCause(err)) {
 				return nil
 			}
 

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -42,6 +42,7 @@ import (
 	"github.com/nuclio/nuclio-sdk-go"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
@@ -783,6 +784,12 @@ func (ap *Platform) EnsureDefaultProjectExistence() error {
 		if err := ap.platform.CreateProject(&platform.CreateProjectOptions{
 			ProjectConfig: newProject.GetConfig(),
 		}); err != nil {
+
+			// if project already exists, return
+			if apierrors.IsAlreadyExists(err) {
+				return nil
+			}
+
 			return errors.Wrap(err, "Failed to create default project")
 		}
 

--- a/pkg/platform/abstract/project/external/client.go
+++ b/pkg/platform/abstract/project/external/client.go
@@ -38,7 +38,7 @@ func NewClient(parentLogger logger.Logger,
 
 	// get leader synchronization interval
 	synchronizationIntervalStr := "0"
-	if platformConfiguration.ProjectsLeader != nil{
+	if platformConfiguration.ProjectsLeader != nil {
 		synchronizationIntervalStr = platformConfiguration.ProjectsLeader.SynchronizationInterval
 	}
 	newClient.synchronizer, err = iguazio.NewSynchronizer(parentLogger, synchronizationIntervalStr, newClient.leaderClient, internalClient)

--- a/pkg/platform/abstract/project/external/client.go
+++ b/pkg/platform/abstract/project/external/client.go
@@ -45,7 +45,9 @@ func NewClient(parentLogger logger.Logger,
 }
 
 func (c *Client) Initialize() error {
-	c.synchronizer.Start()
+	if err := c.synchronizer.Start(); err != nil {
+		return errors.Wrap(err, "Failed to start the projects synchronizer")
+	}
 
 	return c.internalClient.Initialize()
 }

--- a/pkg/platform/abstract/project/external/client.go
+++ b/pkg/platform/abstract/project/external/client.go
@@ -15,8 +15,8 @@ import (
 
 type Client struct {
 	platformConfiguration *platformconfig.Config
-	internalClient        project.Client
 	synchronizer          *iguazio.Synchronizer
+	internalClient        project.Client
 	leaderClient          leader.Client
 }
 
@@ -36,7 +36,12 @@ func NewClient(parentLogger logger.Logger,
 		return nil, errors.Wrap(err, "Failed to create leader client")
 	}
 
-	newClient.synchronizer, err = iguazio.NewSynchronizer(parentLogger, platformConfiguration, newClient.leaderClient, internalClient)
+	// get leader synchronization interval
+	synchronizationIntervalStr := "0"
+	if platformConfiguration.ProjectsLeader != nil{
+		synchronizationIntervalStr = platformConfiguration.ProjectsLeader.SynchronizationInterval
+	}
+	newClient.synchronizer, err = iguazio.NewSynchronizer(parentLogger, synchronizationIntervalStr, newClient.leaderClient, internalClient)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create synchronizer")
 	}

--- a/pkg/platform/abstract/project/external/client.go
+++ b/pkg/platform/abstract/project/external/client.go
@@ -16,6 +16,7 @@ import (
 type Client struct {
 	platformConfiguration *platformconfig.Config
 	internalClient        project.Client
+	synchronizer          *iguazio.Synchronizer
 	leaderClient          leader.Client
 }
 
@@ -35,13 +36,18 @@ func NewClient(parentLogger logger.Logger,
 		return nil, errors.Wrap(err, "Failed to create leader client")
 	}
 
+	newClient.synchronizer, err = iguazio.NewSynchronizer(parentLogger, platformConfiguration, newClient.leaderClient, internalClient)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create synchronizer")
+	}
+
 	return &newClient, nil
 }
 
 func (c *Client) Initialize() error {
+	c.synchronizer.Start()
 
-	// do nothing
-	return nil
+	return c.internalClient.Initialize()
 }
 
 func (c *Client) Get(getProjectsOptions *platform.GetProjectsOptions) ([]platform.Project, error) {

--- a/pkg/platform/abstract/project/external/client.go
+++ b/pkg/platform/abstract/project/external/client.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
-	"github.com/nuclio/nuclio-sdk-go"
 )
 
 type Client struct {
@@ -70,7 +69,7 @@ func (c *Client) Create(createProjectOptions *platform.CreateProjectOptions) (pl
 			return nil, errors.Wrap(err, "Failed while requesting from the leader to create the project")
 		}
 
-		return nil, nuclio.NewErrAccepted("Successfully requested from the leader to create the project")
+		return nil, platform.ErrSuccessfulCreateProjectLeader
 	}
 }
 
@@ -83,7 +82,7 @@ func (c *Client) Update(updateProjectOptions *platform.UpdateProjectOptions) (pl
 			return nil, errors.Wrap(err, "Failed while requesting from the leader to update the project")
 		}
 
-		return nil, nuclio.NewErrAccepted("Successfully requested from the leader to update the project")
+		return nil, platform.ErrSuccessfulUpdateProjectLeader
 	}
 }
 
@@ -96,7 +95,7 @@ func (c *Client) Delete(deleteProjectOptions *platform.DeleteProjectOptions) err
 			return errors.Wrap(err, "Failed while requesting from the leader to delete the project")
 		}
 
-		return nuclio.NewErrAccepted("Successfully requested from the leader to delete the project")
+		return platform.ErrSuccessfulDeleteProjectLeader
 	}
 }
 

--- a/pkg/platform/abstract/project/external/client_test.go
+++ b/pkg/platform/abstract/project/external/client_test.go
@@ -50,8 +50,8 @@ func (suite *ExternalProjectClientTestSuite) SetupSuite() {
 	// create external projects client
 	suite.Client = &Client{
 		platformConfiguration: &platformConfiguration,
-		internalClient: suite.mockInternalProjectsClient,
-		leaderClient: suite.mockLeaderProjectsClient,
+		internalClient:        suite.mockInternalProjectsClient,
+		leaderClient:          suite.mockLeaderProjectsClient,
 	}
 	suite.Require().NoError(err)
 }

--- a/pkg/platform/abstract/project/external/client_test.go
+++ b/pkg/platform/abstract/project/external/client_test.go
@@ -1,0 +1,190 @@
+package external
+
+import (
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platform/abstract/project"
+	leadermock "github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader/mock"
+	internalmock "github.com/nuclio/nuclio/pkg/platform/abstract/project/mock"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	ProjectsLeaderKindMock = "mock-leader"
+)
+
+type ExternalProjectClientTestSuite struct {
+	suite.Suite
+
+	project.Client
+	Logger                     logger.Logger
+	mockInternalProjectsClient *internalmock.Client
+	mockLeaderProjectsClient   *leadermock.Client
+}
+
+func (suite *ExternalProjectClientTestSuite) SetupSuite() {
+	var err error
+
+	// create logger
+	suite.Logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+
+	// mock internal client
+	suite.mockInternalProjectsClient = &internalmock.Client{}
+
+	//mock leader client
+	suite.mockLeaderProjectsClient = &leadermock.Client{}
+
+	// create platform configuration
+	platformConfiguration := platformconfig.Config{
+		ProjectsLeader: &platformconfig.ProjectsLeader{
+			Kind: ProjectsLeaderKindMock,
+		},
+	}
+
+	// create external projects client
+	suite.Client = &Client{
+		platformConfiguration: &platformConfiguration,
+		internalClient: suite.mockInternalProjectsClient,
+		leaderClient: suite.mockLeaderProjectsClient,
+	}
+	suite.Require().NoError(err)
+}
+
+func (suite *ExternalProjectClientTestSuite) TestLeaderCreate() {
+	createProjectOptions := platform.CreateProjectOptions{
+		RequestOrigin: ProjectsLeaderKindMock,
+		ProjectConfig: &platform.ProjectConfig{
+			Meta: platform.ProjectMeta{
+				Name: "test-func",
+			},
+		},
+	}
+
+	suite.mockInternalProjectsClient.
+		On("Create", &createProjectOptions).
+		Return(&platform.AbstractProject{}, nil).
+		Once()
+
+	_, err := suite.Client.Create(&createProjectOptions)
+	suite.Require().NoError(err)
+}
+
+func (suite *ExternalProjectClientTestSuite) TestLeaderUpdate() {
+	updateProjectOptions := platform.UpdateProjectOptions{
+		RequestOrigin: ProjectsLeaderKindMock,
+		ProjectConfig: platform.ProjectConfig{
+			Meta: platform.ProjectMeta{
+				Name: "test-func",
+			},
+		},
+	}
+
+	suite.mockInternalProjectsClient.
+		On("Update", &updateProjectOptions).
+		Return(&platform.AbstractProject{}, nil).
+		Once()
+
+	_, err := suite.Client.Update(&updateProjectOptions)
+	suite.Require().NoError(err)
+}
+
+func (suite *ExternalProjectClientTestSuite) TestLeaderDelete() {
+	deleteProjectOptions := platform.DeleteProjectOptions{
+		RequestOrigin: ProjectsLeaderKindMock,
+		Meta: platform.ProjectMeta{
+			Name: "test-func",
+		},
+	}
+
+	suite.mockInternalProjectsClient.
+		On("Delete", &deleteProjectOptions).
+		Return(nil).
+		Once()
+
+	err := suite.Client.Delete(&deleteProjectOptions)
+	suite.Require().NoError(err)
+}
+
+func (suite *ExternalProjectClientTestSuite) TestNotLeaderCreate() {
+	createProjectOptions := platform.CreateProjectOptions{
+		RequestOrigin: "not-leader",
+		ProjectConfig: &platform.ProjectConfig{
+			Meta: platform.ProjectMeta{
+				Name: "test-func",
+			},
+		},
+	}
+
+	suite.mockLeaderProjectsClient.
+		On("Create", &createProjectOptions).
+		Return(nil, nil).
+		Once()
+
+	_, err := suite.Client.Create(&createProjectOptions)
+	suite.Require().Error(err)
+	suite.Require().Equal(err, platform.ErrSuccessfulCreateProjectLeader)
+}
+
+func (suite *ExternalProjectClientTestSuite) TestNotLeaderUpdate() {
+	updateProjectOptions := platform.UpdateProjectOptions{
+		RequestOrigin: "not-leader",
+		ProjectConfig: platform.ProjectConfig{
+			Meta: platform.ProjectMeta{
+				Name: "test-func",
+			},
+		},
+	}
+
+	suite.mockLeaderProjectsClient.
+		On("Update", &updateProjectOptions).
+		Return(nil, nil).
+		Once()
+
+	_, err := suite.Client.Update(&updateProjectOptions)
+	suite.Require().Error(err)
+	suite.Require().Equal(err, platform.ErrSuccessfulUpdateProjectLeader)
+}
+
+func (suite *ExternalProjectClientTestSuite) TestNotLeaderDelete() {
+	deleteProjectOptions := platform.DeleteProjectOptions{
+		RequestOrigin: "not-leader",
+		Meta: platform.ProjectMeta{
+			Name: "test-func",
+		},
+	}
+
+	suite.mockLeaderProjectsClient.
+		On("Delete", &deleteProjectOptions).
+		Return(nil).
+		Once()
+
+	err := suite.Client.Delete(&deleteProjectOptions)
+	suite.Require().Error(err)
+	suite.Require().Equal(err, platform.ErrSuccessfulDeleteProjectLeader)
+}
+
+func (suite *ExternalProjectClientTestSuite) TestGet() {
+	getProjectOptions := platform.GetProjectsOptions{
+		Meta: platform.ProjectMeta{
+			Name: "test-func",
+		},
+	}
+
+	suite.mockInternalProjectsClient.
+		On("Get", &getProjectOptions).
+		Return([]platform.Project{}, nil).
+		Once()
+
+	_, err := suite.Client.Get(&getProjectOptions)
+	suite.Require().NoError(err)
+}
+
+func TestExternalProjectClientTestSuite(t *testing.T) {
+	suite.Run(t, new(ExternalProjectClientTestSuite))
+}

--- a/pkg/platform/abstract/project/external/leader/iguazio/client.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/client.go
@@ -137,8 +137,8 @@ func (c *Client) Delete(deleteProjectOptions *platform.DeleteProjectOptions) err
 	return nil
 }
 
-func (c *Client) GetAll(updatedAfterTime *time.Time) ([]platform.Project, error) {
-	c.logger.DebugWith("Sending get all projects request to leader", "updatedAfterTime", updatedAfterTime)
+func (c *Client) GetUpdatedAfter(updatedAfterTime *time.Time) ([]platform.Project, error) {
+	c.logger.DebugWith("Fetching all projects from leader", "updatedAfterTime", updatedAfterTime)
 
 	// if updatedAfterTime arg was specified, filter by it
 	updatedAfterTimestampQuery := ""
@@ -180,7 +180,7 @@ func (c *Client) generateCommonRequestHeaders() map[string]string {
 }
 
 func (c *Client) generateProjectRequestBody(projectConfig *platform.ProjectConfig) ([]byte, error) {
-	project := CreateProjectFromProjectConfig(projectConfig)
+	project := NewProjectFromProjectConfig(projectConfig)
 	c.enrichProjectWithNuclioFields(&project)
 
 	return json.Marshal(project)

--- a/pkg/platform/abstract/project/external/leader/iguazio/client.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/client.go
@@ -176,7 +176,6 @@ func (c *Client) GetAll(updatedAfterTimestamp string) ([]platform.Project, error
 	return projectsList.ToSingleProjectList(), nil
 }
 
-
 func (c *Client) generateCommonRequestHeaders() map[string]string {
 	return map[string]string{
 		ProjectsRoleHeaderKey: ProjectsRoleHeaderValueNuclio,

--- a/pkg/platform/abstract/project/external/leader/iguazio/client.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/client.go
@@ -150,7 +150,7 @@ func (c *Client) GetAll(updatedAfterTimestamp string) ([]platform.Project, error
 	// get iguazio session - must exist in order to perform this GET operation against iguazio dashboard API
 	iguazioSession := c.platformConfiguration.IguazioSession
 	if iguazioSession == "" {
-		return nil, errors.New("Iguazio access key must be specified to get projects from its api")
+		return nil, errors.New("Iguazio session must be specified to get projects from its api")
 	}
 
 	// send the request

--- a/pkg/platform/abstract/project/external/leader/iguazio/client.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/client.go
@@ -139,13 +139,13 @@ func (c *Client) Delete(deleteProjectOptions *platform.DeleteProjectOptions) err
 	return nil
 }
 
-func (c *Client) GetAll(updatedAfterTimestamp string) ([]platform.Project, error) {
-	c.logger.DebugWith("Sending get all projects request to leader",
-		"updatedAfterTimestamp", updatedAfterTimestamp)
+func (c *Client) GetAll(updatedAfterTime *time.Time) ([]platform.Project, error) {
+	c.logger.DebugWith("Sending get all projects request to leader", "updatedAfterTime", updatedAfterTime)
 
-	// if updatedAfterTimestamp arg was given, filter by it
+	// if updatedAfterTime arg was given, filter by it
 	updatedAfterTimestampQuery := ""
-	if updatedAfterTimestamp != "" {
+	if updatedAfterTime != nil {
+		updatedAfterTimestamp := updatedAfterTime.Format(time.RFC3339Nano)
 		updatedAfterTimestampQuery = fmt.Sprintf("?filter[updated_at]=[$gt]%s", updatedAfterTimestamp)
 	}
 

--- a/pkg/platform/abstract/project/external/leader/iguazio/client.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/client.go
@@ -177,7 +177,7 @@ func (c *Client) GetUpdatedAfter(updatedAfterTime *time.Time) ([]platform.Projec
 			updatedAfterTimestampQuery),
 		nil,
 		headers,
-		[]*http.Cookie{{Name: "session", Value: c.platformConfiguration.IguazioSession}},
+		[]*http.Cookie{{Name: "session", Value: c.platformConfiguration.IguazioSessionCookie}},
 		http.StatusOK,
 		true,
 		DefaultRequestTimeout)

--- a/pkg/platform/abstract/project/external/leader/iguazio/client.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/client.go
@@ -152,7 +152,7 @@ func (c *Client) GetAll(updatedAfterTimestamp string) ([]platform.Project, error
 	// get the encoded iguazio session - used to perform this GET operation against iguazio dashboard API
 	encodedIguazioSession, err := c.getEncodedIguazioSession()
 	if err != nil {
-	   return nil, errors.Wrap(err, "Failed to get encoded iguazio session")
+		return nil, errors.Wrap(err, "Failed to get encoded iguazio session")
 	}
 
 	// send the request

--- a/pkg/platform/abstract/project/external/leader/iguazio/helper.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/helper.go
@@ -1,0 +1,21 @@
+package iguazio
+
+func labelListToMap(labelList []Label) map[string]string {
+	labelsMap := map[string]string{}
+
+	for _, label := range labelList {
+		labelsMap[label.Name] = label.Value
+	}
+
+	return labelsMap
+}
+
+func labelMapToList(labelMap map[string]string) []Label {
+	var labelList []Label
+
+	for labelName, labelValue := range labelMap {
+		labelList = append(labelList, Label{Name: labelName, Value: labelValue})
+	}
+
+	return labelList
+}

--- a/pkg/platform/abstract/project/external/leader/iguazio/synchronizer.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/synchronizer.go
@@ -179,6 +179,7 @@ func (c *Synchronizer) synchronizeProjectsAccordingToLeader() error {
 					"name", createProjectConfig.ProjectConfig.Meta.Name,
 					"namespace", createProjectConfig.ProjectConfig.Meta.Namespace,
 					"err", err)
+				return
 			}
 			c.logger.DebugWith("Successfully created project (during sync)",
 				"name", createProjectConfig.ProjectConfig.Meta.Name,
@@ -202,6 +203,7 @@ func (c *Synchronizer) synchronizeProjectsAccordingToLeader() error {
 					"name", updateProjectOptions.ProjectConfig.Meta.Name,
 					"namespace", updateProjectOptions.ProjectConfig.Meta.Namespace,
 					"err", err)
+				return
 			}
 			c.logger.DebugWith("Successfully updated project (during sync)",
 				"name", updateProjectOptions.ProjectConfig.Meta.Name,

--- a/pkg/platform/abstract/project/external/leader/iguazio/synchronizer.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/synchronizer.go
@@ -134,6 +134,12 @@ func (c *Synchronizer) SynchronizeProjectsFromLeader() error {
 
 	// filter modified projects
 	projectsToCreate, projectsToUpdate, mostRecentUpdatedProjectTime := c.GetModifiedProjects(leaderProjects, internalProjects)
+
+	// update most recent updated project time
+	if mostRecentUpdatedProjectTime != nil {
+		c.mostRecentUpdatedProjectTime = mostRecentUpdatedProjectTime
+	}
+
 	if len(projectsToCreate) == 0 && len(projectsToUpdate) == 0 {
 
 		// nothing to create/update - return
@@ -193,9 +199,6 @@ func (c *Synchronizer) SynchronizeProjectsFromLeader() error {
 				"namespace", updateProjectOptions.ProjectConfig.Meta.Namespace)
 		}()
 	}
-
-	// update most recent updated project time
-	c.mostRecentUpdatedProjectTime = mostRecentUpdatedProjectTime
 
 	return nil
 }

--- a/pkg/platform/abstract/project/external/leader/iguazio/synchronizer.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/synchronizer.go
@@ -71,7 +71,7 @@ func (c *Synchronizer) synchronizationLoop() {
 func (c *Synchronizer) updateLastSuccessfulSyncTimestamp() {
 	loc, err := time.LoadLocation("GMT")
 	if err != nil {
-		c.logger.WarnWith("Failed to load GMT location (Should not happen on unix based systems). " +
+		c.logger.WarnWith("Failed to load GMT location (Should not happen on unix based systems). "+
 			"Skipping last successful sync timestamp update",
 			"err", err)
 		return
@@ -120,7 +120,7 @@ func (c *Synchronizer) getModifiedProjects(leaderProjects []platform.Project, in
 		matchingInternalProjectConfig, found := internalProjectsMap[namespaceAndNameKey]
 		if !found {
 			projectsToCreate = append(projectsToCreate, leaderProjectConfig)
-		} else  if !matchingInternalProjectConfig.IsEqual(leaderProjectConfig, true) {
+		} else if !matchingInternalProjectConfig.IsEqual(leaderProjectConfig, true) {
 
 			// if the project exists both internally and on the leader - update it
 			projectsToUpdate = append(projectsToUpdate, leaderProjectConfig)

--- a/pkg/platform/abstract/project/external/leader/iguazio/synchronizer.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/synchronizer.go
@@ -1,0 +1,208 @@
+package iguazio
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platform/abstract/project"
+	"github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+)
+
+type Synchronizer struct {
+	logger                      logger.Logger
+	platformConfiguration       *platformconfig.Config
+	leaderClient                leader.Client
+	internalProjectsClient      project.Client
+	lastSuccessfulSyncTimestamp string
+}
+
+func NewSynchronizer(parentLogger logger.Logger,
+	platformConfiguration *platformconfig.Config,
+	leaderClient leader.Client,
+	internalProjectsClient project.Client) (*Synchronizer, error) {
+
+	parentLogger.DebugWith("Creating project synchronizer")
+	newSynchronizer := Synchronizer{
+		logger:                 parentLogger.GetChild("leader-synchronizer-iguazio"),
+		platformConfiguration:  platformConfiguration,
+		leaderClient:           leaderClient,
+		internalProjectsClient: internalProjectsClient,
+	}
+
+	return &newSynchronizer, nil
+}
+
+func (c *Synchronizer) Start() {
+	go c.synchronizationLoop()
+}
+
+func (c *Synchronizer) synchronizationLoop() {
+	synchronizationInterval := c.platformConfiguration.ProjectsLeader.SynchronizationInterval
+	if synchronizationInterval == 0 {
+		c.logger.InfoWith("Synchronization interval set to 0. Projects will not synchronize with leader")
+		return
+	}
+
+	c.logger.InfoWith("Starting synchronization loop", "synchronizationInterval", synchronizationInterval)
+
+	ticker := time.NewTicker(c.platformConfiguration.ProjectsLeader.SynchronizationInterval * time.Second)
+	for {
+		select {
+		case _ = <-ticker.C:
+			c.logger.DebugWith("Synchronizing projects according to leader")
+
+			if err := c.synchronizeProjectsAccordingToLeader(); err != nil {
+				c.logger.WarnWith("Failed to synchronize projects according to leader", "err", err)
+				continue
+			}
+
+			// update last successful sync timestamp
+			c.updateLastSuccessfulSyncTimestamp()
+		}
+	}
+}
+
+func (c *Synchronizer) updateLastSuccessfulSyncTimestamp() {
+	loc, err := time.LoadLocation("GMT")
+	if err != nil {
+		c.logger.WarnWith("Failed to load GMT location (Should not happen on unix based systems). " +
+			"Skipping last successful sync timestamp update",
+			"err", err)
+		return
+	}
+
+	t := time.Now().In(loc)
+	c.lastSuccessfulSyncTimestamp = t.Format(time.RFC3339)
+}
+
+func (c *Synchronizer) getModifiedProjects(leaderProjects []platform.Project, internalProjects []platform.Project) (
+	projectsToCreate []*platform.ProjectConfig,
+	projectsToUpdate []*platform.ProjectConfig) {
+
+	// create a mapping of all existing internal projects
+	internalProjectsMap := map[string]*platform.ProjectConfig{}
+	for _, internalProject := range internalProjects {
+		internalProjectConfig := internalProject.GetConfig()
+		if internalProjectConfig == nil {
+			continue
+		}
+
+		// generate a unique namespace+name key for the project
+		namespaceAndNameKey := fmt.Sprintf("%s:%s",
+			internalProjectConfig.Meta.Namespace,
+			internalProjectConfig.Meta.Name)
+
+		internalProjectsMap[namespaceAndNameKey] = internalProjectConfig
+	}
+
+	// iterate over matching leader projects and create/update each according to the existing internal projects
+	for _, leaderProject := range leaderProjects {
+		leaderProjectConfig := leaderProject.GetConfig()
+
+		// skip projects that their status is not online
+		if leaderProjectConfig == nil ||
+			leaderProjectConfig.Status.OperationalStatus != "online" ||
+			leaderProjectConfig.Status.AdminStatus != "online" {
+			continue
+		}
+
+		// generate a unique namespace+name key for the project (same as above)
+		namespaceAndNameKey := fmt.Sprintf("%s:%s",
+			leaderProjectConfig.Meta.Namespace,
+			leaderProjectConfig.Meta.Name)
+
+		matchingInternalProjectConfig, found := internalProjectsMap[namespaceAndNameKey]
+		if !found {
+			projectsToCreate = append(projectsToCreate, leaderProjectConfig)
+		} else  if !matchingInternalProjectConfig.IsEqual(leaderProjectConfig, true) {
+
+			// if the project exists both internally and on the leader - update it
+			projectsToUpdate = append(projectsToUpdate, leaderProjectConfig)
+		}
+	}
+
+	return
+}
+
+func (c *Synchronizer) synchronizeProjectsAccordingToLeader() error {
+
+	// fetch projects from leader
+	leaderProjects, err := c.leaderClient.GetAll(c.lastSuccessfulSyncTimestamp)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get leader projects")
+	}
+
+	// fetch internal projects
+	// TODO: fetch projects from every managed namespace - could be done by implementing GetAll()
+	namespace := "default-tenant"
+	internalProjects, err :=
+		c.internalProjectsClient.Get(&platform.GetProjectsOptions{Meta: platform.ProjectMeta{Namespace: "default-tenant"}})
+	if err != nil {
+		return errors.Wrapf(err, "Failed to get internal projects from namespace: %s", namespace)
+	}
+
+	// filter modified projects
+	projectsToCreate, projectsToUpdate := c.getModifiedProjects(leaderProjects, internalProjects)
+	if len(projectsToCreate) == 0 && len(projectsToUpdate) == 0 {
+
+		// nothing to create/update - return
+		return nil
+	}
+
+	c.logger.DebugWith("Synchronization loop modified projects",
+		"projectsToCreateNum", len(projectsToCreate),
+		"projectsToUpdateNum", len(projectsToUpdate))
+
+	// create projects that exist on the leader but weren't created internally
+	for _, projectInstance := range projectsToCreate {
+		projectInstance := projectInstance
+		go func() {
+			c.logger.DebugWith("Creating project (during sync)", "projectInstance", *projectInstance)
+			createProjectConfig := &platform.CreateProjectOptions{
+				ProjectConfig: &platform.ProjectConfig{
+					Meta: projectInstance.Meta,
+					Spec: projectInstance.Spec},
+			}
+			if _, err := c.internalProjectsClient.Create(createProjectConfig); err != nil {
+				c.logger.WarnWith("Failed to create project (during sync)",
+					"name", createProjectConfig.ProjectConfig.Meta.Name,
+					"namespace", createProjectConfig.ProjectConfig.Meta.Namespace,
+					"err", err)
+			}
+			c.logger.DebugWith("Successfully created project (during sync)",
+				"name", createProjectConfig.ProjectConfig.Meta.Name,
+				"namespace", createProjectConfig.ProjectConfig.Meta.Namespace)
+		}()
+	}
+
+	// update projects that exist both internally and on the leader
+	for _, projectInstance := range projectsToUpdate {
+		projectInstance := projectInstance
+		go func() {
+			c.logger.DebugWith("Updating project (during sync)", "projectInstance", *projectInstance)
+			updateProjectOptions := &platform.UpdateProjectOptions{
+				ProjectConfig: platform.ProjectConfig{
+					Meta: projectInstance.Meta,
+					Spec: projectInstance.Spec,
+				},
+			}
+			if _, err := c.internalProjectsClient.Update(updateProjectOptions); err != nil {
+				c.logger.WarnWith("Failed to update project (during sync)",
+					"name", updateProjectOptions.ProjectConfig.Meta.Name,
+					"namespace", updateProjectOptions.ProjectConfig.Meta.Namespace,
+					"err", err)
+			}
+			c.logger.DebugWith("Successfully updated project (during sync)",
+				"name", updateProjectOptions.ProjectConfig.Meta.Name,
+				"namespace", updateProjectOptions.ProjectConfig.Meta.Namespace)
+		}()
+	}
+
+	return nil
+}

--- a/pkg/platform/abstract/project/external/leader/iguazio/synchronizer.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/synchronizer.go
@@ -4,16 +4,17 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/nuclio/errors"
-	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/abstract/project"
 	"github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
 )
 
 type Synchronizer struct {
 	logger                       logger.Logger
-	synchronizationIntervalStr      string
+	synchronizationIntervalStr   string
 	leaderClient                 leader.Client
 	internalProjectsClient       project.Client
 	mostRecentUpdatedProjectTime *time.Time
@@ -26,10 +27,10 @@ func NewSynchronizer(parentLogger logger.Logger,
 
 	parentLogger.DebugWith("Creating project synchronizer")
 	newSynchronizer := Synchronizer{
-		logger:                  parentLogger.GetChild("leader-synchronizer-iguazio"),
+		logger:                     parentLogger.GetChild("leader-synchronizer-iguazio"),
 		synchronizationIntervalStr: synchronizationIntervalStr,
-		leaderClient:            leaderClient,
-		internalProjectsClient:  internalProjectsClient,
+		leaderClient:               leaderClient,
+		internalProjectsClient:     internalProjectsClient,
 	}
 
 	return &newSynchronizer, nil

--- a/pkg/platform/abstract/project/external/leader/iguazio/synchronizer_test.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/synchronizer_test.go
@@ -1,0 +1,183 @@
+package iguazio
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/platform"
+	leadermock "github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader/mock"
+	internalmock "github.com/nuclio/nuclio/pkg/platform/abstract/project/mock"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type SynchronizerTestSuite struct {
+	suite.Suite
+
+	synchronizer               Synchronizer
+	logger                     logger.Logger
+	mockInternalProjectsClient *internalmock.Client
+	mockLeaderProjectsClient   *leadermock.Client
+}
+
+func (suite *SynchronizerTestSuite) SetupTest() {
+	var err error
+
+	// create logger
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+
+	// mock internal client
+	suite.mockInternalProjectsClient = &internalmock.Client{}
+
+	//mock leader client
+	suite.mockLeaderProjectsClient = &leadermock.Client{}
+
+	// create synchronizer
+	suite.synchronizer =  Synchronizer{
+		logger: suite.logger,
+		internalProjectsClient: suite.mockInternalProjectsClient,
+		leaderClient: suite.mockLeaderProjectsClient,
+		synchronizationIntervalStr: "0",
+	}
+}
+
+func (suite *SynchronizerTestSuite) TestNoLeaderProjects() {
+	testBeginningTime := time.Now()
+
+	suite.testSynchronizeProjectsFromLeader([]platform.Project{},
+		[]platform.Project{
+			suite.createAbstractProject("test-internal-project", "", "online", testBeginningTime),
+		},
+		[]*platform.CreateProjectOptions{},
+		[]*platform.UpdateProjectOptions{},
+		nil)
+}
+
+func (suite *SynchronizerTestSuite) TestLeaderProjectsDoesntExistInternally() {
+	testBeginningTime := time.Now()
+
+	suite.testSynchronizeProjectsFromLeader([]platform.Project{
+		suite.createAbstractProject("leader-project-most-updated", "", "online", testBeginningTime.Add(time.Hour)),
+		suite.createAbstractProject("leader-project-less-updated", "", "online", testBeginningTime),
+	},
+		[]platform.Project{},
+		[]*platform.CreateProjectOptions{
+			{
+				ProjectConfig: &suite.createAbstractProject("leader-project-most-updated", "", "online", testBeginningTime.Add(time.Hour)).ProjectConfig,
+			},
+			{
+				ProjectConfig: &suite.createAbstractProject("leader-project-less-updated", "", "online", testBeginningTime).ProjectConfig,
+			},
+		},
+		[]*platform.UpdateProjectOptions{},
+		common.TimeToTimePointer(testBeginningTime.Add(time.Hour)))
+}
+
+func (suite *SynchronizerTestSuite) TestLeaderProjectsIsntUpdatedInternally() {
+	testBeginningTime := time.Now()
+
+	suite.testSynchronizeProjectsFromLeader(
+		[]platform.Project{
+			suite.createAbstractProject("leader-project", "updated", "online", testBeginningTime),
+		},
+		[]platform.Project{
+			suite.createAbstractProject("leader-project", "not-updated", "online", testBeginningTime),
+		},
+		[]*platform.CreateProjectOptions{},
+		[]*platform.UpdateProjectOptions{
+			{
+				ProjectConfig: suite.createAbstractProject("leader-project", "updated", "online", testBeginningTime).ProjectConfig,
+			},
+		},
+		&testBeginningTime)
+}
+
+func (suite *SynchronizerTestSuite) testSynchronizeProjectsFromLeader(leaderProjects []platform.Project,
+	internalProjects []platform.Project,
+	projectsToCreate []*platform.CreateProjectOptions,
+	projectsToUpdate []*platform.UpdateProjectOptions,
+	expectedMostRecentUpdatedProjectTime *time.Time) {
+
+	// mock leader client get projects
+	suite.mockLeaderProjectsClient.
+		On("GetUpdatedAfter", suite.synchronizer.mostRecentUpdatedProjectTime).
+		Return(leaderProjects, nil).
+		Once()
+
+	// mock internal client get projects
+	suite.mockInternalProjectsClient.
+		On("Get", &platform.GetProjectsOptions{}).
+		Return(internalProjects, nil).
+		Once()
+
+	// mock internal client create project for each expected project to create
+	for _, createProjectOptions := range projectsToCreate {
+		suite.mockInternalProjectsClient.
+			On("Create", createProjectOptions).
+			Return(&platform.AbstractProject{}, nil).
+			Once()
+	}
+
+	// mock internal client update project for each expected project to update
+	for _, updateProjectOptions := range projectsToUpdate {
+		suite.mockInternalProjectsClient.
+			On("Update", updateProjectOptions).
+			Return(&platform.AbstractProject{}, nil).
+			Once()
+	}
+
+	err := suite.synchronizer.SynchronizeProjectsFromLeader()
+	suite.Require().NoError(err)
+
+	suite.Require().Equal(suite.synchronizer.mostRecentUpdatedProjectTime, expectedMostRecentUpdatedProjectTime)
+
+	// sleep for 1 second so every mock create/update go routine would finish
+	time.Sleep(1 * time.Second)
+
+	// assert that it created all expected projects
+	for _, createProjectOptions := range projectsToCreate {
+		suite.mockInternalProjectsClient.AssertCalled(suite.T(), "Create", createProjectOptions)
+	}
+	if len(projectsToCreate) == 0 {
+		suite.mockInternalProjectsClient.AssertNotCalled(suite.T(), "Create", mock.Anything)
+	}
+
+	// assert that it updated all expected projects
+	for _, updateProjectOptions := range projectsToUpdate {
+		suite.mockInternalProjectsClient.AssertCalled(suite.T(), "Update", updateProjectOptions)
+	}
+	if len(projectsToUpdate) == 0 {
+		suite.mockInternalProjectsClient.AssertNotCalled(suite.T(), "Update", mock.Anything)
+	}
+}
+
+func (suite *SynchronizerTestSuite) createAbstractProject(name string,
+	description string,
+	status string,
+	updatedAt time.Time) *platform.AbstractProject {
+
+	return &platform.AbstractProject{
+		ProjectConfig: platform.ProjectConfig{
+			Meta: platform.ProjectMeta{
+				Name: name,
+			},
+			Spec: platform.ProjectSpec{
+				Description: description,
+			},
+			Status: platform.ProjectStatus{
+				OperationalStatus: status,
+				AdminStatus: status,
+				UpdatedAt: updatedAt,
+			},
+		},
+	}
+}
+
+func TestSynchronizerTestSuite(t *testing.T) {
+	suite.Run(t, new(SynchronizerTestSuite))
+}

--- a/pkg/platform/abstract/project/external/leader/iguazio/synchronizer_test.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/synchronizer_test.go
@@ -61,17 +61,18 @@ func (suite *SynchronizerTestSuite) TestNoLeaderProjects() {
 func (suite *SynchronizerTestSuite) TestLeaderProjectsDoesntExistInternally() {
 	testBeginningTime := time.Now()
 
-	suite.testSynchronizeProjectsFromLeader([]platform.Project{
-		suite.createAbstractProject("leader-project-most-updated", "", "online", testBeginningTime.Add(time.Hour)),
-		suite.createAbstractProject("leader-project-less-updated", "", "online", testBeginningTime),
-	},
+	leaderProjectMostUpdated := suite.createAbstractProject("leader-project-most-updated", "", "online", testBeginningTime.Add(time.Hour))
+	leaderProjectLessUpdated := suite.createAbstractProject("leader-project-less-updated", "", "online", testBeginningTime)
+
+	suite.testSynchronizeProjectsFromLeader(
+		[]platform.Project{leaderProjectMostUpdated, leaderProjectLessUpdated},
 		[]platform.Project{},
 		[]*platform.CreateProjectOptions{
 			{
-				ProjectConfig: &suite.createAbstractProject("leader-project-most-updated", "", "online", testBeginningTime.Add(time.Hour)).ProjectConfig,
+				ProjectConfig: &leaderProjectMostUpdated.ProjectConfig,
 			},
 			{
-				ProjectConfig: &suite.createAbstractProject("leader-project-less-updated", "", "online", testBeginningTime).ProjectConfig,
+				ProjectConfig: &leaderProjectLessUpdated.ProjectConfig,
 			},
 		},
 		[]*platform.UpdateProjectOptions{},
@@ -81,19 +82,27 @@ func (suite *SynchronizerTestSuite) TestLeaderProjectsDoesntExistInternally() {
 func (suite *SynchronizerTestSuite) TestLeaderProjectsIsntUpdatedInternally() {
 	testBeginningTime := time.Now()
 
+	updatedProject := suite.createAbstractProject("leader-project", "updated", "online", testBeginningTime)
+	notUpdatedProject := suite.createAbstractProject("leader-project", "not-updated", "online", testBeginningTime)
+
 	suite.testSynchronizeProjectsFromLeader(
-		[]platform.Project{
-			suite.createAbstractProject("leader-project", "updated", "online", testBeginningTime),
-		},
-		[]platform.Project{
-			suite.createAbstractProject("leader-project", "not-updated", "online", testBeginningTime),
-		},
+		[]platform.Project{updatedProject},
+		[]platform.Project{notUpdatedProject},
 		[]*platform.CreateProjectOptions{},
-		[]*platform.UpdateProjectOptions{
-			{
-				ProjectConfig: suite.createAbstractProject("leader-project", "updated", "online", testBeginningTime).ProjectConfig,
-			},
-		},
+		[]*platform.UpdateProjectOptions{{ProjectConfig: updatedProject.ProjectConfig}},
+		&testBeginningTime)
+}
+
+func (suite *SynchronizerTestSuite) TestLeaderProjectsThatExistInternally() {
+	testBeginningTime := time.Now()
+
+	projectInstance := suite.createAbstractProject("leader-project", "updated", "online", testBeginningTime)
+
+	suite.testSynchronizeProjectsFromLeader(
+		[]platform.Project{projectInstance},
+		[]platform.Project{projectInstance},
+		[]*platform.CreateProjectOptions{},
+		[]*platform.UpdateProjectOptions{},
 		&testBeginningTime)
 }
 

--- a/pkg/platform/abstract/project/external/leader/iguazio/synchronizer_test.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/synchronizer_test.go
@@ -38,10 +38,10 @@ func (suite *SynchronizerTestSuite) SetupTest() {
 	suite.mockLeaderProjectsClient = &leadermock.Client{}
 
 	// create synchronizer
-	suite.synchronizer =  Synchronizer{
-		logger: suite.logger,
-		internalProjectsClient: suite.mockInternalProjectsClient,
-		leaderClient: suite.mockLeaderProjectsClient,
+	suite.synchronizer = Synchronizer{
+		logger:                     suite.logger,
+		internalProjectsClient:     suite.mockInternalProjectsClient,
+		leaderClient:               suite.mockLeaderProjectsClient,
 		synchronizationIntervalStr: "0",
 	}
 }
@@ -180,8 +180,8 @@ func (suite *SynchronizerTestSuite) createAbstractProject(name string,
 			},
 			Status: platform.ProjectStatus{
 				OperationalStatus: status,
-				AdminStatus: status,
-				UpdatedAt: updatedAt,
+				AdminStatus:       status,
+				UpdatedAt:         updatedAt,
 			},
 		},
 	}

--- a/pkg/platform/abstract/project/external/leader/iguazio/types.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/types.go
@@ -14,7 +14,7 @@ type Project struct {
 	Data ProjectData `json:"data,omitempty"`
 }
 
-func CreateProjectFromProjectConfig(projectConfig *platform.ProjectConfig) Project {
+func NewProjectFromProjectConfig(projectConfig *platform.ProjectConfig) Project {
 	return Project{
 		Data: ProjectData{
 			Type: ProjectType,
@@ -33,8 +33,8 @@ func (pl *Project) GetConfig() *platform.ProjectConfig {
 		Meta: platform.ProjectMeta{
 			Name:        pl.Data.Attributes.Name,
 			Namespace:   pl.Data.Attributes.Namespace,
-			Annotations: pl.labelListToMap(pl.Data.Attributes.Annotations),
-			Labels:      pl.labelListToMap(pl.Data.Attributes.Labels),
+			Annotations: labelListToMap(pl.Data.Attributes.Annotations),
+			Labels:      labelListToMap(pl.Data.Attributes.Labels),
 		},
 		Spec: platform.ProjectSpec{
 			Description: pl.Data.Attributes.Description,
@@ -47,31 +47,11 @@ func (pl *Project) GetConfig() *platform.ProjectConfig {
 	}
 }
 
-func labelMapToList(labelMap map[string]string) []Label {
-	var labelList []Label
-
-	for labelName, labelValue := range labelMap {
-		labelList = append(labelList, Label{Name: labelName, Value: labelValue})
-	}
-
-	return labelList
-}
-
 func (pl *Project) parseTimeFromTimestamp(timestamp string) time.Time {
 	loc, _ := time.LoadLocation("GMT")
 	layout := "2006-01-02T15:04:05.000000+00:00"
 	t, _ := time.ParseInLocation(layout, timestamp, loc)
 	return t
-}
-
-func (pl *Project) labelListToMap(labelList []Label) map[string]string {
-	labelsMap := map[string]string{}
-
-	for _, label := range labelList {
-		labelsMap[label.Name] = label.Value
-	}
-
-	return labelsMap
 }
 
 type ProjectData struct {

--- a/pkg/platform/abstract/project/external/leader/iguazio/types.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/types.go
@@ -32,16 +32,16 @@ func CreateProjectFromProjectConfig(projectConfig *platform.ProjectConfig) Proje
 func (pl *Project) GetConfig() *platform.ProjectConfig {
 	return &platform.ProjectConfig{
 		Meta: platform.ProjectMeta{
-			Name: pl.Data.Attributes.Name,
-			Namespace: pl.Data.Attributes.Namespace,
+			Name:        pl.Data.Attributes.Name,
+			Namespace:   pl.Data.Attributes.Namespace,
 			Annotations: pl.labelListToMap(pl.Data.Attributes.Annotations),
-			Labels: pl.labelListToMap(pl.Data.Attributes.Labels),
+			Labels:      pl.labelListToMap(pl.Data.Attributes.Labels),
 		},
 		Spec: platform.ProjectSpec{
 			Description: pl.Data.Attributes.Description,
 		},
 		Status: platform.ProjectStatus{
-			AdminStatus: pl.Data.Attributes.AdminStatus,
+			AdminStatus:       pl.Data.Attributes.AdminStatus,
 			OperationalStatus: pl.Data.Attributes.OperationalStatus,
 		},
 	}
@@ -51,7 +51,7 @@ func labelMapToList(labelMap map[string]string) []Label {
 	var labelList []Label
 
 	for labelName, labelValue := range labelMap {
-		labelList = append(labelList, Label{Name: labelName, Value:labelValue})
+		labelList = append(labelList, Label{Name: labelName, Value: labelValue})
 	}
 
 	return labelList
@@ -106,7 +106,7 @@ func (pl *ProjectList) ToSingleProjectList() []platform.Project {
 		if projectData.Attributes.Namespace == "" {
 			projectData.Attributes.Namespace = "default-tenant"
 		}
-		projects = append(projects, &Project{Data:projectData})
+		projects = append(projects, &Project{Data: projectData})
 	}
 
 	return projects

--- a/pkg/platform/abstract/project/external/leader/iguazio/types.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/types.go
@@ -1,5 +1,7 @@
 package iguazio
 
+import "github.com/nuclio/nuclio/pkg/platform"
+
 const (
 	ProjectType = "project"
 )
@@ -8,20 +10,104 @@ type Project struct {
 	Data ProjectData `json:"data,omitempty"`
 }
 
+func CreateProjectFromProjectConfig(projectConfig *platform.ProjectConfig) Project {
+	// TODO: REMOVE THIS when zebo is sending project config with namespace
+	if projectConfig.Meta.Namespace == "" {
+		projectConfig.Meta.Namespace = "default-tenant"
+	}
+	return Project{
+		Data: ProjectData{
+			Type: ProjectType,
+			Attributes: ProjectAttributes{
+				Name:        projectConfig.Meta.Name,
+				Namespace:   projectConfig.Meta.Namespace,
+				Labels:      labelMapToList(projectConfig.Meta.Labels),
+				Annotations: labelMapToList(projectConfig.Meta.Annotations),
+				Description: projectConfig.Spec.Description,
+			},
+		},
+	}
+}
+
+func (pl *Project) GetConfig() *platform.ProjectConfig {
+	return &platform.ProjectConfig{
+		Meta: platform.ProjectMeta{
+			Name: pl.Data.Attributes.Name,
+			Namespace: pl.Data.Attributes.Namespace,
+			Annotations: pl.labelListToMap(pl.Data.Attributes.Annotations),
+			Labels: pl.labelListToMap(pl.Data.Attributes.Labels),
+		},
+		Spec: platform.ProjectSpec{
+			Description: pl.Data.Attributes.Description,
+		},
+		Status: platform.ProjectStatus{
+			AdminStatus: pl.Data.Attributes.AdminStatus,
+			OperationalStatus: pl.Data.Attributes.OperationalStatus,
+		},
+	}
+}
+
+func labelMapToList(labelMap map[string]string) []Label {
+	var labelList []Label
+
+	for labelName, labelValue := range labelMap {
+		labelList = append(labelList, Label{Name: labelName, Value:labelValue})
+	}
+
+	return labelList
+}
+
+func (pl *Project) labelListToMap(labelList []Label) map[string]string {
+	labelsMap := map[string]string{}
+
+	for _, label := range labelList {
+		labelsMap[label.Name] = label.Value
+	}
+
+	return labelsMap
+}
+
 type ProjectData struct {
 	Type       string            `json:"type,omitempty"`
 	Attributes ProjectAttributes `json:"attributes,omitempty"`
 }
 
 type ProjectAttributes struct {
-	Name          string            `json:"name,omitempty"`
-	Namespace     string            `json:"namespace,omitempty"`
-	Labels        map[string]string `json:"labels,omitempty"`
-	Annotations   map[string]string `json:"annotations,omitempty"`
-	Description   string            `json:"description,omitempty"`
-	NuclioProject NuclioProject     `json:"nuclio_project,omitempty"`
+	Name              string        `json:"name,omitempty"`
+	Namespace         string        `json:"namespace,omitempty"`
+	Labels            []Label       `json:"labels,omitempty"`
+	Annotations       []Label       `json:"annotations,omitempty"`
+	Description       string        `json:"description,omitempty"`
+	AdminStatus       string        `json:"admin_status,omitempty"`
+	OperationalStatus string        `json:"operational_status,omitempty"`
+	NuclioProject     NuclioProject `json:"nuclio_project,omitempty"`
+}
+
+type Label struct {
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 type NuclioProject struct {
 	// currently no nuclio specific fields are needed
+}
+
+type ProjectList struct {
+	Data []ProjectData `json:"data,omitempty"`
+}
+
+// ProjectList -> []Project
+func (pl *ProjectList) ToSingleProjectList() []platform.Project {
+	var projects []platform.Project
+
+	for _, projectData := range pl.Data {
+
+		// TODO: Remove this once zebo is sending namesapces
+		if projectData.Attributes.Namespace == "" {
+			projectData.Attributes.Namespace = "default-tenant"
+		}
+		projects = append(projects, &Project{Data:projectData})
+	}
+
+	return projects
 }

--- a/pkg/platform/abstract/project/external/leader/iguazio/types.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/types.go
@@ -11,10 +11,6 @@ type Project struct {
 }
 
 func CreateProjectFromProjectConfig(projectConfig *platform.ProjectConfig) Project {
-	// TODO: REMOVE THIS when zebo is sending project config with namespace
-	if projectConfig.Meta.Namespace == "" {
-		projectConfig.Meta.Namespace = "default-tenant"
-	}
 	return Project{
 		Data: ProjectData{
 			Type: ProjectType,
@@ -101,11 +97,6 @@ func (pl *ProjectList) ToSingleProjectList() []platform.Project {
 	var projects []platform.Project
 
 	for _, projectData := range pl.Data {
-
-		// TODO: Remove this once zebo is sending namesapces
-		if projectData.Attributes.Namespace == "" {
-			projectData.Attributes.Namespace = "default-tenant"
-		}
 		projects = append(projects, &Project{Data: projectData})
 	}
 

--- a/pkg/platform/abstract/project/external/leader/iguazio/types.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/types.go
@@ -1,6 +1,10 @@
 package iguazio
 
-import "github.com/nuclio/nuclio/pkg/platform"
+import (
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/platform"
+)
 
 const (
 	ProjectType = "project"
@@ -16,7 +20,6 @@ func CreateProjectFromProjectConfig(projectConfig *platform.ProjectConfig) Proje
 			Type: ProjectType,
 			Attributes: ProjectAttributes{
 				Name:        projectConfig.Meta.Name,
-				Namespace:   projectConfig.Meta.Namespace,
 				Labels:      labelMapToList(projectConfig.Meta.Labels),
 				Annotations: labelMapToList(projectConfig.Meta.Annotations),
 				Description: projectConfig.Spec.Description,
@@ -39,6 +42,7 @@ func (pl *Project) GetConfig() *platform.ProjectConfig {
 		Status: platform.ProjectStatus{
 			AdminStatus:       pl.Data.Attributes.AdminStatus,
 			OperationalStatus: pl.Data.Attributes.OperationalStatus,
+			UpdatedAt:         pl.parseTimeFromTimestamp(pl.Data.Attributes.UpdatedAt),
 		},
 	}
 }
@@ -51,6 +55,13 @@ func labelMapToList(labelMap map[string]string) []Label {
 	}
 
 	return labelList
+}
+
+func (pl *Project) parseTimeFromTimestamp(timestamp string) time.Time {
+	loc, _ := time.LoadLocation("GMT")
+	layout := "2006-01-02T15:04:05.000000+00:00"
+	t, _ := time.ParseInLocation(layout, timestamp, loc)
+	return t
 }
 
 func (pl *Project) labelListToMap(labelList []Label) map[string]string {
@@ -76,6 +87,7 @@ type ProjectAttributes struct {
 	Description       string        `json:"description,omitempty"`
 	AdminStatus       string        `json:"admin_status,omitempty"`
 	OperationalStatus string        `json:"operational_status,omitempty"`
+	UpdatedAt         string        `json:"updated_at,omitempty"`
 	NuclioProject     NuclioProject `json:"nuclio_project,omitempty"`
 }
 

--- a/pkg/platform/abstract/project/external/leader/mlrun/client.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/client.go
@@ -1,6 +1,8 @@
 package mlrun
 
 import (
+	"time"
+
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
@@ -34,6 +36,6 @@ func (c *Client) Delete(deleteProjectOptions *platform.DeleteProjectOptions) err
 	return nuclio.ErrNotImplemented
 }
 
-func (c *Client) GetAll(updatedAfterTimestamp string) ([]platform.Project, error) {
+func (c *Client) GetAll(updatedAfterTime *time.Time) ([]platform.Project, error) {
 	return nil, nuclio.ErrNotImplemented
 }

--- a/pkg/platform/abstract/project/external/leader/mlrun/client.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/client.go
@@ -33,3 +33,7 @@ func (c *Client) Update(updateProjectOptions *platform.UpdateProjectOptions) err
 func (c *Client) Delete(deleteProjectOptions *platform.DeleteProjectOptions) error {
 	return nuclio.ErrNotImplemented
 }
+
+func (c *Client) GetAll(updatedAfterTimestamp string) ([]platform.Project, error) {
+	return nil, nuclio.ErrNotImplemented
+}

--- a/pkg/platform/abstract/project/external/leader/mlrun/client.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/client.go
@@ -36,6 +36,6 @@ func (c *Client) Delete(deleteProjectOptions *platform.DeleteProjectOptions) err
 	return nuclio.ErrNotImplemented
 }
 
-func (c *Client) GetAll(updatedAfterTime *time.Time) ([]platform.Project, error) {
+func (c *Client) GetUpdatedAfter(updatedAfterTime *time.Time) ([]platform.Project, error) {
 	return nil, nuclio.ErrNotImplemented
 }

--- a/pkg/platform/abstract/project/external/leader/mock/client.go
+++ b/pkg/platform/abstract/project/external/leader/mock/client.go
@@ -1,0 +1,33 @@
+package mock
+
+import (
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/platform"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type Client struct {
+	mock.Mock
+}
+
+func (c *Client) Create(createProjectOptions *platform.CreateProjectOptions) error {
+	args := c.Called(createProjectOptions)
+	return args.Error(0)
+}
+
+func (c *Client) Update(updateProjectOptions *platform.UpdateProjectOptions) error {
+	args := c.Called(updateProjectOptions)
+	return args.Error(0)
+}
+
+func (c *Client) Delete(deleteProjectOptions *platform.DeleteProjectOptions) error {
+	args := c.Called(deleteProjectOptions)
+	return args.Error(0)
+}
+
+func (c *Client) GetUpdatedAfter(updatedAfterTime *time.Time) ([]platform.Project, error) {
+	args := c.Called(updatedAfterTime)
+	return args.Get(0).([]platform.Project), args.Error(1)
+}

--- a/pkg/platform/abstract/project/external/leader/types.go
+++ b/pkg/platform/abstract/project/external/leader/types.go
@@ -1,6 +1,8 @@
 package leader
 
 import (
+	"time"
+
 	"github.com/nuclio/nuclio/pkg/platform"
 )
 
@@ -16,5 +18,5 @@ type Client interface {
 	Delete(*platform.DeleteProjectOptions) error
 
 	// Gets all projects from the leader (gets projects that have been updated since the given timestamp)
-	GetAll(string) ([]platform.Project, error)
+	GetAll(*time.Time) ([]platform.Project, error)
 }

--- a/pkg/platform/abstract/project/external/leader/types.go
+++ b/pkg/platform/abstract/project/external/leader/types.go
@@ -17,6 +17,6 @@ type Client interface {
 	// Delegates project deletion to leader
 	Delete(*platform.DeleteProjectOptions) error
 
-	// Gets all projects from the leader (gets projects that have been updated since the given timestamp)
-	GetAll(*time.Time) ([]platform.Project, error)
+	// Gets all projects from the leader that updated after the given time (to get all, pass nil time)
+	GetUpdatedAfter(*time.Time) ([]platform.Project, error)
 }

--- a/pkg/platform/abstract/project/external/leader/types.go
+++ b/pkg/platform/abstract/project/external/leader/types.go
@@ -14,4 +14,7 @@ type Client interface {
 
 	// Delegates project deletion to leader
 	Delete(*platform.DeleteProjectOptions) error
+
+	// Gets all projects from the leader (gets projects that have been updated since the given timestamp)
+	GetAll(string) ([]platform.Project, error)
 }

--- a/pkg/platform/abstract/project/mock/client.go
+++ b/pkg/platform/abstract/project/mock/client.go
@@ -1,0 +1,35 @@
+package mock
+
+import (
+	"github.com/nuclio/nuclio/pkg/platform"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type Client struct {
+	mock.Mock
+}
+
+func (c *Client) Initialize() error {
+	return nil
+}
+
+func (c *Client) Get(getProjectsOptions *platform.GetProjectsOptions) ([]platform.Project, error) {
+	args := c.Called(getProjectsOptions)
+	return args.Get(0).([]platform.Project), args.Error(1)
+}
+
+func (c *Client) Create(createProjectOptions *platform.CreateProjectOptions) (platform.Project, error) {
+	args := c.Called(createProjectOptions)
+	return args.Get(0).(platform.Project), args.Error(1)
+}
+
+func (c *Client) Update(updateProjectOptions *platform.UpdateProjectOptions) (platform.Project, error) {
+	args := c.Called(updateProjectOptions)
+	return args.Get(0).(platform.Project), args.Error(1)
+}
+
+func (c *Client) Delete(deleteProjectOptions *platform.DeleteProjectOptions) error {
+	args := c.Called(deleteProjectOptions)
+	return args.Error(0)
+}

--- a/pkg/platform/errors.go
+++ b/pkg/platform/errors.go
@@ -20,6 +20,11 @@ import (
 	"github.com/nuclio/nuclio-sdk-go"
 )
 
+// projects
+var ErrSuccessfulCreateProjectLeader = nuclio.NewErrAccepted("Successfully requested from the leader to create the project")
+var ErrSuccessfulUpdateProjectLeader = nuclio.NewErrAccepted("Successfully requested from the leader to update the project")
+var ErrSuccessfulDeleteProjectLeader = nuclio.NewErrAccepted("Successfully requested from the leader to delete the project")
+
 // A project containing resources(functions/api gateways), cannot be deleted
 var ErrProjectContainsFunctions = nuclio.NewErrPreconditionFailed("Project contains functions")
 var ErrProjectContainsAPIGateways = nuclio.NewErrPreconditionFailed("Project contains api gateways")

--- a/pkg/platform/factory/factory.go
+++ b/pkg/platform/factory/factory.go
@@ -49,7 +49,7 @@ func CreatePlatform(parentLogger logger.Logger,
 
 	case "auto":
 
-		// kubeconfig path is set, or running in kubernetes clsuter
+		// kubeconfig path is set, or running in kubernetes cluster
 		if common.GetKubeconfigPath(platformConfiguration.Kube.KubeConfigPath) != "" ||
 			kube.IsInCluster() {
 
@@ -69,8 +69,11 @@ func CreatePlatform(parentLogger logger.Logger,
 		return nil, errors.Wrapf(err, "Failed to create %s platform", platformType)
 	}
 
-	if err = newPlatform.Initialize(); err != nil {
-		return nil, errors.Wrap(err, "Failed to initialize platform")
+	if platformType != "auto" {
+		parentLogger.DebugWith("Initializing platform", "platformType", platformType)
+		if err = newPlatform.Initialize(); err != nil {
+			return nil, errors.Wrap(err, "Failed to initialize platform")
+		}
 	}
 
 	return newPlatform, nil

--- a/pkg/platform/factory/factory.go
+++ b/pkg/platform/factory/factory.go
@@ -69,6 +69,8 @@ func CreatePlatform(parentLogger logger.Logger,
 		return nil, errors.Wrapf(err, "Failed to create %s platform", platformType)
 	}
 
+	// under this section, add actions to be performed only after platform type had been resolved
+	// (so it won't be performed more than once)
 	if platformType != "auto" {
 		parentLogger.DebugWith("Initializing platform", "platformType", platformType)
 		if err = newPlatform.Initialize(); err != nil {

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -151,16 +151,15 @@ func NewPlatform(parentLogger logger.Logger,
 }
 
 func (p *Platform) Initialize() error {
+	if err := p.projectsClient.Initialize(); err != nil {
+		return errors.Wrap(err, "Failed to initialize projects client")
+	}
 
 	// ensure default project existence only when projects aren't managed by external leader
 	if p.Config.ProjectsLeader == nil {
 		if err := p.EnsureDefaultProjectExistence(); err != nil {
 			return errors.Wrap(err, "Failed to ensure default project existence")
 		}
-	}
-
-	if err := p.projectsClient.Initialize(); err != nil {
-		return errors.Wrap(err, "Failed to initialize projects client")
 	}
 
 	return nil

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -888,7 +888,11 @@ func (p *Platform) GetExternalIPAddresses() ([]string, error) {
 
 // ResolveDefaultNamespace returns the proper default resource namespace, given the current default namespace
 func (p *Platform) ResolveDefaultNamespace(defaultNamespace string) string {
-	if defaultNamespace == "@nuclio.selfNamespace" || p.DefaultNamespace == "@nuclio.selfNamespace" {
+	if defaultNamespace == "" {
+		defaultNamespace = p.DefaultNamespace
+	}
+
+	if defaultNamespace == "@nuclio.selfNamespace" {
 
 		// get namespace from within the pod. if found, return that
 		if namespacePod, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
@@ -897,9 +901,6 @@ func (p *Platform) ResolveDefaultNamespace(defaultNamespace string) string {
 	}
 
 	if defaultNamespace == "" {
-		if p.DefaultNamespace != "" {
-			return p.DefaultNamespace
-		}
 
 		return "default"
 	}

--- a/pkg/platform/kube/project/client.go
+++ b/pkg/platform/kube/project/client.go
@@ -24,7 +24,7 @@ type Client struct {
 
 func NewClient(parentLogger logger.Logger, platformInstance platform.Platform, consumer *client.Consumer) (abstractproject.Client, error) {
 	newClient := Client{
-		Logger:        parentLogger.GetChild("projects-client-kube"),
+		Logger:        parentLogger.GetChild("projects-kube"),
 		consumer:      consumer,
 		platform:      platformInstance,
 		projectsCache: NewSafeCache(),

--- a/pkg/platform/kube/project/client.go
+++ b/pkg/platform/kube/project/client.go
@@ -241,9 +241,12 @@ func (c *Client) getProjectsFromCache(getProjectOptions *platform.GetProjectsOpt
 
 		// if a specific namespace and name were requested - return this project (can't be more than one)
 		if getProjectOptions.Meta.Name != "" {
-			if projectConfig.Meta.Name == getProjectOptions.Meta.Name {
-				return []platform.Project{projectInstance}
+			if projectConfig.Meta.Name != getProjectOptions.Meta.Name {
+				continue
 			}
+
+			// name matches - return the matching project
+			return []platform.Project{projectInstance}
 		}
 
 		matchingProjects = append(matchingProjects, projectInstance)

--- a/pkg/platform/kube/project/client.go
+++ b/pkg/platform/kube/project/client.go
@@ -51,7 +51,7 @@ func (c *Client) Create(createProjectOptions *platform.CreateProjectOptions) (pl
 		return nil, errors.Wrap(err, "Failed to create nuclio project")
 	}
 
-	platformProject, err :=  c.nuclioProjectToPlatformProject(nuclioProject)
+	platformProject, err := c.nuclioProjectToPlatformProject(nuclioProject)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to convert nuclio project to platform project")
 	}
@@ -83,7 +83,7 @@ func (c *Client) Update(updateProjectOptions *platform.UpdateProjectOptions) (pl
 		return nil, errors.Wrap(err, "Failed to update nuclio project")
 	}
 
-	platformProject, err :=  c.nuclioProjectToPlatformProject(nuclioProject)
+	platformProject, err := c.nuclioProjectToPlatformProject(nuclioProject)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to convert nuclio project to platform project")
 	}
@@ -128,7 +128,6 @@ func (c *Client) Get(getProjectsOptions *platform.GetProjectsOptions) ([]platfor
 
 	return c.getProjectsFromKube(getProjectsOptions)
 }
-
 
 func (c *Client) getProjectsFromKube(getProjectsOptions *platform.GetProjectsOptions) ([]platform.Project, error) {
 	var platformProjects []platform.Project
@@ -236,7 +235,7 @@ func (c *Client) getProjectsFromCache(getProjectOptions *platform.GetProjectsOpt
 
 	for _, projectInstance := range c.projectsCache {
 		projectConfig := projectInstance.GetConfig()
-		if projectConfig.Meta.Namespace != getProjectOptions.Meta.Namespace{
+		if projectConfig.Meta.Namespace != getProjectOptions.Meta.Namespace {
 			continue
 		}
 

--- a/pkg/platform/kube/project/client.go
+++ b/pkg/platform/kube/project/client.go
@@ -215,7 +215,6 @@ func (c *Client) updateProjectInCache(projectInstance platform.Project) {
 }
 
 func (c *Client) deleteProjectFromCache(namespace, name string) {
-	c.Logger.DebugWith("deletion start", "cache", c.projectsCache)
 	newProjectsCache := []platform.Project{}
 
 	for _, projectInstance := range c.projectsCache {
@@ -227,7 +226,6 @@ func (c *Client) deleteProjectFromCache(namespace, name string) {
 	}
 
 	c.projectsCache = newProjectsCache
-	c.Logger.DebugWith("deletion end", "cache", c.projectsCache)
 }
 
 func (c *Client) getProjectsFromCache(getProjectOptions *platform.GetProjectsOptions) []platform.Project {
@@ -235,13 +233,19 @@ func (c *Client) getProjectsFromCache(getProjectOptions *platform.GetProjectsOpt
 
 	for _, projectInstance := range c.projectsCache {
 		projectConfig := projectInstance.GetConfig()
-		if projectConfig.Meta.Namespace != getProjectOptions.Meta.Namespace {
-			continue
-		}
 
-		if getProjectOptions.Meta.Name != "" {
-			if projectConfig.Meta.Name == getProjectOptions.Meta.Name {
-				return []platform.Project{projectInstance}
+		if projectConfig.Meta.Namespace != "" {
+
+			// if a specific namespace was requested and this project is not in it - skip it
+			if projectConfig.Meta.Namespace != getProjectOptions.Meta.Namespace {
+				continue
+			}
+
+			// if a specific namespace and name were requested - return this project (can't be more than one)
+			if getProjectOptions.Meta.Name != "" {
+				if projectConfig.Meta.Name == getProjectOptions.Meta.Name {
+					return []platform.Project{projectInstance}
+				}
 			}
 		}
 

--- a/pkg/platform/kube/project/safecache.go
+++ b/pkg/platform/kube/project/safecache.go
@@ -17,38 +17,34 @@ func NewSafeCache() *SafeCache {
 
 func (c *SafeCache) Add(projectInstance platform.Project) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	c.add(projectInstance)
-
-	c.mu.Unlock()
 }
 
 func (c *SafeCache) AddMany(projectInstances []platform.Project) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	for _, projectInstance := range projectInstances {
 		c.add(projectInstance)
 	}
-
-	c.mu.Unlock()
 }
 
 func (c *SafeCache) Update(projectInstance platform.Project) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	// delete project and re-add it to update the cache
 	c.delete(projectInstance.GetConfig().Meta.Namespace, projectInstance.GetConfig().Meta.Name)
 	c.add(projectInstance)
-
-	c.mu.Unlock()
 }
 
 func (c *SafeCache) Delete(namespace, name string) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	c.delete(namespace, name)
-
-	c.mu.Unlock()
 }
 
 func (c *SafeCache) Get(getProjectOptions *platform.GetProjectsOptions) []platform.Project {

--- a/pkg/platform/kube/project/safecache.go
+++ b/pkg/platform/kube/project/safecache.go
@@ -1,0 +1,97 @@
+package project
+
+import (
+	"sync"
+
+	"github.com/nuclio/nuclio/pkg/platform"
+)
+
+type SafeCache struct {
+	mu            sync.Mutex
+	projectsCache []platform.Project
+}
+
+func NewSafeCache() *SafeCache {
+	return &SafeCache{projectsCache: []platform.Project{}}
+}
+
+func (c *SafeCache) Add(projectInstance platform.Project) {
+	c.mu.Lock()
+
+	c.add(projectInstance)
+
+	c.mu.Unlock()
+}
+
+func (c *SafeCache) AddMany(projectInstances []platform.Project) {
+	c.mu.Lock()
+
+	for _, projectInstance := range projectInstances {
+		c.add(projectInstance)
+	}
+
+	c.mu.Unlock()
+}
+
+func (c *SafeCache) Update(projectInstance platform.Project) {
+	c.mu.Lock()
+
+	// delete project and re-add it to update the cache
+	c.delete(projectInstance.GetConfig().Meta.Namespace, projectInstance.GetConfig().Meta.Name)
+	c.add(projectInstance)
+
+	c.mu.Unlock()
+}
+
+func (c *SafeCache) Delete(namespace, name string) {
+	c.mu.Lock()
+
+	c.delete(namespace, name)
+
+	c.mu.Unlock()
+}
+
+func (c *SafeCache) Get(getProjectOptions *platform.GetProjectsOptions) []platform.Project {
+	matchingProjects := []platform.Project{}
+
+	for _, projectInstance := range c.projectsCache {
+		projectConfig := projectInstance.GetConfig()
+
+		// if a specific namespace was requested and this project is not in it - skip it
+		if projectConfig.Meta.Namespace != getProjectOptions.Meta.Namespace {
+			continue
+		}
+
+		// if a specific namespace and name were requested - return this project (can't be more than one)
+		if getProjectOptions.Meta.Name != "" {
+			if projectConfig.Meta.Name != getProjectOptions.Meta.Name {
+				continue
+			}
+
+			// name matches - return the matching project
+			return []platform.Project{projectInstance}
+		}
+
+		matchingProjects = append(matchingProjects, projectInstance)
+	}
+
+	return matchingProjects
+}
+
+func (c *SafeCache) add(projectInstance platform.Project) {
+	c.projectsCache = append(c.projectsCache, projectInstance)
+}
+
+func (c *SafeCache) delete(namespace, name string) {
+	newProjectsCache := []platform.Project{}
+
+	for _, projectInstance := range c.projectsCache {
+		projectConfig := projectInstance.GetConfig()
+		if projectConfig.Meta.Namespace == namespace && projectConfig.Meta.Name == name {
+			continue
+		}
+		newProjectsCache = append(newProjectsCache, projectInstance)
+	}
+
+	c.projectsCache = newProjectsCache
+}

--- a/pkg/platform/kube/project/safecache_test.go
+++ b/pkg/platform/kube/project/safecache_test.go
@@ -27,10 +27,9 @@ func (suite *SafeCacheTestSuite) TestAdd() {
 	projectInstance := suite.createProjectInstance("test-name", "test-namespace")
 
 	suite.safeCache.Add(projectInstance)
-	projects := suite.safeCache.Get(&platform.GetProjectsOptions{Meta:platform.ProjectMeta{Namespace: "test-namespace", Name: "test-name"}})
+	projects := suite.safeCache.Get(&platform.GetProjectsOptions{Meta: platform.ProjectMeta{Namespace: "test-namespace", Name: "test-name"}})
 	suite.Require().Equal(projects, []platform.Project{projectInstance})
 }
-
 
 func (suite *SafeCacheTestSuite) TestAddMany() {
 	projectInstances := []platform.Project{}
@@ -42,7 +41,7 @@ func (suite *SafeCacheTestSuite) TestAddMany() {
 
 	suite.safeCache.AddMany(projectInstances)
 
-	projects := suite.safeCache.Get(&platform.GetProjectsOptions{Meta:platform.ProjectMeta{Namespace:"test-namespace"}})
+	projects := suite.safeCache.Get(&platform.GetProjectsOptions{Meta: platform.ProjectMeta{Namespace: "test-namespace"}})
 	suite.Require().Equal(len(projects), 10)
 
 	for _, projectInstance := range projectInstances {
@@ -51,19 +50,18 @@ func (suite *SafeCacheTestSuite) TestAddMany() {
 	}
 }
 
-
 func (suite *SafeCacheTestSuite) TestUpdate() {
 	projectInstance := suite.createProjectInstance("test-name", "test-namespace")
 
 	// add project
 	suite.safeCache.Add(projectInstance)
-	projects := suite.safeCache.Get(&platform.GetProjectsOptions{Meta:platform.ProjectMeta{Namespace: "test-namespace", Name: "test-name"}})
+	projects := suite.safeCache.Get(&platform.GetProjectsOptions{Meta: platform.ProjectMeta{Namespace: "test-namespace", Name: "test-name"}})
 	suite.Require().Equal(projects[0].GetConfig().Spec.Description, "default-description")
 
 	// update project
 	projectInstance.ProjectConfig.Spec.Description = "new-description"
 	suite.safeCache.Update(projectInstance)
-	projects = suite.safeCache.Get(&platform.GetProjectsOptions{Meta:platform.ProjectMeta{Namespace: "test-namespace", Name: "test-name"}})
+	projects = suite.safeCache.Get(&platform.GetProjectsOptions{Meta: platform.ProjectMeta{Namespace: "test-namespace", Name: "test-name"}})
 	suite.Require().Equal(projects[0].GetConfig().Spec.Description, "new-description")
 }
 
@@ -72,12 +70,12 @@ func (suite *SafeCacheTestSuite) TestDelete() {
 
 	// add project
 	suite.safeCache.Add(projectInstance)
-	projects := suite.safeCache.Get(&platform.GetProjectsOptions{Meta:platform.ProjectMeta{Namespace: "test-namespace", Name: "test-name"}})
+	projects := suite.safeCache.Get(&platform.GetProjectsOptions{Meta: platform.ProjectMeta{Namespace: "test-namespace", Name: "test-name"}})
 	suite.Require().Equal(projects, []platform.Project{projectInstance})
 
 	// delete project
 	suite.safeCache.Delete("test-namespace", "test-name")
-	projects = suite.safeCache.Get(&platform.GetProjectsOptions{Meta:platform.ProjectMeta{Namespace: "test-namespace", Name: "test-name"}})
+	projects = suite.safeCache.Get(&platform.GetProjectsOptions{Meta: platform.ProjectMeta{Namespace: "test-namespace", Name: "test-name"}})
 	suite.Require().Equal(projects, []platform.Project{})
 }
 
@@ -98,7 +96,7 @@ func (suite *SafeCacheTestSuite) TestGet() {
 	}
 
 	for _, namespace := range namespaces {
-		projects := suite.safeCache.Get(&platform.GetProjectsOptions{Meta:platform.ProjectMeta{Namespace:namespace}})
+		projects := suite.safeCache.Get(&platform.GetProjectsOptions{Meta: platform.ProjectMeta{Namespace: namespace}})
 		suite.Require().Equal(len(projects), 10)
 
 		for _, projectInstanceInNamespace := range projectInstancesByNamespace[namespace] {
@@ -111,11 +109,11 @@ func (suite *SafeCacheTestSuite) TestGet() {
 func (suite *SafeCacheTestSuite) createProjectInstance(name, namespace string) *platform.AbstractProject {
 	return &platform.AbstractProject{
 		ProjectConfig: platform.ProjectConfig{
-			Meta:platform.ProjectMeta{
-				Name: name,
+			Meta: platform.ProjectMeta{
+				Name:      name,
 				Namespace: namespace,
 			},
-			Spec:platform.ProjectSpec{
+			Spec: platform.ProjectSpec{
 				Description: "default-description",
 			},
 		},

--- a/pkg/platform/kube/project/safecache_test.go
+++ b/pkg/platform/kube/project/safecache_test.go
@@ -1,0 +1,127 @@
+package project
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/platform"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type SafeCacheTestSuite struct {
+	suite.Suite
+
+	logger    logger.Logger
+	safeCache *SafeCache
+}
+
+func (suite *SafeCacheTestSuite) SetupTest() {
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
+	suite.safeCache = NewSafeCache()
+}
+
+func (suite *SafeCacheTestSuite) TestAdd() {
+	projectInstance := suite.createProjectInstance("test-name", "test-namespace")
+
+	suite.safeCache.Add(projectInstance)
+	projects := suite.safeCache.Get(&platform.GetProjectsOptions{Meta:platform.ProjectMeta{Namespace: "test-namespace", Name: "test-name"}})
+	suite.Require().Equal(projects, []platform.Project{projectInstance})
+}
+
+
+func (suite *SafeCacheTestSuite) TestAddMany() {
+	projectInstances := []platform.Project{}
+
+	for i := 0; i < 10; i++ {
+		testName := fmt.Sprintf("test-name-%d", i)
+		projectInstances = append(projectInstances, suite.createProjectInstance(testName, "test-namespace"))
+	}
+
+	suite.safeCache.AddMany(projectInstances)
+
+	projects := suite.safeCache.Get(&platform.GetProjectsOptions{Meta:platform.ProjectMeta{Namespace:"test-namespace"}})
+	suite.Require().Equal(len(projects), 10)
+
+	for _, projectInstance := range projectInstances {
+		projects := suite.safeCache.Get(&platform.GetProjectsOptions{Meta: projectInstance.GetConfig().Meta})
+		suite.Require().Equal(projects, []platform.Project{projectInstance})
+	}
+}
+
+
+func (suite *SafeCacheTestSuite) TestUpdate() {
+	projectInstance := suite.createProjectInstance("test-name", "test-namespace")
+
+	// add project
+	suite.safeCache.Add(projectInstance)
+	projects := suite.safeCache.Get(&platform.GetProjectsOptions{Meta:platform.ProjectMeta{Namespace: "test-namespace", Name: "test-name"}})
+	suite.Require().Equal(projects[0].GetConfig().Spec.Description, "default-description")
+
+	// update project
+	projectInstance.ProjectConfig.Spec.Description = "new-description"
+	suite.safeCache.Update(projectInstance)
+	projects = suite.safeCache.Get(&platform.GetProjectsOptions{Meta:platform.ProjectMeta{Namespace: "test-namespace", Name: "test-name"}})
+	suite.Require().Equal(projects[0].GetConfig().Spec.Description, "new-description")
+}
+
+func (suite *SafeCacheTestSuite) TestDelete() {
+	projectInstance := suite.createProjectInstance("test-name", "test-namespace")
+
+	// add project
+	suite.safeCache.Add(projectInstance)
+	projects := suite.safeCache.Get(&platform.GetProjectsOptions{Meta:platform.ProjectMeta{Namespace: "test-namespace", Name: "test-name"}})
+	suite.Require().Equal(projects, []platform.Project{projectInstance})
+
+	// delete project
+	suite.safeCache.Delete("test-namespace", "test-name")
+	projects = suite.safeCache.Get(&platform.GetProjectsOptions{Meta:platform.ProjectMeta{Namespace: "test-namespace", Name: "test-name"}})
+	suite.Require().Equal(projects, []platform.Project{})
+}
+
+func (suite *SafeCacheTestSuite) TestGet() {
+	projectInstancesByNamespace := map[string][]platform.Project{}
+
+	namespaces := []string{}
+	for i := 0; i < 10; i++ {
+		namespaces = append(namespaces, fmt.Sprintf("namespace-%d", i))
+	}
+
+	for _, namespace := range namespaces {
+		for i := 0; i < 10; i++ {
+			testName := fmt.Sprintf("test-name-%d", i)
+			projectInstancesByNamespace[namespace] = append(projectInstancesByNamespace[namespace], suite.createProjectInstance(testName, namespace))
+		}
+		suite.safeCache.AddMany(projectInstancesByNamespace[namespace])
+	}
+
+	for _, namespace := range namespaces {
+		projects := suite.safeCache.Get(&platform.GetProjectsOptions{Meta:platform.ProjectMeta{Namespace:namespace}})
+		suite.Require().Equal(len(projects), 10)
+
+		for _, projectInstanceInNamespace := range projectInstancesByNamespace[namespace] {
+			projects := suite.safeCache.Get(&platform.GetProjectsOptions{Meta: projectInstanceInNamespace.GetConfig().Meta})
+			suite.Require().Equal(projects, []platform.Project{projectInstanceInNamespace})
+		}
+	}
+}
+
+func (suite *SafeCacheTestSuite) createProjectInstance(name, namespace string) *platform.AbstractProject {
+	return &platform.AbstractProject{
+		ProjectConfig: platform.ProjectConfig{
+			Meta:platform.ProjectMeta{
+				Name: name,
+				Namespace: namespace,
+			},
+			Spec:platform.ProjectSpec{
+				Description: "default-description",
+			},
+		},
+	}
+}
+
+func TestSafeCacheTestSuite(t *testing.T) {
+	suite.Run(t, new(SafeCacheTestSuite))
+}

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -1104,7 +1104,7 @@ func (suite *ProjectTestSuite) TestDelete() {
 		Meta: projectConfig.Meta,
 	})
 	suite.Require().NoError(err, "Failed to get projects")
-	suite.Require().Equal(len(projects), 0)
+	suite.Require().Equal(0, len(projects))
 }
 
 func (suite *ProjectTestSuite) TestDeleteCascading() {

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -141,6 +141,9 @@ func NewPlatform(parentLogger logger.Logger,
 }
 
 func (p *Platform) Initialize() error {
+	if err := p.projectsClient.Initialize(); err != nil {
+		return errors.Wrap(err, "Failed to initialize projects client")
+	}
 
 	// ensure default project existence only when projects aren't managed by external leader
 	if p.Config.ProjectsLeader == nil {
@@ -149,7 +152,7 @@ func (p *Platform) Initialize() error {
 		}
 	}
 
-	return p.projectsClient.Initialize()
+	return nil
 }
 
 // CreateFunction will simply run a docker image

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -141,6 +141,14 @@ func NewPlatform(parentLogger logger.Logger,
 }
 
 func (p *Platform) Initialize() error {
+
+	// ensure default project existence only when projects aren't managed by external leader
+	if p.Config.ProjectsLeader == nil {
+		if err := p.EnsureDefaultProjectExistence(); err != nil {
+			return errors.Wrap(err, "Failed to ensure default project existence")
+		}
+	}
+
 	return p.projectsClient.Initialize()
 }
 

--- a/pkg/platform/local/project/client.go
+++ b/pkg/platform/local/project/client.go
@@ -26,7 +26,7 @@ func NewClient(parentLogger logger.Logger, platform platform.Platform, localStor
 }
 
 func (c *Client) Initialize() error {
-	return c.platform.EnsureDefaultProjectExistence()
+	return nil
 }
 
 func (c *Client) Create(createProjectOptions *platform.CreateProjectOptions) (platform.Project, error) {

--- a/pkg/platform/local/project/client.go
+++ b/pkg/platform/local/project/client.go
@@ -17,7 +17,7 @@ type Client struct {
 
 func NewClient(parentLogger logger.Logger, platform platform.Platform, localStore *client.Store) (abstractproject.Client, error) {
 	newClient := Client{
-		Logger:     parentLogger.GetChild("projects-client-local"),
+		Logger:     parentLogger.GetChild("projects-local"),
 		localStore: localStore,
 		platform:   platform,
 	}

--- a/pkg/platform/local/project/client.go
+++ b/pkg/platform/local/project/client.go
@@ -17,7 +17,7 @@ type Client struct {
 
 func NewClient(parentLogger logger.Logger, platform platform.Platform, localStore *client.Store) (abstractproject.Client, error) {
 	newClient := Client{
-		Logger:     parentLogger.GetChild("projects-client"),
+		Logger:     parentLogger.GetChild("projects-client-local"),
 		localStore: localStore,
 		platform:   platform,
 	}

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -165,10 +165,10 @@ type ProjectMeta struct {
 }
 
 func (pm ProjectMeta) IsEqual(other ProjectMeta) bool {
-	labels := common.GetStringStringMapOrEmpty(pm.Labels)
-	otherLabels := common.GetStringStringMapOrEmpty(other.Labels)
-	annotations := common.GetStringStringMapOrEmpty(pm.Annotations)
-	otherAnnotations := common.GetStringStringMapOrEmpty(other.Annotations)
+	labels := common.GetStringToStringMapOrEmpty(pm.Labels)
+	otherLabels := common.GetStringToStringMapOrEmpty(other.Labels)
+	annotations := common.GetStringToStringMapOrEmpty(pm.Annotations)
+	otherAnnotations := common.GetStringToStringMapOrEmpty(other.Annotations)
 
 	return pm.Name == other.Name &&
 		pm.Namespace == other.Namespace &&

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -185,8 +185,9 @@ func (ps ProjectSpec) IsEqual(other ProjectSpec) bool {
 }
 
 type ProjectStatus struct {
-	AdminStatus       string `json:"adminStatus,omitempty"`
-	OperationalStatus string `json:"operationalStatus,omitempty"`
+	AdminStatus       string    `json:"adminStatus,omitempty"`
+	OperationalStatus string    `json:"operationalStatus,omitempty"`
+	UpdatedAt         time.Time `json:"updatedAt,omitempty"`
 }
 
 func (pst ProjectStatus) IsEqual(other ProjectStatus) bool {

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -171,7 +171,7 @@ func (pm ProjectMeta) IsEqual(other ProjectMeta) bool {
 	otherAnnotations := common.GetStringStringMapOrEmpty(other.Annotations)
 
 	return pm.Name == other.Name &&
-		pm.Namespace == pm.Namespace &&
+		pm.Namespace == other.Namespace &&
 		reflect.DeepEqual(labels, otherLabels) &&
 		reflect.DeepEqual(annotations, otherAnnotations)
 }
@@ -180,8 +180,8 @@ type ProjectSpec struct {
 	Description string `json:"description,omitempty"`
 }
 
-func (ps ProjectSpec) IsEqual(other ProjectSpec) bool {
-	return ps == other
+func (ps *ProjectSpec) IsEqual(other *ProjectSpec) bool {
+	return *ps == *other
 }
 
 type ProjectStatus struct {
@@ -189,8 +189,8 @@ type ProjectStatus struct {
 	OperationalStatus string `json:"operationalStatus,omitempty"`
 }
 
-func (ps ProjectStatus) IsEqual(other ProjectStatus) bool {
-	return ps == other
+func (ps *ProjectStatus) IsEqual(other *ProjectStatus) bool {
+	return *ps == *other
 }
 
 type ProjectConfig struct {
@@ -265,10 +265,10 @@ type GetProjectsOptions struct {
 }
 
 // to appease k8s
-func (s *ProjectSpec) DeepCopyInto(out *ProjectSpec) {
+func (ps *ProjectSpec) DeepCopyInto(out *ProjectSpec) {
 
 	// TODO: proper deep copy
-	*out = *s
+	*out = *ps
 }
 
 //

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -180,8 +180,8 @@ type ProjectSpec struct {
 	Description string `json:"description,omitempty"`
 }
 
-func (ps *ProjectSpec) IsEqual(other *ProjectSpec) bool {
-	return *ps == *other
+func (ps ProjectSpec) IsEqual(other ProjectSpec) bool {
+	return ps == other
 }
 
 type ProjectStatus struct {
@@ -189,8 +189,8 @@ type ProjectStatus struct {
 	OperationalStatus string `json:"operationalStatus,omitempty"`
 }
 
-func (ps *ProjectStatus) IsEqual(other *ProjectStatus) bool {
-	return *ps == *other
+func (pst ProjectStatus) IsEqual(other ProjectStatus) bool {
+	return pst == other
 }
 
 type ProjectConfig struct {

--- a/pkg/platform/types_test.go
+++ b/pkg/platform/types_test.go
@@ -1,0 +1,88 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type TypesTestSuite struct {
+	suite.Suite
+
+	logger logger.Logger
+}
+
+func (suite *TypesTestSuite) SetupTest() {
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
+}
+
+func (suite *TypesTestSuite) TestProjectConfigIsEqual() {
+	for _, testCase := range []struct {
+		name                string
+		firstProjectConfig  ProjectConfig
+		secondProjectConfig ProjectConfig
+		shouldBeEqual       bool
+	}{
+		{
+			name: "SimpleEqual",
+			firstProjectConfig: ProjectConfig{
+				Meta: ProjectMeta{
+					Name:        "simple-name",
+					Namespace:   "simple-namespace",
+					Labels:      map[string]string{"label1": "value1"},
+					Annotations: map[string]string{"annotation1": "value1"},
+				},
+				Spec: ProjectSpec{
+					Description: "description",
+				},
+			},
+			secondProjectConfig: ProjectConfig{
+				Meta: ProjectMeta{
+					Name:        "simple-name",
+					Namespace:   "simple-namespace",
+					Labels:      map[string]string{"label1": "value1"},
+					Annotations: map[string]string{"annotation1": "value1"},
+				},
+				Spec: ProjectSpec{
+					Description: "description",
+				},
+			},
+			shouldBeEqual: true,
+		},
+		{
+			name: "EqualWithEmptyAndUndefinedLabelsAndAnnotations",
+			firstProjectConfig: ProjectConfig{
+				Meta: ProjectMeta{
+					Name:        "simple-name",
+					Namespace:   "simple-namespace",
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: ProjectSpec{
+					Description: "description",
+				},
+			},
+			secondProjectConfig: ProjectConfig{
+				Meta: ProjectMeta{
+					Name:      "simple-name",
+					Namespace: "simple-namespace",
+				},
+				Spec: ProjectSpec{
+					Description: "description",
+				},
+			},
+			shouldBeEqual: true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			isEqual := testCase.firstProjectConfig.IsEqual(&testCase.secondProjectConfig, false)
+			suite.Require().Equal(testCase.shouldBeEqual, isEqual)
+		})
+	}
+}
+
+func TestTypesTestSuite(t *testing.T) {
+	suite.Run(t, new(TypesTestSuite))
+}

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -44,6 +44,7 @@ type Config struct {
 	ImageRegistryOverrides   ImageRegistryOverridesConfig `json:"imageRegistryOverrides,omitempty"`
 	Runtime                  *runtimeconfig.Config        `json:"runtime,omitempty"`
 	ProjectsLeader           *ProjectsLeader              `json:"projectsLeader,omitempty"`
+	ManagedNamespaces        []string                     `json:"managedNamespaces,omitempty"`
 
 	ContainerBuilderConfiguration *containerimagebuilderpusher.ContainerBuilderConfiguration `json:"containerBuilderConfiguration,omitempty"`
 }

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -45,6 +45,7 @@ type Config struct {
 	Runtime                  *runtimeconfig.Config        `json:"runtime,omitempty"`
 	ProjectsLeader           *ProjectsLeader              `json:"projectsLeader,omitempty"`
 	ManagedNamespaces        []string                     `json:"managedNamespaces,omitempty"`
+	IguazioSession           string                       `json:"iguazioSession,omitempty"`
 
 	ContainerBuilderConfiguration *containerimagebuilderpusher.ContainerBuilderConfiguration `json:"containerBuilderConfiguration,omitempty"`
 }

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -45,7 +45,7 @@ type Config struct {
 	Runtime                  *runtimeconfig.Config        `json:"runtime,omitempty"`
 	ProjectsLeader           *ProjectsLeader              `json:"projectsLeader,omitempty"`
 	ManagedNamespaces        []string                     `json:"managedNamespaces,omitempty"`
-	IguazioSession           string                       `json:"iguazioSession,omitempty"`
+	IguazioSessionCookie     string                       `json:"iguazioSessionCookie,omitempty"`
 
 	ContainerBuilderConfiguration *containerimagebuilderpusher.ContainerBuilderConfiguration `json:"containerBuilderConfiguration,omitempty"`
 }

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -111,7 +111,7 @@ const (
 type ProjectsLeader struct {
 	Kind                    ProjectsLeaderKind `json:"kind,omitempty"`
 	APIAddress              string             `json:"apiAddress,omitempty"`
-	SynchronizationInterval time.Duration      `json:"synchronizationInterval,omitempty"`
+	SynchronizationInterval string             `json:"synchronizationInterval,omitempty"`
 }
 
 type PlatformKubeConfig struct {


### PR DESCRIPTION
Added a synchronizer component to align projects with leader projects
- Configurable interval `platformConfig.ProjectsLeader.SynchronizationInterval` (0 means no sync)
- Every loop gets only updated projects (filter by `project.updated_at` field) - except for the first interval
- Only creates and update functions (no mechanism for deletion - this can be done by invoking delete again by the leader)
- Added `platformConfig.ManagedNamespaces` (k8s namespaces)

WIP (Adding tests)