### PR TITLE
UI: Cron Trigger: fix unexpected change of schedule fields

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5585,9 +5585,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.36.1.tgz",
-      "integrity": "sha512-1fdLMQl4xWVm0kAfemQIdtcy11FcnvTW9OjYaDQ6shDBgdrZ+vbSf/xYgPTYglexdYnfs+tkLWxz6qkdeQf3HQ==",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.36.2.tgz",
+      "integrity": "sha512-UB4GJLIiuWP4cZouC/aoT2HwPSC9Bv2D7OwpXIgH1nS9aiD5leQNFECsPsHDLNnC6XqjNpbJex2d7O6IabK1gw==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.36.1",
+    "iguazio.dashboard-controls": "^0.36.2",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
- “Function“ screen › “Triggers” tab: [bugfix] For triggers of type Cron, the “Schedule” field (bound to attributes.schedule) was unexpectedly changed from 6 fields (for example 0 0 5 * * *) to 5 fields (for example 0 5 * * *) — which totally changed the scheduling of the trigger.

Depends on https://github.com/iguazio/dashboard-controls/pull/1256