### PR TITLE
Update github workflows

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -46,11 +46,11 @@ jobs:
           RUNNER_CONTEXT: ${{ toJson(runner) }}
 
       # checkout from development
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: github.event.inputs.pr_number == ''
 
       # checkout from PR
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: github.event.inputs.pr_number != ''
         with:
           fetch-depth: 0

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -82,7 +82,7 @@ jobs:
           echo "NUCLIO_LABEL=bm-$GITHUB_RUN_ID" >> $GITHUB_ENV
 
       - name: Install python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
 
@@ -134,7 +134,7 @@ jobs:
             await script({ github, context, prNumber, labelsToAdd, labelsToRemove })
 
       - name: Upload benchmarking results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: benchmarking
           path: ./.benchmarking

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,18 +48,11 @@ jobs:
         env:
           RUNNER_CONTEXT: ${{ toJson(runner) }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: "1.17"
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
 
       - name: Ensure go test files are build annotated
         run: make ensure-test-files-annotated
@@ -71,7 +64,7 @@ jobs:
     name: Check copyright and license
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Check License Lines
         uses: kt3k/license_checker@v1.0.6
@@ -103,18 +96,11 @@ jobs:
     name: Test short
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: "1.17"
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
 
       - name: Run unit test
         run: |
@@ -124,11 +110,11 @@ jobs:
     name: Build nuctl
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: "1.17"
+          cache: true
 
       - name: Build
         run: |
@@ -158,7 +144,7 @@ jobs:
       - name: Dump github ref
         run: echo "$GITHUB_REF"
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # since github-actions gives us 14G only, and fills it up with some garbage
       # we will free up some space for us (~2GB)
@@ -170,14 +156,14 @@ jobs:
       - name: Extract git branch
         id: git_info
         run: |
-          echo "::set-output name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})"
+          echo "name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})" >> $GITHUB_OUTPUT
 
       - name: Resolve docker cache tag
         id: docker_cache
         run: |
           export version_suffix=$(echo "${{ steps.git_info.outputs.branch }}" | grep -E "^[0-9]+\.[0-9]+\.x$" | tr -d '.')
           export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
-          echo "::set-output name=tag::$(echo $unstable_tag)"
+          echo "name=tag::$(echo $unstable_tag)" >> $GITHUB_OUTPUT
 
       - name: Build
         run: |
@@ -205,22 +191,15 @@ jobs:
     needs:
       - build_docker_images
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: azure/setup-helm@v1
         with:
           version: "v3.6.3"
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: "1.17"
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
 
       - uses: manusa/actions-setup-minikube@v2.6.0
         with:
@@ -292,18 +271,11 @@ jobs:
     needs:
       - build_docker_images
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: "1.17"
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
 
       - name: Fetch nuclio docker images
         uses: actions/download-artifact@v2
@@ -327,22 +299,15 @@ jobs:
     needs:
       - build_docker_images
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: azure/setup-helm@v1
         with:
           version: "v3.6.3"
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: "1.17"
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
 
       - uses: manusa/actions-setup-minikube@v2.6.0
         with:
@@ -400,7 +365,7 @@ jobs:
     name: Test python
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run python test
         run: |
@@ -410,7 +375,7 @@ jobs:
     name: Test NodeJS
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run NodeJS test
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -180,7 +180,7 @@ jobs:
         run: make save-docker-images
 
       - name: Upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: nuclio-docker-images
           path: nuclio-docker-images-*.tar.gz
@@ -193,7 +193,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: azure/setup-helm@v1
+      - uses: azure/setup-helm@v3
         with:
           version: "v3.6.3"
 
@@ -201,9 +201,9 @@ jobs:
         with:
           cache: true
 
-      - uses: manusa/actions-setup-minikube@v2.6.0
+      - uses: manusa/actions-setup-minikube@v2.7.1
         with:
-          minikube version: "v1.25.2"
+          minikube version: "v1.26.1"
           kubernetes version: "v1.23.7"
           driver: docker
           github token: ${{ github.token }}
@@ -220,7 +220,7 @@ jobs:
           minikube kubectl -- config view --flatten > kubeconfig_flatten
 
       - name: Fetch nuclio docker images
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: nuclio-docker-images
 
@@ -278,7 +278,7 @@ jobs:
           cache: true
 
       - name: Fetch nuclio docker images
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: nuclio-docker-images
 
@@ -301,7 +301,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: azure/setup-helm@v1
+      - uses: azure/setup-helm@v3
         with:
           version: "v3.6.3"
 
@@ -309,9 +309,9 @@ jobs:
         with:
           cache: true
 
-      - uses: manusa/actions-setup-minikube@v2.6.0
+      - uses: manusa/actions-setup-minikube@v2.7.1
         with:
-          minikube version: "v1.25.2"
+          minikube version: "v1.26.1"
           kubernetes version: "v1.23.7"
           driver: docker
           github token: ${{ github.token }}
@@ -328,7 +328,7 @@ jobs:
           minikube kubectl -- config view --flatten > kubeconfig_flatten
 
       - name: Fetch nuclio docker images
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: nuclio-docker-images
 

--- a/.github/workflows/long_ci.yaml
+++ b/.github/workflows/long_ci.yaml
@@ -33,7 +33,7 @@ jobs:
     name: PR-${{ github.event.inputs.pr_number }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: refs/pull/${{ github.event.inputs.pr_number }}/merge

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -37,7 +37,7 @@ jobs:
       env:
         RUNNER_CONTEXT: ${{ toJson(runner) }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # since github-actions gives us 14G only, and fills it up with some garbage
     # we will free up some space for us (~2GB)

--- a/.github/workflows/pr_label.yaml
+++ b/.github/workflows/pr_label.yaml
@@ -20,7 +20,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v2
+      - uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: ".github/labels.yaml"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,23 +67,23 @@ jobs:
       run: |
         echo "NUCLIO_LABEL=${{ steps.release_info.outputs.REF_TAG }}" >> $GITHUB_ENV
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: "1.17"
+        cache: true
 
     - name: Extract git branch
       id: git_info
       run: |
-        echo "::set-output name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})"
+        echo "name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})" >> $GITHUB_OUTPUT
 
     - name: Resolve docker cache tag
       id: docker_cache
       run: |
         export version_suffix=$(echo "${{ steps.git_info.outputs.branch }}" | grep -E "^[0-9]+\.[0-9]+\.x$" | tr -d '.')
         export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
-        echo "::set-output name=tag::$(echo $unstable_tag)"      
+        echo "name=tag::$(echo $unstable_tag)" >> $GITHUB_OUTPUT
 
     # since github-actions gives us 14G only, and fills it up with some garbage
     # we will free up some space for us (~2GB)
@@ -131,7 +131,7 @@ jobs:
         NUCLIO_CACHE_LABEL: ${{ steps.docker_cache.outputs.tag }}
 
     - name: Tag and push stable images
-      if: env.NUCLIO_LABEL != 'unstable'
+      if: env.NUCLIO_LABEL != 'unstable' && github.event.release.target_commitish == 'master'
       run: |
         docker tag "$NUCLIO_DOCKER_REPO/dashboard:$NUCLIO_LABEL-$NUCLIO_ARCH" "$NUCLIO_DOCKER_REPO/dashboard:stable-$NUCLIO_ARCH"
         docker push "$NUCLIO_DOCKER_REPO/dashboard:stable-$NUCLIO_ARCH"
@@ -153,7 +153,7 @@ jobs:
         NUCLIO_ARCH: ${{ matrix.arch }}
 
     - name: Upload binaries
-      uses: AButler/upload-release-assets@v2.0
+      uses: AButler/upload-release-assets@v2.0.2
       if: github.event_name == 'release'
       with:
         files: '/home/runner/go/bin/nuctl-*'


### PR DESCRIPTION
1. update to use latest packages
2. fix released from branched out causes nuclio stable to use older versions