### PR TITLE
UI: Set i18n cache timeout for development on build time

### DIFF
--- a/pkg/dashboard/ui/gulpfile.js
+++ b/pkg/dashboard/ui/gulpfile.js
@@ -560,6 +560,10 @@ function buildConfigFromArgs() {
               /* default */              'production'
     };
 
+    if (state.isDevMode) {
+        buildConfig.i18nextExpirationTime = 0;
+    }
+
     // if at least one URL was set, create the config
     // eslint-disable-next-line
     return !lodash.isEmpty(buildConfig) ? JSON.stringify(buildConfig) : null;

--- a/pkg/dashboard/ui/src/app/app.run.js
+++ b/pkg/dashboard/ui/src/app/app.run.js
@@ -21,7 +21,6 @@
             })
             .then(function (config) {
                 lodash.merge(ConfigService, config.data);
-                initializeI18next();
             })
             .then(function () {
                 NuclioProjectsDataService.getFrontendSpec()
@@ -50,39 +49,34 @@
             .use($window.i18nextChainedBackend)
             .use($window.i18nextBrowserLanguageDetector);
 
-        /**
-         * Initializes the i18next module and configures it.
-         */
-        function initializeI18next() {
-            i18next.init({
-                debug: false,
-                fallbackLng: 'en',
-                preload: ['en'],
-                initImmediate: false,
-                nonExplicitWhitelist: true,
-                partialBundledLanguages: true,
-                defaultNs: 'common',
-                ns: [
-                    'common',
-                    'functions'
+        i18next.init({
+            debug: false,
+            fallbackLng: 'en',
+            preload: ['en'],
+            initImmediate: false,
+            nonExplicitWhitelist: true,
+            partialBundledLanguages: true,
+            defaultNs: 'common',
+            ns: [
+                'common',
+                'functions'
+            ],
+            // @if !IGZ_TESTING
+            backend: {
+                backends: [
+                    $window.i18nextLocalStorageBackend,
+                    $window.i18nextXHRBackend
                 ],
-                // @if !IGZ_TESTING
-                backend: {
-                    backends: [
-                        $window.i18nextLocalStorageBackend,
-                        $window.i18nextXHRBackend
-                    ],
-                    backendOptions: [
-                        {
-                            expirationTime: ConfigService.i18nextExpirationTime
-                        },
-                        {
-                            loadPath: 'assets/i18n/{{lng}}/{{ns}}.json'
-                        }
-                    ]
-                }
-                // @endif
-            });
-        }
+                backendOptions: [
+                    {
+                        expirationTime: ConfigService.i18nextExpirationTime
+                    },
+                    {
+                        loadPath: 'assets/i18n/{{lng}}/{{ns}}.json'
+                    }
+                ]
+            }
+            // @endif
+        });
     }
 }());


### PR DESCRIPTION
Instead of waiting for the async request to `dashboard-config.json` file, set the `0` default for development environment **on build time** in `gulpfile.js` file through the existing `--dev` flag.

Reverts part of PR https://github.com/nuclio/nuclio/pull/2372