### PR TITLE
Default more field to be JSON compliant

### DIFF
--- a/pkg/loggersink/stdout/types.go
+++ b/pkg/loggersink/stdout/types.go
@@ -58,7 +58,12 @@ func NewConfiguration(name string, loggerSinkConfiguration *platformconfig.Logge
 	}
 
 	if newConfiguration.VarGroupMode == "" {
-		newConfiguration.VarGroupMode = nucliozap.DefaultVarGroupMode
+		switch newConfiguration.Encoding {
+		case "json":
+			newConfiguration.VarGroupMode = nucliozap.VarGroupModeStructured
+		default:
+			newConfiguration.VarGroupMode = nucliozap.VarGroupModeFlattened
+		}
 	}
 
 	return &newConfiguration, nil


### PR DESCRIPTION
when encoding is JSON, default the more field to be JSON compliant as well


before


```
{"level":"debug","time":"2021-10-18T14:40:56.473Z","name":"processor","message":"Starting triggers","more":"triggers=[0xc000a82000]"}
{"level":"info","time":"2021-10-18T14:40:56.473Z","name":"processor.http","message":"Starting","more":"listenAddress=:8080 || readBufferSize=16384 || maxRequestBodySize=4194304 || cors=<nil>"}
{"level":"info","time":"2021-10-18T14:40:56.473Z","name":"processor.webadmin.server","message":"Listening","more":"listenAddress=:8081"}
{"level":"debug","time":"2021-10-18T14:40:56.473Z","name":"processor","message":"Processor started"}
{"level":"debug","time":"2021-10-18T14:40:56.473Z","name":"processor.prompull.myPrometheusPull","message":"Listening","more":"addr=:8090"}
```

after

```
{"level":"debug","time":"2021-10-18T14:44:43.485Z","name":"processor","message":"Starting triggers","more":{"triggers":[{"Statistics":{"EventsHandledSuccessTotal":0,"EventsHandledFailureTotal":0,"WorkerAllocatorStatistics":{"WorkerAllocationCount":0,"WorkerAllocationSuccessImmediateTotal":0,"WorkerAllocationSuccessAfterWaitTotal":0,"WorkerAllocationTimeoutTotal":0,"WorkerAllocationWaitDurationMilliSecondsSum":0,"WorkerAllocationWorkersAvailablePercentage":0}},"ID":"default-http","Logger":{},"WorkerAllocator":{},"Class":"sync","Kind":"http","Name":"default-http","Namespace":"default-tenant","FunctionName":"structured"}]}}
{"level":"info","time":"2021-10-18T14:44:43.486Z","name":"processor.http","message":"Starting","more":{"cors":null,"listenAddress":":8080","maxRequestBodySize":4194304,"readBufferSize":16384}}
{"level":"info","time":"2021-10-18T14:44:43.486Z","name":"processor.webadmin.server","message":"Listening","more":{"listenAddress":":8081"}}
{"level":"debug","time":"2021-10-18T14:44:43.486Z","name":"processor","message":"Processor started"}
{"level":"debug","time":"2021-10-18T14:44:43.486Z","name":"processor.prompull.myPrometheusPull","message":"Listening","more":{"addr":":8090"}}
```
