### PR TITLE
Nuctl - Inject context to commands from root commandeer

### DIFF
--- a/pkg/containerimagebuilderpusher/containerimagebuilder.go
+++ b/pkg/containerimagebuilderpusher/containerimagebuilder.go
@@ -1,6 +1,10 @@
 package containerimagebuilderpusher
 
-import "github.com/nuclio/nuclio/pkg/processor/build/runtime"
+import (
+	"context"
+
+	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
+)
 
 // BuilderPusher is a builder of container images
 type BuilderPusher interface {
@@ -9,7 +13,7 @@ type BuilderPusher interface {
 	GetKind() string
 
 	// BuildAndPushContainerImage builds container image and pushes it into container registry
-	BuildAndPushContainerImage(buildOptions *BuildOptions, namespace string) error
+	BuildAndPushContainerImage(ctx context.Context, buildOptions *BuildOptions, namespace string) error
 
 	// Get Onbuild stage for multistage builds
 	GetOnbuildStages(onbuildArtifacts []runtime.Artifact) ([]string, error)

--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -1,6 +1,7 @@
 package containerimagebuilderpusher
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -44,7 +45,7 @@ func (d *Docker) GetKind() string {
 	return "docker"
 }
 
-func (d *Docker) BuildAndPushContainerImage(buildOptions *BuildOptions, namespace string) error {
+func (d *Docker) BuildAndPushContainerImage(ctx context.Context, buildOptions *BuildOptions, namespace string) error {
 	if err := d.gatherArtifactsForSingleStageDockerfile(buildOptions); err != nil {
 		return errors.Wrap(err, "Failed to build image artifacts")
 	}
@@ -61,7 +62,7 @@ func (d *Docker) BuildAndPushContainerImage(buildOptions *BuildOptions, namespac
 		return errors.Wrap(err, "Failed to save docker image")
 	}
 
-	d.logger.InfoWith("Docker image was successfully built and pushed into docker registry",
+	d.logger.InfoWithCtx(ctx, "Docker image was successfully built and pushed into docker registry",
 		"image", buildOptions.Image)
 
 	return nil

--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -62,7 +62,8 @@ func (d *Docker) BuildAndPushContainerImage(ctx context.Context, buildOptions *B
 		return errors.Wrap(err, "Failed to save docker image")
 	}
 
-	d.logger.InfoWithCtx(ctx, "Docker image was successfully built and pushed into docker registry",
+	d.logger.InfoWithCtx(ctx,
+		"Docker image was successfully built and pushed into docker registry",
 		"image", buildOptions.Image)
 
 	return nil

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -78,7 +78,7 @@ func (k *Kaniko) BuildAndPushContainerImage(ctx context.Context, buildOptions *B
 	jobSpec := k.compileJobSpec(namespace, buildOptions, bundleFilename)
 
 	// create job
-	k.logger.DebugWith("Creating job", "namespace", namespace, "jobSpec", jobSpec)
+	k.logger.DebugWithCtx(ctx, "Creating job", "namespace", namespace, "jobSpec", jobSpec)
 	job, err := k.kubeClientSet.BatchV1().Jobs(namespace).Create(ctx, jobSpec, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "Failed to publish kaniko job")

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -63,7 +63,7 @@ func (k *Kaniko) GetKind() string {
 	return "kaniko"
 }
 
-func (k *Kaniko) BuildAndPushContainerImage(buildOptions *BuildOptions, namespace string) error {
+func (k *Kaniko) BuildAndPushContainerImage(ctx context.Context, buildOptions *BuildOptions, namespace string) error {
 	bundleFilename, assetPath, err := k.createContainerBuildBundle(buildOptions.Image,
 		buildOptions.ContextDir,
 		buildOptions.TempDir)
@@ -79,7 +79,7 @@ func (k *Kaniko) BuildAndPushContainerImage(buildOptions *BuildOptions, namespac
 
 	// create job
 	k.logger.DebugWith("Creating job", "namespace", namespace, "jobSpec", jobSpec)
-	job, err := k.kubeClientSet.BatchV1().Jobs(namespace).Create(context.Background(), jobSpec, metav1.CreateOptions{})
+	job, err := k.kubeClientSet.BatchV1().Jobs(namespace).Create(ctx, jobSpec, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "Failed to publish kaniko job")
 	}

--- a/pkg/containerimagebuilderpusher/nop.go
+++ b/pkg/containerimagebuilderpusher/nop.go
@@ -1,6 +1,8 @@
 package containerimagebuilderpusher
 
 import (
+	"context"
+
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 
 	"github.com/nuclio/logger"
@@ -21,7 +23,7 @@ func (n Nop) GetKind() string {
 	return "nop"
 }
 
-func (n Nop) BuildAndPushContainerImage(buildOptions *BuildOptions, namespace string) error {
+func (n Nop) BuildAndPushContainerImage(ctx context.Context, buildOptions *BuildOptions, namespace string) error {
 	return nil
 }
 

--- a/pkg/nuctl/command/common/renderers.go
+++ b/pkg/nuctl/command/common/renderers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/renderer"
 
+	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 )
 
@@ -45,6 +46,10 @@ func RenderFunctions(ctx context.Context,
 			}
 			return nil
 		})
+	}
+
+	if err := errGroup.Wait(); err != nil {
+		return errors.Wrap(err, "Failed to initialize functions")
 	}
 
 	rendererInstance := renderer.NewRenderer(writer)

--- a/pkg/nuctl/command/create.go
+++ b/pkg/nuctl/command/create.go
@@ -33,7 +33,7 @@ type createCommandeer struct {
 	rootCommandeer *RootCommandeer
 }
 
-func newCreateCommandeer(rootCommandeer *RootCommandeer) *createCommandeer {
+func newCreateCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *createCommandeer {
 	commandeer := &createCommandeer{
 		rootCommandeer: rootCommandeer,
 	}
@@ -44,9 +44,9 @@ func newCreateCommandeer(rootCommandeer *RootCommandeer) *createCommandeer {
 		Short:   "Create resources",
 	}
 
-	createProjectCommand := newCreateProjectCommandeer(commandeer).cmd
-	createFunctionEventCommand := newCreateFunctionEventCommandeer(commandeer).cmd
-	createAPIGatewayCommand := newCreateAPIGatewayCommandeer(commandeer).cmd
+	createProjectCommand := newCreateProjectCommandeer(ctx, commandeer).cmd
+	createFunctionEventCommand := newCreateFunctionEventCommandeer(ctx, commandeer).cmd
+	createAPIGatewayCommand := newCreateAPIGatewayCommandeer(ctx, commandeer).cmd
 
 	cmd.AddCommand(
 		createProjectCommand,
@@ -64,7 +64,7 @@ type createProjectCommandeer struct {
 	projectConfig platform.ProjectConfig
 }
 
-func newCreateProjectCommandeer(createCommandeer *createCommandeer) *createProjectCommandeer {
+func newCreateProjectCommandeer(ctx context.Context, createCommandeer *createCommandeer) *createProjectCommandeer {
 	commandeer := &createProjectCommandeer{
 		createCommandeer: createCommandeer,
 	}
@@ -89,7 +89,7 @@ func newCreateProjectCommandeer(createCommandeer *createCommandeer) *createProje
 			commandeer.projectConfig.Meta.Name = args[0]
 			commandeer.projectConfig.Meta.Namespace = createCommandeer.rootCommandeer.namespace
 
-			if err := createCommandeer.rootCommandeer.platform.CreateProject(context.Background(), &platform.CreateProjectOptions{
+			if err := createCommandeer.rootCommandeer.platform.CreateProject(ctx, &platform.CreateProjectOptions{
 				ProjectConfig: &commandeer.projectConfig,
 			}); err != nil {
 				return err
@@ -127,7 +127,7 @@ type createAPIGatewayCommandeer struct {
 	encodedAttributes  string
 }
 
-func newCreateAPIGatewayCommandeer(createCommandeer *createCommandeer) *createAPIGatewayCommandeer {
+func newCreateAPIGatewayCommandeer(ctx context.Context, createCommandeer *createCommandeer) *createAPIGatewayCommandeer {
 	commandeer := &createAPIGatewayCommandeer{
 		createCommandeer: createCommandeer,
 	}
@@ -221,7 +221,7 @@ func newCreateAPIGatewayCommandeer(createCommandeer *createCommandeer) *createAP
 
 			commandeer.apiGatewayConfig.Status.State = platform.APIGatewayStateWaitingForProvisioning
 
-			if err := createCommandeer.rootCommandeer.platform.CreateAPIGateway(context.Background(),
+			if err := createCommandeer.rootCommandeer.platform.CreateAPIGateway(ctx,
 				&platform.CreateAPIGatewayOptions{
 					APIGatewayConfig: &commandeer.apiGatewayConfig,
 				}); err != nil {
@@ -261,7 +261,7 @@ type createFunctionEventCommandeer struct {
 	functionName        string
 }
 
-func newCreateFunctionEventCommandeer(createCommandeer *createCommandeer) *createFunctionEventCommandeer {
+func newCreateFunctionEventCommandeer(ctx context.Context, createCommandeer *createCommandeer) *createFunctionEventCommandeer {
 	commandeer := &createFunctionEventCommandeer{
 		createCommandeer: createCommandeer,
 	}
@@ -298,7 +298,7 @@ func newCreateFunctionEventCommandeer(createCommandeer *createCommandeer) *creat
 				return errors.Wrap(err, "Failed to decode a function's event attributes")
 			}
 
-			if err := createCommandeer.rootCommandeer.platform.CreateFunctionEvent(context.Background(),
+			if err := createCommandeer.rootCommandeer.platform.CreateFunctionEvent(ctx,
 				&platform.CreateFunctionEventOptions{
 					FunctionEventConfig: commandeer.functionEventConfig,
 				}); err != nil {

--- a/pkg/nuctl/command/delete.go
+++ b/pkg/nuctl/command/delete.go
@@ -32,7 +32,7 @@ type deleteCommandeer struct {
 	rootCommandeer *RootCommandeer
 }
 
-func newDeleteCommandeer(rootCommandeer *RootCommandeer) *deleteCommandeer {
+func newDeleteCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *deleteCommandeer {
 	commandeer := &deleteCommandeer{
 		rootCommandeer: rootCommandeer,
 	}
@@ -43,10 +43,10 @@ func newDeleteCommandeer(rootCommandeer *RootCommandeer) *deleteCommandeer {
 		Short:   "Delete resources",
 	}
 
-	deleteFunctionCommand := newDeleteFunctionCommandeer(commandeer).cmd
-	deleteProjectCommand := newDeleteProjectCommandeer(commandeer).cmd
-	deleteFunctionEventCommand := newDeleteFunctionEventCommandeer(commandeer).cmd
-	deleteAPIGatewayCommand := newDeleteAPIGatewayCommandeer(commandeer).cmd
+	deleteFunctionCommand := newDeleteFunctionCommandeer(ctx, commandeer).cmd
+	deleteProjectCommand := newDeleteProjectCommandeer(ctx, commandeer).cmd
+	deleteFunctionEventCommand := newDeleteFunctionEventCommandeer(ctx, commandeer).cmd
+	deleteAPIGatewayCommand := newDeleteAPIGatewayCommandeer(ctx, commandeer).cmd
 
 	cmd.AddCommand(
 		deleteFunctionCommand,
@@ -65,7 +65,7 @@ type deleteFunctionCommandeer struct {
 	functionConfig functionconfig.Config
 }
 
-func newDeleteFunctionCommandeer(deleteCommandeer *deleteCommandeer) *deleteFunctionCommandeer {
+func newDeleteFunctionCommandeer(ctx context.Context, deleteCommandeer *deleteCommandeer) *deleteFunctionCommandeer {
 	commandeer := &deleteFunctionCommandeer{
 		deleteCommandeer: deleteCommandeer,
 		functionConfig:   *functionconfig.NewConfig(),
@@ -90,7 +90,7 @@ func newDeleteFunctionCommandeer(deleteCommandeer *deleteCommandeer) *deleteFunc
 			commandeer.functionConfig.Meta.Name = args[0]
 			commandeer.functionConfig.Meta.Namespace = deleteCommandeer.rootCommandeer.namespace
 
-			return deleteCommandeer.rootCommandeer.platform.DeleteFunction(context.Background(), &platform.DeleteFunctionOptions{
+			return deleteCommandeer.rootCommandeer.platform.DeleteFunction(ctx, &platform.DeleteFunctionOptions{
 				FunctionConfig: commandeer.functionConfig,
 			})
 		},
@@ -109,7 +109,7 @@ type deleteProjectCommandeer struct {
 	waitTimeout      time.Duration
 }
 
-func newDeleteProjectCommandeer(deleteCommandeer *deleteCommandeer) *deleteProjectCommandeer {
+func newDeleteProjectCommandeer(ctx context.Context, deleteCommandeer *deleteCommandeer) *deleteProjectCommandeer {
 	commandeer := &deleteProjectCommandeer{
 		deleteCommandeer: deleteCommandeer,
 	}
@@ -133,7 +133,7 @@ func newDeleteProjectCommandeer(deleteCommandeer *deleteCommandeer) *deleteProje
 			commandeer.projectMeta.Name = args[0]
 			commandeer.projectMeta.Namespace = deleteCommandeer.rootCommandeer.namespace
 
-			return deleteCommandeer.rootCommandeer.platform.DeleteProject(context.Background(), &platform.DeleteProjectOptions{
+			return deleteCommandeer.rootCommandeer.platform.DeleteProject(ctx, &platform.DeleteProjectOptions{
 				Meta:     commandeer.projectMeta,
 				Strategy: platform.ResolveProjectDeletionStrategyOrDefault(commandeer.deletionStrategy),
 
@@ -157,7 +157,7 @@ type deleteAPIGatewayCommandeer struct {
 	apiGatewayMeta platform.APIGatewayMeta
 }
 
-func newDeleteAPIGatewayCommandeer(deleteCommandeer *deleteCommandeer) *deleteAPIGatewayCommandeer {
+func newDeleteAPIGatewayCommandeer(ctx context.Context, deleteCommandeer *deleteCommandeer) *deleteAPIGatewayCommandeer {
 	commandeer := &deleteAPIGatewayCommandeer{
 		deleteCommandeer: deleteCommandeer,
 	}
@@ -181,7 +181,7 @@ func newDeleteAPIGatewayCommandeer(deleteCommandeer *deleteCommandeer) *deleteAP
 			commandeer.apiGatewayMeta.Name = args[0]
 			commandeer.apiGatewayMeta.Namespace = deleteCommandeer.rootCommandeer.namespace
 
-			return deleteCommandeer.rootCommandeer.platform.DeleteAPIGateway(context.Background(), &platform.DeleteAPIGatewayOptions{
+			return deleteCommandeer.rootCommandeer.platform.DeleteAPIGateway(ctx, &platform.DeleteAPIGatewayOptions{
 				Meta: commandeer.apiGatewayMeta,
 			})
 		},
@@ -197,7 +197,7 @@ type deleteFunctionEventCommandeer struct {
 	functionEventMeta platform.FunctionEventMeta
 }
 
-func newDeleteFunctionEventCommandeer(deleteCommandeer *deleteCommandeer) *deleteFunctionEventCommandeer {
+func newDeleteFunctionEventCommandeer(ctx context.Context, deleteCommandeer *deleteCommandeer) *deleteFunctionEventCommandeer {
 	commandeer := &deleteFunctionEventCommandeer{
 		deleteCommandeer: deleteCommandeer,
 	}
@@ -221,7 +221,7 @@ func newDeleteFunctionEventCommandeer(deleteCommandeer *deleteCommandeer) *delet
 			commandeer.functionEventMeta.Name = args[0]
 			commandeer.functionEventMeta.Namespace = deleteCommandeer.rootCommandeer.namespace
 
-			return deleteCommandeer.rootCommandeer.platform.DeleteFunctionEvent(context.Background(), &platform.DeleteFunctionEventOptions{
+			return deleteCommandeer.rootCommandeer.platform.DeleteFunctionEvent(ctx, &platform.DeleteFunctionEventOptions{
 				Meta: commandeer.functionEventMeta,
 			})
 		},

--- a/pkg/nuctl/command/get.go
+++ b/pkg/nuctl/command/get.go
@@ -33,7 +33,7 @@ type getCommandeer struct {
 	rootCommandeer *RootCommandeer
 }
 
-func newGetCommandeer(rootCommandeer *RootCommandeer) *getCommandeer {
+func newGetCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *getCommandeer {
 	commandeer := &getCommandeer{
 		rootCommandeer: rootCommandeer,
 	}
@@ -43,10 +43,10 @@ func newGetCommandeer(rootCommandeer *RootCommandeer) *getCommandeer {
 		Short: "Display resource information",
 	}
 
-	getFunctionCommand := newGetFunctionCommandeer(commandeer).cmd
-	getProjectCommand := newGetProjectCommandeer(commandeer).cmd
-	getFunctionEventCommand := newGetFunctionEventCommandeer(commandeer).cmd
-	getAPIGatewayCommand := newGetAPIGatewayCommandeer(commandeer).cmd
+	getFunctionCommand := newGetFunctionCommandeer(ctx, commandeer).cmd
+	getProjectCommand := newGetProjectCommandeer(ctx, commandeer).cmd
+	getFunctionEventCommand := newGetFunctionEventCommandeer(ctx, commandeer).cmd
+	getAPIGatewayCommand := newGetAPIGatewayCommandeer(ctx, commandeer).cmd
 
 	cmd.AddCommand(
 		getFunctionCommand,
@@ -66,7 +66,7 @@ type getFunctionCommandeer struct {
 	output              string
 }
 
-func newGetFunctionCommandeer(getCommandeer *getCommandeer) *getFunctionCommandeer {
+func newGetFunctionCommandeer(ctx context.Context, getCommandeer *getCommandeer) *getFunctionCommandeer {
 	commandeer := &getFunctionCommandeer{
 		getCommandeer: getCommandeer,
 	}
@@ -91,7 +91,7 @@ func newGetFunctionCommandeer(getCommandeer *getCommandeer) *getFunctionCommande
 
 			commandeer.getFunctionsOptions.Namespace = getCommandeer.rootCommandeer.namespace
 
-			functions, err := getCommandeer.rootCommandeer.platform.GetFunctions(context.Background(), &commandeer.getFunctionsOptions)
+			functions, err := getCommandeer.rootCommandeer.platform.GetFunctions(ctx, &commandeer.getFunctionsOptions)
 			if err != nil {
 				return errors.Wrap(err, "Failed to get functions")
 			}
@@ -105,7 +105,8 @@ func newGetFunctionCommandeer(getCommandeer *getCommandeer) *getFunctionCommande
 			}
 
 			// render the functions
-			return common.RenderFunctions(commandeer.rootCommandeer.loggerInstance,
+			return common.RenderFunctions(ctx,
+				commandeer.rootCommandeer.loggerInstance,
 				functions,
 				commandeer.output,
 				cmd.OutOrStdout(),
@@ -140,7 +141,7 @@ type getProjectCommandeer struct {
 	output             string
 }
 
-func newGetProjectCommandeer(getCommandeer *getCommandeer) *getProjectCommandeer {
+func newGetProjectCommandeer(ctx context.Context, getCommandeer *getCommandeer) *getProjectCommandeer {
 	commandeer := &getProjectCommandeer{
 		getCommandeer: getCommandeer,
 	}
@@ -166,7 +167,7 @@ func newGetProjectCommandeer(getCommandeer *getCommandeer) *getProjectCommandeer
 			// get namespace
 			commandeer.getProjectsOptions.Meta.Namespace = getCommandeer.rootCommandeer.namespace
 
-			projects, err := getCommandeer.rootCommandeer.platform.GetProjects(context.Background(), &commandeer.getProjectsOptions)
+			projects, err := getCommandeer.rootCommandeer.platform.GetProjects(ctx, &commandeer.getProjectsOptions)
 			if err != nil {
 				return errors.Wrap(err, "Failed to get projects")
 			}
@@ -180,7 +181,7 @@ func newGetProjectCommandeer(getCommandeer *getCommandeer) *getProjectCommandeer
 			}
 
 			// render the projects
-			return common.RenderProjects(projects, commandeer.output, cmd.OutOrStdout(), commandeer.renderProjectConfig)
+			return common.RenderProjects(ctx, projects, commandeer.output, cmd.OutOrStdout(), commandeer.renderProjectConfig)
 		},
 	}
 
@@ -191,7 +192,7 @@ func newGetProjectCommandeer(getCommandeer *getCommandeer) *getProjectCommandeer
 	return commandeer
 }
 
-func (g *getProjectCommandeer) renderProjectConfig(projects []platform.Project, renderer func(interface{}) error) error {
+func (g *getProjectCommandeer) renderProjectConfig(ctx context.Context, projects []platform.Project, renderer func(interface{}) error) error {
 	for _, project := range projects {
 		if err := renderer(project.GetConfig()); err != nil {
 			return errors.Wrap(err, "Failed to render project config")
@@ -207,7 +208,7 @@ type getAPIGatewayCommandeer struct {
 	output                string
 }
 
-func newGetAPIGatewayCommandeer(getCommandeer *getCommandeer) *getAPIGatewayCommandeer {
+func newGetAPIGatewayCommandeer(ctx context.Context, getCommandeer *getCommandeer) *getAPIGatewayCommandeer {
 	commandeer := &getAPIGatewayCommandeer{
 		getCommandeer: getCommandeer,
 	}
@@ -232,7 +233,7 @@ func newGetAPIGatewayCommandeer(getCommandeer *getCommandeer) *getAPIGatewayComm
 
 			commandeer.getAPIGatewaysOptions.Namespace = getCommandeer.rootCommandeer.namespace
 
-			apiGateways, err := getCommandeer.rootCommandeer.platform.GetAPIGateways(context.Background(), &commandeer.getAPIGatewaysOptions)
+			apiGateways, err := getCommandeer.rootCommandeer.platform.GetAPIGateways(ctx, &commandeer.getAPIGatewaysOptions)
 			if err != nil {
 				return errors.Wrap(err, "Failed to get api gateways")
 			}
@@ -274,7 +275,7 @@ type getFunctionEventCommandeer struct {
 	functionName             string
 }
 
-func newGetFunctionEventCommandeer(getCommandeer *getCommandeer) *getFunctionEventCommandeer {
+func newGetFunctionEventCommandeer(ctx context.Context, getCommandeer *getCommandeer) *getFunctionEventCommandeer {
 	commandeer := &getFunctionEventCommandeer{
 		getCommandeer: getCommandeer,
 	}
@@ -305,7 +306,7 @@ func newGetFunctionEventCommandeer(getCommandeer *getCommandeer) *getFunctionEve
 				}
 			}
 
-			functionEvents, err := getCommandeer.rootCommandeer.platform.GetFunctionEvents(context.Background(),
+			functionEvents, err := getCommandeer.rootCommandeer.platform.GetFunctionEvents(ctx,
 				&commandeer.getFunctionEventsOptions)
 			if err != nil {
 				return errors.Wrap(err, "Failed to get function events")

--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -21,7 +21,7 @@ type importCommandeer struct {
 	rootCommandeer *RootCommandeer
 }
 
-func newImportCommandeer(rootCommandeer *RootCommandeer) *importCommandeer {
+func newImportCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *importCommandeer {
 	commandeer := &importCommandeer{
 		rootCommandeer: rootCommandeer,
 	}
@@ -33,8 +33,8 @@ func newImportCommandeer(rootCommandeer *RootCommandeer) *importCommandeer {
 from a configuration file or from the standard input (default)`,
 	}
 
-	importFunctionCommand := newImportFunctionCommandeer(commandeer).cmd
-	importProjectCommand := newImportProjectCommandeer(commandeer).cmd
+	importFunctionCommand := newImportFunctionCommandeer(ctx, commandeer).cmd
+	importProjectCommand := newImportProjectCommandeer(ctx, commandeer).cmd
 
 	cmd.AddCommand(
 		importFunctionCommand,
@@ -115,7 +115,7 @@ type importFunctionCommandeer struct {
 	*importCommandeer
 }
 
-func newImportFunctionCommandeer(importCommandeer *importCommandeer) *importFunctionCommandeer {
+func newImportFunctionCommandeer(ctx context.Context, importCommandeer *importCommandeer) *importFunctionCommandeer {
 	commandeer := &importFunctionCommandeer{
 		importCommandeer: importCommandeer,
 	}
@@ -168,7 +168,7 @@ Use --help for more information`)
 				},
 			}
 
-			return commandeer.importFunctions(context.Background(), functionConfigs, platformConfig)
+			return commandeer.importFunctions(ctx, functionConfigs, platformConfig)
 		},
 	}
 
@@ -213,7 +213,7 @@ type importProjectCommandeer struct {
 	skipTransformDisplayName bool
 }
 
-func newImportProjectCommandeer(importCommandeer *importCommandeer) *importProjectCommandeer {
+func newImportProjectCommandeer(ctx context.Context, importCommandeer *importCommandeer) *importProjectCommandeer {
 	commandeer := &importProjectCommandeer{
 		importCommandeer: importCommandeer,
 	}
@@ -260,7 +260,7 @@ Use --help for more information`)
 				return errors.Wrap(err, "Failed to resolve the imported project configuration")
 			}
 
-			return commandeer.importProjects(context.Background(), importProjectsOptions)
+			return commandeer.importProjects(ctx, importProjectsOptions)
 		},
 	}
 

--- a/pkg/nuctl/command/invoke.go
+++ b/pkg/nuctl/command/invoke.go
@@ -51,7 +51,7 @@ type invokeCommandeer struct {
 	body                            string
 }
 
-func newInvokeCommandeer(rootCommandeer *RootCommandeer) *invokeCommandeer {
+func newInvokeCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *invokeCommandeer {
 	commandeer := &invokeCommandeer{
 		rootCommandeer: rootCommandeer,
 	}
@@ -126,7 +126,7 @@ func newInvokeCommandeer(rootCommandeer *RootCommandeer) *invokeCommandeer {
 			}
 
 			commandeer.createFunctionInvocationOptions.Timeout = commandeer.timeout
-			invokeResult, err := rootCommandeer.platform.CreateFunctionInvocation(context.Background(),
+			invokeResult, err := rootCommandeer.platform.CreateFunctionInvocation(ctx,
 				&commandeer.createFunctionInvocationOptions)
 			if err != nil {
 				return errors.Wrap(err, "Failed to invoke function")

--- a/pkg/nuctl/command/nuctl.go
+++ b/pkg/nuctl/command/nuctl.go
@@ -59,6 +59,7 @@ func NewRootCommandeer() *RootCommandeer {
 
 	defaultPlatformType := common.GetEnvOrDefaultString("NUCTL_PLATFORM", "auto")
 	defaultNamespace := os.Getenv("NUCTL_NAMESPACE")
+	ctx := context.Background()
 
 	cmd.PersistentFlags().BoolVarP(&commandeer.verbose, "verbose", "v", false, "Verbose output")
 	cmd.PersistentFlags().StringVarP(&commandeer.platformName, "platform", "", defaultPlatformType, "Platform identifier - \"kube\", \"local\", or \"auto\"")
@@ -70,15 +71,15 @@ func NewRootCommandeer() *RootCommandeer {
 	// add children
 	cmd.AddCommand(
 		newBuildCommandeer(commandeer).cmd,
-		newDeployCommandeer(context.Background(), commandeer).cmd,
-		newInvokeCommandeer(commandeer).cmd,
-		newGetCommandeer(commandeer).cmd,
-		newDeleteCommandeer(commandeer).cmd,
-		newUpdateCommandeer(commandeer).cmd,
+		newDeployCommandeer(ctx, commandeer).cmd,
+		newInvokeCommandeer(ctx, commandeer).cmd,
+		newGetCommandeer(ctx, commandeer).cmd,
+		newDeleteCommandeer(ctx, commandeer).cmd,
+		newUpdateCommandeer(ctx, commandeer).cmd,
 		newVersionCommandeer(commandeer).cmd,
-		newCreateCommandeer(commandeer).cmd,
-		newExportCommandeer(commandeer).cmd,
-		newImportCommandeer(commandeer).cmd,
+		newCreateCommandeer(ctx, commandeer).cmd,
+		newExportCommandeer(ctx, commandeer).cmd,
+		newImportCommandeer(ctx, commandeer).cmd,
 	)
 
 	commandeer.cmd = cmd

--- a/pkg/nuctl/command/update.go
+++ b/pkg/nuctl/command/update.go
@@ -35,7 +35,7 @@ type updateCommandeer struct {
 	commands       stringSliceFlag
 }
 
-func newUpdateCommandeer(rootCommandeer *RootCommandeer) *updateCommandeer {
+func newUpdateCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *updateCommandeer {
 	commandeer := &updateCommandeer{
 		rootCommandeer: rootCommandeer,
 	}
@@ -47,7 +47,7 @@ func newUpdateCommandeer(rootCommandeer *RootCommandeer) *updateCommandeer {
 	}
 
 	cmd.AddCommand(
-		newUpdateFunctionCommandeer(commandeer).cmd,
+		newUpdateFunctionCommandeer(ctx, commandeer).cmd,
 	)
 
 	commandeer.cmd = cmd
@@ -64,7 +64,7 @@ type updateFunctionCommandeer struct {
 	encodedEnv          string
 }
 
-func newUpdateFunctionCommandeer(updateCommandeer *updateCommandeer) *updateFunctionCommandeer {
+func newUpdateFunctionCommandeer(ctx context.Context, updateCommandeer *updateCommandeer) *updateFunctionCommandeer {
 	commandeer := &updateFunctionCommandeer{
 		updateCommandeer: updateCommandeer,
 		functionConfig:   *functionconfig.NewConfig(),
@@ -113,7 +113,7 @@ func newUpdateFunctionCommandeer(updateCommandeer *updateCommandeer) *updateFunc
 			commandeer.functionConfig.Meta.Namespace = updateCommandeer.rootCommandeer.namespace
 			commandeer.functionConfig.Spec.Build.Commands = updateCommandeer.commands
 
-			return updateCommandeer.rootCommandeer.platform.UpdateFunction(context.Background(), &platform.UpdateFunctionOptions{
+			return updateCommandeer.rootCommandeer.platform.UpdateFunction(ctx, &platform.UpdateFunctionOptions{
 				FunctionMeta: &commandeer.functionConfig.Meta,
 				FunctionSpec: &commandeer.functionConfig.Spec,
 			})

--- a/pkg/nuctl/test/suite.go
+++ b/pkg/nuctl/test/suite.go
@@ -159,6 +159,9 @@ func (suite *Suite) RetryExecuteNuctlUntilSuccessful(positionalArgs []string,
 
 			// execute
 			err := suite.ExecuteNuctl(positionalArgs, namedArgs)
+			if err != nil {
+				suite.logger.DebugWith("TOMER - nuctl execution failed", "err", err, "errCause", errors.Cause(err))
+			}
 			if expectFailure {
 				return err != nil
 			}

--- a/pkg/nuctl/test/suite.go
+++ b/pkg/nuctl/test/suite.go
@@ -159,9 +159,6 @@ func (suite *Suite) RetryExecuteNuctlUntilSuccessful(positionalArgs []string,
 
 			// execute
 			err := suite.ExecuteNuctl(positionalArgs, namedArgs)
-			if err != nil {
-				suite.logger.DebugWith("TOMER - nuctl execution failed", "err", err, "errCause", errors.Cause(err))
-			}
 			if expectFailure {
 				return err != nil
 			}

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -893,8 +893,9 @@ func (ap *Platform) ResolveDefaultNamespace(defaultNamespace string) string {
 }
 
 // BuildAndPushContainerImage builds container image and pushes it into docker registry
-func (ap *Platform) BuildAndPushContainerImage(buildOptions *containerimagebuilderpusher.BuildOptions) error {
-	return ap.ContainerBuilder.BuildAndPushContainerImage(buildOptions,
+func (ap *Platform) BuildAndPushContainerImage(ctx context.Context, buildOptions *containerimagebuilderpusher.BuildOptions) error {
+	return ap.ContainerBuilder.BuildAndPushContainerImage(ctx,
+		buildOptions,
 		ap.platform.ResolveDefaultNamespace("@nuclio.selfNamespace"))
 }
 

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -284,7 +284,7 @@ func (mp *Platform) GetDefaultInvokeIPAddresses() ([]string, error) {
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (mp *Platform) BuildAndPushContainerImage(buildOptions *containerimagebuilderpusher.BuildOptions) error {
+func (mp *Platform) BuildAndPushContainerImage(ctx context.Context, buildOptions *containerimagebuilderpusher.BuildOptions) error {
 	return nil
 }
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -184,7 +184,7 @@ type Platform interface {
 	ResolveDefaultNamespace(string) string
 
 	// BuildAndPushContainerImage builds container image and pushes it into container registry
-	BuildAndPushContainerImage(buildOptions *containerimagebuilderpusher.BuildOptions) error
+	BuildAndPushContainerImage(ctx context.Context, buildOptions *containerimagebuilderpusher.BuildOptions) error
 
 	// GetOnbuildStages Get Onbuild stage for multistage builds
 	GetOnbuildStages(onbuildArtifacts []runtime.Artifact) ([]string, error)

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -18,6 +18,7 @@ package build
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -1055,23 +1056,24 @@ func (b *Builder) buildProcessorImage() (string, error) {
 		"registryURL", registryURL,
 		"imageName", imageName)
 
-	err = b.platform.BuildAndPushContainerImage(&containerimagebuilderpusher.BuildOptions{
-		ContextDir:     b.stagingDir,
-		Image:          imageName,
-		TempDir:        b.tempDir,
-		DockerfileInfo: processorDockerfileInfo,
+	err = b.platform.BuildAndPushContainerImage(context.Background(),
+		&containerimagebuilderpusher.BuildOptions{
+			ContextDir:     b.stagingDir,
+			Image:          imageName,
+			TempDir:        b.tempDir,
+			DockerfileInfo: processorDockerfileInfo,
 
-		// Conjunct Pull with NoCache
-		// To ensure that when forcing a function build, the base images would be pulled as well.
-		Pull:                b.options.FunctionConfig.Spec.Build.NoCache,
-		NoCache:             b.options.FunctionConfig.Spec.Build.NoCache,
-		NoBaseImagePull:     b.GetNoBaseImagePull(),
-		BuildArgs:           buildArgs,
-		RegistryURL:         registryURL,
-		SecretName:          b.options.FunctionConfig.Spec.ImagePullSecrets,
-		OutputImageFile:     b.options.OutputImageFile,
-		BuildTimeoutSeconds: b.resolveBuildTimeoutSeconds(),
-	})
+			// Conjunct Pull with NoCache
+			// To ensure that when forcing a function build, the base images would be pulled as well.
+			Pull:                b.options.FunctionConfig.Spec.Build.NoCache,
+			NoCache:             b.options.FunctionConfig.Spec.Build.NoCache,
+			NoBaseImagePull:     b.GetNoBaseImagePull(),
+			BuildArgs:           buildArgs,
+			RegistryURL:         registryURL,
+			SecretName:          b.options.FunctionConfig.Spec.ImagePullSecrets,
+			OutputImageFile:     b.options.OutputImageFile,
+			BuildTimeoutSeconds: b.resolveBuildTimeoutSeconds(),
+		})
 
 	return imageName, err
 }


### PR DESCRIPTION
As a follow-up to the k8s bump (#2428), we inject the same context in nuctl from the root commandeer to all command's commandeers. 