### PR TITLE
Add default window size presets

### DIFF
--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -246,15 +246,20 @@ func (fsr *frontendSpecResource) resolveValidFunctionPriorityClassNames() []stri
 
 func (fsr *frontendSpecResource) resolveAutoScaleMetrics(inactivityWindowPresets []string) map[string]interface{} {
 	var supportedAutoScaleMetrics []functionconfig.AutoScaleMetric
+	windowSizePresets := inactivityWindowPresets
 	if dashboardServer, ok := fsr.resource.GetServer().(*dashboard.Server); ok {
 		supportedAutoScaleMetrics = dashboardServer.GetPlatformConfiguration().SupportedAutoScaleMetrics
 		if len(supportedAutoScaleMetrics) == 0 {
 			supportedAutoScaleMetrics = dashboardServer.GetPlatformConfiguration().GetDefaultSupportedAutoScaleMetrics()
 		}
+		if len(windowSizePresets) == 0 {
+			windowSizePresets = dashboardServer.GetPlatformConfiguration().GetDefaultWindowSizePresets()
+		}
 	}
+
 	return map[string]interface{}{
 		"metricPresets":     supportedAutoScaleMetrics,
-		"windowSizePresets": inactivityWindowPresets,
+		"windowSizePresets": windowSizePresets,
 	}
 }
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -264,6 +264,16 @@ func (c *Config) GetDefaultSupportedAutoScaleMetrics() []functionconfig.AutoScal
 	}
 }
 
+func (c *Config) GetDefaultWindowSizePresets() []string {
+	return []string{
+		"1m",
+		"2m",
+		"5m",
+		"10m",
+		"30m",
+	}
+}
+
 // EnrichContainerResources enriches an object's requests and limits with the default
 // resources defined in the platform config, only if they are not already configured
 func (c *Config) EnrichContainerResources(ctx context.Context,


### PR DESCRIPTION
When working in an open-source setup, the scale to zero window size presets are not populated (null).
Since metrics also use window size presets, we add default presets in case the scale to zero presets are not present.

Current defaults are for 1,2,5,10,30 minutes. 