### PR TITLE
Move fast failure logic from dashboard to controller

### DIFF
--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -314,10 +314,14 @@ func waitForFunctionReadiness(loggerInstance logger.Logger,
 		default:
 
 			// keep waiting
+			loggerInstance.DebugWith("TOMER - Deployer - still waiting for function state",
+				"functionState", function.Status.State)
 			return false, nil
 		}
 	}
 
 	err = wait.PollInfinite(250*time.Millisecond, conditionFunc)
+	loggerInstance.DebugWith("TOMER - Deployer - FINISHED waiting for function state",
+		"functionState", function.Status.State)
 	return function, err
 }

--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -123,7 +123,6 @@ func (d *Deployer) Deploy(functionInstance *nuclioio.NuclioFunction,
 
 	// do the create / update
 	// TODO: Infer timestamp from function config (consider create/update scenarios)
-	functionCreateOrUpdateTimestamp := time.Now()
 	if _, err := d.CreateOrUpdateFunction(functionInstance,
 		createFunctionOptions,
 		&functionconfig.Status{
@@ -136,8 +135,7 @@ func (d *Deployer) Deploy(functionInstance *nuclioio.NuclioFunction,
 	updatedFunctionInstance, err := waitForFunctionReadiness(deployLogger,
 		d.consumer,
 		functionInstance.Namespace,
-		functionInstance.Name,
-		functionCreateOrUpdateTimestamp)
+		functionInstance.Name)
 	if err != nil {
 		podLogs, briefErrorsMessage := d.getFunctionPodLogsAndEvents(functionInstance.Namespace, functionInstance.Name)
 		return nil, updatedFunctionInstance, briefErrorsMessage, errors.Wrapf(err, "Failed to wait for function readiness.\n%s", podLogs)
@@ -288,63 +286,10 @@ func (d *Deployer) getLastCreatedPod(pods []v1.Pod) v1.Pod {
 	return latestPod
 }
 
-func isFunctionDeploymentFailed(consumer *Consumer,
-	namespace string,
-	name string,
-	functionCreateOrUpdateTimestamp time.Time) (bool, error) {
-
-	// list function pods
-	pods, err := consumer.KubeClientSet.CoreV1().
-		Pods(namespace).
-		List(metav1.ListOptions{
-			LabelSelector: common.CompileListFunctionPodsLabelSelector(name),
-		})
-	if err != nil {
-		return false, errors.Wrap(err, "Failed to Get pods")
-	}
-
-	// infer from the pod statuses if the function deployment had failed
-	// failure of one pod is enough to tell that the deployment had failed
-	for _, pod := range pods.Items {
-
-		// skip irrelevant pods (leftovers of previous function deployments)
-		// (subtract 2 seconds from create/update timestamp because of ms accuracy loss of pod.creationTimestamp)
-		if !pod.GetCreationTimestamp().After(functionCreateOrUpdateTimestamp.Add(-2 * time.Second)) {
-			continue
-		}
-
-		for _, containerStatus := range pod.Status.ContainerStatuses {
-
-			if pod.Status.ContainerStatuses[0].State.Waiting != nil {
-
-				// check if the pod is on a crashLoopBackoff
-				if containerStatus.State.Waiting.Reason == "CrashLoopBackOff" {
-
-					return true, errors.Errorf("NuclioFunction pod (%s) is in a crash loop", pod.Name)
-				}
-			}
-		}
-
-		for _, condition := range pod.Status.Conditions {
-
-			// check if the pod is in pending state, and the reason is that it is unschedulable
-			// (meaning no k8s node can currently run it, because of insufficient resources etc..)
-			if pod.Status.Phase == v1.PodPending &&
-				condition.Reason == "Unschedulable" {
-
-				return true, errors.Errorf("NuclioFunction pod (%s) is unschedulable", pod.Name)
-			}
-		}
-	}
-
-	return false, nil
-}
-
 func waitForFunctionReadiness(loggerInstance logger.Logger,
 	consumer *Consumer,
 	namespace string,
-	name string,
-	functionCreateOrUpdateTimestamp time.Time) (*nuclioio.NuclioFunction, error) {
+	name string) (*nuclioio.NuclioFunction, error) {
 	var err error
 	var function *nuclioio.NuclioFunction
 
@@ -367,19 +312,8 @@ func waitForFunctionReadiness(loggerInstance logger.Logger,
 				function.Status.State,
 				function.Status.Message)
 		default:
-			if !function.Spec.WaitReadinessTimeoutBeforeFailure {
 
-				// check if function deployment had failed
-				// (ignore the error if there's no concrete indication of failure, because it might still stabilize)
-				if functionDeploymentFailed, err := isFunctionDeploymentFailed(consumer,
-					namespace,
-					name,
-					functionCreateOrUpdateTimestamp); functionDeploymentFailed {
-
-					return false, errors.Wrapf(err, "NuclioFunction deployment failed")
-				}
-			}
-
+			// keep waiting
 			return false, nil
 		}
 	}

--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -314,14 +314,10 @@ func waitForFunctionReadiness(loggerInstance logger.Logger,
 		default:
 
 			// keep waiting
-			loggerInstance.DebugWith("TOMER - Deployer - still waiting for function state",
-				"functionState", function.Status.State)
 			return false, nil
 		}
 	}
 
 	err = wait.PollInfinite(250*time.Millisecond, conditionFunc)
-	loggerInstance.DebugWith("TOMER - Deployer - FINISHED waiting for function state",
-		"functionState", function.Status.State)
 	return function, err
 }

--- a/pkg/platform/kube/client/updater.go
+++ b/pkg/platform/kube/client/updater.go
@@ -93,7 +93,6 @@ func (u *Updater) Update(updateFunctionOptions *platform.UpdateFunctionOptions) 
 	}
 
 	// trigger an update
-	functionCreateOrUpdateTimestamp := time.Now()
 	updatedFunction, err := nuclioClientSet.
 		NuclioV1beta1().
 		NuclioFunctions(updateFunctionOptions.FunctionMeta.Namespace).
@@ -106,8 +105,7 @@ func (u *Updater) Update(updateFunctionOptions *platform.UpdateFunctionOptions) 
 	if _, err := waitForFunctionReadiness(u.logger,
 		u.consumer,
 		updatedFunction.Namespace,
-		updatedFunction.Name,
-		functionCreateOrUpdateTimestamp); err != nil {
+		updatedFunction.Name); err != nil {
 		return errors.Wrap(err, "Failed to wait for function readiness")
 	}
 

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -184,7 +184,7 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 			function.Name,
 			functionResourcesCreateOrUpdateTimestamp); err != nil {
 			return fo.setFunctionError(function,
-				functionconfig.FunctionStateUnhealthy,
+				functionconfig.FunctionStateError,
 				errors.Wrap(err, "Failed to wait for function resources to be available"))
 		}
 	}

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -161,6 +161,8 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 		"readinessTimeout", readinessTimeout,
 		"functionName", function.Name)
 
+	functionResourcesCreateOrUpdateTimestamp := time.Now()
+
 	// ensure function resources (deployment, ingress, configmap, etc ...)
 	resources, err := fo.functionresClient.CreateOrUpdate(ctx, function, fo.imagePullSecrets)
 	if err != nil {
@@ -177,7 +179,10 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 		defer cancel()
 
 		// wait until the function resources are ready
-		if err = fo.functionresClient.WaitAvailable(waitContext, function.Namespace, function.Name); err != nil {
+		if err = fo.functionresClient.WaitAvailable(waitContext,
+			function.Namespace,
+			function.Name,
+			functionResourcesCreateOrUpdateTimestamp); err != nil {
 			return fo.setFunctionError(function,
 				functionconfig.FunctionStateUnhealthy,
 				errors.Wrap(err, "Failed to wait for function resources to be available"))

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -179,12 +179,12 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 		defer cancel()
 
 		// wait until the function resources are ready
-		if err = fo.functionresClient.WaitAvailable(waitContext,
+		if err, functionState := fo.functionresClient.WaitAvailable(waitContext,
 			function.Namespace,
 			function.Name,
 			functionResourcesCreateOrUpdateTimestamp); err != nil {
 			return fo.setFunctionError(function,
-				functionconfig.FunctionStateError,
+				functionState,
 				errors.Wrap(err, "Failed to wait for function resources to be available"))
 		}
 	}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -303,6 +303,8 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context,
 			}
 		}
 
+		lc.logger.Debug("TOMER - Getting pods to check deployment failure")
+
 		// get the deployment pods. if it doesn't exist yet, retry a bit later
 		pods, err := lc.kubeClientSet.CoreV1().
 			Pods(namespace).
@@ -317,6 +319,8 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context,
 			functionResourcesCreateOrUpdateTimestamp); functionDeploymentFailed {
 			return errors.Wrapf(err, "NuclioFunction deployment failed")
 		}
+
+		lc.logger.Debug("TOMER - Checked pods, function deployment has not failed")
 	}
 }
 

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2161,8 +2161,6 @@ func (lc *lazyClient) getMetricResourceByName(resourceName string) v1.ResourceNa
 func (lc *lazyClient) isFunctionDeploymentFailed(pods []v1.Pod,
 	functionResourcesCreateOrUpdateTimestamp time.Time) (bool, error) {
 
-	lc.logger.Debug("Tomer - Checking if function deployment failed")
-	
 	// infer from the pod statuses if the function deployment had failed
 	// failure of one pod is enough to tell that the deployment had failed
 	for _, pod := range pods {

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -303,8 +303,6 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context,
 			}
 		}
 
-		lc.logger.Debug("TOMER - Getting pods to check deployment failure")
-
 		// get the deployment pods. if it doesn't exist yet, retry a bit later
 		pods, err := lc.kubeClientSet.CoreV1().
 			Pods(namespace).

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2161,6 +2161,8 @@ func (lc *lazyClient) getMetricResourceByName(resourceName string) v1.ResourceNa
 func (lc *lazyClient) isFunctionDeploymentFailed(pods []v1.Pod,
 	functionResourcesCreateOrUpdateTimestamp time.Time) (bool, error) {
 
+	lc.logger.Debug("Tomer - Checking if function deployment failed")
+	
 	// infer from the pod statuses if the function deployment had failed
 	// failure of one pod is enough to tell that the deployment had failed
 	for _, pod := range pods {

--- a/pkg/platform/kube/functionres/types.go
+++ b/pkg/platform/kube/functionres/types.go
@@ -2,6 +2,7 @@ package functionres
 
 import (
 	"context"
+	"time"
 
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
@@ -34,7 +35,7 @@ type Client interface {
 	CreateOrUpdate(context.Context, *nuclioio.NuclioFunction, string) (Resources, error)
 
 	// WaitAvailable waits until the resources are ready
-	WaitAvailable(context.Context, string, string) error
+	WaitAvailable(context.Context, string, string, time.Time) error
 
 	// Delete deletes resources
 	Delete(context.Context, string, string) error

--- a/pkg/platform/kube/functionres/types.go
+++ b/pkg/platform/kube/functionres/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/functionconfig"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
@@ -35,7 +36,7 @@ type Client interface {
 	CreateOrUpdate(context.Context, *nuclioio.NuclioFunction, string) (Resources, error)
 
 	// WaitAvailable waits until the resources are ready
-	WaitAvailable(context.Context, string, string, time.Time) error
+	WaitAvailable(context.Context, string, string, time.Time) (error, functionconfig.FunctionState)
 
 	// Delete deletes resources
 	Delete(context.Context, string, string) error

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -70,7 +70,7 @@ type KubeTestSuite struct {
 	DisableControllerStart bool
 }
 
-// To run this test suite you should:
+// SetupSuite To run this test suite you should:
 // - Kubernetes for Mac: Ingress controller installed (you can install it by running "test/k8s/ci_assets/install_nginx_ingress_controller.sh")
 // - have Nuclio CRDs installed (you can install them by running "test/k8s/ci_assets/install_nuclio_crds.sh")
 // - have docker registry running (you can run docker registry by running "docker run --rm -d -p 5000:5000 registry:2")


### PR DESCRIPTION
There was a race condition between the dashboard and the controller since the fast failure logic was located in the dashboard.

Moving it to the controller makes the controller the only source of truth regarding the function deployment state, and removing the race condition.

Tested manually on several failing functions, where the logs show the controller fails immediately in `waitAvailable`.