### PR TITLE
Volume enrichment and validation updates

### DIFF
--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -1246,6 +1246,20 @@ func (suite *AbstractPlatformTestSuite) TestValidateVolumes() {
 			shouldFailValidation: true,
 		},
 		{
+			name: "invalidNameReference",
+			functionVolumes: []functionconfig.Volume{
+				{
+					Volume: v1.Volume{
+						Name: "x",
+					},
+					VolumeMount: v1.VolumeMount{
+						Name: "y",
+					},
+				},
+			},
+			shouldFailValidation: true,
+		},
+		{
 			name: "differentVolumesMultipleMounts",
 			functionVolumes: []functionconfig.Volume{
 				{
@@ -1308,9 +1322,12 @@ func (suite *AbstractPlatformTestSuite) TestValidateVolumes() {
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
 				"nuclio.io/project-name": platform.DefaultProjectName,
 			}
-			suite.Logger.DebugWith("Checking function ", "functionName", functionName)
+			suite.Logger.DebugWith("Checking function", "functionName", functionName)
 
-			err := suite.Platform.ValidateFunctionConfig(&createFunctionOptions.FunctionConfig)
+			err := suite.Platform.EnrichFunctionConfig(&createFunctionOptions.FunctionConfig)
+			suite.Require().NoError(err)
+
+			err = suite.Platform.ValidateFunctionConfig(&createFunctionOptions.FunctionConfig)
 			if testCase.shouldFailValidation {
 				suite.Require().Error(err, "Validation passed unexpectedly")
 			} else {


### PR DESCRIPTION
Follow-up #2321 - it introduced a non BC change for local platform where it required volume mount name to be filled.
This pr introduces name enrichment and a validation for volume name and volume mount name matching (as each function volume is compiled by a coupled volume and volume mount).