### PR TITLE
Bugfix - silent failure on function deployment

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -232,7 +232,9 @@ func (fr *functionResource) export(function platform.Function) restful.Attribute
 	return attributes
 }
 
-func (fr *functionResource) storeAndDeployFunction(functionInfo *functionInfo, authConfig *platform.AuthConfig, waitForFunction bool) error {
+func (fr *functionResource) storeAndDeployFunction(functionInfo *functionInfo,
+	authConfig *platform.AuthConfig,
+	waitForFunction bool) error {
 
 	creationStateUpdatedTimeout := 45 * time.Second
 
@@ -278,7 +280,9 @@ func (fr *functionResource) storeAndDeployFunction(functionInfo *functionInfo, a
 		})
 
 		if err != nil {
-			fr.Logger.WarnWith("Failed to deploy function", "err", err)
+			fr.Logger.WarnWith("Failed to deploy function resource",
+				"err", err,
+				"functionInfo", functionInfo)
 			errDeployingChan <- err
 		}
 
@@ -292,7 +296,8 @@ func (fr *functionResource) storeAndDeployFunction(functionInfo *functionInfo, a
 	case <-creationStateUpdatedChan:
 		break
 	case errDeploying := <-errDeployingChan:
-		return errors.RootCause(errDeploying)
+		return nuclio.NewErrInternalServerError(
+			fmt.Sprintf("Failed to deploy function resource: %s", errDeploying))
 	case <-time.After(creationStateUpdatedTimeout):
 		return nuclio.NewErrInternalServerError("Timed out waiting for creation state to be set")
 	}

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -296,8 +296,7 @@ func (fr *functionResource) storeAndDeployFunction(functionInfo *functionInfo,
 	case <-creationStateUpdatedChan:
 		break
 	case errDeploying := <-errDeployingChan:
-		return nuclio.NewErrInternalServerError(
-			fmt.Sprintf("Failed to deploy function resource: %s", errDeploying))
+		return errors.Wrapf(errors.Cause(errDeploying), "Failed deploying function %s", functionInfo.Meta.Name)
 	case <-time.After(creationStateUpdatedTimeout):
 		return nuclio.NewErrInternalServerError("Timed out waiting for creation state to be set")
 	}

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -427,7 +427,6 @@ func (suite *functionTestSuite) TestCreateFunctionWithInvalidName() {
 	suite.mockPlatform.AssertExpectations(suite.T())
 }
 
-
 func (suite *functionTestSuite) TestCreateDeploymentError() {
 
 	// mock a failure before the function is updated (e.g during project fetching)

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -21,6 +21,10 @@ import (
 // to run over it
 type Platform struct {
 	mock.Mock
+
+	// a mock only field signifying whether, during the CreateFunction call, the CreationStateUpdated channel
+	// should be populated. This is used to mock failures before/after the update on the production types
+	CreateFunctionCreationStateUpdated bool
 }
 
 //
@@ -41,8 +45,12 @@ func (mp *Platform) CreateFunctionBuild(createFunctionBuildOptions *platform.Cre
 func (mp *Platform) CreateFunction(createFunctionOptions *platform.CreateFunctionOptions) (*platform.CreateFunctionResult, error) {
 
 	// release requester
-	if createFunctionOptions.CreationStateUpdated != nil {
-		createFunctionOptions.CreationStateUpdated <- true
+	if mp.CreateFunctionCreationStateUpdated {
+
+		// the exact same condition as kube/local platform
+		if createFunctionOptions.CreationStateUpdated != nil {
+			createFunctionOptions.CreationStateUpdated <- true
+		}
 	}
 
 	args := mp.Called(createFunctionOptions)


### PR DESCRIPTION
## Flow:
- An internal k8s failure spews a warning but `POST /functions` still returns 204
- Deployment failed, so consecutive `GET /functions/<whatever>` still fails

## Log example:
```
{"level":"warn","time":"2021-05-06T21:53:20.605Z","name":"dashboard.server.api/functions","message":"Failed to deploy function","err":"Failed to enrich and validate a function configuration","errVerbose":"\nError - etcdserver: request timed out\n    /nuc
lio/pkg/platform/kube/platform.go:532\n\nCall stack:\nFailed to get a project\n    /nuclio/pkg/platform/kube/platform.go:532\nFailed to get projects\n    ...//nuclio/pkg/platform/abstract/platform.go:1091\nProject existence validation failed\n    ...//nu
clio/pkg/platform/abstract/platform.go:349\nFailed to validate a function configuration\n    /nuclio/pkg/platform/kube/platform.go:1215\nFailed to enrich and validate a function configuration\n    /nuclio/pkg/platform/kube/platform.go:144\nFailed to enri
ch and validate a function configuration","errCauses":[{"error":"Failed to validate a function configuration","errorVerbose":"\nError - etcdserver: request timed out\n    /nuclio/pkg/platform/kube/platform.go:532\n\nCall stack:\nFailed to get a project\n
    /nuclio/pkg/platform/kube/platform.go:532\nFailed to get projects\n    ...//nuclio/pkg/platform/abstract/platform.go:1091\nProject existence validation failed\n    ...//nuclio/pkg/platform/abstract/platform.go:349\nFailed to validate a function confi
guration\n    /nuclio/pkg/platform/kube/platform.go:1215\nFailed to validate a function configuration","errorCauses":[{"error":"Project existence validation failed","errorVerbose":"\nError - etcdserver: request timed out\n    /nuclio/pkg/platform/kube/pl
atform.go:532\n\nCall stack:\nFailed to get a project\n    /nuclio/pkg/platform/kube/platform.go:532\nFailed to get projects\n    ...//nuclio/pkg/platform/abstract/platform.go:1091\nProject existence validation failed\n    ...//nuclio/pkg/platform/abstra
ct/platform.go:349\nProject existence validation failed","errorCauses":[{"error":"Failed to get projects","errorVerbose":"\nError - etcdserver: request timed out\n    /nuclio/pkg/platform/kube/platform.go:532\n\nCall stack:\nFailed to get a project\n
/nuclio/pkg/platform/kube/platform.go:532\nFailed to get projects\n    ...//nuclio/pkg/platform/abstract/platform.go:1091\nFailed to get projects","errorCauses":[{"error":"Failed to get a project","errorVerbose":"\nError - etcdserver: request timed out\n
    /nuclio/pkg/platform/kube/platform.go:532\n\nCall stack:\nFailed to get a project\n    /nuclio/pkg/platform/kube/platform.go:532\nFailed to get a project","errorCauses":[{"error":"etcdserver: request timed out"}]}]}]}]}]}

{"level":"debug","time":"2021-05-06T21:53:20.605Z","name":"dashboard.server","message":"Handled request","more":"requestMethod=POST || requestPath=/api/functions || requestHeaders=map[Accept-Encoding:[gzip] Connection:[close] Content-Length:[3959] Content-Type:[application/json] X-Forwarded-For:[10.0.128.4] X-Forwarded-Host:[nuclio-platform-api.default-tenant.app.z-azure-nuclio-110.iguazio-cd1.com] X-Forwarded-Port:[80] X-Forwarded-Proto:[http] X-Nuclio-Function-Namespace:[default-tenant] X-Nuclio-Project-Name:[gfyaiyzobg] X-Real-Ip:[10.0.128.4] X-Request-Id:[e7cbb9b7d501e8c99a995b28bc97f062] X-Scheme:[http]] || requestBody={\"metadata\": {\"name\": \"aggqanqpht\", \"namespace\": \"default-tenant\", \"labels\": {\"nuclio.io/project-name\": \"gfyaiyzobg\"}, \"annotations\": {}}, \"spec\": {\"description\": \"\", \"disable\": false, \"handler\": \"main:handler\", \"runtime\": \"python:3.6\", \"env\": [], \"httpPort\": 0, \"minReplicas\": 0, \"maxReplicas\": 4, \"triggers\": {\"okodl\": {\"name\": \"okodl\", \"kind\": \"http\", \"maxWorkers\": 1, \"attributes\": {\"jobBackoffLimit\": 0, \"ingresses\": {\"0\": {\"paths\": [\"/\"], \"host\": \"okodl.default-tenant.app.z-azure-nuclio-110.iguazio-cd1.com\"}}, \"port\": 0, \"serviceType\": \"ClusterIP\", \"numContainerWorkers\": 0, \"readBatchSize\": 0, \"pollingIntervalMs\": 0, \"fetchDefault\": 0, \"intervalMs\": 0, \"maxBatchSize\": 0, \"maxBatchWaitMs\": 0, \"protocolVersion\": 0}, \"disabled\": false, \"annotations\": {}, \"workerAvailabilityTimeoutMilliseconds\": 10000, \"workerAllocatorName\": \"\"}}, \"version\": 0, \"build\": {\"functionSourceCode\": \"aW1wb3J0IGpzb24NCmltcG9ydCBtYXRoDQpmcm9tIHR5cGluZyBpbXBvcnQgQW55LCBMaXN0LCBEaWN0LCBVbmlvbg0KZnJvbSB0aW1laXQgaW1wb3J0IGRlZmF1bHRfdGltZXIgYXMgdGltZQ0KaW1wb3J0IG51bXB5IGFzIG5wDQpmcm9tIG51bWJhIGltcG9ydCB2ZWN0b3JpemUNCg0KDQpERUZBVUxUX1RBUkdFVFMgPSBbJ2N1ZGEnLCAnY3B1JywgJ3BhcmFsbGVsJ10NCg0KDQpkZWYgZ2VuZXJhdGVfaW5wdXQobiwgZHR5cGUpOg0KICAgICMgdHlwZTogKGludCwgdHlwZSkgLT4gbnAuYXJyYXlbQW55XQ0KICAgIGEgPSBucC5hcnJheShucC5yYW5kb20uc2FtcGxlKG4pLCBkdHlwZT1kdHlwZSkNCiAgICBiID0gbnAuYXJyYXkobnAucmFuZG9tLnNhbXBsZShuKSArIDEwLCBkdHlwZT1kdHlwZSkNCiAgICByZXR1cm4gYSwgYg0KDQoNCmRlZiBzaW5jb3MoeCwgeSk6DQogICAgIyB0eXBlOiAoZmxvYXQsIGZsb2F0KSAtPiBmbG9hdA0KICAgIHJlcyA9IDANCiAgICBmb3IgXyBpbiByYW5nZSgxMDAwMCk6DQogICAgICAgIHJlcyArPSBtYXRoLnNxcnQobWF0aC5zaW4oeCkgKyBtYXRoLmNvcyh5KSkNCiAgICAgICAgdG1weCA9IHgNCiAgICAgICAgeCA9IHggKiogeQ0KICAgICAgICB5ID0geSAqKiB0bXB4DQogICAgcmV0dXJuIHJlcw0KDQoNCmRlZiB2ZWN0b3JfY2FsYyhjb250ZXh0LCBuLCB0YXJnZXRzPU5vbmUpOg0KICAgICMgdHlwZTogKGludCwgTGlzdCkgLT4gRGljdFtzdHIsIFVuaW9uW2ludCwgZmxvYXRdXQ0KICAgIGlmIHRhcmdldHMgaXMgTm9uZToNCiAgICAgICAgdGFyZ2V0cyA9IERFRkFVTFRfVEFSR0VUUw0KICAgIGNvbnRleHQubG9nZ2VyLmRlYnVnX3dpdGgoImdlbmVyYXRpbmcgaW5wdXQiLCBuPW4pDQogICAgYSwgYiA9IGdlbmVyYXRlX2lucHV0KG4sIG5wLmZsb2F0NjQpDQogICAgdmVjdG9yX2lucHV0ID0gWydmNChmNCwgZjQpJywgJ2Y4KGY4LCBmOCknXQ0KICAgIHJlcyA9IHsnRGF0YSBzaXplJzogbn0NCiAgICBmb3IgdGFyZ2V0IGluIHRhcmdldHM6DQogICAgICAgIGNvbnRleHQubG9nZ2VyLmRlYnVnX3dpdGgoInZlY3Rvcml6aW5nIiwgdGFyZ2V0PXRhcmdldCkNCiAgICAgICAgZnVuYyA9IHZlY3Rvcml6ZSh2ZWN0b3JfaW5wdXQsIHRhcmdldD10YXJnZXQpKHNpbmNvcykNCiAgICAgICAgdHMgPSB0aW1lKCkNCiAgICAgICAgY29udGV4dC5sb2dnZXIuZGVidWdfd2l0aCgicnVubmluZyBmdW5jdGlvbiIsIHRzPXRzKQ0KICAgICAgICBmdW5jKGEsIGIpDQogICAgICAgIHRlID0gdGltZSgpDQogICAgICAgIGNvbnRleHQubG9nZ2VyLmRlYnVnX3dpdGgoImRvbmUiLCB0ZT10ZSkNCiAgICAgICAgcmVzW3RhcmdldF0gPSB0ZSAtIHRzDQogICAgcmV0dXJuIHJlcw0KDQoNCmRlZiBoYW5kbGVyKGNvbnRleHQsIGV2ZW50KToNCiAgICBjb250ZXh0LmxvZ2dlci5kZWJ1ZygiUmVjZWl2ZWQgaW5jb21pbmcgcmVxdWVzdCIpDQogICAgbiA9IGV2ZW50LmJvZHlbJ04nXQ0KICAgIGlmICd0YXJnZXRzJyBpbiBldmVudC5ib2R5Og0KICAgICAgICB0YXJnZXRzID0gW3RhcmdldCBmb3IgdGFyZ2V0IGluIGV2ZW50LmJvZHlbJ3RhcmdldHMnXSBpZiB0YXJnZXQgaW4gREVGQVVMVF9UQVJHRVRTXQ0KICAgIGVsc2U6DQogICAgICAgIHRhcmdldHMgPSBERUZBVUxUX1RBUkdFVFMNCiAgICBjb250ZXh0LmxvZ2dlci5kZWJ1Z193aXRoKCJjYWxjdWxhdGluZyB2ZWN0b3IiLCBuPW4sIHRhcmdldHM9dGFyZ2V0cykNCiAgICByZXMgPSB2ZWN0b3JfY2FsYyhjb250ZXh0LCBuLCB0YXJnZXRzKQ0KICAgIHJldHVybiBjb250ZXh0LlJlc3BvbnNlKGJvZHk9anNvbi5kdW1wcyhyZXMpLCBjb250ZW50X3R5cGU9J2FwcGxpY2F0aW9uL2pzb24nLCBzdGF0dXNfY29kZT0yMDAp\", \"noBaseImagesPull\": false, \"noCache\": false, \"baseImage\": \"gcr.io/iguazio/python-cuda-rapids:0.1.0\", \"codeEntryType\": \"sourceCode\", \"image\": \"\", \"noCleanup\": false, \"offline\": false, \"dependencies\": [], \"runtimeAttributes\": {\"repositories\": []}, \"timestamp\": 0, \"mode\": \"alwaysBuild\"}, \"loggerSinks\": [{\"level\": \"debug\", \"sink\": \"\"}], \"readinessTimeoutSeconds\": 120, \"timeoutSeconds\": 0, \"publish\": false, \"scaleToZero\": {\"scaleResources\": [{\"metricName\": \"nuclio_processor_handled_events_total\", \"windowSize\": \"1m\", \"threshold\": 0}]}, \"waitReadinessTimeoutBeforeFailure\": false}} || responseStatus=204 || responseTime=18.786743635s"}

{"level":"debug","time":"2021-05-06T21:53:20.636Z","name":"dashboard.server","message":"Handled request","more":"requestMethod=GET || requestPath=/api/functions/aggqanqpht || requestHeaders=map[Accept-Encoding:[gzip] Connection:[close] X-Forwarded-For:[10.0.128.4] X-Forwarded-Host:[nuclio-platform-api.default-tenant.app.z-azure-nuclio-110.iguazio-cd1.com] X-Forwarded-Port:[80] X-Forwarded-Proto:[http] X-Nuclio-Function-Enrich-Apigateways:[false] X-Nuclio-Function-Namespace:[default-tenant] X-Real-Ip:[10.0.128.4] X-Request-Id:[b9704caf0fafdf3cfcf473d3ba02a023] X-Scheme:[http]] || requestBody= || responseStatus=404 || responseTime=3.74293ms"}
```
## RCA:
- `storeAndDeployFunction` had a flow not returning a valid HTTP error, and so the error was ignored and a success returned.

## Fix:
- The error is now wrapped in `InternalServerError 500` + UT added
