### PR TITLE
Auth - fix cache key to include url

### DIFF
--- a/pkg/auth/iguazio/auth.go
+++ b/pkg/auth/iguazio/auth.go
@@ -128,7 +128,7 @@ func (a *Auth) Authenticate(request *http.Request, options *authpkg.Options) (au
 		}
 	}
 
-	a.cache.Add(authorization+cookie, authInfo, a.config.Iguazio.CacheExpirationTimeout)
+	a.cache.Add(cacheKey, authInfo, a.config.Iguazio.CacheExpirationTimeout)
 	a.logger.InfoWithCtx(ctx,
 		"Authentication succeeded",
 		"url", url,

--- a/pkg/auth/iguazio/auth.go
+++ b/pkg/auth/iguazio/auth.go
@@ -67,16 +67,11 @@ func (a *Auth) Authenticate(request *http.Request, options *authpkg.Options) (au
 		url = a.config.Iguazio.VerificationDataEnrichmentURL
 	}
 
-	// TODO: cache needs to be digested with url
-	cacheKey := sha256.Sum256([]byte(cookie + authorization))
+	cacheKey := sha256.Sum256([]byte(cookie + authorization + url))
 
 	// try resolve from cache
 	if cacheData, found := a.cache.Get(cacheKey); found {
-		cachedSession := cacheData.(*authpkg.IguazioSession)
-		a.logger.DebugWithCtx(ctx,
-			"Authentication found in cache",
-			"username", cachedSession.GetUsername())
-		return cachedSession, nil
+		return cacheData.(*authpkg.IguazioSession), nil
 	}
 
 	response, err := a.performHTTPRequest(request.Context(),

--- a/pkg/auth/iguazio/auth.go
+++ b/pkg/auth/iguazio/auth.go
@@ -57,10 +57,14 @@ func (a *Auth) Authenticate(request *http.Request, options *authpkg.Options) (au
 		return nil, nuclio.NewErrForbidden("Authentication headers are missing")
 	}
 
-	// try resolve from cache
-	if cacheData, found := a.cache.Get(cacheKey); found {
-		return cacheData.(*authpkg.IguazioSession), nil
-	}
+	//// try resolve from cache
+	//// TODO: cache needs to be digested with url
+	//if cacheData, found := a.cache.Get(cacheKey); found {
+	//	cachedSession := cacheData.(*authpkg.IguazioSession)
+	//	a.logger.DebugWithCtx(ctx, "Authentication found in cache",
+	//		"username", cachedSession.GetUsername())
+	//	return cachedSession, nil
+	//}
 
 	authHeaders := map[string]string{
 		"authorization": authorization,
@@ -124,6 +128,7 @@ func (a *Auth) Authenticate(request *http.Request, options *authpkg.Options) (au
 	a.cache.Add(authorization+cookie, authInfo, a.config.Iguazio.CacheExpirationTimeout)
 	a.logger.InfoWithCtx(ctx,
 		"Authentication succeeded",
+		"url", url,
 		"username", authInfo.GetUsername())
 	return authInfo, nil
 }

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -78,8 +78,16 @@ func (k *Kaniko) BuildAndPushContainerImage(ctx context.Context, buildOptions *B
 	jobSpec := k.compileJobSpec(namespace, buildOptions, bundleFilename)
 
 	// create job
-	k.logger.DebugWithCtx(ctx, "Creating job", "namespace", namespace, "jobSpec", jobSpec)
-	job, err := k.kubeClientSet.BatchV1().Jobs(namespace).Create(ctx, jobSpec, metav1.CreateOptions{})
+	k.logger.DebugWithCtx(ctx,
+		"Creating job",
+		"namespace", namespace,
+		"jobSpec", jobSpec,
+		"timeoutSeconds", buildOptions.BuildTimeoutSeconds,
+	)
+	job, err := k.kubeClientSet.
+		BatchV1().
+		Jobs(namespace).
+		Create(ctx, jobSpec, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "Failed to publish kaniko job")
 	}
@@ -406,7 +414,7 @@ func (k *Kaniko) waitForJobCompletion(namespace string, jobName string, buildTim
 		}
 
 		k.logger.DebugWith("Waiting for job completion",
-			"ttl", time.Until(timeout),
+			"ttl", time.Until(timeout).String(),
 			"jobName", jobName)
 		time.Sleep(10 * time.Second)
 	}

--- a/pkg/restful/middleware/middleware.go
+++ b/pkg/restful/middleware/middleware.go
@@ -84,8 +84,14 @@ func RequestResponseLogger(logger logger.Logger) func(next http.Handler) http.Ha
 			request.Body = ioutil.NopCloser(bytes.NewBuffer(requestBody))
 
 			requestHeaders := request.Header.Clone() // for logging purposes
-			requestHeaders.Set("cookie", "[redacted]")
-			requestHeaders.Set("x-v3io-session-key", "[redacted]")
+			for _, headerToRedact := range []string{
+				"cookie",
+				"x-v3io-session-key",
+			} {
+				if requestHeaders.Get(headerToRedact) != "" {
+					requestHeaders.Set(headerToRedact, "[redacted]")
+				}
+			}
 
 			// when request processing is done, log the request / response
 			defer func() {

--- a/pkg/restful/middleware/middleware.go
+++ b/pkg/restful/middleware/middleware.go
@@ -101,7 +101,7 @@ func RequestResponseLogger(logger logger.Logger) func(next http.Handler) http.Ha
 					"requestHeaders", requestHeaders,
 					"requestBody", string(requestBody),
 					"responseStatus", responseWrapper.Status(),
-					"responseTime", time.Since(requestStartTime),
+					"responseTime", time.Since(requestStartTime).String(),
 				}
 
 				// response body is too spammy


### PR DESCRIPTION
It is observed that when url is changed between authentication, we need to invalidate cache to ensure it enriches with data plane.

In addition, few fixes to some duration logs