### PR TITLE
Project - cache upon creation

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -439,7 +439,7 @@ func (ap *Platform) ValidateDeleteProjectOptions(ctx context.Context,
 
 		}
 
-		// project does not exists, stop here
+		// project does not exist, stop here
 		if len(projects) == 0 {
 			return nil
 		}

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher"
@@ -48,6 +49,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/cache"
 )
 
 type Platform struct {
@@ -59,6 +61,7 @@ type Platform struct {
 	kubeconfigPath string
 	consumer       *client.Consumer
 	projectsClient project.Client
+	projectsCache  *cache.Expiring
 }
 
 const Mib = 1048576
@@ -151,6 +154,8 @@ func NewPlatform(ctx context.Context,
 			return nil, errors.Wrap(err, "Failed to create a Docker builder")
 		}
 	}
+
+	newPlatform.projectsCache = cache.NewExpiring()
 
 	return newPlatform, nil
 }
@@ -648,11 +653,22 @@ func (p *Platform) CreateProject(ctx context.Context, createProjectOptions *plat
 	}
 
 	// create
-	p.Logger.DebugWithCtx(ctx, "Creating project",
+	p.Logger.DebugWithCtx(ctx,
+		"Creating project",
 		"projectName", createProjectOptions.ProjectConfig.Meta.Name)
-	if _, err := p.projectsClient.Create(ctx, createProjectOptions); err != nil {
+	createdProject, err := p.projectsClient.Create(ctx, createProjectOptions)
+	if err != nil {
 		return errors.Wrap(err, "Failed to create project")
 	}
+
+	// adding to cache for 30 seconds, allowing
+	p.projectsCache.Set(
+		p.getProjectCacheKey(
+			createProjectOptions.ProjectConfig.Meta,
+			createProjectOptions.ProjectConfig.Spec.Owner,
+		),
+		createdProject,
+		time.Second*30)
 
 	return nil
 }
@@ -688,22 +704,66 @@ func (p *Platform) DeleteProject(ctx context.Context, deleteProjectOptions *plat
 	}
 
 	if deleteProjectOptions.WaitForResourcesDeletionCompletion {
-		return p.Platform.WaitForProjectResourcesDeletion(ctx,
+		if err := p.Platform.WaitForProjectResourcesDeletion(ctx,
 			&deleteProjectOptions.Meta,
-			deleteProjectOptions.WaitForResourcesDeletionCompletionDuration)
+			deleteProjectOptions.WaitForResourcesDeletionCompletionDuration); err != nil {
+			return errors.Wrap(err, "Failed waiting for project resources deletion")
+		}
 	}
 
+	// cache revocation
+	p.projectsCache.Delete(p.getProjectCacheKey(deleteProjectOptions.Meta,
+		deleteProjectOptions.AuthSession.GetUsername()))
 	return nil
 }
 
 // GetProjects will list existing projects
-func (p *Platform) GetProjects(ctx context.Context, getProjectsOptions *platform.GetProjectsOptions) ([]platform.Project, error) {
+func (p *Platform) GetProjects(ctx context.Context,
+	getProjectsOptions *platform.GetProjectsOptions) ([]platform.Project, error) {
 	projects, err := p.projectsClient.Get(ctx, getProjectsOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed getting projects")
 	}
 
-	return p.Platform.FilterProjectsByPermissions(&getProjectsOptions.PermissionOptions, projects)
+	filteredProjectList, err := p.Platform.FilterProjectsByPermissions(&getProjectsOptions.PermissionOptions, projects)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to filter projects by permission")
+	}
+
+	// tl;dr simply bypass opa manifest authorization
+	// iterate over the original retrieved project list
+	// if has been recently cached, re-add to filtered project list
+	// this is done to avoid cases where
+	// 1. project is being created by leader
+	// 2. opa manifest distribution did not occur yet
+	// 3. user GET on his recently added project
+	for _, projectInstance := range projects {
+		if _, exist := p.projectsCache.Get(
+			p.getProjectCacheKey(
+				projectInstance.GetConfig().Meta,
+				getProjectsOptions.AuthSession.GetUsername(),
+			),
+		); exist {
+			var found bool
+			for _, filteredProject := range filteredProjectList {
+				if filteredProject.GetConfig().Meta.IsEqual(projectInstance.GetConfig().Meta) {
+					found = true
+					break
+				}
+			}
+
+			// re-add project instance to filtered out as it has been cached
+			if !found {
+
+				p.Logger.DebugWithCtx(ctx,
+					"Project is readded from cache",
+					"projectName", projectInstance.GetConfig().Meta.Name)
+				filteredProjectList = append(filteredProjectList, projectInstance)
+			}
+		}
+	}
+
+	return filteredProjectList, nil
 }
 
 // CreateAPIGateway creates and deploys a new api gateway
@@ -1779,4 +1839,8 @@ func (p *Platform) getAPIGatewayUpstreamFunctions(ctx context.Context,
 		return nil, errors.Wrap(err, "Failed to get upstream functions")
 	}
 	return upstreamFunctions, nil
+}
+
+func (p *Platform) getProjectCacheKey(projectMeta platform.ProjectMeta, owner string) string {
+	return fmt.Sprintf("%s/%s", projectMeta.Name, owner)
 }

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/abstract"
 	"github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	"github.com/nuclio/nuclio/pkg/platform/kube/client"
 	"github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/mocks"
 	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
@@ -50,12 +51,12 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
 type KubePlatformTestSuite struct {
 	suite.Suite
-	mockedPlatform                   *mockplatform.Platform
 	nuclioioV1beta1InterfaceMock     *mocks.NuclioV1beta1Interface
 	nuclioFunctionInterfaceMock      *mocks.NuclioFunctionInterface
 	nuclioProjectInterfaceMock       *mocks.NuclioProjectInterface
@@ -66,8 +67,9 @@ type KubePlatformTestSuite struct {
 	abstractPlatform                 *abstract.Platform
 	Namespace                        string
 	Logger                           logger.Logger
-	Platform                         *Platform
-	PlatformKubeConfig               *platformconfig.PlatformKubeConfig
+	mockedPlatform                   *mockplatform.Platform
+	platform                         *Platform
+	platformKubeConfig               *platformconfig.PlatformKubeConfig
 	mockedOpaClient                  *opa.MockClient
 	opaOverrideHeaderValue           string
 	ctx                              context.Context
@@ -84,12 +86,12 @@ func (suite *KubePlatformTestSuite) SetupSuite() {
 
 	suite.ctx = context.Background()
 
-	suite.PlatformKubeConfig = &platformconfig.PlatformKubeConfig{
+	suite.platformKubeConfig = &platformconfig.PlatformKubeConfig{
 		DefaultServiceType: v1.ServiceTypeClusterIP,
 	}
 	suite.mockedPlatform = &mockplatform.Platform{}
 	abstractPlatform, err := abstract.NewPlatform(suite.Logger, suite.mockedPlatform, &platformconfig.Config{
-		Kube: *suite.PlatformKubeConfig,
+		Kube: *suite.platformKubeConfig,
 	}, "")
 	suite.Require().NoError(err, "Could not create platform")
 
@@ -133,21 +135,117 @@ func (suite *KubePlatformTestSuite) ResetCRDMocks() {
 		On("NuclioAPIGateways", suite.Namespace).
 		Return(suite.nuclioAPIGatewayInterfaceMock)
 
-	getter, err := client.NewGetter(suite.Logger, suite.Platform)
+	getter, err := client.NewGetter(suite.Logger, suite.platform)
 	suite.Require().NoError(err)
 
-	suite.Platform = &Platform{
+	suite.platform = &Platform{
 		Platform: suite.abstractPlatform,
 		getter:   getter,
 		consumer: &client.Consumer{
 			NuclioClientSet: suite.nuclioioInterfaceMock,
 			KubeClientSet:   &suite.kubeClientSet,
 		},
+		projectsCache: cache.NewExpiring(),
 	}
-	suite.Platform.updater, _ = client.NewUpdater(suite.Logger, suite.Platform.consumer, suite.Platform)
-	suite.Platform.deleter, _ = client.NewDeleter(suite.Logger, suite.Platform)
-	suite.Platform.deployer, _ = client.NewDeployer(suite.Logger, suite.Platform.consumer, suite.Platform)
-	suite.Platform.projectsClient, _ = NewProjectsClient(suite.Platform, suite.abstractPlatform.Config)
+	suite.platform.updater, _ = client.NewUpdater(suite.Logger, suite.platform.consumer, suite.platform)
+	suite.platform.deleter, _ = client.NewDeleter(suite.Logger, suite.platform)
+	suite.platform.deployer, _ = client.NewDeployer(suite.Logger, suite.platform.consumer, suite.platform)
+	suite.platform.projectsClient, _ = NewProjectsClient(suite.platform, suite.abstractPlatform.Config)
+}
+
+func (suite *FunctionKubePlatformTestSuite) TestGetProjectsCache() {
+	suite.nuclioProjectInterfaceMock.On("Create",
+		suite.ctx,
+		mock.Anything,
+		mock.Anything).
+		Return(&nuclioio.NuclioProject{}, nil).
+		Once()
+	defer suite.nuclioProjectInterfaceMock.AssertExpectations(suite.T())
+
+	// create project
+	err := suite.platform.CreateProject(suite.ctx, &platform.CreateProjectOptions{
+		AuthSession: &auth.NopSession{},
+		ProjectConfig: &platform.ProjectConfig{
+			Meta: platform.ProjectMeta{
+				Name:      "some-name",
+				Namespace: suite.Namespace,
+			},
+		},
+	})
+	suite.Require().NoError(err)
+
+	// project has been cached
+	suite.Require().NotZero(suite.platform.projectsCache.Len())
+
+	// make sure "recently created" is being filtered (returns false) and other project
+	// that have been created long time ago is returned
+	suite.mockedOpaClient.
+		On("QueryPermissionsMultiResources",
+			[]string{
+				fmt.Sprintf("/projects/%s", "some-name"),
+				fmt.Sprintf("/projects/%s", "other-name"),
+			},
+			opa.ActionRead,
+			mock.Anything).
+		Return([]bool{false, true}, nil).
+		Once()
+	defer suite.mockedOpaClient.AssertExpectations(suite.T())
+
+	// return both projects from k8s
+	suite.nuclioProjectInterfaceMock.On("List",
+		suite.ctx,
+		mock.Anything,
+		mock.Anything).
+		Return(&v1beta1.NuclioProjectList{
+			Items: []nuclioio.NuclioProject{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: suite.Namespace,
+						Name:      "some-name",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: suite.Namespace,
+						Name:      "other-name",
+					},
+				},
+			},
+		}, nil).
+		Once()
+
+	projects, err := suite.platform.GetProjects(suite.ctx, &platform.GetProjectsOptions{
+		AuthSession: &auth.NopSession{},
+		Meta: platform.ProjectMeta{
+			Namespace: suite.Namespace,
+		},
+		PermissionOptions: opa.PermissionOptions{
+			MemberIds:           []string{"id1"},
+			RaiseForbidden:      false,
+			OverrideHeaderValue: suite.opaOverrideHeaderValue,
+		},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(projects, 2, "Expected both projects to returned")
+
+	// delete project, make sure cache revocation works
+	suite.nuclioProjectInterfaceMock.On("Delete",
+		suite.ctx,
+		mock.Anything,
+		mock.Anything).
+		Return(nil).
+		Once()
+	err = suite.platform.DeleteProject(suite.ctx, &platform.DeleteProjectOptions{
+		AuthSession: &auth.NopSession{},
+		Meta: platform.ProjectMeta{
+			Name:      "some-name",
+			Namespace: suite.Namespace,
+		},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Equal(suite.platform.projectsCache.Len(),
+		0,
+		"project was not removed from cache")
 }
 
 type FunctionKubePlatformTestSuite struct {
@@ -158,7 +256,7 @@ func (suite *FunctionKubePlatformTestSuite) TestFunctionNodeSelectorEnrichment()
 	defaultNodeSelector := map[string]string{
 		"a": "b",
 	}
-	suite.Platform.Config.Kube.DefaultFunctionNodeSelector = defaultNodeSelector
+	suite.platform.Config.Kube.DefaultFunctionNodeSelector = defaultNodeSelector
 	for _, testCase := range []struct {
 		name                 string
 		nodeSelector         map[string]string
@@ -187,7 +285,7 @@ func (suite *FunctionKubePlatformTestSuite) TestFunctionNodeSelectorEnrichment()
 		suite.Run(testCase.name, func() {
 			functionConfig := functionconfig.NewConfig()
 			functionConfig.Spec.NodeSelector = testCase.nodeSelector
-			err := suite.Platform.EnrichFunctionConfig(suite.ctx, functionConfig)
+			err := suite.platform.EnrichFunctionConfig(suite.ctx, functionConfig)
 			suite.Require().NoError(err)
 			suite.Require().Equal(testCase.expectedNodeSelector, functionConfig.Spec.NodeSelector)
 
@@ -261,7 +359,7 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateServiceType() {
 			}
 			suite.Logger.DebugWith("Checking function ", "functionName", functionName)
 
-			err := suite.Platform.ValidateFunctionConfig(suite.ctx, &createFunctionOptions.FunctionConfig)
+			err := suite.platform.ValidateFunctionConfig(suite.ctx, &createFunctionOptions.FunctionConfig)
 			if testCase.shouldFailValidation {
 				suite.Require().Error(err, "Validation passed unexpectedly")
 			} else {
@@ -294,7 +392,7 @@ func (suite *FunctionKubePlatformTestSuite) TestFunctionTriggersEnrichmentAndVal
 			expectedEnrichedTriggers: func() map[string]functionconfig.Trigger {
 				defaultHTTPTrigger := functionconfig.GetDefaultHTTPTrigger()
 				defaultHTTPTrigger.Attributes = map[string]interface{}{
-					"serviceType": suite.PlatformKubeConfig.DefaultServiceType,
+					"serviceType": suite.platformKubeConfig.DefaultServiceType,
 				}
 				return map[string]functionconfig.Trigger{
 					defaultHTTPTrigger.Name: defaultHTTPTrigger,
@@ -428,7 +526,7 @@ func (suite *FunctionKubePlatformTestSuite) TestFunctionTriggersEnrichmentAndVal
 			suite.Logger.DebugWith("Enriching and validating function", "functionName", functionName)
 
 			// run enrichment
-			err := suite.Platform.EnrichFunctionConfig(suite.ctx, &createFunctionOptions.FunctionConfig)
+			err := suite.platform.EnrichFunctionConfig(suite.ctx, &createFunctionOptions.FunctionConfig)
 			suite.Require().NoError(err, "Failed to enrich function")
 
 			if testCase.expectedEnrichedTriggers != nil {
@@ -437,7 +535,7 @@ func (suite *FunctionKubePlatformTestSuite) TestFunctionTriggersEnrichmentAndVal
 			}
 
 			// run validation
-			err = suite.Platform.ValidateFunctionConfig(suite.ctx, &createFunctionOptions.FunctionConfig)
+			err = suite.platform.ValidateFunctionConfig(suite.ctx, &createFunctionOptions.FunctionConfig)
 			if testCase.validationError != "" {
 				suite.Require().Error(err, "Validation passed unexpectedly")
 				suite.Require().Equal(testCase.validationError, errors.RootCause(err).Error())
@@ -530,7 +628,7 @@ func (suite *FunctionKubePlatformTestSuite) TestGetFunctionInstanceAndConfig() {
 				defer suite.nuclioAPIGatewayInterfaceMock.AssertExpectations(suite.T())
 			}
 
-			functionInstance, functionConfigAndStatus, err := suite.Platform.
+			functionInstance, functionConfigAndStatus, err := suite.platform.
 				getFunctionInstanceAndConfig(suite.ctx,
 					&platform.GetFunctionsOptions{
 						Name:                  testCase.functionName,
@@ -638,7 +736,7 @@ func (suite *FunctionKubePlatformTestSuite) TestGetFunctionsPermissions() {
 					Once()
 				defer suite.mockedOpaClient.AssertExpectations(suite.T())
 			}
-			functions, err := suite.Platform.GetFunctions(suite.ctx, &platform.GetFunctionsOptions{
+			functions, err := suite.platform.GetFunctions(suite.ctx, &platform.GetFunctionsOptions{
 				Name:      functionName,
 				Namespace: suite.Namespace,
 				PermissionOptions: opa.PermissionOptions{
@@ -742,7 +840,7 @@ func (suite *FunctionKubePlatformTestSuite) TestUpdateFunctionPermissions() {
 				defer suite.nuclioFunctionInterfaceMock.AssertExpectations(suite.T())
 			}
 
-			err := suite.Platform.UpdateFunction(suite.ctx, &platform.UpdateFunctionOptions{
+			err := suite.platform.UpdateFunction(suite.ctx, &platform.UpdateFunctionOptions{
 				FunctionMeta: &functionconfig.Meta{
 					Name:      functionName,
 					Namespace: suite.Namespace,
@@ -833,7 +931,7 @@ func (suite *FunctionKubePlatformTestSuite) TestDeleteFunctionPermissions() {
 				defer suite.nuclioFunctionInterfaceMock.AssertExpectations(suite.T())
 			}
 
-			err := suite.Platform.DeleteFunction(suite.ctx, &platform.DeleteFunctionOptions{
+			err := suite.platform.DeleteFunction(suite.ctx, &platform.DeleteFunctionOptions{
 				FunctionConfig: functionconfig.Config{
 					Meta: functionconfig.Meta{
 						Name:      functionName,
@@ -857,7 +955,7 @@ func (suite *FunctionKubePlatformTestSuite) TestDeleteFunctionPermissions() {
 }
 
 func (suite *FunctionKubePlatformTestSuite) TestRenderFunctionIngress() {
-	suite.Platform.Config.Kube.DefaultHTTPIngressHostTemplate = "{{ .ResourceName }}.{{ .Namespace }}.test.com"
+	suite.platform.Config.Kube.DefaultHTTPIngressHostTemplate = "{{ .ResourceName }}.{{ .Namespace }}.test.com"
 
 	for _, testCase := range []struct {
 		name        string
@@ -1002,7 +1100,7 @@ func (suite *FunctionKubePlatformTestSuite) TestRenderFunctionIngress() {
 					},
 				},
 			}
-			err := suite.Platform.enrichHTTPTriggers(suite.ctx, functionConfig)
+			err := suite.platform.enrichHTTPTriggers(suite.ctx, functionConfig)
 			suite.Require().NoError(err)
 			suite.Require().Equal(testCase.want,
 				functionConfig.Spec.Triggers[testCase.httpTrigger.Name].Attributes["ingresses"])
@@ -1038,7 +1136,7 @@ func (suite *FunctionKubePlatformTestSuite) TestAlignIngressHostSubdomain() {
 		},
 	} {
 		suite.Run(testCase.name, func() {
-			alignedIngressHostSubdomain := suite.Platform.alignIngressHostSubdomainLevel(testCase.args.host, testCase.args.randomCharsLength)
+			alignedIngressHostSubdomain := suite.platform.alignIngressHostSubdomainLevel(testCase.args.host, testCase.args.randomCharsLength)
 			suite.Require().Regexp(testCase.want, alignedIngressHostSubdomain)
 		})
 	}
@@ -1067,7 +1165,7 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithUserNameLabel(
 
 	suite.Logger.DebugWith("Enriching function", "functionName", functionName)
 
-	err := suite.Platform.EnrichFunctionConfig(ctx, &createFunctionOptions.FunctionConfig)
+	err := suite.platform.EnrichFunctionConfig(ctx, &createFunctionOptions.FunctionConfig)
 	suite.Require().NoError(err)
 
 	suite.Require().Equal("some-user", createFunctionOptions.FunctionConfig.Meta.Labels[iguazio.IguzioUsernameLabel])
@@ -1151,7 +1249,7 @@ func (suite *FunctionEventKubePlatformTestSuite) TestGetFunctionEventsPermission
 					Once()
 				defer suite.mockedOpaClient.AssertExpectations(suite.T())
 			}
-			functionEvents, err := suite.Platform.GetFunctionEvents(suite.ctx, &platform.GetFunctionEventsOptions{
+			functionEvents, err := suite.platform.GetFunctionEvents(suite.ctx, &platform.GetFunctionEventsOptions{
 				Meta: platform.FunctionEventMeta{
 					Name:      functionEventName,
 					Namespace: suite.Namespace,
@@ -1253,7 +1351,7 @@ func (suite *FunctionEventKubePlatformTestSuite) TestUpdateFunctionEventPermissi
 				defer suite.nuclioFunctionEventInterfaceMock.AssertExpectations(suite.T())
 			}
 
-			err := suite.Platform.UpdateFunctionEvent(suite.ctx, &platform.UpdateFunctionEventOptions{
+			err := suite.platform.UpdateFunctionEvent(suite.ctx, &platform.UpdateFunctionEventOptions{
 				FunctionEventConfig: platform.FunctionEventConfig{
 					Meta: platform.FunctionEventMeta{
 						Name:      functionEventName,
@@ -1342,7 +1440,7 @@ func (suite *FunctionEventKubePlatformTestSuite) TestDeleteFunctionEventPermissi
 				defer suite.nuclioFunctionEventInterfaceMock.AssertExpectations(suite.T())
 			}
 
-			err := suite.Platform.DeleteFunctionEvent(suite.ctx, &platform.DeleteFunctionEventOptions{
+			err := suite.platform.DeleteFunctionEvent(suite.ctx, &platform.DeleteFunctionEventOptions{
 				Meta: platform.FunctionEventMeta{
 					Name:      functionEventName,
 					Namespace: suite.Namespace,
@@ -1708,7 +1806,7 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayEnrichmentAndValidat
 				if testCase.authSession != nil {
 					suite.ctx = context.WithValue(suite.ctx, auth.AuthSessionContextKey, *testCase.authSession)
 				}
-				suite.Platform.EnrichLabels(suite.ctx, testCase.expectedEnrichedAPIGateway.Meta.Labels)
+				suite.platform.EnrichLabels(suite.ctx, testCase.expectedEnrichedAPIGateway.Meta.Labels)
 			}
 
 			// run test case specific set up function if given
@@ -1718,7 +1816,7 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayEnrichmentAndValidat
 			}
 
 			// run enrichment
-			suite.Platform.enrichAPIGatewayConfig(suite.ctx, testCase.apiGatewayConfig, nil)
+			suite.platform.enrichAPIGatewayConfig(suite.ctx, testCase.apiGatewayConfig, nil)
 			if testCase.expectedEnrichedAPIGateway != nil {
 				suite.Require().Empty(cmp.Diff(testCase.expectedEnrichedAPIGateway, testCase.apiGatewayConfig))
 			}
@@ -1745,7 +1843,7 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayEnrichmentAndValidat
 			}
 
 			// run validation
-			err := suite.Platform.validateAPIGatewayConfig(suite.ctx, testCase.apiGatewayConfig,
+			err := suite.platform.validateAPIGatewayConfig(suite.ctx, testCase.apiGatewayConfig,
 				testCase.validateFunctionsExistence,
 				nil)
 			if testCase.validationError != "" {
@@ -1840,7 +1938,7 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayUpdate() {
 				Once()
 
 			// update
-			err := suite.Platform.UpdateAPIGateway(suite.ctx, updateAPIGatewayOptions)
+			err := suite.platform.UpdateAPIGateway(suite.ctx, updateAPIGatewayOptions)
 			suite.Require().NoError(err)
 		})
 	}

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -153,7 +153,11 @@ func (suite *KubePlatformTestSuite) ResetCRDMocks() {
 	suite.platform.projectsClient, _ = NewProjectsClient(suite.platform, suite.abstractPlatform.Config)
 }
 
-func (suite *FunctionKubePlatformTestSuite) TestGetProjectsCache() {
+type ProjectKubePlatformTestSuite struct {
+	KubePlatformTestSuite
+}
+
+func (suite *ProjectKubePlatformTestSuite) TestGetProjectsCache() {
 	suite.nuclioProjectInterfaceMock.On("Create",
 		suite.ctx,
 		mock.Anything,
@@ -1970,6 +1974,7 @@ func (suite *APIGatewayKubePlatformTestSuite) compileAPIGatewayConfig() platform
 }
 
 func TestKubePlatformTestSuite(t *testing.T) {
+	suite.Run(t, new(ProjectKubePlatformTestSuite))
 	suite.Run(t, new(FunctionKubePlatformTestSuite))
 	suite.Run(t, new(FunctionEventKubePlatformTestSuite))
 	suite.Run(t, new(APIGatewayKubePlatformTestSuite))


### PR DESCRIPTION
We do that to allow unblock get operations because opa manifest distribution may take some time to kick in.

by default 30 seconds expiration is set