### PR TITLE
UI: Add proxy to dev server on '/api', rename env vars for ports

### DIFF
--- a/pkg/dashboard/ui/README.md
+++ b/pkg/dashboard/ui/README.md
@@ -2,13 +2,11 @@
 
 ## Setting up for development environment
 1. npm install
-2. bower install
-3. gulp
+2. gulp --dev
 
 ## Setting up for production(staging) environment
 1. npm install --production
-2. bower install
-3. gulp --production (gulp --staging)
+2. gulp --production (gulp --staging)
 
 ## Watch
 Instead of rebuilding the project after every little modification to the source code, `gulp watch` could be used to watch for changes in source code files and automatically re-build.
@@ -28,8 +26,8 @@ to reload every time you make a change in one of your files.
 
 Finally, activate the chrome extension in your tab by clicking on the new LiveReload icon next to the address bar, turning the circle in the middle of it from hollow to opaque.
 
-## Debug flag
-Add `--debug` flag to your `gulp` command in order to prevent minifcation and uglification of source code.  
+## Dev flag
+Add `--dev` flag to your `gulp` command in order to prevent minifcation and uglification of source code.  
 This way it's easier to debug using the browser's developer tools.
 
 # Demo mode
@@ -38,16 +36,20 @@ Add `--demo` to your `gulp` command for building the project with **all** of its
 
 # Configuration
 
-## Run-time configuration file
+## Runtime configuration file
 If a file named `dashboard-config.json` exists in the root of the web-app (i.e. where also 'index.html' exists), then it is used.  
 You can find a sample file in the root of this project.
 
 This file is read on **run-time** and not on build time.  
 This means that if you modify it between refreshes, then the changes will take effect.
 
-This file's JSON is merged with the configuration of the web app, so it doesn't have to consist of _all_ of the avaiable configuration entires.
+This file's JSON is merged with the configuration of the web app, so it does not have to consist of _all_ of the available configuration entries.
 
-## Port number listening
+## Port numbers
 
-Preview server listens by default on port number 8000
-You can override this by setting the environment variable IGZ_PREVIEW_LISTEN_PORT
+Environment variables can be used to override default port numbers:
+
+| Name                    | Description                    | Default value |
+|-------------------------|--------------------------------|---------------|
+| NCL_PREVIEW_LISTEN_PORT | Preview server for development | 8000          |
+| NCL_BACKEND_LISTEN_PORT | Backend server                 | 8070          |

--- a/pkg/dashboard/ui/resources/previewServer/app.js
+++ b/pkg/dashboard/ui/resources/previewServer/app.js
@@ -1,5 +1,6 @@
 var express = require('express');
 var serveStatic = require('serve-static');
+var proxy = require('express-http-proxy');
 var path = require('path');
 var _ = require('lodash');
 
@@ -7,15 +8,27 @@ var app = express();
 
 var previewServer = function () {
     var start = function (log, rootPath) {
-        app.use(serveStatic(path.resolve(__dirname, '../../' + rootPath), {
+        var root = path.resolve(__dirname, '../../' + rootPath);
+        var backendPort = _.defaultTo(process.env.NCL_BACKEND_LISTEN_PORT, 8070);
+
+        // if a request sent to /api/path?query redirect to http://127.0.0.1:8070/api/path?query
+        app.use('/api', proxy('http://127.0.0.1:' + backendPort, {
+            limit: '15mb',
+            proxyReqPathResolver: function (request) {
+                return request.originalUrl;
+            }
+        }));
+
+        app.use(serveStatic(root, {
             maxAge: '1d',
             setHeaders: setCustomCacheControl
         }));
+
         app.all('*', function (req, res) {
-            res.sendFile(path.resolve(__dirname, '../../' + rootPath + '/index.html'));
+            res.sendFile(root + '/index.html');
         });
 
-        var port = process.env.IGZ_PREVIEW_LISTEN_PORT || 8000;
+        var port = process.env.NCL_PREVIEW_LISTEN_PORT || 8000;
 
         this.server = app.listen(port, function () {
             log('Preview server listening on ' + port);

--- a/pkg/dashboard/ui/resources/previewServer/package-lock.json
+++ b/pkg/dashboard/ui/resources/previewServer/package-lock.json
@@ -129,6 +129,11 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
     "escape-html": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
@@ -287,6 +292,31 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
           "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+        }
+      }
+    },
+    "express-http-proxy": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/express-http-proxy/-/express-http-proxy-1.6.2.tgz",
+      "integrity": "sha512-soP7UXySFdLbeeMYL1foBkEoZj6HELq9BDAOCr1sLRpqjPaFruN5o6+bZeC+7U4USWIl4JMKEiIvTeKJ2WQdlQ==",
+      "requires": {
+        "debug": "^3.0.1",
+        "es6-promise": "^4.1.1",
+        "raw-body": "^2.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },

--- a/pkg/dashboard/ui/resources/previewServer/package.json
+++ b/pkg/dashboard/ui/resources/previewServer/package.json
@@ -5,6 +5,7 @@
   "main": "app.js",
   "dependencies": {
     "express": "^4.17.1",
+    "express-http-proxy": "^1.6.2",
     "serve-static": "1.9.2"
   }
 }

--- a/pkg/dashboard/ui/src/app/app.config.js
+++ b/pkg/dashboard/ui/src/app/app.config.js
@@ -6,7 +6,7 @@
     var defaultConfig = {
         url: {
             nuclio: {
-                baseUrl: location.protocol + '//' + location.hostname + ':8070/api'
+                baseUrl: '/api'
             }
         },
         mode: 'production',


### PR DESCRIPTION
- Added proxy to dev server from `/api` to `http://127.0.0.1:8070` by default
- Can override above port number via new env var `NCL_BACKEND_LISTEN_PORT`
- Renamed env var `IGZ_PREVIEW_LISTEN_PORT` to `NCL_PREVIEW_LISTEN_PORT`
- Updated **README.md** file in accordance to the above
- Now even without **dashboard-config.json** file, everything should work find in both dev and prod environments.