### PR TITLE
Kafka - Decouple worker termination signal from explicit ack

### DIFF
--- a/pkg/common/consts.go
+++ b/pkg/common/consts.go
@@ -22,7 +22,7 @@ const (
 	UnexpectedTerminationChildProcess ReusedMessage = "Unexpected termination of child process"
 	WorkDirectoryDoesNotExist         ReusedMessage = "Work directory does not exist"
 	WorkDirectoryExpectedBeString     ReusedMessage = "Work directory is expected to be string"
-	FailedReadFromConnection          ReusedMessage = "Failed to read from connection"
+	FailedReadFromEventConnection     ReusedMessage = "Failed to read from event connection"
 	FailedReadControlMessage          ReusedMessage = "Failed to read control message"
 )
 

--- a/pkg/logprocessing/logprocessing.go
+++ b/pkg/logprocessing/logprocessing.go
@@ -199,7 +199,7 @@ func shouldAddToBriefErrorsMessage(logLevel uint8, logMessage, workerID string) 
 	knownFailureSubstrings := [...]string{"Failed to connect to broker"}
 	ignoreFailureSubstrings := [...]string{
 		string(common.UnexpectedTerminationChildProcess),
-		string(common.FailedReadFromConnection),
+		string(common.FailedReadFromEventConnection),
 		string(common.FailedReadControlMessage),
 	}
 

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -429,7 +429,7 @@ func (r *AbstractRuntime) eventWrapperOutputHandler(conn io.Reader, resultChan c
 
 		// TODO: sync between event and control output handlers using a shared context
 		case <-r.cancelHandlerChan:
-			r.Logger.Warn("Control output handler was canceled (Restart called?)")
+			r.Logger.Warn("Event output handler was canceled (Restart called?)")
 			return
 
 		default:
@@ -440,7 +440,7 @@ func (r *AbstractRuntime) eventWrapperOutputHandler(conn io.Reader, resultChan c
 			data, unmarshalledResult.err = outReader.ReadBytes('\n')
 
 			if unmarshalledResult.err != nil {
-				r.Logger.WarnWith(string(common.FailedReadFromConnection), "err", unmarshalledResult.err)
+				r.Logger.WarnWith(string(common.FailedReadFromEventConnection), "err", unmarshalledResult.err)
 				resultChan <- unmarshalledResult
 				continue
 			}

--- a/pkg/processor/runtime/rpc/controlmessagebroker.go
+++ b/pkg/processor/runtime/rpc/controlmessagebroker.go
@@ -68,7 +68,7 @@ func (b *rpcControlMessageBroker) ReadControlMessage(reader *bufio.Reader) (*con
 	// read data from reader
 	data, err := reader.ReadBytes('\n')
 	if err != nil {
-		return nil, errors.Wrap(err, string(common.FailedReadFromConnection))
+		return nil, errors.Wrap(err, string(common.FailedReadFromEventConnection))
 	}
 
 	unmarshalledControlMessage := &controlcommunication.ControlMessage{}

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -271,9 +271,7 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 			// don't consume any more messages
 			consumeMessages = false
 
-			if functionconfig.ExplicitAckEnabled(k.configuration.ExplicitAckMode) {
-				go k.signalWorkerTermination(workerTerminationCompleteChan)
-			}
+			go k.signalWorkerTermination(workerTerminationCompleteChan)
 
 			// trigger is ready for rebalance if both the handler is done and
 			// the workers are finished with the graceful termination


### PR DESCRIPTION
If explicit ack mode is `disable`, the Kafka workers won't get signaled for termination.
This causes the `workerTerminationCompleteChan` channel to never get sent on, and eventually be closed without any traffic.

However - If a channel is blocking some code flow, and then closed, it unblocks code and it executes whats after it.
In the case of a disabled explicit ack mode, when all the relevant channels are closed, the following code section is executed, causing a `panic: send on closed channel` on the `readyForRebalanceChan` channel:

https://github.com/nuclio/nuclio/blob/development/pkg/processor/trigger/kafka/trigger.go#L288-L295

```
	go func() {
		<-workerTerminationCompleteChan
		k.Logger.DebugWith("Workers terminated", "partition", claim.Partition())
		wg.Done()
	}()

	wg.Wait()
	readyForRebalanceChan <- true
```

Decoupling the termination signal from explicit ack allows the termination signal to be sent to all workers, and when the process exists a signal will be sent to the `workerTerminationCompleteChan` and the race condition will be fixed.

JIRA: https://jira.iguazeng.com/browse/IG-21134