### PR TITLE
Revert "Auth - protect /version endpoint"

### DIFF
--- a/pkg/dashboard/resource/version.go
+++ b/pkg/dashboard/resource/version.go
@@ -30,11 +30,6 @@ type versionResource struct {
 	versionInfo *version.Info
 }
 
-func (vr *versionResource) ExtendMiddlewares() error {
-	vr.resource.addAuthMiddleware()
-	return nil
-}
-
 // GetAll returns all versions
 func (vr *versionResource) GetAll(request *http.Request) (map[string]restful.Attributes, error) {
 	response := map[string]restful.Attributes{


### PR DESCRIPTION
Reverts nuclio/nuclio#2268

The reason is that some clients would want to know nuclio version to understand how to interact with its backend