### PR TITLE
Log Kubernetes server warnings nicely

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,3 +65,7 @@ issues:
     - path: _test\.go
       linters:
         - goconst
+
+      # false positive
+    - path: pkg/common/k8s.go
+      text: "deprecatedComment: the proper format is `Deprecated: <text>`"

--- a/cmd/autoscaler/app/autoscaler.go
+++ b/cmd/autoscaler/app/autoscaler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/v3io/scaler/pkg/autoscaler"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/metrics/pkg/client/custom_metrics"
 )
@@ -100,6 +101,8 @@ func createAutoScaler(platformConfigurationPath string,
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create autoscaler")
 	}
+
+	rest.SetDefaultWarningHandler(common.NewKubernetesClientWarningHandler(rootLogger.GetChild("kube_warnings")))
 
 	return autoScaler, nil
 }

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/nuclio/errors"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 func Run(kubeconfigPath string,
@@ -166,6 +167,8 @@ func createController(kubeconfigPath string,
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create api gateway provisioner")
 	}
+
+	rest.SetDefaultWarningHandler(common.NewKubernetesClientWarningHandler(rootLogger.GetChild("kube_warnings")))
 
 	newController, err := controller.NewController(rootLogger,
 		namespace,

--- a/cmd/dashboard/app/run.go
+++ b/cmd/dashboard/app/run.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	commonhealthcheck "github.com/nuclio/nuclio/pkg/common/healthcheck"
 	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/dashboard"
@@ -23,6 +24,7 @@ import (
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/v3io/version-go"
+	"k8s.io/client-go/rest"
 )
 
 func Run(listenAddress string,
@@ -159,6 +161,10 @@ func Run(listenAddress string,
 			monitorDockerDeamonMaxConsecutiveErrors,
 			dockerClient)
 		defer cancel()
+	}
+
+	if platformInstance.GetName() == "kube" {
+		rest.SetDefaultWarningHandler(common.NewKubernetesClientWarningHandler(rootLogger.GetChild("kube_warnings")))
 	}
 
 	if err := dashboardInstance.server.Start(); err != nil {

--- a/cmd/dlx/app/dlx.go
+++ b/cmd/dlx/app/dlx.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/v3io/scaler/pkg/dlx"
+	"k8s.io/client-go/rest"
 )
 
 func Run(platformConfigurationPath string,
@@ -100,5 +101,7 @@ func newDLX(platformConfigurationPath string,
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create dlx instance")
 	}
+
+	rest.SetDefaultWarningHandler(common.NewKubernetesClientWarningHandler(rootLogger.GetChild("kube_warnings")))
 	return dlxInstance, nil
 }

--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -317,7 +317,6 @@ func (suite *FunctionMonitoringTestSuite) TestRecoverErrorStateFunctionWhenResou
 		}()
 		defer func() { showFunctionDeploymentStatusChan <- struct{}{} }()
 
-		time.Sleep(10 * time.Second)
 		// wait for function state to become ready again
 		suite.WaitForFunctionState(getFunctionOptions,
 			functionconfig.FunctionStateReady,

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -52,6 +52,7 @@ import (
 	kubeapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 type OnAfterIngressCreated func(*networkingv1.Ingress)
@@ -95,6 +96,9 @@ func (suite *KubeTestSuite) SetupSuite() {
 
 	// only set up parent AFTER we set platform's type
 	suite.TestSuite.SetupSuite()
+
+	// log kubernetes deprecation warnings
+	rest.SetDefaultWarningHandler(common.NewKubernetesClientWarningHandler(suite.Logger.GetChild("kube_warnings")))
 
 	// fill test external ip addresses
 	err = suite.Platform.SetExternalIPAddresses(strings.Split(suite.GetTestHost(), ","))


### PR DESCRIPTION
Instead of letting klog logging to stdout/stderr - use nuclio's logger facility