### PR TITLE
Increase ingress readiness wait time to 2.5 minutes

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -313,11 +313,12 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context,
 
 			// deployment is ready
 			// ingress is not yet (being too slow I guess, marking as unhealthy)
-			// give ingress a minute to be ready
+			// give ingress 2.5 minutes to be ready - since nginx ingress controller's
+			// sync cycle is 1 minute this ensures we'll wait at least 2 cycles.
 			// apply fail-fast when user did not ask to wait the full timeout
 			if deploymentReady &&
 				!ingressReady &&
-				time.Since(timeDeploymentReady) >= time.Minute &&
+				time.Since(timeDeploymentReady) >= 150*time.Second &&
 				!function.Spec.WaitReadinessTimeoutBeforeFailure {
 				lc.logger.WarnWithCtx(ctx,
 					"Function deployment is ready while ingress is not yet, stop waiting",


### PR DESCRIPTION
Since the Nginx ingress controller's Sync cycle is 1 minute, waiting only 1 minute for the ingress to be ready can miss a cycle by a matter of minutes and cause the deployment to fail fast.

In this PR we increase the ingress readiness wait time to 2.5 minutes - this way we can ensure we have at least 2 sync cycles in the ingress controller.
If function readiness timeout is shorter than 2.5 minutes and the ingress is not ready, the context will be canceled and the the deployment will fail fast as expected.

Related bug: https://jira.iguazeng.com/browse/IG-21127