### PR TITLE
Prevent command injection

### DIFF
--- a/pkg/dashboard/ui/resources/installRequire/app.js
+++ b/pkg/dashboard/ui/resources/installRequire/app.js
@@ -40,8 +40,7 @@ function _checkDependenciesStatus(src) {
 function _installDependencies(src) {
     gutil.log('Installing node dependencies for', src);
     try {
-        var commands = ['cd ' + src, 'npm install --silent'];
-        execSync(commands.join(' && '));
+        execSync('npm install --silent', { cwd: src });
     } catch (e) {
         gutil.log(
             'An error has occurred during dependency installation for',


### PR DESCRIPTION
The original code is vulnerable to command injection. 
(Although currently, path validation will be performed on `src` before passing to `_installDependencies(src)`, it is better to prevent command injection in case there are new changes/calls to `_installDependencies(src)`.)