### PR TITLE
Use newer alpine images

### DIFF
--- a/cmd/autoscaler/Dockerfile
+++ b/cmd/autoscaler/Dockerfile
@@ -17,7 +17,7 @@
 #
 
 ARG NUCLIO_LABEL
-ARG ALPINE_IMAGE=gcr.io/iguazio/alpine:3.11
+ARG ALPINE_IMAGE=gcr.io/iguazio/alpine:3.15
 
 FROM nuclio-base:$NUCLIO_LABEL as build-autoscaler
 

--- a/cmd/controller/Dockerfile
+++ b/cmd/controller/Dockerfile
@@ -17,7 +17,7 @@
 #
 
 ARG NUCLIO_LABEL
-ARG ALPINE_IMAGE=gcr.io/iguazio/alpine:3.11
+ARG ALPINE_IMAGE=gcr.io/iguazio/alpine:3.15
 
 FROM nuclio-base:$NUCLIO_LABEL as build-controller
 

--- a/cmd/dlx/Dockerfile
+++ b/cmd/dlx/Dockerfile
@@ -17,7 +17,7 @@
 #
 
 ARG NUCLIO_LABEL
-ARG ALPINE_IMAGE=gcr.io/iguazio/alpine:3.11
+ARG ALPINE_IMAGE=gcr.io/iguazio/alpine:3.15
 
 FROM nuclio-base:$NUCLIO_LABEL as build-dlx
 

--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -415,7 +415,7 @@ func (s *Store) runCommand(env map[string]string, format string, args ...interfa
 
 		// run a container that simply volumizes the volume with the storage and sleeps for 6 hours
 		// using alpine mirrored to gcr.io/iguazio for stability
-		_, err = s.dockerClient.RunContainer("gcr.io/iguazio/alpine:3.11", &dockerclient.RunOptions{
+		_, err = s.dockerClient.RunContainer("gcr.io/iguazio/alpine:3.15", &dockerclient.RunOptions{
 			Volumes:          map[string]string{volumeName: baseDir},
 			Remove:           true,
 			Command:          `/bin/sh -c "/bin/sleep 6h"`,

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -1197,7 +1197,7 @@ func (p *Platform) prepareFunctionVolumeMount(createFunctionOptions *platform.Cr
 	}
 
 	// dumping contents to volume's processor path
-	if _, err := p.dockerClient.RunContainer("gcr.io/iguazio/alpine:3.11", &dockerclient.RunOptions{
+	if _, err := p.dockerClient.RunContainer("gcr.io/iguazio/alpine:3.15", &dockerclient.RunOptions{
 		Remove: true,
 		MountPoints: []dockerclient.MountPoint{
 			{

--- a/pkg/processor/build/runtime/golang/runtime.go
+++ b/pkg/processor/build/runtime/golang/runtime.go
@@ -63,7 +63,7 @@ func (g *golang) GetName() string {
 func (g *golang) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{
-		BaseImage: "alpine:3.11",
+		BaseImage: "alpine:3.15",
 	}
 
 	// if the base image is not default (which is alpine) and is not alpine based, must use the non-alpine onbuild image

--- a/pkg/processor/build/runtime/shell/runtime.go
+++ b/pkg/processor/build/runtime/shell/runtime.go
@@ -38,7 +38,7 @@ func (s *shell) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
 	// set the default base image
-	processorDockerfileInfo.BaseImage = "alpine:3.11"
+	processorDockerfileInfo.BaseImage = "alpine:3.15"
 
 	// fill onbuild artifact
 	artifact := runtime.Artifact{


### PR DESCRIPTION
Addressing some security scan concerns in older 3.11 alpine image and picking up newest 3.15