### PR TITLE
Mark sensitive fields regex with end of string

### DIFF
--- a/pkg/functionconfig/mask_test.go
+++ b/pkg/functionconfig/mask_test.go
@@ -208,14 +208,14 @@ func (suite *MaskTestSuite) getSensitiveFieldsPathsRegex() []*regexp.Regexp {
 	for _, sensitiveFieldPath := range []string{
 
 		// Path nested in a map
-		"^/Spec/Build/CodeEntryAttributes/password",
+		"^/Spec/Build/CodeEntryAttributes/password$",
 		// Path nested in an array
-		"^/Spec/Volumes\\[\\d+\\]/Volume/VolumeSource/FlexVolume/Options/accesskey",
-		"^/Spec/Volumes\\[\\d+\\]/Volume/FlexVolume/Options/accesskey",
+		"^/Spec/Volumes\\[\\d+\\]/Volume/VolumeSource/FlexVolume/Options/accesskey$",
+		"^/Spec/Volumes\\[\\d+\\]/Volume/FlexVolume/Options/accesskey$",
 		// Path for any map element
-		"^/Spec/Triggers/.+/Password",
+		"^/Spec/Triggers/.+/Password$",
 		// Nested path in any map element
-		"^/Spec/Triggers/.+/Attributes/password",
+		"^/Spec/Triggers/.+/Attributes/password$",
 	} {
 		regexpList = append(regexpList, regexp.MustCompile("(?i)"+sensitiveFieldPath))
 	}

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -277,26 +277,26 @@ func (sfc *SensitiveFieldsConfig) GetDefaultSensitiveFields() []string {
 	return []string{
 
 		// build
-		"^/spec/build/codeentryattributes/password",
+		"^/spec/build/codeentryattributes/password$",
 		// volumes
-		"^/spec/volumes\\[\\d+\\]/volume/volumesource/flexvolume/options/accesskey",
-		"^/spec/volumes\\[\\d+\\]/volume/flexvolume/options/accesskey",
+		"^/spec/volumes\\[\\d+\\]/volume/volumesource/flexvolume/options/accesskey$",
+		"^/spec/volumes\\[\\d+\\]/volume/flexvolume/options/accesskey$",
 
 		// triggers - global
-		"^/spec/triggers/.+/password",
-		"^/spec/triggers/.+/secret",
+		"^/spec/triggers/.+/password$",
+		"^/spec/triggers/.+/secret$",
 		// triggers - specific
 		// - v3io stream
-		"^/spec/triggers/.+/attributes/password",
+		"^/spec/triggers/.+/attributes/password$",
 		// - kinesis
-		"^/spec/triggers/.+/attributes/accesskeyid",
-		"^/spec/triggers/.+/attributes/secretaccesskey",
+		"^/spec/triggers/.+/attributes/accesskeyid$",
+		"^/spec/triggers/.+/attributes/secretaccesskey$",
 		// - kafka
-		"^/spec/triggers/.+/attributes/cacert",
-		"^/spec/triggers/.+/attributes/accesskey",
-		"^/spec/triggers/.+/attributes/accesscertificate",
-		"^/spec/triggers/.+/attributes/sasl/password",
-		"^/spec/triggers/.+/attributes/sasl/oauth/clientsecret",
+		"^/spec/triggers/.+/attributes/cacert$",
+		"^/spec/triggers/.+/attributes/accesskey$",
+		"^/spec/triggers/.+/attributes/accesscertificate$",
+		"^/spec/triggers/.+/attributes/sasl/password$",
+		"^/spec/triggers/.+/attributes/sasl/oauth/clientsecret$",
 	}
 }
 


### PR DESCRIPTION
Missing `$` at the end of the regex custom caused the `Scrub` functions to mask and reference unwanted fields in the function configuration.

Relates to https://jira.iguazeng.com/browse/IG-21408