### PR TITLE
UI: Pre-populate default node-selector entries and allow revert

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5585,9 +5585,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.36.4",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.36.4.tgz",
-      "integrity": "sha512-AXqgzGhHK6lxMPbGHXI5yUYMTA7qxv0bgKZuQ60+x6wB6uZKCXXDif0jPzQYFVRJtmu+OwiRPKVpmv9SuD0MaQ==",
+      "version": "0.36.5",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.36.5.tgz",
+      "integrity": "sha512-IxWHb4aoSDg6b0VB8tRq850kWxGvwG0fQCwo8Cw55MTOknikbVyzpS6EY7zRCPUBrAsi/nveId9+H75340zdsA==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.36.4",
+    "iguazio.dashboard-controls": "^0.36.5",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
- “Function” screen › “Configuration” tab › “Node Selector” section:
  - Pre-populates with default node-selector entries coming from `GET /api/frontend_spec` endpoint.
  - Added “Revert to defaults” action to restore these defaults if they were changed.
  ![image](https://user-images.githubusercontent.com/13918850/130333590-fe42293f-6389-4c85-a5a8-09824c8f48d2.png)
  ![image](https://user-images.githubusercontent.com/13918850/130333593-443a5da3-2bf2-4526-af98-bb42cbe80942.png)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/1265