### PR TITLE
Fix TestRecoverErrorStateFunctionWhenResourcesAvailable CI test

### DIFF
--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -224,7 +224,11 @@ func (suite *FunctionMonitoringTestSuite) TestRecoverErrorStateFunctionWhenResou
 		Namespace: createFunctionOptions.FunctionConfig.Meta.Namespace,
 	}
 
-	functionMonitoringSleepTimeout := suite.Controller.GetFunctionMonitoringInterval() + 60*time.Second
+	one := 1
+	createFunctionOptions.FunctionConfig.Spec.MinReplicas = &one
+
+	functionMonitoringSleepTimeout := 2*suite.Controller.GetFunctionMonitoringInterval() +
+		monitoring.PostDeploymentMonitoringBlockingInterval
 	suite.DeployFunction(createFunctionOptions, func(deployResults *platform.CreateFunctionResult) bool {
 
 		// get the function
@@ -257,6 +261,8 @@ func (suite *FunctionMonitoringTestSuite) TestRecoverErrorStateFunctionWhenResou
 		}, func() {
 
 			suite.DeleteFunctionPods(functionName)
+
+			time.Sleep(10 * time.Second)
 
 			// wait for controller to mark function in error due to pods being unschedulable
 			suite.WaitForFunctionState(getFunctionOptions,

--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -224,8 +224,8 @@ func (suite *FunctionMonitoringTestSuite) TestRecoverErrorStateFunctionWhenResou
 		Namespace: createFunctionOptions.FunctionConfig.Meta.Namespace,
 	}
 
-	functionMonitoringSleepTimeout := 2*suite.Controller.GetFunctionMonitoringInterval() +
-		monitoring.PostDeploymentMonitoringBlockingInterval
+	functionMonitoringSleepTimeout := 2 * (suite.Controller.GetFunctionMonitoringInterval() +
+		monitoring.PostDeploymentMonitoringBlockingInterval)
 	suite.DeployFunction(createFunctionOptions, func(deployResults *platform.CreateFunctionResult) bool {
 
 		// get the function

--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -224,8 +224,7 @@ func (suite *FunctionMonitoringTestSuite) TestRecoverErrorStateFunctionWhenResou
 		Namespace: createFunctionOptions.FunctionConfig.Meta.Namespace,
 	}
 
-	functionMonitoringSleepTimeout := 2 * (suite.Controller.GetFunctionMonitoringInterval() +
-		monitoring.PostDeploymentMonitoringBlockingInterval)
+	functionMonitoringSleepTimeout := suite.Controller.GetFunctionMonitoringInterval() + 60*time.Second
 	suite.DeployFunction(createFunctionOptions, func(deployResults *platform.CreateFunctionResult) bool {
 
 		// get the function


### PR DESCRIPTION
`TestRecoverErrorStateFunctionWhenResourcesAvailable` sometimes fails on timeout while waiting for for function to become unhealthy after creating a resource quota and deleting pods.
Waiting after deleting pods and before checking function status solves this.