### PR TITLE
Support ECR with kaniko

### DIFF
--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -139,7 +139,7 @@ This is rather straightforward; however, note the following:
 ECR requires handling repository creations and time limited authorization tokens. To do so, provide nuclio with the following values.
 - Image with AWS CLI binary installed to create repositories of function images (default to `amazon/aws-cli:2.7.10`)
 - AWS secret name generated from `.aws/credentials` file configured with proper access key id and secret access key so that it has access to pull/push images and create a repository.
-- ECR secret name to be used as `imagePullSecret` of function pods (since ECR tokens stale after 12 hours, the secret must be refreshed periodically - can be done with a cron job as stated in [Sergey's blog](https://skryvets.com/blog/2021/03/15/kubernetes-pull-image-from-private-ecr-registry/#update---aws-ecr-token-refresh))
+- ECR secret name to be used as `imagePullSecret` of function pods (since ECR tokens stale after 12 hours, the secret must be refreshed periodically - can be done with a cron job as described in [Sergey's blog](https://skryvets.com/blog/2021/03/15/kubernetes-pull-image-from-private-ecr-registry/#update---aws-ecr-token-refresh))
     ```sh
     --set dashboard.kaniko.initContainerImage.awscli.repository=<repository> \
     --set dashboard.kaniko.initContainerImage.awscli.tag=<tag> \

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -147,6 +147,3 @@ ECR requires handling repository creations and time limited authorization tokens
     --set registry.secretName=<ecr-secret-name>
     ```
 
-
-> **Note:** The Nuclio team is also looking into enabling Docker-in-Docker (DinD) as a possible mode of operation.
-

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -134,7 +134,7 @@ This is rather straightforward; however, note the following:
     --set dashboard.kaniko.cacheRepo=quay.io/<repo name>/cache
     ```
 
-###Using kaniko with amazon elastic container registry (ECR):
+### Using kaniko with amazon elastic container registry (ECR):
 
 ECR requires handling repository creations and time limited authorization tokens. To do so, provide nuclio with the following values.
 - Image with AWS CLI binary installed to create repositories of function images (default to `amazon/aws-cli:2.7.10`)

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -134,5 +134,19 @@ This is rather straightforward; however, note the following:
     --set dashboard.kaniko.cacheRepo=quay.io/<repo name>/cache
     ```
 
+###Using kaniko with amazon elastic container registry (ECR):
+
+ECR requires handling repository creations and time limited authorization tokens. To do so, provide nuclio with the following values.
+- Image with AWS CLI binary installed to create repositories of function images (default to `amazon/aws-cli:2.7.10`)
+- AWS secret name generated from `.aws/credentials` file configured with proper access key id and secret access key so that it has access to pull/push images and create a repository.
+- ECR secret name to be used as `imagePullSecret` of function pods (since ECR tokens stale after 12 hours, the secret must be refreshed periodically - can be done with a cron job as stated in [Sergey's blog](https://skryvets.com/blog/2021/03/15/kubernetes-pull-image-from-private-ecr-registry/#update---aws-ecr-token-refresh))
+    ```sh
+    --set dashboard.kaniko.initContainerImage.awscli.repository=<repository> \
+    --set dashboard.kaniko.initContainerImage.awscli.tag=<tag> \
+    --set dashboard.kaniko.awsSecretName=<aws-secret-name> \
+    --set registry.secretName=<ecr-secret-name>
+    ```
+
+
 > **Note:** The Nuclio team is also looking into enabling Docker-in-Docker (DinD) as a possible mode of operation.
 

--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.12.15
+version: 0.13.15
 appVersion: 1.8.15
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.13.15
+version: 0.13.0
 appVersion: 1.8.15
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -95,7 +95,9 @@ spec:
         {{- end }}
         env:
         - name: NUCLIO_BUSYBOX_CONTAINER_IMAGE
-          value: {{ .Values.dashboard.kaniko.initContainerImage.repository }}:{{ .Values.dashboard.kaniko.initContainerImage.tag}}
+          value: {{ .Values.dashboard.kaniko.initContainerImage.busybox.repository }}:{{ .Values.dashboard.kaniko.initContainerImage.busybox.tag}}
+        - name: NUCLIO_AWS_CLI_CONTAINER_IMAGE
+          value: {{ .Values.dashboard.kaniko.initContainerImage.awscli.repository }}:{{ .Values.dashboard.kaniko.initContainerImage.awscli.tag}}
         - name: NUCLIO_KANIKO_PUSH_IMAGES_RETRIES
           value: {{ .Values.dashboard.kaniko.pushImagesRetries | quote }}
         - name: NUCLIO_AUTH_KIND

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -183,7 +183,7 @@ spec:
         {{- if .Values.dashboard.kaniko.awsSecretName }}
         - name: NUCLIO_KANIKO_AWS_CREDENTIALS_SECRET_NAME
           value: {{ .Values.dashboard.kaniko.awsSecretName | quote }}
-        {{ - end }}
+        {{- end }}
         - name: NUCLIO_DASHBOARD_EXTERNAL_IP_ADDRESSES
           value: {{ template "nuclio.externalIPAddresses" . }}
         - name: NUCLIO_DASHBOARD_IMAGE_NAME_PREFIX_TEMPLATE

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -180,6 +180,10 @@ spec:
           value: {{ .Values.dashboard.monitorDockerDeamon.maxConsecutiveErrors | quote }}
         - name: NUCLIO_REGISTRY_CREDENTIALS_SECRET_NAME
           value: {{ template "nuclio.registry.credentialsSecretName" . }}
+        {{- if .Values.dashboard.kaniko.awsSecretName }}
+        - name: NUCLIO_KANIKO_AWS_CREDENTIALS_SECRET_NAME
+          value: {{ .Values.dashboard.kaniko.awsSecretName | quote }}
+        {{ - end }}
         - name: NUCLIO_DASHBOARD_EXTERNAL_IP_ADDRESSES
           value: {{ template "nuclio.externalIPAddresses" . }}
         - name: NUCLIO_DASHBOARD_IMAGE_NAME_PREFIX_TEMPLATE

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -133,8 +133,12 @@ dashboard:
       pullPolicy: IfNotPresent
 
     initContainerImage:
-      repository: busybox
-      tag: stable
+      busybox:
+        repository: busybox
+        tag: stable
+      awscli:
+        repository: aws-cli
+        tag: stable
 
     # How long to wait before deleting the build job
     jobDeletionTimeout: 30m

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -138,7 +138,7 @@ dashboard:
         tag: stable
       awscli:
         repository: aws-cli
-        tag: stable
+        tag: 2.7.0
 
     # How long to wait before deleting the build job
     jobDeletionTimeout: 30m

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -146,6 +146,9 @@ dashboard:
     # How many times to retry pushing images to registry
     pushImagesRetries: 3
 
+    # secret from aws credentials file for pushing images to ECR
+    # awsSecretName: ""
+
   # Uncomment to configure node port
   # nodePort: 32050
 

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -137,8 +137,8 @@ dashboard:
         repository: busybox
         tag: stable
       awscli:
-        repository: aws-cli
-        tag: 2.7.0
+        repository: amazon/aws-cli
+        tag: 2.7.10
 
     # How long to wait before deleting the build job
     jobDeletionTimeout: 30m

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -322,7 +322,7 @@ func (k *Kaniko) compileJobSpec(namespace string,
 		},
 	}
 
-	// if SecretName is defined - configure mount with credentials
+	// if SecretName is defined - configure mount with docker/aws credentials
 	if len(buildOptions.SecretName) > 0 {
 		k.configureSecretVolumeMount(buildOptions, kanikoJobSpec)
 	}

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -248,10 +248,10 @@ func (k *Kaniko) compileJobSpec(namespace string,
 		MountPath: "/tmp",
 	}
 
-	awsSecret := v1.VolumeMount{
-		Name:      "aws-secret",
-		MountPath: "/root/.aws/",
-	}
+	//awsSecret := v1.VolumeMount{
+	//	Name:      "aws-secret",
+	//	MountPath: "/root/.aws/",
+	//}
 
 	jobName := k.compileJobName(buildOptions.Image)
 
@@ -279,7 +279,18 @@ func (k *Kaniko) compileJobSpec(namespace string,
 							Image:           k.builderConfiguration.KanikoImage,
 							ImagePullPolicy: v1.PullPolicy(k.builderConfiguration.KanikoImagePullPolicy),
 							Args:            buildArgs,
-							VolumeMounts:    []v1.VolumeMount{tmpFolderVolumeMount, awsSecret},
+							VolumeMounts:    []v1.VolumeMount{tmpFolderVolumeMount},
+							Env: []v1.EnvVar{
+								{
+									Name: "AWS_SDK_LOAD_CONFIG",
+									Value: "true",
+								},
+								{
+									Name: "AWS_EC2_METADATA_DISABLED",
+									Value: "true",
+								},
+
+							},
 						},
 					},
 					InitContainers: []v1.Container{
@@ -316,12 +327,12 @@ func (k *Kaniko) compileJobSpec(namespace string,
 							},
 						},
 						{
-							Name: awsSecret.Name,
-							VolumeSource: v1.VolumeSource{
-								Secret: &v1.SecretVolumeSource{
-									SecretName: awsSecret.Name,
-								},
-							},
+							//Name: awsSecret.Name,
+							//VolumeSource: v1.VolumeSource{
+							//	Secret: &v1.SecretVolumeSource{
+							//		SecretName: awsSecret.Name,
+							//	},
+							//},
 						},
 					},
 					RestartPolicy:     v1.RestartPolicyNever,

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -326,14 +326,14 @@ func (k *Kaniko) compileJobSpec(namespace string,
 								EmptyDir: &v1.EmptyDirVolumeSource{},
 							},
 						},
-						{
+						//{
 							//Name: awsSecret.Name,
 							//VolumeSource: v1.VolumeSource{
 							//	Secret: &v1.SecretVolumeSource{
 							//		SecretName: awsSecret.Name,
 							//	},
 							//},
-						},
+						//},
 					},
 					RestartPolicy:     v1.RestartPolicyNever,
 					NodeSelector:      buildOptions.NodeSelector,

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -331,11 +331,11 @@ func (k *Kaniko) compileJobSpec(namespace string,
 }
 
 func (k *Kaniko) configureSecretVolumeMount(buildOptions *BuildOptions, kanikoJobSpec *batchv1.Job) {
-	if k.matchEcrUrl(buildOptions.RegistryURL) {
+	if k.matchECRUrl(buildOptions.RegistryURL) {
 		k.configureECRInitContainerAndMount(buildOptions, kanikoJobSpec)
 	} else {
 
-		// configure docker config
+		// configure mount with docker credentials
 		kanikoJobSpec.Spec.Template.Spec.Containers[0].VolumeMounts =
 			append(kanikoJobSpec.Spec.Template.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
 				Name:      "docker-config",
@@ -646,6 +646,6 @@ func (k *Kaniko) deleteJob(namespace string, jobName string) error {
 	return nil
 }
 
-func (k *Kaniko) matchEcrUrl(registryURL string) bool {
+func (k *Kaniko) matchECRUrl(registryURL string) bool {
 	return strings.HasSuffix(registryURL, ".amazonaws.com") && strings.Contains(registryURL, ".ecr.")
 }

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -324,7 +324,7 @@ func (k *Kaniko) compileJobSpec(namespace string,
 
 	// if SecretName is defined - configure mount with credentials
 	if len(buildOptions.SecretName) > 0 {
-		if k.matchECRRegex(buildOptions.RegistryURL) {
+		if k.matchEcrUrl(buildOptions.RegistryURL) {
 
 			// Add init container to create the repository - ignore already exists
 			createRepoCommand := fmt.Sprintf("aws ecr create-repository --repository-name %s"+
@@ -637,8 +637,6 @@ func (k *Kaniko) deleteJob(namespace string, jobName string) error {
 	return nil
 }
 
-func (k *Kaniko) matchECRRegex(registryURL string) bool {
-	ecrRegex := regexp.MustCompile(
-		`([a-zA-Z0-9][a-zA-Z0-9-_]*)\.dkr\.ecr\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.amazonaws\.com`)
-	return ecrRegex.MatchString(registryURL)
+func (k *Kaniko) matchEcrUrl(registryURL string) bool {
+	return strings.HasSuffix(registryURL, ".amazonaws.com") && strings.Contains(registryURL, ".ecr.")
 }

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -387,7 +387,7 @@ func (k *Kaniko) configureEcrInitContainerAndMount(buildOptions *BuildOptions, k
 			},
 			VolumeMounts: []v1.VolumeMount{
 				{
-					Name:      buildOptions.SecretName,
+					Name:      k.builderConfiguration.AWSSecretName,
 					MountPath: "/tmp",
 				},
 			},
@@ -397,7 +397,7 @@ func (k *Kaniko) configureEcrInitContainerAndMount(buildOptions *BuildOptions, k
 	kanikoJobSpec.Spec.Template.Spec.Containers[0].VolumeMounts = append(
 		kanikoJobSpec.Spec.Template.Spec.Containers[0].VolumeMounts,
 		v1.VolumeMount{
-			Name:      buildOptions.SecretName,
+			Name:      k.builderConfiguration.AWSSecretName,
 			MountPath: "/root/.aws/",
 		})
 	kanikoJobSpec.Spec.Template.Spec.Volumes = append(kanikoJobSpec.Spec.Template.Spec.Volumes,
@@ -405,7 +405,7 @@ func (k *Kaniko) configureEcrInitContainerAndMount(buildOptions *BuildOptions, k
 			Name: buildOptions.SecretName,
 			VolumeSource: v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{
-					SecretName: buildOptions.SecretName,
+					SecretName: k.builderConfiguration.AWSSecretName,
 				},
 			},
 		})

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -332,7 +332,7 @@ func (k *Kaniko) compileJobSpec(namespace string,
 
 func (k *Kaniko) configureSecretVolumeMount(buildOptions *BuildOptions, kanikoJobSpec *batchv1.Job) {
 	if k.matchEcrUrl(buildOptions.RegistryURL) {
-		k.configureEcrInitContainerAndMount(buildOptions, kanikoJobSpec)
+		k.configureECRInitContainerAndMount(buildOptions, kanikoJobSpec)
 	} else {
 
 		// configure docker config
@@ -360,7 +360,7 @@ func (k *Kaniko) configureSecretVolumeMount(buildOptions *BuildOptions, kanikoJo
 	}
 }
 
-func (k *Kaniko) configureEcrInitContainerAndMount(buildOptions *BuildOptions, kanikoJobSpec *batchv1.Job) {
+func (k *Kaniko) configureECRInitContainerAndMount(buildOptions *BuildOptions, kanikoJobSpec *batchv1.Job) {
 
 	// Add init container to create the repository - ignore already exists
 	createRepoCommand := fmt.Sprintf("aws ecr create-repository --repository-name %s"+

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -402,7 +402,7 @@ func (k *Kaniko) configureECRInitContainerAndMount(buildOptions *BuildOptions, k
 		})
 	kanikoJobSpec.Spec.Template.Spec.Volumes = append(kanikoJobSpec.Spec.Template.Spec.Volumes,
 		v1.Volume{
-			Name: buildOptions.SecretName,
+			Name: k.builderConfiguration.AWSSecretName,
 			VolumeSource: v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{
 					SecretName: k.builderConfiguration.AWSSecretName,

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -337,7 +337,8 @@ func (k *Kaniko) configureSecretVolumeMount(buildOptions *BuildOptions, kanikoJo
 			k.configureECRInitContainerAndMount(buildOptions, kanikoJobSpec)
 		} else {
 
-			// assume instance role
+			// assume instance role has permissions to register, and store a container image
+			// https://github.com/GoogleContainerTools/kaniko#pushing-to-amazon-ecr
 			kanikoJobSpec.Spec.Template.Spec.Containers[0].Env = append(kanikoJobSpec.Spec.Template.Spec.Containers[0].Env,
 				[]v1.EnvVar{
 					{

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -337,7 +337,7 @@ func (k *Kaniko) configureSecretVolumeMount(buildOptions *BuildOptions, kanikoJo
 			k.configureECRInitContainerAndMount(buildOptions, kanikoJobSpec)
 		} else {
 
-			// assume instance role has permissions to register, and store a container image
+			// assume instance role has permissions to register and store a container image
 			// https://github.com/GoogleContainerTools/kaniko#pushing-to-amazon-ecr
 			kanikoJobSpec.Spec.Template.Spec.Containers[0].Env = append(kanikoJobSpec.Spec.Template.Spec.Containers[0].Env,
 				[]v1.EnvVar{

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -327,7 +327,7 @@ func (k *Kaniko) compileJobSpec(namespace string,
 		if k.matchECRRegex(buildOptions.RegistryURL) {
 
 			// Add init container to create the repository - ignore already exists
-			createRepoCommand := fmt.Sprintf("aws ecr create-repository --repository-name %s" +
+			createRepoCommand := fmt.Sprintf("aws ecr create-repository --repository-name %s"+
 				"|| if [ $? -eq 254 ]; then echo 'Ignoring repository already exits'; else exit $?; fi",
 				buildOptions.RepoName)
 			kanikoJobSpec.Spec.Template.Spec.InitContainers = append(kanikoJobSpec.Spec.Template.Spec.InitContainers,

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -326,9 +326,10 @@ func (k *Kaniko) compileJobSpec(namespace string,
 	if len(buildOptions.SecretName) > 0 {
 		if k.matchECRRegex(buildOptions.RegistryURL) {
 
-			// TODO: wrap with error catcher
-			// Add init container to create the repository
-			createRepoCommand := fmt.Sprintf("aws ecr create-repository --repository-name %s", buildOptions.RepoName)
+			// Add init container to create the repository - ignore already exists
+			createRepoCommand := fmt.Sprintf("aws ecr create-repository --repository-name %s" +
+				"|| if [ $? -eq 254 ]; then echo 'Ignoring repository already exits'; else exit $?; fi",
+				buildOptions.RepoName)
 			kanikoJobSpec.Spec.Template.Spec.InitContainers = append(kanikoJobSpec.Spec.Template.Spec.InitContainers,
 				v1.Container{
 					Name:  "create-repo",

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -632,8 +632,8 @@ func (k *Kaniko) deleteJob(namespace string, jobName string) error {
 	return nil
 }
 
-func (k *Kaniko) matchECRRegex(RegistryURL string) bool {
-	isECRRegex := regexp.MustCompile(
+func (k *Kaniko) matchECRRegex(registryURL string) bool {
+	ecrRegex := regexp.MustCompile(
 		`([a-zA-Z0-9][a-zA-Z0-9-_]*)\.dkr\.ecr\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.amazonaws\.com`)
-	return isECRRegex.MatchString(RegistryURL)
+	return ecrRegex.MatchString(registryURL)
 }

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -67,7 +67,7 @@ func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) 
 	}
 	if containerBuilderConfiguration.AWSCLIImage == "" {
 		containerBuilderConfiguration.AWSCLIImage = common.GetEnvOrDefaultString("NUCLIO_AWS_CLI_CONTAINER_IMAGE",
-			"aws-cli:2.7.0")
+			"aws-cli:2.7.10")
 	}
 	if containerBuilderConfiguration.AWSSecretName == "" {
 		containerBuilderConfiguration.AWSSecretName = common.GetEnvOrDefaultString("NUCLIO_KANIKO_AWS_CREDENTIALS_SECRET_NAME",

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -67,7 +67,7 @@ func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) 
 	}
 	if containerBuilderConfiguration.AWSCLIImage == "" {
 		containerBuilderConfiguration.AWSCLIImage = common.GetEnvOrDefaultString("NUCLIO_AWS_CLI_CONTAINER_IMAGE",
-			"aws-cli:2.7.10")
+			"amazon/aws-cli:2.7.10")
 	}
 	if containerBuilderConfiguration.AWSSecretName == "" {
 		containerBuilderConfiguration.AWSSecretName = common.GetEnvOrDefaultString("NUCLIO_KANIKO_AWS_CREDENTIALS_SECRET_NAME",

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -38,6 +38,7 @@ type ContainerBuilderConfiguration struct {
 	Kind                                 string
 	BusyBoxImage                         string
 	AWSCLIImage                          string
+	AWSSecretName                        string
 	KanikoImage                          string
 	KanikoImagePullPolicy                string
 	JobPrefix                            string
@@ -65,8 +66,12 @@ func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) 
 			"busybox:stable")
 	}
 	if containerBuilderConfiguration.AWSCLIImage == "" {
-		containerBuilderConfiguration.BusyBoxImage = common.GetEnvOrDefaultString("NUCLIO_AWS_CLI_CONTAINER_IMAGE",
+		containerBuilderConfiguration.AWSCLIImage = common.GetEnvOrDefaultString("NUCLIO_AWS_CLI_CONTAINER_IMAGE",
 			"aws-cli:stable")
+	}
+	if containerBuilderConfiguration.AWSSecretName == "" {
+		containerBuilderConfiguration.AWSSecretName = common.GetEnvOrDefaultString("NUCLIO_KANIKO_AWS_CREDENTIALS_SECRET_NAME",
+			"")
 	}
 	if containerBuilderConfiguration.KanikoImage == "" {
 		containerBuilderConfiguration.KanikoImage = common.GetEnvOrDefaultString("NUCLIO_KANIKO_CONTAINER_IMAGE",

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -22,6 +22,7 @@ type BuildOptions struct {
 	NoBaseImagePull         bool
 	BuildArgs               map[string]string
 	RegistryURL             string
+	RepoName                string
 	SecretName              string
 	OutputImageFile         string
 	BuildTimeoutSeconds     int64
@@ -36,6 +37,7 @@ type BuildOptions struct {
 type ContainerBuilderConfiguration struct {
 	Kind                                 string
 	BusyBoxImage                         string
+	AWSCLIImage                          string
 	KanikoImage                          string
 	KanikoImagePullPolicy                string
 	JobPrefix                            string
@@ -61,6 +63,10 @@ func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) 
 	if containerBuilderConfiguration.BusyBoxImage == "" {
 		containerBuilderConfiguration.BusyBoxImage = common.GetEnvOrDefaultString("NUCLIO_BUSYBOX_CONTAINER_IMAGE",
 			"busybox:stable")
+	}
+	if containerBuilderConfiguration.AWSCLIImage == "" {
+		containerBuilderConfiguration.BusyBoxImage = common.GetEnvOrDefaultString("NUCLIO_AWS_CLI_CONTAINER_IMAGE",
+			"aws-cli:stable")
 	}
 	if containerBuilderConfiguration.KanikoImage == "" {
 		containerBuilderConfiguration.KanikoImage = common.GetEnvOrDefaultString("NUCLIO_KANIKO_CONTAINER_IMAGE",

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -67,7 +67,7 @@ func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) 
 	}
 	if containerBuilderConfiguration.AWSCLIImage == "" {
 		containerBuilderConfiguration.AWSCLIImage = common.GetEnvOrDefaultString("NUCLIO_AWS_CLI_CONTAINER_IMAGE",
-			"aws-cli:stable")
+			"aws-cli:2.7.0")
 	}
 	if containerBuilderConfiguration.AWSSecretName == "" {
 		containerBuilderConfiguration.AWSSecretName = common.GetEnvOrDefaultString("NUCLIO_KANIKO_AWS_CREDENTIALS_SECRET_NAME",

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1049,17 +1049,17 @@ func (b *Builder) buildProcessorImage() (string, error) {
 		return "", errors.Wrap(err, "Failed to create processor dockerfile")
 	}
 
-	imageName := fmt.Sprintf("%s:%s", b.processorImage.imageName, b.processorImage.imageTag)
+	taggedImageName := fmt.Sprintf("%s:%s", b.processorImage.imageName, b.processorImage.imageTag)
 	registryURL := b.options.FunctionConfig.Spec.Build.Registry
 
 	b.logger.InfoWith("Building processor image",
 		"registryURL", registryURL,
-		"imageName", imageName)
+		"taggedImageName", taggedImageName)
 
 	err = b.platform.BuildAndPushContainerImage(context.Background(),
 		&containerimagebuilderpusher.BuildOptions{
 			ContextDir:     b.stagingDir,
-			Image:          imageName,
+			Image:          taggedImageName,
 			TempDir:        b.tempDir,
 			DockerfileInfo: processorDockerfileInfo,
 
@@ -1070,6 +1070,7 @@ func (b *Builder) buildProcessorImage() (string, error) {
 			NoBaseImagePull:     b.GetNoBaseImagePull(),
 			BuildArgs:           buildArgs,
 			RegistryURL:         registryURL,
+			RepoName:            b.processorImage.imageName,
 			SecretName:          b.options.FunctionConfig.Spec.ImagePullSecrets,
 			OutputImageFile:     b.options.OutputImageFile,
 			BuildTimeoutSeconds: b.resolveBuildTimeoutSeconds(),
@@ -1084,7 +1085,7 @@ func (b *Builder) buildProcessorImage() (string, error) {
 				b.options.FunctionConfig.Spec.ReadinessTimeoutSeconds),
 		})
 
-	return imageName, err
+	return taggedImageName, err
 }
 
 func (b *Builder) createProcessorDockerfile(baseImageRegistry string, onbuildImageRegistry string) (


### PR DESCRIPTION
- Volume aws secret generated from `.aws/credentials` file to communicate with ECR.
- Use init container with aws cli to create the ECR repository if it does not exist.
- If aws secret was not given - assume instance role