### PR TITLE
Kaniko - Improve job status polling

### DIFF
--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -388,7 +388,8 @@ func (k *Kaniko) waitForJobCompletion(namespace string,
 			Jobs(namespace).
 			Get(context.Background(), jobName, metav1.GetOptions{})
 		if err != nil {
-			return errors.Wrap(err, "Failed to poll kaniko job status")
+			k.logger.WarnWith("Failed to poll kaniko job status", "err", err.Error())
+			continue
 		}
 
 		if runningJob.Status.Succeeded > 0 {


### PR DESCRIPTION
Don't fail Kaniko job polling on first error, but rather wait the build timeout duration.

Related bug: https://jira.iguazeng.com/browse/IG-20629