### PR TITLE
Preemption - fix potential bug when setting mode to prevent

### DIFF
--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1323,6 +1323,9 @@ func (p *Platform) enrichFunctionPreemptionSpec(ctx context.Context,
 		functionConfig.PruneTolerations(preemptibleNodes.Tolerations)
 		functionConfig.PruneTolerations(preemptibleNodes.GPUTolerations)
 
+		// ensure no preemptible node selector
+		functionConfig.PruneNodeSelector(preemptibleNodes.NodeSelector)
+
 		// if tolerations were given, purge `affinity` preemption related configuration
 		if preemptibleNodes.Tolerations != nil {
 			functionConfig.


### PR DESCRIPTION
In case function had a preset of node selector, function would have conflicting spec by having an anti affinity to that selector and label selector.
Fix by pruning the label selector first.