### PR TITLE
[Invoke] Default to internal address for better backwards compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -538,7 +538,7 @@ lint: modules ensure-test-files-annotated
 		&& chmod +x $(GOPATH)/bin/impi)
 
 	@test -e $(GOPATH)/bin/golangci-lint || \
-	  	(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.50.0)
+	  	(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.50.1)
 
 	@echo Verifying imports...
 	$(GOPATH)/bin/impi \

--- a/pkg/dashboard/resource/invocation.go
+++ b/pkg/dashboard/resource/invocation.go
@@ -67,9 +67,6 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 	functionName := request.Header.Get("x-nuclio-function-name")
 	invokeURL := request.Header.Get("x-nuclio-invoke-url")
 
-	// for API backwards compatibility
-	invokeVia := request.Header.Get("x-nuclio-invoke-via")
-
 	// get namespace from request or use the provided default
 	functionNamespace := tr.getNamespaceOrDefault(request.Header.Get("x-nuclio-function-namespace"))
 
@@ -105,7 +102,6 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 		Body:      requestBody,
 		URL:       invokeURL,
 		Timeout:   invokeTimeout,
-		Via:       invokeVia,
 
 		// auth & permissions
 		AuthSession: tr.getCtxSession(ctx),

--- a/pkg/platform/abstract/invoker.go
+++ b/pkg/platform/abstract/invoker.go
@@ -57,8 +57,8 @@ func (i *invoker) invoke(ctx context.Context,
 	}
 
 	// for API backwards compatibility - enrich url in case it's not given
-	if createFunctionInvocationOptions.Via != "" && // nolint: staticcheck
-		createFunctionInvocationOptions.URL == "" {
+	if createFunctionInvocationOptions.URL == "" &&
+		len(createFunctionInvocationOptions.FunctionInstance.GetStatus().InvocationURLs()) > 0 {
 		invocationURL := createFunctionInvocationOptions.FunctionInstance.GetStatus().InvocationURLs()[0]
 		i.logger.DebugWithCtx(ctx,
 			"Using default invocation URL",

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -130,10 +130,6 @@ type CreateFunctionInvocationOptions struct {
 	Timeout      time.Duration
 	URL          string
 
-	// Deprecated: Use URL instead.
-	// Remaining for backwards compatibility, if not empty, url will be enriched and used.
-	Via string
-
 	PermissionOptions opa.PermissionOptions
 	AuthSession       auth.Session
 


### PR DESCRIPTION
cover cases where deprecated `invoke-via` was not given at all along without providing `url`