### PR TITLE
TestTimeout - increase timeout and sleep time

### DIFF
--- a/pkg/processor/runtime/python/test/timeout_test.go
+++ b/pkg/processor/runtime/python/test/timeout_test.go
@@ -53,13 +53,13 @@ func (suite *timeoutSuite) TestTimeout() {
 	createFunctionOptions := suite.GetDeployOptions("timeout",
 		path.Join(suite.GetTestFunctionsDir(), "python", "timeout"))
 
-	timeout := 100 * time.Millisecond
+	timeout := 500 * time.Millisecond
 	createFunctionOptions.FunctionConfig.Spec.EventTimeout = timeout.String()
 	createFunctionOptions.FunctionConfig.Spec.Handler = "timeout:handler"
 	var oldPID int
 	okStatusCode := http.StatusOK
 	timeoutStatusCode := http.StatusRequestTimeout
-	sleepTime := 1 * time.Second
+	sleepTime := 2 * time.Second
 
 	suite.DeployFunctionAndRequests(createFunctionOptions, []*httpsuite.Request{
 		{
@@ -87,7 +87,7 @@ func (suite *timeoutSuite) TestTimeout() {
 			RequestHeaders: requestHeaders,
 
 			RetryUntilSuccessfulStatusCode: &okStatusCode,
-			RetryUntilSuccessfulInterval:   1,
+			RetryUntilSuccessfulInterval:   10 * time.Millisecond,
 			RetryUntilSuccessfulDuration:   2 * sleepTime,
 		},
 		{


### PR DESCRIPTION
`TestTimeout` for python runtime sometime fails transiently during CI.
Increasing timeouts and sleep times to make the test a bit more lenient.