### PR TITLE
Projects: code updates

### DIFF
--- a/pkg/common/consts.go
+++ b/pkg/common/consts.go
@@ -17,8 +17,9 @@ const (
 
 type NuclioResourceLabelKey string
 
-const NuclioResourceLabelKeyFunctionName = "nuclio.io/function-name"
 const NuclioResourceLabelKeyProjectName = "nuclio.io/project-name"
+const NuclioResourceLabelKeyFunctionName = "nuclio.io/function-name"
+const NuclioResourceLabelKeyApiGatewayName = "nuclio.io/apigateway-name"
 
 // KubernetesDomainLevelMaxLength DNS domain level limitation is 63 chars
 // https://en.wikipedia.org/wiki/Subdomain#Overview

--- a/pkg/dashboard/resource/apigateway.go
+++ b/pkg/dashboard/resource/apigateway.go
@@ -59,7 +59,9 @@ func (agr *apiGatewayResource) GetAll(request *http.Request) (map[string]restful
 	// filter by project name (when it's specified)
 	getAPIGatewaysOptions := platform.GetAPIGatewaysOptions{Namespace: namespace}
 	if projectName != "" {
-		getAPIGatewaysOptions.Labels = fmt.Sprintf("nuclio.io/project-name=%s", projectName)
+		getAPIGatewaysOptions.Labels = fmt.Sprintf("%s=%s",
+			common.NuclioResourceLabelKeyProjectName,
+			projectName)
 	}
 
 	return agr.GetAllByNamespace(&getAPIGatewaysOptions, exportFunction)
@@ -316,7 +318,7 @@ func (agr *apiGatewayResource) enrichAPIGatewayInfo(apiGatewayInfoInstance *apiG
 			apiGatewayInfoInstance.Meta.Labels = map[string]string{}
 		}
 
-		apiGatewayInfoInstance.Meta.Labels["nuclio.io/project-name"] = projectName
+		apiGatewayInfoInstance.Meta.Labels[common.NuclioResourceLabelKeyProjectName] = projectName
 	}
 
 	// override namespace if applicable

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -554,7 +554,8 @@ func (fr *functionResource) resolveGetFunctionOptionsFromRequest(request *http.R
 	// if the user wants to filter by project, do that
 	projectNameFilter := request.Header.Get("x-nuclio-project-name")
 	if projectNameFilter != "" {
-		getFunctionsOptions.Labels = fmt.Sprintf("nuclio.io/project-name=%s", projectNameFilter)
+		getFunctionsOptions.Labels = fmt.Sprintf("%s=%s", common.NuclioResourceLabelKeyProjectName,
+			projectNameFilter)
 	}
 	return getFunctionsOptions
 }
@@ -577,7 +578,7 @@ func (fr *functionResource) processFunctionInfo(functionInfoInstance *functionIn
 			functionInfoInstance.Meta.Labels = map[string]string{}
 		}
 
-		functionInfoInstance.Meta.Labels["nuclio.io/project-name"] = projectName
+		functionInfoInstance.Meta.Labels[common.NuclioResourceLabelKeyProjectName] = projectName
 	}
 
 	//

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -225,9 +225,11 @@ func (pr *projectResource) getFunctionsAndFunctionEventsMap(request *http.Reques
 	functionEventsMap := map[string]restful.Attributes{}
 
 	getFunctionsOptions := &platform.GetFunctionsOptions{
-		Name:        "",
-		Namespace:   project.GetConfig().Meta.Namespace,
-		Labels:      fmt.Sprintf("nuclio.io/project-name=%s", project.GetConfig().Meta.Name),
+		Name:      "",
+		Namespace: project.GetConfig().Meta.Namespace,
+		Labels: fmt.Sprintf("%s=%s",
+			common.NuclioResourceLabelKeyProjectName,
+			project.GetConfig().Meta.Name),
 		AuthSession: pr.getCtxSession(request),
 		PermissionOptions: opa.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(pr.getCtxSession(request)),
@@ -436,7 +438,7 @@ func (pr *projectResource) importProjectFunctions(request *http.Request, project
 			if function.Meta.Labels == nil {
 				function.Meta.Labels = map[string]string{}
 			}
-			function.Meta.Labels["nuclio.io/project-name"] = projectImportInfoInstance.Project.Meta.Name
+			function.Meta.Labels[common.NuclioResourceLabelKeyProjectName] = projectImportInfoInstance.Project.Meta.Name
 
 			if err := pr.importFunction(request, function, authConfig); err != nil {
 				pr.Logger.WarnWith("Failed importing function upon project import ",
@@ -468,7 +470,7 @@ func (pr *projectResource) importProjectFunctions(request *http.Request, project
 func (pr *projectResource) importFunction(request *http.Request, function *functionInfo, authConfig *platform.AuthConfig) error {
 	pr.Logger.InfoWith("Importing project function",
 		"function", function.Meta.Name,
-		"project", function.Meta.Labels["nuclio.io/project-name"])
+		"project", function.Meta.Labels[common.NuclioResourceLabelKeyProjectName])
 	functions, err := pr.getPlatform().GetFunctions(&platform.GetFunctionsOptions{
 		Name:        function.Meta.Name,
 		Namespace:   function.Meta.Namespace,
@@ -769,19 +771,19 @@ func (pr *projectResource) enrichProjectImportInfoImportResources(projectImportI
 
 	for _, functionConfig := range projectImportInfoInstance.Functions {
 		if functionConfig.Meta.Labels != nil {
-			functionConfig.Meta.Labels["nuclio.io/project-name"] = projectImportInfoInstance.Project.Meta.Name
+			functionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName] = projectImportInfoInstance.Project.Meta.Name
 		}
 	}
 
 	for _, apiGateway := range projectImportInfoInstance.APIGateways {
 		if apiGateway.Meta.Labels != nil {
-			apiGateway.Meta.Labels["nuclio.io/project-name"] = projectImportInfoInstance.Project.Meta.Name
+			apiGateway.Meta.Labels[common.NuclioResourceLabelKeyProjectName] = projectImportInfoInstance.Project.Meta.Name
 		}
 	}
 
 	for _, functionEvent := range projectImportInfoInstance.FunctionEvents {
 		if functionEvent.Meta.Labels != nil {
-			functionEvent.Meta.Labels["nuclio.io/project-name"] = projectImportInfoInstance.Project.Meta.Name
+			functionEvent.Meta.Labels[common.NuclioResourceLabelKeyProjectName] = projectImportInfoInstance.Project.Meta.Name
 		}
 	}
 }

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -81,6 +81,7 @@ func (pr *projectResource) GetAll(request *http.Request) (map[string]restful.Att
 			Namespace: namespace,
 		},
 		PermissionOptions: opa.PermissionOptions{
+			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(pr.getCtxSession(request)),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
 		AuthSession:   pr.getCtxSession(request),
@@ -579,6 +580,7 @@ func (pr *projectResource) getProjectByName(request *http.Request, projectName, 
 		},
 		AuthSession: pr.getCtxSession(request),
 		PermissionOptions: opa.PermissionOptions{
+			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(pr.getCtxSession(request)),
 			RaiseForbidden:      true,
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},

--- a/pkg/nuctl/command/common/renderers.go
+++ b/pkg/nuctl/command/common/renderers.go
@@ -65,7 +65,7 @@ func RenderFunctions(logger logger.Logger,
 			functionFields := []string{
 				function.GetConfig().Meta.Namespace,
 				function.GetConfig().Meta.Name,
-				function.GetConfig().Meta.Labels["nuclio.io/project-name"],
+				function.GetConfig().Meta.Labels[common.NuclioResourceLabelKeyProjectName],
 				encodeFunctionState(function),
 				strconv.Itoa(function.GetStatus().HTTPPort),
 				fmt.Sprintf("%d/%d", availableReplicas, specifiedReplicas),

--- a/pkg/nuctl/command/create.go
+++ b/pkg/nuctl/command/create.go
@@ -19,6 +19,7 @@ package command
 import (
 	"encoding/json"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
 
@@ -157,7 +158,7 @@ func newCreateAPIGatewayCommandeer(createCommandeer *createCommandeer) *createAP
 
 			if commandeer.project != "" {
 				commandeer.apiGatewayConfig.Meta.Labels = map[string]string{
-					"nuclio.io/project-name": commandeer.project,
+					common.NuclioResourceLabelKeyProjectName: commandeer.project,
 				}
 			}
 

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -572,7 +572,7 @@ func (d *deployCommandeer) enrichConfigWithComplexArgs() error {
 
 	// if the project name was set, add it as a label (not in string enrichment, because it's part of the labels)
 	if d.projectName != "" {
-		d.functionConfig.Meta.Labels["nuclio.io/project-name"] = d.projectName
+		d.functionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName] = d.projectName
 	}
 
 	// decode env

--- a/pkg/nuctl/command/export.go
+++ b/pkg/nuctl/command/export.go
@@ -3,8 +3,9 @@ package command
 import (
 	"fmt"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
-	"github.com/nuclio/nuclio/pkg/nuctl/command/common"
+	nuctlcommon "github.com/nuclio/nuclio/pkg/nuctl/command/common"
 	"github.com/nuclio/nuclio/pkg/platform"
 
 	"github.com/nuclio/errors"
@@ -93,7 +94,7 @@ Arguments:
 			}
 
 			// render the functions
-			return common.RenderFunctions(commandeer.rootCommandeer.loggerInstance,
+			return nuctlcommon.RenderFunctions(commandeer.rootCommandeer.loggerInstance,
 				functions,
 				commandeer.output,
 				cmd.OutOrStdout(),
@@ -101,7 +102,7 @@ Arguments:
 		},
 	}
 
-	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", common.OutputFormatYAML, "Output format - \"json\" or \"yaml\"")
+	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", nuctlcommon.OutputFormatYAML, "Output format - \"json\" or \"yaml\"")
 	cmd.PersistentFlags().BoolVar(&commandeer.noScrub, "no-scrub", false, "Export all function data, including sensitive and unnecessary data")
 
 	commandeer.cmd = cmd
@@ -182,11 +183,11 @@ Arguments:
 			}
 
 			// render the projects
-			return common.RenderProjects(projects, commandeer.output, cmd.OutOrStdout(), commandeer.renderProjectConfig)
+			return nuctlcommon.RenderProjects(projects, commandeer.output, cmd.OutOrStdout(), commandeer.renderProjectConfig)
 		},
 	}
 
-	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", common.OutputFormatYAML, "Output format - \"json\" or \"yaml\"")
+	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", nuctlcommon.OutputFormatYAML, "Output format - \"json\" or \"yaml\"")
 	commandeer.cmd = cmd
 
 	return commandeer
@@ -214,7 +215,8 @@ func (e *exportProjectCommandeer) getFunctionEvents(functionConfig *functionconf
 func (e *exportProjectCommandeer) exportAPIGateways(projectConfig *platform.ProjectConfig) (map[string]*platform.APIGatewayConfig, error) {
 	getAPIGatewaysOptions := &platform.GetAPIGatewaysOptions{
 		Namespace: projectConfig.Meta.Namespace,
-		Labels:    fmt.Sprintf("nuclio.io/project-name=%s", projectConfig.Meta.Name),
+		Labels: fmt.Sprintf("%s=%s", common.NuclioResourceLabelKeyProjectName,
+			projectConfig.Meta.Name),
 	}
 
 	// get all api gateways in the project
@@ -239,7 +241,7 @@ func (e *exportProjectCommandeer) exportProjectFunctionsAndFunctionEvents(projec
 	map[string]*functionconfig.Config, map[string]*platform.FunctionEventConfig, error) {
 	getFunctionOptions := &platform.GetFunctionsOptions{
 		Namespace: projectConfig.Meta.Namespace,
-		Labels:    fmt.Sprintf("nuclio.io/project-name=%s", projectConfig.Meta.Name),
+		Labels:    fmt.Sprintf("%s=%s", common.NuclioResourceLabelKeyProjectName, projectConfig.Meta.Name),
 	}
 	functions, err := e.rootCommandeer.platform.GetFunctions(getFunctionOptions)
 	if err != nil {

--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -67,7 +67,7 @@ func (i *importCommandeer) importFunction(functionConfig *functionconfig.Config,
 	functionConfig.Meta.Namespace = project.Meta.Namespace
 
 	if project.Meta.Name != "" {
-		functionConfig.Meta.Labels["nuclio.io/project-name"] = project.Meta.Name
+		functionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName] = project.Meta.Name
 	}
 
 	functions, err := i.rootCommandeer.platform.GetFunctions(&platform.GetFunctionsOptions{
@@ -508,21 +508,21 @@ func (i *importProjectCommandeer) enrichProjectImportConfig(projectImportConfig 
 	for _, functionConfig := range projectImportConfig.Functions {
 		functionConfig.Meta.Namespace = projectImportConfig.Project.Meta.Namespace
 		if functionConfig.Meta.Labels != nil {
-			functionConfig.Meta.Labels["nuclio.io/project-name"] = projectImportConfig.Project.Meta.Name
+			functionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName] = projectImportConfig.Project.Meta.Name
 		}
 	}
 
 	for _, apiGateway := range projectImportConfig.APIGateways {
 		apiGateway.Meta.Namespace = projectImportConfig.Project.Meta.Namespace
 		if apiGateway.Meta.Labels != nil {
-			apiGateway.Meta.Labels["nuclio.io/project-name"] = projectImportConfig.Project.Meta.Name
+			apiGateway.Meta.Labels[common.NuclioResourceLabelKeyProjectName] = projectImportConfig.Project.Meta.Name
 		}
 	}
 
 	for _, functionEvent := range projectImportConfig.FunctionEvents {
 		functionEvent.Meta.Namespace = projectImportConfig.Project.Meta.Namespace
 		if functionEvent.Meta.Labels != nil {
-			functionEvent.Meta.Labels["nuclio.io/project-name"] = projectImportConfig.Project.Meta.Name
+			functionEvent.Meta.Labels[common.NuclioResourceLabelKeyProjectName] = projectImportConfig.Project.Meta.Name
 		}
 	}
 }

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1076,6 +1076,9 @@ func (ap *Platform) QueryOPAFunctionPermissions(projectName,
 	functionName string,
 	action opa.Action,
 	permissionOptions *opa.PermissionOptions) (bool, error) {
+	if projectName == "" {
+		projectName = "*"
+	}
 	if functionName == "" {
 		functionName = "*"
 	}
@@ -1089,6 +1092,9 @@ func (ap *Platform) QueryOPAFunctionEventPermissions(projectName,
 	functionEventName string,
 	action opa.Action,
 	permissionOptions *opa.PermissionOptions) (bool, error) {
+	if projectName == "" {
+		projectName = "*"
+	}
 	if functionName == "" {
 		functionName = "*"
 	}

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -634,6 +634,47 @@ func (suite *AbstractPlatformTestSuite) TestValidateCreateFunctionOptionsAgainst
 	}
 }
 
+func (suite *AbstractPlatformTestSuite) TestResolveProjectNameFromLabelsStr() {
+	for _, testCase := range []struct {
+		name                string
+		label               string
+		expectedProjectName string
+		expectedError       bool
+	}{
+		{
+			name:                "empty",
+			label:               "",
+			expectedProjectName: "",
+		},
+		{
+			name:                "with-project",
+			label:               fmt.Sprintf("%s=x", common.NuclioResourceLabelKeyProjectName),
+			expectedProjectName: "x",
+		},
+		{
+			name:                "other-label",
+			label:               "something-else=y",
+			expectedProjectName: "",
+		},
+		{
+			name:          "with-malformed-project",
+			label:         "/%12",
+			expectedError: true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			projectName, err := suite.Platform.ResolveProjectNameFromLabelsStr(testCase.label)
+			if testCase.expectedError {
+				suite.Require().Error(err)
+				return
+			}
+			suite.Require().NoError(err)
+			suite.Require().Equal(testCase.expectedProjectName, projectName)
+
+		})
+	}
+}
+
 // Test function with invalid min max replicas
 func (suite *AbstractPlatformTestSuite) TestMinMaxReplicas() {
 	zero := 0

--- a/pkg/platform/abstract/project/external/client.go
+++ b/pkg/platform/abstract/project/external/client.go
@@ -70,19 +70,6 @@ func (c *Client) Initialize() error {
 
 func (c *Client) Get(getProjectsOptions *platform.GetProjectsOptions) ([]platform.Project, error) {
 	return c.internalClient.Get(getProjectsOptions)
-	//
-	//switch getProjectsOptions.RequestOrigin {
-	//
-	//
-	//// if request came from leader, get from CRD
-	//case c.platformConfiguration.ProjectsLeader.Kind:
-	//	return c.internalClient.Get(getProjectsOptions)
-	//
-	//// request came from user / non-leader client
-	//// get from leader
-	//default:
-	//	return c.leaderClient.Get(getProjectsOptions)
-	//}
 }
 
 func (c *Client) Create(createProjectOptions *platform.CreateProjectOptions) (platform.Project, error) {

--- a/pkg/platform/abstract/project/external/client.go
+++ b/pkg/platform/abstract/project/external/client.go
@@ -69,17 +69,20 @@ func (c *Client) Initialize() error {
 }
 
 func (c *Client) Get(getProjectsOptions *platform.GetProjectsOptions) ([]platform.Project, error) {
-	switch getProjectsOptions.RequestOrigin {
-
-	// if request came from leader, get from CRD
-	case c.platformConfiguration.ProjectsLeader.Kind:
-		return c.internalClient.Get(getProjectsOptions)
-
-	// request came from user / non-leader client
-	// get from leader
-	default:
-		return c.leaderClient.Get(getProjectsOptions)
-	}
+	return c.internalClient.Get(getProjectsOptions)
+	//
+	//switch getProjectsOptions.RequestOrigin {
+	//
+	//
+	//// if request came from leader, get from CRD
+	//case c.platformConfiguration.ProjectsLeader.Kind:
+	//	return c.internalClient.Get(getProjectsOptions)
+	//
+	//// request came from user / non-leader client
+	//// get from leader
+	//default:
+	//	return c.leaderClient.Get(getProjectsOptions)
+	//}
 }
 
 func (c *Client) Create(createProjectOptions *platform.CreateProjectOptions) (platform.Project, error) {

--- a/pkg/platform/abstract/project/external/client_test.go
+++ b/pkg/platform/abstract/project/external/client_test.go
@@ -174,7 +174,7 @@ func (suite *ExternalProjectClientTestSuite) TestGet() {
 		},
 	}
 
-	suite.mockLeaderProjectsClient.
+	suite.mockInternalProjectsClient.
 		On("Get", &getProjectOptions).
 		Return([]platform.Project{}, nil).
 		Once()

--- a/pkg/platform/kube/apigatewayres/lazy.go
+++ b/pkg/platform/kube/apigatewayres/lazy.go
@@ -226,7 +226,7 @@ func (lc *lazyClient) generateNginxIngress(ctx context.Context,
 	commonIngressSpec := ingress.Spec{
 		APIGatewayName: apiGateway.Name,
 		Namespace:      apiGateway.Namespace,
-		ProjectName:    apiGateway.Labels["nuclio.io/project-name"],
+		ProjectName:    apiGateway.Labels[common.NuclioResourceLabelKeyProjectName],
 		Host:           apiGateway.Spec.Host,
 		Path:           apiGateway.Spec.Path,
 		ServiceName:    serviceName,

--- a/pkg/platform/kube/client/updater.go
+++ b/pkg/platform/kube/client/updater.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/opa"
 	"github.com/nuclio/nuclio/pkg/platform"
 
@@ -58,7 +59,7 @@ func (u *Updater) Update(updateFunctionOptions *platform.UpdateFunctionOptions) 
 	// Check OPA permissions
 	permissionOptions := updateFunctionOptions.PermissionOptions
 	permissionOptions.RaiseForbidden = true
-	if _, err := u.platform.QueryOPAFunctionPermissions(function.Labels["nuclio.io/project-name"],
+	if _, err := u.platform.QueryOPAFunctionPermissions(function.Labels[common.NuclioResourceLabelKeyProjectName],
 		updateFunctionOptions.FunctionMeta.Name,
 		opa.ActionUpdate,
 		&permissionOptions); err != nil {

--- a/pkg/platform/kube/controller/apigateway.go
+++ b/pkg/platform/kube/controller/apigateway.go
@@ -97,8 +97,8 @@ func (ago *apiGatewayOperator) CreateOrUpdate(ctx context.Context, object runtim
 	}
 
 	// set default project-name if none given
-	if apiGateway.Labels["nuclio.io/project-name"] == "" {
-		apiGateway.Labels["nuclio.io/project-name"] = platform.DefaultProjectName
+	if apiGateway.Labels[common.NuclioResourceLabelKeyProjectName] == "" {
+		apiGateway.Labels[common.NuclioResourceLabelKeyProjectName] = platform.DefaultProjectName
 	}
 
 	// validate api gateway name is according to k8s convention

--- a/pkg/platform/kube/controller/project.go
+++ b/pkg/platform/kube/controller/project.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	"github.com/nuclio/nuclio/pkg/platform/kube/operator"
 
@@ -85,7 +86,7 @@ func (po *projectOperator) CreateOrUpdate(ctx context.Context, object runtime.Ob
 func (po *projectOperator) Delete(ctx context.Context, namespace string, name string) error {
 	po.logger.InfoWith("Deleting project resources", "namespace", namespace, "projectName", name)
 
-	projectNameLabelSelector := fmt.Sprintf("nuclio.io/project-name=%s", name)
+	projectNameLabelSelector := fmt.Sprintf("%s=%s", common.NuclioResourceLabelKeyProjectName, name)
 
 	// delete api gateways
 	if err := po.controller.nuclioClientSet.

--- a/pkg/platform/kube/ingress/ingress.go
+++ b/pkg/platform/kube/ingress/ingress.go
@@ -480,6 +480,6 @@ func (m *Manager) compileBasicAuthAnnotationsAndSecret(ctx context.Context, spec
 func (m *Manager) enrichLabels(spec Spec, labels map[string]string) {
 	labels["nuclio.io/class"] = "apigateway"
 	labels["nuclio.io/app"] = "ingress-manager"
-	labels["nuclio.io/apigateway-name"] = spec.APIGatewayName
-	labels["nuclio.io/project-name"] = spec.ProjectName
+	labels[common.NuclioResourceLabelKeyApiGatewayName] = spec.APIGatewayName
+	labels[common.NuclioResourceLabelKeyProjectName] = spec.ProjectName
 }

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -184,7 +184,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	// Check OPA permissions
 	permissionOptions := createFunctionOptions.PermissionOptions
 	permissionOptions.RaiseForbidden = true
-	if _, err := p.QueryOPAFunctionPermissions(createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"],
+	if _, err := p.QueryOPAFunctionPermissions(createFunctionOptions.FunctionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName],
 		createFunctionOptions.FunctionConfig.Meta.Name,
 		opa.ActionCreate,
 		&permissionOptions); err != nil {
@@ -616,7 +616,12 @@ func (p *Platform) DeleteProject(deleteProjectOptions *platform.DeleteProjectOpt
 
 // GetProjects will list existing projects
 func (p *Platform) GetProjects(getProjectsOptions *platform.GetProjectsOptions) ([]platform.Project, error) {
-	return p.projectsClient.Get(getProjectsOptions)
+	projects, err := p.projectsClient.Get(getProjectsOptions)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed getting projects")
+	}
+
+	return p.Platform.FilterProjectsByPermissions(&getProjectsOptions.PermissionOptions, projects)
 }
 
 // CreateAPIGateway creates and deploys a new api gateway
@@ -1538,7 +1543,7 @@ func (p *Platform) enrichHTTPTriggerIngresses(httpTrigger *functionconfig.Trigge
 		"Name":         functionConfig.Meta.Name,
 		"ResourceName": functionConfig.Meta.Name,
 		"Namespace":    functionConfig.Meta.Namespace,
-		"ProjectName":  functionConfig.Meta.Labels["nuclio.io/project-name"],
+		"ProjectName":  functionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName],
 	}
 
 	// iterate over the encoded ingresses map and created ingress structures

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -438,6 +438,15 @@ func (p Platform) EnrichFunctionConfig(functionConfig *functionconfig.Config) er
 
 // GetFunctions will return deployed functions
 func (p *Platform) GetFunctions(getFunctionsOptions *platform.GetFunctionsOptions) ([]platform.Function, error) {
+	projectName, err := p.Platform.ResolveProjectNameFromLabelsStr(getFunctionsOptions.Labels)
+	if err != nil {
+		return nil, errors.Wrap(err, "")
+	}
+
+	if err := p.Platform.EnsureProjectRead(projectName, &getFunctionsOptions.PermissionOptions); err != nil {
+		return nil, errors.Wrap(err, "Failed to ensure project read permission")
+	}
+
 	functions, err := p.getter.Get(p.consumer, getFunctionsOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get functions")

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -407,7 +407,7 @@ func (suite *KubeTestSuite) CreateImportedFunction(functionName, projectName str
 		functionconfig.FunctionAnnotationSkipBuild:  "true",
 		functionconfig.FunctionAnnotationSkipDeploy: "true",
 	}
-	createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"] = projectName
+	createFunctionOptions.FunctionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName] = projectName
 	suite.PopulateDeployOptions(createFunctionOptions)
 	_, err := suite.Platform.CreateFunction(createFunctionOptions)
 	suite.Require().NoError(err)

--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -100,7 +100,7 @@ func (s *Store) GetProjects(projectMeta *platform.ProjectMeta) ([]platform.Proje
 func (s *Store) DeleteProject(projectMeta *platform.ProjectMeta) error {
 	functions, err := s.GetProjectFunctions(&platform.GetFunctionsOptions{
 		Namespace: projectMeta.Namespace,
-		Labels:    fmt.Sprintf("nuclio.io/project-name=%s", projectMeta.Name),
+		Labels:    fmt.Sprintf("%s=%s", common.NuclioResourceLabelKeyProjectName, projectMeta.Name),
 	})
 	if err != nil {
 		return errors.Wrap(err, "Failed to get project functions")
@@ -204,7 +204,7 @@ func (s *Store) GetProjectFunctions(getFunctionsOptions *platform.GetFunctionsOp
 	var functions []platform.Function
 
 	// get project filter
-	projectName := common.StringToStringMap(getFunctionsOptions.Labels, "=")["nuclio.io/project-name"]
+	projectName := common.StringToStringMap(getFunctionsOptions.Labels, "=")[common.NuclioResourceLabelKeyProjectName]
 
 	// get all the functions in the store. these functions represent both functions that are deployed
 	// and functions that failed to build
@@ -219,7 +219,7 @@ func (s *Store) GetProjectFunctions(getFunctionsOptions *platform.GetFunctionsOp
 
 	// filter by project name
 	for _, localStoreFunction := range localStoreFunctions {
-		if projectName != "" && localStoreFunction.GetConfig().Meta.Labels["nuclio.io/project-name"] != projectName {
+		if projectName != "" && localStoreFunction.GetConfig().Meta.Labels[common.NuclioResourceLabelKeyProjectName] != projectName {
 			continue
 		}
 		functions = append(functions, localStoreFunction)

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -171,7 +171,7 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 	// Check OPA permissions
 	permissionOptions := createFunctionOptions.PermissionOptions
 	permissionOptions.RaiseForbidden = true
-	if _, err := p.QueryOPAFunctionPermissions(createFunctionOptions.FunctionConfig.Meta.Labels["nuclio.io/project-name"],
+	if _, err := p.QueryOPAFunctionPermissions(createFunctionOptions.FunctionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName],
 		createFunctionOptions.FunctionConfig.Meta.Name,
 		opa.ActionCreate,
 		&permissionOptions); err != nil {
@@ -485,7 +485,7 @@ func (p *Platform) GetProjects(getProjectsOptions *platform.GetProjectsOptions) 
 		return nil, errors.Wrap(err, "Failed getting projects")
 	}
 
-	return projects, nil
+	return p.Platform.FilterProjectsByPermissions(&getProjectsOptions.PermissionOptions, projects)
 }
 
 // CreateFunctionEvent will create a new function event that can later be used as a template from

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -345,6 +345,15 @@ func (p *Platform) CreateFunction(createFunctionOptions *platform.CreateFunction
 
 // GetFunctions will return deployed functions
 func (p *Platform) GetFunctions(getFunctionsOptions *platform.GetFunctionsOptions) ([]platform.Function, error) {
+	projectName, err := p.Platform.ResolveProjectNameFromLabelsStr(getFunctionsOptions.Labels)
+	if err != nil {
+		return nil, errors.Wrap(err, "")
+	}
+
+	if err := p.Platform.EnsureProjectRead(projectName, &getFunctionsOptions.PermissionOptions); err != nil {
+		return nil, errors.Wrap(err, "Failed to ensure project read permission")
+	}
+
 	functions, err := p.localStore.GetProjectFunctions(getFunctionsOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to read functions from a local store")

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -281,7 +281,7 @@ func (b *Builder) GetFunctionPath() string {
 
 // GetProjectName returns the name of the project
 func (b *Builder) GetProjectName() string {
-	return b.options.FunctionConfig.Meta.Labels["nuclio.io/project-name"]
+	return b.options.FunctionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName]
 }
 
 // GetFunctionName returns the name of the function


### PR DESCRIPTION
Some updates and refining:

- reused `nuclio.io/project-name` using `common` var
- filter projects using OPA (except from when request is made by leader)
- list projects from CRD instead of leader
