### PR TITLE
Kafka - Enrich runtime configuration with worker termination timeout

### DIFF
--- a/pkg/processor/trigger/kafka/types.go
+++ b/pkg/processor/trigger/kafka/types.go
@@ -299,6 +299,9 @@ func NewConfiguration(id string,
 		newConfiguration.maxWaitHandlerDuringRebalance = workerTerminationTimeout
 	}
 
+	// enrich runtime configuration with worker termination timeout
+	runtimeConfiguration.WorkerTerminationTimeout = workerTerminationTimeout
+
 	if newConfiguration.WorkerAllocationMode == "" {
 		newConfiguration.WorkerAllocationMode = partitionworker.AllocationModePool
 	}


### PR DESCRIPTION
Worker termination timeout is configured in the Trigger's spec, and used in the runtime's `Terminate` function (currently relevant only for Kafka during rebalance).
When creating a new kafka configuration, enrich the runtime's configuration with the worker termination timeout duration.