### PR TITLE
Fix flex volume secrets issues

### DIFF
--- a/pkg/functionconfig/mask.go
+++ b/pkg/functionconfig/mask.go
@@ -200,6 +200,10 @@ func GenerateFunctionSecretName(functionName, secretPrefix string) string {
 	if len(secretName) > common.KubernetesDomainLevelMaxLength {
 		secretName = secretName[:common.KubernetesDomainLevelMaxLength]
 	}
+
+	// remove trailing non-alphanumeric characters
+	secretName = strings.TrimRight(secretName, "-_")
+
 	return secretName
 }
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1235,10 +1235,11 @@ func (p *Platform) GetFunctionSecrets(ctx context.Context, functionName, functio
 		LabelSelector: fmt.Sprintf("%s=%s", common.NuclioResourceLabelKeyFunctionName, functionName),
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to list function flex volume secrets")
+		return nil, errors.Wrapf(err, "Failed to list secrets for function - %s", functionName)
 	}
 
 	for _, secret := range secrets.Items {
+		secret := secret
 		functionSecrets = append(functionSecrets, platform.FunctionSecret{
 			Kubernetes: &secret,
 		})


### PR DESCRIPTION
This PR addresses several bugs found regarding flex volume secrets:

- Remove trailing non-alphanumeric characters from flex volume secret names (fixes https://jira.iguazeng.com/browse/IG-21443)
- When getting function secrets, copy reference to a new variable so they won't get overridden (fixes https://jira.iguazeng.com/browse/IG-21438)
- Deep copy volumes config in the lazy controller, so manipulating them won't affect the volumes in the function config (fixes https://jira.iguazeng.com/browse/IG-21438)
- Delete stale volume secrets by secret name instead of by volume name label
- Improve logging a bit