### PR TITLE
UI: Add N/A to invocation URLs and move hint to tooltip

### DIFF
--- a/pkg/dashboard/ui/package-lock.json
+++ b/pkg/dashboard/ui/package-lock.json
@@ -5585,9 +5585,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "iguazio.dashboard-controls": {
-      "version": "0.37.6",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.37.6.tgz",
-      "integrity": "sha512-1MAGk1LSh+37KrFEAe+GL+Ns7j1KoKEkge4YPWvvZnm4H5z3uuBcz0DKBukH/ObTJsQattG4UouOoeHoUTwjyw==",
+      "version": "0.37.7",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-controls/-/iguazio.dashboard-controls-0.37.7.tgz",
+      "integrity": "sha512-XYW6Rsn5uNE+2D3OFFmNgwjuMhF4RNDIzU6aqwIZn5GQkG0tQ780BmD9bz+6XSksEiYB0r7MaDDkpDI6uOOrqQ==",
       "requires": {
         "@uirouter/angularjs": "^1.0.20",
         "angular": "^1.7.9",

--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^1.0.1",
     "i18next-localstorage-backend": "^2.1.2",
     "i18next-xhr-backend": "^2.0.1",
-    "iguazio.dashboard-controls": "^0.37.6",
+    "iguazio.dashboard-controls": "^0.37.7",
     "jquery": "*",
     "jquery-ui": "1.12.0",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
- “Function” screen › “Status” tab: Moved description of how to add external invocation URLs into a more-info tooltip, and made sure “N/A” is displayed for both internal and external URL lists when no such URL is available (during deploy and on error, too).
  ![image](https://user-images.githubusercontent.com/13918850/138698558-c6e8149c-7a2a-4c42-b6ed-42e5a3b614e7.png)
  ![image](https://user-images.githubusercontent.com/13918850/138698563-dd45b756-449e-417f-b7f6-a4f54077a053.png)
  ![image](https://user-images.githubusercontent.com/13918850/138698610-81b9532e-b6e2-4dc0-97a6-802886957d8d.png)
- “Function” screen › “Configuration” tab › “Resources” pane › “Target CPU” field › Tooltip: Wrong (inconsistent with the rest of the app) styling of the link text on idle and hover.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/138690098-0caccdbb-f10e-4823-a88d-ab4ca0cbdc5b.png) ![image](https://user-images.githubusercontent.com/13918850/138690103-0ac48067-783d-4647-8c45-8ade0de2ad35.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/138690130-33691c2e-f955-48c1-95b5-67872ae90e39.png) ![image](https://user-images.githubusercontent.com/13918850/138690133-695a39cb-e10e-43e2-9dd5-6fc18bab59d6.png)

Depends on PR https://github.com/iguazio/dashboard-controls/pull/1292

Jira ticket IG-18847