### PR TITLE
Logger - support JSON compliant extra vars

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/nuclio/logger v0.0.1
 	github.com/nuclio/logger-appinsights v0.0.1
 	github.com/nuclio/nuclio-sdk-go v0.2.0
-	github.com/nuclio/zap v0.0.5
+	github.com/nuclio/zap v0.0.6
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/nuclio/logger v0.0.1
 	github.com/nuclio/logger-appinsights v0.0.1
 	github.com/nuclio/nuclio-sdk-go v0.2.0
-	github.com/nuclio/zap v0.0.4
+	github.com/nuclio/zap v0.0.5
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -447,8 +447,8 @@ github.com/nuclio/nuclio-sdk-go v0.2.0 h1:acd+hCRKupV6n70F2dX+bGPTuYl6kiHOHI+tar
 github.com/nuclio/nuclio-sdk-go v0.2.0/go.mod h1:OBDhOcCf2GLO1e16GdWNU4EBjFoa9DAUJgzR226FMBc=
 github.com/nuclio/zap v0.0.2/go.mod h1:SUxPsgePvlyjx6c5MtGdB50pf0IQThtlyLwISLboeuc=
 github.com/nuclio/zap v0.0.3/go.mod h1:SUxPsgePvlyjx6c5MtGdB50pf0IQThtlyLwISLboeuc=
-github.com/nuclio/zap v0.0.4 h1:pc6zNr5O/VgB/gRc0cQp3cTf1kYAhfFBkgx2nSPkom4=
-github.com/nuclio/zap v0.0.4/go.mod h1:4kiW3CKmgomEjYgB68ZWrOWgQfm68tytD9goMD/miy4=
+github.com/nuclio/zap v0.0.5 h1:rSYqE9YRZ7MzuGyez/raeqQ/W7iec7pcU/GUUZSx1Cs=
+github.com/nuclio/zap v0.0.5/go.mod h1:4kiW3CKmgomEjYgB68ZWrOWgQfm68tytD9goMD/miy4=
 github.com/nwaples/rardecode v1.0.0 h1:r7vGuS5akxOnR4JQSkko62RJ1ReCMXxQRPtxsiFMBOs=
 github.com/nwaples/rardecode v1.0.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8urCTFX88=

--- a/go.sum
+++ b/go.sum
@@ -447,8 +447,8 @@ github.com/nuclio/nuclio-sdk-go v0.2.0 h1:acd+hCRKupV6n70F2dX+bGPTuYl6kiHOHI+tar
 github.com/nuclio/nuclio-sdk-go v0.2.0/go.mod h1:OBDhOcCf2GLO1e16GdWNU4EBjFoa9DAUJgzR226FMBc=
 github.com/nuclio/zap v0.0.2/go.mod h1:SUxPsgePvlyjx6c5MtGdB50pf0IQThtlyLwISLboeuc=
 github.com/nuclio/zap v0.0.3/go.mod h1:SUxPsgePvlyjx6c5MtGdB50pf0IQThtlyLwISLboeuc=
-github.com/nuclio/zap v0.0.5 h1:rSYqE9YRZ7MzuGyez/raeqQ/W7iec7pcU/GUUZSx1Cs=
-github.com/nuclio/zap v0.0.5/go.mod h1:4kiW3CKmgomEjYgB68ZWrOWgQfm68tytD9goMD/miy4=
+github.com/nuclio/zap v0.0.6 h1:gzkwx4nDy824QJpsnyj5dyo0GYaFSYAfnqXEtnwBL6s=
+github.com/nuclio/zap v0.0.6/go.mod h1:4kiW3CKmgomEjYgB68ZWrOWgQfm68tytD9goMD/miy4=
 github.com/nwaples/rardecode v1.0.0 h1:r7vGuS5akxOnR4JQSkko62RJ1ReCMXxQRPtxsiFMBOs=
 github.com/nwaples/rardecode v1.0.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8urCTFX88=

--- a/pkg/loggersink/stdout/factory.go
+++ b/pkg/loggersink/stdout/factory.go
@@ -54,6 +54,7 @@ func (f *factory) Create(name string,
 	encoderConfig := nucliozap.NewEncoderConfig()
 	encoderConfig.JSON.LineEnding = "\n"
 	encoderConfig.JSON.VarGroupName = configuration.VarGroupName
+	encoderConfig.JSON.VarGroupMode = configuration.VarGroupMode
 	encoderConfig.JSON.TimeFieldName = configuration.TimeFieldName
 	encoderConfig.JSON.TimeFieldEncoding = configuration.TimeFieldEncoding
 

--- a/pkg/loggersink/stdout/types.go
+++ b/pkg/loggersink/stdout/types.go
@@ -22,12 +22,14 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/nuclio/errors"
+	nucliozap "github.com/nuclio/zap"
 )
 
 type Configuration struct {
 	loggersink.Configuration
 	Encoding          string
 	VarGroupName      string
+	VarGroupMode      nucliozap.VarGroupMode
 	TimeFieldName     string
 	TimeFieldEncoding string
 }
@@ -53,6 +55,10 @@ func NewConfiguration(name string, loggerSinkConfiguration *platformconfig.Logge
 
 	if newConfiguration.TimeFieldEncoding == "" {
 		newConfiguration.TimeFieldEncoding = "epoch-millis"
+	}
+
+	if newConfiguration.VarGroupMode == "" {
+		newConfiguration.VarGroupMode = nucliozap.DefaultVarGroupMode
 	}
 
 	return &newConfiguration, nil


### PR DESCRIPTION
For a log record of `loggerInstance.DebugWith("some-message", "a", "c")` you will get


`{"level":"debug","time":1624547045572.538,"name":"something","message":"some-message","extra":{"a":"c"}}`

instead of

`{"level":"debug","time":1624547025451.832,"name":"something","message":"some-message","extra":"a=c"}`

note the "extra" is structured.


