### PR TITLE
Scale to zero - verify function readiness [1.5.x]

### DIFF
--- a/cmd/dlx/main.go
+++ b/cmd/dlx/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/nuclio/nuclio/cmd/dlx/app"
+	"github.com/nuclio/nuclio/pkg/common"
 
 	"github.com/nuclio/errors"
 )
@@ -30,11 +31,15 @@ func main() {
 	kubeconfigPath := flag.String("kubeconfig-path", os.Getenv("KUBECONFIG"), "Path of kubeconfig file")
 	namespace := flag.String("namespace", "", "Namespace to listen on, or * for all")
 	platformConfigurationPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
+	functionReadinessVerificationEnabled := flag.Bool("function-readiness-verification-enabled", common.GetEnvOrDefaultBool("NUCLIO_RESOURCESCALER_FUNCTION_READINESS_VERIFICATION_ENABLED", false), "Whether to verify function readiness")
 	flag.Parse()
 
 	*namespace = getNamespace(*namespace)
 
-	if err := app.Run(*platformConfigurationPath, *namespace, *kubeconfigPath); err != nil {
+	if err := app.Run(*platformConfigurationPath,
+		*namespace,
+		*kubeconfigPath,
+		*functionReadinessVerificationEnabled); err != nil {
 		errors.PrintErrorStack(os.Stderr, err, 5)
 		os.Exit(1)
 	}

--- a/hack/k8s/helm/nuclio/templates/deployment/dlx.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dlx.yaml
@@ -41,6 +41,9 @@ spec:
       serviceAccountName: {{ template "nuclio.serviceAccountName" . }}
       containers:
       - name: {{ template "nuclio.dlxName" . }}
+        env:
+        - name: NUCLIO_RESOURCESCALER_FUNCTION_READINESS_VERIFICATION_ENABLED
+          value: {{ .Values.dlx.functionReadinessVerificationEnabled | quote }}
         image: {{ .Values.dlx.image.repository }}:{{ .Values.dlx.image.tag }}
         imagePullPolicy: {{ .Values.dlx.image.pullPolicy }}
         {{- if .Values.dlx.resources }}

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -181,6 +181,9 @@ dlx:
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
 
+  # Whether to verify function readiness before redirecting incoming requests
+  functionReadinessVerificationEnabled: false
+
 registry:
 
   # By default, the chart does not advocate using helm to manage registry credentials. You should create a secret

--- a/pkg/platform/kube/resourcescaler/resourcescaler.go
+++ b/pkg/platform/kube/resourcescaler/resourcescaler.go
@@ -92,7 +92,7 @@ func (n *NuclioResourceScaler) SetFunctionReadinessVerificationEnabled(enable bo
 }
 
 func (n *NuclioResourceScaler) SetScale(resources []scaler_types.Resource, scale int) error {
-	functionNames := make([]string, len(resources))
+	functionNames := make([]string, 0)
 	for _, resource := range resources {
 		functionNames = append(functionNames, resource.Name)
 	}
@@ -339,8 +339,8 @@ func (n *NuclioResourceScaler) verifyReadiness(function *nuclioio.NuclioFunction
 
 			// response is within [200, 300)
 			if response.StatusCode >= http.StatusOK && response.StatusCode < 300 {
-				n.logger.InfoWith("Readiness has verified",
-					"timeForHealthz", time.Since(startTime),
+				n.logger.InfoWith("Function readiness is verified",
+					"took", time.Since(startTime),
 					"healthzEndpoint", healthzEndpoint)
 				return true
 			}
@@ -351,7 +351,7 @@ func (n *NuclioResourceScaler) verifyReadiness(function *nuclioio.NuclioFunction
 				"responseStatusCode", response.StatusCode)
 			return false
 		}); err != nil {
-		return errors.Wrap(err, "Exhausting waiting for function readiness verification")
+		return errors.Wrap(err, "Exhausted waiting for function readiness verification")
 	}
 	return nil
 }

--- a/pkg/platform/kube/resourcescaler/resourcescaler.go
+++ b/pkg/platform/kube/resourcescaler/resourcescaler.go
@@ -87,6 +87,7 @@ func New(kubeconfigPath string, namespace string) (scaler_types.ResourceScaler, 
 }
 
 func (n *NuclioResourceScaler) SetFunctionReadinessVerificationEnabled(enable bool) {
+	n.logger.InfoWith("Setting function readiness verification", "enable", enable)
 	n.functionReadinessVerificationEnabled = enable
 }
 

--- a/pkg/processor/trigger/http/http_test.go
+++ b/pkg/processor/trigger/http/http_test.go
@@ -172,6 +172,40 @@ func (suite *TestSuite) TestCORS() {
 	}
 }
 
+func (suite *TestSuite) TestInternalHealthiness() {
+	client := suite.getClient()
+	for _, testCase := range []struct {
+		name string
+	}{
+		{
+			name: "sanity",
+		},
+	} {
+
+		suite.Run(testCase.name, func() {
+			suite.Logger.DebugWith("Testing internal healthiness endpoint", "testCase", testCase)
+
+			// ensure trigger is ready
+			suite.trigger.status = status.Ready
+
+			request, err := nethttp.NewRequest(nethttp.MethodGet,
+				"http://foo.bar"+string(suite.trigger.internalHealthzPath),
+				nil)
+			suite.Require().NoError(err, "Failed to create new request")
+
+			// do request
+			response, err := client.Do(request)
+			suite.Require().NoError(err, "Failed to do request")
+			suite.Logger.DebugWith("Received response",
+				"headers", response.Header,
+				"statusCode", response.StatusCode)
+
+			suite.Require().Equal(response.StatusCode, nethttp.StatusOK)
+		})
+
+	}
+}
+
 func (suite *TestSuite) serveDummyHTTPServer(handler fasthttp.RequestHandler) {
 	go func() {
 		suite.fastDummyHTTPServerStarted = true

--- a/pkg/processor/trigger/http/http_test.go
+++ b/pkg/processor/trigger/http/http_test.go
@@ -189,7 +189,7 @@ func (suite *TestSuite) TestInternalHealthiness() {
 			suite.trigger.status = status.Ready
 
 			request, err := nethttp.NewRequest(nethttp.MethodGet,
-				"http://foo.bar"+string(suite.trigger.internalHealthzPath),
+				"http://foo.bar"+string(suite.trigger.internalHealthPath),
 				nil)
 			suite.Require().NoError(err, "Failed to create new request")
 

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -45,14 +45,14 @@ var (
 
 type http struct {
 	trigger.AbstractTrigger
-	configuration       *Configuration
-	events              []Event
-	bufferLoggerPool    *nucliozap.BufferLoggerPool
-	status              status.Status
-	activeContexts      []*fasthttp.RequestCtx
-	timeouts            []uint64 // flag of worker is in timeout
-	answering           []uint64 // flag the worker is answering
-	server              *fasthttp.Server
+	configuration      *Configuration
+	events             []Event
+	bufferLoggerPool   *nucliozap.BufferLoggerPool
+	status             status.Status
+	activeContexts     []*fasthttp.RequestCtx
+	timeouts           []uint64 // flag of worker is in timeout
+	answering          []uint64 // flag the worker is answering
+	server             *fasthttp.Server
 	internalHealthPath []byte
 }
 
@@ -87,13 +87,13 @@ func newTrigger(logger logger.Logger,
 	}
 
 	newTrigger := http{
-		AbstractTrigger:     abstractTrigger,
-		configuration:       configuration,
-		bufferLoggerPool:    bufferLoggerPool,
-		status:              status.Initializing,
-		activeContexts:      make([]*fasthttp.RequestCtx, numWorkers),
-		timeouts:            make([]uint64, numWorkers),
-		answering:           make([]uint64, numWorkers),
+		AbstractTrigger:    abstractTrigger,
+		configuration:      configuration,
+		bufferLoggerPool:   bufferLoggerPool,
+		status:             status.Initializing,
+		activeContexts:     make([]*fasthttp.RequestCtx, numWorkers),
+		timeouts:           make([]uint64, numWorkers),
+		answering:          make([]uint64, numWorkers),
 		internalHealthPath: []byte(InternalHealthPath),
 	}
 

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -53,7 +53,7 @@ type http struct {
 	timeouts            []uint64 // flag of worker is in timeout
 	answering           []uint64 // flag the worker is answering
 	server              *fasthttp.Server
-	internalHealthzPath []byte
+	internalHealthPath []byte
 }
 
 func newTrigger(logger logger.Logger,
@@ -94,7 +94,7 @@ func newTrigger(logger logger.Logger,
 		activeContexts:      make([]*fasthttp.RequestCtx, numWorkers),
 		timeouts:            make([]uint64, numWorkers),
 		answering:           make([]uint64, numWorkers),
-		internalHealthzPath: []byte(InternalHealthinessPath),
+		internalHealthPath: []byte(InternalHealthPath),
 	}
 
 	newTrigger.allocateEvents(numWorkers)
@@ -393,7 +393,7 @@ func (h *http) handleRequest(ctx *fasthttp.RequestCtx) {
 
 	// internal endpoint to allow clients the information whether the http server is taking requests in
 	// this is an internal endpoint, we do not want to update statistics here
-	if bytes.HasPrefix(ctx.URI().Path(), h.internalHealthzPath) {
+	if bytes.HasPrefix(ctx.URI().Path(), h.internalHealthPath) {
 		ctx.Response.SetStatusCode(nethttp.StatusOK)
 		return
 	}

--- a/pkg/processor/trigger/http/types.go
+++ b/pkg/processor/trigger/http/types.go
@@ -28,6 +28,7 @@ import (
 
 const DefaultReadBufferSize = 16 * 1024
 const DefaultMaxRequestBodySize = 4 * 1024 * 1024
+const InternalHealthinessPath = "/__internal/healthz"
 
 type Configuration struct {
 	trigger.Configuration

--- a/pkg/processor/trigger/http/types.go
+++ b/pkg/processor/trigger/http/types.go
@@ -28,7 +28,7 @@ import (
 
 const DefaultReadBufferSize = 16 * 1024
 const DefaultMaxRequestBodySize = 4 * 1024 * 1024
-const InternalHealthinessPath = "/__internal/healthz"
+const InternalHealthPath = "/__internal/health"
 
 type Configuration struct {
 	trigger.Configuration


### PR DESCRIPTION
On some env it is noticed that function that scale from zero become ready while its http trigger is not ready to take in requests.
In this PR I added an internal endpoint that serves healthiness checkup requests, and while the function scale from zero, the DLX component will verify that the function is ready AND can take in requests by checking on that added endpoint. (that mode is disabled by default, by can be easily turned on by setting `NUCLIO_RESOURCESCALER_FUNCTION_READINESS_VERIFICATION_ENABLED` envvar  to `"true"`.

The drawback is that, if you only take in this fix without _redeploying_ your functions, then DLX readiness verification flow would get to the user code and add incoming requests to statistics thought those requests are just for checkups.
To ensure that readiness verification requests stops at the processor http server, it is required to _redeploy_ your functions.

internal ticket - `IG-19031`

post-fix example logs


```
21.07.29 08:07:04.589           resource-scaler (D) Scaling from zero {"functionNames": ["abc"]}
21.07.29 08:07:04.598           resource-scaler (D) Waiting for function readiness {"functionName": "abc"}
21.07.29 08:07:04.603           resource-scaler (D) Function not ready yet {"functionName": "abc", "currentState": "waitingForScaleResourceFromZero"}
21.07.29 08:07:07.607           resource-scaler (D) Function not ready yet {"functionName": "abc", "currentState": "waitingForScaleResourceFromZero"}
21.07.29 08:07:10.612           resource-scaler (I) Function is ready {"functionName": "abc"}
21.07.29 08:07:11.650           resource-scaler (W) Failed to send request {"err": "Get \"http://nuclio-abc.default.svc.cluster.local:8080/__internal/healthz\": dial tcp 10.51.248.225:8080: connect: connection refused", "timeForHealthz": "1.038138675s", "healthzEndpoint": "http://nuclio-abc.default.svc.cluster.local:8080/__internal/health"}
21.07.29 08:07:13.666           resource-scaler (W) Failed to send request {"err": "Get \"http://nuclio-abc.default.svc.cluster.local:8080/__internal/healthz\": dial tcp 10.51.248.225:8080: connect: connection refused", "timeForHealthz": "3.05412482s", "healthzEndpoint": "http://nuclio-abc.default.svc.cluster.local:8080/__internal/health"}
21.07.29 08:07:15.682           resource-scaler (W) Failed to send request {"err": "Get \"http://nuclio-abc.default.svc.cluster.local:8080/__internal/healthz\": dial tcp 10.51.248.225:8080: connect: connection refused", "timeForHealthz": "5.070142828s", "healthzEndpoint": "http://nuclio-abc.default.svc.cluster.local:8080/__internal/health"}
21.07.29 08:07:16.685           resource-scaler (I) Function readiness is verified {"took": "6.072730012s", "url": "http://nuclio-abc.default.svc.cluster.local:8080/__internal/health"}
```