### PR TITLE
Validate volume secret exists if access key is already scrubbed

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -228,13 +228,16 @@ func (fr *functionResource) GetCustomRoutes() ([]restful.CustomRoute, error) {
 
 func (fr *functionResource) export(ctx context.Context, function platform.Function) (restful.Attributes, error) {
 
+	// create a scrubber instance for restoring the function config
+	scrubber := functionconfig.NewScrubber(nil, nil)
+
 	functionConfig := function.GetConfig()
 
 	// restore the function config, if needed
-	if scrubbed, err := functionconfig.HasScrubbedConfig(functionConfig,
+	if scrubbed, err := scrubber.HasScrubbedConfig(functionConfig,
 		fr.getPlatform().GetConfig().SensitiveFields.CompileSensitiveFieldsRegex()); err == nil && scrubbed {
 		var restoreErr error
-		functionConfig, restoreErr = functionconfig.RestoreFunctionConfig(ctx,
+		functionConfig, restoreErr = scrubber.RestoreFunctionConfig(ctx,
 			functionConfig,
 			fr.getPlatform().GetName(),
 			fr.getPlatform().GetFunctionSecretMap)

--- a/pkg/functionconfig/scrubber.go
+++ b/pkg/functionconfig/scrubber.go
@@ -212,6 +212,75 @@ func (s *Scrubber) GenerateFunctionSecretName(functionName, secretPrefix string)
 	return secretName
 }
 
+// RestoreFunctionConfig restores a function config from a secret, in case we're running in a kube platform
+func (s *Scrubber) RestoreFunctionConfig(ctx context.Context,
+	functionConfig *Config,
+	platformName string,
+	getSecretMapCallback func(ctx context.Context, functionName, functionNamespace string) (map[string]string, error)) (*Config, error) {
+
+	// if we're in kube platform, we need to restore the function config's
+	// sensitive data from the function's secret
+	if platformName == "common.KubePlatformName" {
+		secretMap, err := getSecretMapCallback(ctx,
+			functionConfig.Meta.Name,
+			functionConfig.Meta.Namespace)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to get function secret")
+		}
+		if secretMap != nil {
+
+			// restore the function config
+			restoredFunctionConfig, err := s.Restore(functionConfig, secretMap)
+			if err != nil {
+				return nil, errors.Wrap(err, "Failed to restore function config")
+			}
+			return restoredFunctionConfig, nil
+		}
+	}
+
+	// if we're not in kube platform, or the function doesn't have a secret, just return the function config
+	return functionConfig, nil
+}
+
+// HasScrubbedConfig checks if a function config has scrubbed data, using the Scrub function
+func (s *Scrubber) HasScrubbedConfig(functionConfig *Config, sensitiveFields []*regexp.Regexp) (bool, error) {
+	var hasScrubbed bool
+
+	// hack to support avoid losing unexported fields while scrubbing.
+	// scrub the function config to map[string]interface{} and revert it back to a function config later
+	functionConfigAsMap := common.StructureToMap(functionConfig)
+	if len(functionConfigAsMap) == 0 {
+		return false, errors.New("Failed to convert function config to map")
+	}
+
+	// scrub the function config
+	_, _ = gosecretive.Scrub(functionConfigAsMap, func(fieldPath string, valueToScrub interface{}) *string {
+
+		for _, fieldPathRegexToScrub := range sensitiveFields {
+
+			// if the field path matches the field path to scrub, scrub it
+			if fieldPathRegexToScrub.MatchString(fieldPath) {
+
+				// if the value to is a string, check if it's a reference
+				if kind := reflect.ValueOf(valueToScrub).Kind(); kind == reflect.String {
+					stringValue := reflect.ValueOf(valueToScrub).String()
+
+					if strings.HasPrefix(stringValue, ReferencePrefix) {
+						hasScrubbed = true
+					}
+				}
+
+				// we never actually scrub the value
+				return nil
+			}
+		}
+
+		return nil
+	})
+
+	return hasScrubbed, nil
+}
+
 // encodeSecretKey encodes a secret key
 func (s *Scrubber) encodeSecretKey(fieldPath string) string {
 	encodedFieldPath := base64.StdEncoding.EncodeToString([]byte(fieldPath))

--- a/pkg/functionconfig/scrubber.go
+++ b/pkg/functionconfig/scrubber.go
@@ -17,18 +17,22 @@ limitations under the License.
 package functionconfig
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/nuclio/nuclio/pkg/common"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/gosecretive"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -42,8 +46,22 @@ const (
 	FunctionSecretMountPath          = "/etc/nuclio/secrets"
 )
 
+type Scrubber struct {
+	SensitiveFields []*regexp.Regexp
+	KubeClientSet   kubernetes.Interface
+}
+
+// NewScrubber returns a new scrubber
+// If the scrubber is only used for restoring, the arguments and logger can be nil
+func NewScrubber(sensitiveFields []*regexp.Regexp, kubeClientSet kubernetes.Interface) *Scrubber {
+	return &Scrubber{
+		SensitiveFields: sensitiveFields,
+		KubeClientSet:   kubeClientSet,
+	}
+}
+
 // Scrub scrubs sensitive data from a function config
-func Scrub(functionConfig *Config,
+func (s *Scrubber) Scrub(functionConfig *Config,
 	existingSecretMap map[string]string,
 	sensitiveFields []*regexp.Regexp) (*Config, map[string]string, error) {
 
@@ -64,7 +82,7 @@ func Scrub(functionConfig *Config,
 			// if the field path matches the field path to scrub, scrub it
 			if fieldPathRegexToScrub.MatchString(fieldPath) {
 
-				secretKey := generateSecretKey(fieldPath)
+				secretKey := s.generateSecretKey(fieldPath)
 
 				// if the value to scrub is a string, make sure that we need to scrub it
 				if kind := reflect.ValueOf(valueToScrub).Kind(); kind == reflect.String {
@@ -75,17 +93,9 @@ func Scrub(functionConfig *Config,
 						return nil
 					}
 
-					// if it's already a reference, validate that it a previous secret map exists,
-					// and contains the reference
+					// if it's already a reference, validate that the value exists
 					if strings.HasPrefix(stringValue, ReferencePrefix) {
-						if existingSecretMap != nil {
-							trimmedSecretKey := strings.ToLower(strings.TrimSpace(secretKey))
-							if _, exists := existingSecretMap[trimmedSecretKey]; !exists {
-								scrubErr = errors.New(fmt.Sprintf("Config data in path %s is already masked, but original value does not exist in secret", fieldPath))
-							}
-						} else {
-							scrubErr = errors.New(fmt.Sprintf("Config data in path %s is already masked, but secret does not exist.", fieldPath))
-						}
+						scrubErr = s.validateReference(functionConfig, existingSecretMap, fieldPath, secretKey, stringValue)
 						return nil
 					}
 				}
@@ -119,18 +129,18 @@ func Scrub(functionConfig *Config,
 }
 
 // Restore restores sensitive data in a function config from a secrets map
-func Restore(scrubbedFunctionConfig *Config, secretsMap map[string]string) (*Config, error) {
+func (s *Scrubber) Restore(scrubbedFunctionConfig *Config, secretsMap map[string]string) (*Config, error) {
 	restored := gosecretive.Restore(scrubbedFunctionConfig, secretsMap)
 	return restored.(*Config), nil
 }
 
 // EncodeSecretsMap encodes the keys of a secrets map
-func EncodeSecretsMap(secretsMap map[string]string) (map[string]string, error) {
+func (s *Scrubber) EncodeSecretsMap(secretsMap map[string]string) (map[string]string, error) {
 	encodedSecretsMap := map[string]string{}
 
 	// encode secret map keys
 	for secretKey, secretValue := range secretsMap {
-		encodedSecretsMap[encodeSecretKey(secretKey)] = secretValue
+		encodedSecretsMap[s.encodeSecretKey(secretKey)] = secretValue
 	}
 
 	if len(encodedSecretsMap) > 0 {
@@ -147,7 +157,7 @@ func EncodeSecretsMap(secretsMap map[string]string) (map[string]string, error) {
 }
 
 // DecodeSecretsMapContent decodes the secrets map content
-func DecodeSecretsMapContent(secretsMapContent string) (map[string]string, error) {
+func (s *Scrubber) DecodeSecretsMapContent(secretsMapContent string) (map[string]string, error) {
 
 	// decode secret
 	secretContentStr, err := base64.StdEncoding.DecodeString(secretsMapContent)
@@ -163,7 +173,7 @@ func DecodeSecretsMapContent(secretsMapContent string) (map[string]string, error
 
 	// decode secret keys and values
 	// convert values to byte array for decoding purposes
-	secretMap, err := DecodeSecretData(common.MapStringStringToMapStringBytesArray(encodedSecretMap))
+	secretMap, err := s.DecodeSecretData(common.MapStringStringToMapStringBytesArray(encodedSecretMap))
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to decode function secret data")
 	}
@@ -172,7 +182,7 @@ func DecodeSecretsMapContent(secretsMapContent string) (map[string]string, error
 }
 
 // DecodeSecretData decodes the keys of a secrets map
-func DecodeSecretData(secretData map[string][]byte) (map[string]string, error) {
+func (s *Scrubber) DecodeSecretData(secretData map[string][]byte) (map[string]string, error) {
 	decodedSecretsMap := map[string]string{}
 	for secretKey, secretValue := range secretData {
 		if secretKey == SecretContentKey {
@@ -181,7 +191,7 @@ func DecodeSecretData(secretData map[string][]byte) (map[string]string, error) {
 			// which we don't care about when decoding
 			continue
 		}
-		decodedSecretKey, err := decodeSecretKey(secretKey)
+		decodedSecretKey, err := s.decodeSecretKey(secretKey)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to decode secret key")
 		}
@@ -190,12 +200,7 @@ func DecodeSecretData(secretData map[string][]byte) (map[string]string, error) {
 	return decodedSecretsMap, nil
 }
 
-func ResolveEnvVarNameFromReference(reference string) string {
-	fieldPath := strings.TrimPrefix(reference, ReferencePrefix)
-	return encodeSecretKey(fieldPath)
-}
-
-func GenerateFunctionSecretName(functionName, secretPrefix string) string {
+func (s *Scrubber) GenerateFunctionSecretName(functionName, secretPrefix string) string {
 	secretName := fmt.Sprintf("%s%s", secretPrefix, functionName)
 	if len(secretName) > common.KubernetesDomainLevelMaxLength {
 		secretName = secretName[:common.KubernetesDomainLevelMaxLength]
@@ -208,14 +213,14 @@ func GenerateFunctionSecretName(functionName, secretPrefix string) string {
 }
 
 // encodeSecretKey encodes a secret key
-func encodeSecretKey(fieldPath string) string {
+func (s *Scrubber) encodeSecretKey(fieldPath string) string {
 	encodedFieldPath := base64.StdEncoding.EncodeToString([]byte(fieldPath))
 	encodedFieldPath = strings.ReplaceAll(encodedFieldPath, "=", "_")
 	return fmt.Sprintf("%s%s", ReferenceToEnvVarPrefix, encodedFieldPath)
 }
 
 // decodeSecretKey decodes a secret key and returns the original field
-func decodeSecretKey(secretKey string) (string, error) {
+func (s *Scrubber) decodeSecretKey(secretKey string) (string, error) {
 	encodedFieldPath := strings.TrimPrefix(secretKey, ReferenceToEnvVarPrefix)
 	encodedFieldPath = strings.ReplaceAll(encodedFieldPath, "_", "=")
 	decodedFieldPath, err := base64.StdEncoding.DecodeString(encodedFieldPath)
@@ -225,6 +230,52 @@ func decodeSecretKey(secretKey string) (string, error) {
 	return string(decodedFieldPath), nil
 }
 
-func generateSecretKey(fieldPath string) string {
+func (s *Scrubber) generateSecretKey(fieldPath string) string {
 	return fmt.Sprintf("%s%s", ReferencePrefix, strings.ToLower(fieldPath))
+}
+
+func (s *Scrubber) validateReference(functionConfig *Config,
+	existingSecretMap map[string]string,
+	fieldPath,
+	secretKey,
+	stringValue string) error {
+
+	// for flex volume access keys, we need to check if the volume secret exists
+	if strings.Contains(stringValue, "flexvolume") {
+
+		// get the volume name
+		volumeIndexStr := strings.Split(strings.Split(stringValue, "[")[1], "]")[0]
+		volumeIndex, err := strconv.Atoi(volumeIndexStr)
+		if err != nil {
+			return errors.Wrap(err, "Failed to parse volume index")
+		}
+		volumeName := functionConfig.Spec.Volumes[volumeIndex].Volume.Name
+
+		// list secrets with the volume name label selector
+		volumeSecrets, err := s.KubeClientSet.CoreV1().Secrets(functionConfig.Meta.Namespace).List(context.Background(),
+			metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("%s=%s", common.NuclioResourceLabelKeyVolumeName, volumeName),
+			})
+		if err != nil {
+			return errors.Wrap(err, "Failed to list volume secrets")
+		}
+
+		// if no secret exists, return an error
+		if len(volumeSecrets.Items) == 0 {
+			return errors.New(fmt.Sprintf("No secret exists for volume %s", volumeName))
+		}
+
+		return nil
+	}
+
+	// for other fields, we need to check if the secret exists in the secret map
+	if existingSecretMap != nil {
+		trimmedSecretKey := strings.ToLower(strings.TrimSpace(secretKey))
+		if _, exists := existingSecretMap[trimmedSecretKey]; !exists {
+			return errors.New(fmt.Sprintf("Config data in path %s is already scrubbed, but original value does not exist in secret", fieldPath))
+		}
+		return nil
+	}
+
+	return errors.New(fmt.Sprintf("Config data in path %s is already masked, but secret does not exist.", fieldPath))
 }

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -158,7 +158,7 @@ func (ap *Platform) HandleDeployFunction(ctx context.Context,
 
 		// if the function is updated, it might have scrubbed data in the spec that the builder requires,
 		// so we need to restore it before building
-		restoredFunctionConfig, err := functionconfig.RestoreFunctionConfig(ctx,
+		restoredFunctionConfig, err := ap.Scrubber.RestoreFunctionConfig(ctx,
 			&createFunctionOptions.FunctionConfig,
 			ap.platform.GetName(),
 			ap.GetFunctionSecretMap)
@@ -1219,29 +1219,6 @@ func (ap *Platform) QueryOPAMultipleResources(resources []string,
 // GetFunctionSecrets returns all the function's secrets
 func (ap *Platform) GetFunctionSecrets(ctx context.Context, functionName, functionNamespace string) ([]platform.FunctionSecret, error) {
 	return nil, nil
-}
-
-// RestoreFunctionConfig restores a function config from the function secret
-func (ap *Platform) RestoreFunctionConfig(ctx context.Context, config *functionconfig.Config) (*functionconfig.Config, error) {
-
-	// get the function secrets
-	secretMap, err := ap.GetFunctionSecretMap(ctx, config.Meta.Name, config.Meta.Namespace)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get function secrets")
-	}
-
-	// if there are no secrets, return the original config
-	if secretMap == nil {
-		return config, nil
-	}
-
-	// restore the function config from the secret
-	restoredConfig, err := ap.Scrubber.Restore(config, secretMap)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to restore function config")
-	}
-
-	return restoredConfig, nil
 }
 
 // GetFunctionSecretMap returns a map of function sensitive data

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2266,11 +2266,12 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(ctx context.Context,
 
 	// volume the function secret as optional
 	secretVolumeName := "function-secret"
+	scrubber := functionconfig.NewScrubber(nil, nil)
 	volumeNameToVolume[secretVolumeName] = v1.Volume{
 		Name: secretVolumeName,
 		VolumeSource: v1.VolumeSource{
 			Secret: &v1.SecretVolumeSource{
-				SecretName: functionconfig.GenerateFunctionSecretName(function.Name, functionconfig.NuclioSecretNamePrefix),
+				SecretName: scrubber.GenerateFunctionSecretName(function.Name, functionconfig.NuclioSecretNamePrefix),
 				Optional:   &trueVal,
 			},
 		},

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2230,7 +2230,8 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(ctx context.Context,
 			if accessKeyExists && strings.HasPrefix(accessKey, functionconfig.ReferencePrefix) {
 
 				// get the flex volume secret name
-				secretName, err := lc.getFlexVolumeSecretName(ctx, function, configVolume.Volume.Name)
+				volumeName := configVolume.Volume.Name
+				secretName, err := lc.getFlexVolumeSecretName(ctx, function, volumeName)
 				if err != nil {
 					lc.logger.WarnWithCtx(ctx,
 						"Failed to get flex volume secret name for access key value",


### PR DESCRIPTION
If the function has a flex volume and is then duplicated, the access key field in the function config contains a `$ref`.
We validate that a secret already exists for the same volume name, and not fail due to missing existing secret.

Followup of this PR will be how to resolve all other secrets when duplicating a function, since they're all in the original function's secret.

Also, in this PR I did a bit of a refactor to the mask module -
- Renamed `mask.go` to `scrubber.go`
- Added the `Scrubber` object, that is responsible for all of the scrubbing/restoring/encoding/decoding

Fixes https://jira.iguazeng.com/browse/IG-21490