### PR TITLE
Check deployment and ingress readiness before readiness timeout

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -265,6 +265,10 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context,
 
 	for counter := 0; ; counter++ {
 
+		if deploymentReady && ingressReady {
+			return nil, functionconfig.FunctionStateReady
+		}
+
 		// wait a bit
 		time.Sleep(time.Duration(waitMs) * time.Millisecond)
 
@@ -277,10 +281,6 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context,
 		// check if context is still OK
 		if err := ctx.Err(); err != nil {
 			return err, functionconfig.FunctionStateUnhealthy
-		}
-
-		if deploymentReady && ingressReady {
-			return nil, functionconfig.FunctionStateReady
 		}
 
 		// deployment is ready


### PR DESCRIPTION
Fix an edge case of `WaitAvailable`:
Currently, after checking the ingress there is a `sleep` period, and a context check that verifies weather `readinessTimeout` has passed.
If the function ingress is ready after a period of _almost_ `readinessTimeout`, after sleeping the context is canceled and the function state is set to `Unhealthy`, although both deployment and ingress are ready.

Checking the `ingressReady` and `deploymentReady` flags before sleeping will fix this issue.