### PR TITLE
CI - Run unit test with race-condition detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -581,7 +581,7 @@ generate-crds: modules ensure-gopath
 
 .PHONY: test-unit
 test-unit: modules ensure-gopath
-	go test -tags=test_unit -v ./cmd/... ./pkg/... -short
+	go test -race -tags=test_unit -v ./cmd/... ./pkg/... -short
 
 .PHONY: test-k8s-nuctl
 test-k8s-nuctl:

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/cmdrunner"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/loggersink"
 	"github.com/nuclio/nuclio/pkg/platform/kube/apigatewayres"
@@ -156,8 +157,14 @@ func createController(kubeconfigPath string,
 		return nil, errors.Wrap(err, "Failed to create function deployment client")
 	}
 
+	// create cmd runner
+	cmdRunner, err := cmdrunner.NewShellRunner(rootLogger)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create cmd runner")
+	}
+
 	// create ingress manager
-	ingressManager, err := ingress.NewManager(rootLogger, kubeClientSet, platformConfiguration)
+	ingressManager, err := ingress.NewManager(rootLogger, kubeClientSet, cmdRunner, platformConfiguration)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create ingress manager")
 	}

--- a/cmd/dashboard/app/dashboard_test.go
+++ b/cmd/dashboard/app/dashboard_test.go
@@ -20,6 +20,7 @@ package app
 
 import (
 	"context"
+	"go.uber.org/atomic"
 	"testing"
 	"time"
 
@@ -48,10 +49,7 @@ func (suite *DashboardTestSuite) SetupSuite() {
 
 func (suite *DashboardTestSuite) SetupTest() {
 	suite.ctx = context.Background()
-	suite.dashboard = &Dashboard{
-		logger: suite.logger,
-		status: status.Initializing,
-	}
+	suite.dashboard = NewDashboard(suite.logger)
 	suite.dockerClient = dockerclient.NewMockDockerClient()
 }
 
@@ -103,23 +101,33 @@ func (suite *DashboardTestSuite) TestStayReadyOnTransientFailures() {
 	interval := 100 * time.Millisecond
 
 	// return OK, error, error, OK, OK, OK, ...
+	getVersionCounter := atomic.Int32{}
 	suite.dockerClient.
 		On("GetVersion", true).
+		Run(func(args mock.Arguments) {
+			getVersionCounter.Add(1)
+		}).
 		Return("1", nil).
 		Once()
 	suite.dockerClient.
 		On("GetVersion", true).
+		Run(func(args mock.Arguments) {
+			getVersionCounter.Add(2)
+		}).
 		Return("", errors.New("Something bad happened")).
 		Twice()
 	suite.dockerClient.
 		On("GetVersion", true).
+		Run(func(args mock.Arguments) {
+			getVersionCounter.Add(1)
+		}).
 		Return("2", nil)
 
 	go func() {
 		err := common.RetryUntilSuccessful(3*time.Second,
 			interval,
 			func() bool {
-				return len(suite.dockerClient.Calls) >= 4
+				return getVersionCounter.Load() >= 4
 			})
 		suite.Require().NoError(err, "Exhausted waiting for docker client to perform healthcheck validation")
 

--- a/cmd/dashboard/app/run.go
+++ b/cmd/dashboard/app/run.go
@@ -87,11 +87,7 @@ func Run(listenAddress string,
 		return errors.Wrap(err, "Failed to create logger")
 	}
 
-	dashboardInstance := &Dashboard{
-		logger: rootLogger,
-		status: status.Initializing,
-	}
-
+	dashboardInstance := NewDashboard(rootLogger)
 	dashboardInstance.healthCheckServer, err = createAndStartHealthCheckServer(platformConfiguration,
 		rootLogger,
 		dashboardInstance)
@@ -190,7 +186,7 @@ func Run(listenAddress string,
 		return errors.Wrap(err, "Failed to start server")
 	}
 
-	dashboardInstance.status = status.Ready
+	dashboardInstance.SetStatus(status.Ready)
 	select {}
 }
 

--- a/pkg/cmdrunner/cmdrunner_test.go
+++ b/pkg/cmdrunner/cmdrunner_test.go
@@ -1,4 +1,4 @@
-//go:build test_unit
+//go:build test_integration
 
 /*
 Copyright 2017 The Nuclio Authors.
@@ -102,5 +102,8 @@ func (suite *CmdRunnerTestSuite) TestStdin() {
 }
 
 func TestCmdRunnerTestSuite(t *testing.T) {
+	if testing.Short() {
+		return
+	}
 	suite.Run(t, new(CmdRunnerTestSuite))
 }

--- a/pkg/cmdrunner/shellrunner_test.go
+++ b/pkg/cmdrunner/shellrunner_test.go
@@ -1,4 +1,4 @@
-//go:build test_unit
+//go:build test_integration
 
 /*
 Copyright 2017 The Nuclio Authors.
@@ -191,5 +191,8 @@ func (suite *ShellRunnerTestSuite) TestRunAndCaptureOutputCombinedRedactsStrings
 }
 
 func TestShellRunnerTestSuite(t *testing.T) {
+	if testing.Short() {
+		return
+	}
 	suite.Run(t, new(ShellRunnerTestSuite))
 }

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -77,6 +77,10 @@ func (suite *dashboardTestSuite) SetupTest() {
 	templateRepository, err := functiontemplates.NewRepository(suite.logger, []functiontemplates.FunctionTemplateFetcher{})
 	suite.Require().NoError(err)
 
+	suite.mockPlatform.
+		On("GetContainerBuilderKind").
+		Return("")
+
 	// create a mock platform
 	suite.dashboardServer, err = dashboard.NewServer(suite.logger,
 		suite.mockPlatform.GetContainerBuilderKind(),
@@ -3480,7 +3484,7 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
 	suite.mockPlatform.AssertExpectations(suite.T())
 }
 
-func TestDashboardTestSuite(t *testing.T) {
+func TestDashboardServerTestSuite(t *testing.T) {
 	suite.Run(t, new(functionTestSuite))
 	suite.Run(t, new(projectTestSuite))
 	suite.Run(t, new(functionEventTestSuite))

--- a/pkg/errgroup/errgroup_test.go
+++ b/pkg/errgroup/errgroup_test.go
@@ -40,7 +40,6 @@ func (suite *ErrGroupTestSuite) SetupTest() {
 }
 
 func (suite *ErrGroupTestSuite) TestSemaphoredErrGroup() {
-
 	for _, testCase := range []struct {
 		name          string
 		concurrency   uint
@@ -73,9 +72,9 @@ func (suite *ErrGroupTestSuite) TestSemaphoredErrGroup() {
 
 					suite.logger.DebugWithCtx(errGroupCtx,
 						"In a goroutine",
-						"callCount", concurrentCallCount)
+						"callCount", atomic.LoadInt32(totalCallCount))
 					if testCase.concurrency > 0 {
-						suite.Require().LessOrEqual(uint(*concurrentCallCount), testCase.concurrency)
+						suite.Require().LessOrEqual(atomic.LoadInt32(concurrentCallCount), int32(testCase.concurrency))
 					}
 
 					atomic.AddInt32(concurrentCallCount, -1)

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1028,17 +1028,16 @@ func (ap *Platform) WaitForProjectResourcesDeletion(ctx context.Context, project
 	return nil
 }
 
-func (ap *Platform) GetProjectResources(ctx context.Context, projectMeta *platform.ProjectMeta) ([]platform.Function,
-	[]platform.APIGateway,
-	error) {
+func (ap *Platform) GetProjectResources(ctx context.Context,
+	projectMeta *platform.ProjectMeta) ([]platform.Function, []platform.APIGateway, error) {
 
-	var err error
 	var functions []platform.Function
 	var apiGateways []platform.APIGateway
 	errGroup, _ := errgroup.WithContext(ctx, ap.Logger)
 
 	// get api gateways
 	errGroup.Go("GetAPIGateways", func() error {
+		var err error
 		apiGateways, err = ap.platform.GetAPIGateways(ctx, &platform.GetAPIGatewaysOptions{
 			Namespace: projectMeta.Namespace,
 			Labels:    fmt.Sprintf("%s=%s", common.NuclioResourceLabelKeyProjectName, projectMeta.Name),
@@ -1051,6 +1050,7 @@ func (ap *Platform) GetProjectResources(ctx context.Context, projectMeta *platfo
 
 	// get functions
 	errGroup.Go("GetFunctions", func() error {
+		var err error
 		functions, err = ap.platform.GetFunctions(ctx, &platform.GetFunctionsOptions{
 			Namespace: projectMeta.Namespace,
 			Labels:    fmt.Sprintf("%s=%s", common.NuclioResourceLabelKeyProjectName, projectMeta.Name),

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -571,11 +571,13 @@ func (suite *AbstractPlatformTestSuite) TestGetProjectResources() {
 
 			suite.mockedPlatform.
 				On("GetAPIGateways", suite.ctx, mock.Anything).
-				Return(testCase.apiGateways, nil).Once()
+				Return(testCase.apiGateways, nil).
+				Once()
 
 			suite.mockedPlatform.
 				On("GetFunctions", suite.ctx, mock.Anything).
-				Return(testCase.functions, testCase.getFunctionsError).Once()
+				Return(testCase.functions, testCase.getFunctionsError).
+				Once()
 
 			projectFunctions, projectAPIGateways, err := suite.Platform.GetProjectResources(suite.ctx,
 				&platform.ProjectMeta{

--- a/pkg/platform/kube/ingress/ingress.go
+++ b/pkg/platform/kube/ingress/ingress.go
@@ -50,16 +50,8 @@ type Manager struct {
 
 func NewManager(parentLogger logger.Logger,
 	kubecClientSet kubernetes.Interface,
+	cmdRunner cmdrunner.CmdRunner,
 	platformConfiguration *platformconfig.Config) (*Manager, error) {
-
-	managerLogger := parentLogger.GetChild("manager")
-
-	// create cmd runner
-	cmdRunner, err := cmdrunner.NewShellRunner(managerLogger)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create cmd runner")
-	}
-
 	return &Manager{
 		logger:                parentLogger.GetChild("manager"),
 		cmdRunner:             cmdRunner,

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/auth"
@@ -1939,6 +1940,8 @@ func (p *Platform) alignIngressHostSubdomainLevel(host string, randomCharsLength
 func (p *Platform) getAPIGatewayUpstreamFunctions(ctx context.Context,
 	apiGateway *platform.APIGatewayConfig,
 	validateFunctionExistence bool) ([]platform.Function, error) {
+
+	var upstreamFunctionLock sync.Mutex
 	var upstreamFunctions []platform.Function
 
 	// get upstream functions
@@ -1967,7 +1970,9 @@ func (p *Platform) getAPIGatewayUpstreamFunctions(ctx context.Context,
 				return errors.Wrap(err, "Failed to initialize function")
 			}
 
+			upstreamFunctionLock.Lock()
 			upstreamFunctions = append(upstreamFunctions, functionInstance)
+			upstreamFunctionLock.Unlock()
 			return nil
 		})
 	}

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -629,8 +629,12 @@ func (suite *KubeTestSuite) createController() *controller.Controller {
 	suite.FunctionClient, err = functionres.NewLazyClient(suite.Logger, suite.KubeClientSet, suite.FunctionClientSet)
 	suite.Require().NoError(err)
 
+	// create cmd runner
+	cmdRunner, err := cmdrunner.NewShellRunner(suite.Logger)
+	suite.Require().NoError(err)
+
 	// create ingress manager
-	ingressManager, err := ingress.NewManager(suite.Logger, suite.KubeClientSet, suite.PlatformConfiguration)
+	ingressManager, err := ingress.NewManager(suite.Logger, suite.KubeClientSet, cmdRunner, suite.PlatformConfiguration)
 	suite.Require().NoError(err)
 
 	// create api-gateway provisioner

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -56,7 +56,8 @@ func (mp *Platform) GetConfig() *platformconfig.Config {
 }
 
 func (mp *Platform) GetContainerBuilderKind() string {
-	return "docker"
+	args := mp.Called()
+	return args.Get(0).(string)
 }
 
 // CreateFunctionBuild will locally build a processor image and return its name (or the error)

--- a/pkg/processor/runtime/rpc/abstract_test.go
+++ b/pkg/processor/runtime/rpc/abstract_test.go
@@ -1,4 +1,4 @@
-//go:build test_unit
+//go:build test_integration
 
 /*
 Copyright 2017 The Nuclio Authors.
@@ -235,5 +235,8 @@ func (suite *RuntimeSuite) createConfig(loggerInstance logger.Logger) *runtime.C
 }
 
 func TestRuntime(t *testing.T) {
+	if testing.Short() {
+		return
+	}
 	suite.Run(t, new(RuntimeSuite))
 }

--- a/pkg/processor/runtime/rpc/rpc_test.go
+++ b/pkg/processor/runtime/rpc/rpc_test.go
@@ -48,18 +48,18 @@ func (suite *RPCSuite) TestLogBeforeEvent() {
 
 	var sink bytes.Buffer
 	var errSink bytes.Buffer
-	logger, err := nucliozap.NewNuclioZap("RPCTest", "json", nil, &sink, &errSink, nucliozap.DebugLevel)
+	loggerInstance, err := nucliozap.NewNuclioZap("RPCTest", "json", nil, &sink, &errSink, nucliozap.DebugLevel)
 	suite.Require().NoError(err, "Can't create logger")
 
 	var conn net.Conn
 
-	_, err = NewAbstractRuntime(logger, suite.runtimeConfiguration(logger), nil)
+	_, err = NewAbstractRuntime(loggerInstance, suite.runtimeConfiguration(loggerInstance), nil)
 	suite.Require().NoError(err, "Can't create RPC runtime")
 
 	message := "testing log before"
 	suite.emitLog(message, conn)
 	time.Sleep(time.Millisecond) // Give TCP time to move bits around
-	logger.Flush()
+	loggerInstance.Flush()
 	suite.True(strings.Contains(sink.String(), message), "Didn't get log")
 }
 

--- a/pkg/processor/runtime/shell/runtime_test.go
+++ b/pkg/processor/runtime/shell/runtime_test.go
@@ -1,4 +1,4 @@
-//go:build test_unit
+//go:build test_integration
 
 /*
 Copyright 2017 The Nuclio Authors.
@@ -123,5 +123,8 @@ func (suite *ShellRuntimeSuite) resolveRuntimeConfiguration(loggerInstance logge
 }
 
 func TestShellRuntimeSuite(t *testing.T) {
+	if testing.Short() {
+		return
+	}
 	suite.Run(t, new(ShellRuntimeSuite))
 }

--- a/pkg/processor/trigger/cron/cron_test.go
+++ b/pkg/processor/trigger/cron/cron_test.go
@@ -23,29 +23,26 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nuclio/nuclio/pkg/processor/test/suite"
-
 	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+	nucliozap "github.com/nuclio/zap"
 	cronlib "github.com/robfig/cron/v3"
 	"github.com/stretchr/testify/suite"
 )
 
 type TestSuite struct {
-	processorsuite.TestSuite
+	suite.Suite
 	trigger cron
+	logger  logger.Logger
 }
 
 func (suite *TestSuite) SetupSuite() {
-	suite.TestSuite.SetupSuite()
-}
-
-func (suite *TestSuite) TearDownSuite() {
-	suite.TestSuite.TearDownTest()
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
 }
 
 func (suite *TestSuite) SetupTest() {
 	suite.trigger = cron{}
-	suite.trigger.Logger = suite.Logger.GetChild("cron")
+	suite.trigger.Logger = suite.logger.GetChild("cron")
 }
 
 func (suite *TestSuite) TestScheduleBackwardsCompatibility() {

--- a/pkg/processor/trigger/http/http_test.go
+++ b/pkg/processor/trigger/http/http_test.go
@@ -25,28 +25,29 @@ import (
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/common/status"
-	"github.com/nuclio/nuclio/pkg/processor/test/suite"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/cors"
 
+	"github.com/nuclio/logger"
+	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
 	"github.com/valyala/fasthttp"
 	"github.com/valyala/fasthttp/fasthttputil"
 )
 
 type TestSuite struct {
-	processorsuite.TestSuite
-	trigger http
-
+	suite.Suite
+	trigger                    http
+	logger                     logger.Logger
 	fastDummyHTTPServer        *fasthttputil.InmemoryListener
 	fastDummyHTTPServerStarted bool
 }
 
 func (suite *TestSuite) SetupSuite() {
-	suite.TestSuite.SetupSuite()
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
 	suite.trigger = http{
 		AbstractTrigger: trigger.AbstractTrigger{
-			Logger: suite.Logger,
+			Logger: suite.logger,
 		},
 		configuration: &Configuration{},
 	}
@@ -121,7 +122,7 @@ func (suite *TestSuite) TestCORS() {
 			ExpectedEventsHandledFailureTotal: 1,
 		},
 	} {
-		suite.Logger.DebugWith("Testing CORS", "testCase", testCase)
+		suite.logger.DebugWith("Testing CORS", "testCase", testCase)
 
 		// set cors configuration
 		corsInstance := cors.NewCORS()
@@ -151,7 +152,7 @@ func (suite *TestSuite) TestCORS() {
 		// do request
 		response, err := client.Do(request)
 		suite.Require().NoError(err, "Failed to do request")
-		suite.Logger.DebugWith("Received response",
+		suite.logger.DebugWith("Received response",
 			"headers", response.Header,
 			"statusCode", response.StatusCode)
 
@@ -185,7 +186,7 @@ func (suite *TestSuite) TestInternalHealthiness() {
 	} {
 
 		suite.Run(testCase.name, func() {
-			suite.Logger.DebugWith("Testing internal healthiness endpoint", "testCase", testCase)
+			suite.logger.DebugWith("Testing internal healthiness endpoint", "testCase", testCase)
 
 			// ensure trigger is ready
 			suite.trigger.status = status.Ready
@@ -198,7 +199,7 @@ func (suite *TestSuite) TestInternalHealthiness() {
 			// do request
 			response, err := client.Do(request)
 			suite.Require().NoError(err, "Failed to do request")
-			suite.Logger.DebugWith("Received response",
+			suite.logger.DebugWith("Received response",
 				"headers", response.Header,
 				"statusCode", response.StatusCode)
 

--- a/pkg/processor/trigger/mqtt/iotcore/iotcore_test.go
+++ b/pkg/processor/trigger/mqtt/iotcore/iotcore_test.go
@@ -30,7 +30,6 @@ import (
 
 type TestSuite struct {
 	suite.Suite
-	//processorsuite.TestSuite
 	trigger iotcoremqtt
 }
 
@@ -88,6 +87,6 @@ NSoWKZp3rjklHIznbbSiBuRtuT47bYcpo/3IOFwKv3F3rr7zAXg=
 
 }
 
-func TestRabbitMQSuite(t *testing.T) {
+func TestRabbitMQIOTCoreSuite(t *testing.T) {
 	suite.Run(t, new(TestSuite))
 }

--- a/pkg/processor/trigger/rabbitmq/rabbitmq_test.go
+++ b/pkg/processor/trigger/rabbitmq/rabbitmq_test.go
@@ -23,8 +23,9 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/processor"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
-	"github.com/nuclio/nuclio/pkg/processor/test/suite"
 
+	"github.com/nuclio/logger"
+	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -34,21 +35,18 @@ const (
 )
 
 type TestSuite struct {
-	processorsuite.TestSuite
+	suite.Suite
 	trigger rabbitMq
+	logger  logger.Logger
 }
 
 func (suite *TestSuite) SetupSuite() {
-	suite.TestSuite.SetupSuite()
-}
-
-func (suite *TestSuite) TearDownSuite() {
-	suite.TestSuite.TearDownTest()
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
 }
 
 func (suite *TestSuite) SetupTest() {
 	suite.trigger = rabbitMq{}
-	suite.trigger.Logger = suite.Logger.GetChild("rabbitMQ")
+	suite.trigger.Logger = suite.logger.GetChild("rabbitMQ")
 
 	suite.trigger.configuration = &Configuration{
 		QueueName:    queueName,


### PR DESCRIPTION
Detect race-condition during unit-testings

- moved some unit-tests that used `shell` to `integration`
- fixed some race conditions, mainly on test-specific cases