### PR TITLE
API Gateways - Support extra labels

### DIFF
--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -3036,6 +3036,9 @@ func (suite *apiGatewayTestSuite) TestCreateSuccessful() {
 		suite.Require().Equal("f4", createAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[1].NuclioFunction.Name)
 		suite.Require().Equal(50, createAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[1].Percentage)
 
+		suite.Require().Contains(createAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[0].ExtraLabels, "some-label-key")
+		suite.Require().Equal("some-label-value", createAPIGatewayOptions.APIGatewayConfig.Spec.Upstreams[0].ExtraLabels["some-label-key"])
+
 		return true
 	}
 
@@ -3060,7 +3063,10 @@ func (suite *apiGatewayTestSuite) TestCreateSuccessful() {
           "kind": "nucliofunction",
           "nucliofunction": {
             "name": "f3"
-          }
+          },
+		  "extraLabels": {
+			"some-label-key": "some-label-value"
+		  }
         },
         {
           "kind": "nucliofunction",

--- a/pkg/platform/kube/apigatewayres/lazy.go
+++ b/pkg/platform/kube/apigatewayres/lazy.go
@@ -300,6 +300,12 @@ func (lc *lazyClient) generateNginxIngress(ctx context.Context,
 		commonIngressSpec.PathType = &defaultPathType
 	}
 
+	if upstream.ExtraLabels != nil {
+		commonIngressSpec.Labels = upstream.ExtraLabels
+	} else {
+		commonIngressSpec.Labels = map[string]string{}
+	}
+
 	return lc.ingressManager.GenerateResources(ctx, commonIngressSpec)
 }
 

--- a/pkg/platform/kube/apigatewayres/lazy.go
+++ b/pkg/platform/kube/apigatewayres/lazy.go
@@ -254,6 +254,7 @@ func (lc *lazyClient) generateNginxIngress(ctx context.Context,
 		ServiceName:    serviceName,
 		ServicePort:    servicePort,
 		RewriteTarget:  upstream.RewriteTarget,
+		Labels:         upstream.ExtraLabels,
 	}
 
 	switch apiGateway.Spec.AuthenticationMode {

--- a/pkg/platform/kube/ingress/ingress.go
+++ b/pkg/platform/kube/ingress/ingress.go
@@ -75,7 +75,7 @@ func (m *Manager) GenerateResources(ctx context.Context,
 			Name:        spec.Name,
 			Namespace:   spec.Namespace,
 			Annotations: ingressAnnotations,
-			Labels:      map[string]string{},
+			Labels:      spec.Labels,
 		},
 		Spec: networkingv1.IngressSpec{
 			Rules: []networkingv1.IngressRule{

--- a/pkg/platform/kube/ingress/types.go
+++ b/pkg/platform/kube/ingress/types.go
@@ -39,6 +39,7 @@ type Spec struct {
 	UpstreamVhost        string
 	ProxyReadTimeout     string
 	Annotations          map[string]string
+	Labels               map[string]string
 }
 
 type SpecRole string

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -420,6 +420,7 @@ type APIGatewayUpstreamSpec struct {
 	Percentage       int                           `json:"percentage,omitempty"`
 	RewriteTarget    string                        `json:"rewriteTarget,omitempty"`
 	ExtraAnnotations map[string]string             `json:"extraAnnotations,omitempty"`
+	ExtraLabels      map[string]string             `json:"extraLabels,omitempty"`
 }
 
 type APIGatewaySpec struct {


### PR DESCRIPTION
Add the ability to add custom labels to api gateways' upstreams, so they will be populated as Ingress labels.

Usage: In the api gateway spec, add `spec.upstreams[<index>].extraLabels` as key-value object with the extra labels, as such:

```
{
    "spec": {
        "name": "<apigateway-name>",
        "description": "some description",
        "path": "/some/path", 
        "authenticationMode": "none",
        "upstreams": [
            {
                "kind": "nucliofunction",
                "nucliofunction": {
                    "name": "function-name-to-invoke"
                },
                "percentage": 0,
                "extraLabels": {
                    "my-custom-label": "some-label-value"
                }
            }
        ],
        "host": "<apigateway-name>-<project-name>.<nuclio-host-name>"
    },
    "metadata": {
        "labels": {
            "nuclio.io/project-name": "default"
        },
        "name": "<apigateway-name>"
    }
}
``` 

If using `nuctl`, add the extra labels in a  JSON-encoded string and pass it to the `--labels` flag (or `--canary-labels` if setting custom labels to the canary function). e.g:
```
nuctl create apigateway my-api-gateway ... --function my-func --labels "{"my-custom-label": "some-label-value"}"
```


**NOTE:** Currently only available via via http/nuctl, not UI.

Implements #2710 