### PR TITLE
Ingress - improve resource creation waiting

### DIFF
--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -196,7 +196,8 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 		GetPlatformConfiguration().
 		GetFunctionReadinessTimeoutOrDefault(function.Spec.ReadinessTimeoutSeconds)
 
-	fo.logger.DebugWithCtx(ctx, "Ensuring function resources",
+	fo.logger.DebugWithCtx(ctx,
+		"Ensuring function resources",
 		"functionNamespace", function.Namespace,
 		"readinessTimeout", readinessTimeout,
 		"functionName", function.Name)

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -221,10 +221,8 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 
 		// wait until the function resources are ready
 		if err, functionState := fo.functionresClient.WaitAvailable(waitContext,
-			function.Namespace,
-			function.Name,
-			functionResourcesCreateOrUpdateTimestamp,
-			function.Spec.WaitReadinessTimeoutBeforeFailure); err != nil {
+			function,
+			functionResourcesCreateOrUpdateTimestamp); err != nil {
 			return fo.setFunctionError(ctx,
 				function,
 				functionState,

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -459,8 +459,8 @@ func (lc *lazyClient) waitFunctionIngressReadiness(ctx context.Context,
 	}
 
 	for _, ingress := range functionIngresses.Status.LoadBalancer.Ingress {
-		if ingress.IP != "" {
-			lc.logger.DebugWithCtx(ctx, "Found at least one ingress ip, assuming ingress is ready")
+		if ingress.IP != "" || ingress.Hostname != "" {
+			lc.logger.DebugWithCtx(ctx, "Found at least one configured ingress, assuming ingress is ready")
 			return nil
 		}
 	}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -325,6 +325,13 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context,
 		}
 
 		if !ingressReady {
+
+			// if function have no ingress, assume ready and bail ingress readiness
+			if len(functionconfig.GetFunctionIngresses(client.NuclioioToFunctionConfig(function))) == 0 {
+				ingressReady = true
+				continue
+			}
+
 			if err := lc.waitFunctionIngressReadiness(ctx, function); err != nil {
 
 				// to avoid spamming the output
@@ -436,12 +443,6 @@ func (lc *lazyClient) SetPlatformConfigurationProvider(platformConfigurationProv
 
 func (lc *lazyClient) waitFunctionIngressReadiness(ctx context.Context,
 	function *nuclioio.NuclioFunction) error {
-
-	if len(functionconfig.GetFunctionIngresses(client.NuclioioToFunctionConfig(function))) == 0 {
-
-		// no ingresses were requested, bail
-		return nil
-	}
 
 	functionIngresses, err := lc.kubeClientSet.NetworkingV1().
 		Ingresses(function.Namespace).

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -422,9 +422,9 @@ func (lc *lazyClient) SetPlatformConfigurationProvider(platformConfigurationProv
 func (lc *lazyClient) waitFunctionIngressReadiness(ctx context.Context,
 	function *nuclioio.NuclioFunction) error {
 
-	// no ingresses were requested, bail
-	if functionIngressesSpec :=
-		functionconfig.GetFunctionIngresses(client.NuclioioToFunctionConfig(function)); functionIngressesSpec == nil {
+	if len(functionconfig.GetFunctionIngresses(client.NuclioioToFunctionConfig(function))) == 0 {
+
+		// no ingresses were requested, bail
 		return nil
 	}
 

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2376,7 +2376,7 @@ func (lc *lazyClient) resolveFailFast(ctx context.Context,
 
 					lc.logger.DebugWithCtx(errGroupCtx,
 						"Waiting for autoscale evaluation",
-						"nodeScaleUpSleepTimeout", lc.nodeScaleUpSleepTimeout,
+						"nodeScaleUpSleepTimeout", lc.nodeScaleUpSleepTimeout.String(),
 						"podName", pod.Name)
 					time.Sleep(lc.nodeScaleUpSleepTimeout)
 

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -326,6 +326,7 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context,
 					"name", function.Name)
 				continue
 			}
+			ingressReady = true
 		}
 	}
 }

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -199,8 +199,6 @@ func (suite *lazyTestSuite) TestEnrichIngressWithDefaultAnnotations() {
 			functionLabels := suite.client.getFunctionLabels(&function)
 			functionLabels["nuclio.io/function-name"] = function.Name
 
-			suite.client.nginxIngressUpdateGracePeriod = 0
-
 			// "create the ingress
 			ingressInstance, err := suite.client.createOrUpdateIngress(suite.ctx, functionLabels, &function)
 			suite.Require().NoError(err)
@@ -259,8 +257,6 @@ func (suite *lazyTestSuite) TestNoChanges() {
 			},
 		},
 	})
-
-	suite.client.nginxIngressUpdateGracePeriod = 0
 
 	// "create the ingress
 	ingressInstance, err := suite.client.createOrUpdateIngress(suite.ctx, functionLabels, &function)

--- a/pkg/platform/kube/functionres/types.go
+++ b/pkg/platform/kube/functionres/types.go
@@ -36,7 +36,7 @@ type Client interface {
 	CreateOrUpdate(context.Context, *nuclioio.NuclioFunction, string) (Resources, error)
 
 	// WaitAvailable waits until the resources are ready
-	WaitAvailable(context.Context, string, string, time.Time, bool) (error, functionconfig.FunctionState)
+	WaitAvailable(context.Context, *nuclioio.NuclioFunction, time.Time) (error, functionconfig.FunctionState)
 
 	// Delete deletes resources
 	Delete(context.Context, string, string) error


### PR DESCRIPTION
Instead of hard-coded waiting of 5 seconds for ingress to be populated, wait for the ingress status block to be populated by ingress-controller with its ip. 
A small twist here is that function deployment ready + ingress not ready => function unhealthy. which means, if it takes longer for the function ingress, eventually the function would become ready. this is done to avoid marking function deployment as error and cause some regressions.