### PR TITLE
Increase waiting for function creation timeout

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -218,7 +218,7 @@ func (fr *functionResource) storeAndDeployFunction(request *http.Request,
 	authConfig *platform.AuthConfig,
 	waitForFunction bool) error {
 
-	creationStateUpdatedTimeout := 45 * time.Second
+	creationStateUpdatedTimeout := 1 * time.Minute
 
 	doneChan := make(chan bool, 1)
 	creationStateUpdatedChan := make(chan bool, 1)


### PR DESCRIPTION
it has been noticed that on some flaky k8s envs we would need to wait a little bit longer while creating functions