### PR TITLE
CI - fix latest issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,7 +155,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
 
-    - uses: manusa/actions-setup-minikube@v2.4.0
+    - uses: manusa/actions-setup-minikube@v2.4.2
       with:
         minikube version: "v1.15.1"
         kubernetes version: "v1.17.9"
@@ -168,7 +168,7 @@ jobs:
 
         # redirect $(minikube ip):5000 -> localhost:5000
         docker run --rm --detach --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"
-        kubectl config view --flatten > kubeconfig_flatten
+        minikube kubectl -- config view --flatten > kubeconfig_flatten
 
     - name: Fetch nuclio docker images
       uses: actions/download-artifact@v2
@@ -200,7 +200,7 @@ jobs:
 
     - name: Install nuclio helm chart
       run: |
-        kubectl create namespace ${NAMESPACE}
+        minikube kubectl -- kubectl create namespace ${NAMESPACE}
         cat test/k8s/ci_assets/helm_values.yaml \
           | envsubst \
           | helm install --debug --wait --namespace ${NAMESPACE} -f - nuclio hack/k8s/helm/nuclio/
@@ -262,7 +262,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - uses: manusa/actions-setup-minikube@v2.4.0
+      - uses: manusa/actions-setup-minikube@v2.4.2
         with:
           minikube version: "v1.15.1"
           kubernetes version: "v1.17.9"
@@ -275,7 +275,7 @@ jobs:
 
           # redirect $(minikube ip):5000 -> localhost:5000
           docker run --rm --detach --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"
-          kubectl config view --flatten > kubeconfig_flatten
+          minikube kubectl -- config view --flatten > kubeconfig_flatten
 
       - name: Fetch nuclio docker images
         uses: actions/download-artifact@v2
@@ -298,7 +298,7 @@ jobs:
         run: |
 
           # create namespace
-          kubectl create namespace ${NAMESPACE}
+          minikube kubectl -- create namespace ${NAMESPACE}
 
           # install helm chart
           ./test/k8s/ci_assets/install_nuclio_crds.sh
@@ -320,6 +320,7 @@ jobs:
     - name: Run python test
       run: |
         make test-python
+
   test_nodejs:
     name: Test NodeJS
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -200,7 +200,7 @@ jobs:
 
     - name: Install nuclio helm chart
       run: |
-        minikube kubectl -- kubectl create namespace ${NAMESPACE}
+        minikube kubectl -- create namespace ${NAMESPACE}
         cat test/k8s/ci_assets/helm_values.yaml \
           | envsubst \
           | helm install --debug --wait --namespace ${NAMESPACE} -f - nuclio hack/k8s/helm/nuclio/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,7 +138,7 @@ jobs:
 
   test_k8s_nuctl:
     name: Test Kubernetes nuctl
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs:
     - build_docker_images
     steps:
@@ -245,7 +245,7 @@ jobs:
 
   test_k8s:
     name: Test Kubernetes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs:
       - build_docker_images
     steps:

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,17 @@ load-docker-images: print-docker-images
 	@echo "Load Nuclio docker images"
 	docker load -i nuclio-docker-images-$(NUCLIO_LABEL)-$(NUCLIO_ARCH).tar.gz
 
+pull-docker-images: print-docker-images
+	@echo "Pull Nuclio docker images"
+	@echo $(IMAGES_TO_PUSH) | xargs -n 1 -P 5 docker pull
+
+retag-docker-images: print-docker-images
+	$(eval NUCLIO_NEW_LABEL ?= retagged)
+	$(eval NUCLIO_NEW_LABEL = ${NUCLIO_NEW_LABEL}-${NUCLIO_ARCH})
+	@echo "Retagging Nuclio docker images with ${NUCLIO_NEW_LABEL}"
+	echo $(IMAGES_TO_PUSH) | xargs -n 1 -P 5 -I{} sh -c 'image="{}"; docker tag $$image $$(echo $$image | cut -d : -f 1):$(NUCLIO_NEW_LABEL)'
+	@echo "Done"
+
 print-docker-images:
 	@echo "Nuclio Docker images:"
 	@for image in $(IMAGES_TO_PUSH); do \


### PR DESCRIPTION
Fix CI

- it seems that the `ubuntu-latest` image (20.04) that is shipped with the github action runner has kernel issues that cause the minikube network driver not to work and hit on `dial tcp 10.96.0.1:443: i/o timeout error` error (reference - https://github.com/kubernetes-sigs/kind/issues/2240)
- we want to use the `kubectl` that `minikube` is shipped with to allow perfect version matching.
otherwise, we might hit `kubectl` at version >> minikube, which brings feature incompatibility 
