### PR TITLE
Update V3IO trigger event path

### DIFF
--- a/pkg/processor/trigger/v3iostream/event.go
+++ b/pkg/processor/trigger/v3iostream/event.go
@@ -38,10 +38,6 @@ func (e *Event) GetShardID() int {
 	return *e.record.ShardID
 }
 
-func (e *Event) GetPath() string {
-	return "Unsupported"
-}
-
 func (e *Event) GetOffset() int {
 	return int(e.record.SequenceNumber)
 }


### PR DESCRIPTION
Like other triggers, if `GetPath` is not _supported_ it should return empty string.