### PR TITLE
Bugfix - silent failure on function deployment - continue

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -293,7 +293,7 @@ func (fr *functionResource) storeAndDeployFunction(request *http.Request,
 	case <-creationStateUpdatedChan:
 		break
 	case errDeploying := <-errDeployingChan:
-		return errors.RootCause(errDeploying)
+		return errors.Wrapf(errDeploying, "Failed to deploy function %s", functionInfo.Meta.Name)
 	case <-time.After(creationStateUpdatedTimeout):
 		return nuclio.NewErrInternalServerError("Timed out waiting for creation state to be set")
 	}


### PR DESCRIPTION
Continuing https://github.com/nuclio/nuclio/pull/2195 with a small twist. return the entire err stack instead of wrapping to avoid err with status code being ignored

Thanks to @omesser ❤️ 