### PR TITLE
Support async def init_context and handle

### DIFF
--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -216,7 +216,7 @@ class Wrapper(object):
         int_buf = bytearray(4)
 
         if self._is_entrypoint_coroutine:
-            should_be_four = await self._loop.run_in_executor(None, self._processor_sock.recv_into, int_buf, 4)
+            should_be_four = await self._loop.sock_recv_into(self._processor_sock, int_buf)
         else:
             should_be_four = self._processor_sock.recv_into(int_buf, 4)
 

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -91,7 +91,7 @@ class Wrapper(object):
     async def serve_requests(self, num_requests=None):
         """Read event from socket, send out reply"""
 
-        self._loop = asyncio.get_running_loop()
+        self._loop = asyncio.get_event_loop()
 
         # call init context
         if hasattr(self._entrypoint_module, 'init_context'):

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -210,14 +210,15 @@ class Wrapper(object):
         self._processor_sock_wfile.write(body + '\n')
         self._processor_sock_wfile.flush()
 
+    # Determines the message body size
     async def _resolve_event_message_length(self):
 
-        # used for the first message, to determine the body size
-        int_buf = bytearray(4)
-
         if self._is_entrypoint_coroutine:
-            should_be_four = await self._loop.run_in_executor(None, self._processor_sock.recv_into, int_buf, 4)
+            # loop.sock_recv_into is not python 3.6-compatible.
+            int_buf = await self._loop.sock_recv(self._processor_sock, 4)
+            should_be_four = len(int_buf)
         else:
+            int_buf = bytearray(4)
             should_be_four = self._processor_sock.recv_into(int_buf, 4)
 
         # client disconnect

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+import asyncio
 import json
 import logging
 import re
@@ -61,6 +62,8 @@ class Wrapper(object):
         # holds the function that will be called
         self._entrypoint = self._load_entrypoint_from_handler(handler)
 
+        self._is_entrypoint_coroutine = asyncio.iscoroutinefunction(self._entrypoint)
+
         # connect to processor
         self._processor_sock = self._connect_to_processor()
 
@@ -74,7 +77,7 @@ class Wrapper(object):
         self._event_deserializer_kind = self._resolve_event_deserializer_kind()
 
         # get handler module
-        entrypoint_module = sys.modules[self._entrypoint.__module__]
+        self._entrypoint_module = sys.modules[self._entrypoint.__module__]
 
         # create a context with logger and platform
         self._context = nuclio_sdk.Context(self._logger,
@@ -85,10 +88,19 @@ class Wrapper(object):
         # replace the default output with the process socket
         self._logger.set_handler('default', self._processor_sock_wfile, nuclio_sdk.logger.JSONFormatter())
 
+    async def serve_requests(self, num_requests=None):
+        """Read event from socket, send out reply"""
+
+        self._loop = asyncio.get_running_loop()
+
         # call init context
-        if hasattr(entrypoint_module, 'init_context'):
+        if hasattr(self._entrypoint_module, 'init_context'):
             try:
-                getattr(entrypoint_module, 'init_context')(self._context)
+                init_context = getattr(self._entrypoint_module, 'init_context')
+                init_context_result = getattr(self._entrypoint_module, 'init_context')(self._context)
+                if asyncio.iscoroutinefunction(init_context):
+                    await init_context_result
+
             except:
                 self._logger.error('Exception raised while running init_context')
                 raise
@@ -96,24 +108,21 @@ class Wrapper(object):
         # indicate that we're ready
         self._write_packet_to_processor('s')
 
-    def serve_requests(self, num_requests=None):
-        """Read event from socket, send out reply"""
-
         while True:
 
             try:
 
                 # resolve event message length
-                event_message_length = self._resolve_event_message_length()
+                event_message_length = await self._resolve_event_message_length()
 
                 # resolve event message
-                event_message = self._resolve_event(event_message_length)
+                event_message = await self._resolve_event(event_message_length)
 
                 # instantiate event message
                 event = nuclio_sdk.Event.deserialize(event_message, kind=self._event_deserializer_kind)
 
                 try:
-                    self._handle_event(event)
+                    await self._handle_event(event)
                 except BaseException as exc:
                     self._on_handle_event_error(exc)
 
@@ -201,12 +210,15 @@ class Wrapper(object):
         self._processor_sock_wfile.write(body + '\n')
         self._processor_sock_wfile.flush()
 
-    def _resolve_event_message_length(self):
+    async def _resolve_event_message_length(self):
 
         # used for the first message, to determine the body size
         int_buf = bytearray(4)
 
-        should_be_four = self._processor_sock.recv_into(int_buf, 4)
+        if self._is_entrypoint_coroutine:
+            should_be_four = await self._loop.run_in_executor(None, self._processor_sock.recv_into, int_buf, 4)
+        else:
+            should_be_four = self._processor_sock.recv_into(int_buf, 4)
 
         # client disconnect
         if should_be_four != 4:
@@ -222,12 +234,15 @@ class Wrapper(object):
 
         return bytes_to_read
 
-    def _resolve_event(self, event_bytes_length):
+    async def _resolve_event(self, event_bytes_length):
 
         cumulative_bytes_read = 0
         while cumulative_bytes_read < event_bytes_length:
             bytes_to_read_now = event_bytes_length - cumulative_bytes_read
-            bytes_read = self._processor_sock.recv(bytes_to_read_now)
+            if self._is_entrypoint_coroutine:
+                bytes_read = await self._loop.sock_recv(self._processor_sock, bytes_to_read_now)
+            else:
+                bytes_read = self._processor_sock.recv(bytes_to_read_now)
 
             if not bytes_read:
                 raise WrapperFatalException('Client disconnected')
@@ -265,13 +280,15 @@ class Wrapper(object):
             print('Failed to write message to processor after serving error detected, is socket open?\n'
                   'Exception: {0}'.format(str(exc)))
 
-    def _handle_event(self, event):
+    async def _handle_event(self, event):
 
         # take call time
         start_time = time.time()
 
         # call the entrypoint
         entrypoint_output = self._entrypoint(self._context, event)
+        if self._is_entrypoint_coroutine:
+            entrypoint_output = await entrypoint_output
 
         # measure duration, set to minimum float in case execution was too fast
         duration = time.time() - start_time or sys.float_info.min
@@ -373,8 +390,8 @@ def run_wrapper():
 
         raise SystemExit(1)
 
-    # register the function @ the wrapper
-    wrapper_instance.serve_requests()
+    # 3.6-compatible alternative to asyncio.run()
+    asyncio.get_event_loop().run_until_complete(wrapper_instance.serve_requests())
 
 
 if __name__ == '__main__':

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -216,7 +216,7 @@ class Wrapper(object):
         int_buf = bytearray(4)
 
         if self._is_entrypoint_coroutine:
-            should_be_four = await self._loop.sock_recv_into(self._processor_sock, int_buf)
+            should_be_four = await self._loop.run_in_executor(None, self._processor_sock.recv_into, int_buf, 4)
         else:
             should_be_four = self._processor_sock.recv_into(int_buf, 4)
 

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import asyncio
 import functools
 import http.client
 import json
@@ -99,7 +99,7 @@ class TestSubmitEvents(unittest.TestCase):
         t = threading.Thread(target=self._send_events, args=(events,))
         t.start()
 
-        self._wrapper.serve_requests(num_requests=len(events))
+        asyncio.get_event_loop().run_until_complete(self._wrapper.serve_requests(num_requests=len(events)))
         t.join()
 
         # processor start
@@ -137,7 +137,7 @@ class TestSubmitEvents(unittest.TestCase):
         self._send_event(nuclio_sdk.Event(_id='1'))
 
         self._wrapper._entrypoint = raise_exception
-        self._wrapper.serve_requests(num_requests=1)
+        asyncio.get_event_loop().run_until_complete(self._wrapper.serve_requests(num_requests=1))
 
         # processor start, function log line, response body
         self._wait_until_received_messages(3)
@@ -160,7 +160,7 @@ class TestSubmitEvents(unittest.TestCase):
         self._wrapper._entrypoint = unittest.mock.MagicMock()
         self._wrapper._entrypoint.assert_not_called()
         with self.assertRaises(SystemExit):
-            self._wrapper.serve_requests(num_requests=1)
+            asyncio.get_event_loop().run_until_complete(self._wrapper.serve_requests(num_requests=1))
         t.join()
 
     def test_single_event(self):
@@ -171,7 +171,7 @@ class TestSubmitEvents(unittest.TestCase):
         t = threading.Thread(target=self._send_event, args=(nuclio_sdk.Event(_id=1, body=reverse_text),))
         t.start()
 
-        self._wrapper.serve_requests(num_requests=1)
+        asyncio.get_event_loop().run_until_complete(self._wrapper.serve_requests(num_requests=1))
         t.join()
 
         # processor start, function log line, response body, duration messages
@@ -202,7 +202,7 @@ class TestSubmitEvents(unittest.TestCase):
         t.start()
 
         self._wrapper._entrypoint = functools.partial(record_event, recorded_event_ids)
-        self._wrapper.serve_requests(num_requests=expected_events_length)
+        asyncio.get_event_loop().run_until_complete(self._wrapper.serve_requests(num_requests=expected_events_length))
         t.join()
 
         # record incoming events
@@ -223,7 +223,7 @@ class TestSubmitEvents(unittest.TestCase):
         )
         self._send_events(events)
         self._wrapper._entrypoint = event_recorder
-        self._wrapper.serve_requests(num_of_events)
+        asyncio.get_event_loop().run_until_complete(self._wrapper.serve_requests(num_of_events))
         self.assertEqual(num_of_events, len(recorded_events), 'wrong number of events')
 
         for recorded_event_index, recorded_event in enumerate(sorted(recorded_events, key=operator.attrgetter('id'))):


### PR DESCRIPTION
As discussed, this adds support for `async def handle` and `async def init_context`, by running the wrapper in an asyncio event loop, awaiting where appropriate, and using an async recv call when `handle` is a coroutine.