### PR TITLE
Bump Java SDK

### DIFF
--- a/docs/reference/runtimes/java/java-reference.md
+++ b/docs/reference/runtimes/java/java-reference.md
@@ -47,7 +47,7 @@ dependencies {
     compile group: '{{.Group}}', name: '{{.Name}}', version: '{{.Version}}'
     {{ end }}
 
-    compile files('./nuclio-sdk-java-1.0.0.jar')
+    compile files('./nuclio-sdk-java-1.1.0.jar')
 }
 
 shadowJar {

--- a/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
@@ -84,8 +84,7 @@ COPY pkg/processor/runtime/java/build.gradle \
 RUN cp nuclio-sdk-java-1.1.0.jar /home/gradle/src/wrapper/nuclio-sdk-java-1.1.0.jar
 
 # Download dependencies
-RUN cd /home/gradle/src/wrapper \
-    && gradle --build-cache compileJava
+RUN cd /home/gradle/src/wrapper && gradle --build-cache compileJava
 
 # Build nuclio-java-wrapper.jar
 ONBUILD RUN /home/gradle/src/wrapper/build-wrapped-handler.sh

--- a/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
@@ -46,10 +46,10 @@ COPY pkg/processor/build/runtime/java/docker/onbuild/build-user-handler.sh /home
 RUN chmod +x /home/gradle/src/userHandler/build-user-handler.sh
 
 # Download the nuclio SDK Jar
-RUN curl -LO https://repo1.maven.org/fromsearch?filepath=io/nuclio/nuclio-sdk-java/1.0.0/nuclio-sdk-java-1.0.0.jar
+RUN curl -LO https://repo1.maven.org/fromsearch?filepath=io/nuclio/nuclio-sdk-java/1.1.0/nuclio-sdk-java-1.1.0.jar
 
 # Copy the downloaded SDK Jar to the userHandler folder
-RUN cp nuclio-sdk-java-1.0.0.jar /home/gradle/src/userHandler/nuclio-sdk-java-1.0.0.jar
+RUN cp nuclio-sdk-java-1.1.0.jar /home/gradle/src/userHandler/nuclio-sdk-java-1.1.0.jar
 
 # Copy the gradle build script and user sources to /home/gradle/src/userHandler
 ONBUILD COPY handler/build.gradle /home/gradle/src/userHandler
@@ -62,8 +62,7 @@ ONBUILD ARG NUCLIO_BUILD_LOCAL_HANDLER_DIR=.
 ONBUILD COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} /home/gradle/src/userHandler
 
 # Run the handle builder to create /home/gradle/src/userHandler/build/libs/user-handler.jar.
-ONBUILD RUN cd /home/gradle/src/userHandler \
-    && ./build-user-handler.sh
+ONBUILD RUN cd /home/gradle/src/userHandler && ./build-user-handler.sh
 
 #
 # Build wrapper
@@ -82,7 +81,7 @@ COPY pkg/processor/runtime/java/build.gradle \
     /home/gradle/src/wrapper/
 
 # Copy also the downloaded nuclio SDK Jar to the wrapper folder
-RUN cp nuclio-sdk-java-1.0.0.jar /home/gradle/src/wrapper/nuclio-sdk-java-1.0.0.jar
+RUN cp nuclio-sdk-java-1.1.0.jar /home/gradle/src/wrapper/nuclio-sdk-java-1.1.0.jar
 
 # Download dependencies
 RUN cd /home/gradle/src/wrapper \

--- a/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
@@ -21,7 +21,7 @@ FROM quay.io/nuclio/processor:${NUCLIO_LABEL}-${NUCLIO_ARCH} as processor
 FROM gcr.io/iguazio/openjdk:8-slim as user-handler-builder
 
 RUN apt-get update -qqy \
-    && apt-get install -o APT::Immediate-Configure=false -qqy curl \
+    && apt-get install -o APT::Immediate-Configure=false -qqy curl unzip \
     && curl -LO https://services.gradle.org/distributions/gradle-4.5.1-bin.zip \
     && unzip gradle-4.5.1-bin.zip \
     && rm gradle-4.5.1-bin.zip \

--- a/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
@@ -18,7 +18,7 @@ ARG NUCLIO_ARCH=amd64
 # Supplies processor
 FROM quay.io/nuclio/processor:${NUCLIO_LABEL}-${NUCLIO_ARCH} as processor
 
-FROM gcr.io/iguazio/openjdk:9-slim as user-handler-builder
+FROM gcr.io/iguazio/openjdk:8-slim as user-handler-builder
 
 RUN apt-get update -qqy \
     && apt-get install -o APT::Immediate-Configure=false -qqy curl \

--- a/pkg/processor/build/runtime/java/runtime.go
+++ b/pkg/processor/build/runtime/java/runtime.go
@@ -148,7 +148,7 @@ dependencies {
 	compile group: '{{.Group}}', name: '{{.Name}}', version: '{{.Version}}'
 	{{ end }}
 
-    compile files('./nuclio-sdk-java-1.0.0.jar')
+    compile files('./nuclio-sdk-java-1.1.0.jar')
 }
 
 shadowJar {

--- a/pkg/processor/runtime/java/build.gradle
+++ b/pkg/processor/runtime/java/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.2'
     compile group: 'commons-cli', name: 'commons-cli', version: '1.4'
 
-    compile files('./nuclio-sdk-java-1.0.0.jar')
+    compile files('./nuclio-sdk-java-1.1.0.jar')
     compile files('./user-handler.jar')
 }
 

--- a/test/_functions/java/custom-gradle-script/build.gradle
+++ b/test/_functions/java/custom-gradle-script/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.0'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.0'
 
-    compile files('./nuclio-sdk-java-1.0.0.jar')
+    compile files('./nuclio-sdk-java-1.1.0.jar')
 }
 
 shadowJar {


### PR DESCRIPTION
PR includes

- Bump SDK to `1.1.0` which is compatible with java8+
- Use Java-8 for its LTS