### PR TITLE
Support OPA override header

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -112,7 +112,7 @@ func (fr *functionResource) Create(request *http.Request) (id string, attributes
 	functions, err := fr.getPlatform().GetFunctions(&platform.GetFunctionsOptions{
 		Name:      functionInfo.Meta.Name,
 		Namespace: fr.resolveNamespace(request, functionInfo),
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			RaiseForbidden:      true,
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
@@ -156,7 +156,7 @@ func (fr *functionResource) Update(request *http.Request, id string) (attributes
 	functions, err := fr.getPlatform().GetFunctions(&platform.GetFunctionsOptions{
 		Name:      functionInfo.Meta.Name,
 		Namespace: fr.resolveNamespace(request, functionInfo),
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			RaiseForbidden:      true,
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
@@ -278,7 +278,7 @@ func (fr *functionResource) storeAndDeployFunction(request *http.Request,
 			CreationStateUpdated:       creationStateUpdatedChan,
 			AuthConfig:                 authConfig,
 			DependantImagesRegistryURL: fr.GetServer().(*dashboard.Server).GetDependantImagesRegistryURL(),
-			PermissionOptions: platform.PermissionOptions{
+			PermissionOptions: opa.PermissionOptions{
 				MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 				OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 			},
@@ -436,7 +436,7 @@ func (fr *functionResource) deleteFunction(request *http.Request) (*restful.Cust
 
 	deleteFunctionOptions := platform.DeleteFunctionOptions{
 		AuthConfig: authConfig,
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
@@ -536,7 +536,7 @@ func (fr *functionResource) resolveGetFunctionOptionsFromRequest(request *http.R
 		Namespace:             fr.getNamespaceFromRequest(request),
 		Name:                  functionName,
 		EnrichWithAPIGateways: fr.headerValueIsTrue(request, "x-nuclio-function-enrich-apigateways"),
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			RaiseForbidden:      raiseForbidden,
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -115,6 +115,7 @@ func (fr *functionResource) Create(request *http.Request) (id string, attributes
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds:      opa.GetUserAndGroupIdsFromHeaders(request),
 			RaiseForbidden: true,
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	})
 	if err != nil {
@@ -158,6 +159,7 @@ func (fr *functionResource) Update(request *http.Request, id string) (attributes
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds:      opa.GetUserAndGroupIdsFromHeaders(request),
 			RaiseForbidden: true,
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	})
 	if err != nil {
@@ -278,6 +280,7 @@ func (fr *functionResource) storeAndDeployFunction(request *http.Request,
 			DependantImagesRegistryURL: fr.GetServer().(*dashboard.Server).GetDependantImagesRegistryURL(),
 			PermissionOptions: platform.PermissionOptions{
 				MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+				OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 			},
 		})
 
@@ -435,6 +438,7 @@ func (fr *functionResource) deleteFunction(request *http.Request) (*restful.Cust
 		AuthConfig: authConfig,
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}
 
@@ -535,6 +539,7 @@ func (fr *functionResource) resolveGetFunctionOptionsFromRequest(request *http.R
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds:      opa.GetUserAndGroupIdsFromHeaders(request),
 			RaiseForbidden: raiseForbidden,
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}
 

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -113,8 +113,8 @@ func (fr *functionResource) Create(request *http.Request) (id string, attributes
 		Name:      functionInfo.Meta.Name,
 		Namespace: fr.resolveNamespace(request, functionInfo),
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds:      opa.GetUserAndGroupIdsFromHeaders(request),
-			RaiseForbidden: true,
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
+			RaiseForbidden:      true,
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	})
@@ -157,8 +157,8 @@ func (fr *functionResource) Update(request *http.Request, id string) (attributes
 		Name:      functionInfo.Meta.Name,
 		Namespace: fr.resolveNamespace(request, functionInfo),
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds:      opa.GetUserAndGroupIdsFromHeaders(request),
-			RaiseForbidden: true,
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
+			RaiseForbidden:      true,
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	})
@@ -279,7 +279,7 @@ func (fr *functionResource) storeAndDeployFunction(request *http.Request,
 			AuthConfig:                 authConfig,
 			DependantImagesRegistryURL: fr.GetServer().(*dashboard.Server).GetDependantImagesRegistryURL(),
 			PermissionOptions: platform.PermissionOptions{
-				MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+				MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 				OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 			},
 		})
@@ -437,7 +437,7 @@ func (fr *functionResource) deleteFunction(request *http.Request) (*restful.Cust
 	deleteFunctionOptions := platform.DeleteFunctionOptions{
 		AuthConfig: authConfig,
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}
@@ -537,8 +537,8 @@ func (fr *functionResource) resolveGetFunctionOptionsFromRequest(request *http.R
 		Name:                  functionName,
 		EnrichWithAPIGateways: fr.headerValueIsTrue(request, "x-nuclio-function-enrich-apigateways"),
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds:      opa.GetUserAndGroupIdsFromHeaders(request),
-			RaiseForbidden: raiseForbidden,
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
+			RaiseForbidden:      raiseForbidden,
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}

--- a/pkg/dashboard/resource/functionevent.go
+++ b/pkg/dashboard/resource/functionevent.go
@@ -57,7 +57,7 @@ func (fer *functionEventResource) GetAll(request *http.Request) (map[string]rest
 			Namespace: fer.getNamespaceFromRequest(request),
 		},
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}
@@ -99,8 +99,8 @@ func (fer *functionEventResource) GetByID(request *http.Request, id string) (res
 			Namespace: fer.getNamespaceFromRequest(request),
 		},
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds:      opa.GetUserAndGroupIdsFromHeaders(request),
-			RaiseForbidden: true,
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
+			RaiseForbidden:      true,
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	})
@@ -178,7 +178,7 @@ func (fer *functionEventResource) storeAndDeployFunctionEvent(request *http.Requ
 	err = fer.getPlatform().CreateFunctionEvent(&platform.CreateFunctionEventOptions{
 		FunctionEventConfig: *newFunctionEvent.GetConfig(),
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	})
@@ -199,7 +199,7 @@ func (fer *functionEventResource) getFunctionEvents(request *http.Request, funct
 			},
 		},
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}
@@ -227,7 +227,7 @@ func (fer *functionEventResource) deleteFunctionEvent(request *http.Request) (*r
 
 	deleteFunctionEventOptions := platform.DeleteFunctionEventOptions{
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}
@@ -271,7 +271,7 @@ func (fer *functionEventResource) updateFunctionEvent(request *http.Request) (*r
 	if err = fer.getPlatform().UpdateFunctionEvent(&platform.UpdateFunctionEventOptions{
 		FunctionEventConfig: functionEventConfig,
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}); err != nil {

--- a/pkg/dashboard/resource/functionevent.go
+++ b/pkg/dashboard/resource/functionevent.go
@@ -58,6 +58,7 @@ func (fer *functionEventResource) GetAll(request *http.Request) (map[string]rest
 		},
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}
 
@@ -100,6 +101,7 @@ func (fer *functionEventResource) GetByID(request *http.Request, id string) (res
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds:      opa.GetUserAndGroupIdsFromHeaders(request),
 			RaiseForbidden: true,
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	})
 
@@ -177,6 +179,7 @@ func (fer *functionEventResource) storeAndDeployFunctionEvent(request *http.Requ
 		FunctionEventConfig: *newFunctionEvent.GetConfig(),
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	})
 	if err != nil {
@@ -197,6 +200,7 @@ func (fer *functionEventResource) getFunctionEvents(request *http.Request, funct
 		},
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}
 
@@ -224,6 +228,7 @@ func (fer *functionEventResource) deleteFunctionEvent(request *http.Request) (*r
 	deleteFunctionEventOptions := platform.DeleteFunctionEventOptions{
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}
 	deleteFunctionEventOptions.Meta = *functionEventInfo.Meta
@@ -267,6 +272,7 @@ func (fer *functionEventResource) updateFunctionEvent(request *http.Request) (*r
 		FunctionEventConfig: functionEventConfig,
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}); err != nil {
 		fer.Logger.WarnWith("Failed to update function event", "err", err)

--- a/pkg/dashboard/resource/functionevent.go
+++ b/pkg/dashboard/resource/functionevent.go
@@ -56,7 +56,7 @@ func (fer *functionEventResource) GetAll(request *http.Request) (map[string]rest
 			Name:      request.Header.Get("x-nuclio-function-event-name"),
 			Namespace: fer.getNamespaceFromRequest(request),
 		},
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
@@ -98,7 +98,7 @@ func (fer *functionEventResource) GetByID(request *http.Request, id string) (res
 			Name:      id,
 			Namespace: fer.getNamespaceFromRequest(request),
 		},
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			RaiseForbidden:      true,
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
@@ -177,7 +177,7 @@ func (fer *functionEventResource) storeAndDeployFunctionEvent(request *http.Requ
 	// just deploy. the status is async through polling
 	err = fer.getPlatform().CreateFunctionEvent(&platform.CreateFunctionEventOptions{
 		FunctionEventConfig: *newFunctionEvent.GetConfig(),
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
@@ -198,7 +198,7 @@ func (fer *functionEventResource) getFunctionEvents(request *http.Request, funct
 				"nuclio.io/function-name": function.GetConfig().Meta.Name,
 			},
 		},
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
@@ -226,7 +226,7 @@ func (fer *functionEventResource) deleteFunctionEvent(request *http.Request) (*r
 	}
 
 	deleteFunctionEventOptions := platform.DeleteFunctionEventOptions{
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
@@ -270,7 +270,7 @@ func (fer *functionEventResource) updateFunctionEvent(request *http.Request) (*r
 
 	if err = fer.getPlatform().UpdateFunctionEvent(&platform.UpdateFunctionEventOptions{
 		FunctionEventConfig: functionEventConfig,
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -76,6 +76,7 @@ func (pr *projectResource) GetAll(request *http.Request) (map[string]restful.Att
 		},
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	})
 
@@ -221,6 +222,7 @@ func (pr *projectResource) getFunctionsAndFunctionEventsMap(request *http.Reques
 		Labels:    fmt.Sprintf("nuclio.io/project-name=%s", project.GetConfig().Meta.Name),
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}
 
@@ -271,6 +273,7 @@ func (pr *projectResource) createProject(request *http.Request, projectInfoInsta
 		SessionCookie: sessionCookie,
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}); err != nil {
 		if strings.Contains(errors.Cause(err).Error(), "already exists") {
@@ -353,6 +356,7 @@ func (pr *projectResource) importProjectIfMissing(request *http.Request, project
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds:      opa.GetUserAndGroupIdsFromHeaders(request),
 			RaiseForbidden: true,
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	})
 	if err != nil {
@@ -385,6 +389,7 @@ func (pr *projectResource) importProjectIfMissing(request *http.Request, project
 			ProjectConfig: newProject.GetConfig(),
 			PermissionOptions: platform.PermissionOptions{
 				MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+				OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 			},
 		}); err != nil {
 
@@ -457,6 +462,7 @@ func (pr *projectResource) importFunction(request *http.Request, function *funct
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds:      opa.GetUserAndGroupIdsFromHeaders(request),
 			RaiseForbidden: true,
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	})
 	if err != nil {
@@ -556,6 +562,7 @@ func (pr *projectResource) getProjectByName(request *http.Request, projectName, 
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds:      opa.GetUserAndGroupIdsFromHeaders(request),
 			RaiseForbidden: true,
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	})
 
@@ -592,6 +599,7 @@ func (pr *projectResource) deleteProject(request *http.Request) (*restful.Custom
 		SessionCookie: sessionCookie,
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}); err != nil {
 		return &restful.CustomRouteFuncResponse{
@@ -633,6 +641,7 @@ func (pr *projectResource) updateProject(request *http.Request) (*restful.Custom
 		SessionCookie: sessionCookie,
 		PermissionOptions: platform.PermissionOptions{
 			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}); err != nil {
 		pr.Logger.WarnWith("Failed to update project", "err", err)

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -74,7 +74,7 @@ func (pr *projectResource) GetAll(request *http.Request) (map[string]restful.Att
 			Name:      request.Header.Get("x-nuclio-project-name"),
 			Namespace: namespace,
 		},
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
@@ -220,7 +220,7 @@ func (pr *projectResource) getFunctionsAndFunctionEventsMap(request *http.Reques
 		Name:      "",
 		Namespace: project.GetConfig().Meta.Namespace,
 		Labels:    fmt.Sprintf("nuclio.io/project-name=%s", project.GetConfig().Meta.Name),
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
@@ -271,7 +271,7 @@ func (pr *projectResource) createProject(request *http.Request, projectInfoInsta
 		ProjectConfig: newProject.GetConfig(),
 		RequestOrigin: requestOrigin,
 		SessionCookie: sessionCookie,
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
@@ -353,7 +353,7 @@ func (pr *projectResource) importProjectIfMissing(request *http.Request, project
 
 	projects, err := pr.getPlatform().GetProjects(&platform.GetProjectsOptions{
 		Meta: *projectImportOptions.projectInfo.Project.Meta,
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			RaiseForbidden:      true,
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
@@ -387,7 +387,7 @@ func (pr *projectResource) importProjectIfMissing(request *http.Request, project
 
 		if err := newProject.CreateAndWait(&platform.CreateProjectOptions{
 			ProjectConfig: newProject.GetConfig(),
-			PermissionOptions: platform.PermissionOptions{
+			PermissionOptions: opa.PermissionOptions{
 				MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 				OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 			},
@@ -459,7 +459,7 @@ func (pr *projectResource) importFunction(request *http.Request, function *funct
 	functions, err := pr.getPlatform().GetFunctions(&platform.GetFunctionsOptions{
 		Name:      function.Meta.Name,
 		Namespace: function.Meta.Namespace,
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			RaiseForbidden:      true,
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
@@ -559,7 +559,7 @@ func (pr *projectResource) getProjectByName(request *http.Request, projectName, 
 			Name:      projectName,
 			Namespace: projectNamespace,
 		},
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			RaiseForbidden:      true,
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
@@ -597,7 +597,7 @@ func (pr *projectResource) deleteProject(request *http.Request) (*restful.Custom
 		Strategy:      platform.ResolveProjectDeletionStrategyOrDefault(projectDeletionStrategy),
 		RequestOrigin: requestOrigin,
 		SessionCookie: sessionCookie,
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
@@ -639,7 +639,7 @@ func (pr *projectResource) updateProject(request *http.Request) (*restful.Custom
 		},
 		RequestOrigin: requestOrigin,
 		SessionCookie: sessionCookie,
-		PermissionOptions: platform.PermissionOptions{
+		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -75,7 +75,7 @@ func (pr *projectResource) GetAll(request *http.Request) (map[string]restful.Att
 			Namespace: namespace,
 		},
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	})
@@ -221,7 +221,7 @@ func (pr *projectResource) getFunctionsAndFunctionEventsMap(request *http.Reques
 		Namespace: project.GetConfig().Meta.Namespace,
 		Labels:    fmt.Sprintf("nuclio.io/project-name=%s", project.GetConfig().Meta.Name),
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}
@@ -272,7 +272,7 @@ func (pr *projectResource) createProject(request *http.Request, projectInfoInsta
 		RequestOrigin: requestOrigin,
 		SessionCookie: sessionCookie,
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}); err != nil {
@@ -354,8 +354,8 @@ func (pr *projectResource) importProjectIfMissing(request *http.Request, project
 	projects, err := pr.getPlatform().GetProjects(&platform.GetProjectsOptions{
 		Meta: *projectImportOptions.projectInfo.Project.Meta,
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds:      opa.GetUserAndGroupIdsFromHeaders(request),
-			RaiseForbidden: true,
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
+			RaiseForbidden:      true,
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	})
@@ -388,7 +388,7 @@ func (pr *projectResource) importProjectIfMissing(request *http.Request, project
 		if err := newProject.CreateAndWait(&platform.CreateProjectOptions{
 			ProjectConfig: newProject.GetConfig(),
 			PermissionOptions: platform.PermissionOptions{
-				MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+				MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 				OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 			},
 		}); err != nil {
@@ -460,8 +460,8 @@ func (pr *projectResource) importFunction(request *http.Request, function *funct
 		Name:      function.Meta.Name,
 		Namespace: function.Meta.Namespace,
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds:      opa.GetUserAndGroupIdsFromHeaders(request),
-			RaiseForbidden: true,
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
+			RaiseForbidden:      true,
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	})
@@ -560,8 +560,8 @@ func (pr *projectResource) getProjectByName(request *http.Request, projectName, 
 			Namespace: projectNamespace,
 		},
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds:      opa.GetUserAndGroupIdsFromHeaders(request),
-			RaiseForbidden: true,
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
+			RaiseForbidden:      true,
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	})
@@ -598,7 +598,7 @@ func (pr *projectResource) deleteProject(request *http.Request) (*restful.Custom
 		RequestOrigin: requestOrigin,
 		SessionCookie: sessionCookie,
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}); err != nil {
@@ -640,7 +640,7 @@ func (pr *projectResource) updateProject(request *http.Request) (*restful.Custom
 		RequestOrigin: requestOrigin,
 		SessionCookie: sessionCookie,
 		PermissionOptions: platform.PermissionOptions{
-			MemberIds: opa.GetUserAndGroupIdsFromHeaders(request),
+			MemberIds:           opa.GetUserAndGroupIdsFromHeaders(request),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 	}); err != nil {

--- a/pkg/opa/factory.go
+++ b/pkg/opa/factory.go
@@ -32,7 +32,8 @@ func CreateOpaClient(parentLogger logger.Logger, opaConfiguration *Config) Clien
 			opaConfiguration.Address,
 			opaConfiguration.PermissionQueryPath,
 			time.Duration(opaConfiguration.RequestTimeout)*time.Second,
-			opaConfiguration.LogLevel)
+			opaConfiguration.LogLevel,
+			opaConfiguration.OverrideHeaderValue)
 
 	case ClientKindMock:
 		newOpaClient = &MockClient{}

--- a/pkg/opa/http.go
+++ b/pkg/opa/http.go
@@ -34,24 +34,33 @@ type HTTPClient struct {
 	permissionQueryPath string
 	requestTimeout      time.Duration
 	logLevel            int
+	overrideHeaderValue string
 }
 
 func NewHTTPClient(parentLogger logger.Logger,
 	address string,
 	permissionQueryPath string,
 	requestTimeout time.Duration,
-	logLevel int) *HTTPClient {
+	logLevel int,
+	overrideHeaderValue string) *HTTPClient {
 	newClient := HTTPClient{
 		logger:              parentLogger.GetChild("opa"),
 		address:             address,
 		permissionQueryPath: permissionQueryPath,
 		requestTimeout:      requestTimeout,
 		logLevel:            logLevel,
+		overrideHeaderValue: overrideHeaderValue,
 	}
 	return &newClient
 }
 
-func (c *HTTPClient) QueryPermissions(resource string, action Action, ids []string) (bool, error) {
+func (c *HTTPClient) QueryPermissions(resource string, action Action, ids []string, overrideHeaderValue string) (bool, error) {
+
+	// If the override header value matches the configured override header value, allow without checking
+	if overrideHeaderValue == c.overrideHeaderValue {
+		return true, nil
+	}
+
 	requestURL := fmt.Sprintf("%s%s", c.address, c.permissionQueryPath)
 
 	// send the request

--- a/pkg/opa/http.go
+++ b/pkg/opa/http.go
@@ -54,10 +54,10 @@ func NewHTTPClient(parentLogger logger.Logger,
 	return &newClient
 }
 
-func (c *HTTPClient) QueryPermissions(resource string, action Action, ids []string, overrideHeaderValue string) (bool, error) {
+func (c *HTTPClient) QueryPermissions(resource string, action Action, permissionOptions *PermissionOptions) (bool, error) {
 
 	// If the override header value matches the configured override header value, allow without checking
-	if c.overrideHeaderValue != "" && overrideHeaderValue == c.overrideHeaderValue {
+	if c.overrideHeaderValue != "" && permissionOptions.OverrideHeaderValue == c.overrideHeaderValue {
 		return true, nil
 	}
 
@@ -70,7 +70,7 @@ func (c *HTTPClient) QueryPermissions(resource string, action Action, ids []stri
 	request := PermissionRequest{Input: PermissionRequestInput{
 		resource,
 		string(action),
-		ids,
+		permissionOptions.MemberIds,
 	}}
 	requestBody, err := json.Marshal(request)
 	if err != nil {

--- a/pkg/opa/http.go
+++ b/pkg/opa/http.go
@@ -57,7 +57,7 @@ func NewHTTPClient(parentLogger logger.Logger,
 func (c *HTTPClient) QueryPermissions(resource string, action Action, ids []string, overrideHeaderValue string) (bool, error) {
 
 	// If the override header value matches the configured override header value, allow without checking
-	if overrideHeaderValue == c.overrideHeaderValue {
+	if c.overrideHeaderValue != "" && overrideHeaderValue == c.overrideHeaderValue {
 		return true, nil
 	}
 

--- a/pkg/opa/mock.go
+++ b/pkg/opa/mock.go
@@ -24,7 +24,7 @@ type MockClient struct {
 	mock.Mock
 }
 
-func (mc *MockClient) QueryPermissions(resource string, action Action, ids []string, overrideHeaderValue string) (bool, error) {
-	args := mc.Called(resource, action, ids, overrideHeaderValue)
+func (mc *MockClient) QueryPermissions(resource string, action Action, permissionOptions *PermissionOptions) (bool, error) {
+	args := mc.Called(resource, action, permissionOptions)
 	return args.Get(0).(bool), args.Error(1)
 }

--- a/pkg/opa/mock.go
+++ b/pkg/opa/mock.go
@@ -24,7 +24,7 @@ type MockClient struct {
 	mock.Mock
 }
 
-func (mc *MockClient) QueryPermissions(resource string, action Action, ids []string) (bool, error) {
-	args := mc.Called(resource, action, ids)
+func (mc *MockClient) QueryPermissions(resource string, action Action, ids []string, overrideHeaderValue string) (bool, error) {
+	args := mc.Called(resource, action, ids, overrideHeaderValue)
 	return args.Get(0).(bool), args.Error(1)
 }

--- a/pkg/opa/nop.go
+++ b/pkg/opa/nop.go
@@ -33,12 +33,12 @@ func NewNopClient(parentLogger logger.Logger, logLevel int) *NopClient {
 	return &newClient
 }
 
-func (c *NopClient) QueryPermissions(resource string, action Action, ids []string, overrideHeaderValue string) (bool, error) {
+func (c *NopClient) QueryPermissions(resource string, action Action, permissionOptions *PermissionOptions) (bool, error) {
 	if c.logLevel > 5 {
 		c.logger.InfoWith("Skipping permission query",
 			"resource", resource,
 			"action", action,
-			"ids", ids)
+			"permissionOptions", permissionOptions)
 	}
 	return true, nil
 }

--- a/pkg/opa/nop.go
+++ b/pkg/opa/nop.go
@@ -33,7 +33,7 @@ func NewNopClient(parentLogger logger.Logger, logLevel int) *NopClient {
 	return &newClient
 }
 
-func (c *NopClient) QueryPermissions(resource string, action Action, ids []string) (bool, error) {
+func (c *NopClient) QueryPermissions(resource string, action Action, ids []string, overrideHeaderValue string) (bool, error) {
 	if c.logLevel > 5 {
 		c.logger.InfoWith("Skipping permission query",
 			"resource", resource,

--- a/pkg/opa/opa.go
+++ b/pkg/opa/opa.go
@@ -23,7 +23,7 @@ import (
 )
 
 type Client interface {
-	QueryPermissions(resource string, action Action, ids []string, overrideHeaderValue string) (bool, error)
+	QueryPermissions(resource string, action Action, permissionOptions *PermissionOptions) (bool, error)
 }
 
 func GetUserAndGroupIdsFromHeaders(request *http.Request) []string {

--- a/pkg/opa/opa.go
+++ b/pkg/opa/opa.go
@@ -23,7 +23,7 @@ import (
 )
 
 type Client interface {
-	QueryPermissions(resource string, action Action, ids []string) (bool, error)
+	QueryPermissions(resource string, action Action, ids []string, overrideHeaderValue string) (bool, error)
 }
 
 func GetUserAndGroupIdsFromHeaders(request *http.Request) []string {

--- a/pkg/opa/types.go
+++ b/pkg/opa/types.go
@@ -44,6 +44,9 @@ type Config struct {
 
 	// for extra verbosity on top of nuclio logger
 	LogLevel int `json:"logLevel,omitempty"`
+
+	// the header value for bypassing OPA if needed
+	OverrideHeaderValue string `json:"overrideHeaderValue,omitempty"`
 }
 
 type PermissionRequestInput struct {
@@ -63,6 +66,7 @@ type PermissionResponse struct {
 const (
 	UserIDHeader       string = "x-user-id"
 	UserGroupIdsHeader string = "x-user-group-ids"
+	OverrideHeader     string = "x-projects-role"
 )
 
 type Action string

--- a/pkg/opa/types.go
+++ b/pkg/opa/types.go
@@ -49,6 +49,12 @@ type Config struct {
 	OverrideHeaderValue string `json:"overrideHeaderValue,omitempty"`
 }
 
+type PermissionOptions struct {
+	MemberIds           []string
+	RaiseForbidden      bool
+	OverrideHeaderValue string
+}
+
 type PermissionRequestInput struct {
 	Resource string   `json:"resource,omitempty"`
 	Action   string   `json:"action,omitempty"`

--- a/pkg/platform/kube/client/updater.go
+++ b/pkg/platform/kube/client/updater.go
@@ -60,7 +60,8 @@ func (u *Updater) Update(updateFunctionOptions *platform.UpdateFunctionOptions) 
 		updateFunctionOptions.FunctionMeta.Name,
 		opa.ActionUpdate,
 		updateFunctionOptions.PermissionOptions.MemberIds,
-		true); err != nil {
+		true,
+		updateFunctionOptions.PermissionOptions.OverrideHeaderValue); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 

--- a/pkg/platform/kube/client/updater.go
+++ b/pkg/platform/kube/client/updater.go
@@ -56,12 +56,12 @@ func (u *Updater) Update(updateFunctionOptions *platform.UpdateFunctionOptions) 
 	}
 
 	// Check OPA permissions
+	permissionOptions := updateFunctionOptions.PermissionOptions
+	permissionOptions.RaiseForbidden = true
 	if _, err := u.platform.QueryOPAFunctionPermissions(function.Labels["nuclio.io/project-name"],
 		updateFunctionOptions.FunctionMeta.Name,
 		opa.ActionUpdate,
-		updateFunctionOptions.PermissionOptions.MemberIds,
-		true,
-		updateFunctionOptions.PermissionOptions.OverrideHeaderValue); err != nil {
+		&permissionOptions); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -195,7 +195,8 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 		createFunctionOptions.FunctionConfig.Meta.Name,
 		opa.ActionCreate,
 		createFunctionOptions.PermissionOptions.MemberIds,
-		true); err != nil {
+		true,
+		createFunctionOptions.PermissionOptions.OverrideHeaderValue); err != nil {
 		return nil, errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -551,7 +552,8 @@ func (p *Platform) CreateProject(createProjectOptions *platform.CreateProjectOpt
 	if _, err := p.QueryOPAProjectPermissions(createProjectOptions.ProjectConfig.Meta.Name,
 		opa.ActionCreate,
 		createProjectOptions.PermissionOptions.MemberIds,
-		true); err != nil {
+		true,
+		createProjectOptions.PermissionOptions.OverrideHeaderValue); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -574,7 +576,8 @@ func (p *Platform) UpdateProject(updateProjectOptions *platform.UpdateProjectOpt
 	if _, err := p.QueryOPAProjectPermissions(updateProjectOptions.ProjectConfig.Meta.Name,
 		opa.ActionUpdate,
 		updateProjectOptions.PermissionOptions.MemberIds,
-		true); err != nil {
+		true,
+		updateProjectOptions.PermissionOptions.OverrideHeaderValue); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -595,7 +598,8 @@ func (p *Platform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOpt
 	if _, err := p.QueryOPAProjectPermissions(deleteProjectOptions.Meta.Name,
 		opa.ActionDelete,
 		deleteProjectOptions.PermissionOptions.MemberIds,
-		true); err != nil {
+		true,
+		deleteProjectOptions.PermissionOptions.OverrideHeaderValue); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -791,7 +795,8 @@ func (p *Platform) CreateFunctionEvent(createFunctionEventOptions *platform.Crea
 		newFunctionEvent.Name,
 		opa.ActionCreate,
 		createFunctionEventOptions.PermissionOptions.MemberIds,
-		true); err != nil {
+		true,
+		createFunctionEventOptions.PermissionOptions.OverrideHeaderValue); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -828,7 +833,8 @@ func (p *Platform) UpdateFunctionEvent(updateFunctionEventOptions *platform.Upda
 		functionEvent.Name,
 		opa.ActionUpdate,
 		updateFunctionEventOptions.PermissionOptions.MemberIds,
-		true); err != nil {
+		true,
+		updateFunctionEventOptions.PermissionOptions.OverrideHeaderValue); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -863,7 +869,8 @@ func (p *Platform) DeleteFunctionEvent(deleteFunctionEventOptions *platform.Dele
 		functionEventToDelete.Name,
 		opa.ActionDelete,
 		deleteFunctionEventOptions.PermissionOptions.MemberIds,
-		true); err != nil {
+		true,
+		deleteFunctionEventOptions.PermissionOptions.OverrideHeaderValue); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -191,12 +191,12 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	}
 
 	// Check OPA permissions
+	permissionOptions := createFunctionOptions.PermissionOptions
+	permissionOptions.RaiseForbidden = true
 	if _, err := p.QueryOPAFunctionPermissions(createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"],
 		createFunctionOptions.FunctionConfig.Meta.Name,
 		opa.ActionCreate,
-		createFunctionOptions.PermissionOptions.MemberIds,
-		true,
-		createFunctionOptions.PermissionOptions.OverrideHeaderValue); err != nil {
+		&permissionOptions); err != nil {
 		return nil, errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -549,11 +549,11 @@ func (p *Platform) CreateProject(createProjectOptions *platform.CreateProjectOpt
 	}
 
 	// Check OPA permissions
+	permissionOptions := createProjectOptions.PermissionOptions
+	permissionOptions.RaiseForbidden = true
 	if _, err := p.QueryOPAProjectPermissions(createProjectOptions.ProjectConfig.Meta.Name,
 		opa.ActionCreate,
-		createProjectOptions.PermissionOptions.MemberIds,
-		true,
-		createProjectOptions.PermissionOptions.OverrideHeaderValue); err != nil {
+		&permissionOptions); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -573,11 +573,11 @@ func (p *Platform) UpdateProject(updateProjectOptions *platform.UpdateProjectOpt
 	}
 
 	// Check OPA permissions
+	permissionOptions := updateProjectOptions.PermissionOptions
+	permissionOptions.RaiseForbidden = true
 	if _, err := p.QueryOPAProjectPermissions(updateProjectOptions.ProjectConfig.Meta.Name,
 		opa.ActionUpdate,
-		updateProjectOptions.PermissionOptions.MemberIds,
-		true,
-		updateProjectOptions.PermissionOptions.OverrideHeaderValue); err != nil {
+		&permissionOptions); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -595,11 +595,11 @@ func (p *Platform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOpt
 	}
 
 	// Check OPA permissions
+	permissionOptions := deleteProjectOptions.PermissionOptions
+	permissionOptions.RaiseForbidden = true
 	if _, err := p.QueryOPAProjectPermissions(deleteProjectOptions.Meta.Name,
 		opa.ActionDelete,
-		deleteProjectOptions.PermissionOptions.MemberIds,
-		true,
-		deleteProjectOptions.PermissionOptions.OverrideHeaderValue); err != nil {
+		&permissionOptions); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -790,13 +790,13 @@ func (p *Platform) CreateFunctionEvent(createFunctionEventOptions *platform.Crea
 	projectName := newFunctionEvent.Labels[common.NuclioResourceLabelKeyProjectName]
 
 	// Check OPA permissions
+	permissionOptions := createFunctionEventOptions.PermissionOptions
+	permissionOptions.RaiseForbidden = true
 	if _, err := p.QueryOPAFunctionEventPermissions(projectName,
 		functionName,
 		newFunctionEvent.Name,
 		opa.ActionCreate,
-		createFunctionEventOptions.PermissionOptions.MemberIds,
-		true,
-		createFunctionEventOptions.PermissionOptions.OverrideHeaderValue); err != nil {
+		&permissionOptions); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -828,13 +828,13 @@ func (p *Platform) UpdateFunctionEvent(updateFunctionEventOptions *platform.Upda
 	projectName := functionEvent.Labels[common.NuclioResourceLabelKeyProjectName]
 
 	// Check OPA permissions
+	permissionOptions := updateFunctionEventOptions.PermissionOptions
+	permissionOptions.RaiseForbidden = true
 	if _, err := p.QueryOPAFunctionEventPermissions(projectName,
 		functionName,
 		functionEvent.Name,
 		opa.ActionUpdate,
-		updateFunctionEventOptions.PermissionOptions.MemberIds,
-		true,
-		updateFunctionEventOptions.PermissionOptions.OverrideHeaderValue); err != nil {
+		&permissionOptions); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -864,13 +864,13 @@ func (p *Platform) DeleteFunctionEvent(deleteFunctionEventOptions *platform.Dele
 	projectName := functionEventToDelete.Labels[common.NuclioResourceLabelKeyProjectName]
 
 	// Check OPA permissions
+	permissionOptions := deleteFunctionEventOptions.PermissionOptions
+	permissionOptions.RaiseForbidden = true
 	if _, err := p.QueryOPAFunctionEventPermissions(projectName,
 		functionName,
 		functionEventToDelete.Name,
 		opa.ActionDelete,
-		deleteFunctionEventOptions.PermissionOptions.MemberIds,
-		true,
-		deleteFunctionEventOptions.PermissionOptions.OverrideHeaderValue); err != nil {
+		&permissionOptions); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -65,6 +65,7 @@ type KubePlatformTestSuite struct {
 	Platform                         *Platform
 	PlatformKubeConfig               *platformconfig.PlatformKubeConfig
 	mockedOpaClient                  *opa.MockClient
+	opaOverrideHeaderValue           string
 }
 
 func (suite *KubePlatformTestSuite) SetupSuite() {
@@ -88,6 +89,7 @@ func (suite *KubePlatformTestSuite) SetupSuite() {
 	abstractPlatform.ContainerBuilder, err = containerimagebuilderpusher.NewNop(suite.Logger, nil)
 	suite.Require().NoError(err)
 	suite.abstractPlatform = abstractPlatform
+	suite.opaOverrideHeaderValue = "some-dummy-opa-override-value"
 	suite.mockedOpaClient = &opa.MockClient{}
 	suite.abstractPlatform.OpaClient = suite.mockedOpaClient
 	suite.abstractPlatform.ExternalIPAddresses = []string{
@@ -500,7 +502,8 @@ func (suite *FunctionKubePlatformTestSuite) TestGetFunctionsPermissions() {
 					On("QueryPermissions",
 						fmt.Sprintf("/projects/%s/functions/%s", projectName, functionName),
 						opa.ActionRead,
-						memberIds).
+						memberIds,
+						suite.opaOverrideHeaderValue).
 					Return(testCase.opaResponse, nil).
 					Once()
 				defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -509,8 +512,9 @@ func (suite *FunctionKubePlatformTestSuite) TestGetFunctionsPermissions() {
 				Name:      functionName,
 				Namespace: suite.Namespace,
 				PermissionOptions: platform.PermissionOptions{
-					MemberIds:      memberIds,
-					RaiseForbidden: testCase.raiseForbidden,
+					MemberIds:           memberIds,
+					RaiseForbidden:      testCase.raiseForbidden,
+					OverrideHeaderValue: suite.opaOverrideHeaderValue,
 				},
 			})
 
@@ -574,7 +578,8 @@ func (suite *FunctionKubePlatformTestSuite) TestUpdateFunctionPermissions() {
 				On("QueryPermissions",
 					fmt.Sprintf("/projects/%s/functions/%s", projectName, functionName),
 					opa.ActionUpdate,
-					memberIds).
+					memberIds,
+					suite.opaOverrideHeaderValue).
 				Return(testCase.opaResponse, nil).
 				Once()
 			defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -607,7 +612,8 @@ func (suite *FunctionKubePlatformTestSuite) TestUpdateFunctionPermissions() {
 					Namespace: suite.Namespace,
 				},
 				PermissionOptions: platform.PermissionOptions{
-					MemberIds: memberIds,
+					MemberIds:           memberIds,
+					OverrideHeaderValue: suite.opaOverrideHeaderValue,
 				},
 			})
 
@@ -664,7 +670,8 @@ func (suite *FunctionKubePlatformTestSuite) TestDeleteFunctionPermissions() {
 				On("QueryPermissions",
 					fmt.Sprintf("/projects/%s/functions/%s", projectName, functionName),
 					opa.ActionDelete,
-					memberIds).
+					memberIds,
+					suite.opaOverrideHeaderValue).
 				Return(testCase.opaResponse, nil).
 				Once()
 			defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -691,7 +698,8 @@ func (suite *FunctionKubePlatformTestSuite) TestDeleteFunctionPermissions() {
 					},
 				},
 				PermissionOptions: platform.PermissionOptions{
-					MemberIds: memberIds,
+					MemberIds:           memberIds,
+					OverrideHeaderValue: suite.opaOverrideHeaderValue,
 				},
 			})
 
@@ -774,7 +782,8 @@ func (suite *ProjectKubePlatformTestSuite) TestGetProjectsPermissions() {
 					On("QueryPermissions",
 						fmt.Sprintf("/projects/%s", projectName),
 						opa.ActionRead,
-						memberIds).
+						memberIds,
+						suite.opaOverrideHeaderValue).
 					Return(testCase.opaResponse, nil).
 					Once()
 				defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -785,8 +794,9 @@ func (suite *ProjectKubePlatformTestSuite) TestGetProjectsPermissions() {
 					Namespace: suite.Namespace,
 				},
 				PermissionOptions: platform.PermissionOptions{
-					MemberIds:      memberIds,
-					RaiseForbidden: testCase.raiseForbidden,
+					MemberIds:           memberIds,
+					RaiseForbidden:      testCase.raiseForbidden,
+					OverrideHeaderValue: suite.opaOverrideHeaderValue,
 				},
 			})
 
@@ -850,7 +860,8 @@ func (suite *ProjectKubePlatformTestSuite) TestUpdateProjectPermissions() {
 				On("QueryPermissions",
 					fmt.Sprintf("/projects/%s", projectName),
 					opa.ActionUpdate,
-					memberIds).
+					memberIds,
+					suite.opaOverrideHeaderValue).
 				Return(testCase.opaResponse, nil).
 				Once()
 			defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -885,7 +896,8 @@ func (suite *ProjectKubePlatformTestSuite) TestUpdateProjectPermissions() {
 					},
 				},
 				PermissionOptions: platform.PermissionOptions{
-					MemberIds: memberIds,
+					MemberIds:           memberIds,
+					OverrideHeaderValue: suite.opaOverrideHeaderValue,
 				},
 			})
 
@@ -942,7 +954,8 @@ func (suite *ProjectKubePlatformTestSuite) TestDeleteProjectPermissions() {
 				On("QueryPermissions",
 					fmt.Sprintf("/projects/%s", projectName),
 					opa.ActionDelete,
-					memberIds).
+					memberIds,
+					suite.opaOverrideHeaderValue).
 				Return(testCase.opaResponse, nil).
 				Once()
 			defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -962,7 +975,8 @@ func (suite *ProjectKubePlatformTestSuite) TestDeleteProjectPermissions() {
 					Namespace: suite.Namespace,
 				},
 				PermissionOptions: platform.PermissionOptions{
-					MemberIds: memberIds,
+					MemberIds:           memberIds,
+					OverrideHeaderValue: suite.opaOverrideHeaderValue,
 				},
 			})
 
@@ -1044,7 +1058,8 @@ func (suite *FunctionEventKubePlatformTestSuite) TestGetFunctionEventsPermission
 							functionName,
 							functionEventName),
 						opa.ActionRead,
-						memberIds).
+						memberIds,
+						suite.opaOverrideHeaderValue).
 					Return(testCase.opaResponse, nil).
 					Once()
 				defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -1055,8 +1070,9 @@ func (suite *FunctionEventKubePlatformTestSuite) TestGetFunctionEventsPermission
 					Namespace: suite.Namespace,
 				},
 				PermissionOptions: platform.PermissionOptions{
-					MemberIds:      memberIds,
-					RaiseForbidden: testCase.raiseForbidden,
+					MemberIds:           memberIds,
+					RaiseForbidden:      testCase.raiseForbidden,
+					OverrideHeaderValue: suite.opaOverrideHeaderValue,
 				},
 			})
 
@@ -1120,7 +1136,8 @@ func (suite *FunctionEventKubePlatformTestSuite) TestUpdateFunctionEventPermissi
 						functionName,
 						functionEventName),
 					opa.ActionUpdate,
-					memberIds).
+					memberIds,
+					suite.opaOverrideHeaderValue).
 				Return(testCase.opaResponse, nil).
 				Once()
 			defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -1156,7 +1173,8 @@ func (suite *FunctionEventKubePlatformTestSuite) TestUpdateFunctionEventPermissi
 					Spec: platform.FunctionEventSpec{},
 				},
 				PermissionOptions: platform.PermissionOptions{
-					MemberIds: memberIds,
+					MemberIds:           memberIds,
+					OverrideHeaderValue: suite.opaOverrideHeaderValue,
 				},
 			})
 
@@ -1213,7 +1231,8 @@ func (suite *FunctionEventKubePlatformTestSuite) TestDeleteFunctionEventPermissi
 						functionName,
 						functionEventName),
 					opa.ActionDelete,
-					memberIds).
+					memberIds,
+					suite.opaOverrideHeaderValue).
 				Return(testCase.opaResponse, nil).
 				Once()
 			defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -1233,7 +1252,8 @@ func (suite *FunctionEventKubePlatformTestSuite) TestDeleteFunctionEventPermissi
 					Namespace: suite.Namespace,
 				},
 				PermissionOptions: platform.PermissionOptions{
-					MemberIds: memberIds,
+					MemberIds:           memberIds,
+					OverrideHeaderValue: suite.opaOverrideHeaderValue,
 				},
 			})
 

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -502,8 +502,11 @@ func (suite *FunctionKubePlatformTestSuite) TestGetFunctionsPermissions() {
 					On("QueryPermissions",
 						fmt.Sprintf("/projects/%s/functions/%s", projectName, functionName),
 						opa.ActionRead,
-						memberIds,
-						suite.opaOverrideHeaderValue).
+						&opa.PermissionOptions{
+							MemberIds:           memberIds,
+							RaiseForbidden:      testCase.raiseForbidden,
+							OverrideHeaderValue: suite.opaOverrideHeaderValue,
+						}).
 					Return(testCase.opaResponse, nil).
 					Once()
 				defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -511,7 +514,7 @@ func (suite *FunctionKubePlatformTestSuite) TestGetFunctionsPermissions() {
 			functions, err := suite.Platform.GetFunctions(&platform.GetFunctionsOptions{
 				Name:      functionName,
 				Namespace: suite.Namespace,
-				PermissionOptions: platform.PermissionOptions{
+				PermissionOptions: opa.PermissionOptions{
 					MemberIds:           memberIds,
 					RaiseForbidden:      testCase.raiseForbidden,
 					OverrideHeaderValue: suite.opaOverrideHeaderValue,
@@ -578,8 +581,11 @@ func (suite *FunctionKubePlatformTestSuite) TestUpdateFunctionPermissions() {
 				On("QueryPermissions",
 					fmt.Sprintf("/projects/%s/functions/%s", projectName, functionName),
 					opa.ActionUpdate,
-					memberIds,
-					suite.opaOverrideHeaderValue).
+					&opa.PermissionOptions{
+						MemberIds:           memberIds,
+						RaiseForbidden:      true,
+						OverrideHeaderValue: suite.opaOverrideHeaderValue,
+					}).
 				Return(testCase.opaResponse, nil).
 				Once()
 			defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -611,7 +617,7 @@ func (suite *FunctionKubePlatformTestSuite) TestUpdateFunctionPermissions() {
 					Name:      functionName,
 					Namespace: suite.Namespace,
 				},
-				PermissionOptions: platform.PermissionOptions{
+				PermissionOptions: opa.PermissionOptions{
 					MemberIds:           memberIds,
 					OverrideHeaderValue: suite.opaOverrideHeaderValue,
 				},
@@ -670,8 +676,11 @@ func (suite *FunctionKubePlatformTestSuite) TestDeleteFunctionPermissions() {
 				On("QueryPermissions",
 					fmt.Sprintf("/projects/%s/functions/%s", projectName, functionName),
 					opa.ActionDelete,
-					memberIds,
-					suite.opaOverrideHeaderValue).
+					&opa.PermissionOptions{
+						MemberIds:           memberIds,
+						RaiseForbidden:      true,
+						OverrideHeaderValue: suite.opaOverrideHeaderValue,
+					}).
 				Return(testCase.opaResponse, nil).
 				Once()
 			defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -697,7 +706,7 @@ func (suite *FunctionKubePlatformTestSuite) TestDeleteFunctionPermissions() {
 						Namespace: suite.Namespace,
 					},
 				},
-				PermissionOptions: platform.PermissionOptions{
+				PermissionOptions: opa.PermissionOptions{
 					MemberIds:           memberIds,
 					OverrideHeaderValue: suite.opaOverrideHeaderValue,
 				},
@@ -782,8 +791,11 @@ func (suite *ProjectKubePlatformTestSuite) TestGetProjectsPermissions() {
 					On("QueryPermissions",
 						fmt.Sprintf("/projects/%s", projectName),
 						opa.ActionRead,
-						memberIds,
-						suite.opaOverrideHeaderValue).
+						&opa.PermissionOptions{
+							MemberIds:           memberIds,
+							RaiseForbidden:      testCase.raiseForbidden,
+							OverrideHeaderValue: suite.opaOverrideHeaderValue,
+						}).
 					Return(testCase.opaResponse, nil).
 					Once()
 				defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -793,7 +805,7 @@ func (suite *ProjectKubePlatformTestSuite) TestGetProjectsPermissions() {
 					Name:      projectName,
 					Namespace: suite.Namespace,
 				},
-				PermissionOptions: platform.PermissionOptions{
+				PermissionOptions: opa.PermissionOptions{
 					MemberIds:           memberIds,
 					RaiseForbidden:      testCase.raiseForbidden,
 					OverrideHeaderValue: suite.opaOverrideHeaderValue,
@@ -860,8 +872,11 @@ func (suite *ProjectKubePlatformTestSuite) TestUpdateProjectPermissions() {
 				On("QueryPermissions",
 					fmt.Sprintf("/projects/%s", projectName),
 					opa.ActionUpdate,
-					memberIds,
-					suite.opaOverrideHeaderValue).
+					&opa.PermissionOptions{
+						MemberIds:           memberIds,
+						RaiseForbidden:      true,
+						OverrideHeaderValue: suite.opaOverrideHeaderValue,
+					}).
 				Return(testCase.opaResponse, nil).
 				Once()
 			defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -895,7 +910,7 @@ func (suite *ProjectKubePlatformTestSuite) TestUpdateProjectPermissions() {
 						Namespace: suite.Namespace,
 					},
 				},
-				PermissionOptions: platform.PermissionOptions{
+				PermissionOptions: opa.PermissionOptions{
 					MemberIds:           memberIds,
 					OverrideHeaderValue: suite.opaOverrideHeaderValue,
 				},
@@ -954,8 +969,11 @@ func (suite *ProjectKubePlatformTestSuite) TestDeleteProjectPermissions() {
 				On("QueryPermissions",
 					fmt.Sprintf("/projects/%s", projectName),
 					opa.ActionDelete,
-					memberIds,
-					suite.opaOverrideHeaderValue).
+					&opa.PermissionOptions{
+						MemberIds:           memberIds,
+						RaiseForbidden:      true,
+						OverrideHeaderValue: suite.opaOverrideHeaderValue,
+					}).
 				Return(testCase.opaResponse, nil).
 				Once()
 			defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -974,7 +992,7 @@ func (suite *ProjectKubePlatformTestSuite) TestDeleteProjectPermissions() {
 					Name:      projectName,
 					Namespace: suite.Namespace,
 				},
-				PermissionOptions: platform.PermissionOptions{
+				PermissionOptions: opa.PermissionOptions{
 					MemberIds:           memberIds,
 					OverrideHeaderValue: suite.opaOverrideHeaderValue,
 				},
@@ -1058,8 +1076,11 @@ func (suite *FunctionEventKubePlatformTestSuite) TestGetFunctionEventsPermission
 							functionName,
 							functionEventName),
 						opa.ActionRead,
-						memberIds,
-						suite.opaOverrideHeaderValue).
+						&opa.PermissionOptions{
+							MemberIds:           memberIds,
+							RaiseForbidden:      testCase.raiseForbidden,
+							OverrideHeaderValue: suite.opaOverrideHeaderValue,
+						}).
 					Return(testCase.opaResponse, nil).
 					Once()
 				defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -1069,7 +1090,7 @@ func (suite *FunctionEventKubePlatformTestSuite) TestGetFunctionEventsPermission
 					Name:      functionEventName,
 					Namespace: suite.Namespace,
 				},
-				PermissionOptions: platform.PermissionOptions{
+				PermissionOptions: opa.PermissionOptions{
 					MemberIds:           memberIds,
 					RaiseForbidden:      testCase.raiseForbidden,
 					OverrideHeaderValue: suite.opaOverrideHeaderValue,
@@ -1136,8 +1157,11 @@ func (suite *FunctionEventKubePlatformTestSuite) TestUpdateFunctionEventPermissi
 						functionName,
 						functionEventName),
 					opa.ActionUpdate,
-					memberIds,
-					suite.opaOverrideHeaderValue).
+					&opa.PermissionOptions{
+						MemberIds:           memberIds,
+						RaiseForbidden:      true,
+						OverrideHeaderValue: suite.opaOverrideHeaderValue,
+					}).
 				Return(testCase.opaResponse, nil).
 				Once()
 			defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -1172,7 +1196,7 @@ func (suite *FunctionEventKubePlatformTestSuite) TestUpdateFunctionEventPermissi
 					},
 					Spec: platform.FunctionEventSpec{},
 				},
-				PermissionOptions: platform.PermissionOptions{
+				PermissionOptions: opa.PermissionOptions{
 					MemberIds:           memberIds,
 					OverrideHeaderValue: suite.opaOverrideHeaderValue,
 				},
@@ -1231,8 +1255,11 @@ func (suite *FunctionEventKubePlatformTestSuite) TestDeleteFunctionEventPermissi
 						functionName,
 						functionEventName),
 					opa.ActionDelete,
-					memberIds,
-					suite.opaOverrideHeaderValue).
+					&opa.PermissionOptions{
+						MemberIds:           memberIds,
+						RaiseForbidden:      true,
+						OverrideHeaderValue: suite.opaOverrideHeaderValue,
+					}).
 				Return(testCase.opaResponse, nil).
 				Once()
 			defer suite.mockedOpaClient.AssertExpectations(suite.T())
@@ -1251,7 +1278,7 @@ func (suite *FunctionEventKubePlatformTestSuite) TestDeleteFunctionEventPermissi
 					Name:      functionEventName,
 					Namespace: suite.Namespace,
 				},
-				PermissionOptions: platform.PermissionOptions{
+				PermissionOptions: opa.PermissionOptions{
 					MemberIds:           memberIds,
 					OverrideHeaderValue: suite.opaOverrideHeaderValue,
 				},

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -181,12 +181,12 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	}
 
 	// Check OPA permissions
+	permissionOptions := createFunctionOptions.PermissionOptions
+	permissionOptions.RaiseForbidden = true
 	if _, err := p.QueryOPAFunctionPermissions(createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"],
 		createFunctionOptions.FunctionConfig.Meta.Name,
 		opa.ActionCreate,
-		createFunctionOptions.PermissionOptions.MemberIds,
-		true,
-		createFunctionOptions.PermissionOptions.OverrideHeaderValue); err != nil {
+		&permissionOptions); err != nil {
 		return nil, errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -440,11 +440,11 @@ func (p *Platform) CreateProject(createProjectOptions *platform.CreateProjectOpt
 	}
 
 	// Check OPA permissions
+	permissionOptions := createProjectOptions.PermissionOptions
+	permissionOptions.RaiseForbidden = true
 	if _, err := p.QueryOPAProjectPermissions(createProjectOptions.ProjectConfig.Meta.Name,
 		opa.ActionCreate,
-		createProjectOptions.PermissionOptions.MemberIds,
-		true,
-		createProjectOptions.PermissionOptions.OverrideHeaderValue); err != nil {
+		&permissionOptions); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -463,11 +463,11 @@ func (p *Platform) UpdateProject(updateProjectOptions *platform.UpdateProjectOpt
 	}
 
 	// Check OPA permissions
+	permissionOptions := updateProjectOptions.PermissionOptions
+	permissionOptions.RaiseForbidden = true
 	if _, err := p.QueryOPAProjectPermissions(updateProjectOptions.ProjectConfig.Meta.Name,
 		opa.ActionUpdate,
-		updateProjectOptions.PermissionOptions.MemberIds,
-		true,
-		updateProjectOptions.PermissionOptions.OverrideHeaderValue); err != nil {
+		&permissionOptions); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -485,11 +485,11 @@ func (p *Platform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOpt
 	}
 
 	// Check OPA permissions
+	permissionOptions := deleteProjectOptions.PermissionOptions
+	permissionOptions.RaiseForbidden = true
 	if _, err := p.QueryOPAProjectPermissions(deleteProjectOptions.Meta.Name,
 		opa.ActionDelete,
-		deleteProjectOptions.PermissionOptions.MemberIds,
-		true,
-		deleteProjectOptions.PermissionOptions.OverrideHeaderValue); err != nil {
+		&permissionOptions); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -521,13 +521,13 @@ func (p *Platform) CreateFunctionEvent(createFunctionEventOptions *platform.Crea
 	projectName := createFunctionEventOptions.FunctionEventConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName]
 
 	// Check OPA permissions
+	permissionOptions := createFunctionEventOptions.PermissionOptions
+	permissionOptions.RaiseForbidden = true
 	if _, err := p.QueryOPAFunctionEventPermissions(projectName,
 		functionName,
 		createFunctionEventOptions.FunctionEventConfig.Meta.Name,
 		opa.ActionCreate,
-		createFunctionEventOptions.PermissionOptions.MemberIds,
-		true,
-		createFunctionEventOptions.PermissionOptions.OverrideHeaderValue); err != nil {
+		&permissionOptions); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -552,13 +552,13 @@ func (p *Platform) UpdateFunctionEvent(updateFunctionEventOptions *platform.Upda
 	projectName := updateFunctionEventOptions.FunctionEventConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName]
 
 	// Check OPA permissions
+	permissionOptions := updateFunctionEventOptions.PermissionOptions
+	permissionOptions.RaiseForbidden = true
 	if _, err := p.QueryOPAFunctionEventPermissions(projectName,
 		functionName,
 		functionEventToUpdate.GetConfig().Meta.Name,
 		opa.ActionUpdate,
-		updateFunctionEventOptions.PermissionOptions.MemberIds,
-		true,
-		updateFunctionEventOptions.PermissionOptions.OverrideHeaderValue); err != nil {
+		&permissionOptions); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -580,13 +580,13 @@ func (p *Platform) DeleteFunctionEvent(deleteFunctionEventOptions *platform.Dele
 		projectName := functionEventToDelete.GetConfig().Meta.Labels[common.NuclioResourceLabelKeyProjectName]
 
 		// Check OPA permissions
+		permissionOptions := deleteFunctionEventOptions.PermissionOptions
+		permissionOptions.RaiseForbidden = true
 		if _, err := p.QueryOPAFunctionEventPermissions(projectName,
 			functionName,
 			functionEventToDelete.GetConfig().Meta.Name,
 			opa.ActionDelete,
-			deleteFunctionEventOptions.PermissionOptions.MemberIds,
-			true,
-			deleteFunctionEventOptions.PermissionOptions.OverrideHeaderValue); err != nil {
+			&permissionOptions); err != nil {
 			return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 		}
 	}

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -185,7 +185,8 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 		createFunctionOptions.FunctionConfig.Meta.Name,
 		opa.ActionCreate,
 		createFunctionOptions.PermissionOptions.MemberIds,
-		true); err != nil {
+		true,
+		createFunctionOptions.PermissionOptions.OverrideHeaderValue); err != nil {
 		return nil, errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -442,7 +443,8 @@ func (p *Platform) CreateProject(createProjectOptions *platform.CreateProjectOpt
 	if _, err := p.QueryOPAProjectPermissions(createProjectOptions.ProjectConfig.Meta.Name,
 		opa.ActionCreate,
 		createProjectOptions.PermissionOptions.MemberIds,
-		true); err != nil {
+		true,
+		createProjectOptions.PermissionOptions.OverrideHeaderValue); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -464,7 +466,8 @@ func (p *Platform) UpdateProject(updateProjectOptions *platform.UpdateProjectOpt
 	if _, err := p.QueryOPAProjectPermissions(updateProjectOptions.ProjectConfig.Meta.Name,
 		opa.ActionUpdate,
 		updateProjectOptions.PermissionOptions.MemberIds,
-		true); err != nil {
+		true,
+		updateProjectOptions.PermissionOptions.OverrideHeaderValue); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -485,7 +488,8 @@ func (p *Platform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOpt
 	if _, err := p.QueryOPAProjectPermissions(deleteProjectOptions.Meta.Name,
 		opa.ActionDelete,
 		deleteProjectOptions.PermissionOptions.MemberIds,
-		true); err != nil {
+		true,
+		deleteProjectOptions.PermissionOptions.OverrideHeaderValue); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -522,7 +526,8 @@ func (p *Platform) CreateFunctionEvent(createFunctionEventOptions *platform.Crea
 		createFunctionEventOptions.FunctionEventConfig.Meta.Name,
 		opa.ActionCreate,
 		createFunctionEventOptions.PermissionOptions.MemberIds,
-		true); err != nil {
+		true,
+		createFunctionEventOptions.PermissionOptions.OverrideHeaderValue); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -552,7 +557,8 @@ func (p *Platform) UpdateFunctionEvent(updateFunctionEventOptions *platform.Upda
 		functionEventToUpdate.GetConfig().Meta.Name,
 		opa.ActionUpdate,
 		updateFunctionEventOptions.PermissionOptions.MemberIds,
-		true); err != nil {
+		true,
+		updateFunctionEventOptions.PermissionOptions.OverrideHeaderValue); err != nil {
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
@@ -579,7 +585,8 @@ func (p *Platform) DeleteFunctionEvent(deleteFunctionEventOptions *platform.Dele
 			functionEventToDelete.GetConfig().Meta.Name,
 			opa.ActionDelete,
 			deleteFunctionEventOptions.PermissionOptions.MemberIds,
-			true); err != nil {
+			true,
+			deleteFunctionEventOptions.PermissionOptions.OverrideHeaderValue); err != nil {
 			return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 		}
 	}

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -86,7 +86,7 @@ func (mp *Platform) GetFunctions(getFunctionsOptions *platform.GetFunctionsOptio
 	return args.Get(0).([]platform.Function), args.Error(1)
 }
 
-func (mp *Platform) FilterFunctionsByPermissions(permissionOptions *platform.PermissionOptions,
+func (mp *Platform) FilterFunctionsByPermissions(permissionOptions *opa.PermissionOptions,
 	functions []platform.Function) ([]platform.Function, error) {
 	args := mp.Called(permissionOptions, functions)
 	return args.Get(0).([]platform.Function), args.Error(1)
@@ -132,7 +132,7 @@ func (mp *Platform) GetProjects(getProjectsOptions *platform.GetProjectsOptions)
 	return args.Get(0).([]platform.Project), args.Error(1)
 }
 
-func (mp *Platform) FilterProjectsByPermissions(permissionOptions *platform.PermissionOptions,
+func (mp *Platform) FilterProjectsByPermissions(permissionOptions *opa.PermissionOptions,
 	projects []platform.Project) ([]platform.Project, error) {
 	args := mp.Called(permissionOptions, projects)
 	return args.Get(0).([]platform.Project), args.Error(1)
@@ -200,7 +200,7 @@ func (mp *Platform) GetFunctionEvents(getFunctionEventsOptions *platform.GetFunc
 	return args.Get(0).([]platform.FunctionEvent), args.Error(1)
 }
 
-func (mp *Platform) FilterFunctionEventsByPermissions(permissionOptions *platform.PermissionOptions,
+func (mp *Platform) FilterFunctionEventsByPermissions(permissionOptions *opa.PermissionOptions,
 	functionEvents []platform.FunctionEvent) ([]platform.FunctionEvent, error) {
 	args := mp.Called(permissionOptions, functionEvents)
 	return args.Get(0).([]platform.FunctionEvent), args.Error(1)
@@ -338,20 +338,16 @@ func (mp *Platform) WaitForProjectResourcesDeletion(projectMeta *platform.Projec
 
 func (mp *Platform) QueryOPAProjectPermissions(projectName string,
 	action opa.Action,
-	ids []string,
-	raiseForbidden bool,
-	overrideHeaderValue string) (bool, error) {
-	args := mp.Called(projectName, action, ids, raiseForbidden, overrideHeaderValue)
+	permissionOptions *opa.PermissionOptions) (bool, error) {
+	args := mp.Called(projectName, action, permissionOptions)
 	return args.Get(0).(bool), args.Error(1)
 }
 
 func (mp *Platform) QueryOPAFunctionPermissions(projectName,
 	functionName string,
 	action opa.Action,
-	ids []string,
-	raiseForbidden bool,
-	overrideHeaderValue string) (bool, error) {
-	args := mp.Called(projectName, functionName, action, ids, raiseForbidden, overrideHeaderValue)
+	permissionOptions *opa.PermissionOptions) (bool, error) {
+	args := mp.Called(projectName, functionName, action, permissionOptions)
 	return args.Get(0).(bool), args.Error(1)
 }
 
@@ -359,9 +355,7 @@ func (mp *Platform) QueryOPAFunctionEventPermissions(projectName,
 	functionName,
 	functionEventName string,
 	action opa.Action,
-	ids []string,
-	raiseForbidden bool,
-	overrideHeaderValue string) (bool, error) {
-	args := mp.Called(projectName, functionName, functionEventName, action, ids, raiseForbidden, overrideHeaderValue)
+	permissionOptions *opa.PermissionOptions) (bool, error) {
+	args := mp.Called(projectName, functionName, functionEventName, action, permissionOptions)
 	return args.Get(0).(bool), args.Error(1)
 }

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -339,8 +339,9 @@ func (mp *Platform) WaitForProjectResourcesDeletion(projectMeta *platform.Projec
 func (mp *Platform) QueryOPAProjectPermissions(projectName string,
 	action opa.Action,
 	ids []string,
-	raiseForbidden bool) (bool, error) {
-	args := mp.Called(projectName, action, ids, raiseForbidden)
+	raiseForbidden bool,
+	overrideHeaderValue string) (bool, error) {
+	args := mp.Called(projectName, action, ids, raiseForbidden, overrideHeaderValue)
 	return args.Get(0).(bool), args.Error(1)
 }
 
@@ -348,8 +349,9 @@ func (mp *Platform) QueryOPAFunctionPermissions(projectName,
 	functionName string,
 	action opa.Action,
 	ids []string,
-	raiseForbidden bool) (bool, error) {
-	args := mp.Called(projectName, functionName, action, ids, raiseForbidden)
+	raiseForbidden bool,
+	overrideHeaderValue string) (bool, error) {
+	args := mp.Called(projectName, functionName, action, ids, raiseForbidden, overrideHeaderValue)
 	return args.Get(0).(bool), args.Error(1)
 }
 
@@ -358,7 +360,8 @@ func (mp *Platform) QueryOPAFunctionEventPermissions(projectName,
 	functionEventName string,
 	action opa.Action,
 	ids []string,
-	raiseForbidden bool) (bool, error) {
-	args := mp.Called(projectName, functionName, functionEventName, action, ids, raiseForbidden)
+	raiseForbidden bool,
+	overrideHeaderValue string) (bool, error) {
+	args := mp.Called(projectName, functionName, functionEventName, action, ids, raiseForbidden, overrideHeaderValue)
 	return args.Get(0).(bool), args.Error(1)
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -75,7 +75,7 @@ type Platform interface {
 	GetFunctions(getFunctionsOptions *GetFunctionsOptions) ([]Function, error)
 
 	// FilterFunctionsByPermissions will filter out some functions
-	FilterFunctionsByPermissions(*PermissionOptions, []Function) ([]Function, error)
+	FilterFunctionsByPermissions(*opa.PermissionOptions, []Function) ([]Function, error)
 
 	// GetDefaultInvokeIPAddresses will return a list of ip addresses to be used by the platform to invoke a function
 	GetDefaultInvokeIPAddresses() ([]string, error)
@@ -103,7 +103,7 @@ type Platform interface {
 	GetProjects(getProjectsOptions *GetProjectsOptions) ([]Project, error)
 
 	// FilterProjectsByPermissions will filter out some projects
-	FilterProjectsByPermissions(*PermissionOptions, []Project) ([]Project, error)
+	FilterProjectsByPermissions(*opa.PermissionOptions, []Project) ([]Project, error)
 
 	// Ensures default project exists, creates it otherwise
 	EnsureDefaultProjectExistence() error
@@ -129,7 +129,7 @@ type Platform interface {
 	GetFunctionEvents(getFunctionEventsOptions *GetFunctionEventsOptions) ([]FunctionEvent, error)
 
 	// FilterFunctionEventsByPermissions will filter out some function events
-	FilterFunctionEventsByPermissions(*PermissionOptions, []FunctionEvent) ([]FunctionEvent, error)
+	FilterFunctionEventsByPermissions(*opa.PermissionOptions, []FunctionEvent) ([]FunctionEvent, error)
 
 	//
 	// API Gateway
@@ -225,11 +225,11 @@ type Platform interface {
 	//
 
 	// QueryOPAProjectPermissions queries opa permissions for a certain project
-	QueryOPAProjectPermissions(projectName string, action opa.Action, ids []string, raiseForbidden bool, overrideHeaderValue string) (bool, error)
+	QueryOPAProjectPermissions(projectName string, action opa.Action, permissionOptions *opa.PermissionOptions) (bool, error)
 
 	// QueryOPAFunctionPermissions queries opa permissions for a certain function
-	QueryOPAFunctionPermissions(projectName, functionName string, action opa.Action, ids []string, raiseForbidden bool, overrideHeaderValue string) (bool, error)
+	QueryOPAFunctionPermissions(projectName, functionName string, action opa.Action, permissionOptions *opa.PermissionOptions) (bool, error)
 
 	// QueryOPAFunctionEventPermissions queries opa permissions for a certain function event
-	QueryOPAFunctionEventPermissions(projectName, functionName, functionEventName string, action opa.Action, ids []string, raiseForbidden bool, overrideHeaderValue string) (bool, error)
+	QueryOPAFunctionEventPermissions(projectName, functionName, functionEventName string, action opa.Action, permissionOptions *opa.PermissionOptions) (bool, error)
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -225,11 +225,11 @@ type Platform interface {
 	//
 
 	// QueryOPAProjectPermissions queries opa permissions for a certain project
-	QueryOPAProjectPermissions(projectName string, action opa.Action, ids []string, raiseForbidden bool) (bool, error)
+	QueryOPAProjectPermissions(projectName string, action opa.Action, ids []string, raiseForbidden bool, overrideHeaderValue string) (bool, error)
 
 	// QueryOPAFunctionPermissions queries opa permissions for a certain function
-	QueryOPAFunctionPermissions(projectName, functionName string, action opa.Action, ids []string, raiseForbidden bool) (bool, error)
+	QueryOPAFunctionPermissions(projectName, functionName string, action opa.Action, ids []string, raiseForbidden bool, overrideHeaderValue string) (bool, error)
 
 	// QueryOPAFunctionEventPermissions queries opa permissions for a certain function event
-	QueryOPAFunctionEventPermissions(projectName, functionName, functionEventName string, action opa.Action, ids []string, raiseForbidden bool) (bool, error)
+	QueryOPAFunctionEventPermissions(projectName, functionName, functionEventName string, action opa.Action, ids []string, raiseForbidden bool, overrideHeaderValue string) (bool, error)
 }

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -36,8 +36,9 @@ import (
 //
 
 type PermissionOptions struct {
-	MemberIds      []string
-	RaiseForbidden bool
+	MemberIds           []string
+	RaiseForbidden      bool
+	OverrideHeaderValue string
 }
 
 type AuthConfig struct {

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/opa"
 	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
@@ -34,12 +35,6 @@ import (
 //
 // Auth
 //
-
-type PermissionOptions struct {
-	MemberIds           []string
-	RaiseForbidden      bool
-	OverrideHeaderValue string
-}
 
 type AuthConfig struct {
 	Token string
@@ -65,7 +60,7 @@ type CreateFunctionOptions struct {
 	InputImageFile             string
 	AuthConfig                 *AuthConfig
 	DependantImagesRegistryURL string
-	PermissionOptions          PermissionOptions
+	PermissionOptions          opa.PermissionOptions
 }
 
 type UpdateFunctionOptions struct {
@@ -73,13 +68,13 @@ type UpdateFunctionOptions struct {
 	FunctionSpec      *functionconfig.Spec
 	FunctionStatus    *functionconfig.Status
 	AuthConfig        *AuthConfig
-	PermissionOptions PermissionOptions
+	PermissionOptions opa.PermissionOptions
 }
 
 type DeleteFunctionOptions struct {
 	FunctionConfig    functionconfig.Config
 	AuthConfig        *AuthConfig
-	PermissionOptions PermissionOptions
+	PermissionOptions opa.PermissionOptions
 }
 
 // CreateFunctionBuildResult holds information detected/generated as a result of a build process
@@ -104,7 +99,7 @@ type GetFunctionsOptions struct {
 	Namespace         string
 	Labels            string
 	AuthConfig        *AuthConfig
-	PermissionOptions PermissionOptions
+	PermissionOptions opa.PermissionOptions
 
 	// Enrich functions with their api gateways
 	EnrichWithAPIGateways bool
@@ -222,14 +217,14 @@ type CreateProjectOptions struct {
 	ProjectConfig     *ProjectConfig
 	RequestOrigin     platformconfig.ProjectsLeaderKind
 	SessionCookie     *http.Cookie
-	PermissionOptions PermissionOptions
+	PermissionOptions opa.PermissionOptions
 }
 
 type UpdateProjectOptions struct {
 	ProjectConfig     ProjectConfig
 	RequestOrigin     platformconfig.ProjectsLeaderKind
 	SessionCookie     *http.Cookie
-	PermissionOptions PermissionOptions
+	PermissionOptions opa.PermissionOptions
 }
 
 type DeleteProjectStrategy string
@@ -259,7 +254,7 @@ type DeleteProjectOptions struct {
 	Strategy          DeleteProjectStrategy
 	RequestOrigin     platformconfig.ProjectsLeaderKind
 	SessionCookie     *http.Cookie
-	PermissionOptions PermissionOptions
+	PermissionOptions opa.PermissionOptions
 
 	// allowing us to "block" until related resources are removed.
 	// used in testings
@@ -269,7 +264,7 @@ type DeleteProjectOptions struct {
 
 type GetProjectsOptions struct {
 	Meta              ProjectMeta
-	PermissionOptions PermissionOptions
+	PermissionOptions opa.PermissionOptions
 }
 
 // to appease k8s
@@ -305,23 +300,23 @@ type FunctionEventConfig struct {
 
 type CreateFunctionEventOptions struct {
 	FunctionEventConfig FunctionEventConfig
-	PermissionOptions   PermissionOptions
+	PermissionOptions   opa.PermissionOptions
 }
 
 type UpdateFunctionEventOptions struct {
 	FunctionEventConfig FunctionEventConfig
-	PermissionOptions   PermissionOptions
+	PermissionOptions   opa.PermissionOptions
 }
 
 type DeleteFunctionEventOptions struct {
 	Meta              FunctionEventMeta
-	PermissionOptions PermissionOptions
+	PermissionOptions opa.PermissionOptions
 }
 
 type GetFunctionEventsOptions struct {
 	Meta              FunctionEventMeta
 	FunctionNames     []string
-	PermissionOptions PermissionOptions
+	PermissionOptions opa.PermissionOptions
 }
 
 // DeepCopyInto to appease k8s


### PR DESCRIPTION
For the Iguazio leader functionality, added a configurable header in the Platform Config so that if a request comes with the `x-projects-role` header and the header value matches the configured override header value, the OPA is bypassed and allows the action automatically.