### PR TITLE
Add default function pod resources to frontend spec

### DIFF
--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -82,6 +82,7 @@ func (fsr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restfu
 	defaultFunctionConfig := fsr.getDefaultFunctionConfig()
 	defaultHTTPIngressHostTemplate := fsr.getDefaultHTTPIngressHostTemplate()
 	validFunctionPriorityClassNames := fsr.resolveValidFunctionPriorityClassNames()
+	defaultFunctionPodResources := fsr.resolveDefaultFunctionPodResources()
 
 	frontendSpec := map[string]restful.Attributes{
 		"frontendSpec": { // frontendSpec is the ID of this singleton resource
@@ -94,6 +95,7 @@ func (fsr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restfu
 			"platformKind":                    platformKind,
 			"allowedAuthenticationModes":      allowedAuthenticationModes,
 			"validFunctionPriorityClassNames": validFunctionPriorityClassNames,
+			"defaultFunctionPodResources":     defaultFunctionPodResources,
 		},
 	}
 
@@ -212,6 +214,14 @@ func (fsr *frontendSpecResource) resolveDefaultFunctionPriorityClassName() strin
 		defaultFunctionPriorityClassName = dashboardServer.GetPlatformConfiguration().Kube.DefaultFunctionPriorityClassName
 	}
 	return defaultFunctionPriorityClassName
+}
+
+func (fsr *frontendSpecResource) resolveDefaultFunctionPodResources() platformconfig.PodResourceRequirements {
+	var defaultFunctionPodResources platformconfig.PodResourceRequirements
+	if dashboardServer, ok := fsr.resource.GetServer().(*dashboard.Server); ok {
+		defaultFunctionPodResources = dashboardServer.GetPlatformConfiguration().Kube.DefaultFunctionPodResources
+	}
+	return defaultFunctionPodResources
 }
 
 func (fsr *frontendSpecResource) resolveValidFunctionPriorityClassNames() []string {

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -3437,6 +3437,16 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
         }
     },
     "defaultHTTPIngressHostTemplate": "{{ .FunctionName }}.{{ .ProjectName }}.{{ .Namespace }}.test.com",
+    "defaultFunctionPodResources": {
+        "Requests": {
+			"CPU": "",
+			"Memory": ""
+		},
+		"Limits": {
+			"CPU": "",
+			"Memory": ""
+		}
+    },
     "externalIPAddresses": [
         "address1",
         "address2",


### PR DESCRIPTION
For UI purposes.
Add a `defaultFunctionPodResources` field, that looks as such:
```
 {
   ...
   "defaultFunctionPodResources": {
        "Requests": {
            "CPU": "25m",
            "Memory": "1Mi"
        },
        "Limits": {
            "CPU": "2",
            "Memory": "20Gi"
        }
    },
   ...
}
```