### PR TITLE
Allow support for function pods to run on preemptible nodes part 2

### DIFF
--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -330,7 +330,12 @@ type Spec struct {
 type RunOnPreemptibleNodeMode string
 
 const (
+
+	// RunOnPreemptibleNodesAllow makes function pods be able to run on preemptible nodes
 	RunOnPreemptibleNodesAllow RunOnPreemptibleNodeMode = "allow"
+
+	// RunOnPreemptibleNodesConstrain makes the function pods run on preemtible nodes only
+	RunOnPreemptibleNodesConstrain RunOnPreemptibleNodeMode = "constrain"
 )
 
 type ScaleToZeroSpec struct {

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -154,8 +154,8 @@ type PlatformKubeConfig struct {
 
 // PreemptibleNodes Holds data needed when user decided to run his function pods on a preemptible node (aka Spot node)
 type PreemptibleNodes struct {
-	Tolerations   []corev1.Toleration `json:"tolerations,omitempty"`
-	NodeSelectors map[string]string   `json:"nodeSelectors,omitempty"`
+	Tolerations  []corev1.Toleration `json:"tolerations,omitempty"`
+	NodeSelector map[string]string   `json:"nodeSelector,omitempty"`
 }
 
 type PlatformLocalConfig struct {


### PR DESCRIPTION
This PR adds a constraint mode which attach function pods to preemptible nodes