### PR TITLE
Default ingress annotations

### DIFF
--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -383,6 +383,8 @@ platform: {}
 #       nodeLabelKey: nodeLabelValue
 #     defaultServiceType: ClusterIP
 #     defaultHTTPIngressHostTemplate: ""
+#     defaultHTTPIngressAnnotations:
+#       ingressAnnotationKey: ingressAnnotationValue
 #   imageRegistryOverrides:
 #     baseImageRegistries:
 #       "python:3.6": "myregistry"

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1107,9 +1107,9 @@ func (lc *lazyClient) createOrUpdateIngress(functionLabels labels.Set,
 
 			// if there are no rules and previously were, delete the ingress resource
 			if ingressRulesExist {
-				propogationPolicy := metav1.DeletePropagationForeground
+				propagationPolicy := metav1.DeletePropagationForeground
 				deleteOptions := &metav1.DeleteOptions{
-					PropagationPolicy: &propogationPolicy,
+					PropagationPolicy: &propagationPolicy,
 				}
 
 				err := lc.kubeClientSet.ExtensionsV1beta1().

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1653,6 +1653,8 @@ func (lc *lazyClient) populateIngressConfig(functionLabels labels.Set,
 	spec *extv1beta1.IngressSpec) error {
 	meta.Annotations = make(map[string]string)
 
+	platformConfig := lc.platformConfigurationProvider.GetPlatformConfiguration()
+
 	// get the first HTTP trigger and look for annotations that we shove to the ingress
 	// there should only be 0 or 1. if there are more, just take the first
 	for _, httpTrigger := range functionconfig.GetTriggersByKind(function.Spec.Triggers, "http") {
@@ -1686,6 +1688,15 @@ func (lc *lazyClient) populateIngressConfig(functionLabels labels.Set,
 			if _, ok := meta.Annotations[key]; !ok {
 				meta.Annotations[key] = value
 			}
+		}
+	}
+
+	// enrich with default ingress annotations
+	for key, value := range platformConfig.Kube.DefaultHTTPIngressAnnotations {
+
+		// only if not requested by the user
+		if _, found := meta.Annotations[key]; !found {
+			meta.Annotations[key] = value
 		}
 	}
 

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1694,7 +1694,7 @@ func (lc *lazyClient) populateIngressConfig(functionLabels labels.Set,
 	// enrich with default ingress annotations
 	for key, value := range platformConfig.Kube.DefaultHTTPIngressAnnotations {
 
-		// only if not requested by the user
+		// selectively take only undefined annotations
 		if _, found := meta.Annotations[key]; !found {
 			meta.Annotations[key] = value
 		}

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -325,7 +325,7 @@ func (suite *lazyTestSuite) TestTriggerDefinedNoIngresses() {
 		"nuclio.io/function-version": "latest",
 	}
 
-	// ensure no ingress is populated
+	// ensure no ingress rules are populated
 	err := suite.client.populateIngressConfig(labels,
 		&functionInstance,
 		&ingressMeta,

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -132,6 +132,7 @@ type PlatformKubeConfig struct {
 	DefaultServiceType             corev1.ServiceType `json:"defaultServiceType,omitempty"`
 	DefaultFunctionNodeSelector    map[string]string  `json:"defaultFunctionNodeSelector,omitempty"`
 	DefaultHTTPIngressHostTemplate string             `json:"defaultHTTPIngressHostTemplate,omitempty"`
+	DefaultHTTPIngressAnnotations  map[string]string  `json:"default_http_ingress_annotation,omitempty"`
 }
 
 type PlatformLocalConfig struct {

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -132,7 +132,7 @@ type PlatformKubeConfig struct {
 	DefaultServiceType             corev1.ServiceType `json:"defaultServiceType,omitempty"`
 	DefaultFunctionNodeSelector    map[string]string  `json:"defaultFunctionNodeSelector,omitempty"`
 	DefaultHTTPIngressHostTemplate string             `json:"defaultHTTPIngressHostTemplate,omitempty"`
-	DefaultHTTPIngressAnnotations  map[string]string  `json:"default_http_ingress_annotation,omitempty"`
+	DefaultHTTPIngressAnnotations  map[string]string  `json:"defaultHTTPIngressAnnotations,omitempty"`
 }
 
 type PlatformLocalConfig struct {


### PR DESCRIPTION
Allowing to customize default ingress annotation that would be added upon each function deployment.

These default are enriched as long as the user did not specify otherwise.