### PR TITLE
Cleanup evicted function pods

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -47,6 +47,7 @@ func Run(kubeconfigPath string,
 	resyncIntervalStr string,
 	functionMonitorIntervalStr,
 	cronJobStaleResourcesCleanupIntervalStr string,
+	evictedPodsCleanupIntervalStr string,
 	functionEventOperatorNumWorkersStr string,
 	projectOperatorNumWorkersStr string,
 	apiGatewayOperatorNumWorkersStr string) error {
@@ -60,6 +61,7 @@ func Run(kubeconfigPath string,
 		resyncIntervalStr,
 		functionMonitorIntervalStr,
 		cronJobStaleResourcesCleanupIntervalStr,
+		evictedPodsCleanupIntervalStr,
 		functionEventOperatorNumWorkersStr,
 		projectOperatorNumWorkersStr,
 		apiGatewayOperatorNumWorkersStr)
@@ -85,6 +87,7 @@ func createController(kubeconfigPath string,
 	resyncIntervalStr string,
 	functionMonitorIntervalStr string,
 	cronJobStaleResourcesCleanupIntervalStr string,
+	evictedPodsCleanupIntervalStr string,
 	functionEventOperatorNumWorkersStr string,
 	projectOperatorNumWorkersStr string,
 	apiGatewayOperatorNumWorkersStr string) (*controller.Controller, error) {
@@ -110,6 +113,11 @@ func createController(kubeconfigPath string,
 	}
 
 	cronJobStaleResourcesCleanupInterval, err := time.ParseDuration(cronJobStaleResourcesCleanupIntervalStr)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to parse cron job stale pods deletion interval")
+	}
+
+	evictedPodsCleanupInterval, err := time.ParseDuration(evictedPodsCleanupIntervalStr)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to parse cron job stale pods deletion interval")
 	}
@@ -187,6 +195,7 @@ func createController(kubeconfigPath string,
 		resyncInterval,
 		functionMonitorInterval,
 		cronJobStaleResourcesCleanupInterval,
+		evictedPodsCleanupInterval,
 		platformConfiguration,
 		platformConfigurationName,
 		functionOperatorNumWorkers,

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -55,6 +55,7 @@ func main() {
 
 	functionMonitorIntervalStr := flag.String("function-monitor-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_MONITOR_INTERVAL", "3m"), "Set function monitor interval (optional)")
 	cronJobStaleResourcesCleanupIntervalStr := flag.String("cron-job-stale-resources-cleanup-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_CRON_JOB_STALE_RESOURCES_CLEANUP_INTERVAL", "1m"), "Set interval for the cleanup of stale cron job resources (optional)")
+	evictedPodsCleanupIntervalStr := flag.String("evicted-pods-cleanup-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_EVICTED_PODS_CLEANUP_INTERVAL", "30m"), "Set interval for the cleanup of evicted function pods (optional)")
 	functionEventOperatorNumWorkersStr := flag.String("function-event-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_EVENT_OPERATOR_NUM_WORKERS", "2"), "Set number of workers for the function event operator (optional)")
 	projectOperatorNumWorkersStr := flag.String("project-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_PROJECT_OPERATOR_NUM_WORKERS", "2"), "Set number of workers for the project operator (optional)")
 	apiGatewayOperatorNumWorkersStr := flag.String("api-gateway-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_API_GATEWAY_OPERATOR_NUM_WORKERS", "2"), "Set number of workers for the api gateway operator (optional)")
@@ -82,6 +83,7 @@ func main() {
 		*resyncIntervalStr,
 		*functionMonitorIntervalStr,
 		*cronJobStaleResourcesCleanupIntervalStr,
+		*evictedPodsCleanupIntervalStr,
 		*functionEventOperatorNumWorkersStr,
 		*projectOperatorNumWorkersStr,
 		*apiGatewayOperatorNumWorkersStr); err != nil {

--- a/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
@@ -78,6 +78,8 @@ spec:
           value: {{ .Values.controller.operator.apiGateway.numWorkers | quote }}
         - name: NUCLIO_CONTROLLER_RESYNC_INTERVAL
           value: {{ .Values.controller.resyncInterval | quote }}
+        - name: NUCLIO_CONTROLLER_EVICTED_PODS_CLEANUP_INTERVAL
+          value: {{ .Values.controller.evictedPodsCleanupInterval | quote }}
         {{- if .Values.platform }}
         volumeMounts:
         - name: platform-config

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -62,6 +62,8 @@ controller:
   # Note: 0 means cancelling resync mechanism. any other value (e.g.: 10m) would turn it on.
   resyncInterval: 0
 
+  evictedPodsCleanupInterval: 30m
+
   operator:
     function:
       numWorkers: 4

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -62,6 +62,8 @@ controller:
   # Note: 0 means cancelling resync mechanism. any other value (e.g.: 10m) would turn it on.
   resyncInterval: 0
 
+  # evicted pods cleanup interval defines how often the Controller goes through all evicted pods and deletes them
+  # Note: 0 means cancelling cleanup mechanism. any other value (e.g.: 10m) would turn it on.
   evictedPodsCleanupInterval: 30m
 
   operator:

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -565,3 +565,13 @@ func RemoveDuplicatesFromSliceString(slice []string) []string {
 	}
 	return list
 }
+
+func RemoveStringSliceItemsFromStringSlice(slice []string, itemsToRemove []string) []string {
+	var list []string
+	for _, item := range slice {
+		if !StringSliceContainsString(itemsToRemove, item) {
+			list = append(list, item)
+		}
+	}
+	return list
+}

--- a/pkg/common/k8s.go
+++ b/pkg/common/k8s.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/nuclio/logger"
+	"k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -79,6 +80,20 @@ func NewKubernetesClientWarningHandler(logger logger.Logger) *KubernetesClientWa
 	return &KubernetesClientWarningHandler{
 		logger: logger,
 	}
+}
+
+// CompileStalePodsFieldSelector creates a field selector(string) for stale pods
+func CompileStalePodsFieldSelector() string {
+	var fieldSelectors []string
+
+	// filter out non-stale pods by their phase
+	nonStalePodPhases := []v1.PodPhase{v1.PodPending, v1.PodRunning}
+	for _, nonStalePodPhase := range nonStalePodPhases {
+		selector := fmt.Sprintf("status.phase!=%s", string(nonStalePodPhase))
+		fieldSelectors = append(fieldSelectors, selector)
+	}
+
+	return strings.Join(fieldSelectors, ",")
 }
 
 // HandleWarningHeader handles miscellaneous warning messages yielded by Kubernetes api server

--- a/pkg/platform/kube/controller/controller_test.go
+++ b/pkg/platform/kube/controller/controller_test.go
@@ -49,6 +49,7 @@ func (suite *ControllerTestSuite) SetupTest() {
 	var err error
 	resyncInterval := 0 * time.Second
 	functionMonitoringInterval := 10 * time.Second
+	evictedPodsCleanupInterval := 30 * time.Minute
 	cronJobInterval := 10 * time.Second
 	defaultNumWorkers := 1
 
@@ -79,6 +80,7 @@ func (suite *ControllerTestSuite) SetupTest() {
 		nil,
 		resyncInterval,
 		functionMonitoringInterval,
+		evictedPodsCleanupInterval,
 		cronJobInterval,
 		platformConfig,
 		"configuration-name",

--- a/pkg/platform/kube/controller/cronjobmonitoring.go
+++ b/pkg/platform/kube/controller/cronjobmonitoring.go
@@ -18,13 +18,12 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"runtime/debug"
-	"strings"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/common"
+
 	"github.com/nuclio/logger"
-	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -70,7 +69,7 @@ func (cjm *CronJobMonitoring) start(ctx context.Context) {
 					"stack", string(callStack))
 			}
 		}()
-		stalePodsFieldSelector := cjm.compileStalePodsFieldSelector()
+		stalePodsFieldSelector := common.CompileStalePodsFieldSelector()
 		cjm.logger.InfoWithCtx(ctx, "Starting cron job stale resources cleanup loop",
 			"cronJobStaleResourcesCleanupInterval", cjm.cronJobStaleResourcesCleanupInterval,
 			"fieldSelectors", stalePodsFieldSelector)
@@ -153,18 +152,4 @@ func (cjm *CronJobMonitoring) deleteStaleJobs(ctx context.Context) {
 			}
 		}
 	}
-}
-
-// create a field selector(string) for stale pods
-func (cjm *CronJobMonitoring) compileStalePodsFieldSelector() string {
-	var fieldSelectors []string
-
-	// filter out non stale pods by their phase
-	nonStalePodPhases := []v1.PodPhase{v1.PodPending, v1.PodRunning}
-	for _, nonStalePodPhase := range nonStalePodPhases {
-		selector := fmt.Sprintf("status.phase!=%s", string(nonStalePodPhase))
-		fieldSelectors = append(fieldSelectors, selector)
-	}
-
-	return strings.Join(fieldSelectors, ",")
 }

--- a/pkg/platform/kube/controller/evictedpodsmonitoring.go
+++ b/pkg/platform/kube/controller/evictedpodsmonitoring.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/common"
+
+	"github.com/nuclio/logger"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type EvictedPodsMonitoring struct {
+	logger                     logger.Logger
+	controller                 *Controller
+	evictedPodsCleanupInterval *time.Duration
+	podNamesToDelete           []string
+	stopChan                   chan struct{}
+}
+
+func NewEvictedPodsMonitoring(ctx context.Context,
+	parentLogger logger.Logger,
+	controller *Controller,
+	evictedPodsCleanupInterval *time.Duration) *EvictedPodsMonitoring {
+
+	loggerInstance := parentLogger.GetChild("cron_job_monitoring")
+
+	newEvictedPodsMonitoring := &EvictedPodsMonitoring{
+		logger:                     loggerInstance,
+		controller:                 controller,
+		evictedPodsCleanupInterval: evictedPodsCleanupInterval,
+	}
+
+	parentLogger.DebugWithCtx(ctx, "Successfully created evicted pods monitoring instance",
+		"evictedPodsCleanupInterval", evictedPodsCleanupInterval)
+
+	return newEvictedPodsMonitoring
+}
+
+func (epm *EvictedPodsMonitoring) start(ctx context.Context) {
+
+	// create stop channel
+	epm.stopChan = make(chan struct{}, 1)
+
+	// start a go routine that will periodically clean up stale resources
+	go epm.cleanupEvictedPods(ctx)
+}
+
+func (epm *EvictedPodsMonitoring) stop(ctx context.Context) {
+	epm.logger.DebugWithCtx(ctx, "Stopping evicted pods monitoring")
+
+	if epm.stopChan != nil {
+		epm.stopChan <- struct{}{}
+	}
+}
+
+func (epm *EvictedPodsMonitoring) cleanupEvictedPods(ctx context.Context) {
+	epm.logger.DebugWithCtx(ctx, "Starting evicted pods cleanup")
+
+	// run forever
+	for {
+		select {
+		case <-epm.stopChan:
+			epm.logger.DebugWithCtx(ctx, "Stopping evicted pods cleanup")
+
+			// remove all pods that were marked for deletion
+			epm.podNamesToDelete = nil
+			return
+
+		case <-time.After(*epm.evictedPodsCleanupInterval):
+			epm.logger.DebugWithCtx(ctx, "Cleaning up evicted pods")
+
+			// get all failed function pods
+			stalePodsFieldSelector := common.CompileStalePodsFieldSelector()
+			pods, err := epm.controller.kubeClientSet.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+				LabelSelector: "nuclio.io/class=function",
+				FieldSelector: stalePodsFieldSelector,
+			})
+			if err != nil {
+				epm.logger.WarnWithCtx(ctx, "Failed to list pods", "err", err)
+				continue
+			}
+
+			var deletedPodNames []string
+
+			// iterate over pods
+			for _, pod := range pods.Items {
+
+				if strings.Contains(pod.Status.Reason, "Evicted") {
+
+					// evicted pod was found in the last interval, delete it
+					if common.StringSliceContainsString(epm.podNamesToDelete, pod.Name) {
+						deletedPodNames = append(deletedPodNames, pod.Name)
+						epm.logger.DebugWithCtx(ctx, "Deleting evicted pod", "podName", pod.Name)
+
+						// delete pod
+						err := epm.controller.kubeClientSet.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+						if err != nil && !apierrors.IsNotFound(err) {
+							epm.logger.WarnWithCtx(ctx, "Failed to delete pod",
+								"podName", pod.Name,
+								"err", err)
+						}
+					} else {
+
+						// a newly-evicted pod, add it to the list of pods to delete
+						// this is a hack to make sure the pods are evicted for longer than the interval
+						epm.podNamesToDelete = append(epm.podNamesToDelete, pod.Name)
+					}
+				}
+			}
+
+			// remove deleted pods from the list of pods to delete
+			epm.podNamesToDelete = common.RemoveStringSliceItemsFromStringSlice(epm.podNamesToDelete, deletedPodNames)
+		}
+	}
+}

--- a/pkg/platform/kube/controller/nucliofunction_test.go
+++ b/pkg/platform/kube/controller/nucliofunction_test.go
@@ -51,6 +51,7 @@ func (suite *NuclioFunctionTestSuite) SetupTest() {
 	var err error
 	resyncInterval := 0 * time.Second
 	functionMonitoringInterval := 10 * time.Second
+	evictedPodsCleanupInterval := 30 * time.Minute
 	cronJobInterval := 10 * time.Second
 	defaultNumWorkers := 1
 
@@ -79,6 +80,7 @@ func (suite *NuclioFunctionTestSuite) SetupTest() {
 		nil,
 		resyncInterval,
 		functionMonitoringInterval,
+		evictedPodsCleanupInterval,
 		cronJobInterval,
 		platformConfig,
 		"configuration-name",

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -654,6 +654,7 @@ func (suite *KubeTestSuite) createController() *controller.Controller {
 		0,              // disable resync interval
 		time.Second*5,  // monitor interval
 		time.Second*30, // cronjob stale duration
+		time.Minute*30, // evicted pods cleanup duration
 		suite.PlatformConfiguration,
 		"nuclio-platform-config",
 		1,


### PR DESCRIPTION
Kubernetes sometimes evicts pods if they are too resource-heavy and reclaims the used resources.
Evicted the pods stay in the cluster in `Evicted` state.

In this PR, the nuclio controller spins up a goroutine that looks for evicted pods periodically according to the configurable `evictedPodsCleanupInterval`. 
If the pod is evicted for more than the interval period, it is deleted.

JIRA: https://jira.iguazeng.com/browse/IG-21377