### PR TITLE
Add deprecation warnings when deploying a function with python 3.6

### DIFF
--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -158,7 +158,10 @@ Error - plugin: symbol ExpectedHandler not found in plugin github.com/nuclio/nuc
 				createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = base64.StdEncoding.EncodeToString([]byte(functionSourceCode))
 				return createFunctionOptions
 			}(),
-			ExpectedBriefErrorsMessage: `Handler not found [handler="main:expected_handler" || worker_id="0"]
+
+			// TODO: remove deprecation notice once python 3.6 is made obsolete
+			ExpectedBriefErrorsMessage: `Python 3.6 runtime is deprecated and will soon not be supported. Please migrate your code and use Python 3.7 runtime or higher
+Handler not found [handler="main:expected_handler" || worker_id="0"]
 Caught unhandled exception while initializing [err="module 'main' has no attribute 'expected_handler'" || traceback="Traceback (most recent call last):
   File "/opt/nuclio/_nuclio_wrapper.py", line 409, in run_wrapper
     args.trigger_name)

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -160,11 +160,11 @@ Error - plugin: symbol ExpectedHandler not found in plugin github.com/nuclio/nuc
 			}(),
 			ExpectedBriefErrorsMessage: `Handler not found [handler="main:expected_handler" || worker_id="0"]
 Caught unhandled exception while initializing [err="module 'main' has no attribute 'expected_handler'" || traceback="Traceback (most recent call last):
-  File "/opt/nuclio/_nuclio_wrapper.py", line 325, in run_wrapper
+  File "/opt/nuclio/_nuclio_wrapper.py", line 409, in run_wrapper
     args.trigger_name)
-  File "/opt/nuclio/_nuclio_wrapper.py", line 56, in __init__
+  File "/opt/nuclio/_nuclio_wrapper.py", line 71, in __init__
     self._entrypoint = self._load_entrypoint_from_handler(handler)
-  File "/opt/nuclio/_nuclio_wrapper.py", line 148, in _load_entrypoint_from_handler
+  File "/opt/nuclio/_nuclio_wrapper.py", line 200, in _load_entrypoint_from_handler
     entrypoint_address = getattr(module, entrypoint)
 AttributeError: module 'main' has no attribute 'expected_handler'
 " || worker_id="0"]`,

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -90,6 +90,9 @@ func (p *python) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config,
 
 		// true for python & python:3.6
 		baseImage = "python:3.6"
+
+		p.Logger.Warn("Python 3.6 runtime is deprecated and will soon not be supported. " +
+			"Please migrate your code 3.7 or higher")
 		installSDKDependenciesCommand = fmt.Sprintf("pip install %s %s",
 			strings.Join(pythonCommonModules, " "),
 			strings.Join(pipInstallArgs, " "),

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -92,7 +92,7 @@ func (p *python) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config,
 		baseImage = "python:3.6"
 
 		p.Logger.Warn("Python 3.6 runtime is deprecated and will soon not be supported. " +
-			"Please migrate your code 3.7 or higher")
+			"Please migrate your code and use Python 3.7 runtime (`python:3.7`) or higher")
 		installSDKDependenciesCommand = fmt.Sprintf("pip install %s %s",
 			strings.Join(pythonCommonModules, " "),
 			strings.Join(pipInstallArgs, " "),

--- a/pkg/processor/runtime/python/runtime.go
+++ b/pkg/processor/runtime/python/runtime.go
@@ -64,7 +64,7 @@ func (py *python) RunWrapper(socketPath string) (*os.Process, error) {
 	_, runtimeVersion := common.GetRuntimeNameAndVersion(py.configuration.Spec.Runtime)
 	if runtimeVersion == "" || runtimeVersion == "3.6" {
 		py.Logger.Warn("Python 3.6 runtime is deprecated and will soon not be supported. " +
-			"Please migrate your code 3.7 or higher")
+			"Please migrate your code and use Python 3.7 runtime (`python:3.7`) or higher")
 	}
 
 	wrapperScriptPath := py.getWrapperScriptPath()

--- a/pkg/processor/runtime/python/runtime.go
+++ b/pkg/processor/runtime/python/runtime.go
@@ -59,6 +59,14 @@ func NewRuntime(parentLogger logger.Logger, configuration *runtime.Configuration
 }
 
 func (py *python) RunWrapper(socketPath string) (*os.Process, error) {
+
+	// TODO: remove warning once python 3.6 is not supported
+	_, runtimeVersion := common.GetRuntimeNameAndVersion(py.configuration.Spec.Runtime)
+	if runtimeVersion == "" || runtimeVersion == "3.6" {
+		py.Logger.Warn("Python 3.6 runtime is deprecated and will soon not be supported. " +
+			"Please migrate your code 3.7 or higher")
+	}
+
 	wrapperScriptPath := py.getWrapperScriptPath()
 	py.Logger.DebugWith("Using Python wrapper script path", "path", wrapperScriptPath)
 	if !common.IsFile(wrapperScriptPath) {


### PR DESCRIPTION
A part of an effort to drop python 3.6 support form Nuclio altogether.
Added a deprecation warning in the function logs and in the UI build logs. 

Requirement: https://jira.iguazeng.com/browse/IG-20142