### PR TITLE
Enrich nil service type in http trigger

### DIFF
--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1726,7 +1726,9 @@ func (p *Platform) enrichTriggerWithServiceType(ctx context.Context,
 		trigger.Attributes = map[string]interface{}{}
 	}
 
-	if triggerServiceType, serviceTypeExists := trigger.Attributes["serviceType"]; !serviceTypeExists || triggerServiceType == "" {
+	if triggerServiceType, serviceTypeExists := trigger.Attributes["serviceType"]; !serviceTypeExists ||
+		triggerServiceType == "" ||
+		triggerServiceType == nil {
 
 		p.Logger.DebugWithCtx(ctx, "Enriching function HTTP trigger with service type",
 			"functionName", functionConfig.Meta.Name,

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -636,6 +636,30 @@ func (suite *DeployFunctionTestSuite) TestHTTPTriggerServiceTypes() {
 		suite.Require().Equal(v1.ServiceTypeNodePort, serviceInstance.Spec.Type)
 		return true
 	})
+
+	// create a function with a nil service type
+	nilServiceTypeFunctionName := "with-nil-service-type"
+	nilServiceTypeFunctionOptions := suite.CompileCreateFunctionOptions(nilServiceTypeFunctionName)
+	triggerAttributesJSON := `{ "serviceType": null }`
+	triggerAttributes := map[string]interface{}{}
+	err := json.Unmarshal([]byte(triggerAttributesJSON), &triggerAttributes)
+	suite.Require().NoError(err)
+	nilServiceTypeTrigger := functionconfig.Trigger{
+		Kind:       "http",
+		Name:       "nil-service-type-trigger",
+		MaxWorkers: 1,
+		Attributes: triggerAttributes,
+	}
+	nilServiceTypeFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{
+		nilServiceTypeTrigger.Name: nilServiceTypeTrigger,
+	}
+	suite.DeployFunction(nilServiceTypeFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+		serviceInstance := &v1.Service{}
+		suite.GetResourceAndUnmarshal("service", kube.ServiceNameFromFunctionName(nilServiceTypeFunctionName), serviceInstance)
+		suite.Require().Equal(v1.ServiceTypeNodePort, serviceInstance.Spec.Type)
+		return true
+	})
+
 }
 
 func (suite *DeployFunctionTestSuite) createPlatformConfigmapWithJSONLogger() *v1.ConfigMap {


### PR DESCRIPTION
When an http's trigger was set to `nil / null` it was only enriched to the default service type in the controller.
This caused the function config scrubbing (done beforehand in the dashboard) to fail on a zero type.

This PR enriches nil service types in `EnrichFunctionConfig`, right when the Create Function process starts.

https://jira.iguazeng.com/browse/IG-21413 