### PR TITLE
Refactor platform secret handling and add attributes to sensitive fields

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -151,6 +151,15 @@ func (ap *Platform) HandleDeployFunction(ctx context.Context,
 
 	// check if we need to build the image
 	if functionBuildRequired && !functionconfig.ShouldSkipBuild(createFunctionOptions.FunctionConfig.Meta.Annotations) {
+
+		// if the function is updated, it might have scrubbed data in the spec that the builder requires,
+		// so we need to restore it before building
+		restoredFunctionConfig, err := ap.RestoreFunctionConfig(ctx, &createFunctionOptions.FunctionConfig)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to restore function config")
+		}
+		createFunctionOptions.FunctionConfig = *restoredFunctionConfig
+
 		buildResult, buildErr = ap.platform.CreateFunctionBuild(&platform.CreateFunctionBuildOptions{
 			Logger:                     createFunctionOptions.Logger,
 			FunctionConfig:             createFunctionOptions.FunctionConfig,
@@ -1202,6 +1211,53 @@ func (ap *Platform) QueryOPAMultipleResources(resources []string,
 
 // GetFunctionSecrets returns all the function's secrets
 func (ap *Platform) GetFunctionSecrets(ctx context.Context, functionName, functionNamespace string) ([]platform.FunctionSecret, error) {
+	return nil, nil
+}
+
+// RestoreFunctionConfig restores a function config from the function secret
+func (ap *Platform) RestoreFunctionConfig(ctx context.Context, config *functionconfig.Config) (*functionconfig.Config, error) {
+
+	// get the function secrets
+	secretMap, err := ap.GetFunctionSecretMap(ctx, config.Meta.Name, config.Meta.Namespace)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get function secrets")
+	}
+
+	// if there are no secrets, return the original config
+	if secretMap == nil {
+		return config, nil
+	}
+
+	// restore the function config from the secret
+	restoredConfig, err := functionconfig.Restore(config, secretMap)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to restore function config")
+	}
+
+	return restoredConfig, nil
+}
+
+// GetFunctionSecretMap returns a map of function sensitive data
+func (ap *Platform) GetFunctionSecretMap(ctx context.Context, functionName, functionNamespace string) (map[string]string, error) {
+
+	// get existing function secret
+	ap.Logger.DebugWithCtx(ctx, "Getting function secret", "functionName", functionName, "functionNamespace", functionNamespace)
+	functionSecretData, err := ap.platform.GetFunctionSecretData(ctx, functionName, functionNamespace)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get function secret")
+	}
+
+	// if secret exists, get the data
+	if functionSecretData != nil {
+		functionSecretMap, err := functionconfig.DecodeSecretData(functionSecretData)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to decode function secret data")
+		}
+		return functionSecretMap, nil
+	}
+
+	// secret doesn't exist
+	ap.Logger.DebugWithCtx(ctx, "Function secret doesn't exist", "functionName", functionName, "functionNamespace", functionNamespace)
 	return nil, nil
 }
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1247,6 +1247,30 @@ func (p *Platform) GetFunctionSecrets(ctx context.Context, functionName, functio
 	return functionSecrets, nil
 }
 
+// GetFunctionSecretData returns the function's secret data
+func (p *Platform) GetFunctionSecretData(ctx context.Context, functionName, functionNamespace string) (map[string][]byte, error) {
+
+	// get existing function secret
+	functionSecrets, err := p.GetFunctionSecrets(ctx, functionName, functionNamespace)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get function secret")
+	}
+
+	// if secret exists, get the data
+	for _, functionSecret := range functionSecrets {
+		functionSecret := functionSecret.Kubernetes
+
+		// if it is a flex volume secret, skip it
+		if strings.HasPrefix(functionSecret.Name, functionconfig.NuclioFlexVolumeSecretNamePrefix) {
+			continue
+		}
+
+		return functionSecret.Data, nil
+	}
+
+	return nil, nil
+}
+
 func (p *Platform) generateFunctionToAPIGatewaysMapping(ctx context.Context, namespace string) (map[string][]string, error) {
 	functionToAPIGateways := map[string][]string{}
 

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -818,6 +818,17 @@ func (p *Platform) GetFunctionVolumeMountName(functionConfig *functionconfig.Con
 		functionConfig.Meta.Name)
 }
 
+// GetFunctionSecrets returns all the function's secrets
+func (p *Platform) GetFunctionSecrets(ctx context.Context, functionName, functionNamespace string) ([]platform.FunctionSecret, error) {
+
+	// TODO: implement function secrets on local platform
+	return nil, nil
+}
+
+func (p *Platform) GetFunctionSecretData(ctx context.Context, functionName, functionNamespace string) (map[string][]byte, error) {
+	return nil, nil
+}
+
 func (p *Platform) deployFunction(createFunctionOptions *platform.CreateFunctionOptions,
 	previousHTTPPort int) (*platform.CreateFunctionResult, error) {
 

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -373,3 +373,15 @@ func (mp *Platform) QueryOPAFunctionEventPermissions(projectName,
 func (mp *Platform) GetFunctionSecrets(ctx context.Context, functionName, functionNamespace string) ([]platform.FunctionSecret, error) {
 	return nil, nil
 }
+
+func (mp *Platform) RestoreFunctionConfig(ctx context.Context, config *functionconfig.Config) (*functionconfig.Config, error) {
+	return nil, nil
+}
+
+func (mp *Platform) GetFunctionSecretMap(ctx context.Context, functionName, functionNamespace string) (map[string]string, error) {
+	return nil, nil
+}
+
+func (mp *Platform) GetFunctionSecretData(ctx context.Context, functionName, functionNamespace string) (map[string][]byte, error) {
+	return nil, nil
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -204,6 +204,15 @@ type Platform interface {
 	// GetFunctionSecrets returns all the function's secrets
 	GetFunctionSecrets(ctx context.Context, functionName, functionNamespace string) ([]FunctionSecret, error)
 
+	// RestoreFunctionConfig restores function config from the secret, if it exists
+	RestoreFunctionConfig(ctx context.Context, functionConfig *functionconfig.Config) (*functionconfig.Config, error)
+
+	// GetFunctionSecretMap returns a map of function's sensitive data
+	GetFunctionSecretMap(ctx context.Context, functionName, functionNamespace string) (map[string]string, error)
+
+	// GetFunctionSecretData returns the function's secret data
+	GetFunctionSecretData(ctx context.Context, functionName, functionNamespace string) (map[string][]byte, error)
+
 	// SaveFunctionDeployLogs Save build logs from platform logger to function store or k8s
 	SaveFunctionDeployLogs(ctx context.Context, functionName, namespace string) error
 

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -278,6 +278,11 @@ func (sfc *SensitiveFieldsConfig) GetDefaultSensitiveFields() []string {
 
 		// build
 		"^/spec/build/codeentryattributes/password$",
+		"^/spec/build/codeentryattributes/x-v3io-session-key$",
+		"^/spec/build/codeentryattributes/s3secretaccesskey$",
+		"^/spec/build/codeentryattributes/s3sessiontoken$",
+		"^/spec/build/codeentryattributes/headers/authorization$",
+
 		// volumes
 		"^/spec/volumes\\[\\d+\\]/volume/volumesource/flexvolume/options/accesskey$",
 		"^/spec/volumes\\[\\d+\\]/volume/flexvolume/options/accesskey$",


### PR DESCRIPTION
When using function code from Github, S3 and Archive there is sensitive information in the function spec, so we'll scrub it too.

Since the image builder requires that information, and when updating a function these field will have the `$ref:..` reference, the function config is restored before building the image.
This causes some refactoring to allow some better code re-use.

fixes https://jira.iguazeng.com/browse/IG-21430