### PR TITLE
API Gateway - add needed header to allow STZ mechanism to work [1.5.x]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/tedsuo/ifrit v0.0.0-20191009134036-9a97d0632f00 // indirect
 	github.com/tsenart/vegeta v6.3.0+incompatible
-	github.com/v3io/scaler v0.4.0
+	github.com/v3io/scaler v0.4.2
 	github.com/v3io/scaler-types v1.7.0
 	github.com/v3io/v3io-go v0.2.3
 	github.com/v3io/v3io-go-http v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -386,8 +386,8 @@ github.com/tsenart/vegeta v6.3.0+incompatible/go.mod h1:Smz/ZWfhKRcyDDChZkG3CyTH
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
-github.com/v3io/scaler v0.4.0 h1:VKY+FnWnKYcQLP75FpbltoO2VCH76ZO5ZIi91UbrbV0=
-github.com/v3io/scaler v0.4.0/go.mod h1:FEB9OKfYV4qcm9aXISZk0uCi6yK3Ak9JsdYVZFbu5tM=
+github.com/v3io/scaler v0.4.2 h1:+55ExEB30QFIuk9jdCZlQxYLA2YEsiJuq3YvO1241rg=
+github.com/v3io/scaler v0.4.2/go.mod h1:FEB9OKfYV4qcm9aXISZk0uCi6yK3Ak9JsdYVZFbu5tM=
 github.com/v3io/scaler-types v1.7.0 h1:ZTbJaYUxZgnPjiOWU64l74jCk5iRmEoA2ZxyzUQbtn0=
 github.com/v3io/scaler-types v1.7.0/go.mod h1:fnjcQnuYD8wTmkmsv7QLnXShuk5HNRRwfFHfR+khYRs=
 github.com/v3io/v3io-go v0.2.3 h1:VIUmto4u8OGXe4BoOaBSmL6Bxh/G5Ns0sw7Ntn7nh3Q=

--- a/pkg/platform/kube/apigatewayres/lazy.go
+++ b/pkg/platform/kube/apigatewayres/lazy.go
@@ -57,85 +57,67 @@ func (lc *lazyClient) Get(ctx context.Context, namespace string, name string) (R
 }
 
 func (lc *lazyClient) CreateOrUpdate(ctx context.Context, apiGateway *nuclioio.NuclioAPIGateway) (Resources, error) {
-	var appliedIngressNames []string
-
 	apiGateway.Status.Name = apiGateway.Spec.Name
 
 	if err := lc.validateSpec(apiGateway); err != nil {
 		return nil, errors.Wrap(err, "Api gateway spec validation failed")
 	}
 
-	// generate an ingress for each upstream
-	upstreams := apiGateway.Spec.Upstreams
-	ingresses := map[string]*ingress.Resources{}
-
 	// always try to remove previous canary ingress first, because
 	// nginx returns 503 on all requests if primary service == secondary service. (happens on every promotion)
 	// so during promotion all requests will be sent to the primary ingress
 	lc.tryRemovePreviousCanaryIngress(ctx, apiGateway)
 
-	if len(upstreams) == 1 {
+	// generate an ingress for each upstream
+	ingressesResources := map[string]*ingress.Resources{}
+	var ingressesToCreate []*ingress.Resources
 
-		// create just a single ingress
-		ingressResources, err := lc.generateNginxIngress(ctx, apiGateway, upstreams[0])
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to generate nginx ingress")
-		}
+	primaryUpstream, canaryUpstream, err := lc.resolveBaseAndCanaryUpstreamsFromSpec(apiGateway.Spec.Upstreams)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to resolve base and canary upstreams")
+	}
 
-		ingresses[ingressResources.Ingress.Name] = ingressResources
+	// create primary ingress
+	primaryIngressResources, err := lc.generateNginxIngress(ctx, apiGateway, primaryUpstream)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to generate primary nginx ingress")
+	}
 
-	} else if len(upstreams) == 2 {
-		var canaryUpstream platform.APIGatewayUpstreamSpec
-		var baseUpstream platform.APIGatewayUpstreamSpec
+	lc.enrichPrimaryIngressResources(primaryIngressResources, primaryUpstream, canaryUpstream)
+	ingressesResources[primaryIngressResources.Ingress.Name] = primaryIngressResources
+	ingressesToCreate = append(ingressesToCreate, primaryIngressResources)
 
-		// determine which upstream is the canary one
-		if upstreams[0].Percentage != 0 {
-			baseUpstream = upstreams[1]
-			canaryUpstream = upstreams[0]
-		} else if upstreams[1].Percentage != 0 {
-			baseUpstream = upstreams[0]
-			canaryUpstream = upstreams[1]
-		} else {
-			return nil, errors.New("Percentage must be set on one of the upstreams (canary)")
-		}
+	// add the canary ingress
+	if canaryUpstream != nil {
 
-		// validity check
+		// percentage range
 		if canaryUpstream.Percentage > 100 || canaryUpstream.Percentage < 1 {
 			return nil, errors.New("The canary upstream percentage must be between 1 and 100")
 		}
 
-		// add the base ingress
-		baseIngressResources, err := lc.generateNginxIngress(ctx, apiGateway, baseUpstream)
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to generate the base nginx ingress")
-		}
-		ingresses[baseIngressResources.Ingress.Name] = baseIngressResources
-
-		// add the canary ingress
 		canaryIngressResources, err := lc.generateNginxIngress(ctx, apiGateway, canaryUpstream)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to generate the canary nginx ingress")
 		}
-		ingresses[canaryIngressResources.Ingress.Name] = canaryIngressResources
+
+		ingressesResources[canaryIngressResources.Ingress.Name] = canaryIngressResources
+		ingressesToCreate = append(ingressesToCreate, canaryIngressResources)
 	}
 
 	// create ingresses
 	// must be done synchronously, first primary and then canary
 	// otherwise, when there is only canary ingress, the endpoint will not work (nginx behavior)
-	for ingressName, ingressResources := range ingresses {
+	for _, ingressResources := range ingressesToCreate {
 		if _, _, err := lc.ingressManager.CreateOrUpdateResources(ingressResources); err != nil {
 			lc.Logger.WarnWithCtx(ctx, "Failed to create/update api gateway ingress resources",
 				"err", errors.Cause(err),
-				"ingressName", ingressName,
-				"appliedIngressNames", appliedIngressNames)
+				"ingressName", ingressResources.Ingress.Name)
 			return nil, errors.New("Failed to create/update api gateway ingress resources")
 		}
-
-		appliedIngressNames = append(appliedIngressNames, ingressName)
 	}
 
 	return &lazyResources{
-		ingressResourcesMap: ingresses,
+		ingressResourcesMap: ingressesResources,
 	}, nil
 }
 
@@ -171,8 +153,9 @@ func (lc *lazyClient) tryRemovePreviousCanaryIngress(ctx context.Context, apiGat
 	// remove old canary ingress if it exists
 	// this works thanks to an assumption that ingress names == api gateway name
 	previousCanaryIngressName := kube.IngressNameFromAPIGatewayName(apiGateway.Name, true)
-	err := lc.ingressManager.DeleteByName(previousCanaryIngressName, apiGateway.Namespace, true)
-	if err != nil {
+	if err := lc.ingressManager.DeleteByName(previousCanaryIngressName,
+		apiGateway.Namespace,
+		true); err != nil {
 		lc.Logger.WarnWithCtx(ctx,
 			"Failed to delete previous canary ingress on api gateway update",
 			"previousCanaryIngressName", previousCanaryIngressName,
@@ -229,9 +212,9 @@ func (lc *lazyClient) getAllExistingUpstreamFunctionNames(namespace, apiGatewayN
 
 func (lc *lazyClient) generateNginxIngress(ctx context.Context,
 	apiGateway *nuclioio.NuclioAPIGateway,
-	upstream platform.APIGatewayUpstreamSpec) (*ingress.Resources, error) {
+	upstream *platform.APIGatewayUpstreamSpec) (*ingress.Resources, error) {
 
-	serviceName, servicePort, err := lc.getServiceNameAndPort(upstream, apiGateway.Namespace)
+	serviceName, servicePort, err := lc.getServiceNameAndPort(upstream)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get service name")
 	}
@@ -292,27 +275,21 @@ func (lc *lazyClient) generateNginxIngress(ctx context.Context,
 	return lc.ingressManager.GenerateResources(ctx, commonIngressSpec)
 }
 
-func (lc *lazyClient) getServiceNameAndPort(upstream platform.APIGatewayUpstreamSpec,
-	namespace string) (string, int, error) {
+func (lc *lazyClient) getServiceNameAndPort(upstream *platform.APIGatewayUpstreamSpec) (string, int, error) {
 	switch upstream.Kind {
 	case platform.APIGatewayUpstreamKindNuclioFunction:
-		return lc.getNuclioFunctionServiceNameAndPort(upstream, namespace)
+
+		// we used to get service name by actually getting the function's service
+		// it was "stupified" to this logic, in order to prevent api-gateway failing when a function has no service
+		// (which may happen when a function is imported, but not yet deployed, and in that point we import an api-gateway
+		// that has this function as an upstream)
+		serviceName := kube.ServiceNameFromFunctionName(upstream.Nucliofunction.Name)
+
+		// use default port
+		return serviceName, abstract.FunctionContainerHTTPPort, nil
 	default:
 		return "", 0, errors.Errorf("Unsupported API gateway upstream kind: %s", upstream.Kind)
 	}
-}
-
-func (lc *lazyClient) getNuclioFunctionServiceNameAndPort(upstream platform.APIGatewayUpstreamSpec,
-	namespace string) (string, int, error) {
-
-	// we used to get service name by actually getting the function's service
-	// it was "stupified" to this logic, in order to prevent api-gateway failing when a function has no service
-	// (which may happen when a function is imported, but not yet deployed, and in that point we import an api-gateway
-	// that has this function as an upstream)
-	serviceName := kube.ServiceNameFromFunctionName(upstream.Nucliofunction.Name)
-
-	// use default port
-	return serviceName, abstract.FunctionContainerHTTPPort, nil
 }
 
 func (lc *lazyClient) getServiceHTTPPort(service v1.Service) (int, error) {
@@ -337,6 +314,53 @@ func (lc *lazyClient) resolveCommonAnnotations(canaryDeployment bool, upstreamPe
 		annotations["nginx.ingress.kubernetes.io/canary-weight"] = strconv.Itoa(upstreamPercentage)
 	}
 	return annotations
+}
+
+func (lc *lazyClient) resolveBaseAndCanaryUpstreamsFromSpec(upstreams []platform.APIGatewayUpstreamSpec) (
+	*platform.APIGatewayUpstreamSpec, *platform.APIGatewayUpstreamSpec, error) {
+
+	if len(upstreams) == 1 {
+		return &upstreams[0], nil, nil
+	}
+
+	var primary *platform.APIGatewayUpstreamSpec
+	var canary *platform.APIGatewayUpstreamSpec
+
+	// determine which upstream is the canary one
+	switch {
+	case upstreams[0].Percentage != 0:
+		primary = &upstreams[1]
+		canary = &upstreams[0]
+	case upstreams[1].Percentage != 0:
+		primary = &upstreams[0]
+		canary = &upstreams[1]
+	default:
+		return nil, nil, errors.New("Percentage must be set on one of the upstreams (canary)")
+	}
+
+	return primary, canary, nil
+}
+
+func (lc *lazyClient) enrichPrimaryIngressResources(primaryIngressResources *ingress.Resources,
+	primaryUpstream *platform.APIGatewayUpstreamSpec,
+	canaryUpstream *platform.APIGatewayUpstreamSpec) {
+
+	// set nuclio target header on ingress
+	encodedPrimaryTargetHeader := fmt.Sprintf(`proxy_set_header X-Nuclio-Target "%s";`, primaryUpstream.Nucliofunction.Name)
+	annotations := primaryIngressResources.Ingress.Annotations
+	configurationSnippetHeaderName := "nginx.ingress.kubernetes.io/configuration-snippet"
+
+	if _, headerExists := annotations[configurationSnippetHeaderName]; headerExists {
+		annotations[configurationSnippetHeaderName] += fmt.Sprintf("\n%s", encodedPrimaryTargetHeader)
+	} else {
+		annotations[configurationSnippetHeaderName] = encodedPrimaryTargetHeader
+	}
+
+	// TODO: uncomment after work is done on scaler part
+	//if canaryUpstream != nil {
+	//	encodedCanaryTargetHeader := fmt.Sprintf(`proxy_set_header X-Nuclio-Sub-Targets "%s";`, canaryUpstream.NuclioFunction.Name)
+	//	annotations[configurationSnippetHeaderName] += fmt.Sprintf("\n%s", encodedCanaryTargetHeader)
+	//}
 }
 
 //

--- a/pkg/platform/kube/apigatewayres/lazy_test.go
+++ b/pkg/platform/kube/apigatewayres/lazy_test.go
@@ -110,7 +110,7 @@ func (suite *lazyTestSuite) TestEnsurePrimaryIngressHasXNuclioTargetHeader() {
 
 	// expect primary function ingress to have `X-Nuclio-Target`
 	// so that if has STZ option, it would wake up upon a request
-	suite.Require().Equal(`proxy_set_header X-Nuclio-Target "primary-function-name";`,
+	suite.Require().Equal(`proxy_set_header X-Nuclio-Target "primary-function-name,canary-function-name";`,
 		primaryIngressResources.Ingress.Annotations["nginx.ingress.kubernetes.io/configuration-snippet"])
 }
 

--- a/pkg/platform/kube/apigatewayres/lazy_test.go
+++ b/pkg/platform/kube/apigatewayres/lazy_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apigatewayres
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platform"
+	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+	"github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/versioned/fake"
+	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+type lazyTestSuite struct {
+	suite.Suite
+	logger         logger.Logger
+	client         Client
+	ingressManager *ingress.Manager
+}
+
+func (suite *lazyTestSuite) SetupTest() {
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
+
+	platformConfig, err := platformconfig.NewPlatformConfig("")
+	suite.Require().NoError(err)
+
+	kubeClientset := k8sfake.NewSimpleClientset()
+	suite.ingressManager, err = ingress.NewManager(suite.logger, kubeClientset, platformConfig)
+	suite.Require().NoError(err)
+
+	suite.client, err = NewLazyClient(suite.logger,
+		kubeClientset,
+		fake.NewSimpleClientset(),
+		suite.ingressManager)
+	suite.Require().NoError(err)
+}
+
+func (suite *lazyTestSuite) TestEnsurePrimaryIngressHasXNuclioTargetHeader() {
+	primaryFunctionConfig := *functionconfig.NewConfig()
+	primaryFunctionConfig.Meta.Name = "primary-function-name"
+	canaryFunctionConfig := *functionconfig.NewConfig()
+	canaryFunctionConfig.Meta.Name = "canary-function-name"
+	resources, err := suite.client.CreateOrUpdate(context.TODO(), &nuclioio.NuclioAPIGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-name",
+			Namespace: "test-namespace",
+		},
+
+		Spec: platform.APIGatewaySpec{
+			Host:               "some-host.com",
+			Name:               "test-name",
+			AuthenticationMode: ingress.AuthenticationModeBasicAuth,
+			Authentication: &platform.APIGatewayAuthenticationSpec{
+				BasicAuth: &platform.BasicAuth{
+					Username: "moshe",
+					Password: "ehsom",
+				},
+			},
+			Upstreams: []platform.APIGatewayUpstreamSpec{
+				{
+					Kind: platform.APIGatewayUpstreamKindNuclioFunction,
+					Nucliofunction: &platform.NuclioFunctionAPIGatewaySpec{
+						Name: primaryFunctionConfig.Meta.Name,
+					},
+				},
+				{
+					Kind: platform.APIGatewayUpstreamKindNuclioFunction,
+					Nucliofunction: &platform.NuclioFunctionAPIGatewaySpec{
+						Name: canaryFunctionConfig.Meta.Name,
+					},
+					Percentage: 20,
+				},
+			},
+		},
+	})
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resources.IngressResourcesMap())
+
+	var primaryIngressResources ingress.Resources
+
+	for resourceName, resources := range resources.IngressResourcesMap() {
+		if !strings.HasSuffix(resourceName, "-canary") {
+			primaryIngressResources = *resources
+		}
+	}
+
+	// expect primary function ingress to have `X-Nuclio-Target`
+	// so that if has STZ option, it would wake up upon a request
+	suite.Require().Equal(`proxy_set_header X-Nuclio-Target "primary-function-name";`,
+		primaryIngressResources.Ingress.Annotations["nginx.ingress.kubernetes.io/configuration-snippet"])
+}
+
+func TestLazyTestSuite(t *testing.T) {
+	suite.Run(t, new(lazyTestSuite))
+}

--- a/pkg/platform/kube/apigatewayres/lazy_test.go
+++ b/pkg/platform/kube/apigatewayres/lazy_test.go
@@ -73,13 +73,7 @@ func (suite *lazyTestSuite) TestEnsurePrimaryIngressHasXNuclioTargetHeader() {
 		Spec: platform.APIGatewaySpec{
 			Host:               "some-host.com",
 			Name:               "test-name",
-			AuthenticationMode: ingress.AuthenticationModeBasicAuth,
-			Authentication: &platform.APIGatewayAuthenticationSpec{
-				BasicAuth: &platform.BasicAuth{
-					Username: "moshe",
-					Password: "ehsom",
-				},
-			},
+			AuthenticationMode: ingress.AuthenticationModeNone,
 			Upstreams: []platform.APIGatewayUpstreamSpec{
 				{
 					Kind: platform.APIGatewayUpstreamKindNuclioFunction,

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -898,6 +898,8 @@ func (suite *DeployAPIGatewayTestSuite) TestDexAuthMode() {
 		err := suite.deployAPIGateway(createAPIGatewayOptions, func(ingress *extensionsv1beta1.Ingress) {
 			suite.Assert().NotContains(ingress.Annotations, "nginx.ingress.kubernetes.io/auth-signin")
 			suite.Assert().Contains(ingress.Annotations["nginx.ingress.kubernetes.io/auth-url"], configOauth2ProxyURL)
+			suite.Assert().Contains(ingress.Annotations["nginx.ingress.kubernetes.io/configuration-snippet"],
+				fmt.Sprintf(`proxy_set_header X-Nuclio-Target "%s";`, functionName))
 		})
 		suite.Require().NoError(err)
 


### PR DESCRIPTION
backports both #2247 and #2267 onto 1.5.x to make sure both primary and canary are registered on the `X-Nuclio-Target` header.

Note: need to backport the relevant part on `v3io/scaler` as well, to support multiple targets