### PR TITLE
Bump Java SDK - 11

### DIFF
--- a/docs/reference/runtimes/java/java-reference.md
+++ b/docs/reference/runtimes/java/java-reference.md
@@ -32,7 +32,7 @@ The `handler` field must simply contain the class name. In the example above, th
 When instructed to build the user's handler (to create a user handler JAR), the Java runtime will generate a Gradle build script from the following template:
 ```
 plugins {
-  id 'com.github.johnrengelman.shadow' version '2.0.2'
+  id 'com.github.johnrengelman.shadow' version '5.2.0'
   id 'java'
 }
 
@@ -47,7 +47,7 @@ dependencies {
     compile group: '{{.Group}}', name: '{{.Name}}', version: '{{.Version}}'
     {{ end }}
 
-    compile files('./nuclio-sdk-java-1.0.0.jar')
+    compile files('./nuclio-sdk-java-1.1.0.jar')
 }
 
 shadowJar {
@@ -110,7 +110,7 @@ See [Deploying Functions from a Dockerfile](/docs/tasks/deploy-functions-from-do
 ```
 ARG NUCLIO_LABEL=0.5.6
 ARG NUCLIO_ARCH=amd64
-ARG NUCLIO_BASE_IMAGE=openjdk:9-jre-slim
+ARG NUCLIO_BASE_IMAGE=openjdk:11-jre-slim
 ARG NUCLIO_ONBUILD_IMAGE=nuclio/handler-builder-java-onbuild:${NUCLIO_LABEL}-${NUCLIO_ARCH}
 
 # Supplies processor, handler.jar

--- a/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
@@ -19,14 +19,16 @@ ARG NUCLIO_DOCKER_REPO=quay.io/nuclio
 # Supplies processor
 FROM ${NUCLIO_DOCKER_REPO}/processor:${NUCLIO_LABEL}-${NUCLIO_ARCH} as processor
 
-FROM gcr.io/iguazio/openjdk:9-slim as user-handler-builder
+FROM gcr.io/iguazio/openjdk:11-slim as user-handler-builder
+
+ENV GRADLEVERSION=5.6.4
 
 RUN apt-get update -qqy \
-    && apt-get install -o APT::Immediate-Configure=false -qqy curl \
-    && curl -LO https://services.gradle.org/distributions/gradle-4.5.1-bin.zip \
-    && unzip gradle-4.5.1-bin.zip \
-    && rm gradle-4.5.1-bin.zip \
-    && ln -s /gradle-4.5.1/bin/gradle /usr/local/bin \
+    && apt-get install -o APT::Immediate-Configure=false -qqy unzip curl \
+    && curl -LO https://services.gradle.org/distributions/gradle-${GRADLEVERSION}-bin.zip \
+    && unzip gradle-${GRADLEVERSION}-bin.zip \
+    && rm gradle-${GRADLEVERSION}-bin.zip \
+    && ln -s /gradle-${GRADLEVERSION}/bin/gradle /usr/local/bin \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /home/gradle
@@ -47,10 +49,10 @@ COPY pkg/processor/build/runtime/java/docker/onbuild/build-user-handler.sh /home
 RUN chmod +x /home/gradle/src/userHandler/build-user-handler.sh
 
 # Download the nuclio SDK Jar
-RUN curl -LO https://repo1.maven.org/fromsearch?filepath=io/nuclio/nuclio-sdk-java/1.0.0/nuclio-sdk-java-1.0.0.jar
+RUN curl -LO https://repo1.maven.org/fromsearch?filepath=io/nuclio/nuclio-sdk-java/1.1.0/nuclio-sdk-java-1.1.0.jar
 
 # Copy the downloaded SDK Jar to the userHandler folder
-RUN cp nuclio-sdk-java-1.0.0.jar /home/gradle/src/userHandler/nuclio-sdk-java-1.0.0.jar
+RUN cp nuclio-sdk-java-1.1.0.jar /home/gradle/src/userHandler/nuclio-sdk-java-1.1.0.jar
 
 # Copy the gradle build script and user sources to /home/gradle/src/userHandler
 ONBUILD COPY handler/build.gradle /home/gradle/src/userHandler
@@ -83,7 +85,7 @@ COPY pkg/processor/runtime/java/build.gradle \
     /home/gradle/src/wrapper/
 
 # Copy also the downloaded nuclio SDK Jar to the wrapper folder
-RUN cp nuclio-sdk-java-1.0.0.jar /home/gradle/src/wrapper/nuclio-sdk-java-1.0.0.jar
+RUN cp nuclio-sdk-java-1.1.0.jar /home/gradle/src/wrapper/nuclio-sdk-java-1.1.0.jar
 
 # Download dependencies
 RUN cd /home/gradle/src/wrapper \

--- a/pkg/processor/build/runtime/java/runtime.go
+++ b/pkg/processor/build/runtime/java/runtime.go
@@ -51,7 +51,7 @@ func (j *java) OnAfterStagingDirCreated(runtimeConfig *runtimeconfig.Config, sta
 func (j *java) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
-	processorDockerfileInfo.BaseImage = "openjdk:9-jre-slim"
+	processorDockerfileInfo.BaseImage = "openjdk:11-jre-slim"
 
 	// fill onbuild artifact
 	artifact := runtime.Artifact{
@@ -134,7 +134,7 @@ func (j *java) createGradleBuildScript(stagingBuildDir string) error {
 
 func (j *java) getGradleBuildScriptTemplateContents() string {
 	return `plugins {
-  id 'com.github.johnrengelman.shadow' version '2.0.2'
+  id 'com.github.johnrengelman.shadow' version '5.2.0'
   id 'java'
 }
 
@@ -149,7 +149,7 @@ dependencies {
 	compile group: '{{.Group}}', name: '{{.Name}}', version: '{{.Version}}'
 	{{ end }}
 
-    compile files('./nuclio-sdk-java-1.0.0.jar')
+    compile files('./nuclio-sdk-java-1.1.0.jar')
 }
 
 shadowJar {

--- a/pkg/processor/runtime/java/build.gradle
+++ b/pkg/processor/runtime/java/build.gradle
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '2.0.2'
+    id 'com.github.johnrengelman.shadow' version '5.2.0'
     id 'java'
 }
 
@@ -27,7 +27,7 @@ dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.2'
     compile group: 'commons-cli', name: 'commons-cli', version: '1.4'
 
-    compile files('./nuclio-sdk-java-1.0.0.jar')
+    compile files('./nuclio-sdk-java-1.1.0.jar')
     compile files('./user-handler.jar')
 }
 

--- a/test/_functions/java/custom-gradle-script/build.gradle
+++ b/test/_functions/java/custom-gradle-script/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.github.johnrengelman.shadow' version '2.0.2'
+  id 'com.github.johnrengelman.shadow' version '5.2.0'
   id 'java'
 }
 
@@ -13,7 +13,7 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.0'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.0'
 
-    compile files('./nuclio-sdk-java-1.0.0.jar')
+    compile files('./nuclio-sdk-java-1.1.0.jar')
 }
 
 shadowJar {


### PR DESCRIPTION
PR includes

- Bump SDK to `1.1.0` which is compatible with java11
- Use Java-11 for its LTS
