### PR TITLE
Kaniko - use workdir /kaniko

### DIFF
--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -143,7 +143,7 @@ dashboard:
 
     image:
       repository: gcr.io/kaniko-project/executor
-      tag: v1.8.1
+      tag: v1.9.0
       pullPolicy: IfNotPresent
 
     initContainerImage:

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -255,14 +255,19 @@ func (k *Kaniko) compileJobSpec(namespace string,
 	}
 
 	// Add build options args
-	for k, v := range buildOptions.BuildArgs {
-		buildArgs = append(buildArgs, fmt.Sprintf("--build-arg=%s=%s", k, v))
+	for buildArgName, buildArgValue := range buildOptions.BuildArgs {
+		buildArgs = append(buildArgs, fmt.Sprintf("--build-arg=%s=%s", buildArgName, buildArgValue))
 	}
 
 	tmpFolderVolumeMount := v1.VolumeMount{
 		Name:      "tmp",
 		MountPath: "/tmp",
 	}
+	kanikoWorkingDirFolderVolumeMount := v1.VolumeMount{
+		Name:      "kaniko-wd",
+		MountPath: "/kaniko-wd",
+	}
+	buildArgs = append(buildArgs, fmt.Sprintf("--kaniko-dir=%s/wd", kanikoWorkingDirFolderVolumeMount.MountPath))
 
 	jobName := k.compileJobName(buildOptions.Image)
 

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -264,12 +264,6 @@ func (k *Kaniko) compileJobSpec(namespace string,
 		Name:      "tmp",
 		MountPath: "/tmp",
 	}
-	kanikoWorkingDirFolderVolumeMount := v1.VolumeMount{
-		Name:      "kaniko-wd",
-		MountPath: "/kaniko",
-	}
-	buildArgs = append(buildArgs, fmt.Sprintf("--kaniko-dir=%s", kanikoWorkingDirFolderVolumeMount.MountPath))
-
 	jobName := k.compileJobName(buildOptions.Image)
 
 	assetsURL := fmt.Sprintf("http://%s:8070/kaniko/%s", os.Getenv("NUCLIO_DASHBOARD_DEPLOYMENT_NAME"), bundleFilename)

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -93,7 +93,7 @@ func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) 
 	}
 	if containerBuilderConfiguration.KanikoImage == "" {
 		containerBuilderConfiguration.KanikoImage = common.GetEnvOrDefaultString("NUCLIO_KANIKO_CONTAINER_IMAGE",
-			"gcr.io/kaniko-project/executor:v1.8.1")
+			"gcr.io/kaniko-project/executor:v1.9.0")
 	}
 	if containerBuilderConfiguration.KanikoImagePullPolicy == "" {
 		containerBuilderConfiguration.KanikoImagePullPolicy = common.GetEnvOrDefaultString(

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -49,6 +49,7 @@ type BuildOptions struct {
 	Tolerations             []v1.Toleration
 	ReadinessTimeoutSeconds int
 	ServiceAccountName      string
+	SecurityContext         *v1.PodSecurityContext
 }
 
 type ContainerBuilderConfiguration struct {

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -140,6 +140,7 @@ func NewServer(parentLogger logger.Logger,
 	} else if containerBuilderKind == "kaniko" {
 		if common.GetEnvOrDefaultString("NUCLIO_DASHBOARD_SERVE_KANIKO_ARTIFACTS_MODE",
 			"local") == "local" {
+
 			// allow dashboard server to handle request to get kaniko artifacts for function builds
 			// this is useful when running dashboard locally. in production, nginx will handle this
 			newServer.Router.HandleFunc("/kaniko/*", func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -19,6 +19,7 @@ package dashboard
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/auth"
@@ -135,6 +136,18 @@ func NewServer(parentLogger logger.Logger,
 	if containerBuilderKind == "docker" {
 		if err := newServer.loadDockerKeys(newServer.dockerKeyDir); err != nil {
 			newServer.Logger.WarnWith("Failed to login with docker keys", "err", err.Error())
+		}
+	} else if containerBuilderKind == "kaniko" {
+		if common.GetEnvOrDefaultString("NUCLIO_DASHBOARD_SERVE_KANIKO_ARTIFACTS_MODE",
+			"local") == "local" {
+			// allow dashboard server to handle request to get kaniko artifacts for function builds
+			// this is useful when running dashboard locally. in production, nginx will handle this
+			newServer.Router.HandleFunc("/kaniko/*", func(w http.ResponseWriter, r *http.Request) {
+				ctx := chi.RouteContext(r.Context())
+				serverRoutePrefix := strings.TrimSuffix(ctx.RoutePattern(), "/*")
+				fs := http.StripPrefix(serverRoutePrefix, http.FileServer(http.Dir("/tmp/kaniko-builds")))
+				fs.ServeHTTP(w, r)
+			})
 		}
 	}
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -991,7 +991,7 @@ func (b *Builder) mkDirUnderTemp(name string) (string, error) {
 	dir := path.Join(b.tempDir, name)
 
 	// temp dir needs executable permission for docker to be able to pull from it
-	if err := os.Mkdir(dir, 0744); err != nil {
+	if err := os.MkdirAll(dir, 0744); err != nil {
 		return "", errors.Wrapf(err, "Failed to create temporary subdir %s", dir)
 	}
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1084,6 +1084,7 @@ func (b *Builder) buildProcessorImage() (string, error) {
 			ServiceAccountName: b.options.FunctionConfig.Spec.ServiceAccount,
 			ReadinessTimeoutSeconds: b.platform.GetConfig().GetFunctionReadinessTimeoutOrDefault(
 				b.options.FunctionConfig.Spec.ReadinessTimeoutSeconds),
+			SecurityContext: b.options.FunctionConfig.Spec.SecurityContext,
 		})
 
 	return taggedImageName, err

--- a/pkg/restful/middleware/middleware.go
+++ b/pkg/restful/middleware/middleware.go
@@ -125,6 +125,7 @@ func RequestResponseLogger(logger logger.Logger) func(next http.Handler) http.Ha
 					"/api/functions",
 					"/api/function_templates",
 					"/api/v3io_streams",
+					"/kaniko",
 				}, strings.TrimSuffix(request.URL.Path, "/")) {
 					logVars = append(logVars, "responseBody", responseBodyBuffer.String())
 				}


### PR DESCRIPTION
Preparing the ground for kaniko to work with security context. (it does not work yet, as it requires to all container images being used during buildtime to be working rootless and it is something we cannot guarantee yet.

In this PR
1. bumped kaniko to 1.9.0
2. reduce spammy logs in case job pod was not created
3. kaniko to use `/kaniko` as a working dir during function builds
4. dashboard to serve kaniko artifacts (function .tar.gz) via http server, useful for when running dashboard locally.

Set of envvar I used during my testings to make sure dashboard is running as a process (and not as a pod / container)

```
# all below is relevant for running dashboard as a process with kubeconfig against a kubernetes cluster (minikube)
# set dashboard to use kaniko as container builder
NUCLIO_CONTAINER_BUILDER_KIND=kaniko

# the external ip (aka static ip) in which the kaniko job can reach the dashboard process
NUCLIO_DASHBOARD_DEPLOYMENT_NAME=45.0.0.106

# tell dashboard to serve /kaniko/* as an HTTP file server
NUCLIO_DASHBOARD_SERVE_KANIKO_ARTIFACTS_MODE=local

# kaniko to use insecure pull/push actions against registry 
NUCLIO_KANIKO_INSECURE_PULL_REGISTRY=true
NUCLIO_KANIKO_INSECURE_PUSH_REGISTRY=true

# running as a process we dont have function templates available
NUCLIO_TEMPLATES_ARCHIVE_ADDRESS=nil
```