### PR TITLE
Project Sync - Filter invalid project labels

### DIFF
--- a/pkg/platform/abstract/project/external/leader/iguazio/synchronizer.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/synchronizer.go
@@ -19,6 +19,7 @@ package iguazio
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/errgroup"
@@ -204,10 +205,8 @@ func (c *Synchronizer) synchronizeProjectsFromLeader(ctx context.Context,
 		projectInstance := projectInstance
 		createProjectErrGroup.Go("create projects", func() error {
 
-			// TODO: drop invalid project labels or replace invalid characters that fail with:
-			//   a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.',
-			//   and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345',
-			//   regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
+			// filter out labels that are not allowed by kubernetes
+			projectInstance.Meta.Labels = c.filterInvalidLabels(projectInstance.Meta.Labels)
 
 			c.logger.DebugWithCtx(ctx, "Creating project from leader sync", "projectInstance", *projectInstance)
 			createProjectConfig := &platform.CreateProjectOptions{
@@ -272,4 +271,20 @@ func (c *Synchronizer) synchronizeProjectsFromLeader(ctx context.Context,
 // a helper function - generates unique key to be used by projects maps
 func (c *Synchronizer) generateUniqueProjectKey(configInstance *platform.ProjectConfig) string {
 	return fmt.Sprintf("%s:%s", configInstance.Meta.Namespace, configInstance.Meta.Name)
+}
+
+func (c *Synchronizer) filterInvalidLabels(labels map[string]string) map[string]string {
+
+	// From k8s docs:
+	//   a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.',
+	//   and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345',
+	//   regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
+	regex := regexp.MustCompile(`^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$`)
+	filteredLabels := map[string]string{}
+	for key, value := range labels {
+		if regex.MatchString(key) {
+			filteredLabels[key] = value
+		}
+	}
+	return filteredLabels
 }


### PR DESCRIPTION
When syncing projects from leader, filter out labels that are not allowed in kubernetes so project creation won't fail.

From k8s docs:
> a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.',
and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345',
regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')


Also fixed some unit test mocks following https://github.com/nuclio/nuclio/pull/2792