### PR TITLE
Fix - Pull base images upon building a function without cache

### DIFF
--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -108,6 +108,7 @@ func (d *Docker) buildContainerImage(buildOptions *BuildOptions) error {
 		Image:          buildOptions.Image,
 		DockerfilePath: buildOptions.DockerfileInfo.DockerfilePath,
 		NoCache:        buildOptions.NoCache,
+		Pull:           buildOptions.Pull,
 		BuildArgs:      buildOptions.BuildArgs,
 	})
 

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -12,6 +12,7 @@ type BuildOptions struct {
 	TempDir             string
 	DockerfileInfo      *runtime.ProcessorDockerfileInfo
 	NoCache             bool
+	Pull                bool
 	NoBaseImagePull     bool
 	BuildArgs           map[string]string
 	RegistryURL         string

--- a/pkg/dockerclient/shell_test.go
+++ b/pkg/dockerclient/shell_test.go
@@ -187,7 +187,7 @@ func (suite *ShellClientTestSuite) TestBuildBailOnUnknownError() {
 		On("Run",
 			mock.Anything,
 			mock.MatchedBy(func(command string) bool {
-				return strings.Contains(command, "docker build %s")
+				return strings.Contains(command, "docker build")
 			}),
 			mock.Anything).
 		Return(cmdrunner.RunResult{
@@ -212,7 +212,7 @@ func (suite *ShellClientTestSuite) TestBuildRetryOnErrors() {
 		On("Run",
 			mock.Anything,
 			mock.MatchedBy(func(command string) bool {
-				return strings.Contains(command, "docker build %s")
+				return strings.Contains(command, "docker build")
 			}),
 			mock.Anything).
 		Return(cmdrunner.RunResult{

--- a/pkg/dockerclient/types.go
+++ b/pkg/dockerclient/types.go
@@ -45,6 +45,7 @@ type BuildOptions struct {
 	ContextDir     string
 	DockerfilePath string
 	NoCache        bool
+	Pull           bool
 	BuildArgs      map[string]string
 }
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1054,10 +1054,14 @@ func (b *Builder) buildProcessorImage() (string, error) {
 	b.logger.InfoWith("Building processor image", "imageName", imageName)
 
 	err = b.platform.BuildAndPushContainerImage(&containerimagebuilderpusher.BuildOptions{
-		ContextDir:          b.stagingDir,
-		Image:               imageName,
-		TempDir:             b.tempDir,
-		DockerfileInfo:      processorDockerfileInfo,
+		ContextDir:     b.stagingDir,
+		Image:          imageName,
+		TempDir:        b.tempDir,
+		DockerfileInfo: processorDockerfileInfo,
+
+		// Conjunct Pull with NoCache
+		// To ensure that when forcing a function build, the base images would be pulled as well.
+		Pull:                b.options.FunctionConfig.Spec.Build.NoCache,
 		NoCache:             b.options.FunctionConfig.Spec.Build.NoCache,
 		NoBaseImagePull:     b.GetNoBaseImagePull(),
 		BuildArgs:           buildArgs,


### PR DESCRIPTION
When building a function w/o docker caching layers `--no-cache`, it does not pull base images if they have changed on upstream.

Associating `NoCache` with `Pull` for function building will ensure that base images would be pulled upon function build with `No Cache`.