### PR TITLE
UI: Node selectors, internal & external invocation URLs, owner

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5585,9 +5585,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.34.2.tgz",
-      "integrity": "sha512-t8TLWXZhK/N6vRZ9sm4ccTTSNtW1mE1dwa7eId+JU0HYVKvw0FmaQSE7pDyFz6VgoSoMlu0sFLiw/+APOWHHmg==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.35.0.tgz",
+      "integrity": "sha512-SmrwVHZKaYDc8cSWOQvgN7X4Qg7yLFT4TdSMWJUa/ASXQPqyLBB0MKcnf/m9dkt6pJgZ+sed75NRa6GYzO5KKQ==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.34.2",
+    "iguazio.dashboard-controls": "^0.35.0",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
- “Project” screen › “Functions” tab:
  - Removed “Invocation URL” column.
    Before:
    ![image](https://user-images.githubusercontent.com/13918850/121218818-c2d9e000-c88b-11eb-8f50-8677a6c88dbb.png)
    After:
    ![image](https://user-images.githubusercontent.com/13918850/121218824-c4a3a380-c88b-11eb-9047-9c683a02965e.png)
  - Added an “Owner” column, sortable
    ![image](https://user-images.githubusercontent.com/13918850/120971567-72705e80-c775-11eb-9bbd-665d3a3c2490.png)
- “Function” screen:
  - “Configuration” tab: Added ”Node Selectors”
    ![image](https://user-images.githubusercontent.com/13918850/121217409-7f32a680-c88a-11eb-8b04-8b1900e0d04b.png)
  - “Status” tab: list internal invocation URLs and external invocation URLs with a copy button for each.
    Before:
    ![image](https://user-images.githubusercontent.com/13918850/121218977-eb61da00-c88b-11eb-82a7-02c9660c3521.png)
    After:
    ![image](https://user-images.githubusercontent.com/13918850/121218984-ed2b9d80-c88b-11eb-8b9a-7efed0bb67e3.png)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/1234