### PR TITLE
Scale to zero update

### DIFF
--- a/cmd/autoscaler/app/autoscaler.go
+++ b/cmd/autoscaler/app/autoscaler.go
@@ -19,6 +19,7 @@ package app
 import (
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/loggersink"
+	nuclioioclient "github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/versioned"
 	"github.com/nuclio/nuclio/pkg/platform/kube/resourcescaler"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	// load all sinks
@@ -69,8 +70,18 @@ func createAutoScaler(platformConfigurationPath string,
 		return nil, errors.Wrap(err, "Failed to create new metric custom client")
 	}
 
+	restConfig, err := common.GetClientConfig(kubeconfigPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get client configuration")
+	}
+
+	nuclioClientSet, err := nuclioioclient.NewForConfig(restConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create nuclio client set")
+	}
+
 	// create resource scaler
-	resourceScaler, err := resourcescaler.New(rootLogger, platformConfiguration, kubeconfigPath, namespace)
+	resourceScaler, err := resourcescaler.New(rootLogger, namespace, nuclioClientSet, platformConfiguration)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create resource scaler")
 	}

--- a/cmd/autoscaler/app/autoscaler.go
+++ b/cmd/autoscaler/app/autoscaler.go
@@ -41,7 +41,7 @@ func Run(platformConfigurationPath string, namespace string, kubeconfigPath stri
 	}
 
 	// start autoscaler and run forever
-	if err = autoScaler.Start(); err != nil {
+	if err := autoScaler.Start(); err != nil {
 		return errors.Wrap(err, "Failed to start autoscaler")
 	}
 	select {}
@@ -70,7 +70,7 @@ func createAutoScaler(platformConfigurationPath string,
 	}
 
 	// create resource scaler
-	resourceScaler, err := resourcescaler.New(kubeconfigPath, namespace)
+	resourceScaler, err := resourcescaler.New(rootLogger, platformConfiguration, kubeconfigPath, namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create resource scaler")
 	}

--- a/cmd/dlx/app/dlx.go
+++ b/cmd/dlx/app/dlx.go
@@ -57,7 +57,7 @@ func newDLX(platformConfigurationPath string, namespace string, kubeconfigPath s
 	}
 
 	// create resource scaler
-	resourceScaler, err := resourcescaler.New(kubeconfigPath, namespace)
+	resourceScaler, err := resourcescaler.New(rootLogger, platformConfiguration, kubeconfigPath, namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create resource scaler")
 	}

--- a/cmd/dlx/app/dlx.go
+++ b/cmd/dlx/app/dlx.go
@@ -17,7 +17,9 @@ limitations under the License.
 package app
 
 import (
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/loggersink"
+	nuclioioclient "github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/versioned"
 	"github.com/nuclio/nuclio/pkg/platform/kube/resourcescaler"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	// load all sinks
@@ -56,8 +58,18 @@ func newDLX(platformConfigurationPath string, namespace string, kubeconfigPath s
 		return nil, errors.Wrap(err, "Failed to create logger")
 	}
 
+	restConfig, err := common.GetClientConfig(kubeconfigPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get client configuration")
+	}
+
+	nuclioClientSet, err := nuclioioclient.NewForConfig(restConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create nuclio client set")
+	}
+
 	// create resource scaler
-	resourceScaler, err := resourcescaler.New(rootLogger, platformConfiguration, kubeconfigPath, namespace)
+	resourceScaler, err := resourcescaler.New(rootLogger, namespace, nuclioClientSet, platformConfiguration)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create resource scaler")
 	}

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,6 @@ require (
 	github.com/tedsuo/ifrit v0.0.0-20191009134036-9a97d0632f00 // indirect
 	github.com/tsenart/vegeta/v12 v12.8.4
 	github.com/v3io/scaler v0.4.0
-	github.com/v3io/scaler-types v1.7.0
 	github.com/v3io/v3io-go v0.2.8
 	github.com/v3io/v3io-go-http v0.0.1
 	github.com/v3io/version-go v0.0.2

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tedsuo/ifrit v0.0.0-20191009134036-9a97d0632f00 // indirect
 	github.com/tsenart/vegeta/v12 v12.8.4
-	github.com/v3io/scaler v0.4.0
+	github.com/v3io/scaler v0.5.0
 	github.com/v3io/v3io-go v0.2.8
 	github.com/v3io/v3io-go-http v0.0.1
 	github.com/v3io/version-go v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -549,10 +549,6 @@ github.com/tsenart/vegeta/v12 v12.8.4/go.mod h1:ZiJtwLn/9M4fTPdMY7bdbIeyNeFVE8/A
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
-github.com/v3io/scaler v0.4.0 h1:VKY+FnWnKYcQLP75FpbltoO2VCH76ZO5ZIi91UbrbV0=
-github.com/v3io/scaler v0.4.0/go.mod h1:FEB9OKfYV4qcm9aXISZk0uCi6yK3Ak9JsdYVZFbu5tM=
-github.com/v3io/scaler-types v1.7.0 h1:ZTbJaYUxZgnPjiOWU64l74jCk5iRmEoA2ZxyzUQbtn0=
-github.com/v3io/scaler-types v1.7.0/go.mod h1:fnjcQnuYD8wTmkmsv7QLnXShuk5HNRRwfFHfR+khYRs=
 github.com/v3io/v3io-go v0.2.8 h1:lHb+249TUv0E0vrbRZPMqP6yyg1YWjJy+Az4QtA22Kw=
 github.com/v3io/v3io-go v0.2.8/go.mod h1:WGxAG5MfZ5FeeZa7yGzocW+iLxTlrpkOWdnCIty4QDc=
 github.com/v3io/v3io-go-http v0.0.1 h1:uE+PmPkVfGi6vIMpoFgrSot4yIow5Id48Gj9ZPt02pU=

--- a/go.sum
+++ b/go.sum
@@ -549,6 +549,8 @@ github.com/tsenart/vegeta/v12 v12.8.4/go.mod h1:ZiJtwLn/9M4fTPdMY7bdbIeyNeFVE8/A
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
+github.com/v3io/scaler v0.5.0 h1:OYzrorVxd8BMjMM2xocqb9dCBtAYXE3w6op+JEf6/wU=
+github.com/v3io/scaler v0.5.0/go.mod h1:t/KJ0RstQLMtLgDlAUdxNdiumeo/uP4ZhpitXr5LJtA=
 github.com/v3io/v3io-go v0.2.8 h1:lHb+249TUv0E0vrbRZPMqP6yyg1YWjJy+Az4QtA22Kw=
 github.com/v3io/v3io-go v0.2.8/go.mod h1:WGxAG5MfZ5FeeZa7yGzocW+iLxTlrpkOWdnCIty4QDc=
 github.com/v3io/v3io-go-http v0.0.1 h1:uE+PmPkVfGi6vIMpoFgrSot4yIow5Id48Gj9ZPt02pU=

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/v3io/scaler-types"
+	"github.com/v3io/scaler/pkg/scalertypes"
 	"k8s.io/api/core/v1"
 )
 
@@ -535,8 +535,8 @@ func (s *Status) InvocationURLs() []string {
 }
 
 type ScaleToZeroStatus struct {
-	LastScaleEvent     scaler_types.ScaleEvent `json:"lastScaleEvent,omitempty"`
-	LastScaleEventTime *time.Time              `json:"lastScaleEventTime,omitempty"`
+	LastScaleEvent     scalertypes.ScaleEvent `json:"lastScaleEvent,omitempty"`
+	LastScaleEventTime *time.Time             `json:"lastScaleEventTime,omitempty"`
 }
 
 // DeepCopyInto copies to appease k8s

--- a/pkg/loggersink/loggersink.go
+++ b/pkg/loggersink/loggersink.go
@@ -25,7 +25,7 @@ import (
 	"github.com/nuclio/zap"
 )
 
-// CreateSystemLoggers returns the system loggers
+// CreateSystemLogger returns the system loggers
 func CreateSystemLogger(name string, platformConfiguration *platformconfig.Config) (logger.Logger, error) {
 
 	// get system loggers
@@ -37,7 +37,7 @@ func CreateSystemLogger(name string, platformConfiguration *platformconfig.Confi
 	return createLoggers(name, systemLoggerSinksByName)
 }
 
-// returns the processor logger and the function logger. For now, they are one of the same
+// CreateFunctionLogger returns the processor logger and the function logger. For now, they are one of the same
 func CreateFunctionLogger(name string,
 	functionConfiguration *functionconfig.Config,
 	platformConfiguration *platformconfig.Config) (logger.Logger, error) {
@@ -51,7 +51,7 @@ func CreateFunctionLogger(name string,
 	return createLoggers(name, functionLoggerSinksByName)
 }
 
-// returns the processor logger and the function logger. For now, they are one of the same
+// createLoggers returns the processor logger and the function logger. For now, they are one of the same
 func createLoggers(name string, loggerSinksWithLevel map[string]platformconfig.LoggerSinkWithLevel) (logger.Logger, error) {
 	var loggers []logger.Logger
 	var loggerInstance logger.Logger

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
-	"github.com/v3io/scaler-types"
+	"github.com/v3io/scaler/pkg/scalertypes"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -194,17 +194,17 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 
 	if functionconfig.FunctionStateInSlice(function.Status.State, waitingStates) {
 
-		var scaleEvent scaler_types.ScaleEvent
+		var scaleEvent scalertypes.ScaleEvent
 		var finalState functionconfig.FunctionState
 		switch function.Status.State {
 		case functionconfig.FunctionStateWaitingForScaleResourcesToZero:
-			scaleEvent = scaler_types.ScaleToZeroCompletedScaleEvent
+			scaleEvent = scalertypes.ScaleToZeroCompletedScaleEvent
 			finalState = functionconfig.FunctionStateScaledToZero
 		case functionconfig.FunctionStateWaitingForScaleResourcesFromZero:
-			scaleEvent = scaler_types.ScaleFromZeroCompletedScaleEvent
+			scaleEvent = scalertypes.ScaleFromZeroCompletedScaleEvent
 			finalState = functionconfig.FunctionStateReady
 		case functionconfig.FunctionStateWaitingForResourceConfiguration:
-			scaleEvent = scaler_types.ResourceUpdatedScaleEvent
+			scaleEvent = scalertypes.ResourceUpdatedScaleEvent
 			finalState = functionconfig.FunctionStateReady
 		}
 
@@ -239,7 +239,7 @@ func (fo *functionOperator) Delete(ctx context.Context, namespace string, name s
 
 func (fo *functionOperator) setFunctionScaleToZeroStatus(ctx context.Context,
 	functionStatus *functionconfig.Status,
-	scaleToZeroEvent scaler_types.ScaleEvent) error {
+	scaleToZeroEvent scalertypes.ScaleEvent) error {
 
 	fo.logger.DebugWith("Setting scale to zero status",
 		"LastScaleEvent", scaleToZeroEvent)

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2023,6 +2023,7 @@ func (lc *lazyClient) deleteFunctionEvents(ctx context.Context, functionName str
 	lc.logger.DebugWith("Got function events", "num", len(result.Items))
 
 	for _, functionEvent := range result.Items {
+		functionEvent := functionEvent
 		errGroup.Go(func() error {
 			err = lc.nuclioClientSet.NuclioV1beta1().
 				NuclioFunctionEvents(namespace).

--- a/pkg/platform/kube/resourcescaler/test/resourcescaler_test.go
+++ b/pkg/platform/kube/resourcescaler/test/resourcescaler_test.go
@@ -1,0 +1,221 @@
+// +build test_integration
+// +build test_kube
+
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platform/kube/test"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+
+	"github.com/nuclio/nuclio/pkg/platform/kube/resourcescaler"
+	"github.com/stretchr/testify/suite"
+	"github.com/v3io/scaler/pkg/autoscaler"
+	"github.com/v3io/scaler/pkg/dlx"
+	"github.com/v3io/scaler/pkg/scalertypes"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/metrics/pkg/apis/custom_metrics/v1beta2"
+	"k8s.io/metrics/pkg/client/custom_metrics/fake"
+)
+
+type ResourceScalerTestSuite struct {
+	test.KubeTestSuite
+	dlx            *dlx.DLX
+	autoscaler     *autoscaler.Autoscaler
+	metricClient   *fake.FakeCustomMetricsClient
+	resourceScaler *resourcescaler.NuclioResourceScaler
+}
+
+func (suite *ResourceScalerTestSuite) SetupSuite() {
+	var err error
+
+	suite.PlatformConfiguration = &platformconfig.Config{}
+	suite.PlatformConfiguration.ScaleToZero.ScaleResources = []functionconfig.ScaleResource{
+		{
+			MetricName: "something",
+			WindowSize: "1m",
+			Threshold:  5,
+		},
+	}
+
+	suite.KubeTestSuite.SetupSuite()
+	resourceScaler, err := resourcescaler.New(suite.Logger,
+		suite.Namespace,
+		suite.FunctionClientSet,
+		suite.PlatformConfiguration)
+	suite.Require().NoError(err)
+	suite.resourceScaler = resourceScaler.(*resourcescaler.NuclioResourceScaler)
+
+	resourceScalerConfig, err := resourceScaler.GetConfig()
+	suite.Require().NoError(err)
+
+	suite.dlx, err = dlx.NewDLX(suite.Logger, resourceScaler, resourceScalerConfig.DLXOptions)
+	suite.Require().NoError(err)
+
+	suite.metricClient = &fake.FakeCustomMetricsClient{}
+	suite.autoscaler, err = autoscaler.NewAutoScaler(suite.Logger,
+		resourceScaler,
+		suite.metricClient,
+		resourceScalerConfig.AutoScalerOptions)
+	suite.Require().NoError(err)
+
+}
+func (suite *ResourceScalerTestSuite) SetupTest() {
+	suite.KubeTestSuite.SetupTest()
+	go func() {
+		err := suite.dlx.Start()
+		suite.Require().NoError(err, "Failed to start DLX server")
+	}()
+
+	go func() {
+		err := suite.autoscaler.Start()
+		suite.Require().NoError(err, "Failed to start AutoScaler server")
+	}()
+}
+
+func (suite *ResourceScalerTestSuite) TearDownTest() {
+	err := suite.dlx.Stop(context.TODO())
+	suite.Require().NoError(err, "Failed to stop DLX server")
+
+	err = suite.autoscaler.Stop()
+	suite.Require().NoError(err, "Failed to stop AutoScaler server")
+	suite.KubeTestSuite.TearDownTest()
+}
+
+// TestSanity scale function to / from zero
+func (suite *ResourceScalerTestSuite) TestSanity() {
+	functionName := fmt.Sprintf("resourcescaler-test-%s", suite.TestID)
+	createFunctionOptions := suite.CompileCreateFunctionOptions(functionName)
+	zero := 0
+	one := 1
+	createFunctionOptions.FunctionConfig.Spec.MinReplicas = &zero
+	createFunctionOptions.FunctionConfig.Spec.MaxReplicas = &one
+	createFunctionOptions.FunctionConfig.Spec.ScaleToZero = &functionconfig.ScaleToZeroSpec{
+		ScaleResources: suite.PlatformConfiguration.ScaleToZero.ScaleResources,
+	}
+
+	// when autoscaler requests metric from the custom metric client
+	// ensure that its response is mocked
+	suite.mockMetricClient(functionName, resource.MustParse("0"))
+
+	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+		suite.scaleFunctionToZero(functionName)
+		suite.scaleFunctionFromZero(functionName)
+		return true
+	})
+}
+
+func (suite *ResourceScalerTestSuite) scaleFunctionToZero(functionName string) {
+	suite.Logger.InfoWith("Scaling function to zero", "functionName", functionName)
+
+	// get function resources
+	resources, err := suite.resourceScaler.GetResources()
+	suite.Require().NoError(err)
+
+	// scale function to zero
+	err = suite.resourceScaler.SetScale(resources, 0)
+	suite.Require().NoError(err)
+
+	// wait for function to scale
+	suite.WaitForFunctionState(&platform.GetFunctionsOptions{
+		Namespace: suite.Namespace,
+		Name:      functionName,
+	},
+		functionconfig.FunctionStateScaledToZero,
+		30*time.Second)
+
+	// ensure function deployment replicas is zero
+	suite.WaitForFunctionDeployment(functionName, 15*time.Second, func(deployment *appsv1.Deployment) bool {
+		return deployment.Status.Replicas == 0
+	})
+}
+
+func (suite *ResourceScalerTestSuite) scaleFunctionFromZero(functionName string) {
+	suite.Logger.InfoWith("Scaling function from zero", "functionName", functionName)
+
+	// scale function from zero
+	err := suite.resourceScaler.SetScale([]scalertypes.Resource{
+		{
+			Name:      functionName,
+			Namespace: suite.Namespace,
+		},
+	}, 1)
+	suite.Require().NoError(err)
+
+	// wait for function to scale
+	suite.WaitForFunctionState(&platform.GetFunctionsOptions{
+		Namespace: suite.Namespace,
+		Name:      functionName,
+	},
+		functionconfig.FunctionStateReady,
+		30*time.Second)
+
+	// ensure function deployment replicas is zero
+	suite.WaitForFunctionDeployment(functionName, 15*time.Second, func(deployment *appsv1.Deployment) bool {
+		return deployment.Status.Replicas == 1
+	})
+}
+
+func (suite *ResourceScalerTestSuite) mockMetricClient(functionName string, value resource.Quantity) {
+	config, _ := suite.resourceScaler.GetConfig()
+	windowSizeDuration, _ := time.ParseDuration(suite.PlatformConfiguration.ScaleToZero.ScaleResources[0].WindowSize)
+
+	functionResource := scalertypes.Resource{}
+	functionResource.ScaleResources = []scalertypes.ScaleResource{
+		{
+			MetricName: suite.PlatformConfiguration.ScaleToZero.ScaleResources[0].MetricName,
+			WindowSize: scalertypes.Duration{
+				Duration: windowSizeDuration,
+			},
+			Threshold: suite.PlatformConfiguration.ScaleToZero.ScaleResources[0].Threshold,
+		},
+	}
+	action := fake.NewGetForAction(config.AutoScalerOptions.GroupKind,
+		suite.Namespace,
+		"*",
+		functionResource.ScaleResources[0].GetKubernetesMetricName(), labels.Everything())
+	_, err := suite.metricClient.Invokes(action, &v1beta2.MetricValueList{
+		Items: []v1beta2.MetricValue{
+			{
+				DescribedObject: v1.ObjectReference{
+					Name:      functionName,
+					Namespace: suite.Namespace,
+				},
+				Value: value,
+			},
+		},
+	})
+	suite.Require().NoError(err)
+}
+
+func TestControllerTestSuite(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+	suite.Run(t, new(ResourceScalerTestSuite))
+}

--- a/pkg/platform/kube/resourcescaler/test/resourcescaler_test.go
+++ b/pkg/platform/kube/resourcescaler/test/resourcescaler_test.go
@@ -27,10 +27,10 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platform/kube/resourcescaler"
 	"github.com/nuclio/nuclio/pkg/platform/kube/test"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
-	"github.com/nuclio/nuclio/pkg/platform/kube/resourcescaler"
 	"github.com/stretchr/testify/suite"
 	"github.com/v3io/scaler/pkg/autoscaler"
 	"github.com/v3io/scaler/pkg/dlx"

--- a/pkg/platform/kube/resourcescaler/test/resourcescaler_test.go
+++ b/pkg/platform/kube/resourcescaler/test/resourcescaler_test.go
@@ -21,15 +21,17 @@ package test
 
 import (
 	"context"
+
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/kube/resourcescaler"
 	"github.com/nuclio/nuclio/pkg/platform/kube/test"
-	"github.com/nuclio/nuclio/pkg/platformconfig"
 
 	"github.com/stretchr/testify/suite"
 	"github.com/v3io/scaler/pkg/autoscaler"
@@ -38,7 +40,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/metrics/pkg/apis/custom_metrics/v1beta2"
 	"k8s.io/metrics/pkg/client/custom_metrics/fake"
 )
@@ -54,15 +57,6 @@ type ResourceScalerTestSuite struct {
 func (suite *ResourceScalerTestSuite) SetupSuite() {
 	var err error
 
-	suite.PlatformConfiguration = &platformconfig.Config{}
-	suite.PlatformConfiguration.ScaleToZero.ScaleResources = []functionconfig.ScaleResource{
-		{
-			MetricName: "something",
-			WindowSize: "1m",
-			Threshold:  5,
-		},
-	}
-
 	suite.KubeTestSuite.SetupSuite()
 	resourceScaler, err := resourcescaler.New(suite.Logger,
 		suite.Namespace,
@@ -73,6 +67,10 @@ func (suite *ResourceScalerTestSuite) SetupSuite() {
 
 	resourceScalerConfig, err := resourceScaler.GetConfig()
 	suite.Require().NoError(err)
+
+	resourceScalerConfig.AutoScalerOptions.ScaleInterval = scalertypes.Duration{
+		Duration: 5 * time.Second,
+	}
 
 	suite.dlx, err = dlx.NewDLX(suite.Logger, resourceScaler, resourceScalerConfig.DLXOptions)
 	suite.Require().NoError(err)
@@ -116,101 +114,91 @@ func (suite *ResourceScalerTestSuite) TestSanity() {
 	createFunctionOptions.FunctionConfig.Spec.MinReplicas = &zero
 	createFunctionOptions.FunctionConfig.Spec.MaxReplicas = &one
 	createFunctionOptions.FunctionConfig.Spec.ScaleToZero = &functionconfig.ScaleToZeroSpec{
-		ScaleResources: suite.PlatformConfiguration.ScaleToZero.ScaleResources,
+		ScaleResources: []functionconfig.ScaleResource{
+			{
+				MetricName: "something",
+				Threshold:  1,
+				WindowSize: "250ms",
+			},
+		},
 	}
-
-	// when autoscaler requests metric from the custom metric client
-	// ensure that its response is mocked
-	suite.mockMetricClient(functionName, resource.MustParse("0"))
 
 	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
-		suite.scaleFunctionToZero(functionName)
-		suite.scaleFunctionFromZero(functionName)
+
+		// add metrics data
+		// make metric client return value that is small enough (e.g.: 0)
+		// to ensure scaler will scale the function to zero
+		suite.metricClient.AddReactor("get", "nucliofunctions.nuclio.io", func(action k8stesting.Action) (
+			handled bool, ret runtime.Object, err error) {
+			return true, &v1beta2.MetricValueList{
+				Items: []v1beta2.MetricValue{
+					{
+						DescribedObject: v1.ObjectReference{
+							Name:      functionName,
+							Namespace: suite.Namespace,
+						},
+						Value: resource.MustParse("0"),
+					},
+				},
+			}, nil
+		})
+
+		// wait for the function to scale to zero
+		suite.WaitForFunctionState(&platform.GetFunctionsOptions{
+			Namespace: suite.Namespace,
+			Name:      functionName,
+		},
+			functionconfig.FunctionStateScaledToZero,
+			30*time.Second)
+
+		// ensure function deployment replicas is zero
+		suite.WaitForFunctionDeployment(functionName, 15*time.Second, func(deployment *appsv1.Deployment) bool {
+			return deployment.Status.Replicas == 0
+		})
+
+		// function has scaled to zero, remove the reactor we added to send "fake" metric values
+		suite.metricClient.ReactionChain = suite.metricClient.ReactionChain[:len(suite.metricClient.ReactionChain)-1]
+
+		// try invoke function without the target header
+		// expect DLX to fail on 400
+		_, _, _ = common.SendHTTPRequest(http.MethodGet,
+			fmt.Sprintf("http://%s:8080", suite.GetTestHost()),
+			[]byte{},
+			map[string]string{},
+			nil,
+			http.StatusBadRequest,
+			true,
+			30*time.Second)
+
+		// add target header, expect it to wake up the function
+		// for this specific test case, the response status code is 502
+		// reason dlx tries to reverse-proxy the request to the function by its service
+		// and since the dlx component is running as a process (and not as a POD)
+		// it fails to resolve the internal (kubernetes) function host
+		// TODO: make DLX work in "test" mode, where it invoke the function from within the k8s cluster
+		//       see suite.KubectlInvokeFunctionViaCurl(functionName, "http://function-service-endpoint:8080")
+		responseBody, _, err := common.SendHTTPRequest(http.MethodGet,
+			fmt.Sprintf("http://%s:8080", suite.GetTestHost()),
+			[]byte{},
+			map[string]string{
+				"X-Nuclio-Target": functionName,
+			},
+			nil,
+			0,
+			true,
+			30*time.Second)
+		suite.Require().NoError(err)
+		suite.Require().Equal([]byte{}, responseBody)
+
+		// function has woken up
+		suite.WaitForFunctionState(&platform.GetFunctionsOptions{
+			Namespace: suite.Namespace,
+			Name:      functionName,
+		},
+			functionconfig.FunctionStateReady,
+			30*time.Second)
 		return true
 	})
-}
-
-func (suite *ResourceScalerTestSuite) scaleFunctionToZero(functionName string) {
-	suite.Logger.InfoWith("Scaling function to zero", "functionName", functionName)
-
-	// get function resources
-	resources, err := suite.resourceScaler.GetResources()
-	suite.Require().NoError(err)
-
-	// scale function to zero
-	err = suite.resourceScaler.SetScale(resources, 0)
-	suite.Require().NoError(err)
-
-	// wait for function to scale
-	suite.WaitForFunctionState(&platform.GetFunctionsOptions{
-		Namespace: suite.Namespace,
-		Name:      functionName,
-	},
-		functionconfig.FunctionStateScaledToZero,
-		30*time.Second)
-
-	// ensure function deployment replicas is zero
-	suite.WaitForFunctionDeployment(functionName, 15*time.Second, func(deployment *appsv1.Deployment) bool {
-		return deployment.Status.Replicas == 0
-	})
-}
-
-func (suite *ResourceScalerTestSuite) scaleFunctionFromZero(functionName string) {
-	suite.Logger.InfoWith("Scaling function from zero", "functionName", functionName)
-
-	// scale function from zero
-	err := suite.resourceScaler.SetScale([]scalertypes.Resource{
-		{
-			Name:      functionName,
-			Namespace: suite.Namespace,
-		},
-	}, 1)
-	suite.Require().NoError(err)
-
-	// wait for function to scale
-	suite.WaitForFunctionState(&platform.GetFunctionsOptions{
-		Namespace: suite.Namespace,
-		Name:      functionName,
-	},
-		functionconfig.FunctionStateReady,
-		30*time.Second)
-
-	// ensure function deployment replicas is zero
-	suite.WaitForFunctionDeployment(functionName, 15*time.Second, func(deployment *appsv1.Deployment) bool {
-		return deployment.Status.Replicas == 1
-	})
-}
-
-func (suite *ResourceScalerTestSuite) mockMetricClient(functionName string, value resource.Quantity) {
-	config, _ := suite.resourceScaler.GetConfig()
-	windowSizeDuration, _ := time.ParseDuration(suite.PlatformConfiguration.ScaleToZero.ScaleResources[0].WindowSize)
-
-	functionResource := scalertypes.Resource{}
-	functionResource.ScaleResources = []scalertypes.ScaleResource{
-		{
-			MetricName: suite.PlatformConfiguration.ScaleToZero.ScaleResources[0].MetricName,
-			WindowSize: scalertypes.Duration{
-				Duration: windowSizeDuration,
-			},
-			Threshold: suite.PlatformConfiguration.ScaleToZero.ScaleResources[0].Threshold,
-		},
-	}
-	action := fake.NewGetForAction(config.AutoScalerOptions.GroupKind,
-		suite.Namespace,
-		"*",
-		functionResource.ScaleResources[0].GetKubernetesMetricName(), labels.Everything())
-	_, err := suite.metricClient.Invokes(action, &v1beta2.MetricValueList{
-		Items: []v1beta2.MetricValue{
-			{
-				DescribedObject: v1.ObjectReference{
-					Name:      functionName,
-					Namespace: suite.Namespace,
-				},
-				Value: value,
-			},
-		},
-	})
-	suite.Require().NoError(err)
 }
 
 func TestControllerTestSuite(t *testing.T) {

--- a/pkg/processor/cloudevent/mockevent.go
+++ b/pkg/processor/cloudevent/mockevent.go
@@ -101,7 +101,7 @@ func (me *mockEvent) GetHeaders() map[string]interface{} {
 // GetField returns the field by name as an interface{}
 func (me *mockEvent) GetField(key string) interface{} {
 	args := me.Called(key)
-	return args.Get(0).(interface{})
+	return args.Get(0)
 }
 
 // GetFieldByteSlice returns the field by name as a byte slice

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -299,11 +299,12 @@ func (suite *TestSuite) WaitForFunctionState(getFunctionOptions *platform.GetFun
 	suite.Require().NoError(err, "Function did not reach its desired state")
 }
 
-// CreateFunction builds a docker image, runs a container from it and then
+// DeployFunction builds a docker image, runs a container from it and then
 // runs onAfterContainerRun
 func (suite *TestSuite) DeployFunction(createFunctionOptions *platform.CreateFunctionOptions,
 	onAfterContainerRun OnAfterContainerRun) *platform.CreateFunctionResult {
-	deployResult, _ := suite.deployFunctionPopulateMissingFields(createFunctionOptions, onAfterContainerRun)
+	deployResult, err := suite.deployFunctionPopulateMissingFields(createFunctionOptions, onAfterContainerRun)
+	suite.Require().NoError(err)
 	return deployResult
 }
 

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -221,7 +221,7 @@ func (ar *AbstractResource) parseURLParamValue(paramValue string) interface{} {
 		return parsedUint
 	}
 
-	parsedFloat, err := strconv.ParseFloat(paramValue, 10)
+	parsedFloat, err := strconv.ParseFloat(paramValue, 64)
 	if err == nil {
 		return parsedFloat
 	}


### PR DESCRIPTION
Bump `v3io/scaler` pkg version to 0.5.0

Changes
1. better integration with `v3io/scaler` for further desired features
2. first integration of scale to/from zero (using fake metric client)
3. accomodate scaler loggers to nuclio's loggersinks
