### PR TITLE
API - backwards compatbility fix

### DIFF
--- a/pkg/dashboard/resource/invocation.go
+++ b/pkg/dashboard/resource/invocation.go
@@ -43,7 +43,7 @@ func (tr *invocationResource) ExtendMiddlewares() error {
 	return nil
 }
 
-// called after initialization
+// OnAfterInitialize is called after initialization
 func (tr *invocationResource) OnAfterInitialize() error {
 
 	// all methods
@@ -66,6 +66,9 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 	path := request.Header.Get("x-nuclio-path")
 	functionName := request.Header.Get("x-nuclio-function-name")
 	invokeURL := request.Header.Get("x-nuclio-invoke-url")
+
+	// for API backwards compatibility
+	invokeVia := request.Header.Get("x-nuclio-invoke-via")
 
 	// get namespace from request or use the provided default
 	functionNamespace := tr.getNamespaceOrDefault(request.Header.Get("x-nuclio-function-namespace"))
@@ -102,6 +105,7 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 		Body:      requestBody,
 		URL:       invokeURL,
 		Timeout:   invokeTimeout,
+		Via:       invokeVia,
 
 		// auth & permissions
 		AuthSession: tr.getCtxSession(ctx),

--- a/pkg/platform/abstract/invoker.go
+++ b/pkg/platform/abstract/invoker.go
@@ -56,6 +56,16 @@ func (i *invoker) invoke(ctx context.Context,
 		}
 	}
 
+	// for API backwards compatibility - enrich url in case it's not given
+	if createFunctionInvocationOptions.Via != "" && // nolint: staticcheck
+		createFunctionInvocationOptions.URL == "" {
+		invocationURL := createFunctionInvocationOptions.FunctionInstance.GetStatus().InvocationURLs()[0]
+		i.logger.DebugWithCtx(ctx,
+			"Using default invocation URL",
+			"url", invocationURL)
+		createFunctionInvocationOptions.URL = invocationURL
+	}
+
 	invokeURL, err := i.resolveInvokeURL(ctx, createFunctionInvocationOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to resolve invocation url")

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -130,6 +130,10 @@ type CreateFunctionInvocationOptions struct {
 	Timeout      time.Duration
 	URL          string
 
+	// Deprecated: Use URL instead.
+	// Remaining for backwards compatibility, if not empty, url will be enriched and used.
+	Via string
+
 	PermissionOptions opa.PermissionOptions
 	AuthSession       auth.Session
 


### PR DESCRIPTION
Following up https://github.com/nuclio/nuclio/pull/2796 which eliminated the invokeVia from most places we observed that a non backwards compatibility solution was provided, thus this pr provides a fallback for function invocation where, for older api clients, invoking the function will use an invocation url from functions status, as long as none was explicitly provided.