### PR TITLE
API Gateway - add needed header to allow STZ mechanism to work

### DIFF
--- a/pkg/common/k8s.go
+++ b/pkg/common/k8s.go
@@ -58,8 +58,7 @@ func getKubeconfigFromHomeDir() string {
 	homeKubeConfigPath := filepath.Join(homeDir, ".kube", "config")
 
 	// if the file exists @ home, use it
-	_, err = os.Stat(homeKubeConfigPath)
-	if err == nil {
+	if _, err := os.Stat(homeKubeConfigPath); err == nil {
 		return homeKubeConfigPath
 	}
 

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1742,7 +1742,7 @@ func (suite *projectTestSuite) TestImportSuccessful() {
 		suite.Require().Equal("p1-namespace", createAPIGatewayOptions.APIGatewayConfig.Meta.Namespace)
 		suite.Require().Equal("some-host", createAPIGatewayOptions.APIGatewayConfig.Spec.Host)
 		suite.Require().Equal(platform.APIGatewayUpstreamKindNuclioFunction, createAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[0].Kind)
-		suite.Require().Equal("f1", createAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[0].Nucliofunction.Name)
+		suite.Require().Equal("f1", createAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[0].NuclioFunction.Name)
 
 		return true
 	}
@@ -1896,7 +1896,7 @@ func (suite *projectTestSuite) TestImportFunctionExistsSuccessful() {
 	apiGateway.APIGatewayConfig.Spec.Upstreams = []platform.APIGatewayUpstreamSpec{
 		{
 			Kind: platform.APIGatewayUpstreamKindNuclioFunction,
-			Nucliofunction: &platform.NuclioFunctionAPIGatewaySpec{
+			NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{
 				Name: "f1",
 			},
 		},
@@ -1927,7 +1927,7 @@ func (suite *projectTestSuite) TestImportFunctionExistsSuccessful() {
 		suite.Require().Equal("p1-namespace", createAPIGatewayOptions.APIGatewayConfig.Meta.Namespace)
 		suite.Require().Equal("host-name1", createAPIGatewayOptions.APIGatewayConfig.Spec.Host)
 		suite.Require().Equal(platform.APIGatewayUpstreamKindNuclioFunction, createAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[0].Kind)
-		suite.Require().Equal("f1", createAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[0].Nucliofunction.Name)
+		suite.Require().Equal("f1", createAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[0].NuclioFunction.Name)
 
 		return true
 	}
@@ -2599,12 +2599,12 @@ func (suite *apiGatewayTestSuite) TestGetDetailSuccessful() {
 				Upstreams: []platform.APIGatewayUpstreamSpec{
 					{
 						Kind: platform.APIGatewayUpstreamKindNuclioFunction,
-						Nucliofunction: &platform.NuclioFunctionAPIGatewaySpec{
+						NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{
 							Name: "f1",
 						},
 					}, {
 						Kind: platform.APIGatewayUpstreamKindNuclioFunction,
-						Nucliofunction: &platform.NuclioFunctionAPIGatewaySpec{
+						NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{
 							Name: "f2",
 						},
 						Percentage: 20,
@@ -2710,12 +2710,12 @@ func (suite *apiGatewayTestSuite) TestGetListSuccessful() {
 	returnedAPIGateway1.APIGatewayConfig.Spec.Upstreams = []platform.APIGatewayUpstreamSpec{
 		{
 			Kind: platform.APIGatewayUpstreamKindNuclioFunction,
-			Nucliofunction: &platform.NuclioFunctionAPIGatewaySpec{
+			NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{
 				Name: "f1",
 			},
 		}, {
 			Kind: platform.APIGatewayUpstreamKindNuclioFunction,
-			Nucliofunction: &platform.NuclioFunctionAPIGatewaySpec{
+			NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{
 				Name: "f2",
 			},
 			Percentage: 20,
@@ -2740,12 +2740,12 @@ func (suite *apiGatewayTestSuite) TestGetListSuccessful() {
 	returnedAPIGateway2.APIGatewayConfig.Spec.Upstreams = []platform.APIGatewayUpstreamSpec{
 		{
 			Kind: platform.APIGatewayUpstreamKindNuclioFunction,
-			Nucliofunction: &platform.NuclioFunctionAPIGatewaySpec{
+			NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{
 				Name: "f3",
 			},
 		}, {
 			Kind: platform.APIGatewayUpstreamKindNuclioFunction,
-			Nucliofunction: &platform.NuclioFunctionAPIGatewaySpec{
+			NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{
 				Name: "f4",
 			},
 			Percentage: 50,
@@ -2870,9 +2870,9 @@ func (suite *apiGatewayTestSuite) TestCreateSuccessful() {
 		suite.Require().Equal("some-desc2", createAPIGatewayOptions.APIGatewayConfig.Spec.Description)
 		suite.Require().Equal("some-path2", createAPIGatewayOptions.APIGatewayConfig.Spec.Path)
 		suite.Require().Equal(platform.APIGatewayUpstreamKindNuclioFunction, createAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[0].Kind)
-		suite.Require().Equal("f3", createAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[0].Nucliofunction.Name)
+		suite.Require().Equal("f3", createAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[0].NuclioFunction.Name)
 		suite.Require().Equal(platform.APIGatewayUpstreamKindNuclioFunction, createAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[1].Kind)
-		suite.Require().Equal("f4", createAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[1].Nucliofunction.Name)
+		suite.Require().Equal("f4", createAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[1].NuclioFunction.Name)
 		suite.Require().Equal(50, createAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[1].Percentage)
 
 		return true
@@ -2935,9 +2935,9 @@ func (suite *apiGatewayTestSuite) TestUpdateSuccessful() {
 		suite.Require().Equal("some-desc2", updateAPIGatewayOptions.APIGatewayConfig.Spec.Description)
 		suite.Require().Equal("some-path2", updateAPIGatewayOptions.APIGatewayConfig.Spec.Path)
 		suite.Require().Equal(platform.APIGatewayUpstreamKindNuclioFunction, updateAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[0].Kind)
-		suite.Require().Equal("f3", updateAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[0].Nucliofunction.Name)
+		suite.Require().Equal("f3", updateAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[0].NuclioFunction.Name)
 		suite.Require().Equal(platform.APIGatewayUpstreamKindNuclioFunction, updateAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[1].Kind)
-		suite.Require().Equal("f4", updateAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[1].Nucliofunction.Name)
+		suite.Require().Equal("f4", updateAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[1].NuclioFunction.Name)
 		suite.Require().Equal(50, updateAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[1].Percentage)
 
 		return true

--- a/pkg/nuctl/command/common/renderers.go
+++ b/pkg/nuctl/command/common/renderers.go
@@ -216,13 +216,13 @@ func RenderAPIGateways(apiGateways []platform.APIGateway,
 		for _, apiGateway := range apiGateways {
 
 			// primary function
-			primaryFunction := apiGateway.GetConfig().Spec.Upstreams[0].Nucliofunction.Name
+			primaryFunction := apiGateway.GetConfig().Spec.Upstreams[0].NuclioFunction.Name
 
 			// get canaryFunction if it exists
 			canaryFunction := ""
 			canaryPercentage := 0
 			if len(apiGateway.GetConfig().Spec.Upstreams) == 2 {
-				canaryFunction = apiGateway.GetConfig().Spec.Upstreams[1].Nucliofunction.Name
+				canaryFunction = apiGateway.GetConfig().Spec.Upstreams[1].NuclioFunction.Name
 				canaryPercentage = apiGateway.GetConfig().Spec.Upstreams[1].Percentage
 			}
 

--- a/pkg/nuctl/command/create.go
+++ b/pkg/nuctl/command/create.go
@@ -194,7 +194,7 @@ func newCreateAPIGatewayCommandeer(createCommandeer *createCommandeer) *createAP
 			commandeer.apiGatewayConfig.Spec.Upstreams = []platform.APIGatewayUpstreamSpec{
 				{
 					Kind: platform.APIGatewayUpstreamKindNuclioFunction,
-					Nucliofunction: &platform.NuclioFunctionAPIGatewaySpec{
+					NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{
 						Name: commandeer.function,
 					},
 				},
@@ -207,7 +207,7 @@ func newCreateAPIGatewayCommandeer(createCommandeer *createCommandeer) *createAP
 
 				canaryUpstream := platform.APIGatewayUpstreamSpec{
 					Kind: platform.APIGatewayUpstreamKindNuclioFunction,
-					Nucliofunction: &platform.NuclioFunctionAPIGatewaySpec{
+					NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{
 						Name: commandeer.canaryFunction,
 					},
 					Percentage: commandeer.canaryPercentage,

--- a/pkg/nuctl/test/project_test.go
+++ b/pkg/nuctl/test/project_test.go
@@ -314,7 +314,7 @@ func (suite *projectExportImportTestSuite) TestExportProject() {
 		suite.Assert().Equal(exportedProjectConfig.APIGateways[apiGatewayName].Meta.Name, apiGatewayName)
 		suite.Assert().Equal(exportedProjectConfig.APIGateways[apiGatewayName].Spec.Host, fmt.Sprintf("host-%s", apiGatewayName))
 		suite.Assert().Equal(exportedProjectConfig.APIGateways[apiGatewayName].Spec.Upstreams[0].Kind, platform.APIGatewayUpstreamKindNuclioFunction)
-		suite.Assert().Equal(exportedProjectConfig.APIGateways[apiGatewayName].Spec.Upstreams[0].Nucliofunction.Name, functionName)
+		suite.Assert().Equal(exportedProjectConfig.APIGateways[apiGatewayName].Spec.Upstreams[0].NuclioFunction.Name, functionName)
 	}
 }
 
@@ -669,7 +669,7 @@ func (suite *projectExportImportTestSuite) addUniqueSuffixToImportConfig(configP
 		apiGateways[apiGatewayUniqueName].Spec.Upstreams = []platform.APIGatewayUpstreamSpec{
 			{
 				Kind: platform.APIGatewayUpstreamKindNuclioFunction,
-				Nucliofunction: &platform.NuclioFunctionAPIGatewaySpec{
+				NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{
 					Name: functionNames[index] + uniqueSuffix,
 				},
 			},

--- a/pkg/nuctl/test/suite.go
+++ b/pkg/nuctl/test/suite.go
@@ -239,7 +239,7 @@ func (suite *Suite) verifyAPIGatewayExists(apiGatewayName, primaryFunctionName s
 	suite.Require().NoError(err)
 
 	suite.Assert().Equal(apiGatewayName, apiGateway.Meta.Name)
-	suite.Assert().Equal(primaryFunctionName, apiGateway.Spec.Upstreams[0].Nucliofunction.Name)
+	suite.Assert().Equal(primaryFunctionName, apiGateway.Spec.Upstreams[0].NuclioFunction.Name)
 }
 
 func (suite *Suite) assertFunctionImported(functionName string, imported bool) {

--- a/pkg/platform/kube/apigatewayres/lazy.go
+++ b/pkg/platform/kube/apigatewayres/lazy.go
@@ -26,7 +26,7 @@ import (
 //
 
 type lazyClient struct {
-	Logger          logger.Logger
+	logger          logger.Logger
 	kubeClientSet   kubernetes.Interface
 	nuclioClientSet nuclioio_client.Interface
 	ingressManager  *ingress.Manager
@@ -38,7 +38,7 @@ func NewLazyClient(loggerInstance logger.Logger,
 	ingressManager *ingress.Manager) (Client, error) {
 
 	newClient := lazyClient{
-		Logger:          loggerInstance.GetChild("apigatewayres"),
+		logger:          loggerInstance.GetChild("apigatewayres"),
 		kubeClientSet:   kubeClientSet,
 		nuclioClientSet: nuclioClientSet,
 		ingressManager:  ingressManager,
@@ -56,124 +56,106 @@ func (lc *lazyClient) Get(ctx context.Context, namespace string, name string) (R
 }
 
 func (lc *lazyClient) CreateOrUpdate(ctx context.Context, apiGateway *nuclioio.NuclioAPIGateway) (Resources, error) {
-	var appliedIngressNames []string
-
 	apiGateway.Status.Name = apiGateway.Spec.Name
 
 	if err := lc.validateSpec(apiGateway); err != nil {
 		return nil, errors.Wrap(err, "Api gateway spec validation failed")
 	}
 
-	// generate an ingress for each upstream
-	upstreams := apiGateway.Spec.Upstreams
-	ingresses := map[string]*ingress.Resources{}
-
 	// always try to remove previous canary ingress first, because
 	// nginx returns 503 on all requests if primary service == secondary service. (happens on every promotion)
 	// so during promotion all requests will be sent to the primary ingress
 	lc.tryRemovePreviousCanaryIngress(ctx, apiGateway)
 
-	if len(upstreams) == 1 {
+	// generate an ingress for each upstream
+	ingressesResources := map[string]*ingress.Resources{}
+	var ingressesToCreate []*ingress.Resources
 
-		// create just a single ingress
-		ingressResources, err := lc.generateNginxIngress(ctx, apiGateway, upstreams[0])
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to generate nginx ingress")
-		}
+	primaryUpstream, canaryUpstream, err := lc.resolveBaseAndCanaryUpstreamsFromSpec(apiGateway.Spec.Upstreams)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to resolve base and canary upstreams")
+	}
 
-		ingresses[ingressResources.Ingress.Name] = ingressResources
+	// create primary ingress
+	primaryIngressResources, err := lc.generateNginxIngress(ctx, apiGateway, primaryUpstream)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to generate primary nginx ingress")
+	}
 
-	} else if len(upstreams) == 2 {
-		var canaryUpstream platform.APIGatewayUpstreamSpec
-		var baseUpstream platform.APIGatewayUpstreamSpec
+	lc.enrichPrimaryIngressResources(primaryIngressResources, primaryUpstream, canaryUpstream)
 
-		// determine which upstream is the canary one
-		switch {
-		case upstreams[0].Percentage != 0:
-			baseUpstream = upstreams[1]
-			canaryUpstream = upstreams[0]
-		case upstreams[1].Percentage != 0:
-			baseUpstream = upstreams[0]
-			canaryUpstream = upstreams[1]
-		default:
-			return nil, errors.New("Percentage must be set on one of the upstreams (canary)")
-		}
+	ingressesResources[primaryIngressResources.Ingress.Name] = primaryIngressResources
+	ingressesToCreate = append(ingressesToCreate, primaryIngressResources)
 
-		// validity check
+	// add the canary ingress
+	if canaryUpstream != nil {
+
+		// percentage range
 		if canaryUpstream.Percentage > 100 || canaryUpstream.Percentage < 1 {
 			return nil, errors.New("The canary upstream percentage must be between 1 and 100")
 		}
 
-		// add the base ingress
-		baseIngressResources, err := lc.generateNginxIngress(ctx, apiGateway, baseUpstream)
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to generate the base nginx ingress")
-		}
-		ingresses[baseIngressResources.Ingress.Name] = baseIngressResources
-
-		// add the canary ingress
 		canaryIngressResources, err := lc.generateNginxIngress(ctx, apiGateway, canaryUpstream)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to generate the canary nginx ingress")
 		}
-		ingresses[canaryIngressResources.Ingress.Name] = canaryIngressResources
+		ingressesResources[canaryIngressResources.Ingress.Name] = canaryIngressResources
+		ingressesToCreate = append(ingressesToCreate, canaryIngressResources)
 	}
 
 	// create ingresses
 	// must be done synchronously, first primary and then canary
 	// otherwise, when there is only canary ingress, the endpoint will not work (nginx behavior)
-	for ingressName, ingressResources := range ingresses {
+	for _, ingressResources := range ingressesToCreate {
 		if _, _, err := lc.ingressManager.CreateOrUpdateResources(ingressResources); err != nil {
-			lc.Logger.WarnWithCtx(ctx, "Failed to create/update api gateway ingress resources",
+			lc.logger.WarnWithCtx(ctx, "Failed to create/update api gateway ingress resources",
 				"err", errors.Cause(err),
-				"ingressName", ingressName,
-				"appliedIngressNames", appliedIngressNames)
+				"ingressName", ingressResources.Ingress.Name)
 			return nil, errors.New("Failed to create/update api gateway ingress resources")
 		}
-
-		appliedIngressNames = append(appliedIngressNames, ingressName)
 	}
 
 	return &lazyResources{
-		ingressResourcesMap: ingresses,
+		ingressResourcesMap: ingressesResources,
 	}, nil
 }
 
 func (lc *lazyClient) WaitAvailable(ctx context.Context, namespace string, name string) {
-	lc.Logger.Debug("Sleeping for 4 seconds so nginx controller will stabilize")
+	lc.logger.Debug("Sleeping for 4 seconds so nginx controller will stabilize")
 
 	// sleep 4 seconds as a safety, so nginx will finish updating the ingresses properly (it takes time)
 	time.Sleep(4 * time.Second)
 }
 
 func (lc *lazyClient) Delete(ctx context.Context, namespace string, name string) {
-	lc.Logger.DebugWithCtx(ctx, "Deleting api gateway base ingress", "name", name)
+	lc.logger.DebugWithCtx(ctx, "Deleting api gateway base ingress", "name", name)
 
 	err := lc.ingressManager.DeleteByName(kube.IngressNameFromAPIGatewayName(name, false), namespace, true)
 	if err != nil {
-		lc.Logger.WarnWithCtx(ctx, "Failed to delete base ingress. Continuing with deletion",
+		lc.logger.WarnWithCtx(ctx, "Failed to delete base ingress. Continuing with deletion",
 			"err", errors.Cause(err))
 	}
 
-	lc.Logger.DebugWithCtx(ctx, "Deleting api gateway canary ingress", "name", name)
+	lc.logger.DebugWithCtx(ctx, "Deleting api gateway canary ingress", "name", name)
 
 	err = lc.ingressManager.DeleteByName(kube.IngressNameFromAPIGatewayName(name, true), namespace, true)
 	if err != nil {
-		lc.Logger.WarnWithCtx(ctx, "Failed to delete canary ingress. Continuing with deletion",
+		lc.logger.WarnWithCtx(ctx, "Failed to delete canary ingress. Continuing with deletion",
 			"err", errors.Cause(err))
 	}
 }
 
 func (lc *lazyClient) tryRemovePreviousCanaryIngress(ctx context.Context, apiGateway *nuclioio.NuclioAPIGateway) {
-	lc.Logger.DebugWithCtx(ctx, "Trying to remove previous canary ingress",
+	lc.logger.DebugWithCtx(ctx, "Trying to remove previous canary ingress",
 		"apiGatewayName", apiGateway.Name)
 
 	// remove old canary ingress if it exists
 	// this works thanks to an assumption that ingress names == api gateway name
 	previousCanaryIngressName := kube.IngressNameFromAPIGatewayName(apiGateway.Name, true)
-	err := lc.ingressManager.DeleteByName(previousCanaryIngressName, apiGateway.Namespace, true)
-	if err != nil {
-		lc.Logger.WarnWithCtx(ctx,
+	if err := lc.ingressManager.DeleteByName(previousCanaryIngressName,
+		apiGateway.Namespace,
+		true); err != nil {
+		lc.logger.WarnWithCtx(ctx,
 			"Failed to delete previous canary ingress on api gateway update",
 			"previousCanaryIngressName", previousCanaryIngressName,
 			"err", errors.Cause(err))
@@ -195,9 +177,9 @@ func (lc *lazyClient) validateSpec(apiGateway *nuclioio.NuclioAPIGateway) error 
 		return errors.Wrap(err, "Failed while getting all existing upstreams")
 	}
 	for _, upstream := range upstreams {
-		if common.StringSliceContainsString(existingUpstreamFunctionNames, upstream.Nucliofunction.Name) {
+		if common.StringSliceContainsString(existingUpstreamFunctionNames, upstream.NuclioFunction.Name) {
 			return errors.Errorf("Nuclio function '%s' is already being used in another api gateway",
-				upstream.Nucliofunction.Name)
+				upstream.NuclioFunction.Name)
 		}
 	}
 
@@ -220,7 +202,7 @@ func (lc *lazyClient) getAllExistingUpstreamFunctionNames(namespace, apiGatewayN
 		}
 
 		for _, upstream := range apiGateway.Spec.Upstreams {
-			existingUpstreamNames = append(existingUpstreamNames, upstream.Nucliofunction.Name)
+			existingUpstreamNames = append(existingUpstreamNames, upstream.NuclioFunction.Name)
 		}
 	}
 
@@ -229,9 +211,9 @@ func (lc *lazyClient) getAllExistingUpstreamFunctionNames(namespace, apiGatewayN
 
 func (lc *lazyClient) generateNginxIngress(ctx context.Context,
 	apiGateway *nuclioio.NuclioAPIGateway,
-	upstream platform.APIGatewayUpstreamSpec) (*ingress.Resources, error) {
+	upstream *platform.APIGatewayUpstreamSpec) (*ingress.Resources, error) {
 
-	serviceName, servicePort, err := lc.getServiceNameAndPort(upstream, apiGateway.Namespace)
+	serviceName, servicePort, err := lc.getServiceNameAndPort(upstream)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get service name")
 	}
@@ -292,27 +274,21 @@ func (lc *lazyClient) generateNginxIngress(ctx context.Context,
 	return lc.ingressManager.GenerateResources(ctx, commonIngressSpec)
 }
 
-func (lc *lazyClient) getServiceNameAndPort(upstream platform.APIGatewayUpstreamSpec,
-	namespace string) (string, int, error) {
+func (lc *lazyClient) getServiceNameAndPort(upstream *platform.APIGatewayUpstreamSpec) (string, int, error) {
 	switch upstream.Kind {
 	case platform.APIGatewayUpstreamKindNuclioFunction:
-		return lc.getNuclioFunctionServiceNameAndPort(upstream, namespace)
+
+		// we used to get service name by actually getting the function's service
+		// it was "stupified" to this logic, in order to prevent api-gateway failing when a function has no service
+		// (which may happen when a function is imported, but not yet deployed, and in that point we import an api-gateway
+		// that has this function as an upstream)
+		serviceName := kube.ServiceNameFromFunctionName(upstream.NuclioFunction.Name)
+
+		// use default port
+		return serviceName, abstract.FunctionContainerHTTPPort, nil
 	default:
 		return "", 0, errors.Errorf("Unsupported API gateway upstream kind: %s", upstream.Kind)
 	}
-}
-
-func (lc *lazyClient) getNuclioFunctionServiceNameAndPort(upstream platform.APIGatewayUpstreamSpec,
-	namespace string) (string, int, error) {
-
-	// we used to get service name by actually getting the function's service
-	// it was "stupified" to this logic, in order to prevent api-gateway failing when a function has no service
-	// (which may happen when a function is imported, but not yet deployed, and in that point we import an api-gateway
-	// that has this function as an upstream)
-	serviceName := kube.ServiceNameFromFunctionName(upstream.Nucliofunction.Name)
-
-	// use default port
-	return serviceName, abstract.FunctionContainerHTTPPort, nil
 }
 
 func (lc *lazyClient) resolveCommonAnnotations(canaryDeployment bool, upstreamPercentage int) map[string]string {
@@ -329,6 +305,8 @@ func (lc *lazyClient) resolveCommonAnnotations(canaryDeployment bool, upstreamPe
 	return annotations
 }
 
+func (lc *lazyClient) resolveBaseAndCanaryUpstreamsFromSpec(upstreams []platform.APIGatewayUpstreamSpec) (
+}
 //
 // Resources
 //

--- a/pkg/platform/kube/apigatewayres/lazy_test.go
+++ b/pkg/platform/kube/apigatewayres/lazy_test.go
@@ -1,0 +1,117 @@
+// +build test_unit
+
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apigatewayres
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platform"
+	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+	"github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/versioned/fake"
+	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+type lazyTestSuite struct {
+	suite.Suite
+	logger         logger.Logger
+	client         Client
+	ingressManager *ingress.Manager
+}
+
+func (suite *lazyTestSuite) SetupTest() {
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
+
+	platformConfig, err := platformconfig.NewPlatformConfig("")
+	suite.Require().NoError(err)
+
+	kubeClientset := k8sfake.NewSimpleClientset()
+	suite.ingressManager, err = ingress.NewManager(suite.logger, kubeClientset, platformConfig)
+	suite.Require().NoError(err)
+
+	suite.client, err = NewLazyClient(suite.logger,
+		kubeClientset,
+		fake.NewSimpleClientset(),
+		suite.ingressManager)
+	suite.Require().NoError(err)
+}
+
+func (suite *lazyTestSuite) TestNodeConstrains() {
+	primaryFunctionConfig := *functionconfig.NewConfig()
+	primaryFunctionConfig.Meta.Name = "primary-function-name"
+	canaryFunctionConfig := *functionconfig.NewConfig()
+	canaryFunctionConfig.Meta.Name = "canary-function-name"
+	resources, err := suite.client.CreateOrUpdate(context.TODO(), &nuclioio.NuclioAPIGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-name",
+			Namespace: "test-namespace",
+		},
+
+		Spec: platform.APIGatewaySpec{
+			Host:               "some-host.com",
+			Name:               "test-name",
+			AuthenticationMode: ingress.AuthenticationModeBasicAuth,
+			Authentication: &platform.APIGatewayAuthenticationSpec{
+				BasicAuth: &platform.BasicAuth{
+					Username: "moshe",
+					Password: "ehsom",
+				},
+			},
+			Upstreams: []platform.APIGatewayUpstreamSpec{
+				{
+					Kind: platform.APIGatewayUpstreamKindNuclioFunction,
+					NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{
+						Name: primaryFunctionConfig.Meta.Name,
+					},
+				},
+				{
+					Kind: platform.APIGatewayUpstreamKindNuclioFunction,
+					NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{
+						Name: canaryFunctionConfig.Meta.Name,
+					},
+					Percentage: 20,
+				},
+			},
+		},
+	})
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resources.IngressResourcesMap())
+	for resourceName, resource := range resources.IngressResourcesMap() {
+		if !strings.HasSuffix(resourceName, "-canary") {
+
+			// expect primary function ingress to have `X-Nuclio-Target`
+			// so that if has STZ option, it would wake up upon a request
+			suite.Require().Equal(`proxy_set_header X-Nuclio-Target "primary-function-name";`,
+				resource.Ingress.Annotations["nginx.ingress.kubernetes.io/configuration-snippet"])
+		}
+	}
+}
+
+func TestLazyTestSuite(t *testing.T) {
+	suite.Run(t, new(lazyTestSuite))
+}

--- a/pkg/platform/kube/ingress/ingress.go
+++ b/pkg/platform/kube/ingress/ingress.go
@@ -198,7 +198,7 @@ func (m *Manager) CreateOrUpdateResources(resources *Resources) (*v1beta1.Ingres
 	return appliedIngress, appliedBasicAuthSecret, nil
 }
 
-// deletes ingress resource
+// DeleteByName deletes an ingress resource by name
 // when deleteAuthSecret == true, delete related secret resource too
 func (m *Manager) DeleteByName(ingressName string, namespace string, deleteAuthSecret bool) error {
 	var ingress *v1beta1.Ingress

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1117,8 +1117,8 @@ func (p *Platform) generateFunctionToAPIGatewaysMapping(namespace string) (map[s
 		for _, upstream := range apiGateway.Spec.Upstreams {
 
 			// append the current api gateway to the function's api gateways list
-			functionToAPIGateways[upstream.Nucliofunction.Name] =
-				append(functionToAPIGateways[upstream.Nucliofunction.Name], apiGateway.Name)
+			functionToAPIGateways[upstream.NuclioFunction.Name] =
+				append(functionToAPIGateways[upstream.NuclioFunction.Name], apiGateway.Name)
 		}
 	}
 
@@ -1491,7 +1491,7 @@ func (p *Platform) validateAPIGatewayFunctionsHaveNoIngresses(apiGatewayConfig *
 	for _, upstream := range apiGatewayConfig.Spec.Upstreams {
 		upstream := upstream
 		errGroup.Go("GetFunctionIngresses", func() error {
-			function, err := p.getFunction(apiGatewayConfig.Meta.Namespace, upstream.Nucliofunction.Name)
+			function, err := p.getFunction(apiGatewayConfig.Meta.Namespace, upstream.NuclioFunction.Name)
 			if err != nil {
 				return errors.New("Failed to get upstream function")
 			}
@@ -1505,7 +1505,7 @@ func (p *Platform) validateAPIGatewayFunctionsHaveNoIngresses(apiGatewayConfig *
 			if len(ingresses) > 0 {
 				return nuclio.NewErrPreconditionFailed(
 					fmt.Sprintf("Api gateway upstream function: %s must not have an ingress",
-						upstream.Nucliofunction.Name))
+						upstream.NuclioFunction.Name))
 			}
 			return nil
 		})

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -384,7 +384,7 @@ func (suite *FunctionKubePlatformTestSuite) TestGetFunctionInstanceAndConfig() {
 							Upstreams: []platform.APIGatewayUpstreamSpec{
 								{
 									Kind: platform.APIGatewayUpstreamKindNuclioFunction,
-									Nucliofunction: &platform.NuclioFunctionAPIGatewaySpec{
+									NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{
 										Name: testCase.functionName,
 									},
 								},
@@ -1623,7 +1623,7 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayEnrichmentAndValidat
 			name: "ValidateAPIGatewayFunctionHasNoIngresses",
 			apiGatewayConfig: func() *platform.APIGatewayConfig {
 				apiGatewayConfig := suite.compileAPIGatewayConfig()
-				apiGatewayConfig.Spec.Upstreams[0].Nucliofunction.Name = "function-with-ingresses"
+				apiGatewayConfig.Spec.Upstreams[0].NuclioFunction.Name = "function-with-ingresses"
 				return &apiGatewayConfig
 			}(),
 			upstreamFunctions: []*v1beta1.NuclioFunction{
@@ -1651,10 +1651,10 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayEnrichmentAndValidat
 			name: "ValidateAPIGatewayCanaryFunctionHasNoIngresses",
 			apiGatewayConfig: func() *platform.APIGatewayConfig {
 				apiGatewayConfig := suite.compileAPIGatewayConfig()
-				apiGatewayConfig.Spec.Upstreams[0].Nucliofunction.Name = "function-without-ingresses"
+				apiGatewayConfig.Spec.Upstreams[0].NuclioFunction.Name = "function-without-ingresses"
 				apiGatewayConfig.Spec.Upstreams = append(apiGatewayConfig.Spec.Upstreams, platform.APIGatewayUpstreamSpec{
 					Kind: platform.APIGatewayUpstreamKindNuclioFunction,
-					Nucliofunction: &platform.NuclioFunctionAPIGatewaySpec{
+					NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{
 						Name: "function-with-ingresses-2",
 					},
 				})
@@ -1796,7 +1796,7 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayEnrichmentAndValidat
 				}
 
 				suite.nuclioFunctionInterfaceMock.
-					On("Get", upstream.Nucliofunction.Name, metav1.GetOptions{}).
+					On("Get", upstream.NuclioFunction.Name, metav1.GetOptions{}).
 					Return(upstreamFunction, getFunctionsError).
 					Once()
 			}
@@ -1889,7 +1889,7 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayUpdate() {
 
 			// no function with matching upstreams
 			suite.nuclioFunctionInterfaceMock.
-				On("Get", apiGatewayConfig.Spec.Upstreams[0].Nucliofunction.Name, metav1.GetOptions{}).
+				On("Get", apiGatewayConfig.Spec.Upstreams[0].NuclioFunction.Name, metav1.GetOptions{}).
 				Return(nil,
 					&apierrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}).
 				Once()
@@ -1914,7 +1914,7 @@ func (suite *APIGatewayKubePlatformTestSuite) compileAPIGatewayConfig() platform
 			Upstreams: []platform.APIGatewayUpstreamSpec{
 				{
 					Kind: platform.APIGatewayUpstreamKindNuclioFunction,
-					Nucliofunction: &platform.NuclioFunctionAPIGatewaySpec{
+					NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{
 						Name: "default-func-name",
 					},
 				},

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -1017,8 +1017,8 @@ func (suite *DeployAPIGatewayTestSuite) TestDexAuthMode() {
 		createAPIGatewayOptions := suite.compileCreateAPIGatewayOptions(apiGatewayName, functionName)
 		createAPIGatewayOptions.APIGatewayConfig.Spec.AuthenticationMode = ingress.AuthenticationModeOauth2
 		err := suite.deployAPIGateway(createAPIGatewayOptions, func(ingress *extensionsv1beta1.Ingress) {
-			suite.Assert().NotContains(ingress.Annotations, "nginx.ingress.kubernetes.io/auth-signin")
-			suite.Assert().Contains(ingress.Annotations["nginx.ingress.kubernetes.io/auth-url"], configOauth2ProxyURL)
+			suite.Require().NotContains(ingress.Annotations, "nginx.ingress.kubernetes.io/auth-signin")
+			suite.Require().Contains(ingress.Annotations["nginx.ingress.kubernetes.io/auth-url"], configOauth2ProxyURL)
 		})
 		suite.Require().NoError(err)
 

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -1019,6 +1019,8 @@ func (suite *DeployAPIGatewayTestSuite) TestDexAuthMode() {
 		err := suite.deployAPIGateway(createAPIGatewayOptions, func(ingress *extensionsv1beta1.Ingress) {
 			suite.Require().NotContains(ingress.Annotations, "nginx.ingress.kubernetes.io/auth-signin")
 			suite.Require().Contains(ingress.Annotations["nginx.ingress.kubernetes.io/auth-url"], configOauth2ProxyURL)
+			suite.Require().Contains(ingress.Annotations["nginx.ingress.kubernetes.io/configuration-snippet"],
+				fmt.Sprintf(`proxy_set_header X-Nuclio-Target "%s";`, functionName))
 		})
 		suite.Require().NoError(err)
 

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -642,7 +642,7 @@ func (suite *KubeTestSuite) compileCreateAPIGatewayOptions(apiGatewayName string
 				Upstreams: []platform.APIGatewayUpstreamSpec{
 					{
 						Kind: platform.APIGatewayUpstreamKindNuclioFunction,
-						Nucliofunction: &platform.NuclioFunctionAPIGatewaySpec{
+						NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{
 							Name: functionName,
 						},
 					},

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -380,7 +380,7 @@ type NuclioFunctionAPIGatewaySpec struct {
 
 type APIGatewayUpstreamSpec struct {
 	Kind             APIGatewayUpstreamKind        `json:"kind,omitempty"`
-	Nucliofunction   *NuclioFunctionAPIGatewaySpec `json:"nucliofunction,omitempty"`
+	NuclioFunction   *NuclioFunctionAPIGatewaySpec `json:"nucliofunction,omitempty"`
 	Percentage       int                           `json:"percentage,omitempty"`
 	RewriteTarget    string                        `json:"rewriteTarget,omitempty"`
 	ExtraAnnotations map[string]string             `json:"extraAnnotations,omitempty"`


### PR DESCRIPTION
For scale to zero to work, we need to annotate created ingresses with custom header indicating which function should be woken up upon an HTTP request. for that case, upon creating API Gateway record, annotate its primary ingress with `X-Nuclio-Target`.


This does not cover cases with canary deployment just yet, a follow-up PR would come to resolve cases where apigateway have a canary which needs to be woken up as well (or instead).