### PR TITLE
Fix security context test failure on docker platform

### DIFF
--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1106,7 +1106,6 @@ func (suite *functionDeployTestSuite) TestDeployWaitReadinessTimeoutBeforeFailur
 }
 
 func (suite *functionDeployTestSuite) TestDeployWithSecurityContext() {
-
 	runAsUserID := "1000"
 	runAsGroupID := "2000"
 	fsGroup := "3000"
@@ -1153,12 +1152,10 @@ func (suite *functionDeployTestSuite) TestDeployWithSecurityContext() {
 
 	err = suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"},
 		map[string]string{
-			"image":   imageName,
-			"runtime": "shell",
-			"handler": "main.sh",
-
-			// the `id` command
-			"source":       "aWQ=",
+			"image":        imageName,
+			"runtime":      "shell",
+			"handler":      "main.sh",
+			"source":       base64.StdEncoding.EncodeToString([]byte("id")),
 			"run-as-user":  runAsUserID,
 			"run-as-group": runAsGroupID,
 			"fsgroup":      fsGroup,
@@ -1179,6 +1176,19 @@ func (suite *functionDeployTestSuite) TestDeployWithSecurityContext() {
 	suite.Require().NoError(err)
 
 	// make sure the id command from the handler, returns the correct uid and gids
+	suite.Require().Condition(func() (success bool) {
+		uidGid := strings.Contains(suite.outputBuffer.String(),
+			fmt.Sprintf(`uid=%s gid=%s`,
+				runAsUserID,
+				runAsGroupID))
+		groups := strings.Contains(suite.outputBuffer.String(),
+			fmt.Sprintf(`groups=%s`, fsGroup))
+
+		// it is observed that on azure's docker flavor, the groups are set with both fsGroup and group ID
+		extendedGroups := strings.Contains(suite.outputBuffer.String(),
+			fmt.Sprintf(`groups=%s`, runAsGroupID+","+fsGroup))
+		return uidGid && (groups || extendedGroups)
+	})
 	suite.Require().Contains(suite.outputBuffer.String(), fmt.Sprintf(`uid=%s gid=%s groups=%s`,
 		runAsUserID,
 		runAsGroupID,

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1189,10 +1189,6 @@ func (suite *functionDeployTestSuite) TestDeployWithSecurityContext() {
 			fmt.Sprintf(`groups=%s`, runAsGroupID+","+fsGroup))
 		return uidGid && (groups || extendedGroups)
 	})
-	suite.Require().Contains(suite.outputBuffer.String(), fmt.Sprintf(`uid=%s gid=%s groups=%s`,
-		runAsUserID,
-		runAsGroupID,
-		fsGroup))
 }
 
 func (suite *functionDeployTestSuite) TestDeployServiceTypeClusterIPWithInvocation() {

--- a/pkg/processor/build/runtime/shell/runtime.go
+++ b/pkg/processor/build/runtime/shell/runtime.go
@@ -60,7 +60,7 @@ func (s *shell) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, 
 	return &processorDockerfileInfo, nil
 }
 
-// GetProcessorImageObjectPaths returns the paths of all objects that should reside in the handler
+// GetHandlerDirObjectPaths returns the paths of all objects that should reside in the handler
 // directory
 func (s *shell) GetHandlerDirObjectPaths() []string {
 	if s.FunctionConfig.Spec.Build.Path != "/dev/null" {


### PR DESCRIPTION
On `20.10.17+azure-1` the response for `id` command is `uid=1000 gid=2000 groups=2000,3000` whereas on older version it was `uid=1000 gid=2000 groups=3000`.
This ofcourse should not fail the test as the point of security context test is to make sure the running container populates the user / group /fsgroup ids correctly.
