### PR TITLE
Populate resource version for create/update scenarios

### DIFF
--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -153,6 +153,7 @@ func (d *Deployer) populateFunction(functionConfig *functionconfig.Config,
 	functionInstance.Name = functionConfig.Meta.Name
 	functionInstance.Namespace = functionConfig.Meta.Namespace
 	functionInstance.Annotations = functionConfig.Meta.Annotations
+	functionInstance.ResourceVersion = functionConfig.Meta.ResourceVersion
 
 	// set labels only on function creation (never on update)
 	if !functionExisted {

--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -65,7 +65,8 @@ func (d *Deployer) CreateOrUpdateFunction(ctx context.Context,
 	// the function will be created if it doesn't exit, otherwise will updated
 	functionExists := functionInstance != nil
 
-	createFunctionOptions.Logger.DebugWithCtx(ctx, "Creating/updating function",
+	createFunctionOptions.Logger.DebugWithCtx(ctx,
+		"Creating/updating function",
 		"functionExists", functionExists,
 		"functionInstance", functionInstance)
 
@@ -86,7 +87,8 @@ func (d *Deployer) CreateOrUpdateFunction(ctx context.Context,
 		return nil, errors.Wrap(err, "Failed to populate function")
 	}
 
-	createFunctionOptions.Logger.DebugWithCtx(ctx, "Populated function with configuration and status",
+	createFunctionOptions.Logger.DebugWithCtx(ctx,
+		"Populated function with configuration and status",
 		"function", functionInstance,
 		"functionExists", functionExists)
 
@@ -114,12 +116,14 @@ func (d *Deployer) CreateOrUpdateFunction(ctx context.Context,
 	return functionInstance, nil
 }
 
-func (d *Deployer) Deploy(ctx context.Context, functionInstance *nuclioio.NuclioFunction,
+func (d *Deployer) Deploy(ctx context.Context,
+	functionInstance *nuclioio.NuclioFunction,
 	createFunctionOptions *platform.CreateFunctionOptions) (*platform.CreateFunctionResult, *nuclioio.NuclioFunction, string, error) {
 
 	// do the create / update
 	// TODO: Infer timestamp from function config (consider create/update scenarios)
-	if _, err := d.CreateOrUpdateFunction(ctx, functionInstance,
+	if _, err := d.CreateOrUpdateFunction(ctx,
+		functionInstance,
 		createFunctionOptions,
 		&functionconfig.Status{
 			State: functionconfig.FunctionStateWaitingForResourceConfiguration,
@@ -153,7 +157,6 @@ func (d *Deployer) populateFunction(functionConfig *functionconfig.Config,
 	functionInstance.Name = functionConfig.Meta.Name
 	functionInstance.Namespace = functionConfig.Meta.Namespace
 	functionInstance.Annotations = functionConfig.Meta.Annotations
-	functionInstance.ResourceVersion = functionConfig.Meta.ResourceVersion
 
 	// set labels only on function creation (never on update)
 	if !functionExisted {

--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -108,7 +108,6 @@ func (d *Deployer) CreateOrUpdateFunction(ctx context.Context,
 			NuclioFunctions(functionInstance.Namespace).
 			Update(functionInstance)
 	}
-
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create/update function")
 	}

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -534,9 +534,11 @@ func (suite *FunctionKubePlatformTestSuite) TestGetFunctionInstanceAndConfig() {
 
 			functionInstance, functionConfigAndStatus, err := suite.Platform.
 				getFunctionInstanceAndConfig(suite.ctx,
-					suite.Namespace,
-					testCase.functionName,
-					true)
+					&platform.GetFunctionsOptions{
+						Name:                  testCase.functionName,
+						Namespace:             suite.Namespace,
+						EnrichWithAPIGateways: true,
+					})
 
 			if testCase.expectValidationFailure {
 				suite.Require().Error(err)

--- a/pkg/platform/kube/resourcescaler/test/resourcescaler_test.go
+++ b/pkg/platform/kube/resourcescaler/test/resourcescaler_test.go
@@ -90,6 +90,7 @@ func (suite *ResourceScalerTestSuite) SetupSuite() {
 	suite.Require().NoError(err)
 
 }
+
 func (suite *ResourceScalerTestSuite) SetupTest() {
 	suite.KubeTestSuite.SetupTest()
 
@@ -352,7 +353,7 @@ func (suite *ResourceScalerTestSuite) TestMultiTargetScaleFromZero() {
 	})
 }
 
-func TestControllerTestSuite(t *testing.T) {
+func TestResourceScalerTestSuite(t *testing.T) {
 	if testing.Short() {
 		return
 	}

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -334,8 +334,8 @@ def handler(context, event):
 			"Resource version should be changed between deployments")
 
 		// we expect a failure due to a stale resource version
-		suite.DeployFunctionExpectError(createFunctionOptions,
-			func(deployResult *platform.CreateFunctionResult) bool { // nolint: errcheck
+		suite.DeployFunctionExpectError(createFunctionOptions, // nolint: errcheck
+			func(deployResult *platform.CreateFunctionResult) bool {
 				suite.Require().Nil(deployResult, "Deployment results is nil when creation failed")
 				return true
 			})

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -334,10 +334,11 @@ def handler(context, event):
 			"Resource version should be changed between deployments")
 
 		// we expect a failure due to a stale resource version
-		suite.DeployFunctionExpectError(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool { // nolint: errcheck
-			suite.Require().Nil(deployResult, "Deployment results is nil when creation failed")
-			return true
-		})
+		suite.DeployFunctionExpectError(createFunctionOptions,
+			func(deployResult *platform.CreateFunctionResult) bool { // nolint: errcheck
+				suite.Require().Nil(deployResult, "Deployment results is nil when creation failed")
+				return true
+			})
 
 		return true
 	}
@@ -712,7 +713,10 @@ func (suite *DeployFunctionTestSuite) TestCreateFunctionWithIngress() {
 			suite.WaitForFunctionState(&platform.GetFunctionsOptions{
 				Name:      functionName,
 				Namespace: suite.Namespace,
-			}, functionconfig.FunctionStateReady, time.Minute)
+			},
+				functionconfig.FunctionStateReady,
+				time.Minute,
+			)
 
 			functionIngress := suite.GetFunctionIngress(functionName)
 			suite.Require().Equal(ingressHost, functionIngress.Spec.Rules[0].Host)

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -71,7 +71,7 @@ type KubeTestSuite struct {
 }
 
 // SetupSuite To run this test suite you should:
-// - Have Helm 3 Installed - click here for instructions https://helm.sh/docs/intro/install/
+// - Have Helm 3 Installed - click here for instructions https://helm.sh/docs/intro/install
 // - Kubernetes for Mac: Ingress controller installed (you can install it by running "test/k8s/ci_assets/install_nginx_ingress_controller.sh")
 // - have Nuclio CRDs installed (you can install them by running "test/k8s/ci_assets/install_nuclio_crds.sh")
 // - have docker registry running (you can run docker registry by running "docker run --rm -d -p 5000:5000 registry:2")

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -71,6 +71,7 @@ type KubeTestSuite struct {
 }
 
 // SetupSuite To run this test suite you should:
+// - Have Helm 3 Installed - click here for instructions https://helm.sh/docs/intro/install/
 // - Kubernetes for Mac: Ingress controller installed (you can install it by running "test/k8s/ci_assets/install_nginx_ingress_controller.sh")
 // - have Nuclio CRDs installed (you can install them by running "test/k8s/ci_assets/install_nuclio_crds.sh")
 // - have docker registry running (you can run docker registry by running "docker run --rm -d -p 5000:5000 registry:2")

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -105,6 +105,7 @@ type GetFunctionsOptions struct {
 	Name              string
 	Namespace         string
 	Labels            string
+	ResourceVersion   string
 	AuthConfig        *AuthConfig
 	PermissionOptions opa.PermissionOptions
 	AuthSession       auth.Session


### PR DESCRIPTION
resource version is verified on pre create/update validations but that should be enforced on the api call as well.