### PR TITLE
Support python async handler functions

### DIFF
--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -235,7 +235,10 @@ class TestSubmitEvents(unittest.TestCase):
                 recorded_events.append(_event)
 
             await asyncio.sleep(0, loop=context.event_loop)
-            self._event_loop.create_task(append_event(event))
+
+            # using `ensure_future` to BC with python:3.6 (on >= 3.7, you will see "create_task")
+            # https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+            asyncio.ensure_future(append_event(event), loop=self._event_loop)
             return 'ok'
 
         num_of_events = 10

--- a/pkg/processor/runtime/python/test/outputter/async_handler.py
+++ b/pkg/processor/runtime/python/test/outputter/async_handler.py
@@ -1,0 +1,25 @@
+# Copyright 2021 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+
+async def handler(context, event):
+    body_str = event.body.decode('utf-8')
+
+    if body_str == 'sleep':
+        await asyncio.sleep(0, loop=context.event_loop)
+        return 'slept'
+
+    raise RuntimeError('Unknown return mode: {0}'.format(body_str))

--- a/pkg/processor/runtime/python/test/outputter/async_outputter.py
+++ b/pkg/processor/runtime/python/test/outputter/async_outputter.py
@@ -14,6 +14,8 @@
 
 import asyncio
 
+import aiofile
+
 
 async def handler(context, event):
     body_str = event.body.decode('utf-8')
@@ -21,5 +23,18 @@ async def handler(context, event):
     if body_str == 'sleep':
         await asyncio.sleep(0, loop=context.event_loop)
         return 'slept'
+
+    if body_str == 'async_write':
+        async def write_async():
+            write_mode = 'wb' if isinstance(event.method, bytes) else 'w'
+            async with aiofile.async_open('./async_write', write_mode) as w:
+                await w.write(event.method)
+
+        asyncio.get_event_loop().create_task(write_async())
+        return 'written'
+
+    if body_str == 'read_async_write':
+        async with aiofile.async_open('./async_write', 'r') as r:
+            return await r.read()
 
     raise RuntimeError('Unknown return mode: {0}'.format(body_str))

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -77,6 +77,25 @@ func (suite *TestSuite) TestStress() {
 	suite.BlastHTTP(blastConfiguration)
 }
 
+func (suite *TestSuite) TestAsyncHandler() {
+	statusOK := http.StatusOK
+
+	createFunctionOptions := suite.GetDeployOptions("asyncer",
+		suite.GetFunctionPath("async_handler"))
+
+	createFunctionOptions.FunctionConfig.Spec.Handler = "async_handler:handler"
+
+	testRequests := []*httpsuite.Request{
+		{
+			Name:                       "async sleep",
+			RequestBody:                "sleep",
+			ExpectedResponseBody:       "slept",
+			ExpectedResponseStatusCode: &statusOK,
+		},
+	}
+	suite.DeployFunctionAndRequests(createFunctionOptions, testRequests)
+}
+
 func (suite *TestSuite) TestOutputs() {
 	statusOK := http.StatusOK
 	statusCreated := http.StatusCreated

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -81,19 +81,34 @@ func (suite *TestSuite) TestAsyncHandler() {
 	statusOK := http.StatusOK
 
 	createFunctionOptions := suite.GetDeployOptions("asyncer",
-		suite.GetFunctionPath("async_handler"))
+		suite.GetFunctionPath("outputter"))
 
-	createFunctionOptions.FunctionConfig.Spec.Handler = "async_handler:handler"
+	createFunctionOptions.FunctionConfig.Spec.Handler = "async_outputter:handler"
+	createFunctionOptions.FunctionConfig.Spec.Build.Commands = []string{
+		"python -m pip install aiofile==3.5.0",
+	}
 
-	testRequests := []*httpsuite.Request{
+	suite.DeployFunctionAndRequests(createFunctionOptions, []*httpsuite.Request{
 		{
 			Name:                       "async sleep",
 			RequestBody:                "sleep",
 			ExpectedResponseBody:       "slept",
 			ExpectedResponseStatusCode: &statusOK,
 		},
-	}
-	suite.DeployFunctionAndRequests(createFunctionOptions, testRequests)
+		{
+			Name:                       "async write",
+			RequestMethod:              http.MethodDelete,
+			RequestBody:                "async_write",
+			ExpectedResponseBody:       "written",
+			ExpectedResponseStatusCode: &statusOK,
+		},
+		{
+			Name:                       "async read",
+			RequestBody:                "read_async_write",
+			ExpectedResponseBody:       http.MethodDelete, // "async_write" above ensure requestMethod is returned
+			ExpectedResponseStatusCode: &statusOK,
+		},
+	})
 }
 
 func (suite *TestSuite) TestOutputs() {


### PR DESCRIPTION
This PR:
- **does not** introduce concurrent request handling. 
- **does** introduce support for executing coroutine functions.

Nuclio wrapper create the event loop once and set it on `context` object.
If the function handler is prefixed with `async def` then it would wrap the entrypoint to allow executing the function as a coroutine, with the event loop (run until completed).


TODO:
- [ ] Documentation
- [ ] Example
- [ ] Benchmark (w & w/o async signature)
- [ ] Avoid using 
