### PR TITLE
Function config secret fixes

### DIFF
--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -314,7 +314,7 @@ func (p *Processor) restoreFunctionConfig(config *functionconfig.Config) (*funct
 
 func (p *Processor) getSecretsMap(annotations map[string]string) (map[string]string, error) {
 
-	if hasSecret, hasSecretExists := annotations[functionconfig.HasSecretAnnotation]; hasSecretExists &&
+	if hasSecret, hasSecretExists := annotations[functionconfig.FunctionAnnotationHasSecret]; hasSecretExists &&
 		strings.ToLower(hasSecret) == "true" {
 
 		// the env var is mainly for testing

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -459,6 +459,7 @@ func (fr *functionResource) deleteFunction(request *http.Request) (*restful.Cust
 func (fr *functionResource) functionToAttributes(function platform.Function) restful.Attributes {
 	functionConfig := function.GetConfig()
 	functionConfig.CleanFunctionSpec()
+	functionConfig.CleanFunctionMeta()
 
 	attributes := restful.Attributes{
 		"metadata": functionConfig.Meta,

--- a/pkg/functionconfig/mask.go
+++ b/pkg/functionconfig/mask.go
@@ -39,7 +39,6 @@ const (
 	SecretTypeFunctionConfig         = "nuclio.io/functionconfig"
 	SecretTypeV3ioFuse               = "v3io/fuse"
 	SecretContentKey                 = "content"
-	HasSecretAnnotation              = "nuclio.io/has-secret"
 	FunctionSecretMountPath          = "/etc/nuclio/secrets"
 )
 
@@ -133,12 +132,15 @@ func EncodeSecretsMap(secretsMap map[string]string) (map[string]string, error) {
 		encodedSecretsMap[encodeSecretKey(secretKey)] = secretValue
 	}
 
-	// encode the entire map into a single string
-	secretsMapContent, err := json.Marshal(encodedSecretsMap)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to marshal secrets map")
+	if len(encodedSecretsMap) > 0 {
+
+		// encode the entire map into a single string
+		secretsMapContent, err := json.Marshal(encodedSecretsMap)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to marshal secrets map")
+		}
+		encodedSecretsMap[SecretContentKey] = base64.StdEncoding.EncodeToString(secretsMapContent)
 	}
-	encodedSecretsMap[SecretContentKey] = base64.StdEncoding.EncodeToString(secretsMapContent)
 
 	return encodedSecretsMap, nil
 }

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -494,6 +494,7 @@ func (s *Spec) PositiveGPUResourceLimit() bool {
 const (
 	FunctionAnnotationSkipBuild  = "skip-build"
 	FunctionAnnotationSkipDeploy = "skip-deploy"
+	FunctionAnnotationHasSecret  = "nuclio.io/has-secret"
 )
 
 // Meta identifies a function
@@ -527,6 +528,10 @@ func (m *Meta) RemoveSkipDeployAnnotation() {
 
 func (m *Meta) RemoveSkipBuildAnnotation() {
 	delete(m.Annotations, FunctionAnnotationSkipBuild)
+}
+
+func (m *Meta) RemoveHasSecretAnnotation() {
+	delete(m.Annotations, FunctionAnnotationHasSecret)
 }
 
 func ShouldSkipDeploy(annotations map[string]string) bool {
@@ -568,6 +573,12 @@ func (c *Config) CleanFunctionSpec() {
 	if c.Spec.Build.FunctionSourceCode != "" {
 		c.Spec.Image = ""
 	}
+}
+
+func (c *Config) CleanFunctionMeta() {
+
+	// when a secret is created, the function is updated with an annotation which is not supposed to be user facing
+	c.Meta.RemoveHasSecretAnnotation()
 }
 
 func (c *Config) PrepareFunctionForExport(noScrub bool) {

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -608,6 +608,9 @@ func (c *Config) scrubFunctionData() {
 	// scrub resource version
 	c.Meta.ResourceVersion = ""
 
+	// remove annotations from metadata
+	c.CleanFunctionMeta()
+
 	// remove secrets and passwords from triggers
 	newTriggers := c.Spec.Triggers
 	for triggerName, trigger := range newTriggers {

--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -201,9 +201,9 @@ func (d *Deployer) ScrubFunctionConfig(ctx context.Context,
 		if scrubbedFunctionConfig.Meta.Annotations == nil {
 			scrubbedFunctionConfig.Meta.Annotations = map[string]string{}
 		}
-		scrubbedFunctionConfig.Meta.Annotations[functionconfig.HasSecretAnnotation] = "true"
+		scrubbedFunctionConfig.Meta.Annotations[functionconfig.FunctionAnnotationHasSecret] = "true"
 	} else {
-		delete(scrubbedFunctionConfig.Meta.Annotations, functionconfig.HasSecretAnnotation)
+		delete(scrubbedFunctionConfig.Meta.Annotations, functionconfig.FunctionAnnotationHasSecret)
 	}
 
 	// create or update a secret for the function
@@ -299,6 +299,12 @@ func (d *Deployer) createFlexVolumeSecrets(ctx context.Context, volumes []functi
 
 	for volumeIndex, volume := range volumes {
 		if volume.Volume.FlexVolume != nil && volume.Volume.FlexVolume.Driver == functionconfig.SecretTypeV3ioFuse {
+
+			// if the volume doesn't have an access key, skip it
+			if _, exists := volume.Volume.FlexVolume.Options["accessKey"]; !exists {
+				continue
+			}
+
 			createdSecretVolumeNames = append(createdSecretVolumeNames, volume.Volume.Name)
 			if err := d.createOrUpdateFlexVolumeSecret(ctx,
 				volumeIndex,

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2274,7 +2274,7 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(ctx context.Context,
 	}
 
 	// volume the function secret if needed
-	if hasSecret, hasSecretExists := function.Annotations[functionconfig.HasSecretAnnotation]; hasSecretExists &&
+	if hasSecret, hasSecretExists := function.Annotations[functionconfig.FunctionAnnotationHasSecret]; hasSecretExists &&
 		strings.ToLower(hasSecret) == "true" {
 		secretVolumeName := "function-secret"
 		volumeNameToVolume[secretVolumeName] = v1.Volume{


### PR DESCRIPTION
Some fixes following the new function config masking functionality:

- Skip creating flex volume secrets if they do not contain an access key - fixes https://jira.iguazeng.com/browse/IG-21407
- Skip creation of function secret if secret content is empty.
- Remove "has-secret" annotation on GET /functions, as the dashboard adds/removes this annotation depending on actual secrets existence - fixes https://jira.iguazeng.com/browse/IG-21409 