### PR TITLE
Enhance fail-fast to respect pod scale up events [1.6.x]

### DIFF
--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -123,7 +123,6 @@ func (d *Deployer) Deploy(functionInstance *nuclioio.NuclioFunction,
 
 	// do the create / update
 	// TODO: Infer timestamp from function config (consider create/update scenarios)
-	functionCreateOrUpdateTimestamp := time.Now()
 	if _, err := d.CreateOrUpdateFunction(functionInstance,
 		createFunctionOptions,
 		&functionconfig.Status{
@@ -136,8 +135,7 @@ func (d *Deployer) Deploy(functionInstance *nuclioio.NuclioFunction,
 	updatedFunctionInstance, err := waitForFunctionReadiness(deployLogger,
 		d.consumer,
 		functionInstance.Namespace,
-		functionInstance.Name,
-		functionCreateOrUpdateTimestamp)
+		functionInstance.Name)
 	if err != nil {
 		podLogs, briefErrorsMessage := d.getFunctionPodLogsAndEvents(functionInstance.Namespace, functionInstance.Name)
 		return nil, updatedFunctionInstance, briefErrorsMessage, errors.Wrapf(err, "Failed to wait for function readiness.\n%s", podLogs)
@@ -288,63 +286,10 @@ func (d *Deployer) getLastCreatedPod(pods []v1.Pod) v1.Pod {
 	return latestPod
 }
 
-func isFunctionDeploymentFailed(consumer *Consumer,
-	namespace string,
-	name string,
-	functionCreateOrUpdateTimestamp time.Time) (bool, error) {
-
-	// list function pods
-	pods, err := consumer.KubeClientSet.CoreV1().
-		Pods(namespace).
-		List(metav1.ListOptions{
-			LabelSelector: common.CompileListFunctionPodsLabelSelector(name),
-		})
-	if err != nil {
-		return false, errors.Wrap(err, "Failed to Get pods")
-	}
-
-	// infer from the pod statuses if the function deployment had failed
-	// failure of one pod is enough to tell that the deployment had failed
-	for _, pod := range pods.Items {
-
-		// skip irrelevant pods (leftovers of previous function deployments)
-		// (subtract 2 seconds from create/update timestamp because of ms accuracy loss of pod.creationTimestamp)
-		if !pod.GetCreationTimestamp().After(functionCreateOrUpdateTimestamp.Add(-2 * time.Second)) {
-			continue
-		}
-
-		for _, containerStatus := range pod.Status.ContainerStatuses {
-
-			if pod.Status.ContainerStatuses[0].State.Waiting != nil {
-
-				// check if the pod is on a crashLoopBackoff
-				if containerStatus.State.Waiting.Reason == "CrashLoopBackOff" {
-
-					return true, errors.Errorf("NuclioFunction pod (%s) is in a crash loop", pod.Name)
-				}
-			}
-		}
-
-		for _, condition := range pod.Status.Conditions {
-
-			// check if the pod is in pending state, and the reason is that it is unschedulable
-			// (meaning no k8s node can currently run it, because of insufficient resources etc..)
-			if pod.Status.Phase == v1.PodPending &&
-				condition.Reason == "Unschedulable" {
-
-				return true, errors.Errorf("NuclioFunction pod (%s) is unschedulable", pod.Name)
-			}
-		}
-	}
-
-	return false, nil
-}
-
 func waitForFunctionReadiness(loggerInstance logger.Logger,
 	consumer *Consumer,
 	namespace string,
-	name string,
-	functionCreateOrUpdateTimestamp time.Time) (*nuclioio.NuclioFunction, error) {
+	name string) (*nuclioio.NuclioFunction, error) {
 	var err error
 	var function *nuclioio.NuclioFunction
 
@@ -367,19 +312,8 @@ func waitForFunctionReadiness(loggerInstance logger.Logger,
 				function.Status.State,
 				function.Status.Message)
 		default:
-			if !function.Spec.WaitReadinessTimeoutBeforeFailure {
 
-				// check if function deployment had failed
-				// (ignore the error if there's no concrete indication of failure, because it might still stabilize)
-				if functionDeploymentFailed, err := isFunctionDeploymentFailed(consumer,
-					namespace,
-					name,
-					functionCreateOrUpdateTimestamp); functionDeploymentFailed {
-
-					return false, errors.Wrapf(err, "NuclioFunction deployment failed")
-				}
-			}
-
+			// keep waiting
 			return false, nil
 		}
 	}

--- a/pkg/platform/kube/client/updater.go
+++ b/pkg/platform/kube/client/updater.go
@@ -93,7 +93,6 @@ func (u *Updater) Update(updateFunctionOptions *platform.UpdateFunctionOptions) 
 	}
 
 	// trigger an update
-	functionCreateOrUpdateTimestamp := time.Now()
 	updatedFunction, err := nuclioClientSet.
 		NuclioV1beta1().
 		NuclioFunctions(updateFunctionOptions.FunctionMeta.Namespace).
@@ -106,8 +105,7 @@ func (u *Updater) Update(updateFunctionOptions *platform.UpdateFunctionOptions) 
 	if _, err := waitForFunctionReadiness(u.logger,
 		u.consumer,
 		updatedFunction.Namespace,
-		updatedFunction.Name,
-		functionCreateOrUpdateTimestamp); err != nil {
+		updatedFunction.Name); err != nil {
 		return errors.Wrap(err, "Failed to wait for function readiness")
 	}
 

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -161,6 +161,8 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 		"readinessTimeout", readinessTimeout,
 		"functionName", function.Name)
 
+	functionResourcesCreateOrUpdateTimestamp := time.Now()
+
 	// ensure function resources (deployment, ingress, configmap, etc ...)
 	resources, err := fo.functionresClient.CreateOrUpdate(ctx, function, fo.imagePullSecrets)
 	if err != nil {
@@ -177,9 +179,12 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 		defer cancel()
 
 		// wait until the function resources are ready
-		if err = fo.functionresClient.WaitAvailable(waitContext, function.Namespace, function.Name); err != nil {
+		if err, functionState := fo.functionresClient.WaitAvailable(waitContext,
+			function.Namespace,
+			function.Name,
+			functionResourcesCreateOrUpdateTimestamp); err != nil {
 			return fo.setFunctionError(function,
-				functionconfig.FunctionStateUnhealthy,
+				functionState,
 				errors.Wrap(err, "Failed to wait for function resources to be available"))
 		}
 	}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2260,8 +2260,11 @@ func (lc *lazyClient) isPodAutoScaledUp(ctx context.Context, pod v1.Pod) (bool, 
 	for _, event := range podEvents.Items {
 
 		if event.Source.Component == "cluster-autoscaler" {
+
+			// check autoscaler event reasons according to:
+			// https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-events-are-emitted-by-ca
 			switch event.Reason {
-			case "TriggerScaleUp":
+			case "TriggeredScaleUp":
 				lc.logger.InfoWithCtx(ctx,
 					"Nuclio function pod has triggered a node scale up",
 					"podName", pod.Name)

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -242,7 +242,10 @@ func (lc *lazyClient) CreateOrUpdate(ctx context.Context,
 	return &resources, nil
 }
 
-func (lc *lazyClient) WaitAvailable(ctx context.Context, namespace string, name string) error {
+func (lc *lazyClient) WaitAvailable(ctx context.Context,
+	namespace string,
+	name string,
+	functionResourcesCreateOrUpdateTimestamp time.Time) (error, functionconfig.FunctionState) {
 	deploymentName := kube.DeploymentNameFromFunctionName(name)
 	lc.logger.DebugWith("Waiting for deployment to be available",
 		"namespace", namespace,
@@ -264,7 +267,7 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context, namespace string, name 
 
 		// check if context is still OK
 		if err := ctx.Err(); err != nil {
-			return err
+			return err, functionconfig.FunctionStateUnhealthy
 		}
 
 		// get the deployment. if it doesn't exist yet, retry a bit later
@@ -287,7 +290,7 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context, namespace string, name 
 					lc.logger.DebugWith("Deployment is available",
 						"reason", deploymentCondition.Reason,
 						"deploymentName", deploymentName)
-					return nil
+					return nil, functionconfig.FunctionStateReady
 				}
 
 				lc.logger.DebugWith("Deployment not available yet",
@@ -298,6 +301,23 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context, namespace string, name 
 				// we found the condition, wasn't available
 				break
 			}
+		}
+
+		// get the deployment pods. if it doesn't exist yet, retry a bit later
+		pods, err := lc.kubeClientSet.CoreV1().
+			Pods(namespace).
+			List(metav1.ListOptions{
+				LabelSelector: common.CompileListFunctionPodsLabelSelector(name),
+			})
+		if err != nil {
+			continue
+		}
+
+		// fail-fast mechanism
+		if err := lc.resolveFailFast(pods.Items,
+			functionResourcesCreateOrUpdateTimestamp); err != nil {
+
+			return errors.Wrapf(err, "NuclioFunction deployment failed"), functionconfig.FunctionStateError
 		}
 	}
 }
@@ -2138,6 +2158,47 @@ func (lc *lazyClient) getMetricResourceByName(resourceName string) v1.ResourceNa
 	default:
 		return ""
 	}
+}
+
+func (lc *lazyClient) resolveFailFast(pods []v1.Pod,
+	functionResourcesCreateOrUpdateTimestamp time.Time) error {
+
+	// infer from the pod statuses if the function deployment had failed
+	// failure of one pod is enough to tell that the deployment had failed
+	for _, pod := range pods {
+
+		// skip irrelevant pods (leftovers of previous function deployments)
+		// (subtract 2 seconds from create/update timestamp because of ms accuracy loss of pod.creationTimestamp)
+		if !pod.GetCreationTimestamp().After(functionResourcesCreateOrUpdateTimestamp.Add(-2 * time.Second)) {
+			continue
+		}
+
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+
+			if pod.Status.ContainerStatuses[0].State.Waiting != nil {
+
+				// check if the pod is on a crashLoopBackoff
+				if containerStatus.State.Waiting.Reason == "CrashLoopBackOff" {
+
+					return errors.Errorf("NuclioFunction pod (%s) is in a crash loop", pod.Name)
+				}
+			}
+		}
+
+		for _, condition := range pod.Status.Conditions {
+
+			// check if the pod is in pending state, and the reason is that it is unschedulable
+			// (meaning no k8s node can currently run it, because of insufficient resources etc..)
+			if pod.Status.Phase == v1.PodPending && condition.Reason == "Unschedulable" {
+
+				// TODO: if pods has an event that cluster is going to scale up - don't return error
+
+				return errors.Errorf("NuclioFunction pod (%s) is unschedulable", pod.Name)
+			}
+		}
+	}
+
+	return nil
 }
 
 //

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -311,6 +311,7 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context,
 				LabelSelector: common.CompileListFunctionPodsLabelSelector(name),
 			})
 		if err != nil {
+			lc.logger.DebugWith("Failed to get deployment pods", "err", err.Error())
 			continue
 		}
 
@@ -319,7 +320,7 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context,
 			podsList,
 			functionResourcesCreateOrUpdateTimestamp); err != nil {
 
-			return errors.Wrapf(err, "NuclioFunction deployment failed"), functionconfig.FunctionStateError
+			return errors.Wrapf(err, "NuclioFunction %s deployment failed", name), functionconfig.FunctionStateError
 		}
 	}
 }

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -609,7 +609,7 @@ func (suite *lazyTestSuite) TestFastFailOnAutoScalerEvents() {
 				Source: v1.EventSource{
 					Component: "cluster-autoscaler",
 				},
-				Reason: "TriggerScaleUp",
+				Reason: "TriggeredScaleUp",
 			},
 			expectedError: false,
 		},

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -21,6 +21,7 @@ package functionres
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
@@ -585,6 +586,86 @@ func (suite *lazyTestSuite) TestEnrichDeploymentFromPlatformConfiguration() {
 	suite.True(deployment.Spec.Paused)
 	suite.Equal(deployment.Spec.Template.Spec.ServiceAccountName, "")
 	suite.Require().NoError(err)
+}
+
+func (suite *lazyTestSuite) TestFastFailOnAutoScalerEvents() {
+	namespace := "some-namespace"
+	podName := "my-pod"
+
+	for _, testCase := range []struct {
+		name          string
+		event         v1.Event
+		expectedError bool
+	}{
+		{
+			name: "PodScalingUp",
+			event: v1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "PodScalingUpEvent",
+				},
+				InvolvedObject: v1.ObjectReference{
+					Name: podName,
+				},
+				Source: v1.EventSource{
+					Component: "cluster-autoscaler",
+				},
+				Reason: "TriggerScaleUp",
+			},
+			expectedError: false,
+		},
+		{
+			name: "PodScalingDown",
+			event: v1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "PodScalingDownEvent",
+				},
+				InvolvedObject: v1.ObjectReference{
+					Name: podName,
+				},
+				Source: v1.EventSource{
+					Component: "cluster-autoscaler",
+				},
+				Reason: "ScaleDown",
+			},
+			expectedError: true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+
+			pod := v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              podName,
+					Namespace:         namespace,
+					CreationTimestamp: metav1.Now(),
+				},
+				Status: v1.PodStatus{
+					Phase: v1.PodPending,
+					Conditions: []v1.PodCondition{
+						{
+							Reason: "Unschedulable",
+						},
+					},
+				},
+			}
+			podsList := v1.PodList{
+				Items: []v1.Pod{pod},
+			}
+
+			_, err := suite.client.kubeClientSet.CoreV1().Events(namespace).Create(&testCase.event)
+			suite.Require().NoError(err)
+
+			// call resolveFailFast
+			err = suite.client.resolveFailFast(context.TODO(), &podsList, time.Now())
+			if testCase.expectedError {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+			}
+
+			err = suite.client.kubeClientSet.CoreV1().Events(namespace).Delete(testCase.event.Name, nil)
+			suite.Require().NoError(err)
+		})
+	}
 }
 
 func (suite *lazyTestSuite) getIngressRuleByHost(rules []extv1beta1.IngressRule, host string) *extv1beta1.IngressRule {

--- a/pkg/platform/kube/functionres/types.go
+++ b/pkg/platform/kube/functionres/types.go
@@ -2,7 +2,9 @@ package functionres
 
 import (
 	"context"
+	"time"
 
+	"github.com/nuclio/nuclio/pkg/functionconfig"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
@@ -34,7 +36,7 @@ type Client interface {
 	CreateOrUpdate(context.Context, *nuclioio.NuclioFunction, string) (Resources, error)
 
 	// WaitAvailable waits until the resources are ready
-	WaitAvailable(context.Context, string, string) error
+	WaitAvailable(context.Context, string, string, time.Time) (error, functionconfig.FunctionState)
 
 	// Delete deletes resources
 	Delete(context.Context, string, string) error

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -70,7 +70,7 @@ type KubeTestSuite struct {
 	DisableControllerStart bool
 }
 
-// To run this test suite you should:
+// SetupSuite To run this test suite you should:
 // - Kubernetes for Mac: Ingress controller installed (you can install it by running "test/k8s/ci_assets/install_nginx_ingress_controller.sh")
 // - have Nuclio CRDs installed (you can install them by running "test/k8s/ci_assets/install_nuclio_crds.sh")
 // - have docker registry running (you can run docker registry by running "docker run --rm -d -p 5000:5000 registry:2")


### PR DESCRIPTION
Nuclio version 1.7.x was introduced to a fail-fast solution on function deployment, decreasing waiting time on errors and fixing the race conditions between the dashboard and controller regarding function state by making the controller the source of truth in this case.

#2392 - Move fast failure logic from dashboard to controller
#2399 - Enhance fail-fast to respect pod scale up events
#2414 - Fix autoscale event typo

**Tested on EKS and GKE**
Controller logs:

On `TriggeredScaleUp` event:

```
{"level":"debug","time":"2021-12-28T15:17:02.554Z","name":"controller.functionres","message":"Waiting for deployment to be available","more":{"deploymentName":"nuclio-aqaq","functionName":"aqaq","namespace":"default-tenant"}}
{"level":"debug","time":"2021-12-28T15:17:02.813Z","name":"controller.functionres","message":"Deployment not available yet","more":{"deploymentName":"nuclio-aqaq","reason":"MinimumReplicasUnavailable","unavailableReplicas":1}}
{"level":"debug","time":"2021-12-28T15:17:02.825Z","name":"controller.functionres","message":"Waiting 15 seconds for autoscale evaluation","more":{"podName":"nuclio-aqaq-7c74d896c-nngnt"}}
{"level":"debug","time":"2021-12-28T15:17:17.833Z","name":"controller.functionres","message":"Received pod events","more":{"podEventsLength":2}}
{"level":"info","time":"2021-12-28T15:17:17.833Z","name":"controller.functionres","message":"Nuclio function pod has triggered a node scale up","more":{"podName":"nuclio-aqaq-7c74d896c-nngnt"}}
{"level":"debug","time":"2021-12-28T15:17:17.833Z","name":"controller.functionres","message":"Pod triggered a scale up. Still waiting for deployment to be available"}
...
...
{"level":"debug","time":"2021-12-28T15:19:11.642Z","name":"controller.functionres","message":"Successfully created/updated resources","more":{"functionName":"aqaq","functionNamespace":"default-tenant"}}
{"level":"debug","time":"2021-12-28T15:19:11.642Z","name":"controller.functionres","message":"Waiting for deployment to be available","more":{"deploymentName":"nuclio-aqaq","functionName":"aqaq","namespace":"default-tenant"}}
{"level":"debug","time":"2021-12-28T15:19:11.897Z","name":"controller.functionres","message":"Deployment is available","more":{"deploymentName":"nuclio-aqaq","reason":"MinimumReplicasAvailable"}}
```


On `NotTriggerScaleUp` event:
```
{"level":"debug","time":"2021-12-28T15:23:22.619Z","name":"controller.functionres","message":"Deployment not available yet","more":{"deploymentName":"nuclio-aqaq","reason":"MinimumReplicasAvailable","unavailableReplicas":1}}
{"level":"debug","time":"2021-12-28T15:23:22.628Z","name":"controller.functionres","message":"Waiting 15 seconds for autoscale evaluation","more":{"podName":"nuclio-aqaq-55776d6cb7-zffk8"}}
{"level":"debug","time":"2021-12-28T15:23:37.634Z","name":"controller.functionres","message":"Received pod events","more":{"podEventsLength":2}}
{"level":"debug","time":"2021-12-28T15:23:37.634Z","name":"controller.functionres","message":"Couldn't find node group that can be scaled up to make this pod schedulable","more":{"podName":"nuclio-aqaq-55776d6cb7-zffk8"}}
{"level":"warn","time":"2021-12-28T15:23:37.634Z","name":"controller.function","message":"Setting function error","more":{"err":{},"functionErrorState":"error","functionName":"aqaq"}}
{"level":"debug","time":"2021-12-28T15:23:37.634Z","name":"controller.function","message":"Setting function state","more":{"name":"aqaq","status":{"state":"error","message":"\nError - NuclioFunction pod (nuclio-aqaq-55776d6cb7-zffk8) is unschedulable\n    ...//nuclio/pkg/platform/kube/functionres/lazy.go:2230\n\nCall stack:\nNuclioFunction pod (nuclio-aqaq-55776d6cb7-zffk8) is unschedulable\n    ...//nuclio/pkg/platform/kube/functionres/lazy.go:2230\nFailed to verify at least one pod schedulability\n    ...//nuclio/pkg/platform/kube/functionres/lazy.go:2241\nNuclioFunction deployment failed\n    ...//nuclio/pkg/platform/kube/functionres/lazy.go:322\nFailed to wait for function resources to be available\n    .../platform/kube/controller/nucliofunction.go:188\n"}}}
```