### PR TITLE
Use nuclio/errgroup instead of sync/errgroup

### DIFF
--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -96,13 +96,13 @@ func (i *importCommandeer) importFunction(ctx context.Context, functionConfig *f
 func (i *importCommandeer) importFunctions(ctx context.Context,
 	functionConfigs map[string]*functionconfig.Config,
 	project *platform.ProjectConfig) error {
-	var errGroup errgroup.Group
+	errGroup, errGroupCtx := errgroup.WithContext(ctx, i.rootCommandeer.loggerInstance)
 
 	i.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Importing functions", "functions", functionConfigs)
 	for _, functionConfig := range functionConfigs {
 		functionConfig := functionConfig // https://golang.org/doc/faq#closures_and_goroutines
 		errGroup.Go("Import function", func() error {
-			return i.importFunction(ctx, functionConfig, project)
+			return i.importFunction(errGroupCtx, functionConfig, project)
 		})
 	}
 
@@ -317,14 +317,14 @@ func (i *importProjectCommandeer) importAPIGateway(ctx context.Context, apiGatew
 
 func (i *importProjectCommandeer) importFunctionEvents(ctx context.Context,
 	functionEvents map[string]*platform.FunctionEventConfig) error {
-	var errGroup errgroup.Group
+	errGroup, errGroupCtx := errgroup.WithContext(ctx, i.rootCommandeer.loggerInstance)
 
 	i.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Importing function events",
 		"functionEvents", functionEvents)
 	for _, functionEventConfig := range functionEvents {
 		functionEventConfig := functionEventConfig // https://golang.org/doc/faq#closures_and_goroutines
 		errGroup.Go("Import function event", func() error {
-			return i.importFunctionEvent(ctx, functionEventConfig)
+			return i.importFunctionEvent(errGroupCtx, functionEventConfig)
 		})
 	}
 
@@ -333,7 +333,7 @@ func (i *importProjectCommandeer) importFunctionEvents(ctx context.Context,
 
 func (i *importProjectCommandeer) importAPIGateways(ctx context.Context,
 	apiGateways map[string]*platform.APIGatewayConfig) error {
-	var errGroup errgroup.Group
+	errGroup, errGroupCtx := errgroup.WithContext(ctx, i.rootCommandeer.loggerInstance)
 
 	i.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Importing api gateways", "apiGateways", apiGateways)
 
@@ -344,7 +344,7 @@ func (i *importProjectCommandeer) importAPIGateways(ctx context.Context,
 	for _, apiGatewayConfig := range apiGateways {
 		apiGatewayConfig := apiGatewayConfig // https://golang.org/doc/faq#closures_and_goroutines
 		errGroup.Go("Import API Gateway", func() error {
-			return i.importAPIGateway(ctx, apiGatewayConfig)
+			return i.importAPIGateway(errGroupCtx, apiGatewayConfig)
 		})
 	}
 

--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/errgroup"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	nuctlcommon "github.com/nuclio/nuclio/pkg/nuctl/command/common"
 	"github.com/nuclio/nuclio/pkg/platform"
@@ -12,7 +13,6 @@ import (
 	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/satori/go.uuid"
 	"github.com/spf13/cobra"
-	"golang.org/x/sync/errgroup"
 )
 
 type importCommandeer struct {
@@ -101,7 +101,7 @@ func (i *importCommandeer) importFunctions(ctx context.Context,
 	i.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Importing functions", "functions", functionConfigs)
 	for _, functionConfig := range functionConfigs {
 		functionConfig := functionConfig // https://golang.org/doc/faq#closures_and_goroutines
-		errGroup.Go(func() error {
+		errGroup.Go("Import function", func() error {
 			return i.importFunction(ctx, functionConfig, project)
 		})
 	}
@@ -323,7 +323,7 @@ func (i *importProjectCommandeer) importFunctionEvents(ctx context.Context,
 		"functionEvents", functionEvents)
 	for _, functionEventConfig := range functionEvents {
 		functionEventConfig := functionEventConfig // https://golang.org/doc/faq#closures_and_goroutines
-		errGroup.Go(func() error {
+		errGroup.Go("Import function event", func() error {
 			return i.importFunctionEvent(ctx, functionEventConfig)
 		})
 	}
@@ -343,7 +343,7 @@ func (i *importProjectCommandeer) importAPIGateways(ctx context.Context,
 
 	for _, apiGatewayConfig := range apiGateways {
 		apiGatewayConfig := apiGatewayConfig // https://golang.org/doc/faq#closures_and_goroutines
-		errGroup.Go(func() error {
+		errGroup.Go("Import API Gateway", func() error {
 			return i.importAPIGateway(ctx, apiGatewayConfig)
 		})
 	}

--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -112,11 +112,11 @@ func (s *Store) DeleteProject(ctx context.Context, projectMeta *platform.Project
 	}
 
 	// NOTE: functions delete their related function events
-	deleteFunctionsErrGroup, _ := errgroup.WithContext(ctx, s.logger)
+	deleteFunctionsErrGroup, deleteFunctionsErrGroupCtx := errgroup.WithContext(ctx, s.logger)
 	for _, function := range functions {
 		function := function
 		deleteFunctionsErrGroup.Go("Delete function", func() error {
-			return s.DeleteFunction(ctx, &function.GetConfig().Meta)
+			return s.DeleteFunction(deleteFunctionsErrGroupCtx, &function.GetConfig().Meta)
 		})
 	}
 	if err := deleteFunctionsErrGroup.Wait(); err != nil {

--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -29,13 +29,13 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/dockerclient"
+	"github.com/nuclio/nuclio/pkg/errgroup"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -112,10 +112,10 @@ func (s *Store) DeleteProject(ctx context.Context, projectMeta *platform.Project
 	}
 
 	// NOTE: functions delete their related function events
-	deleteFunctionsErrGroup, _ := errgroup.WithContext(ctx)
+	deleteFunctionsErrGroup, _ := errgroup.WithContext(ctx, s.logger)
 	for _, function := range functions {
 		function := function
-		deleteFunctionsErrGroup.Go(func() error {
+		deleteFunctionsErrGroup.Go("Delete function", func() error {
 			return s.DeleteFunction(ctx, &function.GetConfig().Meta)
 		})
 	}
@@ -274,10 +274,10 @@ func (s *Store) DeleteFunction(ctx context.Context, functionMeta *functionconfig
 		return errors.Wrap(err, "Failed to get function events")
 	}
 
-	deleteFunctionEventsErrGroup, _ := errgroup.WithContext(ctx)
+	deleteFunctionEventsErrGroup, _ := errgroup.WithContext(ctx, s.logger)
 	for _, functionEvent := range functionEvents {
 		functionEvent := functionEvent
-		deleteFunctionEventsErrGroup.Go(func() error {
+		deleteFunctionEventsErrGroup.Go("Delete function event", func() error {
 			return s.DeleteFunctionEvent(&functionEvent.GetConfig().Meta)
 		})
 	}

--- a/pkg/processor/timeout/timeout.go
+++ b/pkg/processor/timeout/timeout.go
@@ -14,6 +14,7 @@ limitations under the License.
 package timeout
 
 import (
+	ctx "context"
 	"fmt"
 	"time"
 
@@ -62,7 +63,7 @@ func (w EventTimeoutWatcher) watch() {
 		now := time.Now()
 
 		// create error group
-		triggerErrGroup := errgroup.Group{}
+		triggerErrGroup, _ := errgroup.WithContext(ctx.Background(), w.logger)
 
 		// TODO: Run in parallel
 		for triggerName, triggerInstance := range w.processor.GetTriggers() {
@@ -71,7 +72,7 @@ func (w EventTimeoutWatcher) watch() {
 			triggerErrGroup.Go("Watch trigger event timeout", func() error {
 
 				// create error group
-				workerErrGroup := errgroup.Group{}
+				workerErrGroup, _ := errgroup.WithContext(ctx.Background(), w.logger)
 
 				// iterate over worker
 				for _, workerInstance := range triggerInstance.GetWorkers() {
@@ -138,7 +139,7 @@ func (w EventTimeoutWatcher) stopTriggers(timedoutWorker *worker.Worker) map[str
 	runningWorkers := make(map[string]*worker.Worker)
 
 	// create error group
-	triggerErrGroup := errgroup.Group{}
+	triggerErrGroup, _ := errgroup.WithContext(ctx.Background(), w.logger)
 
 	for triggerIdx, triggerInstance := range w.processor.GetTriggers() {
 		triggerIdx, triggerInstance := triggerIdx, triggerInstance

--- a/pkg/processor/timeout/timeout.go
+++ b/pkg/processor/timeout/timeout.go
@@ -17,12 +17,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/errgroup"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
 	"github.com/nuclio/nuclio/pkg/processor/worker"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
-	"golang.org/x/sync/errgroup"
 )
 
 // Processor is minimal processor interface
@@ -68,7 +68,7 @@ func (w EventTimeoutWatcher) watch() {
 		for triggerName, triggerInstance := range w.processor.GetTriggers() {
 			triggerName, triggerInstance := triggerName, triggerInstance
 
-			triggerErrGroup.Go(func() error {
+			triggerErrGroup.Go("Watch trigger event timeout", func() error {
 
 				// create error group
 				workerErrGroup := errgroup.Group{}
@@ -77,7 +77,7 @@ func (w EventTimeoutWatcher) watch() {
 				for _, workerInstance := range triggerInstance.GetWorkers() {
 					workerInstance := workerInstance
 
-					workerErrGroup.Go(func() error {
+					workerErrGroup.Go("Watch Event Timeout", func() error {
 						eventTime := workerInstance.GetEventTime()
 						if eventTime == nil {
 							return nil
@@ -143,7 +143,7 @@ func (w EventTimeoutWatcher) stopTriggers(timedoutWorker *worker.Worker) map[str
 	for triggerIdx, triggerInstance := range w.processor.GetTriggers() {
 		triggerIdx, triggerInstance := triggerIdx, triggerInstance
 
-		triggerErrGroup.Go(func() error {
+		triggerErrGroup.Go("Stop trigger", func() error {
 
 			if checkpoint, err := triggerInstance.Stop(false); err != nil {
 				w.logger.ErrorWith("Can't stop trigger", "triggerIdx", triggerIdx, "error", err)

--- a/pkg/processor/worker/factory.go
+++ b/pkg/processor/worker/factory.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/nuclio/nuclio/pkg/errgroup"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
-	"golang.org/x/sync/errgroup"
 )
 
 type Factory struct{}
@@ -112,7 +112,7 @@ func (waf *Factory) createWorkers(logger logger.Logger,
 	for workerIndex := 0; workerIndex < numWorkers; workerIndex++ {
 		workerIndex := workerIndex
 
-		errGroup.Go(func() error {
+		errGroup.Go("Create worker", func() error {
 			worker, err := waf.createWorker(logger, workerIndex, runtimeConfiguration)
 			if err != nil {
 				return errors.Wrap(err, "Failed to create worker")

--- a/pkg/processor/worker/factory.go
+++ b/pkg/processor/worker/factory.go
@@ -17,7 +17,7 @@ limitations under the License.
 package worker
 
 import (
-	ctx "context"
+	"context"
 	"fmt"
 	"strings"
 
@@ -108,7 +108,7 @@ func (waf *Factory) createWorkers(logger logger.Logger,
 	runtimeConfiguration *runtime.Configuration) ([]*Worker, error) {
 	workers := make([]*Worker, numWorkers)
 
-	errGroup, _ := errgroup.WithContext(ctx.Background(), logger)
+	errGroup, _ := errgroup.WithContext(context.Background(), logger)
 
 	for workerIndex := 0; workerIndex < numWorkers; workerIndex++ {
 		workerIndex := workerIndex

--- a/pkg/processor/worker/factory.go
+++ b/pkg/processor/worker/factory.go
@@ -17,6 +17,7 @@ limitations under the License.
 package worker
 
 import (
+	ctx "context"
 	"fmt"
 	"strings"
 
@@ -107,7 +108,7 @@ func (waf *Factory) createWorkers(logger logger.Logger,
 	runtimeConfiguration *runtime.Configuration) ([]*Worker, error) {
 	workers := make([]*Worker, numWorkers)
 
-	errGroup := errgroup.Group{}
+	errGroup, _ := errgroup.WithContext(ctx.Background(), logger)
 
 	for workerIndex := 0; workerIndex < numWorkers; workerIndex++ {
 		workerIndex := workerIndex


### PR DESCRIPTION
Replace all usage of sync/errgroup with nuclio/errgroup for a more unified code base.