### PR TITLE
Kaniko - Retry pushing images to registry

### DIFF
--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -92,6 +92,8 @@ spec:
           {{ toYaml .Values.dashboard.resources | nindent 11 }}
         {{- end }}
         env:
+        - name: NUCLIO_KANIKO_PUSH_IMAGES_RETRIES
+          value: {{ .Values.dashboard.kaniko.pushImagesRestries | quote }}
         - name: NUCLIO_AUTH_KIND
           value: {{ .Values.dashboard.authConfig.kind }}
         - name: NUCLIO_AUTH_OPTIONS_IGUAZIO_TIMEOUT

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -126,6 +126,9 @@ dashboard:
     # How long to wait before deleting the build job
     jobDeletionTimeout: 30m
 
+    # How many times to retry pushing images to registry
+    pushImagesRestries: 3
+
   # Uncomment to configure node port
   # nodePort: 32050
 

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -205,6 +205,7 @@ func (k *Kaniko) compileJobSpec(namespace string,
 		fmt.Sprintf("--dockerfile=%s", buildOptions.DockerfileInfo.DockerfilePath),
 		fmt.Sprintf("--context=%s", buildOptions.ContextDir),
 		fmt.Sprintf("--destination=%s", common.CompileImageName(buildOptions.RegistryURL, buildOptions.Image)),
+		fmt.Sprintf("--push-retry=%d", k.builderConfiguration.PushImagesRetries),
 	}
 
 	if !buildOptions.NoCache {

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -1,6 +1,7 @@
 package containerimagebuilderpusher
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
@@ -38,6 +39,7 @@ type ContainerBuilderConfiguration struct {
 	CacheRepo                            string
 	InsecurePushRegistry                 bool
 	InsecurePullRegistry                 bool
+	PushImagesRetries                    int
 }
 
 func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) {
@@ -86,6 +88,12 @@ func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) 
 
 	containerBuilderConfiguration.CacheRepo =
 		common.GetEnvOrDefaultString("NUCLIO_DASHBOARD_KANIKO_CACHE_REPO", "")
+
+	containerBuilderConfiguration.PushImagesRetries, err =
+		strconv.Atoi(common.GetEnvOrDefaultString("NUCLIO_KANIKO_PUSH_IMAGES_RETRIES", "3"))
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to resolve number of push images retries")
+	}
 
 	jobDeletionTimeout := common.GetEnvOrDefaultString("NUCLIO_KANIKO_JOB_DELETION_TIMEOUT", "30m")
 	containerBuilderConfiguration.JobDeletionTimeout, err = time.ParseDuration(jobDeletionTimeout)


### PR DESCRIPTION
Added `--push-retry` flag to kaniko job spec.

Tested manually by deleting docker registry ingress during nuclio function deployment.
Logs showed 3 retries before failing.