### PR TITLE
Don't remove reference prefix when encoding secret map

### DIFF
--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -18,7 +18,6 @@ package app
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -336,26 +335,7 @@ func (p *Processor) getSecretsMap() (map[string]string, error) {
 		return nil, errors.Wrap(err, "Failed to read function secret")
 	}
 
-	// decode secret
-	secretContentStr, err := base64.StdEncoding.DecodeString(string(encodedSecret))
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to decode function secret")
-	}
-
-	// unmarshal secret into map
-	encodedSecretMap := map[string]string{}
-	if err := json.Unmarshal(secretContentStr, &encodedSecretMap); err != nil {
-		return nil, errors.Wrap(err, "Failed to unmarshal function secret")
-	}
-
-	// decode secret keys and values
-	// convert values to byte array for decoding purposes
-	secretMap, err := functionconfig.DecodeSecretData(common.MapStringStringToMapStringBytesArray(encodedSecretMap))
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to decode function secret data")
-	}
-
-	return secretMap, nil
+	return functionconfig.DecodeSecretsMapContent(string(encodedSecret))
 }
 
 func (p *Processor) createTriggers(processorConfiguration *processor.Configuration) ([]trigger.Trigger, error) {

--- a/pkg/functionconfig/mask.go
+++ b/pkg/functionconfig/mask.go
@@ -179,7 +179,6 @@ func GenerateFunctionSecretName(functionName, secretPrefix string) string {
 
 // encodeSecretKey encodes a secret key
 func encodeSecretKey(fieldPath string) string {
-	fieldPath = strings.TrimPrefix(fieldPath, ReferencePrefix)
 	encodedFieldPath := base64.StdEncoding.EncodeToString([]byte(fieldPath))
 	encodedFieldPath = strings.ReplaceAll(encodedFieldPath, "=", "_")
 	return fmt.Sprintf("%s%s", ReferenceToEnvVarPrefix, encodedFieldPath)

--- a/pkg/functionconfig/mask.go
+++ b/pkg/functionconfig/mask.go
@@ -145,6 +145,31 @@ func EncodeSecretsMap(secretsMap map[string]string) (map[string]string, error) {
 	return encodedSecretsMap, nil
 }
 
+// DecodeSecretsMapContent decodes the secrets map content
+func DecodeSecretsMapContent(secretsMapContent string) (map[string]string, error) {
+
+	// decode secret
+	secretContentStr, err := base64.StdEncoding.DecodeString(secretsMapContent)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to decode function secret")
+	}
+
+	// unmarshal secret into map
+	encodedSecretMap := map[string]string{}
+	if err := json.Unmarshal(secretContentStr, &encodedSecretMap); err != nil {
+		return nil, errors.Wrap(err, "Failed to unmarshal function secret")
+	}
+
+	// decode secret keys and values
+	// convert values to byte array for decoding purposes
+	secretMap, err := DecodeSecretData(common.MapStringStringToMapStringBytesArray(encodedSecretMap))
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to decode function secret data")
+	}
+
+	return secretMap, nil
+}
+
 // DecodeSecretData decodes the keys of a secrets map
 func DecodeSecretData(secretData map[string][]byte) (map[string]string, error) {
 	decodedSecretsMap := map[string]string{}

--- a/pkg/functionconfig/mask.go
+++ b/pkg/functionconfig/mask.go
@@ -79,7 +79,7 @@ func Scrub(functionConfig *Config,
 					// and contains the reference
 					if strings.HasPrefix(stringValue, ReferencePrefix) {
 						if existingSecretMap != nil {
-							trimmedSecretKey := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(secretKey, ReferencePrefix)))
+							trimmedSecretKey := strings.ToLower(strings.TrimSpace(secretKey))
 							if _, exists := existingSecretMap[trimmedSecretKey]; !exists {
 								scrubErr = errors.New(fmt.Sprintf("Config data in path %s is already masked, but original value does not exist in secret", fieldPath))
 							}

--- a/pkg/functionconfig/mask_test.go
+++ b/pkg/functionconfig/mask_test.go
@@ -112,7 +112,7 @@ func (suite *MaskTestSuite) TestMaskBasics() {
 
 func (suite *MaskTestSuite) TestScrubWithExistingSecrets() {
 	existingSecrets := map[string]string{
-		"/spec/build/codeentryattributes/password": "abcd",
+		"$ref:/spec/build/codeentryattributes/password": "abcd",
 	}
 
 	functionConfig := &Config{

--- a/pkg/functionconfig/mask_test.go
+++ b/pkg/functionconfig/mask_test.go
@@ -200,6 +200,51 @@ func (suite *MaskTestSuite) TestEncodeSecretsMap() {
 	}
 }
 
+func (suite *MaskTestSuite) TestDecodeSecretsMapContent() {
+
+	functionConfig := &Config{
+		Spec: Spec{
+			Triggers: map[string]Trigger{
+				"secret-trigger": {
+					Attributes: map[string]interface{}{
+						"password": "1234",
+					},
+					Password: "4567",
+				},
+				"non-secret-trigger": {
+					Attributes: map[string]interface{}{
+						"not-a-password": "4321",
+					},
+				},
+			},
+		},
+	}
+
+	// scrub the function config
+	maskedFunctionConfig, secretMap, err := Scrub(functionConfig, nil, suite.getSensitiveFieldsPathsRegex())
+	suite.Require().NoError(err)
+
+	// encode the secret map
+	encodedSecretMap, err := EncodeSecretsMap(secretMap)
+	suite.Require().NoError(err)
+
+	// get the encoded secret map content
+	encodedSecretMapContent := encodedSecretMap[SecretContentKey]
+	suite.Require().NotEmpty(encodedSecretMapContent)
+
+	decodedSecretMap, err := DecodeSecretsMapContent(encodedSecretMapContent)
+	suite.Require().NoError(err)
+
+	// restore the function config
+	restoredFunctionConfig, err := Restore(maskedFunctionConfig, decodedSecretMap)
+	suite.Require().NoError(err)
+
+	suite.logger.DebugWith("Restored function config", "functionConfig", restoredFunctionConfig)
+
+	// verify that the restored function config is equal to the original function config
+	suite.Require().Equal(functionConfig, restoredFunctionConfig)
+}
+
 // getSensitiveFieldsRegex returns a list of regexes for sensitive fields paths
 // this is implemented here to avoid a circular dependency between platformconfig and functionconfig
 func (suite *MaskTestSuite) getSensitiveFieldsPathsRegex() []*regexp.Regexp {

--- a/pkg/functionconfig/mask_test.go
+++ b/pkg/functionconfig/mask_test.go
@@ -196,7 +196,6 @@ func (suite *MaskTestSuite) TestEncodeSecretsMap() {
 		}
 		decodedKey, err := decodeSecretKey(encodedKey)
 		suite.Require().NoError(err)
-		decodedKey = "$ref:" + decodedKey
 		suite.Require().Equal(secretMap[decodedKey], value)
 	}
 }

--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -273,6 +273,10 @@ func (d *Deployer) createOrUpdateFunctionSecret(ctx context.Context,
 	}
 
 	if len(encodedSecretsMap) > 0 {
+		d.logger.DebugWithCtx(ctx,
+			"Creating/updating function secret",
+			"functionName", name,
+			"functionNamespace", namespace)
 		if err := d.createOrUpdateSecret(ctx, namespace, secretConfig); err != nil {
 			return errors.Wrap(err, "Failed to create function secret")
 		}
@@ -371,6 +375,10 @@ func (d *Deployer) createOrUpdateFlexVolumeSecret(ctx context.Context,
 		},
 	}
 
+	d.logger.DebugWithCtx(ctx,
+		"Creating/updating flex volume secret",
+		"functionName", functionName,
+		"functionNamespace", functionNamespace)
 	if err := d.createOrUpdateSecret(ctx, functionNamespace, secretConfig); err != nil {
 		return errors.Wrap(err, "Failed to create flex volume secret")
 	}

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -827,23 +827,19 @@ func (suite *DeployFunctionTestSuite) TestFunctionSecretCreation() {
 					"decodedSecretData", decodedSecretData)
 
 				// verify password is in secret data
-				secretKey := strings.ToLower("/spec/build/codeEntryAttributes/password")
+				secretKey := strings.ToLower("$ref:/spec/build/codeEntryAttributes/password")
 				suite.Require().Equal(password, decodedSecretData[secretKey])
 
 				// verify secret's "content" also contains the password
-				var decodedSecretsDataContent map[string]string
 				secretContent := string(secret.Data["content"])
-				decodedContents, err := base64.StdEncoding.DecodeString(secretContent)
-				suite.Require().NoError(err)
-				err = json.Unmarshal(decodedContents, &decodedSecretsDataContent)
+				decodedContents, err := functionconfig.DecodeSecretsMapContent(secretContent)
 				suite.Require().NoError(err)
 
 				suite.Logger.DebugWithCtx(suite.Ctx,
 					"Decoded secret data content",
-					"decodedSecretsDataContent", decodedSecretsDataContent)
+					"decodedSecretsDataContent", decodedContents)
 
-				secretKeyEnvVar := functionconfig.ResolveEnvVarNameFromReference(secretKey)
-				suite.Require().Equal(password, decodedSecretsDataContent[secretKeyEnvVar])
+				suite.Require().Equal(password, decodedContents[secretKey])
 
 			} else {
 


### PR DESCRIPTION
When the secret map keys are encoded without the `$ref:` prefix, the processor doesn't restore the scrubbed function config properly. 

Related bug: https://jira.iguazeng.com/browse/IG-21414