### PR TITLE
Fix panic when restarting wrapper process

### DIFF
--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -147,6 +147,7 @@ func (r *AbstractRuntime) Stop() error {
 	r.Logger.WarnWith("Stopping",
 		"status", r.GetStatus(),
 		"wrapperProcess", r.wrapperProcess)
+
 	if r.wrapperProcess != nil {
 
 		// stop waiting for process
@@ -162,6 +163,8 @@ func (r *AbstractRuntime) Stop() error {
 	}
 
 	r.waitForProcessTermination()
+
+	r.wrapperProcess = nil
 
 	r.SetStatus(status.Stopped)
 	r.Logger.Warn("Successfully stopped wrapper process")
@@ -376,16 +379,16 @@ func (r *AbstractRuntime) handleResponseLog(response []byte) {
 		return
 	}
 
-	logger := r.resolveFunctionLogger(r.functionLogger)
-	logFunc := logger.DebugWith
+	loggerInstance := r.resolveFunctionLogger(r.functionLogger)
+	logFunc := loggerInstance.DebugWith
 
 	switch logRecord.Level {
 	case "error", "critical", "fatal":
-		logFunc = logger.ErrorWith
+		logFunc = loggerInstance.ErrorWith
 	case "warning":
-		logFunc = logger.WarnWith
+		logFunc = loggerInstance.WarnWith
 	case "info":
-		logFunc = logger.InfoWith
+		logFunc = loggerInstance.InfoWith
 	}
 
 	vars := common.MapToSlice(logRecord.With)
@@ -397,14 +400,14 @@ func (r *AbstractRuntime) handleResponseMetric(response []byte) {
 		DurationSec float64 `json:"duration"`
 	}
 
-	logger := r.resolveFunctionLogger(r.functionLogger)
+	loggerInstance := r.resolveFunctionLogger(r.functionLogger)
 	if err := json.Unmarshal(response, &metrics); err != nil {
-		logger.ErrorWith("Can't decode metric", "error", err)
+		loggerInstance.ErrorWith("Can't decode metric", "error", err)
 		return
 	}
 
 	if metrics.DurationSec == 0 {
-		logger.ErrorWith("No duration in metrics", "metrics", metrics)
+		loggerInstance.ErrorWith("No duration in metrics", "metrics", metrics)
 		return
 	}
 
@@ -434,7 +437,6 @@ func (r *AbstractRuntime) watchWrapperProcess() {
 
 	// whatever happens, clear wrapper process
 	defer func() {
-		r.wrapperProcess = nil
 		r.stopChan <- struct{}{}
 	}()
 


### PR DESCRIPTION
A rare race-condition between the process watcher to the abstract stop command lead to panic when trying to access the process instance.


logs

```
{"level":"warn","time":"2021-10-14T13:49:24.423Z","name":"processor.kafka-cluster.w8.python.logger","message":"Killing wrapper process","more":"wrapperProcessPid=38"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4d94eb]

goroutine 377 [running]:
os.(*Process).signal(0x0, 0x20f5d20, 0x2f387d8, 0x0, 0x0)
        /usr/local/go/src/os/exec_unix.go:56 +0x3b
os.(*Process).Signal(...)
        /usr/local/go/src/os/exec.go:131
os.(*Process).kill(...)
        /usr/local/go/src/os/exec_posix.go:66
os.(*Process).Kill(...)
        /usr/local/go/src/os/exec.go:116
github.com/nuclio/nuclio/pkg/processor/runtime/rpc.(*AbstractRuntime).Stop(0xc000dde000, 0x139d6a5, 0xc000f080b8)
        /nuclio/pkg/processor/runtime/rpc/abstract.go:158 +0x25c
github.com/nuclio/nuclio/pkg/processor/runtime/rpc.(*AbstractRuntime).Restart(0xc000dde000, 0x0, 0x0)
        /nuclio/pkg/processor/runtime/rpc/abstract.go:173 +0x2f
github.com/nuclio/nuclio/pkg/processor/worker.(*Worker).Restart(...)
        /nuclio/pkg/processor/worker/worker.go:141
github.com/nuclio/nuclio/pkg/processor/trigger/kafka.(*kafka).cancelEventHandling(0xc000c72900, 0xc000c72800, 0x213ed00, 0xc000945f20, 0x2, 0x2)
        /nuclio/pkg/processor/trigger/kafka/trigger.go:307 +0x6a
github.com/nuclio/nuclio/pkg/processor/trigger/kafka.(*kafka).ConsumeClaim(0xc000c72900, 0x2144e80, 0xc000b39b80, 0x213ed00, 0xc000945f20, 0xf, 0x11)
        /nuclio/pkg/processor/trigger/kafka/trigger.go:255 +0x7f6
github.com/Shopify/sarama.(*consumerGroupSession).consume(0xc000b39b80, 0xc000940c50, 0xf, 0x11)
        /go/pkg/mod/github.com/iguazio/sarama@v1.25.1-0.20201117150928-15517d41c014/consumer_group.go:687 +0x27f
github.com/Shopify/sarama.newConsumerGroupSession.func2(0xc000b39b80, 0xc000940c50, 0xf, 0xc000000011)
        /go/pkg/mod/github.com/iguazio/sarama@v1.25.1-0.20201117150928-15517d41c014/consumer_group.go:616 +0x87
created by github.com/Shopify/sarama.newConsumerGroupSession
        /go/pkg/mod/github.com/iguazio/sarama@v1.25.1-0.20201117150928-15517d41c014/consumer_group.go:608 +0x526
```

internal ticket: `IG-19562`