### PR TITLE
Kafka - Disable worker signaling before rebalance

### DIFF
--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -232,7 +232,7 @@ func (r *AbstractRuntime) SupportsControlCommunication() bool {
 func (r *AbstractRuntime) Terminate() error {
 
 	// signal and wait for process termination
-	if err := r.signal(syscall.SIGTERM); err != nil {
+	if err := r.signal(syscall.SIGUSR1); err != nil {
 		return errors.Wrap(err, "Failed to signal wrapper process")
 	}
 

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -232,7 +232,8 @@ func (r *AbstractRuntime) SupportsControlCommunication() bool {
 func (r *AbstractRuntime) Terminate() error {
 
 	// signal and wait for process termination
-	if err := r.signal(syscall.SIGUSR1); err != nil {
+	// NOTE: SIGTERM terminates processes if they don't handle it.
+	if err := r.signal(syscall.SIGTERM); err != nil {
 		return errors.Wrap(err, "Failed to signal wrapper process")
 	}
 

--- a/pkg/processor/trigger/kafka/test/kafka_test.go
+++ b/pkg/processor/trigger/kafka/test/kafka_test.go
@@ -286,7 +286,6 @@ func (suite *testSuite) TestExplicitAck() {
 	})
 }
 
-//
 //func (suite *testSuite) TestEventRecorderRebalance() {
 //
 //	topic := "someTopic"

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
@@ -203,8 +202,6 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 
 	submittedEventChan := make(chan *submittedEvent)
 	explicitAckControlMessageChan := make(chan *controlcommunication.ControlMessage)
-	workerTerminationCompleteChan := make(chan bool)
-	readyForRebalanceChan := make(chan bool)
 
 	// submit the events in a goroutine so that we can unblock immediately
 	go k.eventSubmitter(claim, submittedEventChan)
@@ -274,30 +271,9 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 			// since current implementation is not working (IG-21152)
 			// go k.signalWorkerTermination(workerTerminationCompleteChan)
 
-			// trigger is ready for rebalance if both the handler is done and
-			// the workers are finished with the graceful termination
-			go func() {
-				var wg sync.WaitGroup
-				wg.Add(1)
-				go func() {
-					<-submittedEventInstance.done
-					k.Logger.DebugWith("Handler done", "partition", claim.Partition())
-					wg.Done()
-				}()
-
-				//go func() {
-				//	<-workerTerminationCompleteChan
-				//	k.Logger.DebugWith("Workers terminated", "partition", claim.Partition())
-				//	wg.Done()
-				//}()
-
-				wg.Wait()
-				readyForRebalanceChan <- true
-			}()
-
 			//  wait a for rebalance readiness or max timeout
 			select {
-			case <-readyForRebalanceChan:
+			case <-submittedEventInstance.done:
 				k.Logger.DebugWith("Handler done, rebalancing will commence")
 
 			case <-time.After(k.configuration.maxWaitHandlerDuringRebalance):
@@ -329,8 +305,6 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 	// shut down goroutines and channels
 	close(submittedEventChan)
 	close(explicitAckControlMessageChan)
-	close(workerTerminationCompleteChan)
-	close(readyForRebalanceChan)
 
 	return submitError
 }

--- a/pkg/processor/trigger/kafka/types.go
+++ b/pkg/processor/trigger/kafka/types.go
@@ -296,7 +296,7 @@ func NewConfiguration(id string,
 
 	// on rebalance, we want to wait the max timeout so the workers can exit gracefully before killing them
 	if newConfiguration.maxWaitHandlerDuringRebalance < workerTerminationTimeout {
-		newConfiguration.maxWaitHandlerDuringRebalance = workerTerminationTimeout
+		newConfiguration.maxWaitHandlerDuringRebalance = workerTerminationTimeout + 3*time.Second
 	}
 
 	// enrich runtime configuration with worker termination timeout

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -43,6 +43,7 @@ type Worker struct {
 	structuredCloudEvent cloudevent.Structured
 	binaryCloudEvent     cloudevent.Binary
 	eventTime            *time.Time
+	isTerminated         bool
 }
 
 // NewWorker creates a new worker
@@ -148,7 +149,15 @@ func (w *Worker) SupportsRestart() bool {
 }
 
 func (w *Worker) Terminate() error {
-	return w.runtime.Terminate()
+	err := w.runtime.Terminate()
+	if err == nil {
+		w.isTerminated = true
+	}
+	return err
+}
+
+func (w *Worker) IsTerminated() bool {
+	return w.isTerminated
 }
 
 // Subscribe subscribes to a control message kind


### PR DESCRIPTION
It appears that sending a SIGTERM to the wrapper process terminates the process if not handled otherwise.
This causes workers to exit prematurely when a rebalance occurs.

In this PR we comment out the worker signaling as an intermediate fix until we find a better way to signal the runtime process on an imminent rebalance.

Related bug: https://jira.iguazeng.com/browse/IG-21152 