### PR TITLE
V3io stream trigger - allowing predefined ack window offset

### DIFF
--- a/pkg/processor/trigger/v3iostream/trigger.go
+++ b/pkg/processor/trigger/v3iostream/trigger.go
@@ -196,7 +196,7 @@ func (vs *v3iostream) ConsumeClaim(session streamconsumergroup.Session, claim st
 			if err == nil {
 
 				// offset record sequence number by the trigger's configured ack window size
-				record.SequenceNumber = record.SequenceNumber - uint64(vs.configuration.ackWindowSize)
+				record.SequenceNumber -= uint64(vs.configuration.ackWindowSize)
 				session.MarkRecord(record) // nolint: errcheck
 			}
 

--- a/pkg/processor/trigger/v3iostream/trigger.go
+++ b/pkg/processor/trigger/v3iostream/trigger.go
@@ -163,12 +163,12 @@ func (vs *v3iostream) ConsumeClaim(session streamconsumergroup.Session, claim st
 	// submit the events in a goroutine so that we can unblock immediately
 	go vs.eventSubmitter(claim, submittedEventChan)
 
-	if vs.configuration.ackWindowSize == 0 {
+	if vs.configuration.AckWindowSize == 0 {
 		vs.Logger.DebugWith("Starting claim consumption", "shardID", claim.GetShardID())
 	} else {
 		vs.Logger.DebugWith("Starting claim consumption with ack window",
 			"shardID", claim.GetShardID(),
-			"ackWindowSize", vs.configuration.ackWindowSize)
+			"ackWindowSize", vs.configuration.AckWindowSize)
 	}
 
 	// the exit condition is that (a) the Messages() channel was closed and (b) we got a signal telling us
@@ -196,7 +196,7 @@ func (vs *v3iostream) ConsumeClaim(session streamconsumergroup.Session, claim st
 			if err == nil {
 
 				// offset record sequence number by the trigger's configured ack window size
-				record.SequenceNumber = record.SequenceNumber - uint64(vs.configuration.ackWindowSize)
+				record.SequenceNumber = record.SequenceNumber - uint64(vs.configuration.AckWindowSize)
 				session.MarkRecord(record) // nolint: errcheck
 			}
 

--- a/pkg/processor/trigger/v3iostream/trigger.go
+++ b/pkg/processor/trigger/v3iostream/trigger.go
@@ -163,12 +163,12 @@ func (vs *v3iostream) ConsumeClaim(session streamconsumergroup.Session, claim st
 	// submit the events in a goroutine so that we can unblock immediately
 	go vs.eventSubmitter(claim, submittedEventChan)
 
-	if vs.configuration.AckWindowSize == 0 {
+	if vs.configuration.ackWindowSize == 0 {
 		vs.Logger.DebugWith("Starting claim consumption", "shardID", claim.GetShardID())
 	} else {
 		vs.Logger.DebugWith("Starting claim consumption with ack window",
 			"shardID", claim.GetShardID(),
-			"ackWindowSize", vs.configuration.AckWindowSize)
+			"ackWindowSize", vs.configuration.ackWindowSize)
 	}
 
 	// the exit condition is that (a) the Messages() channel was closed and (b) we got a signal telling us
@@ -196,7 +196,7 @@ func (vs *v3iostream) ConsumeClaim(session streamconsumergroup.Session, claim st
 			if err == nil {
 
 				// offset record sequence number by the trigger's configured ack window size
-				record.SequenceNumber = record.SequenceNumber - uint64(vs.configuration.AckWindowSize)
+				record.SequenceNumber = record.SequenceNumber - uint64(vs.configuration.ackWindowSize)
 				session.MarkRecord(record) // nolint: errcheck
 			}
 

--- a/pkg/processor/trigger/v3iostream/trigger.go
+++ b/pkg/processor/trigger/v3iostream/trigger.go
@@ -163,12 +163,12 @@ func (vs *v3iostream) ConsumeClaim(session streamconsumergroup.Session, claim st
 	// submit the events in a goroutine so that we can unblock immediately
 	go vs.eventSubmitter(claim, submittedEventChan)
 
-	if vs.configuration.AckWindowSize == 0 {
+	if vs.configuration.ackWindowSize == 0 {
 		vs.Logger.DebugWith("Starting claim consumption", "shardID", claim.GetShardID())
 	} else {
-		vs.Logger.DebugWith("Starting claim consumption with commit ack window",
+		vs.Logger.DebugWith("Starting claim consumption with ack window",
 			"shardID", claim.GetShardID(),
-			"commitAckWindowSize", vs.configuration.AckWindowSize)
+			"ackWindowSize", vs.configuration.ackWindowSize)
 	}
 
 	// the exit condition is that (a) the Messages() channel was closed and (b) we got a signal telling us
@@ -195,8 +195,8 @@ func (vs *v3iostream) ConsumeClaim(session streamconsumergroup.Session, claim st
 			// we successfully submitted the message to the handler. mark it
 			if err == nil {
 
-				// offset record sequence number by the trigger's configured commit ack window size
-				record.SequenceNumber = record.SequenceNumber - uint64(vs.configuration.AckWindowSize)
+				// offset record sequence number by the trigger's configured ack window size
+				record.SequenceNumber = record.SequenceNumber - uint64(vs.configuration.ackWindowSize)
 				session.MarkRecord(record) // nolint: errcheck
 			}
 

--- a/pkg/processor/trigger/v3iostream/types.go
+++ b/pkg/processor/trigger/v3iostream/types.go
@@ -56,7 +56,7 @@ type Configuration struct {
 	PollingIntervalMs int
 
 	// resolved attributes
-	AckWindowSize int
+	ackWindowSize int
 }
 
 func NewConfiguration(id string,
@@ -77,14 +77,14 @@ func NewConfiguration(id string,
 	if ackWindowSizeInterface, ok := newConfiguration.Attributes["ackWindowSize"]; ok {
 
 		errMessage := "Failed loading ack window size from trigger attributes"
-		switch ackWindowSizeInterface.(type) {
+		switch ackWindowSize := ackWindowSizeInterface.(type) {
 		case string:
-			newConfiguration.AckWindowSize, err = strconv.Atoi(ackWindowSizeInterface.(string))
+			newConfiguration.ackWindowSize, err = strconv.Atoi(ackWindowSize)
 			if err != nil {
 				return nil, errors.Wrap(err, errMessage)
 			}
 		case int:
-			newConfiguration.AckWindowSize = ackWindowSizeInterface.(int)
+			newConfiguration.ackWindowSize = ackWindowSize
 		default:
 			return nil, errors.New(errMessage)
 		}

--- a/pkg/processor/trigger/v3iostream/types.go
+++ b/pkg/processor/trigger/v3iostream/types.go
@@ -19,6 +19,7 @@ package v3iostream
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -53,6 +54,9 @@ type Configuration struct {
 
 	// backwards compatibility
 	PollingIntervalMs int
+
+	// resolved attributes
+	ackWindowSize                   int
 }
 
 func NewConfiguration(id string,
@@ -60,12 +64,30 @@ func NewConfiguration(id string,
 	runtimeConfiguration *runtime.Configuration) (*Configuration, error) {
 	newConfiguration := Configuration{}
 
+	var err error
+
 	// create base
 	newConfiguration.Configuration = *trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
 
 	// parse attributes
 	if err := mapstructure.Decode(newConfiguration.Configuration.Attributes, &newConfiguration); err != nil {
 		return nil, errors.Wrap(err, "Failed to decode attributes")
+	}
+
+	if ackWindowSizeInterface, ok := newConfiguration.Attributes["ackWindowSize"]; ok {
+
+		errMessage := "Failed loading ack window size from trigger attributes"
+		switch ackWindowSizeInterface.(type) {
+		case string:
+			newConfiguration.ackWindowSize, err = strconv.Atoi(ackWindowSizeInterface.(string))
+			if err != nil {
+				return nil, errors.Wrap(err, errMessage)
+			}
+		case int:
+			newConfiguration.ackWindowSize = ackWindowSizeInterface.(int)
+		default:
+			return nil, errors.New(errMessage)
+		}
 	}
 
 	if newConfiguration.NumTransportWorkers == 0 {
@@ -104,7 +126,7 @@ func NewConfiguration(id string,
 	}
 
 	// if the password is a uuid - assume it is an access key and clear out the username/pass
-	_, err := uuid.ParseUUID(newConfiguration.Password)
+	_, err = uuid.ParseUUID(newConfiguration.Password)
 	if err == nil {
 		newConfiguration.Secret = newConfiguration.Password
 		newConfiguration.Username = ""

--- a/pkg/processor/trigger/v3iostream/types.go
+++ b/pkg/processor/trigger/v3iostream/types.go
@@ -56,7 +56,7 @@ type Configuration struct {
 	PollingIntervalMs int
 
 	// resolved attributes
-	ackWindowSize                   int
+	AckWindowSize int
 }
 
 func NewConfiguration(id string,
@@ -79,12 +79,12 @@ func NewConfiguration(id string,
 		errMessage := "Failed loading ack window size from trigger attributes"
 		switch ackWindowSizeInterface.(type) {
 		case string:
-			newConfiguration.ackWindowSize, err = strconv.Atoi(ackWindowSizeInterface.(string))
+			newConfiguration.AckWindowSize, err = strconv.Atoi(ackWindowSizeInterface.(string))
 			if err != nil {
 				return nil, errors.Wrap(err, errMessage)
 			}
 		case int:
-			newConfiguration.ackWindowSize = ackWindowSizeInterface.(int)
+			newConfiguration.AckWindowSize = ackWindowSizeInterface.(int)
 		default:
 			return nil, errors.New(errMessage)
 		}

--- a/pkg/processor/trigger/v3iostream/types.go
+++ b/pkg/processor/trigger/v3iostream/types.go
@@ -76,17 +76,17 @@ func NewConfiguration(id string,
 
 	if ackWindowSizeInterface, ok := newConfiguration.Attributes["ackWindowSize"]; ok {
 
-		errMessage := "Failed loading ack window size from trigger attributes"
+		errMessage := "Failed loading ack window size from trigger attributes. Unsupported type: %T"
 		switch ackWindowSize := ackWindowSizeInterface.(type) {
 		case string:
 			newConfiguration.ackWindowSize, err = strconv.Atoi(ackWindowSize)
 			if err != nil {
-				return nil, errors.Wrap(err, errMessage)
+				return nil, errors.Wrapf(err, errMessage, ackWindowSize)
 			}
 		case int:
 			newConfiguration.ackWindowSize = ackWindowSize
 		default:
-			return nil, errors.New(errMessage)
+			return nil, errors.Errorf(errMessage, ackWindowSize)
 		}
 	}
 

--- a/pkg/processor/trigger/v3iostream/types.go
+++ b/pkg/processor/trigger/v3iostream/types.go
@@ -76,19 +76,19 @@ func NewConfiguration(id string,
 
 	if ackWindowSizeInterface, ok := newConfiguration.Attributes["ackWindowSize"]; ok {
 
-		errMessage := "Failed loading ack window size from trigger attributes. Unsupported type: %T"
+		errMessage := "Failed loading ack window size from trigger attributes."
 		switch ackWindowSize := ackWindowSizeInterface.(type) {
 		case string:
 			newConfiguration.ackWindowSize, err = strconv.Atoi(ackWindowSize)
 			if err != nil {
-				return nil, errors.Wrapf(err, errMessage, ackWindowSize)
+				return nil, errors.Wrapf(err, errMessage+" Unsupported string: %s", ackWindowSize)
 			}
 		case int:
 			newConfiguration.ackWindowSize = ackWindowSize
 		case float64:
 			newConfiguration.ackWindowSize = int(ackWindowSize)
 		default:
-			return nil, errors.Errorf(errMessage, ackWindowSize)
+			return nil, errors.Errorf(errMessage+" Unsupported type: %T", ackWindowSize)
 		}
 	}
 

--- a/pkg/processor/trigger/v3iostream/types.go
+++ b/pkg/processor/trigger/v3iostream/types.go
@@ -85,6 +85,8 @@ func NewConfiguration(id string,
 			}
 		case int:
 			newConfiguration.ackWindowSize = ackWindowSize
+		case float64:
+			newConfiguration.ackWindowSize = int(ackWindowSize)
 		default:
 			return nil, errors.Errorf(errMessage, ackWindowSize)
 		}


### PR DESCRIPTION
We can set an `ackWindowSize` in a v3io-stream trigger's attributes, which will make the stream consumer commit the sequence number of the event only after another `ackWindowSize` events have been consumed.