### PR TITLE
Fix helm chart external ip address resolution

### DIFF
--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.11.7
+version: 0.11.8
 appVersion: 1.7.9
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/templates/_helpers.tpl
+++ b/hack/k8s/helm/nuclio/templates/_helpers.tpl
@@ -107,3 +107,16 @@ NOTE: make sure to not quote here, because an empty string is false, but a quote
 {{- printf "%s-%s" (include "nuclio.dashboardName" .) .Values.dashboard.opa.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
+
+
+{{- define "nuclio.externalIPAddresses" -}}
+{{- if len .Values.dashboard.externalIPAddresses -}}
+{{- .Values.dashboard.externalIPAddresses | join "," | quote -}}
+{{- else if .Values.global.externalHostAddress -}}
+{{- .Values.global.externalHostAddress  -}}
+{{- else -}}
+# leave empty if no input were given.
+# we resolve external ip address via `kubectl get nodes` or via the kubeconfig host
+{{- "" -}}
+{{- end -}}
+{{- end -}}

--- a/hack/k8s/helm/nuclio/templates/_helpers.tpl
+++ b/hack/k8s/helm/nuclio/templates/_helpers.tpl
@@ -110,10 +110,10 @@ NOTE: make sure to not quote here, because an empty string is false, but a quote
 
 
 {{- define "nuclio.externalIPAddresses" -}}
-{{- if len .Values.dashboard.externalIPAddresses -}}
-{{- .Values.dashboard.externalIPAddresses | join "," | quote -}}
-{{- else if .Values.global.externalHostAddress -}}
+{{- if .Values.global.externalHostAddress -}}
 {{- .Values.global.externalHostAddress  -}}
+{{- else if len .Values.dashboard.externalIPAddresses -}}
+{{- .Values.dashboard.externalIPAddresses | join "," | quote -}}
 {{- else -}}
 # leave empty if no input were given.
 # we resolve external ip address via `kubectl get nodes` or via the kubeconfig host

--- a/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
@@ -49,7 +49,7 @@ spec:
         {{- end }}
         env:
         - name: NUCLIO_CONTROLLER_EXTERNAL_IP_ADDRESSES
-          value: {{ .Values.dashboard.externalIPAddresses | join "," | quote }}
+          value: {{ template "nuclio.externalIPAddresses" . }}
         - name: NUCLIO_CONTROLLER_IMAGE_PULL_SECRETS
           value: {{ template "nuclio.registry.credentialsSecretName" . }}
         - name: NUCLIO_CONTROLLER_CRON_TRIGGER_CRON_JOB_IMAGE_NAME

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -173,7 +173,7 @@ spec:
         - name: NUCLIO_REGISTRY_CREDENTIALS_SECRET_NAME
           value: {{ template "nuclio.registry.credentialsSecretName" . }}
         - name: NUCLIO_DASHBOARD_EXTERNAL_IP_ADDRESSES
-          value: {{ .Values.dashboard.externalIPAddresses | join "," | quote }}
+          value: {{ template "nuclio.externalIPAddresses" . }}
         - name: NUCLIO_DASHBOARD_IMAGE_NAME_PREFIX_TEMPLATE
           value: {{ .Values.dashboard.imageNamePrefixTemplate | quote }}
       {{- if .Values.dashboard.opa.enabled }}

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1146,7 +1146,8 @@ func (p *Platform) GetExternalIPAddresses() ([]string, error) {
 	// try to get an internal IP
 	for _, addressType := range []platform.AddressType{
 		platform.AddressTypeExternalIP,
-		platform.AddressTypeInternalIP} {
+		platform.AddressTypeInternalIP,
+	} {
 
 		for _, node := range nodes {
 			for _, address := range node.GetAddresses() {


### PR DESCRIPTION
Allowing setting the external ip address via ".global" which was ignored for the past few versions.
This PR making sure that the external ip address being injected to dashboard/controller is taking from (the first non empty)
- `global.externalHostAddress`
- `dashboard.externalIPAddresses`
- empty string

NOTE: we try to resolve the external ip address programmatically, if not explicitly given, by:
- checking on the k8s nodes
- using the k8s host