### PR TITLE
[Nuclio] Delete a function while it is deploying

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5585,9 +5585,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.37.1.tgz",
-      "integrity": "sha512-hdtOowaxT6A/CsWVhXa+u+uJasHNc/aoIo5hCYj4Eto0IclfFkvpJ/bkbarib9BUJ193K1Vt6DUK6GdeAa2CRQ==",
+      "version": "0.37.2",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.37.2.tgz",
+      "integrity": "sha512-2rdqID/QH87/DiSJsYZ+FThkTmMDlFBQbVzTAgjQDQqXF42d8I2Om5zKpZ3yNN8v9i/pa+bG071ChQu0kiJdyQ==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.37.1",
+    "iguazio.dashboard-controls": "^0.37.2",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",

--- a/pkg/dashboard/ui/src/app/components/data-wrappers/functions-data-wrapper/functions-data-wrapper.component.js
+++ b/pkg/dashboard/ui/src/app/components/data-wrappers/functions-data-wrapper/functions-data-wrapper.component.js
@@ -66,10 +66,11 @@
         /**
          * Deletes function
          * @param {Object} functionToDelete
+         * @param {Boolean} ignoreValidation - determines whether to forcibly remove the function
          * @returns {Promise}
          */
-        function deleteFunction(functionToDelete) {
-            return NuclioFunctionsDataService.deleteFunction(functionToDelete);
+        function deleteFunction(functionToDelete, ignoreValidation) {
+            return NuclioFunctionsDataService.deleteFunction(functionToDelete, ignoreValidation);
         }
 
         /**

--- a/pkg/dashboard/ui/src/app/components/data-wrappers/functions-data-wrapper/functions-data-wrapper.tpl.html
+++ b/pkg/dashboard/ui/src/app/components/data-wrappers/functions-data-wrapper/functions-data-wrapper.tpl.html
@@ -1,5 +1,5 @@
 <ncl-functions data-create-function="$ctrl.createFunction(version, projectId)"
-               data-delete-function="$ctrl.deleteFunction(functionData)"
+               data-delete-function="$ctrl.deleteFunction(functionData, ignoreValidation)"
                data-get-functions="$ctrl.getFunctions(id, enrichApiGateways)"
                data-get-function="$ctrl.getFunction(metadata, enrichApiGateways)"
                data-get-statistics="$ctrl.getStatistics()"

--- a/pkg/dashboard/ui/src/app/components/data-wrappers/version-data-wrapper/version-data-wrapper.component.js
+++ b/pkg/dashboard/ui/src/app/components/data-wrappers/version-data-wrapper/version-data-wrapper.component.js
@@ -37,10 +37,11 @@
         /**
          * Deletes function
          * @param {Object} functionToDelete
+         * @param {Boolean} ignoreValidation - determines whether to forcibly remove the function
          * @returns {Promise}
          */
-        function deleteFunction(functionToDelete) {
-            return NuclioFunctionsDataService.deleteFunction(functionToDelete);
+        function deleteFunction(functionToDelete, ignoreValidation) {
+            return NuclioFunctionsDataService.deleteFunction(functionToDelete, ignoreValidation);
         }
 
         /**

--- a/pkg/dashboard/ui/src/app/components/data-wrappers/version-data-wrapper/version-data-wrapper.tpl.html
+++ b/pkg/dashboard/ui/src/app/components/data-wrappers/version-data-wrapper/version-data-wrapper.tpl.html
@@ -1,6 +1,6 @@
 <ncl-version data-version="$ctrl.version"
              data-create-version="$ctrl.createFunction(version, projectId)"
-             data-delete-function="$ctrl.deleteFunction(functionData)"
+             data-delete-function="$ctrl.deleteFunction(functionData, ignoreValidation)"
              data-get-function="$ctrl.getFunction(metadata, enrichApiGateways)"
              data-get-functions="$ctrl.getFunctions(id, enrichApiGateways)"
              data-project="$ctrl.project"

--- a/pkg/dashboard/ui/src/app/shared/services/nuclio-functions-data.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/nuclio-functions-data.service.js
@@ -81,9 +81,10 @@
         /**
          * Deletes function
          * @param {Object} functionData
+         * @param {Boolean} ignoreValidation - determines whether to forcibly remove the function
          * @returns {Promise}
          */
-        function deleteFunction(functionData) {
+        function deleteFunction(functionData, ignoreValidation) {
             var headers = {
                 'Content-Type': 'application/json'
             };
@@ -91,6 +92,10 @@
 
             if (lodash.isNil(namespace)) {
                 functionData = lodash.omit(functionData, 'namespace')
+            }
+
+            if (ignoreValidation) {
+                headers['x-nuclio-delete-function-ignore-state-validation'] = true;
             }
 
             var config = {


### PR DESCRIPTION
- Function: An attempt to delete a function while it is deploying will now result in a confirmation dialog that would allow to forcibly delete it (before it just resulted in an error)
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/135261290-1e4c8ef7-e0b8-4ea1-99d5-7b716f8d5701.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/135261039-aef2b3a8-6d61-4bb5-944b-a620ad9efc75.png)
- “Function” screen: if a function was deleted while deploying, a new pop-up dialog would indicate that to the user and suggest to either go to the Functions screen, or deploy the function to recreate it.
  ![image](https://user-images.githubusercontent.com/13918850/134803601-e5bd258f-e72e-4a5f-b6e5-51684a6417f0.png)

Depends in PR https://github.com/iguazio/dashboard-controls/pull/1279

Jira ticket IG-17690