### PR TITLE
Configurable default function readiness timeout

### DIFF
--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -296,6 +296,7 @@ platform: {}
 #       "python:3.6": "myregistry"
 #     onbuildImageRegistries:
 #       "golang": "myregistry"
+#   functionReadinessTimeout: 120s
 
 # global is a stanza that is used if this is used as a subchart. Ignore otherwise
 global:

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -108,7 +108,7 @@ func (fesr *frontendSpecResource) getDefaultFunctionConfig() map[string]interfac
 	defaultFunctionSpec := functionconfig.Spec{
 		MinReplicas:             &one,
 		MaxReplicas:             &one,
-		ReadinessTimeoutSeconds: abstract.DefaultReadinessTimeoutSeconds,
+		ReadinessTimeoutSeconds: fesr.resolveFunctionReadinessTimeoutSeconds(),
 		TargetCPU:               abstract.DefaultTargetCPU,
 		Triggers: map[string]functionconfig.Trigger{
 
@@ -151,6 +151,14 @@ func (fesr *frontendSpecResource) resolveDefaultServiceType() v1.ServiceType {
 		defaultServiceType = dashboardServer.GetPlatformConfiguration().Kube.DefaultServiceType
 	}
 	return defaultServiceType
+}
+
+func (fesr *frontendSpecResource) resolveFunctionReadinessTimeoutSeconds() int {
+	var readinessTimeoutSeconds = platformconfig.DefaultFunctionReadinessTimeoutSeconds
+	if dashboardServer, ok := fesr.resource.GetServer().(*dashboard.Server); ok {
+		return int(dashboardServer.GetPlatformConfiguration().GetFunctionReadinessTimeout(0).Seconds())
+	}
+	return readinessTimeoutSeconds
 }
 
 // register the resource

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -154,9 +154,9 @@ func (fesr *frontendSpecResource) resolveDefaultServiceType() v1.ServiceType {
 }
 
 func (fesr *frontendSpecResource) resolveFunctionReadinessTimeoutSeconds() int {
-	var readinessTimeoutSeconds = platformconfig.DefaultFunctionReadinessTimeoutSeconds
+	readinessTimeoutSeconds := platformconfig.DefaultFunctionReadinessTimeoutSeconds
 	if dashboardServer, ok := fesr.resource.GetServer().(*dashboard.Server); ok {
-		return int(dashboardServer.GetPlatformConfiguration().GetFunctionReadinessTimeout(0).Seconds())
+		return int(dashboardServer.GetPlatformConfiguration().GetDefaultFunctionReadinessTimeout().Seconds())
 	}
 	return readinessTimeoutSeconds
 }

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -341,13 +341,10 @@ func (d *deployCommandeer) populateDeploymentDefaults() {
 		d.functionConfig.Spec.RunRegistry = os.Getenv("NUCTL_RUN_REGISTRY")
 	}
 
-	d.functionConfig.Spec.ReadinessTimeoutSeconds =
-		int(d.rootCommandeer.
-			platformConfiguration.
-			GetFunctionReadinessTimeout(d.functionConfig.
-				Spec.
-				ReadinessTimeoutSeconds).
-			Seconds())
+	if d.functionConfig.Spec.ReadinessTimeoutSeconds == 0 {
+		d.functionConfig.Spec.ReadinessTimeoutSeconds = int(
+			d.rootCommandeer.platformConfiguration.GetDefaultFunctionReadinessTimeout().Seconds())
+	}
 
 	if d.functionConfig.Spec.DataBindings == nil {
 		d.functionConfig.Spec.DataBindings = map[string]functionconfig.DataBinding{}

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -340,9 +340,15 @@ func (d *deployCommandeer) populateDeploymentDefaults() {
 	if d.functionConfig.Spec.RunRegistry == "" {
 		d.functionConfig.Spec.RunRegistry = os.Getenv("NUCTL_RUN_REGISTRY")
 	}
-	if d.functionConfig.Spec.ReadinessTimeoutSeconds == 0 {
-		d.functionConfig.Spec.ReadinessTimeoutSeconds = abstract.DefaultReadinessTimeoutSeconds
-	}
+
+	d.functionConfig.Spec.ReadinessTimeoutSeconds =
+		int(d.rootCommandeer.
+			platformConfiguration.
+			GetFunctionReadinessTimeout(d.functionConfig.
+				Spec.
+				ReadinessTimeoutSeconds).
+			Seconds())
+
 	if d.functionConfig.Spec.DataBindings == nil {
 		d.functionConfig.Spec.DataBindings = map[string]functionconfig.DataBinding{}
 	}

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -50,9 +50,8 @@ import (
 //
 
 const (
-	FunctionContainerHTTPPort      = 8080
-	DefaultReadinessTimeoutSeconds = 60
-	DefaultTargetCPU               = 75
+	FunctionContainerHTTPPort = 8080
+	DefaultTargetCPU          = 75
 )
 
 type Platform struct {

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
-	"github.com/nuclio/nuclio/pkg/platform/abstract"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	"github.com/nuclio/nuclio/pkg/platform/kube/client"
 	"github.com/nuclio/nuclio/pkg/platform/kube/functionres"
@@ -163,12 +162,8 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 	}
 
 	// wait for up to the default readiness timeout or whatever was set in the spec
-	readinessTimeout := function.Spec.ReadinessTimeoutSeconds
-	if readinessTimeout == 0 {
-		readinessTimeout = abstract.DefaultReadinessTimeoutSeconds
-	}
-
-	waitContext, cancel := context.WithDeadline(ctx, time.Now().Add(time.Duration(readinessTimeout)*time.Second))
+	readinessTimeout := fo.controller.GetPlatformConfiguration().GetFunctionReadinessTimeout(function.Spec.ReadinessTimeoutSeconds)
+	waitContext, cancel := context.WithDeadline(ctx, time.Now().Add(readinessTimeout))
 	defer cancel()
 
 	// wait until the function resources are ready

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -1033,12 +1033,7 @@ func (p *Platform) waitForContainer(containerID string, timeout int) error {
 	p.Logger.InfoWith("Waiting for function to be ready",
 		"timeout", timeout)
 
-	var readinessTimeout time.Duration
-	if timeout != 0 {
-		readinessTimeout = time.Duration(timeout) * time.Second
-	} else {
-		readinessTimeout = abstract.DefaultReadinessTimeoutSeconds * time.Second
-	}
+	readinessTimeout := p.Config.GetFunctionReadinessTimeout(timeout)
 
 	if err := p.dockerClient.AwaitContainerHealth(containerID, &readinessTimeout); err != nil {
 		var errMessage string

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -1033,7 +1033,10 @@ func (p *Platform) waitForContainer(containerID string, timeout int) error {
 	p.Logger.InfoWith("Waiting for function to be ready",
 		"timeout", timeout)
 
-	readinessTimeout := p.Config.GetFunctionReadinessTimeout(timeout)
+	readinessTimeout := time.Duration(timeout) * time.Second
+	if timeout == 0 {
+		readinessTimeout = p.Config.GetDefaultFunctionReadinessTimeout()
+	}
 
 	if err := p.dockerClient.AwaitContainerHealth(containerID, &readinessTimeout); err != nil {
 		var errMessage string

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -132,12 +132,7 @@ func (config *Config) GetFunctionLoggerSinks(functionConfig *functionconfig.Conf
 	return config.getLoggerSinksWithLevel(loggerSinkBindings)
 }
 
-func (config *Config) GetFunctionReadinessTimeout(timeout int) time.Duration {
-
-	// usually provided by function spec
-	if timeout != 0 {
-		return time.Duration(timeout) * time.Second
-	}
+func (config *Config) GetDefaultFunctionReadinessTimeout() time.Duration {
 
 	// provided by the platform-config
 	if config.functionReadinessTimeout != nil {

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -24,8 +24,9 @@ import (
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
-	"github.com/nuclio/nuclio/test/compare"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
@@ -46,6 +47,7 @@ func (suite *PlatformConfigTestSuite) SetupTest() {
 
 func (suite *PlatformConfigTestSuite) TestReadConfiguration() {
 	configurationContents := `
+functionReadinessTimeout: 10s
 webAdmin:
   enabled: true
   listenAddress: :8081
@@ -88,6 +90,9 @@ metrics:
 	trueValue := true
 	expectedConfiguration.WebAdmin.Enabled = &trueValue
 	expectedConfiguration.WebAdmin.ListenAddress = ":8081"
+
+	tenSecondsStr := "10s"
+	expectedConfiguration.FunctionReadinessTimeout = &tenSecondsStr
 
 	// logger
 	expectedConfiguration.Logger.System = append(expectedConfiguration.Logger.System, LoggerSinkBinding{
@@ -144,7 +149,7 @@ metrics:
 	err := suite.reader.Read(bytes.NewBufferString(configurationContents), "yaml", &readConfiguration)
 	suite.Require().NoError(err)
 
-	suite.Require().True(compare.NoOrder(expectedConfiguration, readConfiguration))
+	suite.Require().Empty(cmp.Diff(&expectedConfiguration, &readConfiguration, cmpopts.IgnoreUnexported(Config{})))
 }
 
 func (suite *PlatformConfigTestSuite) TestGetSystemLoggerSinks() {
@@ -191,7 +196,7 @@ logger:
 		},
 	}
 
-	suite.Require().True(compare.NoOrder(expectedSystemLoggerSinks, systemLoggerSinks))
+	suite.Require().Empty(cmp.Diff(&expectedSystemLoggerSinks, &systemLoggerSinks, cmpopts.IgnoreUnexported(Config{})))
 }
 
 func (suite *PlatformConfigTestSuite) TestGetSystemLoggerSinksInvalidSink() {
@@ -258,7 +263,7 @@ logger:
 		},
 	}
 
-	suite.Require().True(compare.NoOrder(expectedFunctionLoggerSinks, functionLoggerSinks))
+	suite.Require().Empty(cmp.Diff(&expectedFunctionLoggerSinks, &functionLoggerSinks, cmpopts.IgnoreUnexported(Config{})))
 }
 
 func (suite *PlatformConfigTestSuite) TestGetFunctionLoggerSinksWithFunctionConfig() {
@@ -315,7 +320,7 @@ logger:
 		},
 	}
 
-	suite.Require().True(compare.NoOrder(expectedFunctionLoggerSinks, functionLoggerSinks))
+	suite.Require().Empty(cmp.Diff(&expectedFunctionLoggerSinks, &functionLoggerSinks, cmpopts.IgnoreUnexported(Config{})))
 }
 
 func (suite *PlatformConfigTestSuite) TestGetFunctionLoggerSinksInvalidSink() {
@@ -381,7 +386,7 @@ metrics:
 		},
 	}
 
-	suite.Require().True(compare.NoOrder(expectedSystemMetricSinks, systemMetricSinks))
+	suite.Require().Empty(cmp.Diff(&expectedSystemMetricSinks, &systemMetricSinks, cmpopts.IgnoreUnexported(Config{})))
 }
 
 func (suite *PlatformConfigTestSuite) TestGetSystemMetricSinksInvalidSink() {
@@ -443,7 +448,7 @@ metrics:
 		},
 	}
 
-	suite.Require().True(compare.NoOrder(expectedFunctionMetricSinks, functionMetricSinks))
+	suite.Require().Empty(cmp.Diff(&expectedFunctionMetricSinks, &functionMetricSinks, cmpopts.IgnoreUnexported(Config{})))
 }
 
 func (suite *PlatformConfigTestSuite) TestFunctionAugmentedConfigs() {
@@ -499,8 +504,7 @@ functionAugmentedConfigs:
 		},
 	}
 
-	suite.Require().True(compare.NoOrder(expectedFunctionAugmentedConfigs,
-		readConfiguration.FunctionAugmentedConfigs))
+	suite.Require().Empty(cmp.Diff(&expectedFunctionAugmentedConfigs, &readConfiguration.FunctionAugmentedConfigs, cmpopts.IgnoreUnexported(Config{})))
 }
 
 func TestRegistryTestSuite(t *testing.T) {

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -26,6 +26,8 @@ import (
 	machinarymetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const DefaultFunctionReadinessTimeoutSeconds = 60
+
 type LoggerSink struct {
 	Kind       string                 `json:"kind,omitempty"`
 	URL        string                 `json:"url,omitempty"`


### PR DESCRIPTION
It is desired to have the readiness timeout configurable via the platform config.

Readiness timeout is a timeout used by nuclio-controller to wait until function pods are ready. if the timeout expires, the function then become "unhealthy".

The readinessTimeout is first populated from the function config spec. if that is zero (aka not set), then it checks for the platform config readiness timeout, which is default to 60 seconds.

This PR allowing us to change the default timeout.

Note: if readinessTimeout is set to `0` on the platform config (only), e.g.: `functionReadinessTimeout: 0s` it is then considered as nuclio-controller won't wait for function pods and would mark the function as ready immediately. This is not a best practice as for now, but optional.