### PR TITLE
Allow support for functions to run on preemptible nodes

### DIFF
--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -320,7 +320,18 @@ type Spec struct {
 	// We're letting users write "20s" and not the default marshalled time.Duration
 	// (Which is in nanoseconds)
 	EventTimeout string `json:"eventTimeout"`
+
+	// PreemptionMode is a mode to allow the user to allow running function pods on preemptible nodes
+	// When filled, tolerations, node labels, and affinity would be populated correspondingly to
+	// the platformconfig.PreemptibleNodes values.
+	PreemptionMode RunOnPreemptibleNodeMode `json:"preemptionMode,omitempty"`
 }
+
+type RunOnPreemptibleNodeMode string
+
+const (
+	RunOnPreemptibleNodesAllow RunOnPreemptibleNodeMode = "allow"
+)
 
 type ScaleToZeroSpec struct {
 	ScaleResources []ScaleResource `json:"scaleResources,omitempty"`

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -471,7 +471,7 @@ func (p Platform) EnrichFunctionConfig(ctx context.Context, functionConfig *func
 	if p.Config.Kube.PreemptibleNodes != nil {
 
 		// we do such stuff to allow exposing features before they are exposed on UI
-		if preemptionMode, exists := functionConfig.Meta.Annotations["nuclio.io/preemptible-mode"]; exists {
+		if preemptionMode, exists := functionConfig.Meta.Annotations["custom.nuclio.io/preemptible-mode"]; exists {
 			p.Logger.DebugWithCtx(ctx,
 				"Enriching function preemption mode from function annotations",
 				"preemptionMode", preemptionMode)

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -500,14 +500,19 @@ func (p Platform) EnrichFunctionConfig(ctx context.Context, functionConfig *func
 
 				// only add
 				var tolerationsToAdd []v1.Toleration
-				for _, preemptibleNodeTolerations := range p.Config.Kube.PreemptibleNodes.Tolerations {
-					for _, functionToleration := range functionConfig.Spec.Tolerations {
 
-						// only add non-matching toleratinos as we dont want to have duplicates
+				// only add non-matching toleratinos as we dont want to have duplicates
+				for _, functionToleration := range functionConfig.Spec.Tolerations {
+					for _, preemptibleNodeTolerations := range p.Config.Kube.PreemptibleNodes.Tolerations {
 						if !functionToleration.MatchToleration(&preemptibleNodeTolerations) {
-							tolerationsToAdd = append(tolerationsToAdd, preemptibleNodeTolerations)
+							continue
 						}
 					}
+				}
+
+				// in case function has no toleration, use tolerations from platform config
+				if len(functionConfig.Spec.Tolerations) == 0 {
+					tolerationsToAdd = p.Config.Kube.PreemptibleNodes.Tolerations
 				}
 
 				if tolerationsToAdd != nil {

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -500,11 +500,11 @@ func (p Platform) EnrichFunctionConfig(ctx context.Context, functionConfig *func
 				// only add
 				var tolerationsToAdd []v1.Toleration
 
-				// only add non-matching toleratinos as we dont want to have duplicates
+				// only add non-matching toleratinos to avoid duplications
 				for _, functionToleration := range functionConfig.Spec.Tolerations {
 					for _, preemptibleNodeTolerations := range p.Config.Kube.PreemptibleNodes.Tolerations {
 						if !functionToleration.MatchToleration(&preemptibleNodeTolerations) {
-							continue
+							tolerationsToAdd = append(tolerationsToAdd, preemptibleNodeTolerations)
 						}
 					}
 				}

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -478,8 +478,7 @@ func (p Platform) EnrichFunctionConfig(ctx context.Context, functionConfig *func
 			functionConfig.Spec.PreemptionMode = functionconfig.RunOnPreemptibleNodeMode(preemptionMode)
 		}
 
-		switch functionConfig.Spec.PreemptionMode {
-		case functionconfig.RunOnPreemptibleNodesAllow:
+		if functionConfig.Spec.PreemptionMode == functionconfig.RunOnPreemptibleNodesAllow {
 			p.Logger.DebugWithCtx(ctx,
 				"Allowing function to run on preemptible nodes",
 				"functionName", functionConfig.Meta.Name)

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -143,12 +143,19 @@ type PlatformKubeConfig struct {
 	// TODO: Move IngressConfig here
 	DefaultServiceType               corev1.ServiceType      `json:"defaultServiceType,omitempty"`
 	DefaultFunctionNodeSelector      map[string]string       `json:"defaultFunctionNodeSelector,omitempty"`
-	DefaultFunctionTolerations       []corev1.Toleration     `json:"defaultFunctionTolerations,omitempty"`
 	DefaultHTTPIngressHostTemplate   string                  `json:"defaultHTTPIngressHostTemplate,omitempty"`
 	DefaultHTTPIngressAnnotations    map[string]string       `json:"defaultHTTPIngressAnnotations,omitempty"`
 	DefaultFunctionPriorityClassName string                  `json:"defaultFunctionPriorityClassName,omitempty"`
-	DefaultFunctionPodResources      PodResourceRequirements `json:"defaultFunctionPodResources,omitempty"`
 	ValidFunctionPriorityClassNames  []string                `json:"validFunctionPriorityClassNames,omitempty"`
+	DefaultFunctionPodResources      PodResourceRequirements `json:"defaultFunctionPodResources,omitempty"`
+	DefaultFunctionTolerations       []corev1.Toleration     `json:"defaultFunctionTolerations,omitempty"`
+	PreemptibleNodes                 *PreemptibleNodes       `json:"preemptibleNodes,omitempty"`
+}
+
+// PreemptibleNodes Holds data needed when user decided to run his function pods on a preemptible node (aka Spot node)
+type PreemptibleNodes struct {
+	Tolerations   []corev1.Toleration `json:"tolerations,omitempty"`
+	NodeSelectors map[string]string   `json:"nodeSelectors,omitempty"`
 }
 
 type PlatformLocalConfig struct {


### PR DESCRIPTION
This PR introduce a mode whereas function with specific preemption mode (aka `allow`) will be enriched with given configurations to make sure its pods toleration / node selectors are assigned with values that allows them to run on preemptible nodes (aka `Spot`).

Since each cloud provider has its own configuration to indicate whether a pod is runnable on a spot node - it is up to the user to provide such configuration via the platform config.

e.g.:

```
kube:
  preemptibleNodes:
    tolerations:
      - key: a
         operator: "Equal"
         value: "value1"
         effect: "NoSchedule"
```
once function is deployed and has `preemptionMode: allow`, then its `tolerations` configuration would be enriched automatically with the given configuration.
