### PR TITLE
UI: Node Selector: empty after new function deploy

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5585,9 +5585,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.36.6",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.36.6.tgz",
-      "integrity": "sha512-51iTwFZ53opo4q6Qiwv+LzlqEKgUoR5N+Bkvri/6ZZLaIltREpzrYpx+5HhwDK1rA5NcZULVkqpBv6+bEGRKag==",
+      "version": "0.36.7",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.36.7.tgz",
+      "integrity": "sha512-hX9EAsoqvz1ivuoZP4GhD4V07LAJQ7LqMdkbukRWH9SfelT7DBEzzXomQyv/DboulK9ft6wOxb5OZfmJ7M49xw==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.36.6",
+    "iguazio.dashboard-controls": "^0.36.7",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
- Function › Configuration › Node Selector: When deploying a new function with node-selector entries, on deploy completion the node-selector entries cleared from the view. Refreshing the web-browser tab made them re-appear.

Jira ticket IG-19302

Depends on PR https://github.com/iguazio/dashboard-controls/pull/1272