### PR TITLE
Kubernetes - tweak function availability wait

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -327,7 +327,9 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context,
 			if !deploymentReady {
 
 				// TODO: log waiting for function deployment readiness
-				err, functionState := lc.waitFunctionDeploymentReadiness(ctx, function, functionResourcesCreateOrUpdateTimestamp)
+				err, functionState := lc.waitFunctionDeploymentReadiness(ctx,
+					function,
+					functionResourcesCreateOrUpdateTimestamp)
 				if err == nil {
 					deploymentReady = true
 					timeDeploymentReady = time.Now()
@@ -340,11 +342,13 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context,
 
 				// HACK - we return with empty function state to indicate a possibly transient error
 				if functionState == "" {
-					lc.logger.WarnWithCtx(ctx,
-						"Failed to wait for function deployment readiness (probably a transient error)",
-						"err", err.Error(),
-						"namespace", function.Namespace,
-						"name", function.Name)
+					if counter == 1 || counter%5 == 0 {
+						lc.logger.WarnWithCtx(ctx,
+							"Failed to wait for function deployment readiness (probably a transient error)",
+							"err", err.Error(),
+							"namespace", function.Namespace,
+							"name", function.Name)
+					}
 					continue
 				}
 

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -266,6 +266,10 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context,
 	readinessVerifierTicker := time.NewTicker(time.Duration(waitMs) * time.Millisecond)
 	availableTicker := time.NewTicker(50 * time.Millisecond)
 
+	// cleanup resources once done
+	defer readinessVerifierTicker.Stop()
+	defer availableTicker.Stop()
+
 	for {
 		select {
 

--- a/pkg/platform/kube/monitoring/function.go
+++ b/pkg/platform/kube/monitoring/function.go
@@ -151,11 +151,6 @@ func (fm *FunctionMonitor) updateFunctionStatus(ctx context.Context, function *n
 		return nil
 	}
 
-	fm.logger.DebugWithCtx(ctx,
-		"Getting function deployment function",
-		"functionName", function.Name,
-		"functionNamespace", function.Namespace)
-
 	functionDeployment, err := fm.kubeClientSet.
 		AppsV1().
 		Deployments(function.Namespace).

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -385,7 +385,7 @@ func (suite *KubeTestSuite) GetFunctionPods(functionName string) []v1.Pod {
 }
 
 func (suite *KubeTestSuite) RolloutRestartDeployment(deploymentName string) error {
-	positionalArgs := []string{"rollout", "restart", deploymentName}
+	positionalArgs := []string{"rollout", "restart", "deployment", deploymentName}
 	_, err := suite.executeKubectl(positionalArgs, nil)
 	return err
 }


### PR DESCRIPTION
Following https://github.com/nuclio/nuclio/pull/2553 and great catch by @TomerShor  - This PR tweaks a bit the wait for function availability by using for/select to omit the coupling between "sleep" and the function availability check.
In addition, reduce some noisy logs and removed some needlessly logs.

Note: resources availability verification functionality remained untouched.