### PR TITLE
Increase cluster autoscale wait time 

### DIFF
--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -223,7 +223,8 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 		if err, functionState := fo.functionresClient.WaitAvailable(waitContext,
 			function.Namespace,
 			function.Name,
-			functionResourcesCreateOrUpdateTimestamp); err != nil {
+			functionResourcesCreateOrUpdateTimestamp,
+			function.Spec.WaitReadinessTimeoutBeforeFailure); err != nil {
 			return fo.setFunctionError(ctx,
 				function,
 				functionState,

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -324,7 +324,9 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context,
 						LabelSelector: common.CompileListFunctionPodsLabelSelector(name),
 					})
 			if err != nil {
-				lc.logger.WarnWithCtx(ctx, "Failed to get deployment pods", "namespace", namespace)
+				lc.logger.WarnWithCtx(ctx, "Failed to get deployment pods",
+					"err", errors.GetErrorStackString(err, 10),
+					"namespace", namespace)
 				continue
 			}
 

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2340,8 +2340,7 @@ func (lc *lazyClient) isPodAutoScaledUp(ctx context.Context, pod v1.Pod) (bool, 
 		return false, errors.Wrap(err, "Failed to list pod events")
 	}
 	lc.logger.DebugWithCtx(ctx, "Received pod events",
-		"podEventsLength", len(podEvents.Items),
-		"podEvents", podEvents.Items)
+		"podEventsLength", len(podEvents.Items))
 
 	for _, event := range podEvents.Items {
 

--- a/pkg/platform/kube/functionres/types.go
+++ b/pkg/platform/kube/functionres/types.go
@@ -36,7 +36,7 @@ type Client interface {
 	CreateOrUpdate(context.Context, *nuclioio.NuclioFunction, string) (Resources, error)
 
 	// WaitAvailable waits until the resources are ready
-	WaitAvailable(context.Context, string, string, time.Time) (error, functionconfig.FunctionState)
+	WaitAvailable(context.Context, string, string, time.Time, bool) (error, functionconfig.FunctionState)
 
 	// Delete deletes resources
 	Delete(context.Context, string, string) error


### PR DESCRIPTION
According to https://jira.iguazeng.com/browse/IG-20501, the fail-fast logic doesn't "catch" the cluster auto-scaler events and fails the deployment before they arrive.
To mitigate that, we increase autoscale waiting time from 10s to 60s. 

Also add functionality to `WaitReadinessTimeoutBeforeFailure` flag - if true, skip the fail-fast logic when waiting for function to be available.