### PR TITLE
UI: Git code entry: Enforce only one of Branch, Tag, Reference

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5585,9 +5585,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.36.3",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.36.3.tgz",
-      "integrity": "sha512-gJlEidFxVneyfV5TOwEiq+aM8ykxYz9aPO16JMaa8+L0TxFH2R1HwExapihs/luw+3HIQL1Y/SWu0r/Gxk5cgw==",
+      "version": "0.36.4",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.36.4.tgz",
+      "integrity": "sha512-AXqgzGhHK6lxMPbGHXI5yUYMTA7qxv0bgKZuQ60+x6wB6uZKCXXDif0jPzQYFVRJtmu+OwiRPKVpmv9SuD0MaQ==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.36.3",
+    "iguazio.dashboard-controls": "^0.36.4",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
- “Function” screen › “Code” tab › “Git” code-entry type: Enforce filling only one of “Branch”, ”Tag” or “Reference” fields. When one is filled the others are disabled (and on hovering them when disabled a tooltip shows to explain this)
  ![image](https://user-images.githubusercontent.com/13918850/129399851-0a4d0951-1675-415c-866b-23b3df701304.png)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/1263