### PR TITLE
Add ExplicitAckMode to Trigger config

### DIFF
--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -77,6 +77,7 @@ type Trigger struct {
 	Annotations                           map[string]string `json:"annotations,omitempty"`
 	WorkerAvailabilityTimeoutMilliseconds *int              `json:"workerAvailabilityTimeoutMilliseconds,omitempty"`
 	WorkerAllocatorName                   string            `json:"workerAllocatorName,omitempty"`
+	ExplicitAckMode                       ExplicitAckMode   `json:"explicitAckMode,omitempty"`
 
 	// Dealer Information
 	TotalTasks        int `json:"total_tasks,omitempty"`
@@ -84,6 +85,37 @@ type Trigger struct {
 
 	// General attributes
 	Attributes map[string]interface{} `json:"attributes,omitempty"`
+}
+
+type ExplicitAckMode string
+
+const (
+
+	// ExplicitAckModeEnable allows explicit and implicit ack according to the "no-ack" header
+	ExplicitAckModeEnable ExplicitAckMode = "enable"
+
+	// ExplicitAckModeDisable disables the explicit ack feature and allows only implicit acks (default)
+	ExplicitAckModeDisable ExplicitAckMode = "disable"
+
+	// ExplicitAckModeExplicitOnly allows only explicit acks and disables implicit acks
+	ExplicitAckModeExplicitOnly ExplicitAckMode = "explicitOnly"
+)
+
+func ExplicitAckModeInSlice(ackMode ExplicitAckMode, ackModes []ExplicitAckMode) bool {
+	for _, mode := range ackModes {
+		if ackMode == mode {
+			return true
+		}
+	}
+	return false
+}
+
+func ExplicitAckEnabled(mode ExplicitAckMode) bool {
+	return ExplicitAckModeInSlice(mode,
+		[]ExplicitAckMode{
+			ExplicitAckModeEnable,
+			ExplicitAckModeExplicitOnly,
+		})
 }
 
 // GetTriggersByKind returns a map of triggers by their kind

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -38,6 +38,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/build"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
+	"github.com/nuclio/nuclio/pkg/processor/util/partitionworker"
 
 	"github.com/docker/distribution/reference"
 	"github.com/google/go-cmp/cmp"
@@ -1452,6 +1453,16 @@ func (ap *Platform) validateTriggers(functionConfig *functionconfig.Config) erro
 				continue
 			}
 			return nuclio.NewErrBadRequest("There's more than one http trigger (unsupported)")
+		}
+
+		// explicit ack is only allowed for Static Allocation mode
+		if triggerInstance.Kind == "kafka" {
+			if workerAllocationMode, exists := functionConfig.Meta.Annotations["nuclio.io/kafka-worker-allocation-mode"]; exists {
+				if partitionworker.AllocationMode(workerAllocationMode) != partitionworker.AllocationModeStatic &&
+					functionconfig.ExplicitAckEnabled(triggerInstance.ExplicitAckMode) {
+					return nuclio.NewErrBadRequest("Explicit ack mode is not allowed when using worker pool allocation mode")
+				}
+			}
 		}
 	}
 

--- a/pkg/processor/trigger/kafka/types.go
+++ b/pkg/processor/trigger/kafka/types.go
@@ -157,6 +157,18 @@ func NewConfiguration(id string,
 
 	newConfiguration.WorkerAllocationMode = partitionworker.AllocationMode(workerAllocationModeValue)
 
+	// default explicit ack mode to 'disable'
+	if triggerConfiguration.ExplicitAckMode == "" {
+		newConfiguration.ExplicitAckMode = functionconfig.ExplicitAckModeDisable
+	}
+
+	// explicit ack is only allowed for Static Allocation mode
+	if newConfiguration.WorkerAllocationMode == partitionworker.AllocationModePool &&
+		(triggerConfiguration.ExplicitAckMode == functionconfig.ExplicitAckModeEnable ||
+			triggerConfiguration.ExplicitAckMode == functionconfig.ExplicitAckModeExplicitOnly) {
+		return nil, errors.New("Explicit ack mode is not allowed when using worker pool allocation mode")
+	}
+
 	if ackWindowSizeInterface, ok := newConfiguration.Attributes["ackWindowSize"]; ok {
 		var ackWindowSize int
 		errMessage := "Failed loading ack window size from trigger attributes."

--- a/pkg/processor/trigger/kafka/types.go
+++ b/pkg/processor/trigger/kafka/types.go
@@ -163,9 +163,8 @@ func NewConfiguration(id string,
 	}
 
 	// explicit ack is only allowed for Static Allocation mode
-	if newConfiguration.WorkerAllocationMode == partitionworker.AllocationModePool &&
-		(triggerConfiguration.ExplicitAckMode == functionconfig.ExplicitAckModeEnable ||
-			triggerConfiguration.ExplicitAckMode == functionconfig.ExplicitAckModeExplicitOnly) {
+	if newConfiguration.WorkerAllocationMode != partitionworker.AllocationModeStatic &&
+		functionconfig.ExplicitAckEnabled(triggerConfiguration.ExplicitAckMode) {
 		return nil, errors.New("Explicit ack mode is not allowed when using worker pool allocation mode")
 	}
 


### PR DESCRIPTION
As part of the explicit ack requirement, introduce `ExplicitAckMode` for stream triggers which has three options:
- 'enable': Allows for explicit and implicit acks
- 'disable': Allows only implicit acks (default)
- 'explicitOnly': Allows only explicit acks and ignores implicit acks

Will be used in follow-up PRs.

Requirement: https://jira.iguazeng.com/browse/IG-18655