### PR TITLE
Python - support injecting custom ssl ca for pip commands

### DIFF
--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -69,6 +69,11 @@ spec:
           failureThreshold: 4
           periodSeconds: 15
         volumeMounts:
+        {{- if .Values.dashboard.pipCACertSecretName }}
+        - mountPath: /etc/ssl/certs/nuclio
+          name: pip-ca-cert
+          readOnly: true
+        {{- end }}
         {{- if eq .Values.dashboard.containerBuilderKind "docker" }}
         - mountPath: /var/run/docker.sock
           name: docker-sock
@@ -194,9 +199,18 @@ spec:
         volumeMounts:
           - readOnly: true
             mountPath: /config
-            name: config
+            name: opa-config
       {{- end }}
       volumes:
+      {{- if .Values.dashboard.pipCACertSecretName }}
+      - name: pip-ca-cert
+        secret:
+          secretName: {{ .Values.dashboard.pipCACertSecretName }}
+          items:
+            - key: pip-ca-certificates.crt
+              path: pip-ca-certificates.crt
+              mode: 0400
+      {{- end }}
       {{- if eq .Values.dashboard.containerBuilderKind "docker" }}
       - name: docker-sock
         hostPath:
@@ -214,7 +228,7 @@ spec:
           name: {{ template "nuclio.platformConfigName" . }}
       {{- end }}
       {{- if .Values.dashboard.opa.enabled }}
-      - name: config
+      - name: opa-config
         secret:
           secretName: {{ template "nuclio.dashboard.opa.fullname" . }}
       {{- end }}

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -230,6 +230,10 @@ dashboard:
       periodSeconds: 15
       failureThreshold: 4
 
+  # Uncomment to volumize pip ca cert
+  # Note: secret name must contain "pip-ca-certificates.crt" key
+  # pipCACertSecretName: secret-name
+
 autoscaler:
   enabled: false
   replicas: 1
@@ -372,6 +376,7 @@ crd:
 platform: {}
 #  runtime:
 #    python:
+#      pipCAPath: /path/to/pip-ca-file.crt
 #      buildArgs:
 #        PIP_INDEX_URL: "https://test.pypi.org/simple"
 #   logger:

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -96,6 +96,10 @@ func NewPlatform(parentLogger logger.Logger,
 	return newPlatform, nil
 }
 
+func (ap *Platform) GetConfig() *platformconfig.Config {
+	return ap.Config
+}
+
 func (ap *Platform) CreateFunctionBuild(createFunctionBuildOptions *platform.CreateFunctionBuildOptions) (
 	*platform.CreateFunctionBuildResult, error) {
 

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -30,6 +30,11 @@ type Platform struct {
 // Function
 //
 
+func (mp *Platform) GetConfig() *platformconfig.Config {
+	args := mp.Called()
+	return args.Get(0).(*platformconfig.Config)
+}
+
 func (mp *Platform) GetContainerBuilderKind() string {
 	return "docker"
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -213,6 +213,9 @@ type Platform interface {
 	// GetRuntimeBuildArgs returns the runtime specific build arguments
 	GetRuntimeBuildArgs(runtime runtime.Runtime) map[string]string
 
+	// GetConfig returns platform config
+	GetConfig() *platformconfig.Config
+
 	//
 	// OPA
 	//

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -24,7 +24,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/opa"
-	"github.com/nuclio/nuclio/pkg/runtimeconfig"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 
 	"github.com/nuclio/errors"
 	"github.com/v3io/scaler/pkg/scalertypes"

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -215,7 +215,7 @@ func (b *Builder) Build(options *platform.CreateFunctionBuildOptions) (*platform
 
 	// prepare configuration from both configuration files and things builder infers
 	if !configurationRead {
-		if _, err = b.readConfiguration(); err != nil {
+		if _, err := b.readConfiguration(); err != nil {
 			return nil, errors.Wrap(err, "Failed to read configuration")
 		}
 	}
@@ -228,7 +228,7 @@ func (b *Builder) Build(options *platform.CreateFunctionBuildOptions) (*platform
 
 	// once we're done reading our configuration, we may still have to fill in the blanks
 	// because the user isn't obligated to always pass all the configuration
-	if err = b.validateAndEnrichConfiguration(); err != nil {
+	if err := b.validateAndEnrichConfiguration(); err != nil {
 		return nil, errors.Wrap(err, "Failed to enrich configuration")
 	}
 
@@ -244,13 +244,13 @@ func (b *Builder) Build(options *platform.CreateFunctionBuildOptions) (*platform
 
 	// if a callback is registered, call back
 	if b.options.OnAfterConfigUpdate != nil {
-		if err = b.options.OnAfterConfigUpdate(&enrichedConfiguration); err != nil {
+		if err := b.options.OnAfterConfigUpdate(&enrichedConfiguration); err != nil {
 			return nil, errors.Wrap(err, "OnAfterConfigUpdate returned error")
 		}
 	}
 
 	// prepare a staging directory
-	if err = b.prepareStagingDir(); err != nil {
+	if err := b.prepareStagingDir(); err != nil {
 		return nil, errors.Wrap(err, "Failed to prepare staging dir")
 	}
 
@@ -622,8 +622,7 @@ func (b *Builder) writeFunctionSourceCodeToTempFile(functionSourceCode string) (
 	sourceFilePath := path.Join(tempDir, moduleFileName)
 
 	b.logger.DebugWith("Writing function source code to temporary file", "functionPath", sourceFilePath)
-	err = ioutil.WriteFile(sourceFilePath, decodedFunctionSourceCode, os.FileMode(0644))
-	if err != nil {
+	if err := ioutil.WriteFile(sourceFilePath, decodedFunctionSourceCode, os.FileMode(0644)); err != nil {
 		return "", errors.Wrapf(err, "Failed to write given source code to file %s", sourceFilePath)
 	}
 
@@ -947,7 +946,7 @@ func (b *Builder) prepareStagingDir() error {
 	}
 
 	// first, tell the specific runtime to do its thing
-	if err := b.runtime.OnAfterStagingDirCreated(b.stagingDir); err != nil {
+	if err := b.runtime.OnAfterStagingDirCreated(b.platform.GetConfig().Runtime, b.stagingDir); err != nil {
 		return errors.Wrap(err, "Failed to prepare staging dir")
 	}
 
@@ -1374,7 +1373,7 @@ func (b *Builder) getDockerFileBuildArgs() map[string]string {
 			buildArgs[key] = value
 		} else {
 
-			// value is empty, remote this arg
+			// value is empty, remove this arg
 			delete(buildArgs, key)
 		}
 	}

--- a/pkg/processor/build/runtime/dotnetcore/runtime.go
+++ b/pkg/processor/build/runtime/dotnetcore/runtime.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 )
 
 type dotnetcore struct {
@@ -32,7 +33,7 @@ func (d *dotnetcore) GetName() string {
 }
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-func (d *dotnetcore) GetProcessorDockerfileInfo(onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
+func (d *dotnetcore) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 

--- a/pkg/processor/build/runtime/golang/runtime.go
+++ b/pkg/processor/build/runtime/golang/runtime.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime/golang/eventhandlerparser"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 
 	"github.com/nuclio/errors"
 )
@@ -59,7 +60,7 @@ func (g *golang) GetName() string {
 }
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-func (g *golang) GetProcessorDockerfileInfo(onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
+func (g *golang) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{
 		BaseImage: "alpine:3.11",

--- a/pkg/processor/build/runtime/java/runtime.go
+++ b/pkg/processor/build/runtime/java/runtime.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 
 	"github.com/nuclio/errors"
 )
@@ -41,13 +42,13 @@ func (j *java) GetName() string {
 
 // OnAfterStagingDirCreated will build jar if the source is a Java file
 // It will set generatedJarPath field
-func (j *java) OnAfterStagingDirCreated(stagingDir string) error {
+func (j *java) OnAfterStagingDirCreated(runtimeConfig *runtimeconfig.Config, stagingDir string) error {
 	// create a build script alongside the user's code. if user provided a script, it'll use that
 	return j.createGradleBuildScript(stagingDir)
 }
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-func (j *java) GetProcessorDockerfileInfo(onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
+func (j *java) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 	processorDockerfileInfo.BaseImage = "openjdk:9-jre-slim"

--- a/pkg/processor/build/runtime/nodejs/runtime.go
+++ b/pkg/processor/build/runtime/nodejs/runtime.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 )
 
 type nodejs struct {
@@ -33,7 +34,7 @@ func (n *nodejs) GetName() string {
 }
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-func (n *nodejs) GetProcessorDockerfileInfo(onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
+func (n *nodejs) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -172,5 +172,5 @@ func (p *python) OnAfterStagingDirCreated(runtimeConfig *runtimeconfig.Config, s
 			return errors.Wrap(err, "Failed to write pip ca contents to file")
 		}
 	}
-	return nil
+	return p.AbstractRuntime.OnAfterStagingDirCreated(runtimeConfig, stagingDir)
 }

--- a/pkg/processor/build/runtime/python/test/python_test.go
+++ b/pkg/processor/build/runtime/python/test/python_test.go
@@ -155,8 +155,8 @@ hm4qxFYxldBniYUr+WymXUadDKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveC
 X4XSQRjbgbMEHMUfppIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==
 -----END CERTIFICATE-----`
 
-	validCAFile := suite.writePEMFile("nuclio-curl-ca-cert", caCertContents)
-	invalidCAFile := suite.writePEMFile("nuclio-curl-ca-cert-invalid", []byte(invalidCACertContents))
+	validCAFile := suite.writeFile("nuclio-curl-ca-cert", caCertContents)
+	invalidCAFile := suite.writeFile("nuclio-curl-ca-cert-invalid", []byte(invalidCACertContents))
 
 	// remove leftovers
 	defer os.Remove(validCAFile.Name())
@@ -240,7 +240,7 @@ func (suite *TestSuite) GetFunctionInfo(functionName string) buildsuite.Function
 	return functionInfo
 }
 
-func (suite *TestSuite) writePEMFile(filenamePattern string, contents []byte) *os.File {
+func (suite *TestSuite) writeFile(filenamePattern string, contents []byte) *os.File {
 	tmpFile, err := ioutil.TempFile("", filenamePattern)
 	suite.Require().NoError(err)
 	suite.Require().NoError(tmpFile.Close())

--- a/pkg/processor/build/runtime/ruby/runtime.go
+++ b/pkg/processor/build/runtime/ruby/runtime.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 )
 
 type ruby struct {
@@ -32,7 +33,7 @@ func (r *ruby) GetName() string {
 }
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-func (r *ruby) GetProcessorDockerfileInfo(onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
+func (r *ruby) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -121,7 +121,7 @@ func (ar *AbstractRuntime) OnAfterStagingDirCreated(runtimeConfig *runtimeconfig
 	return nil
 }
 
-// return a map of objects the runtime needs to copy into the processor image
+// GetProcessorImageObjectPaths return a map of objects the runtime needs to copy into the processor image
 // the key can be a dir, a file or a url of a file
 // the value is an absolute path into the docker image
 func (ar *AbstractRuntime) GetProcessorImageObjectPaths() map[string]string {

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -25,7 +25,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
-	"github.com/nuclio/nuclio/pkg/runtimeconfig"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -56,15 +56,15 @@ type Runtime interface {
 
 	// OnAfterStagingDirCreated prepares anything it may need in that directory
 	// towards building a functioning processor,
-	OnAfterStagingDirCreated(stagingDir string) error
+	OnAfterStagingDirCreated(runtimeConfig *runtimeconfig.Config, stagingDir string) error
 
 	// GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-	GetProcessorDockerfileInfo(onbuildImageRegistry string) (*ProcessorDockerfileInfo, error)
+	GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*ProcessorDockerfileInfo, error)
 
 	// GetName returns the name of the runtime, including version if applicable
 	GetName() string
 
-	// GetProcessorImageObjectPaths returns the paths of all objects that should reside in the handler
+	// GetHandlerDirObjectPaths returns the paths of all objects that should reside in the handler
 	// directory
 	GetHandlerDirObjectPaths() []string
 
@@ -117,7 +117,7 @@ func NewAbstractRuntime(logger logger.Logger,
 	return newRuntime, nil
 }
 
-func (ar *AbstractRuntime) OnAfterStagingDirCreated(stagingDir string) error {
+func (ar *AbstractRuntime) OnAfterStagingDirCreated(runtimeConfig *runtimeconfig.Config, stagingDir string) error {
 	return nil
 }
 
@@ -139,7 +139,7 @@ func (ar *AbstractRuntime) GetFunctionDir() string {
 	return path.Dir(ar.FunctionConfig.Spec.Build.Path)
 }
 
-// GetProcessorImageObjectPaths returns the paths of all objects that should reside in the handler
+// GetHandlerDirObjectPaths returns the paths of all objects that should reside in the handler
 // directory
 func (ar *AbstractRuntime) GetHandlerDirObjectPaths() []string {
 

--- a/pkg/processor/build/runtime/shell/runtime.go
+++ b/pkg/processor/build/runtime/shell/runtime.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 )
 
 type shell struct {
@@ -32,7 +33,7 @@ func (s *shell) GetName() string {
 }
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-func (s *shell) GetProcessorDockerfileInfo(onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
+func (s *shell) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 


### PR DESCRIPTION
It is up to the user to create a secret with the ca contents. e.g.:

```
kubectl create secret generic my-ca-secret --from-file=pip-ca-certificates.crt=file.cert
```

and when installing nuclio (using helm) - 
```
helm install nuclio --set dashboard.pipCACertSecretName=my-ca-secret nuclio
```

When user would then build a Python function, the ca cert would be copied (with file permission 0400) onto the function image while `pip` env `PIP_CERT` would point to its location. any following `pip` command would use such certificate automatically.