### PR TITLE
Minor chart templates fixes

### DIFF
--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.15.4
+version: 0.15.5
 appVersion: 1.10.3
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
@@ -22,9 +22,7 @@ home: https://nuclio.io
 sources:
   - https://github.com/nuclio/nuclio
 maintainers:
-  - name: Eran Duchan
-    email: erand@iguazio.com
-  - name: Oded Messer
-    email: odedm@iguazio.com
   - name: Liran Ben Gida
     email: liranb@iguazio.com
+  - name: Tomer Shor
+    email: tomers@iguazio.com

--- a/hack/k8s/helm/nuclio/templates/secret/dashboard-opa.yml
+++ b/hack/k8s/helm/nuclio/templates/secret/dashboard-opa.yml
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-{{- if .Values.dashboard.opa.enabled -}}
+
+{{- if .Values.dashboard.opa.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
The trailing `#` signs caused iguazio system to fail installing nuclio, with the following error:
```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: apiVersion not set
error validating "": error validating data: apiVersion not set
```