### PR TITLE
Support updating apigateways via specific route

### DIFF
--- a/cmd/dashboard/README.md
+++ b/cmd/dashboard/README.md
@@ -786,6 +786,33 @@ in `metadata.labels`.
       "name": "agw",
       "state": "ready"
     }
+  },
+  "another-gateway": {
+    "metadata": {
+      "name": "another-gateway",
+      "namespace": "nuclio",
+      "labels": {
+        "nuclio.io/project-name": "my-project-1"
+      }
+    },
+    "spec": {
+      "host": "<api-gateway-endpoint>",
+      "name": "another-gateway",
+      "path": "/",
+      "authenticationMode": "accessKey",
+      "upstreams": [
+        {
+          "kind": "nucliofunction",
+          "nucliofunction": {
+            "name": "my-func-2"
+          }
+        }
+      ]
+    },
+    "status": {
+      "name": "another-gateway",
+      "state": "ready"
+    }
   }
 }
 ```
@@ -821,7 +848,7 @@ in `metadata.labels`.
       {
         "kind": "nucliofunction",
         "nucliofunction": {
-          "name": "mu-func-1"
+          "name": "my-func-1"
         }
       }
     ]
@@ -931,9 +958,6 @@ Updating an API gateway is similar to creating an API gateway. The only differen
 #### Request
 
 Invoking an API gateway is done by calling endpoint that is given in the api geteway's `spec.host`  field.
-
-The HTTP method you apply to this endpoint is the one with which dashboard will invoke the function. For example, if
-you `DELETE /api/function_invocations`, the HTTP method in the event as received by the function will be `DELETE`.
 
 * URL: `<Method> <api-gateway-endpoint>`
 * Headers:

--- a/cmd/dashboard/README.md
+++ b/cmd/dashboard/README.md
@@ -5,6 +5,7 @@ Table of contents:
 - [Project](#project)
 - [Function event](#function-event)
 - [Function template](#function-template)
+- [API Gateways](#api-gateways)
 - [V3IO Streams](#v3io-streams)
 - [Misc](#misc)
 
@@ -740,6 +741,232 @@ in `metadata.labels`.
   }
 }
 ```
+
+## API Gateways
+
+### Listing all API gateways
+
+#### Request
+
+* URL: `GET /api/api_gateways`
+* Headers:
+  * `x-nuclio-api-gateway-namespace`: Namespace (required)
+  * `x-nuclio-project-name`: Filter by project name (optional)
+
+#### Response
+
+* Status code: 200
+* Body:
+
+```json
+{
+  "agw": {
+    "metadata": {
+      "name": "agw",
+      "namespace": "nuclio",
+      "labels": {
+        "nuclio.io/project-name": "my-project-1"
+      }
+    },
+    "spec": {
+      "host": "<api-gateway-endpoint>",
+      "name": "agw",
+      "path": "/",
+      "authenticationMode": "none",
+      "upstreams": [
+        {
+          "kind": "nucliofunction",
+          "nucliofunction": {
+            "name": "mu-func-1"
+          }
+        }
+      ]
+    },
+    "status": {
+      "name": "agw",
+      "state": "ready"
+    }
+  }
+}
+```
+
+### Getting an API gateway by name
+
+#### Request
+
+* URL: `GET /api/api_gateways/<api-gateway-name>`
+* Headers:
+  * `x-nuclio-api-gateway-namespace`: Namespace (required)
+
+#### Response
+
+* Status code: 200
+* Body:
+
+```json
+{
+  "metadata": {
+    "name": "agw",
+    "namespace": "nuclio",
+    "labels": {
+      "nuclio.io/project-name": "my-project-1"
+    }
+  },
+  "spec": {
+    "name": "agw",
+    "host": "<api-gateway-endpoint>",
+    "path": "/",
+    "authenticationMode": "none",
+    "upstreams": [
+      {
+        "kind": "nucliofunction",
+        "nucliofunction": {
+          "name": "mu-func-1"
+        }
+      }
+    ]
+  },
+  "status": {
+    "name": "agw",
+    "state": "ready"
+  }
+}
+```
+
+### Creating an API gateway
+
+To create an API gateway, provide the following request and then periodically GET the api gateway until `status.state` is set
+to `ready` or `error`. It is guaranteed that by the time the response is returned, getting the api gateway will yield a
+body and not `404`.
+
+#### Request
+
+* URL: `POST /api/api_gateways`
+* Headers:
+  * `Content-Type`: Must be set to `application/json`
+* Body:
+
+```json
+ {
+  "metadata":{
+    "name":"agw",
+    "labels":{
+      "nuclio.io/project-name":"my-project-1"
+    }
+  },
+  "spec":{
+    "name":"agw",
+    "host": "<api-gateway-endpoint>",
+    "description":"",
+    "path":"",
+    "authenticationMode":"none",
+    "upstreams":[
+      {
+        "kind":"nucliofunction",
+        "nucliofunction":{
+          "name":"my-func-1"
+        },
+        "percentage":0
+      }
+    ]
+  }
+}
+```
+
+#### Response
+
+* Status code: 202
+
+### Updating an API gateway
+
+Updating an API gateway is similar to creating an API gateway. The only differences are:
+
+* The method is `PUT` rather than `POST`
+* You must provide certain fields to change, such as `spec.description`, `spec.path` and `spec.authenticationMode`.
+
+#### Request
+
+* URL: `PUT /api/api_gateways/<api-gateway-name>`
+* Headers:
+  * `Content-Type`: Must be set to `application/json`
+* Body:
+
+```json
+{
+  "metadata": {
+    "name": "agw",
+    "namespace": "nuclio",
+    "labels": {
+      "nuclio.io/project-name": "my-project-1"
+    }
+  },
+  "spec": {
+    "name": "agw",
+    "host": "<api-gateway-endpoint>",
+    "path": "new-agw-path",
+    "authenticationMode": "basic",
+    "upstreams": [
+      {
+        "kind": "nucliofunction",
+        "nucliofunction": {
+          "name": "my-func-1"
+        }
+      }
+    ],
+    "description": "new description"
+  },
+  "status": {
+    "name": "agw",
+    "state": "ready"
+  }
+}
+```
+
+#### Response
+
+* Status code: 204
+
+### Invoking an API gateway
+
+#### Request
+
+Invoking an API gateway is done by calling endpoint that is given in the api geteway's `spec.host`  field.
+
+The HTTP method you apply to this endpoint is the one with which dashboard will invoke the function. For example, if
+you `DELETE /api/function_invocations`, the HTTP method in the event as received by the function will be `DELETE`.
+
+* URL: `<Method> <api-gateway-endpoint>`
+* Headers:
+  * Any header is passed transparently to the function
+* Body: Raw body passed as is to the function
+
+#### Response
+
+* Status code: As returned by the function
+* Headers:As returned by the function
+* Body: As returned by the function
+
+### Deleting an API gateway
+
+#### Request
+
+* URL: `DELETE /api/api_gateways`
+* Headers:
+  * `Content-Type`: Must be set to `application/json`
+* Body:
+
+```json
+{
+  "metadata":{
+    "name":"<api-gateway-name>"
+  }
+}
+```
+
+#### Response
+
+* Status code: 204
+
 
 ## V3IO Streams
 

--- a/pkg/dashboard/resource/apigateway.go
+++ b/pkg/dashboard/resource/apigateway.go
@@ -156,8 +156,13 @@ func (agr *apiGatewayResource) Update(request *http.Request, id string) (restful
 	// get api gateway config and status from body
 	apiGatewayInfo, err := agr.getAPIGatewayInfoFromRequest(request)
 	if err != nil {
-		agr.Logger.WarnWithCtx(ctx, "Failed to get api gateway config and status from body", "err", err)
-		return nil, nuclio.WrapErrBadRequest(errors.Wrap(err, "Failed to parse JSON body"))
+		agr.Logger.WarnWithCtx(ctx,"Failed to get api gateway from request", "err", err.Error())
+		return nil, errors.Wrap(err, "Failed to get api gateway from request")
+	}
+
+	// enrich name with id if empty
+	if apiGatewayInfo.Meta.Name == "" {
+		apiGatewayInfo.Meta.Name = id
 	}
 
 	if id != apiGatewayInfo.Meta.Name {
@@ -176,7 +181,7 @@ func (agr *apiGatewayResource) Update(request *http.Request, id string) (restful
 		ValidateFunctionsExistence: agr.headerValueIsTrue(request, "x-nuclio-agw-validate-functions-existence"),
 	}); err != nil {
 		agr.Logger.WarnWithCtx(ctx, "Failed to update api gateway", "err", err)
-		return nil, nuclio.WrapErrInternalServerError(errors.Wrap(err, "Failed to update api gateway"))
+		return nil, errors.Wrap(err, "Failed to update api gateway")
 	}
 
 	return nil, nil

--- a/pkg/dashboard/resource/apigateway.go
+++ b/pkg/dashboard/resource/apigateway.go
@@ -156,7 +156,7 @@ func (agr *apiGatewayResource) Update(request *http.Request, id string) (restful
 	// get api gateway config and status from body
 	apiGatewayInfo, err := agr.getAPIGatewayInfoFromRequest(request)
 	if err != nil {
-		agr.Logger.WarnWithCtx(ctx,"Failed to get api gateway from request", "err", err.Error())
+		agr.Logger.WarnWithCtx(ctx, "Failed to get api gateway from request", "err", err.Error())
 		return nil, errors.Wrap(err, "Failed to get api gateway from request")
 	}
 

--- a/pkg/dashboard/resource/apigateway.go
+++ b/pkg/dashboard/resource/apigateway.go
@@ -14,6 +14,7 @@ limitations under the License.
 package resource
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -144,7 +145,8 @@ func (agr *apiGatewayResource) Create(request *http.Request) (string, restful.At
 	return agr.createAPIGateway(request, apiGatewayInfo)
 }
 
-func (agr *apiGatewayResource) updateAPIGateway(request *http.Request) (*restful.CustomRouteFuncResponse, error) {
+// Update an api gateway
+func (agr *apiGatewayResource) Update(request *http.Request, id string) (restful.Attributes, error) {
 	ctx, cancelCtx := context.WithCancel(nucliocontext.NewDetached(request.Context()))
 	defer cancelCtx()
 
@@ -155,11 +157,11 @@ func (agr *apiGatewayResource) updateAPIGateway(request *http.Request) (*restful
 	apiGatewayInfo, err := agr.getAPIGatewayInfoFromRequest(request)
 	if err != nil {
 		agr.Logger.WarnWithCtx(ctx, "Failed to get api gateway config and status from body", "err", err)
+		return nil, nuclio.WrapErrBadRequest(errors.Wrap(err, "Failed to parse JSON body"))
+	}
 
-		return &restful.CustomRouteFuncResponse{
-			Single:     true,
-			StatusCode: http.StatusBadRequest,
-		}, err
+	if id != apiGatewayInfo.Meta.Name {
+		return nil, nuclio.NewErrBadRequest("Api gateway name is different from request id")
 	}
 
 	apiGatewayConfig := &platform.APIGatewayConfig{
@@ -174,13 +176,47 @@ func (agr *apiGatewayResource) updateAPIGateway(request *http.Request) (*restful
 		ValidateFunctionsExistence: agr.headerValueIsTrue(request, "x-nuclio-agw-validate-functions-existence"),
 	}); err != nil {
 		agr.Logger.WarnWithCtx(ctx, "Failed to update api gateway", "err", err)
+		return nil, nuclio.WrapErrInternalServerError(errors.Wrap(err, "Failed to update api gateway"))
 	}
+
+	return nil, nil
+}
+
+// TODO: deprecate this custom route
+func (agr *apiGatewayResource) updateAPIGateway(request *http.Request) (*restful.CustomRouteFuncResponse, error) {
+
+	ctx := request.Context()
+	agr.Logger.WarnWithCtx(ctx, "Updating api gateways via /api/apigateways has been deprecated. "+
+		"Please use /api/apigateways/<apigateway-name>")
+
+	// get api gateway id from body
+	body, err := ioutil.ReadAll(request.Body)
+	if err != nil {
+		return nil, nuclio.WrapErrInternalServerError(errors.Wrap(err, "Failed to read body"))
+	}
+
+	apiGatewayInfoInstance := apiGatewayInfo{}
+	if err = json.Unmarshal(body, &apiGatewayInfoInstance); err != nil {
+		return nil, nuclio.WrapErrBadRequest(errors.Wrap(err, "Failed to parse JSON body"))
+	}
+	apiGatewayId := apiGatewayInfoInstance.Meta.Name
+
+	// retrieve request body so next handler can read it
+	request.Body.Close() // nolint: errcheck
+	request.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+
+	// update api gateway
+	_, err = agr.Update(request, apiGatewayId)
 
 	// return the stuff
 	return &restful.CustomRouteFuncResponse{
 		ResourceType: "apiGateway",
 		Single:       true,
 		StatusCode:   common.ResolveErrorStatusCodeOrDefault(err, http.StatusNoContent),
+		Headers: map[string]string{
+			"Deprecation": "true",
+			"Link":        fmt.Sprintf("</api/apigateways/%s>; rel=\"alternate\"", apiGatewayId),
+		},
 	}, err
 }
 
@@ -191,6 +227,8 @@ func (agr *apiGatewayResource) GetCustomRoutes() ([]restful.CustomRoute, error) 
 	// we need to register custom routes
 	return []restful.CustomRoute{
 		{
+
+			// TODO: deprecate this custom route
 			Pattern:   "/",
 			Method:    http.MethodPut,
 			RouteFunc: agr.updateAPIGateway,

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -3001,7 +3001,7 @@ func (suite *apiGatewayTestSuite) TestUpdateSuccessful() {
   }`
 
 	suite.sendRequest("PUT",
-		"/api/api_gateways",
+		"/api/api_gateways/agw2",
 		nil,
 		bytes.NewBufferString(requestBody),
 		&expectedStatusCode,


### PR DESCRIPTION
Enable updating apigateways using a specific endpoint:
```
PUT <dashboard-url>/api/apigateways/<apigateway-name>
```

And deprecate updating apigateways via a general and point:
```
PUT <dashboard-url>/api/apigateways/
```

w.r.t https://jira.iguazeng.com/browse/IG-20264 