### PR TITLE
Remove platform config from processor logs

### DIFF
--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -123,11 +123,9 @@ func NewProcessor(configurationPath string, platformConfigurationPath string) (*
 	newProcessor.logger.InfoWith("Starting processor", "version", version.Get())
 
 	indentedProcessorConfiguration, _ := json.MarshalIndent(processorConfiguration, "", "    ")
-	indentedPlatformConfiguration, _ := json.MarshalIndent(platformConfiguration, "", "    ")
 
 	newProcessor.logger.DebugWith("Read configuration",
-		"config", string(indentedProcessorConfiguration),
-		"platformConfig", string(indentedPlatformConfiguration))
+		"config", string(indentedProcessorConfiguration))
 
 	// save platform configuration in process configuration
 	processorConfiguration.PlatformConfig = platformConfiguration


### PR DESCRIPTION
The entire platform config which contains sensitive information is logged when the processor is initialized, and is printed to the dashboard which is visible to users.

This can cause security issues hence removed from the logs.