### PR TITLE
Bump nuclio-sdk-py to v0.5.1

### DIFF
--- a/pkg/processor/controlcommunication/types.go
+++ b/pkg/processor/controlcommunication/types.go
@@ -35,10 +35,9 @@ type ControlMessage struct {
 }
 
 type ControlMessageAttributesExplicitAck struct {
-	Topic       string `json:"topic"`
-	Partition   int32  `json:"partition"`
-	Offset      int64  `json:"offset"`
-	TriggerName string `json:"trigger_name"`
+	Topic     string `json:"topic"`
+	Partition int32  `json:"partition"`
+	Offset    int64  `json:"offset"`
 }
 
 type ControlConsumer struct {

--- a/pkg/processor/runtime/python/py/requirements/common.txt
+++ b/pkg/processor/runtime/python/py/requirements/common.txt
@@ -1,2 +1,2 @@
 mock==2.0.0
-nuclio-sdk==0.5.0
+nuclio-sdk==0.5.1

--- a/pkg/processor/trigger/v3iostream/test/v3iostream_test.go
+++ b/pkg/processor/trigger/v3iostream/test/v3iostream_test.go
@@ -590,6 +590,7 @@ func (suite *testSuite) TestExplicitAck() {
 		time.Sleep(sleepTime)
 
 		current, committed = suite.getShardLagDetails(shardID)
+		suite.Logger.DebugWith("Got shard lag details", "current", current, "committed", committed)
 		suite.Require().LessOrEqual(current-committed, 1, "Current lag is not less than or equal to 1")
 
 		return true

--- a/test/_functions/python/kafka-explicit-ack/explicitacker.py
+++ b/test/_functions/python/kafka-explicit-ack/explicitacker.py
@@ -35,11 +35,13 @@ async def handler(context, event):
 
     if event.trigger.kind in ("kafka-cluster", "v3ioStream", "v3io-stream"):
 
-        context.logger.debug('Adding event to queue - event.body: {0}, event.offset: {1}'.format(event.body,
-                                                                                                 event.offset))
+        context.logger.debug('Adding event to offset queue - event.body: {0}, event.offset: {1}'.format(
+            event.body,
+            event.offset,
+        ))
 
         # add event to file
-        write_event_to_file(context, event)
+        write_event_offset_to_file(context, event)
 
         # ensure no ack on response
         response = nuclio_sdk.Response()
@@ -104,35 +106,28 @@ def get_number_of_enqueued_events():
         return len(events)
 
 
-def write_event_to_file(context, event):
+def write_event_offset_to_file(context, event):
 
     # add event offset to end of file
     offset = event.body.decode('utf-8').split('-')[-1]
 
     with open(events_file_path, 'a') as file:
-        event_json = json.dumps({
+        qualified_offset_json = json.dumps({
             'topic': event.path,
             'partition': event.shard_id,
             'offset': int(offset),
-            'trigger_name': event.trigger.name,
-            'trigger_kind': event.trigger.kind,
             'body': event.body.decode('utf-8')
         })
-        file.write(event_json + '\n')
+        file.write(qualified_offset_json + '\n')
 
 
-def event_attributes_to_event(event):
-    event_attributes = json.loads(event)
-    return nuclio_sdk.Event(
-        body=event_attributes['body'].encode('utf-8'),
-        path=event_attributes['topic'],
-        shard_id=event_attributes['partition'],
-        offset=event_attributes['offset'],
-        trigger=nuclio_sdk.TriggerInfo(
-            name=event_attributes['trigger_name'],
-            kind=event_attributes['trigger_kind'],
-        )
-    )
+def qualified_offset_attributes_to_qualified_offset(qualified_offset):
+    qualified_offset_attributes = json.loads(qualified_offset)
+    return nuclio_sdk.QualifiedOffset(
+        topic=qualified_offset_attributes['topic'],
+        partition=qualified_offset_attributes['partition'],
+        offset=qualified_offset_attributes['offset']
+    ), qualified_offset_attributes['body'].encode('utf-8')
 
 
 async def process_events(context):
@@ -141,14 +136,14 @@ async def process_events(context):
     last_commit_offset = 0
 
     with open(events_file_path, 'r') as file:
-        events = file.readlines()
-        context.logger.info('Number of events left: {0}'.format(len(events)))
-        for event in events:
-            event_to_ack = event_attributes_to_event(event)
-            context.logger.info('Processing event - body: {0}, offset: {1}'.format(event_to_ack.body,
-                                                                                   event_to_ack.offset))
-            last_commit_offset = event_to_ack.offset
-            await context.platform.explicit_ack(event_to_ack)
+        qualified_offsets = file.readlines()
+        context.logger.info('Number of events left: {0}'.format(len(qualified_offsets)))
+        for qualified_offset in qualified_offsets:
+            qualified_offset_to_ack, event_body = qualified_offset_attributes_to_qualified_offset(qualified_offset)
+            context.logger.info('Processing event - body: {0}, offset: {1}'.format(event_body,
+                                                                                   qualified_offset_to_ack.offset))
+            last_commit_offset = qualified_offset_to_ack.offset
+            await context.platform.explicit_ack(qualified_offset_to_ack)
 
     # clear file
     with open(events_file_path, 'w'):


### PR DESCRIPTION
In nuclio-sdk-py 0.5.1 we [introduced the QualifiedOffset object](https://github.com/nuclio/nuclio-sdk-py/pull/38/files) for explicit ack usage.

In this PR we bump the package and update `explicitacker.py` accordingly.

https://github.com/nuclio/nuclio-sdk-py/releases/tag/v0.5.1