### PR TITLE
Add Detached context struct

### DIFF
--- a/pkg/context/detached.go
+++ b/pkg/context/detached.go
@@ -13,7 +13,7 @@ type Detached struct {
 	ctx context.Context
 }
 
-// NewDetached returns a context that is never canceled.
+// NewDetached returns a context that is not affected by its parent.
 func NewDetached(ctx context.Context) *Detached {
 	return &Detached{ctx: ctx}
 }

--- a/pkg/context/detached.go
+++ b/pkg/context/detached.go
@@ -1,0 +1,35 @@
+package context
+
+import (
+	"context"
+	"time"
+)
+
+// Detached enables creating a copy of a context with all of its values,
+// but cancelling the parent context will not cancel the detached.
+// Used when forwarding a request context to a goroutine, and when the request
+// context is cancelled the goroutine can continue its operation.
+type Detached struct {
+	ctx context.Context
+}
+
+// NewDetached returns a context that is never canceled.
+func NewDetached(ctx context.Context) *Detached {
+	return &Detached{ctx: ctx}
+}
+
+func (d *Detached) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+func (d *Detached) Done() <-chan struct{} {
+	return nil
+}
+
+func (d *Detached) Err() error {
+	return nil
+}
+
+func (d *Detached) Value(key interface{}) interface{} {
+	return d.ctx.Value(key)
+}

--- a/pkg/context/detached_test.go
+++ b/pkg/context/detached_test.go
@@ -28,7 +28,7 @@ func (suite *DetachedTestSuite) TestDetachedOnCancelledParent() {
 	parentCtx, cancelParentCtx := context.WithCancel(context.Background())
 	childCtx, cancelChildCtx := context.WithCancel(NewDetached(parentCtx))
 
-	go suite.testChildNotCancelled(childCtx, timerChannel)
+	go suite.measureTimeUntilCancellation(childCtx, timerChannel)
 
 	suite.logger.Debug("Cancelling parent context")
 	cancelParentCtx()
@@ -39,7 +39,7 @@ func (suite *DetachedTestSuite) TestDetachedOnCancelledParent() {
 	suite.Require().Equal(expectedWaitTime, <-timerChannel)
 }
 
-func (suite *DetachedTestSuite) testChildNotCancelled(ctx context.Context, ch chan int) {
+func (suite *DetachedTestSuite) measureTimeUntilCancellation(ctx context.Context, ch chan int) {
 	timer := 0
 	for {
 		select {

--- a/pkg/context/detached_test.go
+++ b/pkg/context/detached_test.go
@@ -1,0 +1,61 @@
+//go:build test_unit
+
+package context
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nuclio/logger"
+	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type DetachedTestSuite struct {
+	suite.Suite
+	logger logger.Logger
+}
+
+func (suite *DetachedTestSuite) SetupTest() {
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
+}
+
+func (suite *DetachedTestSuite) TestDetachedOnCancelledParent() {
+	timerChannel := make(chan int)
+	expectedWaitTime := 5
+
+	parentCtx, cancelParentCtx := context.WithCancel(context.Background())
+	childCtx, cancelChildCtx := context.WithCancel(NewDetached(parentCtx))
+
+	go suite.testChildNotCancelled(childCtx, timerChannel)
+
+	suite.logger.Debug("Cancelling parent context")
+	cancelParentCtx()
+	time.Sleep(6 * time.Second)
+	suite.logger.Debug("Cancelling child context")
+	cancelChildCtx()
+
+	suite.Require().Equal(expectedWaitTime, <-timerChannel)
+}
+
+func (suite *DetachedTestSuite) testChildNotCancelled(ctx context.Context, ch chan int) {
+	timer := 0
+	for {
+		select {
+		case <-ctx.Done():
+
+			// child context is cancelled
+			ch <- timer
+			return
+		case <-time.After(1 * time.Second):
+
+			// child context is still alive
+			timer += 1
+		}
+	}
+}
+
+func TestDetachedTestSuite(t *testing.T) {
+	suite.Run(t, new(DetachedTestSuite))
+}

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	nucliocontext "github.com/nuclio/nuclio/pkg/context"
 	"github.com/nuclio/nuclio/pkg/dashboard"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/opa"
@@ -110,7 +111,7 @@ func (fr *functionResource) GetByID(request *http.Request, id string) (restful.A
 
 // Create and deploy a function
 func (fr *functionResource) Create(request *http.Request) (id string, attributes restful.Attributes, responseErr error) {
-	ctx := fr.createRequestContext(request.Context())
+
 	functionInfo, responseErr := fr.getFunctionInfoFromRequest(request)
 	if responseErr != nil {
 		return
@@ -118,7 +119,7 @@ func (fr *functionResource) Create(request *http.Request) (id string, attributes
 
 	// TODO: Add a lock to prevent race conditions here (prevent 2 functions created with the same name)
 	// validate there are no 2 functions with the same name
-	functions, err := fr.getPlatform().GetFunctions(ctx, &platform.GetFunctionsOptions{
+	functions, err := fr.getPlatform().GetFunctions(request.Context(), &platform.GetFunctionsOptions{
 		Name:        functionInfo.Meta.Name,
 		Namespace:   fr.resolveNamespace(request, functionInfo),
 		AuthSession: fr.getCtxSession(request),
@@ -146,7 +147,7 @@ func (fr *functionResource) Create(request *http.Request) (id string, attributes
 	waitForFunction := fr.headerValueIsTrue(request, "x-nuclio-wait-function-action")
 
 	// validation finished successfully - store and deploy the given function
-	if responseErr = fr.storeAndDeployFunction(ctx, request, functionInfo, authConfig, waitForFunction); responseErr != nil {
+	if responseErr = fr.storeAndDeployFunction(request, functionInfo, authConfig, waitForFunction); responseErr != nil {
 		return
 	}
 
@@ -161,8 +162,6 @@ func (fr *functionResource) Update(request *http.Request, id string) (attributes
 		return
 	}
 
-	ctx := fr.createRequestContext(request.Context())
-
 	// get the authentication configuration for the request
 	authConfig, responseErr := fr.getRequestAuthConfig(request)
 	if responseErr != nil {
@@ -171,7 +170,7 @@ func (fr *functionResource) Update(request *http.Request, id string) (attributes
 
 	waitForFunction := fr.headerValueIsTrue(request, "x-nuclio-wait-function-action")
 
-	if responseErr = fr.storeAndDeployFunction(ctx, request, functionInfo, authConfig, waitForFunction); responseErr != nil {
+	if responseErr = fr.storeAndDeployFunction(request, functionInfo, authConfig, waitForFunction); responseErr != nil {
 		return
 	}
 
@@ -219,8 +218,7 @@ func (fr *functionResource) export(ctx context.Context, function platform.Functi
 	return attributes
 }
 
-func (fr *functionResource) storeAndDeployFunction(ctx context.Context,
-	request *http.Request,
+func (fr *functionResource) storeAndDeployFunction(request *http.Request,
 	functionInfo *functionInfo,
 	authConfig *platform.AuthConfig,
 	waitForFunction bool) error {
@@ -232,6 +230,10 @@ func (fr *functionResource) storeAndDeployFunction(ctx context.Context,
 
 	// asynchronously, do the deploy so that the user doesn't wait
 	go func() {
+
+		ctx, cancelCtx := context.WithCancel(nucliocontext.NewDetached(request.Context()))
+		defer cancelCtx()
+
 		defer func() {
 			if err := recover(); err != nil {
 				callStack := debug.Stack()

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	nucliocontext "github.com/nuclio/nuclio/pkg/context"
 	"github.com/nuclio/nuclio/pkg/dashboard"
 	"github.com/nuclio/nuclio/pkg/opa"
 	"github.com/nuclio/nuclio/pkg/platform"
@@ -266,7 +267,7 @@ func (pr *projectResource) getFunctionsAndFunctionEventsMap(request *http.Reques
 func (pr *projectResource) createProject(request *http.Request, projectInfoInstance *projectInfo) (id string,
 	attributes restful.Attributes, responseErr error) {
 
-	ctx := pr.createRequestContext(request.Context())
+	ctx := nucliocontext.NewDetached(request.Context())
 
 	// create a project config
 	projectConfig := platform.ProjectConfig{
@@ -478,7 +479,7 @@ func (pr *projectResource) importProjectFunctions(request *http.Request, project
 }
 
 func (pr *projectResource) importFunction(request *http.Request, function *functionInfo, authConfig *platform.AuthConfig) error {
-	ctx := pr.createRequestContext(request.Context())
+	ctx := request.Context()
 
 	pr.Logger.InfoWithCtx(ctx,
 		"Importing project function",
@@ -502,7 +503,7 @@ func (pr *projectResource) importFunction(request *http.Request, function *funct
 	}
 
 	// validation finished successfully - store and deploy the given function
-	return functionResourceInstance.storeAndDeployFunction(ctx, request, function, authConfig, false)
+	return functionResourceInstance.storeAndDeployFunction(request, function, authConfig, false)
 }
 
 func (pr *projectResource) importProjectAPIGateways(request *http.Request,
@@ -653,7 +654,7 @@ func (pr *projectResource) deleteProject(request *http.Request) (*restful.Custom
 }
 
 func (pr *projectResource) updateProject(request *http.Request) (*restful.CustomRouteFuncResponse, error) {
-	ctx := pr.createRequestContext(request.Context())
+	ctx := nucliocontext.NewDetached(request.Context())
 	statusCode := http.StatusNoContent
 
 	// get project config and status from body

--- a/pkg/dashboard/resource/resource.go
+++ b/pkg/dashboard/resource/resource.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resource
 
 import (
-	"context"
 	"net/http"
 	"strings"
 
@@ -26,7 +25,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/restful"
 
-	"github.com/go-chi/chi/v5/middleware"
 	"github.com/nuclio/errors"
 	"github.com/nuclio/nuclio-sdk-go"
 )
@@ -102,8 +100,4 @@ func (r *resource) addAuthMiddleware() {
 
 func (r *resource) getCtxSession(request *http.Request) auth.Session {
 	return request.Context().Value(auth.ContextKeyByKind(r.getDashboard().GetAuthenticator().Kind())).(auth.Session)
-}
-
-func (r *resource) createRequestContext(ctx context.Context) context.Context {
-	return context.WithValue(ctx, middleware.RequestIDKey, ctx.Value(middleware.RequestIDKey))
 }


### PR DESCRIPTION
The Detached struct enables creating a copy of a context with all of its values, but cancelling the parent context will not cancel the detached.
It is used when forwarding a request context to a goroutine, thus when the request context is cancelled - the goroutine can continue its operation properly.

Added unit tests and tested by creating a deploying and editing functions on a live system.