### PR TITLE
Fix - Pull base images upon building a function without cache [1.5.x backport]

### DIFF
--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -108,6 +108,7 @@ func (d *Docker) buildContainerImage(buildOptions *BuildOptions) error {
 		Image:          buildOptions.Image,
 		DockerfilePath: buildOptions.DockerfileInfo.DockerfilePath,
 		NoCache:        buildOptions.NoCache,
+		Pull:           buildOptions.Pull,
 		BuildArgs:      buildOptions.BuildArgs,
 	})
 

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -12,6 +12,7 @@ type BuildOptions struct {
 	TempDir             string
 	DockerfileInfo      *runtime.ProcessorDockerfileInfo
 	NoCache             bool
+	Pull                bool
 	NoBaseImagePull     bool
 	BuildArgs           map[string]string
 	RegistryURL         string

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -109,12 +109,7 @@ func (c *ShellClient) Build(buildOptions *BuildOptions) error {
 		buildArgs += fmt.Sprintf("--build-arg %s=%s ", buildArgName, buildArgValue)
 	}
 
-	cacheOption := ""
-	if buildOptions.NoCache {
-		cacheOption = "--no-cache"
-	}
-
-	if err := c.build(buildOptions, buildArgs, cacheOption); err != nil {
+	if err := c.build(buildOptions, buildArgs); err != nil {
 		return errors.Wrap(err, "Failed to build")
 	}
 
@@ -798,8 +793,27 @@ func (c *ShellClient) resolveDockerBuildNetwork() string {
 	}
 }
 
-func (c *ShellClient) build(buildOptions *BuildOptions, buildArgs string, cacheOption string) error {
+func (c *ShellClient) build(buildOptions *BuildOptions, buildArgs string) error {
 	var lastBuildErr error
+
+	cacheOption := ""
+	if buildOptions.NoCache {
+		cacheOption = "--no-cache"
+	}
+
+	pullOption := ""
+	if buildOptions.Pull {
+		pullOption = "--pull"
+	}
+
+	buildCommand := fmt.Sprintf("docker build %s --force-rm -t %s -f %s %s %s %s .",
+		c.resolveDockerBuildNetwork(),
+		buildOptions.Image,
+		buildOptions.DockerfilePath,
+		cacheOption,
+		pullOption,
+		buildArgs)
+
 	retryOnErrorMessages := []string{
 
 		// when one of the underlying image is gone (from cache)
@@ -826,13 +840,7 @@ func (c *ShellClient) build(buildOptions *BuildOptions, buildArgs string, cacheO
 		c.buildRetryInterval,
 		retryOnErrorMessages,
 		func() string {
-			runResults, err := c.runCommand(runOptions,
-				"docker build %s --force-rm -t %s -f %s %s %s .",
-				c.resolveDockerBuildNetwork(),
-				buildOptions.Image,
-				buildOptions.DockerfilePath,
-				cacheOption,
-				buildArgs)
+			runResults, err := c.runCommand(runOptions, buildCommand)
 
 			// preserve error
 			lastBuildErr = err

--- a/pkg/dockerclient/shell_test.go
+++ b/pkg/dockerclient/shell_test.go
@@ -185,7 +185,7 @@ func (suite *ShellClientTestSuite) TestBuildBailOnUnknownError() {
 		On("Run",
 			mock.Anything,
 			mock.MatchedBy(func(command string) bool {
-				return strings.Contains(command, "docker build %s")
+				return strings.Contains(command, "docker build")
 			}),
 			mock.Anything).
 		Return(cmdrunner.RunResult{
@@ -210,7 +210,7 @@ func (suite *ShellClientTestSuite) TestBuildRetryOnErrors() {
 		On("Run",
 			mock.Anything,
 			mock.MatchedBy(func(command string) bool {
-				return strings.Contains(command, "docker build %s")
+				return strings.Contains(command, "docker build")
 			}),
 			mock.Anything).
 		Return(cmdrunner.RunResult{

--- a/pkg/dockerclient/types.go
+++ b/pkg/dockerclient/types.go
@@ -45,6 +45,7 @@ type BuildOptions struct {
 	ContextDir     string
 	DockerfilePath string
 	NoCache        bool
+	Pull           bool
 	BuildArgs      map[string]string
 }
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1047,10 +1047,14 @@ func (b *Builder) buildProcessorImage() (string, error) {
 	b.logger.InfoWith("Building processor image", "imageName", imageName)
 
 	err = b.platform.BuildAndPushContainerImage(&containerimagebuilderpusher.BuildOptions{
-		ContextDir:          b.stagingDir,
-		Image:               imageName,
-		TempDir:             b.tempDir,
-		DockerfileInfo:      processorDockerfileInfo,
+		ContextDir:     b.stagingDir,
+		Image:          imageName,
+		TempDir:        b.tempDir,
+		DockerfileInfo: processorDockerfileInfo,
+
+		// Conjunct Pull with NoCache
+		// To ensure that when forcing a function build, the base images would be pulled as well.
+		Pull:                b.options.FunctionConfig.Spec.Build.NoCache,
 		NoCache:             b.options.FunctionConfig.Spec.Build.NoCache,
 		NoBaseImagePull:     b.GetNoBaseImagePull(),
 		BuildArgs:           buildArgs,


### PR DESCRIPTION
backports  #2263 onto 1.5.x branch
