### PR TITLE
Fix shared worker allocation

### DIFF
--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -78,7 +78,7 @@ type Processor struct {
 	webAdminServer        *webadmin.Server
 	healthCheckServer     commonhealthcheck.Server
 	metricSinks           []metricsink.MetricSink
-	namedWorkerAllocators map[string]worker.Allocator
+	namedWorkerAllocators *worker.AllocatorSyncMap
 	eventTimeoutWatcher   *timeout.EventTimeoutWatcher
 	startComplete         bool
 	stop                  chan bool
@@ -89,7 +89,7 @@ func NewProcessor(configurationPath string, platformConfigurationPath string) (*
 	var err error
 
 	newProcessor := &Processor{
-		namedWorkerAllocators: map[string]worker.Allocator{},
+		namedWorkerAllocators: worker.NewAllocatorSyncMap(),
 		stop:                  make(chan bool, 1),
 	}
 

--- a/cmd/processor/app/processor_test.go
+++ b/cmd/processor/app/processor_test.go
@@ -45,7 +45,7 @@ func (suite *TriggerTestSuite) SetupSuite() {
 	suite.Require().NoError(err)
 }
 
-func (suite *TriggerTestSuite) TestSomething() {
+func (suite *TriggerTestSuite) TestCreateManyTriggersWithSameWorkerAllocatorName() {
 	processorInstance := Processor{
 		logger:                suite.logger,
 		functionLogger:        suite.logger.GetChild("some-function-logger"),

--- a/cmd/processor/app/processor_test.go
+++ b/cmd/processor/app/processor_test.go
@@ -1,0 +1,85 @@
+// +build test_unit
+
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+	"github.com/nuclio/nuclio/pkg/processor"
+	"github.com/nuclio/nuclio/pkg/processor/worker"
+	"testing"
+	// load cron trigger for tests purposes
+	_ "github.com/nuclio/nuclio/pkg/processor/trigger/cron"
+
+	"github.com/nuclio/logger"
+	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type TriggerTestSuite struct {
+	suite.Suite
+	logger logger.Logger
+}
+
+func (suite *TriggerTestSuite) SetupSuite() {
+	var err error
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+}
+
+func (suite *TriggerTestSuite) TestSomething() {
+	processorInstance := Processor{
+		logger:                suite.logger,
+		functionLogger:        suite.logger.GetChild("some-function-logger"),
+		namedWorkerAllocators: worker.NewAllocatorSyncMap(),
+	}
+	totalTriggers := 1000
+	triggerSpecs := map[string]functionconfig.Trigger{}
+	for i := 0; i < totalTriggers; i++ {
+		triggerName := fmt.Sprintf("Cron%d", i)
+		triggerSpecs[triggerName] = functionconfig.Trigger{
+			Name:                triggerName,
+			Kind:                "cron",
+			WorkerAllocatorName: "sameAllocator",
+			Attributes: map[string]interface{}{
+				"interval": "24h",
+			},
+		}
+	}
+	triggers, err := processorInstance.createTriggers(&processor.Configuration{
+		Config: functionconfig.Config{
+			Spec: functionconfig.Spec{
+				Runtime:  "golang",
+				Handler:  "nuclio:builtin",
+				Triggers: triggerSpecs,
+			},
+		},
+		PlatformConfig: &platformconfig.Config{
+			Kind: "local",
+		},
+	})
+
+	suite.Require().NoError(err)
+	suite.Require().Len(triggers, totalTriggers)
+}
+
+func TestTriggerTestSuite(t *testing.T) {
+	suite.Run(t, new(TriggerTestSuite))
+}

--- a/cmd/processor/app/processor_test.go
+++ b/cmd/processor/app/processor_test.go
@@ -79,6 +79,9 @@ func (suite *TriggerTestSuite) TestSomething() {
 
 	suite.Require().NoError(err)
 	suite.Require().Len(triggers, totalTriggers)
+	suite.Require().Len(processorInstance.namedWorkerAllocators.Keys(),
+		1,
+		"Expected only one named allocator to be created")
 }
 
 func TestTriggerTestSuite(t *testing.T) {

--- a/cmd/processor/app/processor_test.go
+++ b/cmd/processor/app/processor_test.go
@@ -20,13 +20,14 @@ package app
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/processor"
-	"github.com/nuclio/nuclio/pkg/processor/worker"
-	"testing"
 	// load cron trigger for tests purposes
 	_ "github.com/nuclio/nuclio/pkg/processor/trigger/cron"
+	"github.com/nuclio/nuclio/pkg/processor/worker"
 
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"

--- a/pkg/processor/trigger/cron/factory.go
+++ b/pkg/processor/trigger/cron/factory.go
@@ -34,7 +34,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	id string,
 	triggerConfiguration *functionconfig.Trigger,
 	runtimeConfiguration *runtime.Configuration,
-	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
+	namedWorkerAllocators *worker.AllocatorSyncMap) (trigger.Trigger, error) {
 
 	// create logger parent
 	triggerLogger := parentLogger.GetChild(triggerConfiguration.Kind)

--- a/pkg/processor/trigger/cron/trigger.go
+++ b/pkg/processor/trigger/cron/trigger.go
@@ -196,6 +196,7 @@ func (c *cron) setInterval(encodedInterval string) error {
 	}
 
 	c.Logger.InfoWith("Set cron trigger interval",
+		"name", c.configuration.Name,
 		"interval", intervalLength)
 	return nil
 }

--- a/pkg/processor/trigger/factory.go
+++ b/pkg/processor/trigger/factory.go
@@ -2,36 +2,13 @@ package trigger
 
 import (
 	"github.com/nuclio/nuclio/pkg/processor/worker"
-
-	"github.com/nuclio/errors"
 )
 
 type Factory struct{}
 
 func (f *Factory) GetWorkerAllocator(workerAllocatorName string,
-	namedWorkerAllocators map[string]worker.Allocator,
+	namedWorkerAllocators *worker.AllocatorSyncMap,
 	workerAllocatorCreator func() (worker.Allocator, error)) (worker.Allocator, error) {
 
-	// if our allocator is unnamed, just create a worker allocator
-	if workerAllocatorName == "" {
-		return workerAllocatorCreator()
-	}
-
-	// try to find worker allocator
-	workerAllocator, workerAllocatorExists := namedWorkerAllocators[workerAllocatorName]
-
-	// if it already exists, just use it
-	if workerAllocatorExists {
-		return workerAllocator, nil
-	}
-
-	// if it doesn't exist - create it
-	workerAllocator, err := workerAllocatorCreator()
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create worker allocator")
-	}
-
-	namedWorkerAllocators[workerAllocatorName] = workerAllocator
-
-	return workerAllocator, nil
+	return namedWorkerAllocators.LoadOrStore(workerAllocatorName, workerAllocatorCreator)
 }

--- a/pkg/processor/trigger/http/factory.go
+++ b/pkg/processor/trigger/http/factory.go
@@ -34,7 +34,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	id string,
 	triggerConfiguration *functionconfig.Trigger,
 	runtimeConfiguration *runtime.Configuration,
-	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
+	namedWorkerAllocators *worker.AllocatorSyncMap) (trigger.Trigger, error) {
 
 	// create logger parent
 	triggerLogger := parentLogger.GetChild(triggerConfiguration.Kind)

--- a/pkg/processor/trigger/kafka/factory.go
+++ b/pkg/processor/trigger/kafka/factory.go
@@ -34,7 +34,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	id string,
 	triggerConfiguration *functionconfig.Trigger,
 	runtimeConfiguration *runtime.Configuration,
-	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
+	namedWorkerAllocators *worker.AllocatorSyncMap) (trigger.Trigger, error) {
 	var triggerInstance trigger.Trigger
 
 	// create logger parent

--- a/pkg/processor/trigger/kickstart/factory.go
+++ b/pkg/processor/trigger/kickstart/factory.go
@@ -34,7 +34,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	id string,
 	triggerConfiguration *functionconfig.Trigger,
 	runtimeConfiguration *runtime.Configuration,
-	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
+	namedWorkerAllocators *worker.AllocatorSyncMap) (trigger.Trigger, error) {
 
 	// create logger parent
 	triggerLogger := parentLogger.GetChild(triggerConfiguration.Kind)

--- a/pkg/processor/trigger/kinesis/factory.go
+++ b/pkg/processor/trigger/kinesis/factory.go
@@ -34,7 +34,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	id string,
 	triggerConfiguration *functionconfig.Trigger,
 	runtimeConfiguration *runtime.Configuration,
-	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
+	namedWorkerAllocators *worker.AllocatorSyncMap) (trigger.Trigger, error) {
 
 	// create logger parent
 	triggerLogger := parentLogger.GetChild(triggerConfiguration.Kind)

--- a/pkg/processor/trigger/mqtt/basic/factory.go
+++ b/pkg/processor/trigger/mqtt/basic/factory.go
@@ -35,7 +35,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	id string,
 	triggerConfiguration *functionconfig.Trigger,
 	runtimeConfiguration *runtime.Configuration,
-	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
+	namedWorkerAllocators *worker.AllocatorSyncMap) (trigger.Trigger, error) {
 
 	// create logger parent
 	triggerLogger := parentLogger.GetChild(triggerConfiguration.Kind)

--- a/pkg/processor/trigger/mqtt/iotcore/factory.go
+++ b/pkg/processor/trigger/mqtt/iotcore/factory.go
@@ -34,7 +34,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	id string,
 	triggerConfiguration *functionconfig.Trigger,
 	runtimeConfiguration *runtime.Configuration,
-	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
+	namedWorkerAllocators *worker.AllocatorSyncMap) (trigger.Trigger, error) {
 
 	// create logger parent
 	triggerLogger := parentLogger.GetChild(triggerConfiguration.Kind)

--- a/pkg/processor/trigger/nats/factory.go
+++ b/pkg/processor/trigger/nats/factory.go
@@ -34,7 +34,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	id string,
 	triggerConfiguration *functionconfig.Trigger,
 	runtimeConfiguration *runtime.Configuration,
-	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
+	namedWorkerAllocators *worker.AllocatorSyncMap) (trigger.Trigger, error) {
 
 	// create logger parent
 	triggerLogger := parentLogger.GetChild(triggerConfiguration.Kind)

--- a/pkg/processor/trigger/partitioned/eventhub/factory.go
+++ b/pkg/processor/trigger/partitioned/eventhub/factory.go
@@ -32,7 +32,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	id string,
 	triggerConfiguration *functionconfig.Trigger,
 	runtimeConfiguration *runtime.Configuration,
-	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
+	namedWorkerAllocators *worker.AllocatorSyncMap) (trigger.Trigger, error) {
 	var triggerInstance trigger.Trigger
 
 	// create logger parent

--- a/pkg/processor/trigger/poller/v3ioitempoller/factory.go
+++ b/pkg/processor/trigger/poller/v3ioitempoller/factory.go
@@ -32,7 +32,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	id string,
 	triggerConfiguration *functionconfig.Trigger,
 	runtimeConfiguration *runtime.Configuration,
-	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
+	namedWorkerAllocators *worker.AllocatorSyncMap) (trigger.Trigger, error) {
 
 	// create logger parent
 	v3ioItemPollerLogger := parentLogger.GetChild("v3io_item_poller")

--- a/pkg/processor/trigger/pubsub/factory.go
+++ b/pkg/processor/trigger/pubsub/factory.go
@@ -34,7 +34,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	id string,
 	triggerConfiguration *functionconfig.Trigger,
 	runtimeConfiguration *runtime.Configuration,
-	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
+	namedWorkerAllocators *worker.AllocatorSyncMap) (trigger.Trigger, error) {
 	var triggerInstance trigger.Trigger
 
 	// create logger parent

--- a/pkg/processor/trigger/rabbitmq/factory.go
+++ b/pkg/processor/trigger/rabbitmq/factory.go
@@ -34,7 +34,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	id string,
 	triggerConfiguration *functionconfig.Trigger,
 	runtimeConfiguration *runtime.Configuration,
-	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
+	namedWorkerAllocators *worker.AllocatorSyncMap) (trigger.Trigger, error) {
 
 	// create logger parent
 	triggerLogger := parentLogger.GetChild(triggerConfiguration.Kind)

--- a/pkg/processor/trigger/registry.go
+++ b/pkg/processor/trigger/registry.go
@@ -29,7 +29,7 @@ import (
 type Creator interface {
 
 	// Create creates a trigger instance
-	Create(logger.Logger, string, *functionconfig.Trigger, *runtime.Configuration, map[string]worker.Allocator) (Trigger, error)
+	Create(logger.Logger, string, *functionconfig.Trigger, *runtime.Configuration, *worker.AllocatorSyncMap) (Trigger, error)
 }
 
 type Registry struct {
@@ -46,7 +46,7 @@ func (r *Registry) NewTrigger(logger logger.Logger,
 	name string,
 	triggerConfiguration *functionconfig.Trigger,
 	runtimeConfiguration *runtime.Configuration,
-	namedWorkerAllocators map[string]worker.Allocator) (Trigger, error) {
+	namedWorkerAllocators *worker.AllocatorSyncMap) (Trigger, error) {
 
 	registree, err := r.Get(kind)
 	if err != nil {

--- a/pkg/processor/trigger/v3iostream/factory.go
+++ b/pkg/processor/trigger/v3iostream/factory.go
@@ -34,7 +34,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	id string,
 	triggerConfiguration *functionconfig.Trigger,
 	runtimeConfiguration *runtime.Configuration,
-	namedWorkerAllocators map[string]worker.Allocator) (trigger.Trigger, error) {
+	namedWorkerAllocators *worker.AllocatorSyncMap) (trigger.Trigger, error) {
 	var triggerInstance trigger.Trigger
 
 	// create logger parent

--- a/pkg/processor/worker/factory.go
+++ b/pkg/processor/worker/factory.go
@@ -41,7 +41,7 @@ func (waf *Factory) CreateFixedPoolWorkerAllocator(logger logger.Logger,
 	// create the workers
 	workers, err := waf.createWorkers(logger, numWorkers, runtimeConfiguration)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create HTTP trigger")
+		return nil, errors.Wrap(err, "Failed to create workers")
 	}
 
 	// create an allocator
@@ -95,15 +95,11 @@ func (waf *Factory) createWorker(parentLogger logger.Logger,
 		return nil, errors.Wrap(err, "Failed to create runtime")
 	}
 
-	err = runtimeInstance.Start()
-
-	if err != nil {
+	if err := runtimeInstance.Start(); err != nil {
 		return nil, errors.Wrap(err, "Failed to start runtime")
 	}
 
-	return NewWorker(workerLogger,
-		workerIndex,
-		runtimeInstance)
+	return NewWorker(workerLogger, workerIndex, runtimeInstance)
 }
 
 func (waf *Factory) createWorkers(logger logger.Logger,

--- a/pkg/processor/worker/sync.go
+++ b/pkg/processor/worker/sync.go
@@ -1,0 +1,76 @@
+package worker
+
+import (
+	"sync"
+
+	"github.com/nuclio/errors"
+)
+
+type AllocatorSyncMap struct {
+	syncMap *sync.Map
+	lock    sync.Locker
+}
+
+func NewAllocatorSyncMap() *AllocatorSyncMap {
+	return &AllocatorSyncMap{
+		syncMap: &sync.Map{},
+		lock:    &sync.Mutex{},
+	}
+}
+
+// Load returns the worker allocator stored in the map for a key
+func (w *AllocatorSyncMap) Load(key string) (Allocator, bool) {
+	load, found := w.syncMap.Load(key)
+	if found {
+		return load.(Allocator), found
+	}
+	return nil, false
+}
+
+// Store sets the worker allocator per key
+func (w *AllocatorSyncMap) Store(key string, value Allocator) {
+	w.syncMap.Store(key, value)
+}
+
+// LoadOrStore tries to load exiting worker by key, if not existing - creates one and returns it
+// if key is empty - always create and return a new worker allocator
+func (w *AllocatorSyncMap) LoadOrStore(key string,
+	workerAllocatorCreator func() (Allocator, error)) (Allocator, error) {
+
+	if key == "" {
+		return workerAllocatorCreator()
+	}
+
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	// try to find worker allocator
+	workerAllocator, loaded := w.Load(key)
+
+	// if it already exists, just use it
+	if loaded {
+		return workerAllocator, nil
+	}
+
+	// if it doesn't exist - create it
+	workerAllocator, err := workerAllocatorCreator()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create worker allocator")
+	}
+
+	w.syncMap.Store(key, workerAllocator)
+	return workerAllocator, nil
+}
+
+// Delete delete worker allocator
+func (w *AllocatorSyncMap) Delete(key string) {
+	w.syncMap.Delete(key)
+}
+
+// Range calls handler for each worker allocator in map
+// if handler returns false, iteration is stopped
+func (w *AllocatorSyncMap) Range(handler func(string, Allocator) bool) {
+	w.syncMap.Range(func(key, value interface{}) bool {
+		return handler(key.(string), value.(Allocator))
+	})
+}

--- a/pkg/processor/worker/sync.go
+++ b/pkg/processor/worker/sync.go
@@ -32,6 +32,16 @@ func (w *AllocatorSyncMap) Store(key string, value Allocator) {
 	w.syncMap.Store(key, value)
 }
 
+// Keys returns all allocator keys
+func (w *AllocatorSyncMap) Keys() []string {
+	var keys []string
+	w.Range(func(s string, allocator Allocator) bool {
+		keys = append(keys, s)
+		return true
+	})
+	return keys
+}
+
 // LoadOrStore tries to load exiting worker by key, if not existing - creates one and returns it
 // if key is empty - always create and return a new worker allocator
 func (w *AllocatorSyncMap) LoadOrStore(key string,


### PR DESCRIPTION
This PR fixes triggers not sharing allocated workers due to race condition on map read/write

Added `AllocatorSyncMap` to administrate all allocation with mutex protection while (sort of) complying to `sync.Map` interface, for conveniency.

Internal ticket: `IG-18888`