### PR TITLE
Add default function node selector to platform config

### DIFF
--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -51,6 +51,9 @@ functionReadinessTimeout: 10s
 webAdmin:
   enabled: true
   listenAddress: :8081
+kube:
+  defaultFunctionNodeSelector:
+    defaultFunctionNodeSelectorKey: defaultFunctionNodeSelectorValue
 logger:
   sinks:
     stdout:
@@ -128,6 +131,10 @@ metrics:
 		Attributes: map[string]interface{}{
 			"dontCrash": true,
 		},
+	}
+
+	expectedConfiguration.Kube.DefaultFunctionNodeSelector = map[string]string{
+		"defaultFunctionNodeSelectorKey": "defaultFunctionNodeSelectorValue",
 	}
 
 	// metric

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -123,7 +123,8 @@ type PlatformKubeConfig struct {
 	KubeConfigPath string `json:"kubeConfigPath,omitempty"`
 
 	// TODO: Move IngressConfig here
-	DefaultServiceType corev1.ServiceType `json:"defaultServiceType,omitempty"`
+	DefaultServiceType          corev1.ServiceType `json:"defaultServiceType,omitempty"`
+	DefaultFunctionNodeSelector map[string]string  `json:"defaultFunctionNodeSelector,omitempty"`
 }
 
 type PlatformLocalConfig struct {


### PR DESCRIPTION
Using default function node selector allowing us to set an initial set of selectors for each created functions

