### PR TITLE
Fix nodejs event leak

### DIFF
--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -332,7 +332,7 @@ registry:
 
   # In some cases the docker server URL in the registry secrets isn't the same as the URL with which
   # you push and pull. For example, in GKE you log into `gcr.io` (or some other regional URL) yet have
-  # to push/pull from `gcr.io/<project-name>. If this is the case, specify the URL here and it will be
+  # to push/pull from `gcr.io/<project-name>. If this is the case, specify the URL here, and it will be
   # used instead of the URL in the secrets
   #
   # pushPullUrl: gcr.io/<project-name>

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -284,7 +284,7 @@ func (pr *projectResource) createProject(request *http.Request, projectInfoInsta
 	requestOrigin, sessionCookie := pr.getRequestOriginAndSessionCookie(request)
 
 	// just deploy. the status is async through polling
-	pr.Logger.DebugWithCtx(ctx, "Creating project", "newProject", newProject)
+	pr.Logger.DebugWithCtx(ctx, "Creating project", "newProject", newProject.GetConfig())
 	if err := pr.getPlatform().CreateProject(ctx, &platform.CreateProjectOptions{
 		ProjectConfig: newProject.GetConfig(),
 		RequestOrigin: requestOrigin,

--- a/pkg/processor/runtime/nodejs/js/wrapper.js
+++ b/pkg/processor/runtime/nodejs/js/wrapper.js
@@ -157,7 +157,7 @@ async function handleEvent(handlerFunction, incomingEvent) {
         // listening on response before executing, to avoid deadlock
         const responseWaiter = new Promise(resolve => context
             ._eventEmitter
-            .on('callback', resolve))
+            .once('callback', resolve))
 
         // call the handler
         handlerFunction(context, incomingEvent)


### PR DESCRIPTION
Fix a leak raised by issue #2460 
Emitting using `on` creates an event listener without deleting it once finished as oppose to `once` where it create & delete the listener.