### PR TITLE
K8s resources (helm/yamls) - Deprecate rbac.authorization.k8s.io/v1beta1, fix k8s 1.22 compatibility

### DIFF
--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.10.2
+version: 0.11.0
 appVersion: 1.7.2
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/templates/role/crd-admin.yaml
+++ b/hack/k8s/helm/nuclio/templates/role/crd-admin.yaml
@@ -14,7 +14,7 @@
 
 {{- if .Values.rbac.create }}
 # All access to the custom resource definitions
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "nuclio.crdAdminName" . }}-clusterrole
@@ -37,7 +37,7 @@ rules:
 {{- else if eq .Values.rbac.crdAccessMode "namespaced" }}
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "nuclio.crdAdminName" . }}-role

--- a/hack/k8s/helm/nuclio/templates/role/function-deployer.yaml
+++ b/hack/k8s/helm/nuclio/templates/role/function-deployer.yaml
@@ -15,7 +15,7 @@
 {{- if .Values.rbac.create }}
 # All access to services, configmaps, deployments, ingresses, HPAs, cronJobs
 # are conditionally limited to the nuclio namespace or cluster-wide
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 {{- if eq .Values.rbac.crdAccessMode "cluster" }}
 kind: ClusterRole
 metadata:

--- a/hack/k8s/helm/nuclio/templates/rolebinding/crd-admin.yaml
+++ b/hack/k8s/helm/nuclio/templates/rolebinding/crd-admin.yaml
@@ -15,7 +15,7 @@
 {{- if .Values.rbac.create }}
 # Bind the service account (used by controller / dashboard) to the crd-admin role,
 # allowing them to create / delete custom resource definitions in the appropriate namespace
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "nuclio.crdAdminName" . }}-clusterrolebinding
@@ -34,7 +34,7 @@ subjects:
 {{- if eq .Values.rbac.crdAccessMode "namespaced" }}
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "nuclio.crdAdminName" . }}-rolebinding

--- a/hack/k8s/helm/nuclio/templates/rolebinding/function-deployer.yaml
+++ b/hack/k8s/helm/nuclio/templates/rolebinding/function-deployer.yaml
@@ -17,7 +17,7 @@
 # allowing them to create deployments, services, etc
 
 {{- if eq .Values.rbac.crdAccessMode "cluster" }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "nuclio.functionDeployerName" . }}-clusterrolebinding
@@ -35,7 +35,7 @@ subjects:
 
 {{- else }}
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "nuclio.functionDeployerName" . }}-rolebinding

--- a/hack/k8s/resources/nuclio-rbac.yaml
+++ b/hack/k8s/resources/nuclio-rbac.yaml
@@ -15,7 +15,7 @@
 ---
 
 # All access to services, configmaps, deployments, ingresses and HPAs limited to the "nuclio" namespace
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: nuclio-function-deployer
@@ -43,7 +43,7 @@ rules:
 
 # Bind the "nuclio" service account (used by controller / dashboard) to the nuclio-function-deployer role,
 # allowing them to create deployments, services, etc
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: nuclio-function-deployer-rolebinding
@@ -60,7 +60,7 @@ subjects:
 ---
 
 # All access to the function/project/functionevents custom resource definition
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: nuclio-functioncr-admin
@@ -76,7 +76,7 @@ rules:
 
 # Bind the "nuclio" service account (used by controller / dashboard) to the nuclio-functioncr-admin role,
 # allowing them to create / delete function custom resource definitions in the "nuclio" namespace
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: nuclio-functioncr-admin-clusterrolebinding


### PR DESCRIPTION
Resolving: https://github.com/nuclio/nuclio/issues/2402
- Changing k8s resources and chart to use `rbac.authorization.k8s.io/v1` and not `rbac.authorization.k8s.io/v1beta1`. No spec changes needed
- Bumping chart minor (resource api change)