### PR TITLE
Increase default function readiness timeout

### DIFF
--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -3431,7 +3431,7 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
                 },
                 "build": {},
                 "platform": {},
-                "readinessTimeoutSeconds": 60,
+                "readinessTimeoutSeconds": 120,
                 "eventTimeout": ""
             }
         }

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -29,7 +29,7 @@ import (
 	machinarymetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const DefaultFunctionReadinessTimeoutSeconds = 60
+const DefaultFunctionReadinessTimeoutSeconds = 120
 
 type LoggerSinkKind string
 


### PR DESCRIPTION
Some bugs occurred in where a function ingress was ready long after the deployment was ready, causing it to fail on readiness timeout exceeded.

In this PR we raise the default function readiness timeout to 2 minutes to mitigate these errors.