### PR TITLE
refactor: use `os.ReadDir` for lightweight directory reading

### DIFF
--- a/pkg/dashboard/functiontemplates/generator/generator.go
+++ b/pkg/dashboard/functiontemplates/generator/generator.go
@@ -185,7 +185,7 @@ func (g *Generator) detectFunctionDirs() ([]string, error) {
 			if info.IsDir() {
 
 				// list function dir files
-				files, err := ioutil.ReadDir(path)
+				files, err := os.ReadDir(path)
 				if err != nil {
 					return errors.Wrapf(err, "Failed to read function dir files", "path", path)
 				}
@@ -213,7 +213,7 @@ func (g *Generator) detectFunctionDirs() ([]string, error) {
 	return functionDirs, nil
 }
 
-func (g *Generator) isFunctionDir(runtime *Runtime, functionDirFiles []os.FileInfo) bool {
+func (g *Generator) isFunctionDir(runtime *Runtime, functionDirFiles []os.DirEntry) bool {
 	for _, file := range functionDirFiles {
 
 		// directory has at least one file related to function's runtime or a function.yaml
@@ -335,7 +335,7 @@ func (g *Generator) getFunctionConfigAndSource(functionDir string) (*functioncon
 
 	// look for the first non-function.yaml file - this is our source code
 	// (multiple-source function templates not yet supported)
-	files, err := ioutil.ReadDir(functionDir)
+	files, err := os.ReadDir(functionDir)
 	if err != nil {
 		return nil, "", errors.Wrapf(err, "Failed to list function directory at %s", functionDir)
 	}

--- a/pkg/dockercreds/dockercreds.go
+++ b/pkg/dockercreds/dockercreds.go
@@ -17,7 +17,7 @@ limitations under the License.
 package dockercreds
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"time"
@@ -56,7 +56,7 @@ func NewDockerCreds(parentLogger logger.Logger,
 }
 
 func (dc *DockerCreds) LoadFromDir(keyDir string) error {
-	dockerKeyFileInfos, err := ioutil.ReadDir(keyDir)
+	dockerKeyFileInfos, err := os.ReadDir(keyDir)
 	if err != nil {
 		return errors.Wrap(err, "Failed to read docker key directory")
 	}

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -770,7 +770,7 @@ func (b *Builder) decompressFunctionArchive(functionPath string) (string, error)
 }
 
 func (b *Builder) resolveGithubArchiveWorkDir(decompressDir string) (string, error) {
-	directories, err := ioutil.ReadDir(decompressDir)
+	directories, err := os.ReadDir(decompressDir)
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to list decompressed directory tree")
 	}

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -468,7 +468,7 @@ func (suite *TestSuite) createFunctionArchive(functionDir string,
 	// use the reverse function
 	archivePath := path.Join(archiveDir, "reverser"+archiveExtension)
 
-	functionFileInfos, err := ioutil.ReadDir(functionDir)
+	functionFileInfos, err := os.ReadDir(functionDir)
 	suite.Require().NoError(err)
 
 	var functionFileNames []string

--- a/pkg/processor/build/util/copy.go
+++ b/pkg/processor/build/util/copy.go
@@ -19,7 +19,6 @@ package util
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -122,7 +121,7 @@ func CopyDir(source string, dest string) (bool, error) {
 		return false, err
 	}
 
-	entries, err := ioutil.ReadDir(source)
+	entries, err := os.ReadDir(source)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
`os.ReadDir` was added in Go 1.16 as part of the deprecation of `ioutil` package. It is a more efficient implementation than `ioutil.ReadDir` as stated here https://pkg.go.dev/io/ioutil#ReadDir. 

The full proposal can be read here: https://<!---->github.com<!---->/<!---->golang<!---->/go/issues/41467