### PR TITLE
Add retries to OPA permission queries

### DIFF
--- a/pkg/opa/http.go
+++ b/pkg/opa/http.go
@@ -111,7 +111,7 @@ func (c *HTTPClient) QueryPermissionsMultiResources(resources []string,
 	}
 	var responseBody []byte
 	err = common.RetryUntilSuccessful(6*time.Second,
-		2*time.Second,
+		1*time.Second,
 		func() bool {
 			responseBody, _, err = common.SendHTTPRequest(c.httpClient,
 				http.MethodPost,
@@ -190,7 +190,7 @@ func (c *HTTPClient) QueryPermissions(resource string,
 	}
 	var responseBody []byte
 	err = common.RetryUntilSuccessful(6*time.Second,
-		2*time.Second,
+		1*time.Second,
 		func() bool {
 			responseBody, _, err = common.SendHTTPRequest(c.httpClient,
 				http.MethodPost,

--- a/pkg/opa/http.go
+++ b/pkg/opa/http.go
@@ -109,13 +109,24 @@ func (c *HTTPClient) QueryPermissionsMultiResources(resources []string,
 			"requestBody", string(requestBody),
 			"requestURL", requestURL)
 	}
-	responseBody, _, err := common.SendHTTPRequest(c.httpClient,
-		http.MethodPost,
-		requestURL,
-		requestBody,
-		headers,
-		[]*http.Cookie{},
-		http.StatusOK)
+	var responseBody []byte
+	err = common.RetryUntilSuccessful(6*time.Second,
+		2*time.Second,
+		func() bool {
+			responseBody, _, err = common.SendHTTPRequest(c.httpClient,
+				http.MethodPost,
+				requestURL,
+				requestBody,
+				headers,
+				[]*http.Cookie{},
+				http.StatusOK)
+			if err != nil {
+				c.logger.WarnWith("Failed to send HTTP request to OPA, retrying",
+					"err", err)
+				return false
+			}
+			return true
+		})
 	if err != nil {
 		if c.logLevel > 5 {
 			c.logger.ErrorWith("Failed to send HTTP request to OPA",
@@ -177,13 +188,24 @@ func (c *HTTPClient) QueryPermissions(resource string,
 			"requestBody", string(requestBody),
 			"requestURL", requestURL)
 	}
-	responseBody, _, err := common.SendHTTPRequest(c.httpClient,
-		http.MethodPost,
-		requestURL,
-		requestBody,
-		headers,
-		[]*http.Cookie{},
-		http.StatusOK)
+	var responseBody []byte
+	err = common.RetryUntilSuccessful(6*time.Second,
+		2*time.Second,
+		func() bool {
+			responseBody, _, err = common.SendHTTPRequest(c.httpClient,
+				http.MethodPost,
+				requestURL,
+				requestBody,
+				headers,
+				[]*http.Cookie{},
+				http.StatusOK)
+			if err != nil {
+				c.logger.WarnWith("Failed to send HTTP request to OPA, retrying",
+					"err", err)
+				return false
+			}
+			return true
+		})
 	if err != nil {
 		if c.logLevel > 5 {
 			c.logger.ErrorWith("Failed to send HTTP request to OPA",

--- a/pkg/opa/http.go
+++ b/pkg/opa/http.go
@@ -122,7 +122,7 @@ func (c *HTTPClient) QueryPermissionsMultiResources(resources []string,
 				http.StatusOK)
 			if err != nil {
 				c.logger.WarnWith("Failed to send HTTP request to OPA, retrying",
-					"err", err)
+					"err", err.Error())
 				return false
 			}
 			return true
@@ -201,7 +201,7 @@ func (c *HTTPClient) QueryPermissions(resource string,
 				http.StatusOK)
 			if err != nil {
 				c.logger.WarnWith("Failed to send HTTP request to OPA, retrying",
-					"err", err)
+					"err", err.Error())
 				return false
 			}
 			return true


### PR DESCRIPTION
Some requests that require permissions fail due to unstable OPA behavior.
Retrying on HTTP requests to OPA should fix this issue.

Related JIRA: https://jira.iguazeng.com/browse/IG-19671 