### PR TITLE
Add default requests and limits to Opa server

### DIFF
--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -197,13 +197,13 @@ dashboard:
       pullPolicy: IfNotPresent
       pullSecrets: []
 
-    resources: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+    resources:
+      requests:
+        cpu: 100m
+        memory: 10Mi
+      limits:
+        cpu: 3
+        memory: 200Mi
 
     securityContext: {}
     # capabilities:


### PR DESCRIPTION
Set explicit limit / request resources on Opa container to avoid cases where opa consumes much resources when under high load.

To figure Opa server needs I first created ~30 projects and few functions on each project.
Then I performed 2 benchmark testings, 1 with cpu/limit and one without and here are the findings
The test is blasting with 200 parallel connections sending as much requests as possible within 60s, each request is a POST with an empty body.

I used [bombardier](https://github.com/codesenberg/bombardier) to simulate high load

results:

w requests/limits: (10Mi 100m CPU /  3 CPU 200Mi)

```
Bombarding http://localhost:8181/v1/data/iguazio/authz/allow for 1m0s using 200 connection(s)
[=======================================================================================================================================================================================================================] 1m0s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec     16584.16    1433.62   22153.40
  Latency       12.06ms     8.22ms   367.38ms
  Latency Distribution
     50%     8.90ms
     75%    16.71ms
     90%    26.77ms
     95%    34.89ms
     99%    54.51ms
  HTTP codes:
    1xx - 0, 2xx - 995096, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     4.35MB/s
```

w/o requests/limits (at the peak, it reached 9800m CPU and 30Mi)
```
Bombarding http://localhost:8181/v1/data/iguazio/authz/allow for 1m0s using 200 connection(s)
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec     37304.30    3809.22   48149.88
  Latency        5.36ms     2.90ms   300.69ms
  Latency Distribution
     50%     3.80ms
     75%     8.28ms
     90%    12.58ms
     95%    15.72ms
     99%    22.51ms
  HTTP codes:
    1xx - 0, 2xx - 2238317, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     9.78MB/s
```

Results show that even with cpu and memory limits, opa was able to process ~1m requests a minute, which is more than needed.