### PR TITLE
Kaniko - Retry extracting image filesystem

### DIFF
--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -100,6 +100,8 @@ spec:
           value: {{ .Values.dashboard.kaniko.initContainerImage.awscli.repository }}:{{ .Values.dashboard.kaniko.initContainerImage.awscli.tag}}
         - name: NUCLIO_KANIKO_PUSH_IMAGES_RETRIES
           value: {{ .Values.dashboard.kaniko.pushImagesRetries | quote }}
+        - name: NUCLIO_KANIKO_IMAGE_FS_EXTRACTION_RETRIES
+          value: {{ .Values.dashboard.kaniko.imageFSExtractionRetries | quote }}
         - name: NUCLIO_AUTH_KIND
           value: {{ .Values.dashboard.authConfig.kind }}
         - name: NUCLIO_AUTH_OPTIONS_IGUAZIO_TIMEOUT

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -164,6 +164,9 @@ dashboard:
     # How many times to retry pushing images to registry
     pushImagesRetries: 3
 
+    # The number of retries that should happen for the extracting an image filesystem
+    imageFSExtractionRetries: 3
+
     # auth secret to attach to kaniko pod for off cluster registries
     # for example: aws-secret in https://github.com/GoogleContainerTools/kaniko#pushing-to-amazon-ecr
     registryProviderSecretName: ""

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -238,6 +238,7 @@ func (k *Kaniko) compileJobSpec(namespace string,
 		fmt.Sprintf("--context=%s", buildOptions.ContextDir),
 		fmt.Sprintf("--destination=%s", common.CompileImageName(buildOptions.RegistryURL, buildOptions.Image)),
 		fmt.Sprintf("--push-retry=%d", k.builderConfiguration.PushImagesRetries),
+		fmt.Sprintf("--image-fs-extract-retry=%d", k.builderConfiguration.ImageFSExtractionRetries),
 	}
 
 	if !buildOptions.NoCache {

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -68,6 +68,7 @@ type ContainerBuilderConfiguration struct {
 	InsecurePushRegistry                 bool
 	InsecurePullRegistry                 bool
 	PushImagesRetries                    int
+	ImageFSExtractionRetries             int
 }
 
 func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) {
@@ -127,6 +128,12 @@ func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) 
 
 	containerBuilderConfiguration.PushImagesRetries, err =
 		strconv.Atoi(common.GetEnvOrDefaultString("NUCLIO_KANIKO_PUSH_IMAGES_RETRIES", "3"))
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to resolve number of push images retries")
+	}
+
+	containerBuilderConfiguration.ImageFSExtractionRetries, err =
+		strconv.Atoi(common.GetEnvOrDefaultString("NUCLIO_KANIKO_IMAGE_FS_EXTRACTION_RETRIES", "3"))
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to resolve number of push images retries")
 	}


### PR DESCRIPTION
Kaniko sometimes fails to get filesystem from image:
```
INFO[0002] Unpacking rootfs as cmd COPY --from=python-onbuild /home/nuclio/bin/processor /usr/local/bin/processor requires it. 
error building image: error building stage: failed to get filesystem from image: read tcp 10.200.254.29:58626->65.9.112.124:443: read: connection timed out
    /nuclio/pkg/processor/build/builder.go:263
```

This is an issue that still hasn't been addressed by Kaniko - https://github.com/GoogleContainerTools/kaniko/issues/1717 

A current workaround is to best-effort retry extracting the image filesystem (default currently set to 3 retries).

JIRA: https://jira.iguazeng.com/browse/IG-21355