### PR TITLE
Fix function deployment is not server-side generated correctly

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -745,9 +745,6 @@ func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 					Annotations: podAnnotations,
 				},
 				Spec: v1.PodSpec{
-					ImagePullSecrets: []v1.LocalObjectReference{
-						{Name: imagePullSecrets},
-					},
 					Containers: []v1.Container{
 						container,
 					},
@@ -761,6 +758,13 @@ func (lc *lazyClient) createOrUpdateDeployment(functionLabels labels.Set,
 					PreemptionPolicy:   function.Spec.PreemptionPolicy,
 				},
 			},
+		}
+
+		// apply when provided
+		if imagePullSecrets != "" {
+			deploymentSpec.Template.Spec.ImagePullSecrets = []v1.LocalObjectReference{
+				{Name: imagePullSecrets},
+			}
 		}
 
 		deployment := &appsv1.Deployment{


### PR DESCRIPTION
It is inspected that image pull secrets is added empty to the list of image pull secrets (even when docker registry requires no authentication).
This causes the server-side enrichment to fail even though the deployment is successfully created (for kubernetes backwards compatibility reasons)
The issue rose when running nuclio on AKS, where pod conditions were not populated, led to node auto scaler dysfunction .
