### PR TITLE
Fix resolving external ip address during function deployment

### DIFF
--- a/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
@@ -48,6 +48,8 @@ spec:
           {{ toYaml .Values.controller.resources | nindent 11 }}
         {{- end }}
         env:
+        - name: NUCLIO_CONTROLLER_EXTERNAL_IP_ADDRESSES
+          value: {{ .Values.dashboard.externalIPAddresses | join "," | quote }}
         - name: NUCLIO_CONTROLLER_IMAGE_PULL_SECRETS
           value: {{ template "nuclio.registry.credentialsSecretName" . }}
         - name: NUCLIO_CONTROLLER_CRON_TRIGGER_CRON_JOB_IMAGE_NAME

--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -190,14 +190,6 @@ func (d *Deployer) populateFunction(functionConfig *functionconfig.Config,
 
 	// update status
 	functionInstance.Status = *functionStatus
-
-	externalIPAddresses, err := d.platform.GetExternalIPAddresses()
-	if err != nil {
-		return errors.Wrap(err, "Failed to get external ip address")
-	}
-
-	// -1 because port was not assigned yet, it is just a placeholder
-	functionInstance.Status.ExternalInvocationURLs = []string{fmt.Sprintf("%s:-1", externalIPAddresses[0])}
 	return nil
 
 }

--- a/pkg/platform/kube/controller/controller.go
+++ b/pkg/platform/kube/controller/controller.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"os"
+	"strings"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/platform/kube/apigatewayres"
@@ -41,6 +43,7 @@ type Controller struct {
 	imagePullSecrets          string
 	platformConfiguration     *platformconfig.Config
 	platformConfigurationName string
+	externalIPAddresses       []string
 
 	// (re)syncers
 	functionOperator      *functionOperator
@@ -192,6 +195,15 @@ func (c *Controller) Stop() error {
 
 func (c *Controller) GetPlatformConfiguration() *platformconfig.Config {
 	return c.platformConfiguration
+}
+
+func (c *Controller) GetExternalIPAddresses() []string {
+	if len(c.externalIPAddresses) > 0 {
+		return c.externalIPAddresses
+	}
+
+	c.externalIPAddresses = strings.Split(os.Getenv("NUCLIO_CONTROLLER_EXTERNAL_IP_ADDRESSES"), ",")
+	return c.externalIPAddresses
 }
 
 func (c *Controller) GetPlatformConfigurationName() string {

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -353,14 +353,13 @@ func (fo *functionOperator) populateFunctionInvocationStatus(function *nuclioio.
 			fmt.Sprintf("%s:%d", serviceHost, servicePort))
 	}
 
-	// TODO: move the information on platformConfig and share with controller?
+	functionStatus.ExternalInvocationURLs = []string{}
+
 	// add external invocation url in form of "external-ip:nodeport"
-	// first item is being filled by nuclio-dashboard to holds the information regarding the external ip address
-	if len(function.Status.ExternalInvocationURLs) > 0 && service.Spec.Type == v1.ServiceTypeNodePort {
-		hostPort := strings.Split(function.Status.ExternalInvocationURLs[0], ":")
-		functionStatus.ExternalInvocationURLs = []string{fmt.Sprintf("%s:%d", hostPort[0], httpPort)}
-	} else {
-		functionStatus.ExternalInvocationURLs = []string{}
+	if service.Spec.Type == v1.ServiceTypeNodePort {
+		for _, externalIPAddress := range fo.controller.GetExternalIPAddresses() {
+			functionStatus.ExternalInvocationURLs = []string{fmt.Sprintf("%s:%d", externalIPAddress, httpPort)}
+		}
 	}
 
 	// add ingresses to external invocation urls


### PR DESCRIPTION
Instead of "passing" a placeholder of external-ip-address on the function status between nuclio dashboard and nuclio controller,  read the value from properly from envvar.

For now, nuclio controller will read its external ip addresses from envvar until it would completely move to platform config.

Behavior:
Upon first function deployment - external/internal urls are empty. 
- if deployment succeeded - populate new values to function.status
- else - leave empty

Upon second+ function deployments - external/internal urls are equal to last succeeded deployment.
- if deployment succeeded -  populate updated values to function.status
- else - do not change

