### PR TITLE
Python - decode utf8 characters by default

### DIFF
--- a/docs/reference/runtimes/python/python-reference.md
+++ b/docs/reference/runtimes/python/python-reference.md
@@ -110,9 +110,17 @@ Key differences and changes:
 
 - Python 3.8+ is 5%-8% faster than Python 3.6 for small sized event messages.
 - Python 3.7, 3.8 and 3.9 base images are `python:3.7`, `python:3.8` and `python:3.9`, respectively.
-- Events metadata, such as headers, path, method, etc are now byte-strings. This may incur changes in your code to refer
-  to the various (now) byte-string event properties correctly in the new runtimes. e.g.: Simple code snipped which
-  worked on python 2.7 and 3.6, using some event metadata, such as `event.path` -
+
+In Python 3.7+ runtimes, events metadata, such as headers, path, method, etc can be decoded as byte-strings. 
+This may incur changes in your code to refer to the various (now) byte-string event properties correctly in the new runtimes. 
+e.g.: Simple code snipped which worked on python 2.7 and 3.6, using some event metadata, such as `event.path`
+
+To disable the utf8 decoding, set the function environment variable: `NUCLIO_PYTHON_DECODE_EVENT_STRINGS` to `disabled`.
+
+Once disabled, your function behavior would change as the event metadata fields are not decoded and served as byte-string.
+E.g.:
+
+Instead of -
 
   ```python
   def handler(context, event):
@@ -120,8 +128,7 @@ Key differences and changes:
       return "I'm doing something..."
   ```
 
-  In Python 3.7+ runtimes, the matching `event.path` property is now a `byte-string` instead of an old `string`,
-  The new snippet will look like this:
+The new snippet would be looking like this:
 
   ```python
   def handler(context, event):
@@ -129,12 +136,8 @@ Key differences and changes:
       return "I'm doing something..."
   ```
 
-  > Note: To decode all incoming event byte-strings automatically by the nuclio python wrapper, set the function
-  > environment variable: `NUCLIO_PYTHON_DECODE_EVENT_STRINGS=true`. Enabling event strings decoding the Nuclio python
-  > wrapper might fail to handle events with non-utf8 metadata contents. Part of the motivation for the change was
-  > to gain robustness against such cases and transfer the encoding task to user-code.
-
-> Note: Python 3.6 runtimes is left unchanged.
+  > Note: To disable decoding to all incoming events to byte-strings, set the function environment variable: `NUCLIO_PYTHON_DECODE_EVENT_STRINGS=false`.
+  > Not disabling event strings decoding means that the Nuclio python wrapper might fail to handle events with non-utf8 metadata contents.
 
 <a id="function-configuration"></a>
 ## Function configuration

--- a/pkg/processor/build/runtime/python/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/python/docker/onbuild/Dockerfile
@@ -16,6 +16,7 @@ ARG NUCLIO_LABEL=latest
 ARG NUCLIO_ARCH=amd64
 ARG NUCLIO_DOCKER_REPO=quay.io/nuclio
 
+# Deprecated
 # Supplies python 3.6 & common wheels
 FROM gcr.io/iguazio/python:3.6 as python36-builder
 

--- a/pkg/processor/runtime/python/runtime.go
+++ b/pkg/processor/runtime/python/runtime.go
@@ -185,21 +185,9 @@ func (py *python) resolveDecodeEvents() bool {
 	// switch case for explicitness
 	// do not resolve empty or null-able values as false/true for forward/backwards compatibility
 	switch strings.ToLower(os.Getenv("NUCLIO_PYTHON_DECODE_EVENT_STRINGS")) {
-	case "true":
-		return true
-	case "false":
+	case "no", "false", "disable", "disabled":
 		return false
-	}
-
-	// resolve by runtime version
-	switch _, runtimeVersion := common.GetRuntimeNameAndVersion(py.configuration.Spec.Runtime); runtimeVersion {
-
-	// python is an alias to 3.6 and hence, versionless runtime is assumed to be python3.6
-	case "", "3.6":
-
-		// backwards compatibility
-		return true
 	default:
-		return false
+		return true
 	}
 }


### PR DESCRIPTION
Following #2087 and its breaking change it introduced by not decoding utf8, we have decided to perform a breaking change by aligning python 3.7+ with python 3.6 behavior to allow seamless upgrade between runtimes.

