### PR TITLE
Add Autoscale metrics to function and frontend spec 

### DIFF
--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -83,6 +83,7 @@ func (fsr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restfu
 	defaultHTTPIngressHostTemplate := fsr.getDefaultHTTPIngressHostTemplate()
 	validFunctionPriorityClassNames := fsr.resolveValidFunctionPriorityClassNames()
 	defaultFunctionPodResources := fsr.resolveDefaultFunctionPodResources()
+	supportedAutoScaleMetrics := fsr.resolveSupportedAutoScaleMetrics()
 
 	frontendSpec := map[string]restful.Attributes{
 		"frontendSpec": { // frontendSpec is the ID of this singleton resource
@@ -96,6 +97,7 @@ func (fsr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restfu
 			"allowedAuthenticationModes":      allowedAuthenticationModes,
 			"validFunctionPriorityClassNames": validFunctionPriorityClassNames,
 			"defaultFunctionPodResources":     defaultFunctionPodResources,
+			"supportedAutoScaleMetrics":       supportedAutoScaleMetrics,
 		},
 	}
 
@@ -240,6 +242,17 @@ func (fsr *frontendSpecResource) resolveValidFunctionPriorityClassNames() []stri
 		validFunctionPriorityClassNames = dashboardServer.GetPlatformConfiguration().Kube.ValidFunctionPriorityClassNames
 	}
 	return validFunctionPriorityClassNames
+}
+
+func (fsr *frontendSpecResource) resolveSupportedAutoScaleMetrics() []functionconfig.AutoScaleMetric {
+	var supportedAutoScaleMetrics []functionconfig.AutoScaleMetric
+	if dashboardServer, ok := fsr.resource.GetServer().(*dashboard.Server); ok {
+		supportedAutoScaleMetrics = dashboardServer.GetPlatformConfiguration().SupportedAutoScaleMetrics
+		if len(supportedAutoScaleMetrics) == 0 {
+			supportedAutoScaleMetrics = dashboardServer.GetPlatformConfiguration().GetDefaultSupportedAutoScaleMetrics()
+		}
+	}
+	return supportedAutoScaleMetrics
 }
 
 func (fsr *frontendSpecResource) getDefaultHTTPIngressHostTemplate() string {

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -3471,7 +3471,44 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
 	"allowedAuthenticationModes": [
 		"none",
 		"basicAuth"
-	]
+	],
+	"supportedAutoScaleMetrics": [
+        {
+            "name": "cpu",
+            "kind": "Resource",
+            "type": "percentage"
+        },
+        {
+            "name": "memory",
+            "kind": "Resource",
+            "type": "percentage"
+        },
+        {
+            "name": "gpu",
+            "kind": "Pods",
+            "type": "percentage"
+        },
+        {
+            "name": "nuclio_processor_stream_high_water_mark_processed_lag",
+            "kind": "External",
+            "type": "int"
+        },
+        {
+            "name": "nuclio_processor_stream_high_water_mark_committed_lag",
+            "kind": "External",
+            "type": "int"
+        },
+        {
+            "name": "nuclio_processor_worker_pending_allocation_current",
+            "kind": "External",
+            "type": "int"
+        },
+        {
+            "name": "nuclio_processor_worker_allocation_wait_duration_ms_sum",
+            "kind": "External",
+            "type": "int"
+        }
+    ]
 }`
 
 	suite.sendRequest("GET",

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -269,6 +269,20 @@ type Metric struct {
 	WindowSize     string `json:"windowSize,omitempty"`
 }
 
+type AutoScaleMetricType string
+
+const (
+	AutoScaleMetricTypeInt        AutoScaleMetricType = "int"
+	AutoScaleMetricTypePercentage AutoScaleMetricType = "percentage"
+)
+
+type AutoScaleMetric struct {
+	Name        string                   `json:"name,omitempty"`
+	Kind        autosv2.MetricSourceType `json:"kind,omitempty"`
+	Type        AutoScaleMetricType      `json:"type,omitempty"`
+	TargetValue int                      `json:"targetValue,omitempty"`
+}
+
 type BuildMode string
 
 const (
@@ -362,6 +376,7 @@ type Spec struct {
 
 	// Scale function's replica (when min < max replicas) based on given custom metric specs
 	CustomScalingMetricSpecs []autosv2.MetricSpec `json:"customScalingMetricSpecs,omitempty"`
+	AutoScaleMetrics         []AutoScaleMetric    `json:"autoScaleMetrics,omitempty"`
 
 	// Currently relevant only for k8s platform
 	// if true - wait the whole ReadinessTimeoutSeconds before marking this function as unhealthy

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -49,6 +49,8 @@ import (
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/v3io/version-go"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	appsv1 "k8s.io/api/apps/v1"
 	autosv2 "k8s.io/api/autoscaling/v2beta1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -1848,7 +1850,7 @@ func (lc *lazyClient) generateCronTriggerCronJobSpec(ctx context.Context,
 	// set concurrency policy if given (default to forbid - to protect the user from overdose of cron jobs)
 	concurrencyPolicy := batchv1.ForbidConcurrent
 	if attributes.ConcurrencyPolicy != "" {
-		concurrencyPolicy = batchv1.ConcurrencyPolicy(strings.Title(attributes.ConcurrencyPolicy))
+		concurrencyPolicy = batchv1.ConcurrencyPolicy(cases.Title(language.Und).String(attributes.ConcurrencyPolicy))
 	}
 	spec.ConcurrencyPolicy = concurrencyPolicy
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -30,32 +30,34 @@ import (
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/v3io/scaler/pkg/scalertypes"
+	autosv2 "k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/api/core/v1"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
 )
 
 type Config struct {
-	Kind                     string                       `json:"kind,omitempty"`
-	WebAdmin                 WebServer                    `json:"webAdmin,omitempty"`
-	HealthCheck              WebServer                    `json:"healthCheck,omitempty"`
-	Logger                   Logger                       `json:"logger,omitempty"`
-	Metrics                  Metrics                      `json:"metrics,omitempty"`
-	ScaleToZero              ScaleToZero                  `json:"scaleToZero,omitempty"`
-	AutoScale                AutoScale                    `json:"autoScale,omitempty"`
-	CronTriggerCreationMode  CronTriggerCreationMode      `json:"cronTriggerCreationMode,omitempty"`
-	FunctionAugmentedConfigs []LabelSelectorAndConfig     `json:"functionAugmentedConfigs,omitempty"`
-	FunctionReadinessTimeout *string                      `json:"functionReadinessTimeout,omitempty"`
-	IngressConfig            IngressConfig                `json:"ingressConfig,omitempty"`
-	Kube                     PlatformKubeConfig           `json:"kube,omitempty"`
-	Local                    PlatformLocalConfig          `json:"local,omitempty"`
-	ImageRegistryOverrides   ImageRegistryOverridesConfig `json:"imageRegistryOverrides,omitempty"`
-	Runtime                  *runtimeconfig.Config        `json:"runtime,omitempty"`
-	ProjectsLeader           *ProjectsLeader              `json:"projectsLeader,omitempty"`
-	ManagedNamespaces        []string                     `json:"managedNamespaces,omitempty"`
-	IguazioSessionCookie     string                       `json:"iguazioSessionCookie,omitempty"`
-	Opa                      opa.Config                   `json:"opa,omitempty"`
-	StreamMonitoring         StreamMonitoringConfig       `json:"streamMonitoring,omitempty"`
-	SensitiveFields          SensitiveFieldsConfig        `json:"sensitiveFieldPaths,omitempty"`
+	Kind                      string                           `json:"kind,omitempty"`
+	WebAdmin                  WebServer                        `json:"webAdmin,omitempty"`
+	HealthCheck               WebServer                        `json:"healthCheck,omitempty"`
+	Logger                    Logger                           `json:"logger,omitempty"`
+	Metrics                   Metrics                          `json:"metrics,omitempty"`
+	ScaleToZero               ScaleToZero                      `json:"scaleToZero,omitempty"`
+	AutoScale                 AutoScale                        `json:"autoScale,omitempty"`
+	SupportedAutoScaleMetrics []functionconfig.AutoScaleMetric `json:"supportedAutoScaleMetrics,omitempty"`
+	CronTriggerCreationMode   CronTriggerCreationMode          `json:"cronTriggerCreationMode,omitempty"`
+	FunctionAugmentedConfigs  []LabelSelectorAndConfig         `json:"functionAugmentedConfigs,omitempty"`
+	FunctionReadinessTimeout  *string                          `json:"functionReadinessTimeout,omitempty"`
+	IngressConfig             IngressConfig                    `json:"ingressConfig,omitempty"`
+	Kube                      PlatformKubeConfig               `json:"kube,omitempty"`
+	Local                     PlatformLocalConfig              `json:"local,omitempty"`
+	ImageRegistryOverrides    ImageRegistryOverridesConfig     `json:"imageRegistryOverrides,omitempty"`
+	Runtime                   *runtimeconfig.Config            `json:"runtime,omitempty"`
+	ProjectsLeader            *ProjectsLeader                  `json:"projectsLeader,omitempty"`
+	ManagedNamespaces         []string                         `json:"managedNamespaces,omitempty"`
+	IguazioSessionCookie      string                           `json:"iguazioSessionCookie,omitempty"`
+	Opa                       opa.Config                       `json:"opa,omitempty"`
+	StreamMonitoring          StreamMonitoringConfig           `json:"streamMonitoring,omitempty"`
+	SensitiveFields           SensitiveFieldsConfig            `json:"sensitiveFieldPaths,omitempty"`
 
 	ContainerBuilderConfiguration *containerimagebuilderpusher.ContainerBuilderConfiguration `json:"containerBuilderConfiguration,omitempty"`
 
@@ -200,6 +202,52 @@ func (c *Config) GetSystemMetricSinks() (map[string]MetricSink, error) {
 
 func (c *Config) GetFunctionMetricSinks() (map[string]MetricSink, error) {
 	return c.getMetricSinks(c.Metrics.Functions)
+}
+
+func (c *Config) GetDefaultSupportedAutoScaleMetrics() []functionconfig.AutoScaleMetric {
+	return []functionconfig.AutoScaleMetric{
+
+		// Resource metrics
+		{
+			Name: string(v1.ResourceCPU),
+			Kind: autosv2.ResourceMetricSourceType,
+			Type: functionconfig.AutoScaleMetricTypePercentage,
+		},
+		{
+			Name: string(v1.ResourceMemory),
+			Kind: autosv2.ResourceMetricSourceType,
+			Type: functionconfig.AutoScaleMetricTypePercentage,
+		},
+		{
+			Name: "gpu",
+			Kind: autosv2.PodsMetricSourceType,
+			Type: functionconfig.AutoScaleMetricTypePercentage,
+		},
+
+		// Stream metrics
+		{
+			Name: "hwm_processed",
+			Kind: autosv2.ExternalMetricSourceType,
+			Type: functionconfig.AutoScaleMetricTypeInt,
+		},
+		{
+			Name: "hwm_committed",
+			Kind: autosv2.ExternalMetricSourceType,
+			Type: functionconfig.AutoScaleMetricTypeInt,
+		},
+
+		// Event metrics
+		{
+			Name: "events_pending_worker_allocation",
+			Kind: autosv2.ExternalMetricSourceType,
+			Type: functionconfig.AutoScaleMetricTypeInt,
+		},
+		{
+			Name: "waiting_time_for_worker_allocation_over_30s",
+			Kind: autosv2.ExternalMetricSourceType,
+			Type: functionconfig.AutoScaleMetricTypeInt,
+		},
+	}
 }
 
 // EnrichContainerResources enriches an object's requests and limits with the default

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -226,24 +226,24 @@ func (c *Config) GetDefaultSupportedAutoScaleMetrics() []functionconfig.AutoScal
 
 		// Stream metrics
 		{
-			Name: "hwm_processed",
+			Name: "nuclio_processor_stream_high_water_mark_processed_lag",
 			Kind: autosv2.ExternalMetricSourceType,
 			Type: functionconfig.AutoScaleMetricTypeInt,
 		},
 		{
-			Name: "hwm_committed",
+			Name: "nuclio_processor_stream_high_water_mark_committed_lag",
 			Kind: autosv2.ExternalMetricSourceType,
 			Type: functionconfig.AutoScaleMetricTypeInt,
 		},
 
 		// Event metrics
 		{
-			Name: "events_pending_worker_allocation",
+			Name: "nuclio_processor_worker_pending_allocation_current",
 			Kind: autosv2.ExternalMetricSourceType,
 			Type: functionconfig.AutoScaleMetricTypeInt,
 		},
 		{
-			Name: "waiting_time_for_worker_allocation_over_30s",
+			Name: "nuclio_processor_worker_allocation_wait_duration_ms_sum",
 			Kind: autosv2.ExternalMetricSourceType,
 			Type: functionconfig.AutoScaleMetricTypeInt,
 		},


### PR DESCRIPTION
To support autoscaling function based on different metrics than cpu usage, this PR adds a list of autoscale metrics to the function config, which will be used to create HPAs in future PRs.

The auto scale metric object contains the following fields:
```
Name - metric name to be used
Kind - Metrics spec kind (Resource / Pods / External)
Type - Tells the UI how to show the metrics value (int / percentage)
TargetValue - the threshold value, above which scaling will occur 
```

In the controller - generate `v2beta1.MetricSpec` for each of the given auto scale metrics, and merge them with the explicitly given metrics in `CustomScalingMetricSpecs`.

In the fronted spec - respond with `supportedAutoScaleMetrics` to be shown in the UI. 
This list is configurable from the platform config under the same field `supportedAutoScaleMetrics`

HLD - https://confluence.iguazeng.com/display/PLAT/Nuclio+scale-up+metrics
JIRA - https://jira.iguazeng.com/browse/IG-21200