### PR TITLE
Create resource context form request

### DIFF
--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -266,7 +266,7 @@ func (pr *projectResource) getFunctionsAndFunctionEventsMap(request *http.Reques
 func (pr *projectResource) createProject(request *http.Request, projectInfoInstance *projectInfo) (id string,
 	attributes restful.Attributes, responseErr error) {
 
-	ctx := request.Context()
+	ctx := pr.createRequestContext(request.Context())
 
 	// create a project config
 	projectConfig := platform.ProjectConfig{
@@ -478,7 +478,7 @@ func (pr *projectResource) importProjectFunctions(request *http.Request, project
 }
 
 func (pr *projectResource) importFunction(request *http.Request, function *functionInfo, authConfig *platform.AuthConfig) error {
-	ctx := request.Context()
+	ctx := pr.createRequestContext(request.Context())
 
 	pr.Logger.InfoWithCtx(ctx,
 		"Importing project function",
@@ -502,7 +502,7 @@ func (pr *projectResource) importFunction(request *http.Request, function *funct
 	}
 
 	// validation finished successfully - store and deploy the given function
-	return functionResourceInstance.storeAndDeployFunction(request, function, authConfig, false)
+	return functionResourceInstance.storeAndDeployFunction(ctx, request, function, authConfig, false)
 }
 
 func (pr *projectResource) importProjectAPIGateways(request *http.Request,
@@ -653,7 +653,7 @@ func (pr *projectResource) deleteProject(request *http.Request) (*restful.Custom
 }
 
 func (pr *projectResource) updateProject(request *http.Request) (*restful.CustomRouteFuncResponse, error) {
-	ctx := request.Context()
+	ctx := pr.createRequestContext(request.Context())
 	statusCode := http.StatusNoContent
 
 	// get project config and status from body

--- a/pkg/dashboard/resource/resource.go
+++ b/pkg/dashboard/resource/resource.go
@@ -105,5 +105,5 @@ func (r *resource) getCtxSession(request *http.Request) auth.Session {
 }
 
 func (r *resource) createRequestContext(ctx context.Context) context.Context {
-	return context.WithValue(context.Background(), middleware.RequestIDKey, ctx.Value(middleware.RequestIDKey))
+	return context.WithValue(ctx, middleware.RequestIDKey, ctx.Value(middleware.RequestIDKey))
 }

--- a/pkg/dashboard/resource/resource.go
+++ b/pkg/dashboard/resource/resource.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resource
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/restful"
 
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/nuclio/errors"
 	"github.com/nuclio/nuclio-sdk-go"
 )
@@ -100,4 +102,8 @@ func (r *resource) addAuthMiddleware() {
 
 func (r *resource) getCtxSession(request *http.Request) auth.Session {
 	return request.Context().Value(auth.ContextKeyByKind(r.getDashboard().GetAuthenticator().Kind())).(auth.Session)
+}
+
+func (r *resource) createRequestContext(ctx context.Context) context.Context {
+	return context.WithValue(context.Background(), middleware.RequestIDKey, ctx.Value(middleware.RequestIDKey))
 }


### PR DESCRIPTION
Create a new context from the request context with its request id, so that the context won't expire during concurrent operations.

Currently implemented in Create and Update for functions and projects.