### PR TITLE
Refactor autoscale metric spec

### DIFF
--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -253,8 +253,8 @@ func (fsr *frontendSpecResource) resolveAutoScaleMetrics(inactivityWindowPresets
 		}
 	}
 	return map[string]interface{}{
-		"supportedAutoScaleMetrics": supportedAutoScaleMetrics,
-		"windowSizePresets":         inactivityWindowPresets,
+		"metricPresets":     supportedAutoScaleMetrics,
+		"windowSizePresets": inactivityWindowPresets,
 	}
 }
 

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -83,7 +83,7 @@ func (fsr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restfu
 	defaultHTTPIngressHostTemplate := fsr.getDefaultHTTPIngressHostTemplate()
 	validFunctionPriorityClassNames := fsr.resolveValidFunctionPriorityClassNames()
 	defaultFunctionPodResources := fsr.resolveDefaultFunctionPodResources()
-	supportedAutoScaleMetrics := fsr.resolveSupportedAutoScaleMetrics()
+	AutoScaleMetrics := fsr.resolveAutoScaleMetrics(inactivityWindowPresets)
 
 	frontendSpec := map[string]restful.Attributes{
 		"frontendSpec": { // frontendSpec is the ID of this singleton resource
@@ -97,7 +97,7 @@ func (fsr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restfu
 			"allowedAuthenticationModes":      allowedAuthenticationModes,
 			"validFunctionPriorityClassNames": validFunctionPriorityClassNames,
 			"defaultFunctionPodResources":     defaultFunctionPodResources,
-			"supportedAutoScaleMetrics":       supportedAutoScaleMetrics,
+			"autoScaleMetrics":                AutoScaleMetrics,
 		},
 	}
 
@@ -244,7 +244,7 @@ func (fsr *frontendSpecResource) resolveValidFunctionPriorityClassNames() []stri
 	return validFunctionPriorityClassNames
 }
 
-func (fsr *frontendSpecResource) resolveSupportedAutoScaleMetrics() []functionconfig.AutoScaleMetric {
+func (fsr *frontendSpecResource) resolveAutoScaleMetrics(inactivityWindowPresets []string) map[string]interface{} {
 	var supportedAutoScaleMetrics []functionconfig.AutoScaleMetric
 	if dashboardServer, ok := fsr.resource.GetServer().(*dashboard.Server); ok {
 		supportedAutoScaleMetrics = dashboardServer.GetPlatformConfiguration().SupportedAutoScaleMetrics
@@ -252,7 +252,10 @@ func (fsr *frontendSpecResource) resolveSupportedAutoScaleMetrics() []functionco
 			supportedAutoScaleMetrics = dashboardServer.GetPlatformConfiguration().GetDefaultSupportedAutoScaleMetrics()
 		}
 	}
-	return supportedAutoScaleMetrics
+	return map[string]interface{}{
+		"supportedAutoScaleMetrics": supportedAutoScaleMetrics,
+		"windowSizePresets":         inactivityWindowPresets,
+	}
 }
 
 func (fsr *frontendSpecResource) getDefaultHTTPIngressHostTemplate() string {

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -3467,7 +3467,8 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
         "scaleResources": [
             {
                 "metricName": "metric_name",
-                "windowSize": "1m"
+                "windowSize": "1m",
+				"threshold": 0
             }
         ]
     },
@@ -3478,41 +3479,48 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
 		"basicAuth"
 	],
 	"autoScaleMetrics": {
-		"supportedAutoScaleMetrics": [
+		"metricPresets": [
 			{
 				"metricName": "cpu",
 				"sourceType": "Resource",
-				"displayType": "percentage"
+				"displayType": "percentage",
+				"threshold": 0
 			},
 			{
 				"metricName": "memory",
 				"sourceType": "Resource",
-				"displayType": "percentage"
+				"displayType": "percentage",
+				"threshold": 0
 			},
 			{
 				"metricName": "gpu",
 				"sourceType": "Pods",
-				"displayType": "percentage"
+				"displayType": "percentage",
+				"threshold": 0
 			},
 			{
 				"metricName": "nuclio_processor_stream_high_water_mark_processed_lag",
 				"sourceType": "External",
-				"displayType": "int"
+				"displayType": "int",
+				"threshold": 0
 			},
 			{
 				"metricName": "nuclio_processor_stream_high_water_mark_committed_lag",
 				"sourceType": "External",
-				"displayType": "int"
+				"displayType": "int",
+				"threshold": 0
 			},
 			{
 				"metricName": "nuclio_processor_worker_pending_allocation_current",
 				"sourceType": "External",
-				"displayType": "int"
+				"displayType": "int",
+				"threshold": 0
 			},
 			{
 				"metricName": "nuclio_processor_worker_allocation_wait_duration_ms_sum",
 				"sourceType": "External",
-				"displayType": "int"
+				"displayType": "int",
+				"threshold": 0
 			}
 		],
 		"windowSizePresets": [

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -3467,8 +3467,7 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
         "scaleResources": [
             {
                 "metricName": "metric_name",
-                "windowSize": "1m",
-                "threshold": 0
+                "windowSize": "1m"
             }
         ]
     },
@@ -3478,43 +3477,49 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
 		"none",
 		"basicAuth"
 	],
-	"supportedAutoScaleMetrics": [
-        {
-            "name": "cpu",
-            "kind": "Resource",
-            "type": "percentage"
-        },
-        {
-            "name": "memory",
-            "kind": "Resource",
-            "type": "percentage"
-        },
-        {
-            "name": "gpu",
-            "kind": "Pods",
-            "type": "percentage"
-        },
-        {
-            "name": "nuclio_processor_stream_high_water_mark_processed_lag",
-            "kind": "External",
-            "type": "int"
-        },
-        {
-            "name": "nuclio_processor_stream_high_water_mark_committed_lag",
-            "kind": "External",
-            "type": "int"
-        },
-        {
-            "name": "nuclio_processor_worker_pending_allocation_current",
-            "kind": "External",
-            "type": "int"
-        },
-        {
-            "name": "nuclio_processor_worker_allocation_wait_duration_ms_sum",
-            "kind": "External",
-            "type": "int"
-        }
-    ]
+	"autoScaleMetrics": {
+		"supportedAutoScaleMetrics": [
+			{
+				"metricName": "cpu",
+				"sourceType": "Resource",
+				"displayType": "percentage"
+			},
+			{
+				"metricName": "memory",
+				"sourceType": "Resource",
+				"displayType": "percentage"
+			},
+			{
+				"metricName": "gpu",
+				"sourceType": "Pods",
+				"displayType": "percentage"
+			},
+			{
+				"metricName": "nuclio_processor_stream_high_water_mark_processed_lag",
+				"sourceType": "External",
+				"displayType": "int"
+			},
+			{
+				"metricName": "nuclio_processor_stream_high_water_mark_committed_lag",
+				"sourceType": "External",
+				"displayType": "int"
+			},
+			{
+				"metricName": "nuclio_processor_worker_pending_allocation_current",
+				"sourceType": "External",
+				"displayType": "int"
+			},
+			{
+				"metricName": "nuclio_processor_worker_allocation_wait_duration_ms_sum",
+				"sourceType": "External",
+				"displayType": "int"
+			}
+		],
+		"windowSizePresets": [
+			"1m",
+			"2m"
+		]
+	}
 }`
 
 	suite.sendRequest("GET",

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -3468,7 +3468,7 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
             {
                 "metricName": "metric_name",
                 "windowSize": "1m",
-				"threshold": 0
+                "threshold": 0
             }
         ]
     },

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -419,7 +419,7 @@ type ScaleToZeroSpec struct {
 type ScaleResource struct {
 	MetricName string `json:"metricName,omitempty"`
 	WindowSize string `json:"windowSize,omitempty"`
-	Threshold  int    `json:"threshold,omitempty"`
+	Threshold  int    `json:"threshold"`
 }
 
 // to appease k8s

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -269,18 +269,17 @@ type Metric struct {
 	WindowSize     string `json:"windowSize,omitempty"`
 }
 
-type AutoScaleMetricType string
+type AutoScaleDisplayType string
 
 const (
-	AutoScaleMetricTypeInt        AutoScaleMetricType = "int"
-	AutoScaleMetricTypePercentage AutoScaleMetricType = "percentage"
+	AutoScaleMetricTypeInt        AutoScaleDisplayType = "int"
+	AutoScaleMetricTypePercentage AutoScaleDisplayType = "percentage"
 )
 
 type AutoScaleMetric struct {
-	Name        string                   `json:"name,omitempty"`
-	Kind        autosv2.MetricSourceType `json:"kind,omitempty"`
-	Type        AutoScaleMetricType      `json:"type,omitempty"`
-	TargetValue int                      `json:"targetValue,omitempty"`
+	ScaleResource `json:",inline"`
+	SourceType    autosv2.MetricSourceType `json:"sourceType,omitempty"`
+	DisplayType   AutoScaleDisplayType     `json:"displayType,omitempty"`
 }
 
 type BuildMode string
@@ -420,7 +419,7 @@ type ScaleToZeroSpec struct {
 type ScaleResource struct {
 	MetricName string `json:"metricName,omitempty"`
 	WindowSize string `json:"windowSize,omitempty"`
-	Threshold  int    `json:"threshold"`
+	Threshold  int    `json:"threshold,omitempty"`
 }
 
 // to appease k8s

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1414,12 +1414,12 @@ func (ap *Platform) validateAutoScaleMetrics(functionConfig *functionconfig.Conf
 	for _, metric := range functionConfig.Spec.AutoScaleMetrics {
 
 		// validate metric name
-		if metric.Name == "" {
+		if metric.MetricName == "" {
 			return nuclio.NewErrBadRequest(fmt.Sprintf("Auto scale metric name is missing - %+v", metric))
 		}
 
 		// validate metric kind
-		if metric.Kind == "" {
+		if metric.SourceType == "" {
 			return nuclio.NewErrBadRequest(fmt.Sprintf("Auto scale metric kind is missing - %+v", metric))
 		}
 
@@ -1429,17 +1429,17 @@ func (ap *Platform) validateAutoScaleMetrics(functionConfig *functionconfig.Conf
 			string(autosv2.ExternalMetricSourceType),
 			string(autosv2.ObjectMetricSourceType),
 			string(autosv2.ContainerResourceMetricSourceType),
-		}, string(metric.Kind)) {
+		}, string(metric.SourceType)) {
 			return nuclio.NewErrBadRequest(fmt.Sprintf("Auto scale metric kind is invalid - %+v", metric))
 		}
 
 		// validate metric value
-		if metric.TargetValue == 0 {
+		if metric.Threshold == 0 {
 			return nuclio.NewErrBadRequest(fmt.Sprintf("Auto scale metric value is missing - %+v", metric))
 		}
 
 		// validate metric value is positive
-		if metric.TargetValue < 0 {
+		if metric.Threshold < 0 {
 			return nuclio.NewErrBadRequest(fmt.Sprintf("Auto scale metric value must be positive - %+v", metric))
 		}
 	}

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -1548,14 +1548,18 @@ func (suite *AbstractPlatformTestSuite) TestValidateFunctionConfigAutoScaleMetri
 			name: "ValidMetrics",
 			AutoScaleMetrics: []functionconfig.AutoScaleMetric{
 				{
-					Name:        "cpu",
-					Kind:        "Resource",
-					TargetValue: 50,
+					ScaleResource: functionconfig.ScaleResource{
+						MetricName: "cpu",
+						Threshold:  50,
+					},
+					SourceType: "Resource",
 				},
 				{
-					Name:        "nuclio_processor_stream_something",
-					Kind:        "Pods",
-					TargetValue: 150,
+					ScaleResource: functionconfig.ScaleResource{
+						MetricName: "nuclio_processor_stream_something",
+						Threshold:  150,
+					},
+					SourceType: "Pods",
 				},
 			},
 		},
@@ -1565,8 +1569,10 @@ func (suite *AbstractPlatformTestSuite) TestValidateFunctionConfigAutoScaleMetri
 			name: "NoName",
 			AutoScaleMetrics: []functionconfig.AutoScaleMetric{
 				{
-					Kind:        "Resource",
-					TargetValue: 50,
+					ScaleResource: functionconfig.ScaleResource{
+						Threshold: 50,
+					},
+					SourceType: "Resource",
 				},
 			},
 			shouldFailValidation: true,
@@ -1575,8 +1581,10 @@ func (suite *AbstractPlatformTestSuite) TestValidateFunctionConfigAutoScaleMetri
 			name: "NoKind",
 			AutoScaleMetrics: []functionconfig.AutoScaleMetric{
 				{
-					Name:        "memory",
-					TargetValue: 75,
+					ScaleResource: functionconfig.ScaleResource{
+						MetricName: "memory",
+						Threshold:  75,
+					},
 				},
 			},
 			shouldFailValidation: true,
@@ -1585,30 +1593,36 @@ func (suite *AbstractPlatformTestSuite) TestValidateFunctionConfigAutoScaleMetri
 			name: "NonValidKind",
 			AutoScaleMetrics: []functionconfig.AutoScaleMetric{
 				{
-					Name:        "memory",
-					Kind:        "something",
-					TargetValue: 75,
+					ScaleResource: functionconfig.ScaleResource{
+						MetricName: "memory",
+						Threshold:  75,
+					},
+					SourceType: "something",
 				},
 			},
 			shouldFailValidation: true,
 		},
 		{
-			name: "NoTargetValue",
+			name: "NoThreshold",
 			AutoScaleMetrics: []functionconfig.AutoScaleMetric{
 				{
-					Name: "memory",
-					Kind: "Resource",
+					ScaleResource: functionconfig.ScaleResource{
+						MetricName: "memory",
+					},
+					SourceType: "Resource",
 				},
 			},
 			shouldFailValidation: true,
 		},
 		{
-			name: "NonValidTargetValue",
+			name: "NonValidThreshold",
 			AutoScaleMetrics: []functionconfig.AutoScaleMetric{
 				{
-					Name:        "memory",
-					Kind:        "something",
-					TargetValue: -13,
+					ScaleResource: functionconfig.ScaleResource{
+						MetricName: "memory",
+						Threshold:  -13,
+					},
+					SourceType: "something",
 				},
 			},
 			shouldFailValidation: true,

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2488,7 +2488,7 @@ func (lc *lazyClient) generateMetricSpecFromAutoScaleMetrics(autoScaleMetrics []
 			metricSpec = autosv2.MetricSpec{
 				Type: autoscaleMetric.SourceType,
 				Pods: &autosv2.PodsMetricSource{
-					MetricName:         autoscaleMetric.MetricName,
+					MetricName:         fmt.Sprintf("%s_per_%s", autoscaleMetric.MetricName, autoscaleMetric.WindowSize),
 					TargetAverageValue: quantity,
 				},
 			}
@@ -2501,7 +2501,7 @@ func (lc *lazyClient) generateMetricSpecFromAutoScaleMetrics(autoScaleMetrics []
 			metricSpec = autosv2.MetricSpec{
 				Type: autoscaleMetric.SourceType,
 				External: &autosv2.ExternalMetricSource{
-					MetricName:  autoscaleMetric.MetricName,
+					MetricName:  fmt.Sprintf("%s_per_%s", autoscaleMetric.MetricName, autoscaleMetric.WindowSize),
 					TargetValue: &quantity,
 				},
 			}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2453,7 +2453,7 @@ func (lc *lazyClient) GetFunctionMetricSpecs(function *nuclioio.NuclioFunction) 
 
 func (lc *lazyClient) resolveMetricSpecs(function *nuclioio.NuclioFunction) ([]autosv2.MetricSpec, error) {
 
-	metricSpecs, err := lc.generateMetricSpecFromAutoscaleMetrics(function.Spec.AutoScaleMetrics)
+	metricSpecs, err := lc.generateMetricSpecFromAutoScaleMetrics(function.Spec.AutoScaleMetrics)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to generate metric specs from autoscale metrics")
 	}
@@ -2465,48 +2465,48 @@ func (lc *lazyClient) resolveMetricSpecs(function *nuclioio.NuclioFunction) ([]a
 	return metricSpecs, nil
 }
 
-func (lc *lazyClient) generateMetricSpecFromAutoscaleMetrics(autoscaleMetrics []functionconfig.AutoScaleMetric) ([]autosv2.MetricSpec, error) {
+func (lc *lazyClient) generateMetricSpecFromAutoScaleMetrics(autoScaleMetrics []functionconfig.AutoScaleMetric) ([]autosv2.MetricSpec, error) {
 
 	var metricSpecs []autosv2.MetricSpec
 	var metricSpec autosv2.MetricSpec
-	for _, autoscaleMetric := range autoscaleMetrics {
-		switch autoscaleMetric.Kind {
+	for _, autoscaleMetric := range autoScaleMetrics {
+		switch autoscaleMetric.SourceType {
 		case autosv2.ResourceMetricSourceType:
-			targetAverageUtilization := int32(autoscaleMetric.TargetValue)
+			targetAverageUtilization := int32(autoscaleMetric.Threshold)
 			metricSpec = autosv2.MetricSpec{
-				Type: autoscaleMetric.Kind,
+				Type: autoscaleMetric.SourceType,
 				Resource: &autosv2.ResourceMetricSource{
-					Name:                     v1.ResourceName(autoscaleMetric.Name),
+					Name:                     v1.ResourceName(autoscaleMetric.MetricName),
 					TargetAverageUtilization: &targetAverageUtilization,
 				},
 			}
 		case autosv2.PodsMetricSourceType:
-			quantity, err := apiresource.ParseQuantity(strconv.Itoa(autoscaleMetric.TargetValue))
+			quantity, err := apiresource.ParseQuantity(strconv.Itoa(autoscaleMetric.Threshold))
 			if err != nil {
 				return nil, errors.Wrap(err, "Failed to parse quantity")
 			}
 			metricSpec = autosv2.MetricSpec{
-				Type: autoscaleMetric.Kind,
+				Type: autoscaleMetric.SourceType,
 				Pods: &autosv2.PodsMetricSource{
-					MetricName:         autoscaleMetric.Name,
+					MetricName:         autoscaleMetric.MetricName,
 					TargetAverageValue: quantity,
 				},
 			}
 
 		case autosv2.ExternalMetricSourceType:
-			quantity, err := apiresource.ParseQuantity(strconv.Itoa(autoscaleMetric.TargetValue))
+			quantity, err := apiresource.ParseQuantity(strconv.Itoa(autoscaleMetric.Threshold))
 			if err != nil {
 				return nil, errors.Wrap(err, "Failed to parse quantity")
 			}
 			metricSpec = autosv2.MetricSpec{
-				Type: autoscaleMetric.Kind,
+				Type: autoscaleMetric.SourceType,
 				External: &autosv2.ExternalMetricSource{
-					MetricName:  autoscaleMetric.Name,
+					MetricName:  autoscaleMetric.MetricName,
 					TargetValue: &quantity,
 				},
 			}
 		default:
-			return nil, errors.Errorf("Unknown metric type: %s", autoscaleMetric.Type)
+			return nil, errors.Errorf("Unknown metric type: %s", autoscaleMetric.SourceType)
 		}
 
 		metricSpecs = append(metricSpecs, metricSpec)

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -209,43 +209,57 @@ func (c *Config) GetDefaultSupportedAutoScaleMetrics() []functionconfig.AutoScal
 
 		// Resource metrics
 		{
-			Name: string(v1.ResourceCPU),
-			Kind: autosv2.ResourceMetricSourceType,
-			Type: functionconfig.AutoScaleMetricTypePercentage,
+			ScaleResource: functionconfig.ScaleResource{
+				MetricName: string(v1.ResourceCPU),
+			},
+			SourceType:  autosv2.ResourceMetricSourceType,
+			DisplayType: functionconfig.AutoScaleMetricTypePercentage,
 		},
 		{
-			Name: string(v1.ResourceMemory),
-			Kind: autosv2.ResourceMetricSourceType,
-			Type: functionconfig.AutoScaleMetricTypePercentage,
+			ScaleResource: functionconfig.ScaleResource{
+				MetricName: string(v1.ResourceMemory),
+			},
+			SourceType:  autosv2.ResourceMetricSourceType,
+			DisplayType: functionconfig.AutoScaleMetricTypePercentage,
 		},
 		{
-			Name: "gpu",
-			Kind: autosv2.PodsMetricSourceType,
-			Type: functionconfig.AutoScaleMetricTypePercentage,
+			ScaleResource: functionconfig.ScaleResource{
+				MetricName: "gpu",
+			},
+			SourceType:  autosv2.PodsMetricSourceType,
+			DisplayType: functionconfig.AutoScaleMetricTypePercentage,
 		},
 
 		// Stream metrics
 		{
-			Name: "nuclio_processor_stream_high_water_mark_processed_lag",
-			Kind: autosv2.ExternalMetricSourceType,
-			Type: functionconfig.AutoScaleMetricTypeInt,
+			ScaleResource: functionconfig.ScaleResource{
+				MetricName: "nuclio_processor_stream_high_water_mark_processed_lag",
+			},
+			SourceType:  autosv2.ExternalMetricSourceType,
+			DisplayType: functionconfig.AutoScaleMetricTypeInt,
 		},
 		{
-			Name: "nuclio_processor_stream_high_water_mark_committed_lag",
-			Kind: autosv2.ExternalMetricSourceType,
-			Type: functionconfig.AutoScaleMetricTypeInt,
+			ScaleResource: functionconfig.ScaleResource{
+				MetricName: "nuclio_processor_stream_high_water_mark_committed_lag",
+			},
+			SourceType:  autosv2.ExternalMetricSourceType,
+			DisplayType: functionconfig.AutoScaleMetricTypeInt,
 		},
 
 		// Event metrics
 		{
-			Name: "nuclio_processor_worker_pending_allocation_current",
-			Kind: autosv2.ExternalMetricSourceType,
-			Type: functionconfig.AutoScaleMetricTypeInt,
+			ScaleResource: functionconfig.ScaleResource{
+				MetricName: "nuclio_processor_worker_pending_allocation_current",
+			},
+			SourceType:  autosv2.ExternalMetricSourceType,
+			DisplayType: functionconfig.AutoScaleMetricTypeInt,
 		},
 		{
-			Name: "nuclio_processor_worker_allocation_wait_duration_ms_sum",
-			Kind: autosv2.ExternalMetricSourceType,
-			Type: functionconfig.AutoScaleMetricTypeInt,
+			ScaleResource: functionconfig.ScaleResource{
+				MetricName: "nuclio_processor_worker_allocation_wait_duration_ms_sum",
+			},
+			SourceType:  autosv2.ExternalMetricSourceType,
+			DisplayType: functionconfig.AutoScaleMetricTypeInt,
 		},
 	}
 }


### PR DESCRIPTION
Metrics are saved in the k8s metric server with a window size (1m, 2m, etc.).
Hence, this should be reflected in the auto scale metrics in the function spec.

In this PR I refactored the `AutoScaleMetric` struct to include the window size, as well as some renaming for the fields so it makes more sense.
This is also reflected in the `frontendSpec`, so the UI will need to handle it accordingly.

Some guidelines for the future UI PR:

Frontend spec - will return `autoScaleMetrics` of the following structure:
```
"autoScaleMetrics": {
    "metricPresets": [
	{
		"metricName": "cpu",
		"sourceType": "Resource",
		"displayType": "percentage"
	},
        ...
    ]
    "windowSizePresets": [
		"1m",
		"2m"
    ]
}
```

The window size presets will be displayed as a dropdown next to the metric selection dropdown, and added to the spec as in the example below.
All other functionality will stay the same.

After choosing values, the UI should return the following in the function spec:
```
{
    ...
    "spec": {
        ...
        "autoScaleMetrics": [
            {
                "metricName": "cpu",
                "windowSize": "2m",
                "threshold": 5,
                "sourceType": "Resource
            }
            ...
        ],
        ...
    }
}
```