### PR TITLE
k8s 1.19 compatibility - helm chart - Bumping CRD apiVesion to v1 + fixing schema validation [1.5.x]

### DIFF
--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.7.24
+version: 0.7.25
 appVersion: 1.5.20
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/templates/crd/api-gateway.yaml
+++ b/hack/k8s/helm/nuclio/templates/crd/api-gateway.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- if and .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: nuclioapigateways.nuclio.io
@@ -27,5 +27,16 @@ spec:
     plural: nuclioapigateways
     singular: nuclioapigateway
   scope: Namespaced
-  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
 {{- end }}

--- a/hack/k8s/helm/nuclio/templates/crd/function-event.yaml
+++ b/hack/k8s/helm/nuclio/templates/crd/function-event.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: nucliofunctionevents.nuclio.io
@@ -27,5 +27,16 @@ spec:
     plural: nucliofunctionevents
     singular: nucliofunctionevent
   scope: Namespaced
-  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
 {{- end }}

--- a/hack/k8s/helm/nuclio/templates/crd/function.yaml
+++ b/hack/k8s/helm/nuclio/templates/crd/function.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: nucliofunctions.nuclio.io
@@ -27,5 +27,16 @@ spec:
     plural: nucliofunctions
     singular: nucliofunction
   scope: Namespaced
-  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
 {{- end }}

--- a/hack/k8s/helm/nuclio/templates/crd/project.yaml
+++ b/hack/k8s/helm/nuclio/templates/crd/project.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: nuclioprojects.nuclio.io
@@ -27,5 +27,16 @@ spec:
     plural: nuclioprojects
     singular: nuclioproject
   scope: Namespaced
-  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
 {{- end }}


### PR DESCRIPTION
Backporting https://github.com/nuclio/nuclio/pull/2218