### PR TITLE
Fix autoscale event typo

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2283,6 +2283,9 @@ func (lc *lazyClient) isPodAutoScaledUp(ctx context.Context, pod v1.Pod) (bool, 
 	for _, event := range podEvents.Items {
 
 		if event.Source.Component == "cluster-autoscaler" {
+
+			// check autoscaler event reasons according to:
+			// https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-events-are-emitted-by-ca
 			switch event.Reason {
 			case "TriggeredScaleUp":
 				lc.logger.InfoWithCtx(ctx,

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2284,7 +2284,7 @@ func (lc *lazyClient) isPodAutoScaledUp(ctx context.Context, pod v1.Pod) (bool, 
 
 		if event.Source.Component == "cluster-autoscaler" {
 			switch event.Reason {
-			case "TriggerScaleUp":
+			case "TriggeredScaleUp":
 				lc.logger.InfoWithCtx(ctx,
 					"Nuclio function pod has triggered a node scale up",
 					"podName", pod.Name)

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -617,7 +617,7 @@ func (suite *lazyTestSuite) TestFastFailOnAutoScalerEvents() {
 				Source: v1.EventSource{
 					Component: "cluster-autoscaler",
 				},
-				Reason: "TriggerScaleUp",
+				Reason: "TriggeredScaleUp",
 			},
 			expectedError: false,
 		},


### PR DESCRIPTION
Change event reason according to: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-events-are-emitted-by-ca