### PR TITLE
Do not allow deleting functions that are being provisioned

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -447,6 +447,8 @@ func (fr *functionResource) deleteFunction(request *http.Request) (*restful.Cust
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fr.getCtxSession(request)),
 			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		},
+		IgnoreFunctionStateValidation: fr.headerValueIsTrue(request,
+			"x-nuclio-delete-function-state-validation"),
 	}
 
 	deleteFunctionOptions.FunctionConfig.Meta = *functionInfo.Meta

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -225,6 +225,7 @@ func (s *Server) InstallMiddleware(router chi.Router) error {
 			"X-nuclio-path",
 			"x-nuclio-filter-contains",
 			"X-nuclio-delete-project-strategy",
+			"X-nuclio-delete-function-state-validation",
 			iguazio.ProjectsRoleHeaderKey,
 		},
 		ExposedHeaders: []string{

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -316,7 +316,7 @@ func (ap *Platform) ValidateResourceVersion(functionConfigWithStatus *functionco
 	// when requestResourceVersion is empty, the existing one will be overridden
 	if requestResourceVersion != "" &&
 		requestResourceVersion != existingResourceVersion {
-		ap.Logger.WarnWith("Create function resource version is stale",
+		ap.Logger.WarnWith("Function resource version is stale",
 			"requestResourceVersion", requestResourceVersion,
 			"existingResourceVersion", existingResourceVersion)
 		return errors.New("Function resource version is stale")

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -456,6 +456,8 @@ func (ap *Platform) ValidateDeleteFunctionOptions(deleteFunctionOptions *platfor
 
 		// do not allow deleting functions that are being provisioned
 		if functionconfig.FunctionStateProvisioning(functionToDelete.GetStatus().State) {
+
+			// update UI when changing text / code
 			return nuclio.NewErrPreconditionFailed("Function is being provisioned and cannot be deleted")
 		}
 	}

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -452,6 +452,14 @@ func (ap *Platform) ValidateDeleteFunctionOptions(deleteFunctionOptions *platfor
 		return nuclio.WrapErrConflict(err)
 	}
 
+	if !deleteFunctionOptions.IgnoreFunctionStateValidation {
+
+		// do not allow deleting functions that are being provisioned
+		if functionconfig.FunctionStateProvisioning(functionToDelete.GetStatus().State) {
+			return nuclio.NewErrPreconditionFailed("Function is being provisioned and cannot be deleted")
+		}
+	}
+
 	// Check OPA permissions
 	permissionOptions := deleteFunctionOptions.PermissionOptions
 	permissionOptions.RaiseForbidden = true

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -317,6 +317,7 @@ func (ap *Platform) ValidateResourceVersion(functionConfigWithStatus *functionco
 	if requestResourceVersion != "" &&
 		requestResourceVersion != existingResourceVersion {
 		ap.Logger.WarnWith("Function resource version is stale",
+			"functionName", functionConfigWithStatus.Meta.Name,
 			"requestResourceVersion", requestResourceVersion,
 			"existingResourceVersion", existingResourceVersion)
 		return errors.New("Function resource version is stale")
@@ -456,6 +457,8 @@ func (ap *Platform) ValidateDeleteFunctionOptions(deleteFunctionOptions *platfor
 
 		// do not allow deleting functions that are being provisioned
 		if functionconfig.FunctionStateProvisioning(functionToDelete.GetStatus().State) {
+			ap.Logger.WarnWith("Function cannot be deleted as it is being provisioned",
+				"functionName", functionToDelete.GetConfig().Meta.Name)
 
 			// update UI when changing text / code
 			return nuclio.NewErrPreconditionFailed("Function is being provisioned and cannot be deleted")

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -207,7 +207,7 @@ func (ap *Platform) HandleDeployFunction(existingFunctionConfig *functionconfig.
 	return deployResult, nil
 }
 
-// Enrichment of function config
+// EnrichFunctionConfig enriches function config
 func (ap *Platform) EnrichFunctionConfig(functionConfig *functionconfig.Config) error {
 
 	// if labels is nil assign an empty map to it
@@ -250,7 +250,7 @@ func (ap *Platform) EnrichFunctionConfig(functionConfig *functionconfig.Config) 
 	return nil
 }
 
-// Enrich labels with default project name
+// EnrichLabelsWithProjectName enriches labels with default project name
 func (ap *Platform) EnrichLabelsWithProjectName(labels map[string]string) {
 	if labels[common.NuclioResourceLabelKeyProjectName] == "" {
 		labels[common.NuclioResourceLabelKeyProjectName] = platform.DefaultProjectName
@@ -271,7 +271,7 @@ func (ap *Platform) enrichDefaultHTTPTrigger(functionConfig *functionconfig.Conf
 	functionConfig.Spec.Triggers[defaultHTTPTrigger.Name] = defaultHTTPTrigger
 }
 
-// Validate a function against its existing instance
+// ValidateCreateFunctionOptionsAgainstExistingFunctionConfig validates a function against its existing instance
 func (ap *Platform) ValidateCreateFunctionOptionsAgainstExistingFunctionConfig(
 	existingFunctionConfig *functionconfig.ConfigWithStatus,
 	createFunctionOptions *platform.CreateFunctionOptions) error {
@@ -299,7 +299,7 @@ func (ap *Platform) ValidateCreateFunctionOptionsAgainstExistingFunctionConfig(
 	return nil
 }
 
-// Validate existing and new create function options resource version
+// ValidateResourceVersion validates existing and new create function options resource version
 func (ap *Platform) ValidateResourceVersion(functionConfigWithStatus *functionconfig.ConfigWithStatus,
 	requestFunctionConfig *functionconfig.Config) error {
 
@@ -324,7 +324,7 @@ func (ap *Platform) ValidateResourceVersion(functionConfigWithStatus *functionco
 	return nil
 }
 
-// Enrich functions status with logs
+// EnrichFunctionsWithDeployLogStream enriches functions status with logs
 func (ap *Platform) EnrichFunctionsWithDeployLogStream(functions []platform.Function) {
 
 	// iterate over functions and enrich with deploy logs
@@ -335,7 +335,7 @@ func (ap *Platform) EnrichFunctionsWithDeployLogStream(functions []platform.Func
 	}
 }
 
-// Validation and enforcement of required function creation logic
+// ValidateFunctionConfig validaets and enforces of required function creation logic
 func (ap *Platform) ValidateFunctionConfig(functionConfig *functionconfig.Config) error {
 
 	if common.StringInSlice(functionConfig.Meta.Name, ap.ResolveReservedResourceNames()) {
@@ -375,7 +375,7 @@ func (ap *Platform) ValidateFunctionConfig(functionConfig *functionconfig.Config
 	return nil
 }
 
-// Validation and enforcement of required project deletion logic
+// ValidateDeleteProjectOptions validates and enforces of required project deletion logic
 func (ap *Platform) ValidateDeleteProjectOptions(deleteProjectOptions *platform.DeleteProjectOptions) error {
 	projectName := deleteProjectOptions.Meta.Name
 
@@ -424,7 +424,7 @@ func (ap *Platform) ValidateDeleteProjectOptions(deleteProjectOptions *platform.
 	return nil
 }
 
-// Validation and enforcement of required function deletion logic
+// ValidateDeleteFunctionOptions validates and enforces of required function deletion logic
 func (ap *Platform) ValidateDeleteFunctionOptions(deleteFunctionOptions *platform.DeleteFunctionOptions) error {
 	functionName := deleteFunctionOptions.FunctionConfig.Meta.Name
 	functionNamespace := deleteFunctionOptions.FunctionConfig.Meta.Namespace
@@ -819,12 +819,12 @@ func (ap *Platform) BuildAndPushContainerImage(buildOptions *containerimagebuild
 		ap.platform.ResolveDefaultNamespace("@nuclio.selfNamespace"))
 }
 
-// Get Onbuild stage for multistage builds
+// GetOnbuildStages get onbuild multistage builds
 func (ap *Platform) GetOnbuildStages(onbuildArtifacts []runtime.Artifact) ([]string, error) {
 	return ap.ContainerBuilder.GetOnbuildStages(onbuildArtifacts)
 }
 
-// Change Onbuild artifact paths depending on the type of the builder used
+// TransformOnbuildArtifactPaths changes Onbuild artifact paths depending on the type of the builder used
 func (ap *Platform) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifact) (map[string]string, error) {
 	return ap.ContainerBuilder.TransformOnbuildArtifactPaths(onbuildArtifacts)
 }

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -274,6 +274,9 @@ func (suite *AbstractPlatformTestSuite) TestValidateDeleteFunctionOptions() {
 							Name: "existing",
 						},
 					},
+					Status: functionconfig.Status{
+						State: functionconfig.FunctionStateReady,
+					},
 				},
 			},
 			deleteFunctionOptions: &platform.DeleteFunctionOptions{
@@ -310,6 +313,9 @@ func (suite *AbstractPlatformTestSuite) TestValidateDeleteFunctionOptions() {
 							ResourceVersion: "1",
 						},
 					},
+					Status: functionconfig.Status{
+						State: functionconfig.FunctionStateReady,
+					},
 				},
 			},
 			deleteFunctionOptions: &platform.DeleteFunctionOptions{
@@ -322,6 +328,31 @@ func (suite *AbstractPlatformTestSuite) TestValidateDeleteFunctionOptions() {
 			},
 		},
 
+		// fail: function is being provisioned
+		{
+			existingFunctions: []platform.Function{
+				&platform.AbstractFunction{
+					Logger:   suite.Logger,
+					Platform: suite.Platform.platform,
+					Config: functionconfig.Config{
+						Meta: functionconfig.Meta{
+							Name: "existing",
+						},
+					},
+					Status: functionconfig.Status{
+						State: functionconfig.FunctionStateBuilding,
+					},
+				},
+			},
+			deleteFunctionOptions: &platform.DeleteFunctionOptions{
+				FunctionConfig: functionconfig.Config{
+					Meta: functionconfig.Meta{
+						Name: "existing",
+					},
+				},
+			},
+			shouldFailValidation: true,
+		},
 		// fail: stale resourceVersion
 		{
 			existingFunctions: []platform.Function{

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -756,6 +756,7 @@ func (suite *FunctionKubePlatformTestSuite) TestDeleteFunctionPermissions() {
 					MemberIds:           memberIds,
 					OverrideHeaderValue: suite.opaOverrideHeaderValue,
 				},
+				IgnoreFunctionStateValidation: true,
 			})
 
 			if !testCase.opaResponse {

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -79,6 +79,9 @@ type DeleteFunctionOptions struct {
 	AuthConfig        *AuthConfig
 	PermissionOptions opa.PermissionOptions
 	AuthSession       auth.Session
+
+	// whether to ignore the validation where functions being provisioned cannot be deleted
+	IgnoreFunctionStateValidation bool
 }
 
 // CreateFunctionBuildResult holds information detected/generated as a result of a build process


### PR DESCRIPTION
To avoid cases where user A deploy function while user B deletes it - added a validation to disallow deleting function being provisioned

To ignore such validation, a request to backend should include header `x-nuclio-delete-function-state-validation: true`