### PR TITLE
Remove CatchAndLogPanic wrapper function

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -421,18 +421,6 @@ func GenerateRandomString(length int, letters []rune) string {
 	return string(randomString)
 }
 
-func CatchAndLogPanic(ctx context.Context,
-	loggerInstance logger.Logger,
-	actionName string) error {
-	return CatchAndLogPanicWithOptions(ctx,
-		loggerInstance,
-		actionName,
-		&CatchAndLogPanicOptions{
-			Args:          nil,
-			CustomHandler: nil,
-		})
-}
-
 func CatchAndLogPanicWithOptions(ctx context.Context,
 	loggerInstance logger.Logger,
 	actionName string,

--- a/pkg/platform/kube/operator/multiworker.go
+++ b/pkg/platform/kube/operator/multiworker.go
@@ -104,9 +104,13 @@ func (mw *MultiWorker) Start(ctx context.Context) error {
 
 	// run the informer
 	go func() {
-		defer common.CatchAndLogPanic(ctx, // nolint: errcheck
+		defer common.CatchAndLogPanicWithOptions(ctx, // nolint: errcheck
 			mw.logger,
-			"running multi worker informer")
+			"running multi worker informer",
+			&common.CatchAndLogPanicOptions{
+				Args:          nil,
+				CustomHandler: nil,
+			})
 
 		mw.informer.Run(mw.stopChannel)
 	}()
@@ -120,9 +124,13 @@ func (mw *MultiWorker) Start(ctx context.Context) error {
 	for workerID := 0; workerID < mw.numWorkers; workerID++ {
 		workerID := workerID
 		go func() {
-			defer common.CatchAndLogPanic(ctx, // nolint: errcheck
+			defer common.CatchAndLogPanicWithOptions(ctx, // nolint: errcheck
 				mw.logger,
-				"processing items")
+				"processing items",
+				&common.CatchAndLogPanicOptions{
+					Args:          nil,
+					CustomHandler: nil,
+				})
 
 			workerCtx := context.WithValue(workersCtx, WorkerIDKey, workerID)
 

--- a/pkg/processor/runtime/python/test/timeout_test.go
+++ b/pkg/processor/runtime/python/test/timeout_test.go
@@ -88,7 +88,7 @@ func (suite *timeoutSuite) TestTimeout() {
 
 			RetryUntilSuccessfulStatusCode: &okStatusCode,
 			RetryUntilSuccessfulInterval:   1,
-			RetryUntilSuccessfulDuration:   3 * sleepTime,
+			RetryUntilSuccessfulDuration:   2 * sleepTime,
 		},
 		{
 			RequestBody:    suite.genTimeoutRequest(time.Millisecond),

--- a/pkg/processor/runtime/python/test/timeout_test.go
+++ b/pkg/processor/runtime/python/test/timeout_test.go
@@ -88,7 +88,7 @@ func (suite *timeoutSuite) TestTimeout() {
 
 			RetryUntilSuccessfulStatusCode: &okStatusCode,
 			RetryUntilSuccessfulInterval:   1,
-			RetryUntilSuccessfulDuration:   2 * sleepTime,
+			RetryUntilSuccessfulDuration:   3 * sleepTime,
 		},
 		{
 			RequestBody:    suite.genTimeoutRequest(time.Millisecond),

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -18,6 +18,7 @@ package rpc
 
 import (
 	"bufio"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -407,11 +408,13 @@ func (r *AbstractRuntime) createTCPListener() (net.Listener, string, error) {
 func (r *AbstractRuntime) eventWrapperOutputHandler(conn io.Reader, resultChan chan *result) {
 
 	// Reset might close outChan, which will cause panic when sending
-	defer func() {
-		if err := recover(); err != nil {
-			r.Logger.WarnWith("Recovered during event output handler (Restart called?)", "err", err)
-		}
-	}()
+	defer common.CatchAndLogPanicWithOptions(context.Background(), // nolint: errcheck
+		r.Logger,
+		"event wrapper output handler (Restart called?)",
+		&common.CatchAndLogPanicOptions{
+			Args:          nil,
+			CustomHandler: nil,
+		})
 
 	outReader := bufio.NewReader(conn)
 
@@ -461,11 +464,13 @@ func (r *AbstractRuntime) eventWrapperOutputHandler(conn io.Reader, resultChan c
 func (r *AbstractRuntime) controlOutputHandler(conn io.Reader) {
 
 	// Reset might close outChan, which will cause panic when sending
-	defer func() {
-		if err := recover(); err != nil {
-			r.Logger.WarnWith("Recovered during control output handler (Restart called?)", "err", err)
-		}
-	}()
+	defer common.CatchAndLogPanicWithOptions(context.Background(), // nolint: errcheck
+		r.Logger,
+		"control wrapper output handler (Restart called?)",
+		&common.CatchAndLogPanicOptions{
+			Args:          nil,
+			CustomHandler: nil,
+		})
 
 	outReader := bufio.NewReader(conn)
 

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -18,7 +18,6 @@ package rpc
 
 import (
 	"bufio"
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -408,9 +407,11 @@ func (r *AbstractRuntime) createTCPListener() (net.Listener, string, error) {
 func (r *AbstractRuntime) eventWrapperOutputHandler(conn io.Reader, resultChan chan *result) {
 
 	// Reset might close outChan, which will cause panic when sending
-	defer common.CatchAndLogPanic(context.Background(), // nolint: errcheck
-		r.Logger,
-		"Recovered during event output handler (Restart called?)")
+	defer func() {
+		if err := recover(); err != nil {
+			r.Logger.WarnWith("Recovered during event output handler (Restart called?)", "err", err)
+		}
+	}()
 
 	outReader := bufio.NewReader(conn)
 
@@ -460,9 +461,11 @@ func (r *AbstractRuntime) eventWrapperOutputHandler(conn io.Reader, resultChan c
 func (r *AbstractRuntime) controlOutputHandler(conn io.Reader) {
 
 	// Reset might close outChan, which will cause panic when sending
-	defer common.CatchAndLogPanic(context.Background(), // nolint: errcheck
-		r.Logger,
-		"Recovered during event output handler (Restart called?)")
+	defer func() {
+		if err := recover(); err != nil {
+			r.Logger.WarnWith("Recovered during control output handler (Restart called?)", "err", err)
+		}
+	}()
 
 	outReader := bufio.NewReader(conn)
 

--- a/pkg/processor/trigger/http/test/suite/suite.go
+++ b/pkg/processor/trigger/http/test/suite/suite.go
@@ -138,6 +138,9 @@ func (suite *TestSuite) DeployFunctionAndRequests(createFunctionOptions *platfor
 		suite.Require().NotNil(deployResult)
 		for _, request := range requests {
 			request.Enrich(deployResult)
+			suite.Logger.DebugWith("Sending request",
+				"requestBody", request.RequestBody,
+				"expectedResponseStatusCode", request.ExpectedResponseStatusCode)
 			if !suite.SendRequestVerifyResponse(request) {
 
 				// fail fast

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -524,9 +524,13 @@ func (ar *AbstractResource) callCustomStreamRouteFunc(responseWriter http.Respon
 		// This go routine helps out and flushing every <interval> giving the user
 		// the experience of lively-streaming output
 		go func() {
-			defer common.CatchAndLogPanic(request.Context(), // nolint: errcheck
+			defer common.CatchAndLogPanicWithOptions(request.Context(), // nolint: errcheck
 				ar.Logger,
-				"flush-custom-stream-func")
+				"flush-custom-stream-func",
+				&common.CatchAndLogPanicOptions{
+					Args:          nil,
+					CustomHandler: nil,
+				})
 
 			for {
 				select {


### PR DESCRIPTION
It appears that the helper function `CatchAndLogPanic` (which provided syntactic sugar for using `CatchAndLogPanicWithOptions` with `nil` options) did not recover properly from panics as it should.

The reason being that when a panic occurs, the `recover` builtin function should be called from a deferred function inside the panicking goroutine.
Calling `recover` from a nested deferred function fails to catch and handle the panic.

References:
https://stackoverflow.com/questions/49344478/why-recover-does-not-work-in-a-nested-deferred-function
https://go.dev/play/p/g2LpMKD5RMA