### PR TITLE
Remove existing ingress and api gateway validation

### DIFF
--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1273,32 +1273,6 @@ func (p *Platform) generateFunctionToAPIGatewaysMapping(ctx context.Context, nam
 	return functionToAPIGateways, nil
 }
 
-func (p *Platform) getFunctionAPIGateways(ctx context.Context, functionName, namespace string) ([]*nuclioio.NuclioAPIGateway, error) {
-	var functionAPIGateways []*nuclioio.NuclioAPIGateway
-
-	// get all api gateways in the namespace
-	apiGateways, err := p.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioAPIGateways(namespace).
-		List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to list API gateways")
-	}
-
-	// iterate over all api gateways
-	for _, apiGateway := range apiGateways.Items {
-
-		// iterate over all upstreams(functions) of the api gateway
-		for _, upstream := range apiGateway.Spec.Upstreams {
-			if upstream.NuclioFunction.Name == functionName {
-
-				functionAPIGateways = append(functionAPIGateways, &apiGateway)
-			}
-		}
-	}
-
-	return functionAPIGateways, nil
-}
-
 func (p *Platform) enrichFunctionsWithAPIGateways(ctx context.Context, functions []platform.Function, namespace string) error {
 	var err error
 	var functionToAPIGateways map[string][]string
@@ -1661,22 +1635,10 @@ func (p *Platform) validateAPIGatewayConfig(ctx context.Context,
 		}
 	}
 
+	// get upstream functions for validating functions existence
 	if _, err := p.getAPIGatewayUpstreamFunctions(ctx, apiGateway, validateFunctionsExistence); err != nil {
 		return errors.Wrap(err, "Failed to get api gateway upstream functions")
 	}
-	//
-	//// validate APIGateway functions ingresses have unique hostnames
-	//for _, upstreamFunction := range upstreamFunctions {
-	//	ingresses := functionconfig.GetFunctionIngresses(upstreamFunction.GetConfig())
-	//	if len(ingresses) > 0 {
-	//		for _, ingressInstance := range ingresses {
-	//			if ingressInstance.Host == apiGateway.Spec.Host &&
-	//				common.StringInSlice(apiGateway.Spec.Path, ingressInstance.Paths) {
-	//				return nuclio.NewErrPreconditionFailed("APIGateway endpoint overrides the function's ingress endpoint")
-	//			}
-	//		}
-	//	}
-	//}
 
 	// ingresses
 	if err := p.validateAPIGatewayIngresses(ctx, apiGateway); err != nil {
@@ -1803,9 +1765,6 @@ func (p *Platform) validateAPIGatewayIngresses(ctx context.Context, apiGatewayCo
 }
 
 func (p *Platform) validateFunctionIngresses(ctx context.Context, functionConfig *functionconfig.Config) error {
-	//if err := p.validateFunctionNoIngressAndAPIGateway(ctx, functionConfig); err != nil {
-	//	return errors.Wrap(err, "Failed to validate: the function isn't exposed by an internal ingresses or an API gateway")
-	//}
 
 	listIngressesOptions := metav1.ListOptions{
 
@@ -1876,35 +1835,6 @@ func (p *Platform) validateIngressHostAndPathAvailability(ctx context.Context,
 				}
 			}
 		}
-	}
-
-	return nil
-}
-
-// validate that a function is not exposed inside http triggers, while it is also exposed by an api gateway
-// this is done to prevent the nginx bug, where it is not working properly when the same service is exposed more than once
-// (e.g. when a service is exposed by an ingress with host-1.com without canary ingress, and on another api gateway with host-2.com
-// with canary ingress, when sending requests to host-1.com we may get directed to the canary ingress defined by the api gateway)
-func (p *Platform) validateFunctionNoIngressAndAPIGateway(ctx context.Context, functionConfig *functionconfig.Config) error {
-	ingresses := functionconfig.GetFunctionIngresses(functionConfig)
-	if len(ingresses) > 0 {
-
-		// TODO: when we'll add upstream labels to api gateway, use get api gateways by label to replace this line
-		apiGateways, err := p.getFunctionAPIGateways(ctx, functionConfig.Meta.Name, functionConfig.Meta.Namespace)
-		if err != nil {
-			return errors.Wrap(err, "Failed to get a function to API-gateways mapping")
-		}
-		for _, apiGateway := range apiGateways {
-			for _, ingressInstance := range ingresses {
-				if ingressInstance.Host == apiGateway.Spec.Host && common.StringInSlice(apiGateway.Spec.Path, ingressInstance.Paths) {
-					return nuclio.NewErrBadRequest("Function can't expose ingresses with the same endpoint exposed by an API gateway")
-				}
-			}
-		}
-		//
-		//if _, found := functionToAPIGateways[functionConfig.Meta.Name]; found {
-		//	return nuclio.NewErrBadRequest("Function can't expose ingresses while it is being exposed by an API gateway")
-		//}
 	}
 
 	return nil

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -1875,7 +1875,6 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayEnrichmentAndValidat
 					},
 				},
 			},
-			//validationError: "Api gateway upstream function: function-with-ingresses must not have an ingress",
 		},
 		{
 			name: "ValidateAPIGatewayCanaryFunctionHasNoIngresses",
@@ -1913,7 +1912,6 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayEnrichmentAndValidat
 					},
 				},
 			},
-			//validationError: "Api gateway upstream function: function-with-ingresses-2 must not have an ingress",
 		},
 		{
 			name: "PathIsAvailable",

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -1875,7 +1875,7 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayEnrichmentAndValidat
 					},
 				},
 			},
-			validationError: "Api gateway upstream function: function-with-ingresses must not have an ingress",
+			//validationError: "Api gateway upstream function: function-with-ingresses must not have an ingress",
 		},
 		{
 			name: "ValidateAPIGatewayCanaryFunctionHasNoIngresses",
@@ -1913,7 +1913,7 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayEnrichmentAndValidat
 					},
 				},
 			},
-			validationError: "Api gateway upstream function: function-with-ingresses-2 must not have an ingress",
+			//validationError: "Api gateway upstream function: function-with-ingresses-2 must not have an ingress",
 		},
 		{
 			name: "PathIsAvailable",
@@ -2014,7 +2014,7 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayEnrichmentAndValidat
 				return &apiGatewayConfig
 			}(),
 			validateFunctionsExistence: true,
-			validationError:            "Function default-func-name does not exists",
+			validationError:            "Function default-func-name does not exist",
 		},
 	} {
 		suite.Run(testCase.name, func() {


### PR DESCRIPTION
Currently it is impossible to create an api gateway for a function that already has an ingress, and vice-versa.

However, the nginx ingress controller allows multiple ingresses to forward to a single service, as long as the endpoint path is different (which is already validated).

Multiple canary ingresses will not work ([as per this nginx issue](https://github.com/kubernetes/ingress-nginx/issues/5848)), but this is not the case with the nuclio api gateway which only creates one canary ingress.

This PR removes validation of existing api gateways when adding an ingress to a function's http trigger, and removes validation of existing ingresses when creating an api gateway for a funcition.