### PR TITLE
Improve secret name generation

### DIFF
--- a/pkg/functionconfig/scrubber.go
+++ b/pkg/functionconfig/scrubber.go
@@ -231,7 +231,7 @@ func (s *Scrubber) DecodeSecretData(secretData map[string][]byte) (map[string]st
 }
 
 // GenerateFunctionSecretName generates a secret name for a function, in the form of:
-// `nuclio-secret-<project-name>-<function-name>`
+// `nuclio-secret-<project-name>-<function-name>-<unique-id>`
 func (s *Scrubber) GenerateFunctionSecretName(functionName, projectName string) string {
 	secretName := fmt.Sprintf("%s-%s-%s", NuclioSecretNamePrefix, projectName, functionName)
 	if len(secretName) > common.KubernetesDomainLevelMaxLength-8 {

--- a/pkg/functionconfig/scrubber_test.go
+++ b/pkg/functionconfig/scrubber_test.go
@@ -345,32 +345,6 @@ func (suite *ScrubberTestSuite) TestHasScrubbedConfig() {
 	}
 }
 
-// getSensitiveFieldsRegex returns a list of regexes for sensitive fields paths
-// this is implemented here to avoid a circular dependency between platformconfig and functionconfig
-func (suite *ScrubberTestSuite) getSensitiveFieldsPathsRegex() []*regexp.Regexp {
-	var regexpList []*regexp.Regexp
-	for _, sensitiveFieldPath := range []string{
-
-		// Path nested in a map
-		"^/Spec/Build/CodeEntryAttributes/password$",
-		"^/spec/build/codeentryattributes/password$",
-		"^/spec/build/codeentryattributes/s3secretaccesskey$",
-		"^/spec/build/codeentryattributes/s3sessiontoken$",
-		"^/spec/build/codeentryattributes/headers/authorization$",
-		"^/spec/build/codeentryattributes/headers/x-v3io-session-key$",
-		// Path nested in an array
-		"^/Spec/Volumes\\[\\d+\\]/Volume/VolumeSource/FlexVolume/Options/accesskey$",
-		"^/Spec/Volumes\\[\\d+\\]/Volume/FlexVolume/Options/accesskey$",
-		// Path for any map element
-		"^/Spec/Triggers/.+/Password$",
-		// Nested path in any map element
-		"^/Spec/Triggers/.+/Attributes/password$",
-	} {
-		regexpList = append(regexpList, regexp.MustCompile("(?i)"+sensitiveFieldPath))
-	}
-	return regexpList
-}
-
 func (suite *ScrubberTestSuite) TestGenerateFunctionSecretName() {
 
 	for _, testCase := range []struct {
@@ -450,6 +424,32 @@ func (suite *ScrubberTestSuite) TestGenerateFlexVolumeSecretName() {
 			suite.Require().Equal(expectedSecretName, secretName)
 		})
 	}
+}
+
+// getSensitiveFieldsRegex returns a list of regexes for sensitive fields paths
+// this is implemented here to avoid a circular dependency between platformconfig and functionconfig
+func (suite *ScrubberTestSuite) getSensitiveFieldsPathsRegex() []*regexp.Regexp {
+	var regexpList []*regexp.Regexp
+	for _, sensitiveFieldPath := range []string{
+
+		// Path nested in a map
+		"^/Spec/Build/CodeEntryAttributes/password$",
+		"^/spec/build/codeentryattributes/password$",
+		"^/spec/build/codeentryattributes/s3secretaccesskey$",
+		"^/spec/build/codeentryattributes/s3sessiontoken$",
+		"^/spec/build/codeentryattributes/headers/authorization$",
+		"^/spec/build/codeentryattributes/headers/x-v3io-session-key$",
+		// Path nested in an array
+		"^/Spec/Volumes\\[\\d+\\]/Volume/VolumeSource/FlexVolume/Options/accesskey$",
+		"^/Spec/Volumes\\[\\d+\\]/Volume/FlexVolume/Options/accesskey$",
+		// Path for any map element
+		"^/Spec/Triggers/.+/Password$",
+		// Nested path in any map element
+		"^/Spec/Triggers/.+/Attributes/password$",
+	} {
+		regexpList = append(regexpList, regexp.MustCompile("(?i)"+sensitiveFieldPath))
+	}
+	return regexpList
 }
 
 func TestScrubberTestSuite(t *testing.T) {

--- a/pkg/functionconfig/scrubber_test.go
+++ b/pkg/functionconfig/scrubber_test.go
@@ -369,7 +369,7 @@ func (suite *ScrubberTestSuite) TestGenerateFunctionSecretName() {
 			name:                 "LongFunctionName",
 			functionName:         "my-function-with-a-very-long-name-which-is-more-than-63-characters-long",
 			projectName:          "my-project",
-			expectedResultSuffix: "my-project-my-function-with-a-very-long-name-whic",
+			expectedResultSuffix: "my-project-my-function-with-a-very-long-name-whic", // nolint: misspell
 		},
 	} {
 		suite.Run(testCase.name, func() {

--- a/pkg/functionconfig/scrubber_test.go
+++ b/pkg/functionconfig/scrubber_test.go
@@ -369,7 +369,7 @@ func (suite *ScrubberTestSuite) TestGenerateFunctionSecretName() {
 			name:                 "LongFunctionName",
 			functionName:         "my-function-with-a-very-long-name-which-is-more-than-63-characters-long",
 			projectName:          "my-project",
-			expectedResultSuffix: "my-project-my-function-with-a-very-long-name-which",
+			expectedResultSuffix: "my-project-my-function-with-a-very-long-name-whic",
 		},
 	} {
 		suite.Run(testCase.name, func() {

--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
-	"github.com/rs/xid"
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -220,7 +219,7 @@ func (d *Deployer) createOrUpdateFunctionSecret(ctx context.Context,
 
 	secretConfig := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: d.scrubber.GenerateFunctionSecretName(name, projectName, false),
+			Name: d.scrubber.GenerateFunctionSecretName(name, projectName),
 			Labels: map[string]string{
 				common.NuclioResourceLabelKeyFunctionName: name,
 				common.NuclioResourceLabelKeyProjectName:  projectName,
@@ -306,9 +305,7 @@ func (d *Deployer) createOrUpdateFlexVolumeSecret(ctx context.Context,
 	}
 
 	// create secret name with unique suffix
-	flexVolumeSecretName := d.scrubber.GenerateFunctionSecretName(fmt.Sprintf("%s-%s", functionName, xid.New().String()),
-		projectName,
-		true)
+	flexVolumeSecretName := d.scrubber.GenerateFlexVolumeSecretName(functionName, projectName, volumeName)
 
 	// check if a secret with the same access key reference already exists
 	existingFlexVolumeSecrets, err := d.consumer.KubeClientSet.CoreV1().Secrets(functionNamespace).List(ctx, metav1.ListOptions{

--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -191,7 +191,7 @@ func (d *Deployer) ScrubFunctionConfig(ctx context.Context,
 		functionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName],
 		secretsMap)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to handle v3io fuse secret")
+		return nil, errors.Wrap(err, "Failed to create flex volume secrets")
 	}
 
 	// encode secrets map
@@ -207,14 +207,15 @@ func (d *Deployer) ScrubFunctionConfig(ctx context.Context,
 		functionConfig.Meta.Namespace,
 		functionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName])
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create function secret")
+		return nil, errors.Wrap(err, "Failed to create or update function secret")
 	}
 
+	// if the secret map is empty, secret name will be empty (no secret was created)
 	if secretName != "" {
 		createdSecrets = append(createdSecrets, secretName)
 	}
 
-	// delete stale secrets
+	// delete older function/volume secrets that are no longer needed
 	if err := d.deleteStaleSecrets(ctx, createdSecrets, functionConfig.Meta.Name, functionConfig.Meta.Namespace); err != nil {
 		return nil, errors.Wrap(err, "Failed to delete stale flex volume secrets")
 	}
@@ -257,6 +258,7 @@ func (d *Deployer) createOrUpdateFunctionSecret(ctx context.Context,
 		"Function has no sensitive data",
 		"functionName", name)
 
+	// no secret needs to be created, return empty secret name
 	return "", nil
 }
 

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2267,14 +2267,19 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(ctx context.Context,
 
 	// volume the function secret as optional
 	secretVolumeName := "function-secret"
-	scrubber := functionconfig.NewScrubber(nil, nil)
+	secretName, err := lc.getFunctionSecretName(ctx, function)
+	if err != nil {
+		lc.logger.WarnWithCtx(ctx,
+			"Failed to get function secret name",
+			"err", err.Error(),
+			"functionName", function.Name)
+	}
 	volumeNameToVolume[secretVolumeName] = v1.Volume{
 		Name: secretVolumeName,
 		VolumeSource: v1.VolumeSource{
 			Secret: &v1.SecretVolumeSource{
-				SecretName: scrubber.GenerateFunctionSecretName(function.Name,
-					function.Labels[common.NuclioResourceLabelKeyProjectName]),
-				Optional: &trueVal,
+				SecretName: secretName,
+				Optional:   &trueVal,
 			},
 		},
 	}
@@ -2305,28 +2310,55 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(ctx context.Context,
 	return volumes, volumeMounts, nil
 }
 
+// getFlexVolumeSecretName returns the secret name for a given flex volume
 func (lc *lazyClient) getFlexVolumeSecretName(ctx context.Context, function *nuclioio.NuclioFunction, volumeName string) (string, error) {
+	secrets, err := lc.getFunctionSecrets(ctx, function)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to get secrets")
+	}
 
-	// get the secret with the volume name label
+	for _, secret := range secrets {
+		if secret.Labels[common.NuclioResourceLabelKeyVolumeName] == volumeName {
+			return secret.Name, nil
+		}
+	}
+	return "", errors.New("No secret found for volume")
+}
+
+// getSecretName returns the function secret name
+func (lc *lazyClient) getFunctionSecretName(ctx context.Context, function *nuclioio.NuclioFunction) (string, error) {
+	secrets, err := lc.getFunctionSecrets(ctx, function)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to get secrets")
+	}
+
+	// find the function secret
+	for _, secret := range secrets {
+		if strings.HasPrefix(secret.Name, functionconfig.NuclioSecretNamePrefix) {
+			return secret.Name, nil
+		}
+	}
+
+	return "", errors.New("Failed to find function secret")
+}
+
+// getSecretName returns the secret name for either a function or a flex volume
+func (lc *lazyClient) getFunctionSecrets(ctx context.Context, function *nuclioio.NuclioFunction) ([]v1.Secret, error) {
+
+	// get the function secrets
 	secretList, err := lc.kubeClientSet.CoreV1().Secrets(function.Namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", common.NuclioResourceLabelKeyVolumeName, volumeName),
+		LabelSelector: fmt.Sprintf("%s=%s", common.NuclioResourceLabelKeyFunctionName, function.Name),
 	})
 	if err != nil {
-		return "", errors.Wrap(err, "Failed to list flex volume secrets")
+		return nil, errors.Wrap(err, "Failed to list function secrets")
 	}
 
 	// if there are no secrets with the label selector, return error
 	if len(secretList.Items) == 0 {
-		return "", errors.New("No flex volume secrets found")
+		return nil, errors.New("No function secrets found")
 	}
 
-	// if there is more than one secret with the label selector, return error
-	if len(secretList.Items) > 1 {
-		return "", errors.New("More than one flex volume secret found")
-	}
-
-	// return the secret name
-	return secretList.Items[0].Name, nil
+	return secretList.Items, nil
 }
 
 // deleteFunctionSecrets deletes the function's secrets

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2273,6 +2273,7 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(ctx context.Context,
 			"Failed to get function secret name",
 			"err", err.Error(),
 			"functionName", function.Name)
+		return nil, nil, errors.Wrap(err, "Failed to get function secret name")
 	}
 	volumeNameToVolume[secretVolumeName] = v1.Volume{
 		Name: secretVolumeName,

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2273,8 +2273,7 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(ctx context.Context,
 		VolumeSource: v1.VolumeSource{
 			Secret: &v1.SecretVolumeSource{
 				SecretName: scrubber.GenerateFunctionSecretName(function.Name,
-					function.Labels[common.NuclioResourceLabelKeyProjectName],
-					false),
+					function.Labels[common.NuclioResourceLabelKeyProjectName]),
 				Optional: &trueVal,
 			},
 		},

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -1020,14 +1020,16 @@ func (suite *DeployFunctionTestSuite) TestRedeployFunctionWithScrubbedField() {
 	firstPassword := "1234"
 	secondPassword := "abcd"
 	passwordPath := "$ref:/spec/build/codeentryattributes/password"
-	secretName := scrubber.GenerateFunctionSecretName(functionName, "default")
 
 	validateSecretPasswordFunc := func(password string) {
-		secret, err := suite.KubeClientSet.CoreV1().Secrets(suite.Namespace).Get(suite.Ctx, secretName, metav1.GetOptions{})
+
+		// get function secret
+		secrets, err := suite.Platform.GetFunctionSecrets(suite.Ctx, functionName, suite.Namespace)
 		suite.Require().NoError(err)
+		suite.Require().Len(secrets, 1)
 
 		// decode secret data
-		decodedContents, err := scrubber.DecodeSecretData(secret.Data)
+		decodedContents, err := scrubber.DecodeSecretData(secrets[0].Kubernetes.Data)
 		suite.Require().NoError(err)
 
 		// make sure first password is in secret

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -1020,7 +1020,7 @@ func (suite *DeployFunctionTestSuite) TestRedeployFunctionWithScrubbedField() {
 	firstPassword := "1234"
 	secondPassword := "abcd"
 	passwordPath := "$ref:/spec/build/codeentryattributes/password"
-	secretName := scrubber.GenerateFunctionSecretName(functionName, "default", false)
+	secretName := scrubber.GenerateFunctionSecretName(functionName, "default")
 
 	validateSecretPasswordFunc := func(password string) {
 		secret, err := suite.KubeClientSet.CoreV1().Secrets(suite.Namespace).Get(suite.Ctx, secretName, metav1.GetOptions{})


### PR DESCRIPTION
Using `XID` to generate random id for the volume secret name and then trimming it according to the k8s guidelines proved to be error-prone, as after the trimming the volume names weren't unique enough, and multiple volumes caused volume secrets to be overridden.

In this PR I improved the secret name generation as follows:

- For function secrets: the format is `nuclio-secret-<project-name>-<function-name>-<unique-id>`. 
If the name > 63 characters, it is trimmed from the right, keeping the unique id.

- For flex volume secrets: the format is `nuclio-flexvolume-<project-name>-<function-name>-<volume-name>-<unique-id>`. 
If the name > 63 characters, the pair `<project-name>-<function-name>` is removed.
If after the removal the name is still too long, trim it from the right, keeping the unique id, meaning: `nuclio-flexvolume-<volume-name>-<unique-id>`.

This changed lead to changing the way creating / updating secrets is done, and the way the lazy controller resolves the function secret name.

Fixes https://jira.iguazeng.com/browse/IG-21489