### PR TITLE
CI - update lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,10 +4,9 @@ linters:
     - deadcode
     - goconst
     - gofmt
-    - golint
+    - revive
     - gosimple
     - ineffassign
-    - interfacer
     - misspell
     - staticcheck
     - unconvert
@@ -37,6 +36,13 @@ run:
     - vendor
 
 linters-settings:
+  revive:
+    rules:
+
+        # avoid  errorf: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)  messages
+      - name: errorf
+        disabled: true
+
   gocritic:
     disabled-checks:
       - commentFormatting # we dont want to enforce space before the comment text

--- a/Makefile
+++ b/Makefile
@@ -449,7 +449,7 @@ lint: modules
 		&& chmod +x $(GOPATH)/bin/impi)
 
 	@test -e $(GOPATH)/bin/golangci-lint || \
-	  	(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.36.0)
+	  	(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.41.1)
 
 	@echo Verifying imports...
 	$(GOPATH)/bin/impi \

--- a/pkg/common/strings.go
+++ b/pkg/common/strings.go
@@ -49,7 +49,7 @@ func CompareTwoStrings(stringOne, stringTwo string) float32 {
 		firstBigrams[bigram] = count
 	}
 
-	var intersectionSize float32 = 0
+	var intersectionSize float32
 
 	for i := 0; i < len(stringTwo)-1; i++ {
 		a := fmt.Sprintf("%c", stringTwo[i])

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -150,7 +150,7 @@ func (fsr *frontendSpecResource) GetCustomRoutes() ([]restful.CustomRoute, error
 }
 
 func (fsr *frontendSpecResource) resolveDefaultServiceType() v1.ServiceType {
-	var defaultServiceType v1.ServiceType = ""
+	var defaultServiceType v1.ServiceType
 	if dashboardServer, ok := fsr.resource.GetServer().(*dashboard.Server); ok {
 		defaultServiceType = dashboardServer.GetPlatformConfiguration().Kube.DefaultServiceType
 	}

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1301,11 +1301,7 @@ func (p *Platform) ValidateAPIGatewayConfig(platformAPIGateway *platform.APIGate
 		return errors.Wrap(err, "Failed to validate the API-gateway spec")
 	}
 
-	if err := p.validateAPIGatewayIngresses(platformAPIGateway); err != nil {
-		return err
-	}
-
-	return nil
+	return p.validateAPIGatewayIngresses(platformAPIGateway)
 }
 
 func (p *Platform) ValidateFunctionConfig(functionConfig *functionconfig.Config) error {


### PR DESCRIPTION
`golint` and `interfacer` are no longer supported.
added `revive` as a replacement  for `golint`