### PR TITLE
Refactor v3io streams resource logging and errors

### DIFF
--- a/pkg/common/v3io/v3io.go
+++ b/pkg/common/v3io/v3io.go
@@ -83,10 +83,9 @@ func GetShardLagsMap(ctx context.Context,
 	}
 
 	dataPlaneInput := v3iodataplane.DataPlaneInput{
-		URL:                    platformConfig.StreamMonitoring.WebapiURL,
-		AccessKey:              accessKey,
-		ContainerName:          info.ContainerName,
-		IncludeResponseInError: true,
+		URL:           platformConfig.StreamMonitoring.WebapiURL,
+		AccessKey:     accessKey,
+		ContainerName: info.ContainerName,
 	}
 	getContainerContentsInput := &v3iodataplane.GetContainerContentsInput{
 		Path:             info.StreamPath,

--- a/pkg/restful/middleware/middleware.go
+++ b/pkg/restful/middleware/middleware.go
@@ -102,6 +102,7 @@ func RequestResponseLogger(logger logger.Logger) func(next http.Handler) http.Ha
 				if !common.StringSliceContainsStringPrefix([]string{
 					"/api/functions",
 					"/api/function_templates",
+					"/api/v3io_streams",
 				}, strings.TrimSuffix(request.URL.Path, "/")) {
 					logVars = append(logVars, "responseBody", responseBodyBuffer.String())
 				}

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -19,6 +19,7 @@ package restful
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -558,7 +559,7 @@ func (ar *AbstractResource) callCustomRouteFunc(responseWriter http.ResponseWrit
 	if err != nil {
 		ar.Logger.WarnWith("Custom routed handler failed",
 			"err", err,
-			"routeFunc", routeFunc,
+			"routeFunc", fmt.Sprintf("%T", routeFunc),
 			"request", request)
 	}
 
@@ -570,7 +571,7 @@ func (ar *AbstractResource) callCustomRouteFunc(responseWriter http.ResponseWrit
 			Headers:    map[string]string{"Content-Type": "application/json"},
 		}
 		ar.Logger.WarnWith("Response object not filled by handler, using placeholder",
-			"routeFunc", routeFunc,
+			"routeFunc", fmt.Sprintf("%T", routeFunc),
 			"request", request,
 			"response", response)
 	}


### PR DESCRIPTION
- Resolve status code on v3io errors (instead of 500).
- Remove spammy response body from dashboard logs for v3io streams resources.
- Pretty-print `routeFunc` name on custom route failure.