### PR TITLE
Add Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -48,24 +48,9 @@ body:
     id: deployment_method
     attributes:
       label: Deployment Method
-      description: >
-        Please paste the output of ``import platform; platform.python_version()``
       options:
         - Docker
         - Kubernetes
-    validations:
-      required: true
-  - type: dropdown
-    id: os
-    attributes:
-      label: Installation OS
-      description: >
-        Please provide the OS you are installing on.
-      options:
-        - Mac
-        - Windows
-        - Linux
-        - Other
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,84 @@
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Bug Report
+description: Report incorrect behavior in Nuclio
+title: "[Bug]: "
+
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Nuclio Version checks
+      options:
+        - label: >
+            I have checked that this issue has not already been reported.
+          required: true
+        - label: >
+            I have confirmed this bug exists on the latest version of Nuclio.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Issue Description
+      description: >
+        Please provide a description of the issue you are experiencing.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: >
+        Please describe or show a code example of the expected behavior.
+    validations:
+      required: true
+  - type: dropdown
+    id: deployment_method
+    attributes:
+      label: Deployment Method
+      description: >
+        Please paste the output of ``import platform; platform.python_version()``
+      options:
+        - Docker
+        - Kubernetes
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Installation OS
+      description: >
+        Please provide the OS you are installing on.
+      options:
+        - Mac
+        - Windows
+        - Linux
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: nuclio_version
+    attributes:
+      label: Nuclio Version
+      description: >
+        Please provide the Nuclio version you are using.
+    validations:
+      required: true
+  - type: textarea
+    id: additional_information
+    attributes:
+      label: Additional Information
+      description: >
+        Please add any aditional information you think may be relevant.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,19 @@
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+blank_issues_enabled: true
+contact_links:
+  - name: Question/Help/Support
+    url: https://lit-oasis-83353.herokuapp.com/
+    about: "If you have a question, please join the Nuclio community on Slack."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -14,6 +14,6 @@
 #
 blank_issues_enabled: true
 contact_links:
-  - name: Question/Help/Support
+  - name: Try Us @ Slack
     url: https://lit-oasis-83353.herokuapp.com/
-    about: "If you have a question, please join the Nuclio community on Slack."
+    about: "If you have any other questions, please join the Nuclio community on Slack."

--- a/.github/ISSUE_TEMPLATE/documentation_improvement.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation_improvement.yaml
@@ -1,0 +1,53 @@
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Documentation Improvement
+description: Report wrong or missing documentation
+title: "[Docs]: "
+
+body:
+  - type: checkboxes
+    attributes:
+      label: Nuclio version checks
+      options:
+        - label: >
+            I have checked that the issue still exists on the latest versions of the docs
+            [here](https://github.com/nuclio/nuclio/tree/development/docs)
+          required: true
+  - type: textarea
+    id: location
+    attributes:
+      label: Location of the documentation
+      description: >
+        Please provide the location of the documentation, in the source code or the URL of the documentation, e.g.
+        "https://github.com/nuclio/nuclio/blob/development/docs/reference/triggers/http.md"
+      placeholder: https://github.com/nuclio/nuclio/blob/development/docs/reference/triggers/http.md
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Documentation problem
+      description: >
+        Please provide a description of what documentation you believe needs to be fixed/improved
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested fix for documentation
+      description: >
+        Please explain the suggested fix and **why** it's better than the existing documentation
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,63 @@
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Feature Request
+description: Suggest an idea for Nuclio
+title: "[Feature Request]: "
+
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Feature Type
+      description: Please check what type of feature request you would like to propose.
+      options:
+        - label: >
+            Adding new functionality to Nuclio
+        - label: >
+            Changing existing functionality in Nuclio
+        - label: >
+            Removing existing functionality in Nuclio
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem Description
+      description: >
+        Please describe what problem the feature would solve, e.g. "I wish I could use Nuclio to ..."
+    validations:
+      required: true
+  - type: textarea
+    id: feature
+    attributes:
+      label: Feature Description
+      description: >
+        Please describe how the new feature would be implemented, using psudocode if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: alternative
+    attributes:
+      label: Alternative Solutions
+      description: >
+        Please describe any alternative solution (existing functionality, 3rd party package, etc.)
+        that would satisfy the feature request.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: >
+        Please provide any relevant Github issues, code examples or references that help describe and support
+        the feature request.

--- a/.github/ISSUE_TEMPLATE/setup_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/setup_issue.yaml
@@ -1,0 +1,104 @@
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Setup Issue
+description: Report issues setting up Nuclio on your system
+title: "[Setup]: "
+
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Setup check
+      options:
+        - label: >
+            I have read the [setting up guide](https://github.com/nuclio/nuclio#further-reading) to my relevant platform.
+          required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      description: >
+        Please provide the OS you are setting up Nuclio on.
+      options:
+        - Mac
+        - Windows
+        - Linux
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: method
+    attributes:
+      label: Setup Method
+      description: >
+        Please provide how you tried to setup Nuclio.
+      options:
+        - Docker
+        - Kubernetes
+    validations:
+      required: true
+  - type: dropdown
+    id: k8s_cluster_type
+    attributes:
+      label: Kubernetes Cluster Type
+      description: >
+        Please select how you are running Kubernetes.
+      options:
+        - N/A - Docker
+        - Kubernetes for Docker Desktop
+        - EKS
+        - AKS
+        - GKE
+        - Minikube
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: nuclio_version
+    attributes:
+      label: Nuclio Version
+      description: >
+        Please provide the Nuclio version you are using.
+    validations:
+      required: true
+  - type: textarea
+    id: issue_description
+    attributes:
+      label: Issue Description
+      description: >
+        Please provide a description of the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Setup Logs
+      description: >
+        Please copy and paste the dashboard/controller logs when attempting to set-up Nuclio.
+      value: >
+        <details>
+
+        Replace this line with the setup logs.
+
+        </details>
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: additional_information
+    attributes:
+      label: Additional Information
+      description: >
+        Please add any additional information you think may be relevant.

--- a/.github/ISSUE_TEMPLATE/setup_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/setup_issue.yaml
@@ -26,19 +26,6 @@ body:
             I have read the [setting up guide](https://github.com/nuclio/nuclio#further-reading) to my relevant platform.
           required: true
   - type: dropdown
-    id: os
-    attributes:
-      label: OS
-      description: >
-        Please provide the OS you are setting up Nuclio on.
-      options:
-        - Mac
-        - Windows
-        - Linux
-        - Other
-    validations:
-      required: true
-  - type: dropdown
     id: method
     attributes:
       label: Setup Method
@@ -88,11 +75,7 @@ body:
       description: >
         Please copy and paste the dashboard/controller logs when attempting to set-up Nuclio.
       value: >
-        <details>
-
         Replace this line with the setup logs.
-
-        </details>
       render: shell
     validations:
       required: true


### PR DESCRIPTION
Added templates for submitting GitHub issues. 
This should improve the whole issue process, with all the needed information upfront.

Includes Setup Issue, Bug Report, Documentation Improvement, Feature Request, and Question/Help/Support (Links to the Nuclio slack community)