### PR TITLE
IG-20345 - add support for project update by id

### DIFF
--- a/cmd/dashboard/README.md
+++ b/cmd/dashboard/README.md
@@ -392,11 +392,11 @@ UUID is generated.
 
 * Status code: 201
 
-### Updating a project
+### Updating a project by name
 
 #### Request
 
-* URL: `PUT /api/projects`
+* URL: `PUT /api/projects/<project-name>`
 * Headers:
     * `Content-Type`: Must be set to `application/json`
 * Body:

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resource
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -25,6 +26,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/common"
 	nucliocontext "github.com/nuclio/nuclio/pkg/context"
 	"github.com/nuclio/nuclio/pkg/dashboard"
@@ -158,6 +160,53 @@ func (pr *projectResource) Create(request *http.Request) (id string, attributes 
 	}
 
 	return pr.createProject(request, projectInfo)
+}
+
+// Update a project
+func (pr *projectResource) Update(request *http.Request, id string) (restful.Attributes, error) {
+	ctx, cancelCtx := context.WithCancel(nucliocontext.NewDetached(request.Context()))
+	defer cancelCtx()
+
+	// inject auth session to new context
+	ctx = context.WithValue(ctx, auth.AuthSessionContextKey, pr.getCtxSession(ctx))
+
+	// get project config and status from body
+	projectInfo, err := pr.getProjectInfoFromRequest(request)
+	if err != nil {
+		pr.Logger.WarnWithCtx(ctx, "Failed to get project config and status from body", "err", err)
+		return nil, errors.Wrap(err, "Failed to get project from request")
+	}
+
+	// enrich name with id if empty
+	if projectInfo.Meta.Name == "" {
+		projectInfo.Meta.Name = id
+	}
+
+	if id != projectInfo.Meta.Name {
+		return nil, nuclio.NewErrBadRequest("Project name is different from request id")
+	}
+
+	requestOrigin, sessionCookie := pr.getRequestOriginAndSessionCookie(request)
+
+	if err := pr.getPlatform().UpdateProject(ctx, &platform.UpdateProjectOptions{
+		ProjectConfig: platform.ProjectConfig{
+			Meta: *projectInfo.Meta,
+			Spec: *projectInfo.Spec,
+		},
+		AuthSession:   pr.getCtxSession(ctx),
+		RequestOrigin: requestOrigin,
+		SessionCookie: sessionCookie,
+		PermissionOptions: opa.PermissionOptions{
+			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
+		},
+	}); err != nil {
+		if statusCode := common.ResolveErrorStatusCodeOrDefault(err, http.StatusInternalServerError); statusCode > 300 {
+			pr.Logger.WarnWithCtx(ctx, "Failed to update project",
+				"err", errors.GetErrorStackString(err, 10))
+		}
+	}
+
+	return nil, nil
 }
 
 // GetCustomRoutes returns a list of custom routes for the resource
@@ -654,45 +703,34 @@ func (pr *projectResource) deleteProject(request *http.Request) (*restful.Custom
 }
 
 func (pr *projectResource) updateProject(request *http.Request) (*restful.CustomRouteFuncResponse, error) {
-	ctx := nucliocontext.NewDetached(request.Context())
-	statusCode := http.StatusNoContent
 
-	// get project config and status from body
-	projectInfo, err := pr.getProjectInfoFromRequest(request)
+	// get project id from body
+	body, err := ioutil.ReadAll(request.Body)
 	if err != nil {
-		pr.Logger.WarnWithCtx(ctx, "Failed to get project config and status from body", "err", err)
-		return &restful.CustomRouteFuncResponse{
-			Single:     true,
-			StatusCode: http.StatusBadRequest,
-		}, err
+		return nil, errors.Wrap(err, "Failed to read body")
 	}
 
-	requestOrigin, sessionCookie := pr.getRequestOriginAndSessionCookie(request)
-
-	if err := pr.getPlatform().UpdateProject(ctx, &platform.UpdateProjectOptions{
-		ProjectConfig: platform.ProjectConfig{
-			Meta: *projectInfo.Meta,
-			Spec: *projectInfo.Spec,
-		},
-		AuthSession:   pr.getCtxSession(ctx),
-		RequestOrigin: requestOrigin,
-		SessionCookie: sessionCookie,
-		PermissionOptions: opa.PermissionOptions{
-			OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
-		},
-	}); err != nil {
-		statusCode = common.ResolveErrorStatusCodeOrDefault(err, http.StatusInternalServerError)
-		if statusCode > 300 {
-			pr.Logger.WarnWithCtx(ctx, "Failed to update project",
-				"err", errors.GetErrorStackString(err, 10))
-		}
+	projectInfoInstance := projectInfo{}
+	if err = json.Unmarshal(body, &projectInfoInstance); err != nil {
+		return nil, errors.Wrap(err, "Failed to parse JSON body")
 	}
+	projectId := projectInfoInstance.Meta.Name
 
-	// return the stuff
+	// retrieve request body so next handler can read it
+	request.Body.Close() // nolint: errcheck
+	request.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+
+	// update project
+	_, err = pr.Update(request, projectId)
+
 	return &restful.CustomRouteFuncResponse{
 		ResourceType: "project",
 		Single:       true,
-		StatusCode:   statusCode,
+		StatusCode:   common.ResolveErrorStatusCodeOrDefault(err, http.StatusNoContent),
+		Headers: map[string]string{
+			"Deprecation": "true",
+			"Link":        fmt.Sprintf("</api/projects/%s>; rel=\"alternate\"", projectId),
+		},
 	}, err
 }
 
@@ -715,7 +753,7 @@ func (pr *projectResource) getProjectInfoFromRequest(request *http.Request) (*pr
 	// read body
 	body, err := ioutil.ReadAll(request.Body)
 	if err != nil {
-		return nil, nuclio.WrapErrInternalServerError(errors.Wrap(err, "Failed to read body"))
+		return nil, errors.Wrap(err, "Failed to read body")
 	}
 
 	projectInfoInstance := projectInfo{}
@@ -724,7 +762,7 @@ func (pr *projectResource) getProjectInfoFromRequest(request *http.Request) (*pr
 	}
 
 	if err := pr.processProjectInfo(&projectInfoInstance); err != nil {
-		return nil, nuclio.WrapErrBadRequest(errors.Wrap(err, "Failed to process project info"))
+		return nil, errors.Wrap(err, "Failed to process project info")
 	}
 
 	return &projectInfoInstance, nil
@@ -815,6 +853,7 @@ var projectResourceInstance = &projectResource{
 		restful.ResourceMethodGetList,
 		restful.ResourceMethodGetDetail,
 		restful.ResourceMethodCreate,
+		restful.ResourceMethodUpdate,
 	}),
 }
 

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -716,7 +716,7 @@ func (pr *projectResource) updateProject(request *http.Request) (*restful.Custom
 	}
 
 	projectInfoInstance := projectInfo{}
-	if err = json.Unmarshal(body, &projectInfoInstance); err != nil {
+	if err := json.Unmarshal(body, &projectInfoInstance); err != nil {
 		return nil, errors.Wrap(err, "Failed to parse JSON body")
 	}
 

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/common"
 	nucliocontext "github.com/nuclio/nuclio/pkg/context"
 	"github.com/nuclio/nuclio/pkg/dashboard"
@@ -164,11 +163,7 @@ func (pr *projectResource) Create(request *http.Request) (id string, attributes 
 
 // Update a project
 func (pr *projectResource) Update(request *http.Request, id string) (restful.Attributes, error) {
-	ctx, cancelCtx := context.WithCancel(nucliocontext.NewDetached(request.Context()))
-	defer cancelCtx()
-
-	// inject auth session to new context
-	ctx = context.WithValue(ctx, auth.AuthSessionContextKey, pr.getCtxSession(ctx))
+	ctx := nucliocontext.NewDetached(request.Context())
 
 	// get project config and status from body
 	projectInfo, err := pr.getProjectInfoFromRequest(request)

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -702,7 +702,12 @@ func (pr *projectResource) deleteProject(request *http.Request) (*restful.Custom
 	}, nil
 }
 
+// TODO: deprecate this custom route
 func (pr *projectResource) updateProject(request *http.Request) (*restful.CustomRouteFuncResponse, error) {
+
+	ctx := request.Context()
+	pr.Logger.WarnWithCtx(ctx, "Updating api gateways via /api/projects has been deprecated. "+
+		"Please use /api/projects/<project-name>")
 
 	// get project id from body
 	body, err := ioutil.ReadAll(request.Body)

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -714,7 +714,11 @@ func (pr *projectResource) updateProject(request *http.Request) (*restful.Custom
 	if err = json.Unmarshal(body, &projectInfoInstance); err != nil {
 		return nil, errors.Wrap(err, "Failed to parse JSON body")
 	}
-	projectId := projectInfoInstance.Meta.Name
+
+	projectId := request.Header.Get("x-nuclio-project-name")
+	if projectInfoInstance.Meta != nil && projectInfoInstance.Meta.Name != "" {
+		projectId = projectInfoInstance.Meta.Name
+	}
 
 	// retrieve request body so next handler can read it
 	request.Body.Close() // nolint: errcheck

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -35,7 +35,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/dashboard"
 	"github.com/nuclio/nuclio/pkg/dashboard/functiontemplates"
@@ -51,6 +50,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/nuclio/logger"
+	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/api/core/v1"

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -50,7 +50,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
-	nucliozap "github.com/nuclio/zap"
+	"github.com/nuclio/zap"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/api/core/v1"
@@ -105,7 +105,7 @@ func (suite *dashboardTestSuite) SetupTest() {
 		panic("Failed to create server")
 	}
 
-	// create a http server from the dashboard server
+	// create an HTTP server from the dashboard server
 	suite.httpServer = httptest.NewServer(suite.dashboardServer.Router)
 }
 

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -27,7 +27,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	nucliozap "github.com/nuclio/zap"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -47,6 +46,7 @@ import (
 	mockplatform "github.com/nuclio/nuclio/pkg/platform/mock"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/restful"
+	nucliozap "github.com/nuclio/zap"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -45,12 +45,12 @@ import (
 	mockplatform "github.com/nuclio/nuclio/pkg/platform/mock"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/restful"
-	nucliozap "github.com/nuclio/zap"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
+	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/api/core/v1"

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -27,7 +27,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/nuclio/nuclio-sdk-go"
 	nucliozap "github.com/nuclio/zap"
 	"io"
 	"io/ioutil"
@@ -37,6 +36,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/dashboard"
 	"github.com/nuclio/nuclio/pkg/dashboard/functiontemplates"


### PR DESCRIPTION
Enable updating projects using a specific endpoint:
`PUT <dashboard-url>/api/projects/<project-name>
`

And deprecate updating projects via a general and point:
`PUT <dashboard-url>/api/projects/
`

https://jira.iguazeng.com/browse/IG-20345