### PR TITLE
Fix Python unit test timings

### DIFF
--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -194,7 +194,6 @@ class Wrapper(object):
                 raise
 
     async def _send_data_on_control_socket(self, data):
-
         self._logger.debug_with('Sending data on control socket', data_length=len(data))
 
         # send message to processor

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -54,13 +54,18 @@ class TestSubmitEvents(unittest.TestCase):
 
         # generate socket path
         self._event_socket_path = os.path.join(self._temp_path, 'nuclio.event.sock')
-        self._control_socket_path = os.path.join(self._temp_path, 'nuclio.control.sock')
+
+        # TODO: to make it work we need to check why having 2 daemon threads
+        #  serving socket cause performance degradation
+        self._control_socket_path = os.path.join(self._temp_path, 'nuclio.event.sock')
 
         # create transport
         self._unix_stream_server, self._unix_stream_server_thread = \
             self._create_unix_stream_server(self._event_socket_path)
-        self._unix_control_stream_server, self._control_unix_stream_server_thread = \
-            self._create_unix_stream_server(self._control_socket_path)
+
+        # before uncommenting, see self._control_socket_path assignment
+        # self._unix_control_stream_server, self._control_unix_stream_server_thread = \
+        #     self._create_unix_stream_server(self._control_socket_path)
 
         # create logger
         self._logger = nuclio_sdk.Logger(logging.DEBUG)
@@ -86,7 +91,9 @@ class TestSubmitEvents(unittest.TestCase):
 
         for unix_stream_server, unix_stream_server_thread in [
             (self._unix_stream_server, self._unix_stream_server_thread),
-            (self._unix_control_stream_server, self._control_unix_stream_server_thread),
+
+            # before uncommenting, see self._control_socket_path assignment
+            # (self._unix_control_stream_server, self._control_unix_stream_server_thread),
         ]:
             unix_stream_server.server_close()
             unix_stream_server.shutdown()


### PR DESCRIPTION
It takes too much time for a daemon thread to run in python unit test