### PR TITLE
Preemption modes - Add prevent

### DIFF
--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -176,7 +176,7 @@ func (fsr *frontendSpecResource) resolveDefaultFunctionPreemptionMode() function
 	var defaultPreemptionMode functionconfig.RunOnPreemptibleNodeMode
 	if dashboardServer, ok := fsr.resource.GetServer().(*dashboard.Server); ok {
 		if dashboardServer.GetPlatformConfiguration().Kube.PreemptibleNodes != nil {
-			defaultPreemptionMode = functionconfig.RunOnPreemptibleNodesPrevent
+			defaultPreemptionMode = dashboardServer.GetPlatformConfiguration().Kube.PreemptibleNodes.DefaultMode
 		}
 	}
 	return defaultPreemptionMode

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -113,6 +113,7 @@ func (fsr *frontendSpecResource) getDefaultFunctionConfig() map[string]interface
 	defaultFunctionTolerations := fsr.resolveDefaultFunctionTolerations()
 	defaultFunctionPriorityClassName := fsr.resolveDefaultFunctionPriorityClassName()
 	defaultServiceType := fsr.resolveDefaultServiceType()
+	defaultPreemptionMode := fsr.resolveDefaultFunctionPreemptionMode()
 	defaultHTTPTrigger := functionconfig.GetDefaultHTTPTrigger()
 	defaultHTTPTrigger.WorkerAvailabilityTimeoutMilliseconds = &defaultWorkerAvailabilityTimeoutMilliseconds
 	defaultHTTPTrigger.Attributes = map[string]interface{}{
@@ -127,6 +128,7 @@ func (fsr *frontendSpecResource) getDefaultFunctionConfig() map[string]interface
 		PriorityClassName:       defaultFunctionPriorityClassName,
 		Tolerations:             defaultFunctionTolerations,
 		TargetCPU:               abstract.DefaultTargetCPU,
+		PreemptionMode:          defaultPreemptionMode,
 		Triggers: map[string]functionconfig.Trigger{
 
 			// this trigger name starts with the prefix "default" and should be used as a default http trigger
@@ -168,6 +170,16 @@ func (fsr *frontendSpecResource) resolveDefaultServiceType() v1.ServiceType {
 		defaultServiceType = dashboardServer.GetPlatformConfiguration().Kube.DefaultServiceType
 	}
 	return defaultServiceType
+}
+
+func (fsr *frontendSpecResource) resolveDefaultFunctionPreemptionMode() functionconfig.RunOnPreemptibleNodeMode {
+	var defaultPreemptionMode functionconfig.RunOnPreemptibleNodeMode
+	if dashboardServer, ok := fsr.resource.GetServer().(*dashboard.Server); ok {
+		if dashboardServer.GetPlatformConfiguration().Kube.PreemptibleNodes != nil {
+			defaultPreemptionMode = functionconfig.RunOnPreemptibleNodesPrevent
+		}
+	}
+	return defaultPreemptionMode
 }
 
 func (fsr *frontendSpecResource) resolveFunctionReadinessTimeoutSeconds() int {

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -594,8 +594,8 @@ func (c *Config) PruneAffinityNodeSelectorRequirement(nodeSelectorRequirements [
 							nodeSelectorRequirement.Operator == expression.Operator &&
 							reflect.DeepEqual(nodeSelectorRequirement.Values, expression.Values) {
 
-							// slice expression
-							nodeSelector.NodeSelectorTerms[termIdx].MatchExpressions = append(
+							// slice expressions
+							nodeSelector.NodeSelectorTerms[termIdx].MatchExpressions = append( // nolint: gocritic
 								term.MatchExpressions[:expressionIndex],
 								term.MatchExpressions[expressionIndex+1:]...,
 							)

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -886,6 +886,13 @@ func (lc *lazyClient) createOrUpdateDeployment(ctx context.Context,
 		deployment.Spec.Template.Spec.PriorityClassName = function.Spec.PriorityClassName
 		deployment.Spec.Template.Spec.PreemptionPolicy = function.Spec.PreemptionPolicy
 
+		// apply when provided
+		if imagePullSecrets != "" {
+			deployment.Spec.Template.Spec.ImagePullSecrets = []v1.LocalObjectReference{
+				{Name: imagePullSecrets},
+			}
+		}
+
 		// enrich deployment spec with default fields that were passed inside the platform configuration
 		// performed on update too, in case the platform config has been modified after the creation of this deployment
 		if err := lc.enrichDeploymentFromPlatformConfiguration(function, deployment, method); err != nil {

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1284,6 +1284,17 @@ func (p *Platform) enrichFunctionsWithAPIGateways(ctx context.Context, functions
 	return nil
 }
 
+// enrichFunctionPreemptionSpec - Enriches function pod with the below described spec. if no platformConfiguration related
+// configuration is given, do nothing.
+// 	`Allow` 	- Adds Tolerations / GPU Tolerations if taints were given. otherwise, assume pods can be scheduled on preemptible nodes.
+//                > Purges any `affinity` / `anti-affinity` preemption related configuration
+// 	`Constrain` - Uses node-affinity to make sure pods are assigned using OR on the given node label selectors.
+//                > Uses `Allow` configuration as well.
+//                > Purges any `anti-affinity` preemption related configuration
+// 	`Prevent`	- Prevention is done either using taints (if Tolerations were given) or anti-affinity.
+//                > Purges any `tolerations` / `gpuTolerations` preemption related configuration
+//                > Purges any `affinity` preemption related configuration
+//                > Adds anti-affinity IF no tolerations were given
 func (p *Platform) enrichFunctionPreemptionSpec(ctx context.Context,
 	preemptibleNodes *platformconfig.PreemptibleNodes,
 	functionConfig *functionconfig.Config,
@@ -1321,6 +1332,7 @@ func (p *Platform) enrichFunctionPreemptionSpec(ctx context.Context,
 		functionConfig.PruneTolerations(preemptibleNodes.Tolerations)
 		functionConfig.PruneTolerations(preemptibleNodes.GPUTolerations)
 
+		// if tolerations were given, purge `affinity` preemption related configuration
 		if preemptibleNodes.Tolerations != nil {
 			functionConfig.
 				PruneAffinityNodeSelectorRequirement(
@@ -1331,10 +1343,12 @@ func (p *Platform) enrichFunctionPreemptionSpec(ctx context.Context,
 			break
 		}
 
+		// initial affinity
 		if functionConfig.Spec.Affinity == nil {
 			functionConfig.Spec.Affinity = &v1.Affinity{}
 		}
 
+		// initial node affinity
 		if functionConfig.Spec.Affinity.NodeAffinity == nil {
 			functionConfig.Spec.Affinity.NodeAffinity = &v1.NodeAffinity{}
 		}
@@ -1352,16 +1366,20 @@ func (p *Platform) enrichFunctionPreemptionSpec(ctx context.Context,
 
 	case functionconfig.RunOnPreemptibleNodesConstrain:
 
-		// add tolerations in case node is tainted
+		// enrich with tolerations
 		functionConfig.EnrichWithTolerations(preemptibleNodes.Tolerations)
+
+		// in case function pod requires gpu resource(s), enrich with gpu tolerations
 		if functionConfig.Spec.PositiveGPUResourceLimit() {
 			functionConfig.EnrichWithTolerations(preemptibleNodes.GPUTolerations)
 		}
 
+		// initial affinity
 		if functionConfig.Spec.Affinity == nil {
 			functionConfig.Spec.Affinity = &v1.Affinity{}
 		}
 
+		// initial node affinity
 		if functionConfig.Spec.Affinity.NodeAffinity == nil {
 			functionConfig.Spec.Affinity.NodeAffinity = &v1.NodeAffinity{}
 		}
@@ -1379,25 +1397,27 @@ func (p *Platform) enrichFunctionPreemptionSpec(ctx context.Context,
 
 	case functionconfig.RunOnPreemptibleNodesAllow:
 
-		switch previousPreemptionMode {
-		case functionconfig.RunOnPreemptibleNodesConstrain:
-			functionConfig.
-				PruneAffinityNodeSelectorRequirement(
-					preemptibleNodes.CompileAffinityByLabelSelector(v1.NodeSelectorOpIn))
-		case functionconfig.RunOnPreemptibleNodesPrevent:
-			functionConfig.
-				PruneAffinityNodeSelectorRequirement(
-					preemptibleNodes.CompileAffinityByLabelSelector(v1.NodeSelectorOpNotIn))
-		}
+		// purges any `affinity` / `anti-affinity` preemption related configuration
+		// remove anti-affinity
+		functionConfig.
+			PruneAffinityNodeSelectorRequirement(
+				preemptibleNodes.CompileAffinityByLabelSelector(v1.NodeSelectorOpNotIn))
 
-		// add tolerations in case node is tainted
-		functionConfig.EnrichWithTolerations(preemptibleNodes.Tolerations)
-		if functionConfig.Spec.PositiveGPUResourceLimit() {
-			functionConfig.EnrichWithTolerations(preemptibleNodes.GPUTolerations)
-		}
+		// remove affinity
+		functionConfig.
+			PruneAffinityNodeSelectorRequirement(
+				preemptibleNodes.CompileAffinityByLabelSelector(v1.NodeSelectorOpIn))
 
 		// remove preemptible nodes constrain
 		functionConfig.PruneNodeSelector(preemptibleNodes.NodeSelector)
+
+		// enrich with tolerations
+		functionConfig.EnrichWithTolerations(preemptibleNodes.Tolerations)
+
+		// in case function pod requires gpu resource(s), enrich with gpu tolerations
+		if functionConfig.Spec.PositiveGPUResourceLimit() {
+			functionConfig.EnrichWithTolerations(preemptibleNodes.GPUTolerations)
+		}
 
 	default:
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1327,7 +1327,7 @@ func (p *Platform) enrichFunctionPreemptionSpec(ctx context.Context,
 		if preemptibleNodes.Tolerations != nil {
 			functionConfig.
 				PruneAffinityNodeSelectorRequirement(
-					preemptibleNodes.CompileAffinityByLabelSelector(v1.NodeSelectorOpIn))
+					preemptibleNodes.CompileAffinityByLabelSelector(v1.NodeSelectorOpIn), "oneOf")
 
 			// prevention is done by tolerations (as spec was explicitly given)
 			// and thus, stop here
@@ -1356,6 +1356,13 @@ func (p *Platform) enrichFunctionPreemptionSpec(ctx context.Context,
 		}
 
 	case functionconfig.RunOnPreemptibleNodesConstrain:
+
+		// remove anti affinity even thought we assign affinity below
+		// which will override the same fields.
+		// doing it here for future proofing
+		functionConfig.
+			PruneAffinityNodeSelectorRequirement(
+				preemptibleNodes.CompileAffinityByLabelSelector(v1.NodeSelectorOpNotIn), "matchAll")
 
 		// enrich with tolerations
 		functionConfig.EnrichWithTolerations(preemptibleNodes.Tolerations)
@@ -1392,12 +1399,12 @@ func (p *Platform) enrichFunctionPreemptionSpec(ctx context.Context,
 		// remove anti-affinity
 		functionConfig.
 			PruneAffinityNodeSelectorRequirement(
-				preemptibleNodes.CompileAffinityByLabelSelector(v1.NodeSelectorOpNotIn))
+				preemptibleNodes.CompileAffinityByLabelSelector(v1.NodeSelectorOpNotIn), "matchAll")
 
 		// remove affinity
 		functionConfig.
 			PruneAffinityNodeSelectorRequirement(
-				preemptibleNodes.CompileAffinityByLabelSelector(v1.NodeSelectorOpIn))
+				preemptibleNodes.CompileAffinityByLabelSelector(v1.NodeSelectorOpIn), "oneOf")
 
 		// remove preemptible nodes constrain
 		functionConfig.PruneNodeSelector(preemptibleNodes.NodeSelector)

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1305,8 +1305,10 @@ func (p *Platform) enrichFunctionPreemptionSpec(ctx context.Context,
 
 	// no preemption mode was selected, default to prevent
 	if functionConfig.Spec.PreemptionMode == "" {
-		p.Logger.DebugWithCtx(ctx, "No preemption mode was given, defaulting to prevent")
-		functionConfig.Spec.PreemptionMode = functionconfig.RunOnPreemptibleNodesPrevent
+		functionConfig.Spec.PreemptionMode = p.Config.Kube.PreemptibleNodes.DefaultMode
+		p.Logger.DebugWithCtx(ctx,
+			"No preemption mode was given, using the default",
+			"newPreemptionMode", functionConfig.Spec.PreemptionMode)
 	}
 
 	p.Logger.DebugWithCtx(ctx,

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1319,6 +1319,7 @@ func (p *Platform) enrichFunctionPreemptionSpec(ctx context.Context,
 
 		// ensure no preemptible node tolerations
 		functionConfig.PruneTolerations(preemptibleNodes.Tolerations)
+		functionConfig.PruneTolerations(preemptibleNodes.GPUTolerations)
 
 		if preemptibleNodes.Tolerations != nil {
 			functionConfig.
@@ -1353,6 +1354,9 @@ func (p *Platform) enrichFunctionPreemptionSpec(ctx context.Context,
 
 		// add tolerations in case node is tainted
 		functionConfig.EnrichWithTolerations(preemptibleNodes.Tolerations)
+		if functionConfig.Spec.PositiveGPUResourceLimit() {
+			functionConfig.EnrichWithTolerations(preemptibleNodes.GPUTolerations)
+		}
 
 		if functionConfig.Spec.Affinity == nil {
 			functionConfig.Spec.Affinity = &v1.Affinity{}
@@ -1388,6 +1392,9 @@ func (p *Platform) enrichFunctionPreemptionSpec(ctx context.Context,
 
 		// add tolerations in case node is tainted
 		functionConfig.EnrichWithTolerations(preemptibleNodes.Tolerations)
+		if functionConfig.Spec.PositiveGPUResourceLimit() {
+			functionConfig.EnrichWithTolerations(preemptibleNodes.GPUTolerations)
+		}
 
 		// remove preemptible nodes constrain
 		functionConfig.PruneNodeSelector(preemptibleNodes.NodeSelector)

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -1178,14 +1178,14 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithPreemptionSpec
 	suite.Require().Equal(functionConfig.Spec.Tolerations, preemptibleNodes.Tolerations)
 	suite.Require().Equal(
 		functionConfig.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-		preemptibleNodes.CompileAntiAffinityByLabelSelectorNoScheduleOnMatchingNodes())
+		preemptibleNodes.CompileAffinityByLabelSelectorScheduleOnOneOfMatchingNodes())
 
 	// Constrain -> Constrain - make sure spec was added once
 	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig, functionconfig.RunOnPreemptibleNodesConstrain)
 	suite.Require().Equal(functionConfig.Spec.Tolerations, preemptibleNodes.Tolerations)
 	suite.Require().Equal(
 		functionConfig.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-		preemptibleNodes.CompileAntiAffinityByLabelSelectorNoScheduleOnMatchingNodes())
+		preemptibleNodes.CompileAffinityByLabelSelectorScheduleOnOneOfMatchingNodes())
 
 	// Constrain -> Allow - make sure node selectors were removed
 	functionConfig.Spec.PreemptionMode = functionconfig.RunOnPreemptibleNodesAllow
@@ -1214,7 +1214,7 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithPreemptionSpec
 	suite.Require().Equal(customFunctionLabels, functionConfig.Spec.NodeSelector)
 	suite.Require().Equal(
 		functionConfig.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-		preemptibleNodes.CompileAntiAffinityByLabelSelectorNoScheduleOnMatchingNodes())
+		preemptibleNodes.CompileAffinityByLabelSelectorScheduleOnOneOfMatchingNodes())
 
 	// Constrain -> Allow - make sure allow does not prune custom labels + constrain label selectors
 	functionConfig.Spec.PreemptionMode = functionconfig.RunOnPreemptibleNodesAllow

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -1280,9 +1280,9 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithPreemptionSpec
 	}
 	suite.platform.Config.Kube.PreemptibleNodes = preemptibleNodes
 	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig)
-	suite.Require().Equal(
+	suite.Require().Empty(cmp.Diff(
 		functionConfig.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-		preemptibleNodes.CompileAntiAffinityByLabelSelectorNoScheduleOnMatchingNodes())
+		preemptibleNodes.CompileAntiAffinityByLabelSelectorNoScheduleOnMatchingNodes()))
 }
 
 func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithUserNameLabel() {

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -1165,23 +1165,23 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithPreemptionSpec
 	functionConfig.Spec.PreemptionMode = functionconfig.RunOnPreemptibleNodesAllow
 
 	// "" -> Allow - add tolerations
-	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig, "")
+	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig)
 	suite.Require().Equal(preemptibleNodes.Tolerations, functionConfig.Spec.Tolerations)
 
 	// Allow -> Allow - make sure tolertions were added once
-	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig, functionconfig.RunOnPreemptibleNodesAllow)
+	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig)
 	suite.Require().Equal(functionConfig.Spec.Tolerations, preemptibleNodes.Tolerations)
 
 	// Allow -> Constrain - make sure it preserves tolerations and add node selectors
 	functionConfig.Spec.PreemptionMode = functionconfig.RunOnPreemptibleNodesConstrain
-	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig, functionconfig.RunOnPreemptibleNodesAllow)
+	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig)
 	suite.Require().Equal(functionConfig.Spec.Tolerations, preemptibleNodes.Tolerations)
 	suite.Require().Equal(
 		functionConfig.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
 		preemptibleNodes.CompileAffinityByLabelSelectorScheduleOnOneOfMatchingNodes())
 
 	// Constrain -> Constrain - make sure spec was added once
-	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig, functionconfig.RunOnPreemptibleNodesConstrain)
+	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig)
 	suite.Require().Equal(functionConfig.Spec.Tolerations, preemptibleNodes.Tolerations)
 	suite.Require().Equal(
 		functionConfig.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
@@ -1189,7 +1189,7 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithPreemptionSpec
 
 	// Constrain -> Allow - make sure node selectors were removed
 	functionConfig.Spec.PreemptionMode = functionconfig.RunOnPreemptibleNodesAllow
-	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig, functionconfig.RunOnPreemptibleNodesConstrain)
+	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig)
 	suite.Require().Equal(functionConfig.Spec.Tolerations, preemptibleNodes.Tolerations)
 	for key := range preemptibleNodes.NodeSelector {
 		_, ok := functionConfig.Spec.NodeSelector[key]
@@ -1203,13 +1203,13 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithPreemptionSpec
 	}
 	functionConfig.Spec.NodeSelector = customFunctionLabels
 
-	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig, functionconfig.RunOnPreemptibleNodesAllow)
+	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig)
 	suite.Require().Equal(functionConfig.Spec.Tolerations, preemptibleNodes.Tolerations)
 	suite.Require().Equal(customFunctionLabels, functionConfig.Spec.NodeSelector)
 
 	// Allow -> Constrain - merge custom labels with preemption labels
 	functionConfig.Spec.PreemptionMode = functionconfig.RunOnPreemptibleNodesConstrain
-	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig, functionconfig.RunOnPreemptibleNodesAllow)
+	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig)
 	suite.Require().Equal(functionConfig.Spec.Tolerations, preemptibleNodes.Tolerations)
 	suite.Require().Equal(customFunctionLabels, functionConfig.Spec.NodeSelector)
 	suite.Require().Equal(
@@ -1218,7 +1218,7 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithPreemptionSpec
 
 	// Constrain -> Allow - make sure allow does not prune custom labels + constrain label selectors
 	functionConfig.Spec.PreemptionMode = functionconfig.RunOnPreemptibleNodesAllow
-	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig, functionconfig.RunOnPreemptibleNodesConstrain)
+	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig)
 	suite.Require().Equal(functionConfig.Spec.Tolerations, preemptibleNodes.Tolerations)
 	suite.Require().Equal(customFunctionLabels, functionConfig.Spec.NodeSelector)
 
@@ -1232,7 +1232,7 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithPreemptionSpec
 	}
 	functionConfig.Spec.Tolerations = []v1.Toleration{customTolerations}
 	functionConfig.Spec.PreemptionMode = functionconfig.RunOnPreemptibleNodesAllow
-	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig, "")
+	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig)
 	suite.Require().NotEmpty(cmp.Diff([]v1.Toleration{
 		{
 			Key:   preemptibleNodes.Tolerations[0].Key,
@@ -1243,7 +1243,7 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithPreemptionSpec
 
 	// Allow -> Constrain - preserve custom tolerations
 	functionConfig.Spec.PreemptionMode = functionconfig.RunOnPreemptibleNodesConstrain
-	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig, functionconfig.RunOnPreemptibleNodesAllow)
+	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig)
 	suite.Require().NotEmpty(cmp.Diff([]v1.Toleration{
 		{
 			Key:   preemptibleNodes.Tolerations[0].Key,
@@ -1262,14 +1262,27 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithPreemptionSpec
 
 	// add constrain spec
 	functionConfig.Spec.PreemptionMode = functionconfig.RunOnPreemptibleNodesConstrain
-	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig, "")
+	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig)
 	functionConfig.Spec.PreemptionMode = functionconfig.RunOnPreemptibleNodesPrevent
-	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig, functionconfig.RunOnPreemptibleNodesConstrain)
+	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig)
 	suite.Require().Empty(functionConfig.Spec.NodeSelector)
 	suite.Require().Empty(functionConfig.Spec.Tolerations)
 
 	// affinity is pruned (prevention is done using taints)
 	suite.Require().Nil(functionConfig.Spec.Affinity.NodeAffinity)
+
+	// prevention is done using node label selectors
+	preemptibleNodes = &platformconfig.PreemptibleNodes{
+		NodeSelector: map[string]string{
+			"node-label-key":   "node-label-value",
+			"node-label-key-2": "node-label-value-2",
+		},
+	}
+	suite.platform.Config.Kube.PreemptibleNodes = preemptibleNodes
+	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig)
+	suite.Require().Equal(
+		functionConfig.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
+		preemptibleNodes.CompileAntiAffinityByLabelSelectorNoScheduleOnMatchingNodes())
 }
 
 func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithUserNameLabel() {

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -95,6 +95,12 @@ func NewPlatformConfig(configurationPath string) (*Config, error) {
 		config.Kube.DefaultServiceType = DefaultServiceType
 	}
 
+	if config.Kube.PreemptibleNodes != nil {
+		if config.Kube.PreemptibleNodes.DefaultMode == "" {
+			config.Kube.PreemptibleNodes.DefaultMode = functionconfig.RunOnPreemptibleNodesPrevent
+		}
+	}
+
 	if config.FunctionReadinessTimeout == nil {
 		encodedReadinessTimeoutDuration := (DefaultFunctionReadinessTimeoutSeconds * time.Second).String()
 		config.FunctionReadinessTimeout = &encodedReadinessTimeoutDuration

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -186,7 +186,7 @@ func (p *PreemptibleNodes) CompileAffinityByLabelSelectorScheduleOnOneOfMatching
 }
 
 func (p *PreemptibleNodes) CompileAntiAffinityByLabelSelectorNoScheduleOnMatchingNodes() []corev1.NodeSelectorTerm {
-	antiAffinity := p.CompileAffinityByLabelSelector(corev1.NodeSelectorOpIn)
+	antiAffinity := p.CompileAffinityByLabelSelector(corev1.NodeSelectorOpNotIn)
 
 	// using a single term with potentially multiple expressions to ensure anti affinity.
 	// when having multiple terms, pod scheduling is succeeded if at least one

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -154,8 +154,9 @@ type PlatformKubeConfig struct {
 
 // PreemptibleNodes Holds data needed when user decided to run his function pods on a preemptible node (aka Spot node)
 type PreemptibleNodes struct {
-	Tolerations  []corev1.Toleration `json:"tolerations,omitempty"`
-	NodeSelector map[string]string   `json:"nodeSelector,omitempty"`
+	Tolerations    []corev1.Toleration `json:"tolerations,omitempty"`
+	GPUTolerations []corev1.Toleration `json:"gpuTolerations,omitempty"`
+	NodeSelector   map[string]string   `json:"nodeSelector,omitempty"`
 }
 
 // CompileAffinityByLabelSelector compiles affinity spec based on pre-configured node selector

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package platformconfig
 
 import (
+	"sort"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
@@ -154,9 +155,10 @@ type PlatformKubeConfig struct {
 
 // PreemptibleNodes Holds data needed when user decided to run his function pods on a preemptible node (aka Spot node)
 type PreemptibleNodes struct {
-	Tolerations    []corev1.Toleration `json:"tolerations,omitempty"`
-	GPUTolerations []corev1.Toleration `json:"gpuTolerations,omitempty"`
-	NodeSelector   map[string]string   `json:"nodeSelector,omitempty"`
+	DefaultMode    functionconfig.RunOnPreemptibleNodeMode `json:"defaultMode,omitempty"`
+	Tolerations    []corev1.Toleration                     `json:"tolerations,omitempty"`
+	GPUTolerations []corev1.Toleration                     `json:"gpuTolerations,omitempty"`
+	NodeSelector   map[string]string                       `json:"nodeSelector,omitempty"`
 }
 
 // CompileAffinityByLabelSelector compiles affinity spec based on pre-configured node selector
@@ -170,6 +172,11 @@ func (p *PreemptibleNodes) CompileAffinityByLabelSelector(
 			Values:   []string{nodeSelectorValue},
 		})
 	}
+
+	//make compilation deterministic
+	sort.Slice(matchExpressions, func(i, j int) bool {
+		return matchExpressions[i].String() < matchExpressions[j].String()
+	})
 	return matchExpressions
 }
 


### PR DESCRIPTION
Enriches function pod with the below described spec. if no platformConfiguration related configuration is given, do nothing.

`Allow` 	- Adds Tolerations / GPU Tolerations if taints were given. otherwise, assume pods can be scheduled on preemptible nodes.
    - Purges any `affinity` / `anti-affinity` preemption related configuration

`Constrain` - Uses node-affinity to make sure pods are assigned using OR on the given node label selectors.
    - Uses `Allow` configuration as well.
    - Purges any `anti-affinity` preemption related configuration

`Prevent`	- Prevention is done either using taints (if Tolerations were given) or anti-affinity.
    - Purges any `tolerations` / `gpuTolerations` preemption related configuration
    - Purges any `affinity` preemption related configuration
    - Adds anti-affinity IF no tolerations were given