### PR TITLE
Local - reduce misleading error log lines

### DIFF
--- a/pkg/cmdrunner/shellrunner.go
+++ b/pkg/cmdrunner/shellrunner.go
@@ -103,12 +103,13 @@ func (sr *ShellRunner) Run(runOptions *RunOptions, format string, vars ...interf
 		}
 
 		runResult.ExitCode = exitCode
-
-		sr.logger.DebugWith("Failed to execute command",
-			"output", runResult.Output,
-			"stderr", runResult.Stderr,
-			"exitCode", runResult.ExitCode,
-			"err", err)
+		if !runOptions.SkipLogOnFailure {
+			sr.logger.DebugWith("Failed to execute command",
+				"output", runResult.Output,
+				"stderr", runResult.Stderr,
+				"exitCode", runResult.ExitCode,
+				"err", err)
+		}
 
 		return runResult, errors.Wrapf(err, "stdout:\n%s\nstderr:\n%s", runResult.Output, runResult.Stderr)
 	}

--- a/pkg/cmdrunner/types.go
+++ b/pkg/cmdrunner/types.go
@@ -36,7 +36,11 @@ type RunOptions struct {
 	LogRedactions     []string
 	CaptureOutputMode CaptureOutputMode
 
+	// will log if command executed successfully
 	LogOnlyOnFailure bool
+
+	// skip logging when command execution fails
+	SkipLogOnFailure bool
 }
 
 // RunResult holds command execution returned values

--- a/pkg/dashboard/resource/functiontemplate.go
+++ b/pkg/dashboard/resource/functiontemplate.go
@@ -84,7 +84,7 @@ func (ftr *functionTemplateResource) GetAll(request *http.Request) (map[string]r
 	return attributes, nil
 }
 
-// returns a list of custom routes for the resource
+// GetCustomRoutes returns a list of custom routes for the resource
 func (ftr *functionTemplateResource) GetCustomRoutes() ([]restful.CustomRoute, error) {
 	return []restful.CustomRoute{
 		{

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -373,18 +373,18 @@ func (c *ShellClient) ExecInContainer(containerID string, execOptions *ExecOptio
 	}
 
 	runResult, err := c.cmdRunner.Run(
-		&cmdrunner.RunOptions{LogRedactions: c.redactedValues},
+		&cmdrunner.RunOptions{
+			LogRedactions: c.redactedValues,
+
+			// too spammy
+			LogOnlyOnFailure: true,
+			SkipLogOnFailure: true,
+		},
 		"docker exec %s %s %s",
 		envArgument,
 		containerID,
 		execOptions.Command)
-
 	if err != nil {
-		c.logger.DebugWith("Failed to execute command in container",
-			"err", err,
-			"stdout", runResult.Output,
-			"stderr", runResult.Stderr)
-
 		return err
 	}
 

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -423,7 +423,7 @@ type ScaleResource struct {
 	Threshold  int    `json:"threshold"`
 }
 
-// to appease k8s
+// DeepCopyInto to appease k8s
 func (s *Spec) DeepCopyInto(out *Spec) {
 
 	// TODO: proper deep copy

--- a/pkg/nuctl/test/apigagteway_test.go
+++ b/pkg/nuctl/test/apigagteway_test.go
@@ -189,7 +189,7 @@ func (suite *apiGatewayInvokeTestSuite) testInvoke(authenticationMode ingress.Au
 
 	// invoke the api-gateway URL to make sure it works (we get the expected function response)
 	// we retry as it takes some time for apigw resource create function ingress
-	err = common.RetryUntilSuccessful(20*time.Second, 1*time.Second, func() bool {
+	err = common.RetryUntilSuccessful(90*time.Second, 1*time.Second, func() bool {
 		request := createHTTPRequest()
 		if authenticationMode == ingress.AuthenticationModeBasicAuth {
 			request.SetBasicAuth(basicAuthUsername, basicAuthPassword)

--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -331,7 +331,7 @@ func (s *Store) getResources(resourceDir string,
 	commandStdout, _, err := s.runCommand(nil, `/bin/sh -c "/bin/cat %s"`, resourcePath)
 	if err != nil {
 
-		// if there error indicates that there's no such file - that means nothing was created yet
+		// if the error indicates that there's no such file that means nothing was created yet
 		cause := errors.Cause(err)
 		if cause != nil && strings.Contains(cause.Error(), "No such file") {
 			return nil
@@ -415,18 +415,18 @@ func (s *Store) runCommand(env map[string]string, format string, args ...interfa
 
 		// run a container that simply volumizes the volume with the storage and sleeps for 6 hours
 		// using alpine mirrored to gcr.io/iguazio for stability
-		_, err = s.dockerClient.RunContainer("gcr.io/iguazio/alpine:3.15", &dockerclient.RunOptions{
+		if _, err := s.dockerClient.RunContainer("gcr.io/iguazio/alpine:3.15", &dockerclient.RunOptions{
 			Volumes:          map[string]string{volumeName: baseDir},
 			Remove:           true,
 			Command:          `/bin/sh -c "/bin/sleep 6h"`,
 			Stdout:           &commandStdout,
 			ImageMayNotExist: true,
 			ContainerName:    containerName,
-		})
-
-		// if we failed and the error is not that it already exists, return the error
-		if err != nil &&
+		}); err != nil &&
 			!strings.Contains(err.Error(), "is already in use by container") {
+
+			// if we failed and the error is not that it already exists, return the error
+
 			return "", "", errors.Wrap(err, "Failed to run container with storage volume")
 		}
 	}
@@ -438,17 +438,15 @@ func (s *Store) deleteResource(resourceDir string, resourceNamespace string, res
 	resourcePath := s.getResourcePath(resourceDir, resourceNamespace, resourceName)
 
 	// stat the file
-	_, _, err := s.runCommand(nil, "/bin/stat %s", resourcePath)
-	if err != nil {
+	if _, _, err := s.runCommand(nil, "/bin/stat %s", resourcePath); err != nil {
 		return nuclio.ErrNotFound
 	}
 
 	// remove the file
-	_, _, err = s.runCommand(nil, "/bin/rm %s", resourcePath)
+	_, _, err := s.runCommand(nil, "/bin/rm %s", resourcePath)
 
-	// if there error indicates that there's no such file - that means nothing was created yet
-	cause := errors.Cause(err)
-	if cause != nil && strings.Contains(cause.Error(), "No such file") {
+	// if the error indicates that there's no such file - that means nothing was created yet
+	if cause := errors.Cause(err); cause != nil && strings.Contains(cause.Error(), "No such file") {
 		return nuclio.NewErrNotFound(fmt.Sprintf("Could not find resource %s", resourceName))
 	}
 


### PR DESCRIPTION
most of logs are due to nuclio local store tries to do "get and create" whereas the get fails because some resource does not exist and thus spamming the log with spammy log lines that has nothing meaninful.