### PR TITLE
Add project to secret name

### DIFF
--- a/pkg/functionconfig/scrubber.go
+++ b/pkg/functionconfig/scrubber.go
@@ -38,8 +38,8 @@ import (
 const (
 	ReferencePrefix                  = "$ref:"
 	ReferenceToEnvVarPrefix          = "NUCLIO_B64_"
-	NuclioSecretNamePrefix           = "nuclio-secret-"
-	NuclioFlexVolumeSecretNamePrefix = "nuclio-flexvolume-"
+	NuclioSecretNamePrefix           = "nuclio-secret"
+	NuclioFlexVolumeSecretNamePrefix = "nuclio-flexvolume"
 	SecretTypeFunctionConfig         = "nuclio.io/functionconfig"
 	SecretTypeV3ioFuse               = "v3io/fuse"
 	SecretContentKey                 = "content"
@@ -230,8 +230,12 @@ func (s *Scrubber) DecodeSecretData(secretData map[string][]byte) (map[string]st
 	return decodedSecretsMap, nil
 }
 
-func (s *Scrubber) GenerateFunctionSecretName(functionName, secretPrefix string) string {
-	secretName := fmt.Sprintf("%s%s", secretPrefix, functionName)
+func (s *Scrubber) GenerateFunctionSecretName(functionName, projectName string, flexVolumeSecret bool) string {
+	secretPrefix := NuclioSecretNamePrefix
+	if flexVolumeSecret {
+		secretPrefix = NuclioFlexVolumeSecretNamePrefix
+	}
+	secretName := fmt.Sprintf("%s-%s-%s", secretPrefix, projectName, functionName)
 	if len(secretName) > common.KubernetesDomainLevelMaxLength {
 		secretName = secretName[:common.KubernetesDomainLevelMaxLength]
 	}

--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -220,7 +220,7 @@ func (d *Deployer) createOrUpdateFunctionSecret(ctx context.Context,
 
 	secretConfig := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: d.scrubber.GenerateFunctionSecretName(name, functionconfig.NuclioSecretNamePrefix),
+			Name: d.scrubber.GenerateFunctionSecretName(name, projectName, false),
 			Labels: map[string]string{
 				common.NuclioResourceLabelKeyFunctionName: name,
 				common.NuclioResourceLabelKeyProjectName:  projectName,
@@ -307,7 +307,8 @@ func (d *Deployer) createOrUpdateFlexVolumeSecret(ctx context.Context,
 
 	// create secret name with unique suffix
 	flexVolumeSecretName := d.scrubber.GenerateFunctionSecretName(fmt.Sprintf("%s-%s", functionName, xid.New().String()),
-		functionconfig.NuclioFlexVolumeSecretNamePrefix)
+		projectName,
+		true)
 
 	// check if a secret with the same access key reference already exists
 	existingFlexVolumeSecrets, err := d.consumer.KubeClientSet.CoreV1().Secrets(functionNamespace).List(ctx, metav1.ListOptions{

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2272,8 +2272,10 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(ctx context.Context,
 		Name: secretVolumeName,
 		VolumeSource: v1.VolumeSource{
 			Secret: &v1.SecretVolumeSource{
-				SecretName: scrubber.GenerateFunctionSecretName(function.Name, functionconfig.NuclioSecretNamePrefix),
-				Optional:   &trueVal,
+				SecretName: scrubber.GenerateFunctionSecretName(function.Name,
+					function.Labels[common.NuclioResourceLabelKeyProjectName],
+					false),
+				Optional: &trueVal,
 			},
 		},
 	}

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -1020,7 +1020,7 @@ func (suite *DeployFunctionTestSuite) TestRedeployFunctionWithScrubbedField() {
 	firstPassword := "1234"
 	secondPassword := "abcd"
 	passwordPath := "$ref:/spec/build/codeentryattributes/password"
-	secretName := scrubber.GenerateFunctionSecretName(functionName, functionconfig.NuclioSecretNamePrefix)
+	secretName := scrubber.GenerateFunctionSecretName(functionName, "default", false)
 
 	validateSecretPasswordFunc := func(password string) {
 		secret, err := suite.KubeClientSet.CoreV1().Secrets(suite.Namespace).Get(suite.Ctx, secretName, metav1.GetOptions{})


### PR DESCRIPTION
Functions in different projects can have the same name, so their secrets need to be different. 
We add the project name to the secret name, with the following format - `nuclio-secret-{project_name}-{func_name} `