### PR TITLE
UI: Test pane: add selection of invocation URL

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5585,9 +5585,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.35.1.tgz",
-      "integrity": "sha512-FFauymEshQ/t7MEPNo3sUdNg44EVuoC6+SWgixJpbfRHuoSWFTMslOK89mVYsAAL/vZUyRQlVSFgAi1uq4Rqbw==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.36.0.tgz",
+      "integrity": "sha512-lb+F4uRqLBjBMa+jk6enEPSCBdPi7a8kHrD2ZSEvHm77BZvrfi1vxPSQ+oXt62GhSIe9/BqIBd7MIzk/ZTytwg==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.35.1",
+    "iguazio.dashboard-controls": "^0.36.0",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",

--- a/pkg/dashboard/ui/src/app/components/data-wrappers/function-events-data-wrapper/function-events-data-wrapper.component.js
+++ b/pkg/dashboard/ui/src/app/components/data-wrappers/function-events-data-wrapper/function-events-data-wrapper.component.js
@@ -10,7 +10,7 @@
             controller: FunctionEventsDataWrapperController
         });
 
-    function FunctionEventsDataWrapperController(NuclioEventDataService, NuclioProjectsDataService) {
+    function FunctionEventsDataWrapperController(NuclioEventDataService) {
         var ctrl = this;
 
         ctrl.createFunctionEvent = createFunctionEvent;
@@ -53,12 +53,12 @@
         /**
          * Invoke function event
          * @param {Object} eventData
-         * @param {string} invokeVia
+         * @param {string} invokeUrl
          * @param {Promise} canceller
          * @returns {Promise}
          */
-        function invokeFunction(eventData, invokeVia, canceller) {
-            return NuclioEventDataService.invokeFunction(eventData, invokeVia, canceller);
+        function invokeFunction(eventData, invokeUrl, canceller) {
+            return NuclioEventDataService.invokeFunction(eventData, invokeUrl, canceller);
         }
     }
 }());

--- a/pkg/dashboard/ui/src/app/components/data-wrappers/function-events-data-wrapper/function-events-data-wrapper.tpl.html
+++ b/pkg/dashboard/ui/src/app/components/data-wrappers/function-events-data-wrapper/function-events-data-wrapper.tpl.html
@@ -2,5 +2,5 @@
                          data-delete-function-event="$ctrl.deleteFunctionEvent(eventData)"
                          data-get-function-events="$ctrl.getFunctionEvents(functionData)"
                          data-create-function-event="$ctrl.createFunctionEvent(eventData, isNewEvent)"
-                         data-invoke-function="$ctrl.invokeFunction(eventData, invokeVia, canceler)">
+                         data-invoke-function="$ctrl.invokeFunction(eventData, invokeUrl, canceler)">
 </ncl-function-event-pane>

--- a/pkg/dashboard/ui/src/app/shared/services/nuclio-event-data.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/nuclio-event-data.service.js
@@ -94,16 +94,15 @@
         /**
          * Invokes the function.
          * @param {Object} eventData - the function event to invoke function with.
-         * @param {string} [invokeVia='external-ip'] - via which mechanism to invoke the function, 'domain-name' or
-         *     'external-ip'.
+         * @param {string} [invokeUrl] - the invocation URL to use (could be internal or external).
          * @param {Promise} [canceler] - if provided, function invocation is canceled on resolving this promise.
          * @returns {Promise}
          */
-        function invokeFunction(eventData, invokeVia, canceler) {
+        function invokeFunction(eventData, invokeUrl, canceler) {
             var userDefinedHeaders = lodash.get(eventData, 'spec.attributes.headers', {});
             var headers = lodash.assign({}, userDefinedHeaders, {
                 'x-nuclio-function-name': eventData.metadata.labels['nuclio.io/function-name'],
-                'x-nuclio-invoke-via': lodash.defaultTo(invokeVia, 'external-ip'),
+                'x-nuclio-invoke-url': invokeUrl,
                 'x-nuclio-path': eventData.spec.attributes.path,
                 'x-nuclio-log-level': eventData.spec.attributes.logLevel
             });


### PR DESCRIPTION
- “Function” screen › “Code” tab › “Test” pane: Added a select field of all internal and external invocation URLs, and replaced use of `x-nuclio-invoke-via` HTTP request header with `x-nuclio-invoke-url` that uses the selected URL.
  ![image](https://user-images.githubusercontent.com/13918850/122563610-10550a80-d04d-11eb-9fcb-695ad452f061.png)
  ![image](https://user-images.githubusercontent.com/13918850/122563617-11863780-d04d-11eb-9a15-226d889e0216.png)
- “Project” screen › “Functions“ tab: [bugfix] table was overflowing the viewport on the right edge
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/122562791-20b8b580-d04c-11eb-9849-a4a400361375.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/122562803-231b0f80-d04c-11eb-9e87-46907f1ac40c.png)