### PR TITLE
Unset function invocation urls in case function deployment fails

### DIFF
--- a/pkg/platform/kube/controller/controller_test.go
+++ b/pkg/platform/kube/controller/controller_test.go
@@ -1,0 +1,97 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+	"github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/versioned/fake"
+	"github.com/nuclio/nuclio/pkg/platform/kube/functionres"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+	nucliozap "github.com/nuclio/zap"
+
+	"github.com/stretchr/testify/suite"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+type ControllerTestSuite struct {
+	suite.Suite
+	logger            logger.Logger
+	controller        *Controller
+	namespace         string
+	functionClientSet *fake.Clientset
+	k8sClientSet      *k8sfake.Clientset
+}
+
+func (suite *ControllerTestSuite) SetupTest() {
+	var err error
+	resyncInterval := 0 * time.Second
+	functionMonitoringInterval := 10 * time.Second
+	cronJobInterval := 10 * time.Second
+	defaultNumWorkers := 1
+
+	// create logger
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+
+	platformConfig, err := platformconfig.NewPlatformConfig("")
+	suite.Require().NoError(err)
+
+	suite.k8sClientSet = k8sfake.NewSimpleClientset()
+	suite.functionClientSet = fake.NewSimpleClientset()
+
+	functionresClient, err := functionres.NewLazyClient(suite.logger,
+		suite.k8sClientSet,
+		suite.functionClientSet)
+	suite.Require().NoError(err)
+
+	// create controller
+	suite.controller, err = NewController(suite.logger, suite.namespace,
+		"",
+		suite.k8sClientSet,
+		suite.functionClientSet,
+		functionresClient,
+		nil,
+		resyncInterval,
+		functionMonitoringInterval,
+		cronJobInterval,
+		platformConfig,
+		"configuration-name",
+		defaultNumWorkers,
+		defaultNumWorkers,
+		defaultNumWorkers,
+		defaultNumWorkers)
+	suite.Require().NoError(err)
+
+	suite.logger.Info("Starting test")
+}
+
+func (suite *ControllerTestSuite) TestFunctionUpdateFailureInvocationURLs() {
+
+	// mock function
+	functionInstance := &nuclioio.NuclioFunction{}
+	functionInstance.Name = "func-name"
+	functionInstance.Status.State = functionconfig.FunctionStateReady
+	functionInstance.Status.InternalInvocationURLs = []string{"internal.url:port1"}
+	functionInstance.Status.ExternalInvocationURLs = []string{"external.url:port2"}
+
+	// call CreateOrUpdate
+	err := suite.controller.functionOperator.CreateOrUpdate(context.TODO(), functionInstance)
+	suite.Require().Error(err)
+
+	// make sure there are no invocation URLs
+	internalInvocationURLs := functionInstance.Status.InternalInvocationURLs
+	externalInvocationURLs := functionInstance.Status.ExternalInvocationURLs
+	suite.logger.DebugWith("Function failed to update", "internalUrls", internalInvocationURLs,
+		"externalUrls", externalInvocationURLs)
+	suite.Require().Empty(internalInvocationURLs)
+	suite.Require().Empty(externalInvocationURLs)
+
+}
+
+func TestControllerUnitTestSuite(t *testing.T) {
+	suite.Run(t, new(ControllerTestSuite))
+}

--- a/pkg/platform/kube/controller/controller_test.go
+++ b/pkg/platform/kube/controller/controller_test.go
@@ -1,3 +1,21 @@
+// +build test_unit
+
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controller
 
 import (
@@ -5,14 +23,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	"github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/versioned/fake"
 	"github.com/nuclio/nuclio/pkg/platform/kube/functionres"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
-	nucliozap "github.com/nuclio/zap"
 
+	"github.com/nuclio/logger"
+	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )

--- a/pkg/platform/kube/controller/controller_test.go
+++ b/pkg/platform/kube/controller/controller_test.go
@@ -67,7 +67,8 @@ func (suite *ControllerTestSuite) SetupTest() {
 	suite.Require().NoError(err)
 
 	// create controller
-	suite.controller, err = NewController(suite.logger, suite.namespace,
+	suite.controller, err = NewController(suite.logger,
+		suite.namespace,
 		"",
 		suite.k8sClientSet,
 		suite.functionClientSet,
@@ -95,6 +96,7 @@ func (suite *ControllerTestSuite) TestFunctionUpdateFailureInvocationURLs() {
 	functionInstance.Status.State = functionconfig.FunctionStateReady
 	functionInstance.Status.InternalInvocationURLs = []string{"internal.url:port1"}
 	functionInstance.Status.ExternalInvocationURLs = []string{"external.url:port2"}
+	functionInstance.Spec.ReadinessTimeoutSeconds = 1
 
 	// call CreateOrUpdate
 	err := suite.controller.functionOperator.CreateOrUpdate(context.TODO(), functionInstance)

--- a/pkg/platform/kube/controller/controller_test.go
+++ b/pkg/platform/kube/controller/controller_test.go
@@ -103,11 +103,11 @@ func (suite *ControllerTestSuite) TestFunctionUpdateFailureInvocationURLs() {
 	// make sure there are no invocation URLs
 	internalInvocationURLs := functionInstance.Status.InternalInvocationURLs
 	externalInvocationURLs := functionInstance.Status.ExternalInvocationURLs
-	suite.logger.DebugWith("Function failed to update", "internalUrls", internalInvocationURLs,
+	suite.logger.DebugWith("Function failed to update",
+		"internalUrls", internalInvocationURLs,
 		"externalUrls", externalInvocationURLs)
 	suite.Require().Empty(internalInvocationURLs)
 	suite.Require().Empty(externalInvocationURLs)
-
 }
 
 func TestControllerUnitTestSuite(t *testing.T) {

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -262,8 +262,6 @@ func (fo *functionOperator) setFunctionError(function *nuclioio.NuclioFunction,
 	functionErrorState functionconfig.FunctionState,
 	err error) error {
 
-	fo.logger.Debug("Tomer wrote this debug message - please, dont forget to delete me!")
-
 	// whatever the error, try to update the function CR
 	fo.logger.WarnWith("Setting function error",
 		"functionErrorState", functionErrorState,

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -269,9 +269,11 @@ func (fo *functionOperator) setFunctionError(function *nuclioio.NuclioFunction,
 		"err", err)
 
 	if setStatusErr := fo.setFunctionStatus(function, &functionconfig.Status{
-		Logs:    function.Status.Logs,
-		State:   functionErrorState,
-		Message: errors.GetErrorStackString(err, 10),
+		Logs:                   function.Status.Logs,
+		State:                  functionErrorState,
+		Message:                errors.GetErrorStackString(err, 10),
+		InternalInvocationURLs: []string{},
+		ExternalInvocationURLs: []string{},
 	}); setStatusErr != nil {
 		fo.logger.WarnWith("Failed to update function on error",
 			"setStatusErr", errors.Cause(setStatusErr))

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -105,9 +105,6 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 			},
 		})
 
-	fo.logger.DebugWith("TOMER 1 - Ensuring function resource version",
-		"functionResourceVersion", function.ResourceVersion)
-
 	// validate function name is according to k8s convention
 	errorMessages := validation.IsQualifiedName(function.Name)
 	if len(errorMessages) != 0 {
@@ -138,9 +135,6 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 
 		return nil
 	}
-
-	fo.logger.DebugWith("TOMER 2 - Ensuring function resource version",
-		"functionResourceVersion", function.ResourceVersion)
 
 	// imported functions have skip deploy annotation, set its state and bail
 	if functionconfig.ShouldSkipDeploy(function.Annotations) {
@@ -177,9 +171,6 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 			errors.Wrap(err, "Failed to create/update function"))
 	}
 
-	fo.logger.DebugWith("TOMER 3 - Ensuring function resource version",
-		"functionResourceVersion", function.ResourceVersion)
-
 	// readinessTimeout would be zero when
 	// - not defined on function spec
 	// - defined 0 on platform-config
@@ -192,8 +183,6 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 			function.Namespace,
 			function.Name,
 			functionResourcesCreateOrUpdateTimestamp); err != nil {
-			fo.logger.DebugWith("TOMER 4 - Ensuring function resource version",
-				"functionResourceVersion", function.ResourceVersion)
 			return fo.setFunctionError(function,
 				functionState,
 				errors.Wrap(err, "Failed to wait for function resources to be available"))
@@ -299,8 +288,7 @@ func (fo *functionOperator) setFunctionError(function *nuclioio.NuclioFunction,
 func (fo *functionOperator) setFunctionStatus(function *nuclioio.NuclioFunction,
 	status *functionconfig.Status) error {
 
-	fo.logger.DebugWith("Setting function state", "name", function.Name, "status", status,
-		"functionResourceVersion", function.ResourceVersion)
+	fo.logger.DebugWith("Setting function state", "name", function.Name, "status", status)
 
 	// indicate error state
 	function.Status = *status

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -262,6 +262,8 @@ func (fo *functionOperator) setFunctionError(function *nuclioio.NuclioFunction,
 	functionErrorState functionconfig.FunctionState,
 	err error) error {
 
+	fo.logger.Debug("Tomer wrote this debug message - please, dont forget to delete me!")
+
 	// whatever the error, try to update the function CR
 	fo.logger.WarnWith("Setting function error",
 		"functionErrorState", functionErrorState,

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -105,6 +105,9 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 			},
 		})
 
+	fo.logger.DebugWith("TOMER 1 - Ensuring function resource version",
+		"functionResourceVersion", function.ResourceVersion)
+
 	// validate function name is according to k8s convention
 	errorMessages := validation.IsQualifiedName(function.Name)
 	if len(errorMessages) != 0 {
@@ -135,6 +138,9 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 
 		return nil
 	}
+
+	fo.logger.DebugWith("TOMER 2 - Ensuring function resource version",
+		"functionResourceVersion", function.ResourceVersion)
 
 	// imported functions have skip deploy annotation, set its state and bail
 	if functionconfig.ShouldSkipDeploy(function.Annotations) {
@@ -171,6 +177,9 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 			errors.Wrap(err, "Failed to create/update function"))
 	}
 
+	fo.logger.DebugWith("TOMER 3 - Ensuring function resource version",
+		"functionResourceVersion", function.ResourceVersion)
+
 	// readinessTimeout would be zero when
 	// - not defined on function spec
 	// - defined 0 on platform-config
@@ -183,6 +192,8 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 			function.Namespace,
 			function.Name,
 			functionResourcesCreateOrUpdateTimestamp); err != nil {
+			fo.logger.DebugWith("TOMER 4 - Ensuring function resource version",
+				"functionResourceVersion", function.ResourceVersion)
 			return fo.setFunctionError(function,
 				functionState,
 				errors.Wrap(err, "Failed to wait for function resources to be available"))
@@ -288,7 +299,8 @@ func (fo *functionOperator) setFunctionError(function *nuclioio.NuclioFunction,
 func (fo *functionOperator) setFunctionStatus(function *nuclioio.NuclioFunction,
 	status *functionconfig.Status) error {
 
-	fo.logger.DebugWith("Setting function state", "name", function.Name, "status", status)
+	fo.logger.DebugWith("Setting function state", "name", function.Name, "status", status,
+		"functionResourceVersion", function.ResourceVersion)
 
 	// indicate error state
 	function.Status = *status

--- a/pkg/platform/kube/controller/test/controller_test.go
+++ b/pkg/platform/kube/controller/test/controller_test.go
@@ -20,7 +20,6 @@ limitations under the License.
 package test
 
 import (
-	"encoding/base64"
 	"fmt"
 	"testing"
 	"time"
@@ -31,7 +30,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform/kube/test"
 
 	"github.com/stretchr/testify/suite"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -47,7 +45,7 @@ func (suite *ControllerTestSuite) SetupSuite() {
 func (suite *ControllerTestSuite) TestStaleResourceVersion() {
 
 	// build function
-	function, _ := suite.buildTestFunction(false)
+	function := suite.buildTestFunction()
 
 	// creating function CRD record
 	functionCRDRecord, err := suite.FunctionClientSet.
@@ -81,97 +79,10 @@ func (suite *ControllerTestSuite) TestStaleResourceVersion() {
 	}, functionconfig.FunctionStateReady, 5*time.Minute)
 }
 
-func (suite *ControllerTestSuite) TestFunctionRedeploymentFailureInvocationURLs() {
-
-	// build function
-	functionConfig, createFunctionOptions := suite.buildTestFunction(true)
-
-	// create function CRD record
-	functionCRDRecord, err := suite.FunctionClientSet.
-		NuclioV1beta1().
-		NuclioFunctions(suite.Namespace).
-		Create(&nuclioio.NuclioFunction{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            functionConfig.Meta.Name,
-				Namespace:       functionConfig.Meta.Namespace,
-				Labels:          functionConfig.Meta.Labels,
-				Annotations:     functionConfig.Meta.Annotations,
-			},
-			Spec: functionConfig.Spec,
-			Status: functionconfig.Status{
-				State: functionconfig.FunctionStateWaitingForResourceConfiguration,
-			},
-		})
-	suite.Require().NoError(err)
-	suite.Require().NotEmpty(functionCRDRecord.ResourceVersion)
-	suite.Logger.DebugWith("Function CRD created", "resourceVersion", functionCRDRecord.ResourceVersion)
-
-	// start controller
-	err = suite.Controller.Start()
-	suite.Require().NoError(err)
-
-	// wait for function to be ready
-	suite.WaitForFunctionState(&platform.GetFunctionsOptions{
-		Namespace: functionCRDRecord.Namespace,
-		Name:      functionCRDRecord.Name,
-	}, functionconfig.FunctionStateReady, 5*time.Minute)
-
-	// update function with errors
-	suite.Logger.Debug("Updating function`s source code with typos")
-
-	badFunctionConfig := suite.buildErroneousTestFunction(createFunctionOptions)
-
-	// Get functions
-	function, err := suite.FunctionClientSet.NuclioV1beta1().
-		NuclioFunctions(functionConfig.Meta.Namespace).
-		Get(functionConfig.Meta.Name, metav1.GetOptions{})
-	suite.Require().NoError(err)
-
-	// Update spec and status
-	function.Spec.Image = badFunctionConfig.Spec.Image
-	function.Spec.ImageHash = badFunctionConfig.Spec.ImageHash
-	function.Status.State = functionconfig.FunctionStateWaitingForResourceConfiguration
-
-	newFunctionCRDRecord, err := suite.FunctionClientSet.
-		NuclioV1beta1().
-		NuclioFunctions(suite.Namespace).
-		Update(function)
-	suite.Require().NoError(err)
-
-	// redeploy function
-	newFunctionOptions := &platform.GetFunctionsOptions{
-		Namespace: newFunctionCRDRecord.Namespace,
-		Name:      newFunctionCRDRecord.Name,
-	}
-
-	// wait for function to become unhealthy (the state might be Building / Error / Ready)
-	suite.WaitForFunctionState(newFunctionOptions, functionconfig.FunctionStateUnhealthy, 2*time.Minute)
-
-	// check function's invocation urls
-	newFunction := suite.GetFunction(newFunctionOptions)
-	internalInvocationURLs := newFunction.GetStatus().InternalInvocationURLs
-	externalInvocationURLs := newFunction.GetStatus().ExternalInvocationURLs
-	newFuncSourceCode := newFunction.GetConfig().Spec.Build.FunctionSourceCode
-
-	suite.Logger.DebugWith("Got function invocation URLs", "internalInvocationURLs",
-		internalInvocationURLs, "externalInvocationURLs", externalInvocationURLs,
-		"sourceCode", newFuncSourceCode, "Status", newFunction.GetStatus())
-}
-
-func (suite *ControllerTestSuite) buildTestFunction(httpTrigger bool) (*functionconfig.Config, *platform.CreateFunctionOptions) {
+func (suite *ControllerTestSuite) buildTestFunction() *functionconfig.Config {
 
 	// create function options
 	createFunctionOptions := suite.CompileCreateFunctionOptions(fmt.Sprintf("test-%s", suite.TestID))
-
-	if httpTrigger {
-		if createFunctionOptions.FunctionConfig.Spec.Triggers == nil {
-			createFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{}
-		}
-		defaultHTTPTrigger := functionconfig.GetDefaultHTTPTrigger()
-		createFunctionOptions.FunctionConfig.Spec.Triggers[defaultHTTPTrigger.Name] = defaultHTTPTrigger
-
-		createFunctionOptions.FunctionConfig.Spec.ServiceType = v1.ServiceTypeNodePort
-	}
 
 	// enrich with defaults
 	err := suite.Platform.EnrichFunctionConfig(&createFunctionOptions.FunctionConfig)
@@ -191,33 +102,7 @@ func (suite *ControllerTestSuite) buildTestFunction(httpTrigger bool) (*function
 	buildFunctionResults.UpdatedFunctionConfig.Spec.Image = fmt.Sprintf("%s/%s",
 		suite.RegistryURL,
 		buildFunctionResults.Image)
-	return &buildFunctionResults.UpdatedFunctionConfig, createFunctionOptions
-}
-
-func (suite *ControllerTestSuite) buildErroneousTestFunction(funcOptions *platform.CreateFunctionOptions) *functionconfig.Config {
-
-	// update function with an erroneous source code (update the CRD)
-	funcOptions.FunctionConfig.Spec.Build.FunctionSourceCode = base64.StdEncoding.EncodeToString([]byte(`
-def handler(context, event):
-  retur "hello world'q
-`))
-
-	// build function
-	newFunction, err := suite.Platform.CreateFunctionBuild(&platform.CreateFunctionBuildOptions{
-		Logger:              suite.Logger,
-		FunctionConfig:      funcOptions.FunctionConfig,
-		PlatformName:        suite.Platform.GetName(),
-		OnAfterConfigUpdate: nil,
-	})
-	suite.Require().NoError(err)
-	suite.Require().NotEmpty(newFunction.Image)
-
-	// update function's image
-	newFunction.UpdatedFunctionConfig.Spec.Image = fmt.Sprintf("%s/%s",
-		suite.RegistryURL,
-		newFunction.Image)
-
-	return &newFunction.UpdatedFunctionConfig
+	return &buildFunctionResults.UpdatedFunctionConfig
 }
 
 func TestControllerTestSuite(t *testing.T) {


### PR DESCRIPTION
When a deployment fails, unset invocation URLs even if previous deployment has succeeded.

Tested on a live system:
After successful deployment:
![Successful depolyment URLs](https://user-images.githubusercontent.com/90552140/143767574-8b5152b2-c589-483d-a202-22d5f90bd01b.png)

After redeployment failure:
![Redeployment Failure URLs](https://user-images.githubusercontent.com/90552140/143767584-73b90fc9-83cf-49da-b322-5c86ae9f5f74.png)

internal ticket: IG-19662