### PR TITLE
Override existing secret map with the new one

### DIFF
--- a/pkg/functionconfig/mask.go
+++ b/pkg/functionconfig/mask.go
@@ -100,8 +100,9 @@ func Scrub(functionConfig *Config,
 	})
 
 	// merge the new secrets map with the existing one
+	// In case of a conflict, the new secrets map will override the existing value
 	if existingSecretMap != nil {
-		secretsMap = labels.Merge(secretsMap, existingSecretMap)
+		secretsMap = labels.Merge(existingSecretMap, secretsMap)
 	}
 
 	// marshal and unmarshal the scrubbed object back to function config

--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -237,6 +237,10 @@ func (d *Deployer) createOrUpdateFunctionSecret(ctx context.Context,
 		return nil
 	}
 
+	d.logger.DebugWithCtx(ctx,
+		"Function has no sensitive data, not deleting previously created secrets (if they exists)",
+		"functionName", name)
+
 	// if secret exists and there are no secrets to set, delete the secret
 	return d.deleteExistingSecret(ctx, namespace, secretConfig.Name)
 }
@@ -331,6 +335,7 @@ func (d *Deployer) createOrUpdateFlexVolumeSecret(ctx context.Context,
 
 	d.logger.DebugWithCtx(ctx,
 		"Creating/updating flex volume secret",
+		"volumeName", volumeName,
 		"functionName", functionName,
 		"functionNamespace", functionNamespace)
 	if err := d.createOrUpdateSecret(ctx, functionNamespace, secretConfig); err != nil {


### PR DESCRIPTION
When an already masked value is changed, the new value should be in the secret.
Due to the functionality of `labels.Merge`, the new map got overridden by the old one.

Fixes https://jira.iguazeng.com/browse/IG-21440 