### PR TITLE
Projects - update and fixes

### DIFF
--- a/pkg/common/testutils/http.go
+++ b/pkg/common/testutils/http.go
@@ -2,13 +2,13 @@ package testutils
 
 import "net/http"
 
-type RoundTripFunc func(req *http.Request) *http.Response
+type roundTripFunc func(req *http.Request) *http.Response
 
-func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req), nil
 }
 
-func newHTTPClient(fn RoundTripFunc) *http.Client { // nolint: interfacer
+func newHTTPClient(fn roundTripFunc) *http.Client { // nolint: interfacer
 	return &http.Client{
 		Transport: fn,
 	}

--- a/pkg/common/url.go
+++ b/pkg/common/url.go
@@ -114,25 +114,22 @@ func NormalizeURLPath(p string) string {
 	return string(res)
 }
 
-// SendHTTPRequest Sends an http request
+// SendHTTPRequest Sends an HTTP request using custom http client
 // ignore expectedStatusCode by setting it to 0
-func SendHTTPRequest(method string,
+func SendHTTPRequest(httpClient *http.Client,
+	method string,
 	requestURL string,
 	body []byte,
 	headers map[string]string,
 	cookies []*http.Cookie,
-	expectedStatusCode int,
-	insecure bool,
-	timeout time.Duration) ([]byte, *http.Response, error) {
+	expectedStatusCode int) ([]byte, *http.Response, error) {
 
-	// create client
-	client := &http.Client{
-		Timeout: timeout,
-	}
-
-	if insecure {
-		client.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
 		}
 	}
 
@@ -153,7 +150,7 @@ func SendHTTPRequest(method string,
 	}
 
 	// perform the request
-	resp, err := client.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "Failed to send HTTP request")
 	}

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -276,7 +276,7 @@ func (fr *functionResource) storeAndDeployFunction(request *http.Request,
 		functionInfo.Spec.Build.Offline = dashboardServer.Offline
 
 		// just deploy. the status is async through polling
-		_, err := fr.getPlatform().CreateFunction(&platform.CreateFunctionOptions{
+		if _, err := fr.getPlatform().CreateFunction(&platform.CreateFunctionOptions{
 			Logger: fr.Logger,
 			FunctionConfig: functionconfig.Config{
 				Meta: *functionInfo.Meta,
@@ -290,9 +290,7 @@ func (fr *functionResource) storeAndDeployFunction(request *http.Request,
 				MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fr.getCtxSession(request)),
 				OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 			},
-		})
-
-		if err != nil {
+		}); err != nil {
 			fr.Logger.WarnWith("Failed to deploy function", "err", err)
 			errDeployingChan <- err
 		}

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -678,6 +678,7 @@ func (pr *projectResource) projectToAttributes(project platform.Project) restful
 	attributes := restful.Attributes{
 		"metadata": project.GetConfig().Meta,
 		"spec":     project.GetConfig().Spec,
+		"status":   project.GetConfig().Status,
 	}
 
 	return attributes

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -284,6 +284,10 @@ func (pr *projectResource) createProject(request *http.Request, projectInfoInsta
 		PermissionOptions: opa.PermissionOptions{
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
+
+		// TODO: read from request header
+		// if false - return "202" and let client to poll on resource until it becomes ready
+		WaitForCreateCompletion: true,
 	}); err != nil {
 		if strings.Contains(errors.Cause(err).Error(), "already exists") {
 			return "", nil, nuclio.WrapErrConflict(err)

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1010,7 +1010,8 @@ func (suite *projectTestSuite) TestGetDetailSuccessful() {
 	},
 	"spec": {
 		"description": "p1Desc"
-	}
+	},
+    "status": {}
 }`
 
 	suite.sendRequest("GET",
@@ -1073,7 +1074,8 @@ func (suite *projectTestSuite) TestGetListSuccessful() {
 		},
 		"spec": {
 			"description": "p1Desc"
-		}
+		},
+        "status": {}
 	},
 	"p2": {
 		"metadata": {
@@ -1082,7 +1084,8 @@ func (suite *projectTestSuite) TestGetListSuccessful() {
 		},
 		"spec": {
 			"description": "p2Desc"
-		}
+		},
+        "status": {}
 	}
 }`
 
@@ -1263,7 +1266,8 @@ func (suite *projectTestSuite) TestExportProjectSuccessful() {
     "metadata": {
       "name": "p1"
     },
-    "spec": {}
+    "spec": {},
+    "status": {}
   }
 }`
 
@@ -1397,7 +1401,8 @@ func (suite *projectTestSuite) TestExportProjectListSuccessful() {
       "metadata": {
         "name": "p1"
       },
-      "spec": {}
+      "spec": {},
+	  "status": {}
     }
   },
   "p2": {
@@ -1432,7 +1437,8 @@ func (suite *projectTestSuite) TestExportProjectListSuccessful() {
       "metadata": {
         "name": "p2"
       },
-      "spec": {}
+      "spec": {},
+      "status": {}
     }
   }
 }`
@@ -1473,13 +1479,23 @@ func (suite *projectTestSuite) TestCreateSuccessful() {
 		"description": "p1Description"
 	}
 }`
+	expectedResponseBody := `{
+	"metadata": {
+		"name": "p1",
+		"namespace": "p1-namespace"
+	},
+	"spec": {
+		"description": "p1Description"
+	},
+    "status": {}
+}`
 
 	suite.sendRequest("POST",
 		"/api/projects",
 		nil,
 		bytes.NewBufferString(requestBody),
 		&expectedStatusCode,
-		requestBody)
+		expectedResponseBody)
 
 	suite.mockPlatform.AssertExpectations(suite.T())
 }

--- a/pkg/nuctl/command/common/renderers.go
+++ b/pkg/nuctl/command/common/renderers.go
@@ -159,6 +159,7 @@ func RenderProjects(projects []platform.Project,
 		if format == OutputFormatWide {
 			header = append(header, []string{
 				"Description",
+				"Owner",
 			}...)
 		}
 
@@ -177,6 +178,7 @@ func RenderProjects(projects []platform.Project,
 			if format == OutputFormatWide {
 				projectFields = append(projectFields, []string{
 					project.GetConfig().Spec.Description,
+					project.GetConfig().Spec.Owner,
 				}...)
 			}
 

--- a/pkg/nuctl/command/create.go
+++ b/pkg/nuctl/command/create.go
@@ -103,6 +103,7 @@ func newCreateProjectCommandeer(createCommandeer *createCommandeer) *createProje
 	}
 
 	cmd.Flags().StringVar(&commandeer.projectConfig.Spec.Description, "description", "", "Project description")
+	cmd.Flags().StringVar(&commandeer.projectConfig.Spec.Owner, "owner", "", "Project owner")
 	commandeer.cmd = cmd
 
 	return commandeer

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -601,10 +601,10 @@ func (ap *Platform) CreateProject(createProjectOptions *platform.CreateProjectOp
 // EnrichCreateProjectConfig enrich project configuration with defaults
 func (ap *Platform) EnrichCreateProjectConfig(createProjectOptions *platform.CreateProjectOptions) error {
 
-	// enrich project owner from auth session
-	if createProjectOptions.AuthSession != nil && createProjectOptions.ProjectConfig.Spec.Owner == "" {
-		createProjectOptions.ProjectConfig.Spec.Owner = createProjectOptions.AuthSession.GetUsername()
-	}
+	// TODO: enrich project owner from auth session
+	//if createProjectOptions.AuthSession != nil && createProjectOptions.ProjectConfig.Spec.Owner == "" {
+	//	createProjectOptions.ProjectConfig.Spec.Owner = createProjectOptions.AuthSession.GetUsername()
+	//}
 
 	return nil
 }

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -600,12 +600,6 @@ func (ap *Platform) CreateProject(createProjectOptions *platform.CreateProjectOp
 
 // EnrichCreateProjectConfig enrich project configuration with defaults
 func (ap *Platform) EnrichCreateProjectConfig(createProjectOptions *platform.CreateProjectOptions) error {
-
-	// TODO: enrich project owner from auth session
-	//if createProjectOptions.AuthSession != nil && createProjectOptions.ProjectConfig.Spec.Owner == "" {
-	//	createProjectOptions.ProjectConfig.Spec.Owner = createProjectOptions.AuthSession.GetUsername()
-	//}
-
 	return nil
 }
 

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -600,6 +600,12 @@ func (ap *Platform) CreateProject(createProjectOptions *platform.CreateProjectOp
 
 // EnrichCreateProjectConfig enrich project configuration with defaults
 func (ap *Platform) EnrichCreateProjectConfig(createProjectOptions *platform.CreateProjectOptions) error {
+
+	// enrich project owner from auth session
+	if createProjectOptions.AuthSession != nil && createProjectOptions.ProjectConfig.Spec.Owner == "" {
+		createProjectOptions.ProjectConfig.Spec.Owner = createProjectOptions.AuthSession.GetUsername()
+	}
+
 	return nil
 }
 

--- a/pkg/platform/abstract/project/external/leader/iguazio/client.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/client.go
@@ -1,6 +1,7 @@
 package iguazio
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,12 +27,19 @@ const (
 type Client struct {
 	logger                logger.Logger
 	platformConfiguration *platformconfig.Config
+	httpClient            *http.Client
 }
 
 func NewClient(parentLogger logger.Logger, platformConfiguration *platformconfig.Config) (*Client, error) {
 	newClient := Client{
 		logger:                parentLogger.GetChild("leader-client-iguazio"),
 		platformConfiguration: platformConfiguration,
+		httpClient: &http.Client{
+			Timeout: DefaultRequestTimeout,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		},
 	}
 
 	return &newClient, nil
@@ -62,18 +70,17 @@ func (c *Client) Get(getProjectOptions *platform.GetProjectsOptions) ([]platform
 		requestURL += fmt.Sprintf("/__name__/%s", getProjectOptions.Meta.Name)
 	}
 
-	// ask for tenant to include the namespace name on response
-	requestURL += "?include=tenant"
+	// include namespace and username
+	requestURL += "?include=tenant,owner"
 
 	// send the request
-	responseBody, _, err := common.SendHTTPRequest(http.MethodGet,
+	responseBody, _, err := common.SendHTTPRequest(c.httpClient,
+		http.MethodGet,
 		requestURL,
 		nil,
 		headers,
 		cookies,
-		http.StatusOK,
-		true,
-		DefaultRequestTimeout)
+		http.StatusOK)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to send request to leader")
 	}
@@ -109,14 +116,14 @@ func (c *Client) Create(createProjectOptions *platform.CreateProjectOptions) err
 	}
 
 	// send the request
-	responseBody, _, err := common.SendHTTPRequest(http.MethodPost,
+	c.logger.DebugWith("Creating project", "body", string(body))
+	responseBody, _, err := common.SendHTTPRequest(c.httpClient,
+		http.MethodPost,
 		fmt.Sprintf("%s/%s", c.platformConfiguration.ProjectsLeader.APIAddress, "projects"),
 		body,
 		headers,
 		cookies,
-		http.StatusCreated,
-		true,
-		DefaultRequestTimeout)
+		http.StatusCreated)
 	if err != nil {
 		return errors.Wrap(err, "Failed to send request to leader")
 	}
@@ -130,9 +137,8 @@ func (c *Client) Create(createProjectOptions *platform.CreateProjectOptions) err
 	c.logger.DebugWith("Successfully sent create project request to leader",
 		"projectData", project.Data)
 
-	createProjectJobID := project.Data.Relationships.LastJob.Data.ID
 	if createProjectOptions.WaitForCreateCompletion {
-		job, err := c.waitForJobCompletion(createProjectJobID)
+		job, err := c.waitForJobCompletion(project.Data.Relationships.LastJob.Data.ID)
 		if err != nil {
 			return errors.Wrap(err, "Failed waiting for create project job completion")
 		}
@@ -173,7 +179,8 @@ func (c *Client) Update(updateProjectOptions *platform.UpdateProjectOptions) err
 	}
 
 	// send the request
-	responseBody, _, err := common.SendHTTPRequest(http.MethodPut,
+	responseBody, _, err := common.SendHTTPRequest(c.httpClient,
+		http.MethodPut,
 		fmt.Sprintf("%s/%s/%s",
 			c.platformConfiguration.ProjectsLeader.APIAddress,
 			"projects/__name__",
@@ -181,9 +188,7 @@ func (c *Client) Update(updateProjectOptions *platform.UpdateProjectOptions) err
 		body,
 		headers,
 		cookies,
-		http.StatusOK,
-		true,
-		DefaultRequestTimeout)
+		http.StatusOK)
 	if err != nil {
 		return errors.Wrap(err, "Failed to send request to leader")
 	}
@@ -224,14 +229,13 @@ func (c *Client) Delete(deleteProjectOptions *platform.DeleteProjectOptions) err
 		cookies = append(cookies, deleteProjectOptions.SessionCookie)
 	}
 
-	if _, _, err := common.SendHTTPRequest(http.MethodDelete,
+	if _, _, err := common.SendHTTPRequest(c.httpClient,
+		http.MethodDelete,
 		fmt.Sprintf("%s/%s", c.platformConfiguration.ProjectsLeader.APIAddress, "projects"),
 		body,
 		headers,
 		cookies,
-		http.StatusAccepted,
-		true,
-		DefaultRequestTimeout); err != nil {
+		http.StatusAccepted); err != nil {
 
 		return errors.Wrap(err, "Failed to send request to leader")
 	}
@@ -261,7 +265,8 @@ func (c *Client) GetUpdatedAfter(updatedAfterTime *time.Time) ([]platform.Projec
 
 	// send the request
 	headers := c.generateCommonRequestHeaders()
-	responseBody, _, err := common.SendHTTPRequest(http.MethodGet,
+	responseBody, _, err := common.SendHTTPRequest(c.httpClient,
+		http.MethodGet,
 		fmt.Sprintf("%s/%s%s",
 			c.platformConfiguration.ProjectsLeader.APIAddress,
 			"projects",
@@ -269,9 +274,7 @@ func (c *Client) GetUpdatedAfter(updatedAfterTime *time.Time) ([]platform.Projec
 		nil,
 		headers,
 		[]*http.Cookie{{Name: "session", Value: c.platformConfiguration.IguazioSessionCookie}},
-		http.StatusOK,
-		true,
-		DefaultRequestTimeout)
+		http.StatusOK)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to send request to leader")
 	}
@@ -310,30 +313,35 @@ func (c *Client) waitForJobCompletion(jobID string) (*JobDetail, error) {
 	headers := c.generateCommonRequestHeaders()
 	var job JobDetail
 
+	c.logger.DebugWith("Waiting for job completion", "jobID", jobID)
 	err := common.RetryUntilSuccessful(time.Minute*5,
 		time.Second*5,
 		func() bool {
-			responseBody, _, err := common.SendHTTPRequest(http.MethodGet,
-				fmt.Sprintf("%s/%s%s",
+			responseBody, _, err := common.SendHTTPRequest(c.httpClient,
+				http.MethodGet,
+				fmt.Sprintf("%s/%s/%s",
 					c.platformConfiguration.ProjectsLeader.APIAddress,
 					"jobs",
 					jobID),
 				nil,
 				headers,
 				[]*http.Cookie{{Name: "session", Value: c.platformConfiguration.IguazioSessionCookie}},
-				http.StatusOK,
-				true,
-				DefaultRequestTimeout)
+				http.StatusOK)
 			if err != nil {
-				c.logger.DebugWith("Failed to send request to leader",
-					"responseBody", responseBody)
+				c.logger.DebugWith("Failed to get job state",
+					"responseBody", string(responseBody))
 				return false
 			}
+
 			if err := json.Unmarshal(responseBody, &job); err != nil {
 				c.logger.DebugWith("Failed to unmarshal response body",
 					"responseBody", responseBody)
 				return false
 			}
+
+			c.logger.DebugWith("Inspecting job state",
+				"jobId", jobID,
+				"jobAttributes", job.Data.Attributes)
 			return JobStateInSlice(job.Data.Attributes.State, []JobState{
 				JobStateCompleted,
 				JobStateCanceled,
@@ -344,6 +352,9 @@ func (c *Client) waitForJobCompletion(jobID string) (*JobDetail, error) {
 		return nil, errors.Wrap(err, "Exhausting waiting for job completion")
 	}
 
+	c.logger.DebugWith("Completed waiting for job completion",
+		"jobAttributes", job.Data.Attributes,
+		"jobID", jobID)
 	return &job, nil
 }
 

--- a/pkg/platform/abstract/project/external/leader/iguazio/client_test.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/client_test.go
@@ -1,0 +1,118 @@
+// +build test_unit
+
+package iguazio
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/common/testutils"
+	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type ClientTestSuite struct {
+	suite.Suite
+
+	logger logger.Logger
+	client *Client
+}
+
+func (suite *ClientTestSuite) SetupTest() {
+	var err error
+
+	// create logger
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+
+	// mock internal client
+	suite.client, err = NewClient(suite.logger, &platformconfig.Config{
+		ProjectsLeader: &platformconfig.ProjectsLeader{
+			APIAddress: "somewhere.com",
+		},
+	})
+	suite.Require().NoError(err)
+
+}
+
+func (suite *ClientTestSuite) TestGet() {
+	for _, testCase := range []struct {
+		name   string
+		detail bool
+	}{
+		{
+			name:   "detail",
+			detail: true,
+		},
+		{
+			name:   "list",
+			detail: false,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.client.httpClient = testutils.CreateDummyHTTPClient(func(r *http.Request) *http.Response {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       suite.mockIgzAPIGetProject(testCase.detail),
+				}
+			})
+
+			getProjectOptions := &platform.GetProjectsOptions{}
+			if testCase.detail {
+				getProjectOptions.Meta = platform.ProjectMeta{
+					Name: "some-project",
+				}
+			}
+			projects, err := suite.client.Get(getProjectOptions)
+			suite.Require().NoError(err)
+			suite.Require().Len(projects, 1)
+			suite.Require().Equal(projects[0].GetConfig().Spec.Owner, "admin")
+
+		})
+
+	}
+}
+
+func (suite *ClientTestSuite) mockIgzAPIGetProject(detail bool) io.ReadCloser {
+	projectData := `{
+        "attributes": {
+            "admin_status": "online",
+            "annotations": [],
+            "created_at": "2021-08-12T07:13:19.620000+00:00",
+            "labels": [],
+            "name": "a1",
+            "operational_status": "online",
+            "owner_username": "admin",
+            "updated_at": "2021-08-12T07:13:29.845000+00:00"
+        },
+        "id": "798d8441-1ca6-407d-8e8a-5ac24ba41ece",
+        "relationships": {
+            "owner": {
+                "data": {
+                    "id": "f595477c-945b-44c5-bf87-d6e4052409af",
+                    "type": "user"
+                }
+            }
+        },
+        "type": "project"
+    }`
+	responseTemplate := `{"data": %s, "included": [], "meta": {"ctx": "11493070626596053818"}}`
+
+	if detail {
+		return ioutil.NopCloser(bytes.NewBufferString(fmt.Sprintf(responseTemplate, projectData)))
+	}
+
+	return ioutil.NopCloser(bytes.NewBufferString(fmt.Sprintf(responseTemplate, "["+projectData+"]")))
+}
+
+func TestClientTestSuite(t *testing.T) {
+	suite.Run(t, new(ClientTestSuite))
+}

--- a/pkg/platform/abstract/project/external/leader/iguazio/synchronizer.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/synchronizer.go
@@ -1,9 +1,11 @@
 package iguazio
 
 import (
+	"context"
 	"fmt"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/errgroup"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/abstract/project"
 	"github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader"
@@ -173,9 +175,10 @@ func (c *Synchronizer) synchronizeProjectsFromLeader(namespace string,
 		"projectsToUpdateNum", len(projectsToUpdate))
 
 	// create projects that exist on the leader but weren't created internally
+	createProjectErrGroup, _ := errgroup.WithContext(context.Background(), c.logger)
 	for _, projectInstance := range projectsToCreate {
 		projectInstance := projectInstance
-		go func() {
+		createProjectErrGroup.Go("create projects", func() error {
 			c.logger.DebugWith("Creating project from leader sync", "projectInstance", *projectInstance)
 			createProjectConfig := &platform.CreateProjectOptions{
 				ProjectConfig: &platform.ProjectConfig{
@@ -189,18 +192,24 @@ func (c *Synchronizer) synchronizeProjectsFromLeader(namespace string,
 					"name", createProjectConfig.ProjectConfig.Meta.Name,
 					"namespace", createProjectConfig.ProjectConfig.Meta.Namespace,
 					"err", err)
-				return
+				return err
 			}
 			c.logger.DebugWith("Successfully created project from leader sync",
 				"name", createProjectConfig.ProjectConfig.Meta.Name,
 				"namespace", createProjectConfig.ProjectConfig.Meta.Namespace)
-		}()
+			return nil
+		})
+	}
+
+	if err := createProjectErrGroup.Wait(); err != nil {
+		return nil, errors.Wrap(err, "Failed to create projects")
 	}
 
 	// update projects that exist both internally and on the leader
+	updateProjectErrGroup, _ := errgroup.WithContext(context.Background(), c.logger)
 	for _, projectInstance := range projectsToUpdate {
 		projectInstance := projectInstance
-		go func() {
+		updateProjectErrGroup.Go("update projects", func() error {
 			c.logger.DebugWith("Updating project from leader sync", "projectInstance", *projectInstance)
 			updateProjectOptions := &platform.UpdateProjectOptions{
 				ProjectConfig: platform.ProjectConfig{
@@ -214,12 +223,17 @@ func (c *Synchronizer) synchronizeProjectsFromLeader(namespace string,
 					"name", updateProjectOptions.ProjectConfig.Meta.Name,
 					"namespace", updateProjectOptions.ProjectConfig.Meta.Namespace,
 					"err", err)
-				return
+				return err
 			}
 			c.logger.DebugWith("Successfully updated project from leader sync",
 				"name", updateProjectOptions.ProjectConfig.Meta.Name,
 				"namespace", updateProjectOptions.ProjectConfig.Meta.Namespace)
-		}()
+			return nil
+		})
+	}
+
+	if err := updateProjectErrGroup.Wait(); err != nil {
+		return nil, errors.Wrap(err, "Failed to update projects")
 	}
 
 	return newMostRecentUpdatedProjectTime, nil

--- a/pkg/platform/abstract/project/external/leader/iguazio/synchronizer.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/synchronizer.go
@@ -115,9 +115,14 @@ func (c *Synchronizer) getModifiedProjects(leaderProjects []platform.Project, in
 			continue
 		}
 
+		// no time was given, set it to empty
+		if leaderProjectConfig.Status.UpdatedAt == nil {
+			leaderProjectConfig.Status.UpdatedAt = &time.Time{}
+		}
+
 		// check if it's the most recent updated project
-		if mostRecentUpdatedProjectTime == nil || mostRecentUpdatedProjectTime.Before(leaderProjectConfig.Status.UpdatedAt) {
-			mostRecentUpdatedProjectTime = &leaderProjectConfig.Status.UpdatedAt
+		if mostRecentUpdatedProjectTime == nil || mostRecentUpdatedProjectTime.Before(*leaderProjectConfig.Status.UpdatedAt) {
+			mostRecentUpdatedProjectTime = leaderProjectConfig.Status.UpdatedAt
 		}
 
 		// check if the project exists internally

--- a/pkg/platform/abstract/project/external/leader/iguazio/types.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/types.go
@@ -56,9 +56,9 @@ func (pl *Project) parseTimeFromTimestamp(timestamp string) time.Time {
 }
 
 type ProjectData struct {
-	Type          string               `json:"type,omitempty"`
-	Attributes    ProjectAttributes    `json:"attributes,omitempty"`
-	Relationships ProjectRelationships `json:"relationships,omitempty"`
+	Type          string                `json:"type,omitempty"`
+	Attributes    ProjectAttributes     `json:"attributes,omitempty"`
+	Relationships *ProjectRelationships `json:"relationships,omitempty"`
 }
 
 type ProjectAttributes struct {
@@ -78,8 +78,8 @@ type ProjectRelationships struct {
 	LastJob struct {
 		Data struct {
 			ID string `json:"id,omitempty"`
-		}
-	}
+		} `json:"data,omitempty"`
+	} `json:"last_job,omitempty"`
 }
 
 type Label struct {

--- a/pkg/platform/abstract/project/external/leader/iguazio/types.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/types.go
@@ -31,6 +31,7 @@ func NewProjectFromProjectConfig(projectConfig *platform.ProjectConfig) Project 
 }
 
 func (pl *Project) GetConfig() *platform.ProjectConfig {
+	updatedAt := pl.parseTimeFromTimestamp(pl.Data.Attributes.UpdatedAt)
 	return &platform.ProjectConfig{
 		Meta: platform.ProjectMeta{
 			Name:        pl.Data.Attributes.Name,
@@ -45,7 +46,7 @@ func (pl *Project) GetConfig() *platform.ProjectConfig {
 		Status: platform.ProjectStatus{
 			AdminStatus:       pl.Data.Attributes.AdminStatus,
 			OperationalStatus: pl.Data.Attributes.OperationalStatus,
-			UpdatedAt:         pl.parseTimeFromTimestamp(pl.Data.Attributes.UpdatedAt),
+			UpdatedAt:         &updatedAt,
 		},
 	}
 }

--- a/pkg/platform/kube/resourcescaler/test/resourcescaler_test.go
+++ b/pkg/platform/kube/resourcescaler/test/resourcescaler_test.go
@@ -195,14 +195,13 @@ func (suite *ResourceScalerTestSuite) TestSanity() {
 
 		// try invoke function without the target header
 		// expect DLX to fail on 400
-		_, _, _ = common.SendHTTPRequest(http.MethodGet,
+		_, _, _ = common.SendHTTPRequest(nil,
+			http.MethodGet,
 			fmt.Sprintf("http://%s:8080", suite.GetTestHost()),
 			[]byte{},
 			map[string]string{},
 			nil,
-			http.StatusBadRequest,
-			true,
-			30*time.Second)
+			http.StatusBadRequest)
 
 		// add target header, expect it to wake up the function
 		// for this specific test case, the response status code is 502
@@ -211,16 +210,15 @@ func (suite *ResourceScalerTestSuite) TestSanity() {
 		// it fails to resolve the internal (kubernetes) function host
 		// TODO: make DLX work in "test" mode, where it invoke the function from within the k8s cluster
 		//       see suite.KubectlInvokeFunctionViaCurl(functionName, "http://function-service-endpoint:8080")
-		responseBody, _, err := common.SendHTTPRequest(http.MethodGet,
+		responseBody, _, err := common.SendHTTPRequest(nil,
+			http.MethodGet,
 			fmt.Sprintf("http://%s:8080", suite.GetTestHost()),
 			[]byte{},
 			map[string]string{
 				"X-Nuclio-Target": functionName,
 			},
 			nil,
-			0,
-			true,
-			30*time.Second)
+			0)
 		suite.Require().NoError(err)
 		suite.Require().Equal([]byte{}, responseBody)
 
@@ -322,16 +320,15 @@ func (suite *ResourceScalerTestSuite) TestMultiTargetScaleFromZero() {
 				// it fails to resolve the internal (kubernetes) function host
 				// TODO: make DLX work in "test" mode, where it invoke the function from within the k8s cluster
 				//       see suite.KubectlInvokeFunctionViaCurl(functionName, "http://function-service-endpoint:8080")
-				responseBody, _, err := common.SendHTTPRequest(http.MethodGet,
+				responseBody, _, err := common.SendHTTPRequest(nil,
+					http.MethodGet,
 					fmt.Sprintf("http://%s:8080", suite.GetTestHost()),
 					[]byte{},
 					map[string]string{
 						"X-Nuclio-Target": fmt.Sprintf("%s,%s", functionName1, functionName2),
 					},
 					nil,
-					0,
-					true,
-					30*time.Second)
+					0)
 				suite.Require().NoError(err)
 				suite.Require().Equal([]byte{}, responseBody)
 

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -191,6 +191,7 @@ func (pm ProjectMeta) IsEqual(other ProjectMeta) bool {
 
 type ProjectSpec struct {
 	Description string `json:"description,omitempty"`
+	Owner       string `json:"owner,omitempty"`
 }
 
 func (ps ProjectSpec) IsEqual(other ProjectSpec) bool {
@@ -222,11 +223,12 @@ func (pc *ProjectConfig) Scrub() {
 }
 
 type CreateProjectOptions struct {
-	ProjectConfig     *ProjectConfig
-	RequestOrigin     platformconfig.ProjectsLeaderKind
-	SessionCookie     *http.Cookie
-	PermissionOptions opa.PermissionOptions
-	AuthSession       auth.Session
+	ProjectConfig           *ProjectConfig
+	RequestOrigin           platformconfig.ProjectsLeaderKind
+	SessionCookie           *http.Cookie
+	PermissionOptions       opa.PermissionOptions
+	AuthSession             auth.Session
+	WaitForCreateCompletion bool
 }
 
 type UpdateProjectOptions struct {

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -199,9 +199,9 @@ func (ps ProjectSpec) IsEqual(other ProjectSpec) bool {
 }
 
 type ProjectStatus struct {
-	AdminStatus       string    `json:"adminStatus,omitempty"`
-	OperationalStatus string    `json:"operationalStatus,omitempty"`
-	UpdatedAt         time.Time `json:"updatedAt,omitempty"`
+	AdminStatus       string     `json:"adminStatus,omitempty"`
+	OperationalStatus string     `json:"operationalStatus,omitempty"`
+	UpdatedAt         *time.Time `json:"updatedAt,omitempty"`
 }
 
 func (pst ProjectStatus) IsEqual(other ProjectStatus) bool {


### PR DESCRIPTION
PR include - 

1. upon create project - wait for job completion
2. fix un-reused http clients (http clients are thread-safe and highly suggested to be re-used)
3. added project `owner` field
4. added project status to response
