### PR TITLE
Remove "has-secret" annotation

### DIFF
--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"sync"
 	"time"
 
@@ -319,8 +320,10 @@ func (p *Processor) getSecretsMap() (map[string]string, error) {
 		filePath = functionconfig.FunctionSecretMountPath
 	}
 
+	contentPath := path.Join(filePath, functionconfig.SecretContentKey)
+
 	// check if a secret is mounted
-	if !common.FileExists(filePath) {
+	if !common.FileExists(contentPath) {
 		p.logger.Debug("No secret is not mounted to function pod, continuing without restoring function config")
 		return map[string]string{}, nil
 	}
@@ -328,7 +331,7 @@ func (p *Processor) getSecretsMap() (map[string]string, error) {
 	p.logger.Debug("Secret is mounted to function pod, restoring function config")
 
 	// read secret content from file
-	encodedSecret, err := os.ReadFile(fmt.Sprintf("%s/%s", filePath, functionconfig.SecretContentKey))
+	encodedSecret, err := os.ReadFile(contentPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to read function secret")
 	}

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -459,7 +459,6 @@ func (fr *functionResource) deleteFunction(request *http.Request) (*restful.Cust
 func (fr *functionResource) functionToAttributes(function platform.Function) restful.Attributes {
 	functionConfig := function.GetConfig()
 	functionConfig.CleanFunctionSpec()
-	functionConfig.CleanFunctionMeta()
 
 	attributes := restful.Attributes{
 		"metadata": functionConfig.Meta,

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -494,7 +494,6 @@ func (s *Spec) PositiveGPUResourceLimit() bool {
 const (
 	FunctionAnnotationSkipBuild  = "skip-build"
 	FunctionAnnotationSkipDeploy = "skip-deploy"
-	FunctionAnnotationHasSecret  = "nuclio.io/has-secret"
 )
 
 // Meta identifies a function
@@ -528,10 +527,6 @@ func (m *Meta) RemoveSkipDeployAnnotation() {
 
 func (m *Meta) RemoveSkipBuildAnnotation() {
 	delete(m.Annotations, FunctionAnnotationSkipBuild)
-}
-
-func (m *Meta) RemoveHasSecretAnnotation() {
-	delete(m.Annotations, FunctionAnnotationHasSecret)
 }
 
 func ShouldSkipDeploy(annotations map[string]string) bool {
@@ -575,12 +570,6 @@ func (c *Config) CleanFunctionSpec() {
 	}
 }
 
-func (c *Config) CleanFunctionMeta() {
-
-	// when a secret is created, the function is updated with an annotation which is not supposed to be user facing
-	c.Meta.RemoveHasSecretAnnotation()
-}
-
 func (c *Config) PrepareFunctionForExport(noScrub bool) {
 	if !noScrub {
 		c.scrubFunctionData()
@@ -607,9 +596,6 @@ func (c *Config) scrubFunctionData() {
 
 	// scrub resource version
 	c.Meta.ResourceVersion = ""
-
-	// remove annotations from metadata
-	c.CleanFunctionMeta()
 
 	// remove secrets and passwords from triggers
 	newTriggers := c.Spec.Triggers

--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -196,16 +196,6 @@ func (d *Deployer) ScrubFunctionConfig(ctx context.Context,
 		return nil, errors.Wrap(err, "Failed to encode secrets map")
 	}
 
-	// if the secret map is not empty, annotate the function so the controller will know to mount the secret
-	if len(encodedSecretsMap) > 0 {
-		if scrubbedFunctionConfig.Meta.Annotations == nil {
-			scrubbedFunctionConfig.Meta.Annotations = map[string]string{}
-		}
-		scrubbedFunctionConfig.Meta.Annotations[functionconfig.FunctionAnnotationHasSecret] = "true"
-	} else {
-		delete(scrubbedFunctionConfig.Meta.Annotations, functionconfig.FunctionAnnotationHasSecret)
-	}
-
 	// create or update a secret for the function
 	if err := d.createOrUpdateFunctionSecret(ctx,
 		encodedSecretsMap,

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2163,7 +2163,6 @@ func (lc *lazyClient) populateConfigMap(functionLabels labels.Set,
 func (lc *lazyClient) getFunctionVolumeAndMounts(ctx context.Context,
 	function *nuclioio.NuclioFunction) ([]v1.Volume, []v1.VolumeMount, error) {
 	trueVal := true
-	falseVal := false
 	var configVolumes []functionconfig.Volume
 	var filteredFunctionVolumes []functionconfig.Volume
 
@@ -2273,25 +2272,22 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(ctx context.Context,
 			configVolume.VolumeMount)
 	}
 
-	// volume the function secret if needed
-	if hasSecret, hasSecretExists := function.Annotations[functionconfig.FunctionAnnotationHasSecret]; hasSecretExists &&
-		strings.ToLower(hasSecret) == "true" {
-		secretVolumeName := "function-secret"
-		volumeNameToVolume[secretVolumeName] = v1.Volume{
-			Name: secretVolumeName,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
-					SecretName: functionconfig.GenerateFunctionSecretName(function.Name, functionconfig.NuclioSecretNamePrefix),
-					Optional:   &falseVal,
-				},
+	// volume the function secret as optional
+	secretVolumeName := "function-secret"
+	volumeNameToVolume[secretVolumeName] = v1.Volume{
+		Name: secretVolumeName,
+		VolumeSource: v1.VolumeSource{
+			Secret: &v1.SecretVolumeSource{
+				SecretName: functionconfig.GenerateFunctionSecretName(function.Name, functionconfig.NuclioSecretNamePrefix),
+				Optional:   &trueVal,
 			},
-		}
-		volumeNameToVolumeMounts[secretVolumeName] = append(volumeNameToVolumeMounts[secretVolumeName], v1.VolumeMount{
-			Name:      secretVolumeName,
-			MountPath: functionconfig.FunctionSecretMountPath,
-			ReadOnly:  true,
-		})
+		},
 	}
+	volumeNameToVolumeMounts[secretVolumeName] = append(volumeNameToVolumeMounts[secretVolumeName], v1.VolumeMount{
+		Name:      secretVolumeName,
+		MountPath: functionconfig.FunctionSecretMountPath,
+		ReadOnly:  true,
+	})
 
 	for _, volume := range volumeNameToVolume {
 		volumes = append(volumes, volume)


### PR DESCRIPTION
Instead of annotating the function with `has-secret = true` for signaling the controller and processor that a secret was created, the controller will always volume the function secret as `optional`, and the processor will just check the existence of the secret in the pre-determined path.