### PR TITLE
Preserve build logs

### DIFF
--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -268,6 +268,7 @@ func (fo *functionOperator) setFunctionError(function *nuclioio.NuclioFunction,
 		"err", err)
 
 	if setStatusErr := fo.setFunctionStatus(function, &functionconfig.Status{
+		Logs:    function.Status.Logs,
 		State:   functionErrorState,
 		Message: errors.GetErrorStackString(err, 10),
 	}); setStatusErr != nil {

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -269,6 +269,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 			functionStatus.HTTPPort = existingFunctionInstance.Status.HTTPPort
 			functionStatus.ExternalInvocationURLs = existingFunctionInstance.Status.ExternalInvocationURLs
 			functionStatus.InternalInvocationURLs = existingFunctionInstance.Status.InternalInvocationURLs
+			functionStatus.Logs = existingFunctionInstance.Status.Logs
 
 			// if function deployment ended up with unhealthy, due to unstable Kubernetes env that lead
 			// to failing on waiting for function readiness.

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -173,20 +173,9 @@ func (p *Platform) Initialize() error {
 func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunctionOptions) (
 	*platform.CreateFunctionResult, error) {
 
+	var err error
 	var existingFunctionInstance *nuclioio.NuclioFunction
 	var existingFunctionConfig *functionconfig.ConfigWithStatus
-
-	// wrap logger
-	logStream, err := abstract.NewLogStream("deployer", nucliozap.InfoLevel, createFunctionOptions.Logger)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create a log stream")
-	}
-
-	// save the log stream for the name
-	p.DeployLogStreams.Store(createFunctionOptions.FunctionConfig.Meta.GetUniqueID(), logStream)
-
-	// replace logger
-	createFunctionOptions.Logger = logStream.GetLogger()
 
 	if err := p.enrichAndValidateFunctionConfig(&createFunctionOptions.FunctionConfig); err != nil {
 		return nil, errors.Wrap(err, "Failed to enrich and validate a function configuration")
@@ -223,6 +212,18 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 		createFunctionOptions); err != nil {
 		return nil, errors.Wrap(err, "Failed to validate a function configuration against an existing configuration")
 	}
+
+	// wrap logger
+	logStream, err := abstract.NewLogStream("deployer", nucliozap.InfoLevel, createFunctionOptions.Logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create a log stream")
+	}
+
+	// save the log stream for the name
+	p.DeployLogStreams.Store(createFunctionOptions.FunctionConfig.Meta.GetUniqueID(), logStream)
+
+	// replace logger
+	createFunctionOptions.Logger = logStream.GetLogger()
 
 	// called when function creation failed, update function status with failure
 	reportCreationError := func(creationError error, briefErrorsMessage string, clearCallStack bool) error {

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -303,8 +303,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 			functionStatus.HTTPPort = createFunctionResult.Port
 			functionStatus.State = functionconfig.FunctionStateReady
 
-			if err := p.populateFunctionInvocationStatus(&functionStatus,
-				createFunctionResult); err != nil {
+			if err := p.populateFunctionInvocationStatus(&functionStatus, createFunctionResult); err != nil {
 				return nil, errors.Wrap(err, "Failed to populate function invocation status")
 			}
 		} else {

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -164,18 +164,6 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	var err error
 	var existingFunctionConfig *functionconfig.ConfigWithStatus
 
-	// wrap logger
-	logStream, err := abstract.NewLogStream("deployer", nucliozap.InfoLevel, createFunctionOptions.Logger)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create a log stream")
-	}
-
-	// save the log stream for the name
-	p.DeployLogStreams.Store(createFunctionOptions.FunctionConfig.Meta.GetUniqueID(), logStream)
-
-	// replace logger
-	createFunctionOptions.Logger = logStream.GetLogger()
-
 	if err := p.enrichAndValidateFunctionConfig(&createFunctionOptions.FunctionConfig); err != nil {
 		return nil, errors.Wrap(err, "Failed to enrich and validate a function configuration")
 	}
@@ -221,6 +209,18 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 		createFunctionOptions); err != nil {
 		return nil, errors.Wrap(err, "Failed to validate a function configuration against an existing configuration")
 	}
+
+	// wrap logger
+	logStream, err := abstract.NewLogStream("deployer", nucliozap.InfoLevel, createFunctionOptions.Logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create a log stream")
+	}
+
+	// save the log stream for the name
+	p.DeployLogStreams.Store(createFunctionOptions.FunctionConfig.Meta.GetUniqueID(), logStream)
+
+	// replace logger
+	createFunctionOptions.Logger = logStream.GetLogger()
 
 	reportCreationError := func(creationError error) error {
 		createFunctionOptions.Logger.WarnWith("Failed to create a function; setting the function status",


### PR DESCRIPTION
Changes

1. if validation has failed, do not empty-out previous build logs
2. if function become unhealthy (or any error occured during k8s resource creation), preserve build logs while updating function status
