### PR TITLE
Restore function config when exporting function

### DIFF
--- a/cmd/dashboard/app/run.go
+++ b/cmd/dashboard/app/run.go
@@ -178,7 +178,7 @@ func Run(listenAddress string,
 		defer cancel()
 	}
 
-	if platformInstance.GetName() == "kube" {
+	if platformInstance.GetName() == common.KubePlatformName {
 		rest.SetDefaultWarningHandler(common.NewKubernetesClientWarningHandler(rootLogger.GetChild("kube_warnings")))
 	}
 

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -353,7 +353,7 @@ func (p *Processor) createTriggers(processorConfiguration *processor.Configurati
 
 		// skipping cron triggers when platform kind is "kube" and k8s cron jobs are enabled- k8s cron jobs will be created instead
 		if triggerConfiguration.Kind == "cron" &&
-			platformKind == "kube" &&
+			platformKind == common.KubePlatformName &&
 			processorConfiguration.PlatformConfig.CronTriggerCreationMode == platformconfig.KubeCronTriggerCreationMode {
 
 			p.logger.DebugWith("Skipping cron trigger creation inside the processor",

--- a/cmd/processor/app/processor_test.go
+++ b/cmd/processor/app/processor_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
@@ -77,7 +78,7 @@ func (suite *TriggerTestSuite) TestCreateManyTriggersWithSameWorkerAllocatorName
 			},
 		},
 		PlatformConfig: &platformconfig.Config{
-			Kind: "local",
+			Kind: common.LocalPlatformName,
 		},
 	})
 
@@ -126,7 +127,7 @@ func (suite *TriggerTestSuite) TestRestartTriggers() {
 			},
 		},
 		PlatformConfig: &platformconfig.Config{
-			Kind: "local",
+			Kind: common.LocalPlatformName,
 		},
 	})
 	suite.Require().NoError(err)

--- a/pkg/common/consts.go
+++ b/pkg/common/consts.go
@@ -42,3 +42,8 @@ const NuclioResourceLabelKeyVolumeName = "nuclio.io/volume-name"
 // KubernetesDomainLevelMaxLength DNS domain level limitation is 63 chars
 // https://en.wikipedia.org/wiki/Subdomain#Overview
 const KubernetesDomainLevelMaxLength = 63
+
+const (
+	KubePlatformName  = "kube"
+	LocalPlatformName = "local"
+)

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -296,7 +296,11 @@ func (pr *projectResource) getFunctionsAndFunctionEventsMap(request *http.Reques
 
 	// create a map of attributes keyed by the function id (name)
 	for _, function := range functions {
-		functionsMap[function.GetConfig().Meta.Name] = functionResourceInstance.export(ctx, function)
+		exportedFunction, err := functionResourceInstance.export(ctx, function)
+		if err != nil {
+			return functionsMap, functionEventsMap
+		}
+		functionsMap[function.GetConfig().Meta.Name] = exportedFunction
 
 		functionEvents := functionEventResourceInstance.getFunctionEvents(request, function, namespace)
 		for _, functionEvent := range functionEvents {

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -29,6 +29,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common"
 	nucliocontext "github.com/nuclio/nuclio/pkg/context"
 	"github.com/nuclio/nuclio/pkg/dashboard"
+	"github.com/nuclio/nuclio/pkg/errgroup"
 	"github.com/nuclio/nuclio/pkg/opa"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader/iguazio"
@@ -295,18 +296,41 @@ func (pr *projectResource) getFunctionsAndFunctionEventsMap(request *http.Reques
 	namespace := project.GetConfig().Meta.Namespace
 
 	// create a map of attributes keyed by the function id (name)
+	functionsMaplock := sync.Mutex{}
+	functionEventsMaplock := sync.Mutex{}
+	errGroup, errGroupCtx := errgroup.WithContextSemaphore(ctx, pr.Logger, errgroup.DefaultErrgroupConcurrency)
 	for _, function := range functions {
-		exportedFunction, err := functionResourceInstance.export(ctx, function)
-		if err != nil {
-			return functionsMap, functionEventsMap
-		}
-		functionsMap[function.GetConfig().Meta.Name] = exportedFunction
+		function := function
+		errGroup.Go("ExportFunction", func() error {
+			exportedFunction, err := functionResourceInstance.export(errGroupCtx, function)
+			if err != nil {
+				pr.Logger.WarnWithCtx(errGroupCtx,
+					"Failed to export function",
+					"functionName", function.GetConfig().Meta.Name,
+					"err", err)
+				return errors.Wrapf(err, "Failed to export function %s", function.GetConfig().Meta.Name)
+			}
+			functionsMaplock.Lock()
+			functionsMap[function.GetConfig().Meta.Name] = exportedFunction
+			functionsMaplock.Unlock()
 
-		functionEvents := functionEventResourceInstance.getFunctionEvents(request, function, namespace)
-		for _, functionEvent := range functionEvents {
-			functionEventsMap[functionEvent.GetConfig().Meta.Name] =
-				functionEventResourceInstance.functionEventToAttributes(functionEvent)
-		}
+			functionEvents := functionEventResourceInstance.getFunctionEvents(request, function, namespace)
+			for _, functionEvent := range functionEvents {
+				functionEventsMaplock.Lock()
+				functionEventsMap[functionEvent.GetConfig().Meta.Name] =
+					functionEventResourceInstance.functionEventToAttributes(functionEvent)
+				functionEventsMaplock.Unlock()
+			}
+			return nil
+		})
+	}
+
+	// wait for all functions to be exported, if one fails, just log it and continue
+	if err := errGroup.Wait(); err != nil {
+		pr.Logger.WarnWithCtx(ctx,
+			"Failed to export project functions",
+			"err", err,
+			"projectName", project.GetConfig().Meta.Name)
 	}
 
 	return functionsMap, functionEventsMap

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -139,7 +139,7 @@ func NewServer(parentLogger logger.Logger,
 		}
 	} else if containerBuilderKind == "kaniko" {
 		if common.GetEnvOrDefaultString("NUCLIO_DASHBOARD_SERVE_KANIKO_ARTIFACTS_MODE",
-			"local") == "local" {
+			"local") == common.LocalPlatformName {
 
 			// allow dashboard server to handle request to get kaniko artifacts for function builds
 			// this is useful when running dashboard locally. in production, nginx will handle this

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -31,6 +31,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -878,8 +879,12 @@ func (suite *functionTestSuite) TestInvokeNoNamespace() {
 
 func (suite *functionTestSuite) TestExportFunctionSuccessful() {
 	replicas := 10
+
+	// we mock a function config with a scrubbed field, that should be unscrubbed on export
 	password := "my-password-1234"
 	passwordReference := "$ref:/spec/build/codeentryattributes/password"
+	passwordPathRegex := regexp.MustCompile("(?i)^/spec/build/codeentryattributes/password$")
+
 	returnedFunction := platform.AbstractFunction{}
 	returnedFunction.Config.Meta.Name = "f1"
 	returnedFunction.Config.Meta.Namespace = "f1-namespace"
@@ -915,6 +920,9 @@ func (suite *functionTestSuite) TestExportFunctionSuccessful() {
 		Return(&platformconfig.Config{
 			SensitiveFields: platformconfig.SensitiveFieldsConfig{
 				MaskSensitiveFields: true,
+				SensitiveFieldsRegex: []*regexp.Regexp{
+					passwordPathRegex,
+				},
 			},
 		}, nil).
 		Once()
@@ -984,7 +992,8 @@ func (suite *functionTestSuite) TestExportFunctionListSuccessful() {
 		On("GetConfig").
 		Return(&platformconfig.Config{
 			SensitiveFields: platformconfig.SensitiveFieldsConfig{
-				MaskSensitiveFields: true,
+				MaskSensitiveFields:  true,
+				SensitiveFieldsRegex: []*regexp.Regexp{},
 			},
 		}, nil).
 		Twice()
@@ -1372,7 +1381,8 @@ func (suite *projectTestSuite) TestExportProjectSuccessful() {
 		On("GetConfig").
 		Return(&platformconfig.Config{
 			SensitiveFields: platformconfig.SensitiveFieldsConfig{
-				MaskSensitiveFields: true,
+				MaskSensitiveFields:  true,
+				SensitiveFieldsRegex: []*regexp.Regexp{},
 			},
 		}, nil).
 		Twice()
@@ -1547,7 +1557,8 @@ func (suite *projectTestSuite) TestExportProjectListSuccessful() {
 		On("GetConfig").
 		Return(&platformconfig.Config{
 			SensitiveFields: platformconfig.SensitiveFieldsConfig{
-				MaskSensitiveFields: true,
+				MaskSensitiveFields:  true,
+				SensitiveFieldsRegex: []*regexp.Regexp{},
 			},
 		}, nil).
 		Twice()

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1537,6 +1537,16 @@ func (suite *projectTestSuite) TestExportProjectListSuccessful() {
 		On("GetFunctionEvents", mock.Anything, mock.MatchedBy(verifyGetFunctionEvents)).
 		Return([]platform.FunctionEvent{}, nil).Twice()
 
+	suite.mockPlatform.
+		On("GetName").
+		Return(common.KubePlatformName).
+		Twice()
+
+	suite.mockPlatform.
+		On("GetFunctionSecretMap", mock.Anything, mock.Anything, mock.Anything).
+		Return(map[string]string{}, nil).
+		Twice()
+
 	headers := map[string]string{
 		"x-nuclio-project-namespace":  "f-namespace",
 		"x-nuclio-function-namespace": "f-namespace",

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -910,6 +910,14 @@ func (suite *functionTestSuite) TestExportFunctionSuccessful() {
 			passwordReference: password,
 		}, nil).
 		Once()
+	suite.mockPlatform.
+		On("GetConfig").
+		Return(&platformconfig.Config{
+			SensitiveFields: platformconfig.SensitiveFieldsConfig{
+				MaskSensitiveFields: true,
+			},
+		}, nil).
+		Once()
 
 	headers := map[string]string{
 		"x-nuclio-function-namespace": "f1-namespace",
@@ -973,13 +981,12 @@ func (suite *functionTestSuite) TestExportFunctionListSuccessful() {
 		Once()
 
 	suite.mockPlatform.
-		On("GetName").
-		Return(common.KubePlatformName).
-		Twice()
-
-	suite.mockPlatform.
-		On("GetFunctionSecretMap", mock.Anything, mock.Anything, mock.Anything).
-		Return(map[string]string{}, nil).
+		On("GetConfig").
+		Return(&platformconfig.Config{
+			SensitiveFields: platformconfig.SensitiveFieldsConfig{
+				MaskSensitiveFields: true,
+			},
+		}, nil).
 		Twice()
 
 	headers := map[string]string{
@@ -1362,13 +1369,12 @@ func (suite *projectTestSuite) TestExportProjectSuccessful() {
 		Once()
 
 	suite.mockPlatform.
-		On("GetName").
-		Return(common.KubePlatformName).
-		Twice()
-
-	suite.mockPlatform.
-		On("GetFunctionSecretMap", mock.Anything, mock.Anything, mock.Anything).
-		Return(map[string]string{}, nil).
+		On("GetConfig").
+		Return(&platformconfig.Config{
+			SensitiveFields: platformconfig.SensitiveFieldsConfig{
+				MaskSensitiveFields: true,
+			},
+		}, nil).
 		Twice()
 
 	headers := map[string]string{
@@ -1538,13 +1544,12 @@ func (suite *projectTestSuite) TestExportProjectListSuccessful() {
 		Return([]platform.FunctionEvent{}, nil).Twice()
 
 	suite.mockPlatform.
-		On("GetName").
-		Return(common.KubePlatformName).
-		Twice()
-
-	suite.mockPlatform.
-		On("GetFunctionSecretMap", mock.Anything, mock.Anything, mock.Anything).
-		Return(map[string]string{}, nil).
+		On("GetConfig").
+		Return(&platformconfig.Config{
+			SensitiveFields: platformconfig.SensitiveFieldsConfig{
+				MaskSensitiveFields: true,
+			},
+		}, nil).
 		Twice()
 
 	headers := map[string]string{

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -972,6 +972,16 @@ func (suite *functionTestSuite) TestExportFunctionListSuccessful() {
 		Return([]platform.Function{&returnedFunction1, &returnedFunction2}, nil).
 		Once()
 
+	suite.mockPlatform.
+		On("GetName").
+		Return(common.KubePlatformName).
+		Twice()
+
+	suite.mockPlatform.
+		On("GetFunctionSecretMap", mock.Anything, mock.Anything, mock.Anything).
+		Return(map[string]string{}, nil).
+		Twice()
+
 	headers := map[string]string{
 		"x-nuclio-function-namespace": "f-namespace",
 	}
@@ -1350,6 +1360,16 @@ func (suite *projectTestSuite) TestExportProjectSuccessful() {
 		On("GetAPIGateways", mock.Anything, mock.MatchedBy(verifyGetAPIGateways)).
 		Return([]platform.APIGateway{&returnedAPIGateway1}, nil).
 		Once()
+
+	suite.mockPlatform.
+		On("GetName").
+		Return(common.KubePlatformName).
+		Twice()
+
+	suite.mockPlatform.
+		On("GetFunctionSecretMap", mock.Anything, mock.Anything, mock.Anything).
+		Return(map[string]string{}, nil).
+		Twice()
 
 	headers := map[string]string{
 		"x-nuclio-project-namespace":  "f-namespace",

--- a/pkg/functionconfig/mask.go
+++ b/pkg/functionconfig/mask.go
@@ -17,6 +17,7 @@ limitations under the License.
 package functionconfig
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -122,6 +123,36 @@ func Scrub(functionConfig *Config,
 func Restore(scrubbedFunctionConfig *Config, secretsMap map[string]string) (*Config, error) {
 	restored := gosecretive.Restore(scrubbedFunctionConfig, secretsMap)
 	return restored.(*Config), nil
+}
+
+// RestoreFunctionConfig restores a function config from a secret, in case we're running in a kube platform
+func RestoreFunctionConfig(ctx context.Context,
+	functionConfig *Config,
+	platformName string,
+	getSecretMapCallback func(ctx context.Context, functionName, functionNamespace string) (map[string]string, error)) (*Config, error) {
+
+	// if we're in kube platform, we need to restore the function config's
+	// sensitive data from the function's secret
+	if platformName == common.KubePlatformName {
+		secretMap, err := getSecretMapCallback(ctx,
+			functionConfig.Meta.Name,
+			functionConfig.Meta.Namespace)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to get function secret")
+		}
+		if secretMap != nil {
+
+			// restore the function config
+			restoredFunctionConfig, err := Restore(functionConfig, secretMap)
+			if err != nil {
+				return nil, errors.Wrap(err, "Failed to restore function config")
+			}
+			return restoredFunctionConfig, nil
+		}
+	}
+
+	// if we're not in kube platform, or the function doesn't have a secret, just return the function config
+	return functionConfig, nil
 }
 
 // EncodeSecretsMap encodes the keys of a secrets map

--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -49,6 +49,9 @@ func newImportCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *i
 from a configuration file or from the standard input (default)`,
 	}
 
+	// disable sensitive field masking in the platform when importing, for backwards compatibility
+	commandeer.rootCommandeer.platform.GetConfig().SensitiveFields.MaskSensitiveFields = false
+
 	importFunctionCommand := newImportFunctionCommandeer(ctx, commandeer).cmd
 	importProjectCommand := newImportProjectCommandeer(ctx, commandeer).cmd
 

--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -49,9 +49,6 @@ func newImportCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *i
 from a configuration file or from the standard input (default)`,
 	}
 
-	// disable sensitive field masking in the platform when importing, for backwards compatibility
-	commandeer.rootCommandeer.platform.GetConfig().SensitiveFields.MaskSensitiveFields = false
-
 	importFunctionCommand := newImportFunctionCommandeer(ctx, commandeer).cmd
 	importProjectCommand := newImportProjectCommandeer(ctx, commandeer).cmd
 
@@ -160,6 +157,9 @@ Arguments:
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 
+			// disable sensitive field masking in the platform when importing, for backwards compatibility
+			commandeer.rootCommandeer.platform.GetConfig().DisableSensitiveFieldMasking()
+
 			functionBody, err := commandeer.resolveInputData(args)
 			if err != nil {
 				return errors.Wrap(err, "Failed to read function data")
@@ -258,6 +258,9 @@ Arguments:
 			if err := importCommandeer.rootCommandeer.initialize(); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
+
+			// disable sensitive field masking in the platform when importing, for backwards compatibility
+			commandeer.rootCommandeer.platform.GetConfig().DisableSensitiveFieldMasking()
 
 			projectBody, err := commandeer.resolveInputData(args)
 			if err != nil {

--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -411,7 +411,7 @@ func (i *importProjectCommandeer) importProject(ctx context.Context,
 	}
 
 	// api gateways are supported only on k8s platform
-	if i.rootCommandeer.platform.GetName() == "kube" {
+	if i.rootCommandeer.platform.GetName() == common.KubePlatformName {
 
 		// import api gateways
 		apiGatewaysImportErr := i.importAPIGateways(ctx, projectImportOptions.projectImportConfig.APIGateways)

--- a/pkg/nuctl/test/apigagteway_test.go
+++ b/pkg/nuctl/test/apigagteway_test.go
@@ -41,7 +41,7 @@ type apiGatewayCreateGetAndDeleteTestSuite struct {
 }
 
 func (suite *apiGatewayCreateGetAndDeleteTestSuite) SetupSuite() {
-	suite.platformKindOverride = "kube"
+	suite.platformKindOverride = common.KubePlatformName
 	suite.Suite.SetupSuite()
 }
 
@@ -126,7 +126,7 @@ type apiGatewayInvokeTestSuite struct {
 }
 
 func (suite *apiGatewayInvokeTestSuite) SetupSuite() {
-	suite.platformKindOverride = "kube"
+	suite.platformKindOverride = common.KubePlatformName
 	suite.Suite.SetupSuite()
 }
 

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -814,7 +814,7 @@ func (suite *functionDeployTestSuite) TestBuildAndDeployFromFileWithOverriddenAr
 func (suite *functionDeployTestSuite) TestDeployWithResourceVersion() {
 
 	// TODO: when we enable some sort of resource validation on other platforms, allow this to run on those as well
-	suite.ensureRunningOnPlatform("kube")
+	suite.ensureRunningOnPlatform(common.KubePlatformName)
 
 	// read and parse the function we're gonna test
 	functionConfig := functionconfig.Config{}
@@ -1203,7 +1203,7 @@ func (suite *functionDeployTestSuite) TestDeployWithSecurityContext() {
 func (suite *functionDeployTestSuite) TestDeployServiceTypeClusterIPWithInvocation() {
 
 	// TODO: remove this if we ever implement "ServiceType" for local platform
-	suite.ensureRunningOnPlatform("kube")
+	suite.ensureRunningOnPlatform(common.KubePlatformName)
 
 	uniqueSuffix := "-" + xid.New().String()
 	functionName := "deploy-reverser" + uniqueSuffix
@@ -1280,7 +1280,7 @@ wget -O - --post-data "$body" $url 2> /dev/null
 func (suite *functionDeployTestSuite) TestDeployWithOverrideServiceTypeFlag() {
 
 	// TODO: remove this if we ever implement "ServiceType" for local platform
-	suite.ensureRunningOnPlatform("kube")
+	suite.ensureRunningOnPlatform(common.KubePlatformName)
 
 	uniqueSuffix := "-" + xid.New().String()
 	functionName := "reverser-cluster-ip" + uniqueSuffix

--- a/pkg/nuctl/test/project_test.go
+++ b/pkg/nuctl/test/project_test.go
@@ -26,9 +26,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/nuctl/command"
-	"github.com/nuclio/nuclio/pkg/nuctl/command/common"
+	nuctlCommon "github.com/nuclio/nuclio/pkg/nuctl/command/common"
 	"github.com/nuclio/nuclio/pkg/platform"
 
 	"github.com/ghodss/yaml"
@@ -278,7 +279,7 @@ type projectExportImportTestSuite struct {
 }
 
 func (suite *projectExportImportTestSuite) TestExportProject() {
-	apiGatewaysEnabled := suite.origPlatformKind == "kube"
+	apiGatewaysEnabled := suite.origPlatformKind == common.KubePlatformName
 
 	uniqueSuffix := "-" + xid.New().String()
 	projectName := "test-project" + uniqueSuffix
@@ -460,7 +461,7 @@ func (suite *projectExportImportTestSuite) TestImportProjectSkipBySelectors() {
 }
 
 func (suite *projectExportImportTestSuite) TestImportProjects() {
-	apiGatewaysEnabled := suite.origPlatformKind == "kube"
+	apiGatewaysEnabled := suite.origPlatformKind == common.KubePlatformName
 
 	projectConfigPath := path.Join(suite.GetImportsDir(), "projects.yaml")
 
@@ -517,7 +518,7 @@ func (suite *projectExportImportTestSuite) TestImportProjects() {
 }
 
 func (suite *projectExportImportTestSuite) TestImportProject() {
-	apiGatewaysEnabled := suite.origPlatformKind == "kube"
+	apiGatewaysEnabled := suite.origPlatformKind == common.KubePlatformName
 
 	uniqueSuffix := "-" + xid.New().String()
 	projectConfigPath := path.Join(suite.GetImportsDir(), "project.yaml")
@@ -758,7 +759,7 @@ func (suite *projectExportImportTestSuite) assertProjectImported(projectName str
 	// reset output buffer for reading the nex output cleanly
 	suite.outputBuffer.Reset()
 	err := suite.RetryExecuteNuctlUntilSuccessful([]string{"get", "project", projectName}, map[string]string{
-		"output": common.OutputFormatYAML,
+		"output": nuctlCommon.OutputFormatYAML,
 	}, false)
 	suite.Require().NoError(err)
 
@@ -775,7 +776,7 @@ func (suite *projectExportImportTestSuite) assertFunctionEventExistenceByFunctio
 	// reset output buffer for reading the nex output cleanly
 	suite.outputBuffer.Reset()
 	err := suite.RetryExecuteNuctlUntilSuccessful([]string{"get", "functionevent"}, map[string]string{
-		"output":   common.OutputFormatYAML,
+		"output":   nuctlCommon.OutputFormatYAML,
 		"function": functionName,
 	}, false)
 	suite.Require().NoError(err)

--- a/pkg/nuctl/test/suite.go
+++ b/pkg/nuctl/test/suite.go
@@ -100,7 +100,7 @@ func (suite *Suite) SetupSuite() {
 
 	// default to local platform if platform isn't set
 	if os.Getenv(nuctlPlatformEnvVarName) == "" {
-		err = os.Setenv(nuctlPlatformEnvVarName, "local")
+		err = os.Setenv(nuctlPlatformEnvVarName, common.LocalPlatformName)
 		suite.Require().NoError(err)
 	}
 

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -155,7 +155,10 @@ func (ap *Platform) HandleDeployFunction(ctx context.Context,
 
 		// if the function is updated, it might have scrubbed data in the spec that the builder requires,
 		// so we need to restore it before building
-		restoredFunctionConfig, err := ap.RestoreFunctionConfig(ctx, &createFunctionOptions.FunctionConfig)
+		restoredFunctionConfig, err := functionconfig.RestoreFunctionConfig(ctx,
+			&createFunctionOptions.FunctionConfig,
+			ap.platform.GetName(),
+			ap.GetFunctionSecretMap)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to restore function config")
 		}
@@ -1213,29 +1216,6 @@ func (ap *Platform) QueryOPAMultipleResources(resources []string,
 // GetFunctionSecrets returns all the function's secrets
 func (ap *Platform) GetFunctionSecrets(ctx context.Context, functionName, functionNamespace string) ([]platform.FunctionSecret, error) {
 	return nil, nil
-}
-
-// RestoreFunctionConfig restores a function config from the function secret
-func (ap *Platform) RestoreFunctionConfig(ctx context.Context, config *functionconfig.Config) (*functionconfig.Config, error) {
-
-	// get the function secrets
-	secretMap, err := ap.GetFunctionSecretMap(ctx, config.Meta.Name, config.Meta.Namespace)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get function secrets")
-	}
-
-	// if there are no secrets, return the original config
-	if secretMap == nil {
-		return config, nil
-	}
-
-	// restore the function config from the secret
-	restoredConfig, err := functionconfig.Restore(config, secretMap)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to restore function config")
-	}
-
-	return restoredConfig, nil
 }
 
 // GetFunctionSecretMap returns a map of function sensitive data

--- a/pkg/platform/factory/factory.go
+++ b/pkg/platform/factory/factory.go
@@ -48,10 +48,10 @@ func CreatePlatform(ctx context.Context,
 	}
 
 	switch platformType {
-	case "local":
+	case common.LocalPlatformName:
 		newPlatform, err = local.NewPlatform(ctx, parentLogger, platformConfiguration, defaultNamespace)
 
-	case "kube":
+	case common.KubePlatformName:
 		newPlatform, err = kube.NewPlatform(ctx, parentLogger, platformConfiguration, defaultNamespace)
 
 	case "auto":
@@ -61,11 +61,11 @@ func CreatePlatform(ctx context.Context,
 			common.IsInKubernetesCluster() {
 
 			// call again, but force kube
-			newPlatform, err = CreatePlatform(ctx, parentLogger, "kube", platformConfiguration, defaultNamespace)
+			newPlatform, err = CreatePlatform(ctx, parentLogger, common.KubePlatformName, platformConfiguration, defaultNamespace)
 		} else {
 
 			// call again, force local
-			newPlatform, err = CreatePlatform(ctx, parentLogger, "local", platformConfiguration, defaultNamespace)
+			newPlatform, err = CreatePlatform(ctx, parentLogger, common.LocalPlatformName, platformConfiguration, defaultNamespace)
 		}
 
 	default:

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -593,7 +593,7 @@ func (p *Platform) GetFunctionReplicaNames(ctx context.Context,
 
 // GetName returns the platform name
 func (p *Platform) GetName() string {
-	return "kube"
+	return common.KubePlatformName
 }
 
 // GetNodes returns a slice of nodes currently in the cluster

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -84,7 +84,7 @@ func (suite *KubeTestSuite) SetupSuite() {
 
 	common.SetVersionFromEnv()
 	suite.Namespace = common.GetEnvOrDefaultString("NUCLIO_TEST_NAMESPACE", "default")
-	suite.PlatformType = "kube"
+	suite.PlatformType = common.KubePlatformName
 
 	if suite.PlatformConfiguration == nil {
 		suite.PlatformConfiguration = &platformconfig.Config{}

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -430,7 +430,7 @@ func (p *Platform) GetHealthCheckMode() platform.HealthCheckMode {
 
 // GetName returns the platform name
 func (p *Platform) GetName() string {
-	return "local"
+	return common.LocalPlatformName
 }
 
 func (p *Platform) GetNodes() ([]platform.Node, error) {
@@ -923,7 +923,7 @@ func (p *Platform) delete(ctx context.Context, deleteFunctionOptions *platform.D
 	getContainerOptions := &dockerclient.GetContainerOptions{
 		Stopped: true,
 		Labels: map[string]string{
-			"nuclio.io/platform":                      "local",
+			"nuclio.io/platform":                      common.LocalPlatformName,
 			"nuclio.io/namespace":                     deleteFunctionOptions.FunctionConfig.Meta.Namespace,
 			common.NuclioResourceLabelKeyFunctionName: deleteFunctionOptions.FunctionConfig.Meta.Name,
 		},
@@ -1229,7 +1229,7 @@ func (p *Platform) compileDeployFunctionEnvMap(createFunctionOptions *platform.C
 
 func (p *Platform) compileDeployFunctionLabels(createFunctionOptions *platform.CreateFunctionOptions) map[string]string {
 	labels := map[string]string{
-		"nuclio.io/platform":                      "local",
+		"nuclio.io/platform":                      common.LocalPlatformName,
 		"nuclio.io/namespace":                     createFunctionOptions.FunctionConfig.Meta.Namespace,
 		common.NuclioResourceLabelKeyFunctionName: createFunctionOptions.FunctionConfig.Meta.Name,
 		"nuclio.io/function-spec":                 p.encodeFunctionSpec(&createFunctionOptions.FunctionConfig.Spec),

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -371,17 +371,16 @@ func (mp *Platform) QueryOPAFunctionEventPermissions(projectName,
 
 // GetFunctionSecrets returns all the function's secrets
 func (mp *Platform) GetFunctionSecrets(ctx context.Context, functionName, functionNamespace string) ([]platform.FunctionSecret, error) {
-	return nil, nil
-}
-
-func (mp *Platform) RestoreFunctionConfig(ctx context.Context, config *functionconfig.Config) (*functionconfig.Config, error) {
-	return nil, nil
+	args := mp.Called(ctx, functionName, functionNamespace)
+	return args.Get(0).([]platform.FunctionSecret), args.Error(1)
 }
 
 func (mp *Platform) GetFunctionSecretMap(ctx context.Context, functionName, functionNamespace string) (map[string]string, error) {
-	return nil, nil
+	args := mp.Called(ctx, functionName, functionNamespace)
+	return args.Get(0).(map[string]string), args.Error(1)
 }
 
 func (mp *Platform) GetFunctionSecretData(ctx context.Context, functionName, functionNamespace string) (map[string][]byte, error) {
-	return nil, nil
+	args := mp.Called(ctx, functionName, functionNamespace)
+	return args.Get(0).(map[string][]byte), args.Error(1)
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -204,9 +204,6 @@ type Platform interface {
 	// GetFunctionSecrets returns all the function's secrets
 	GetFunctionSecrets(ctx context.Context, functionName, functionNamespace string) ([]FunctionSecret, error)
 
-	// RestoreFunctionConfig restores function config from the secret, if it exists
-	RestoreFunctionConfig(ctx context.Context, functionConfig *functionconfig.Config) (*functionconfig.Config, error)
-
 	// GetFunctionSecretMap returns a map of function's sensitive data
 	GetFunctionSecretMap(ctx context.Context, functionName, functionNamespace string) (map[string]string, error)
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -80,9 +80,9 @@ func NewPlatformConfig(configurationPath string) (*Config, error) {
 
 	// determine config kind
 	if len(os.Getenv("KUBERNETES_SERVICE_HOST")) != 0 && len(os.Getenv("KUBERNETES_SERVICE_PORT")) != 0 {
-		config.Kind = "kube"
+		config.Kind = common.KubePlatformName
 	} else {
-		config.Kind = "local"
+		config.Kind = common.LocalPlatformName
 	}
 
 	// enrich opa configuration

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -395,3 +395,11 @@ func (c *Config) enrichOpaConfig() {
 		c.Opa.PermissionFilterPath = opa.DefaultPermissionFilterPath
 	}
 }
+
+func (c *Config) EnableSensitiveFieldMasking() {
+	c.SensitiveFields.MaskSensitiveFields = true
+}
+
+func (c *Config) DisableSensitiveFieldMasking() {
+	c.SensitiveFields.MaskSensitiveFields = false
+}

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -100,7 +100,7 @@ func (suite *TestSuite) SetupSuite() {
 	}
 
 	if suite.PlatformType == "" {
-		suite.PlatformType = "local"
+		suite.PlatformType = common.LocalPlatformName
 	}
 
 	if suite.Namespace == "" {


### PR DESCRIPTION
When a function is exported using nuctl or the dashboards api, we do not want scrubbed fields to still contain references.
So, before exporting the function we restore the scrubbed data in the function config.

This PR also replaces `"kube"` and `"local"` magic string with constants, for better reuse of strings.