### PR TITLE
[PlatformConfig + FrontendSpec] Add auto scale metrics mode

### DIFF
--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -247,6 +247,7 @@ func (fsr *frontendSpecResource) resolveValidFunctionPriorityClassNames() []stri
 func (fsr *frontendSpecResource) resolveAutoScaleMetrics(inactivityWindowPresets []string) map[string]interface{} {
 	var supportedAutoScaleMetrics []functionconfig.AutoScaleMetric
 	windowSizePresets := inactivityWindowPresets
+	customMetricsEnabled := false
 	if dashboardServer, ok := fsr.resource.GetServer().(*dashboard.Server); ok {
 		supportedAutoScaleMetrics = dashboardServer.GetPlatformConfiguration().SupportedAutoScaleMetrics
 		if len(supportedAutoScaleMetrics) == 0 {
@@ -255,11 +256,14 @@ func (fsr *frontendSpecResource) resolveAutoScaleMetrics(inactivityWindowPresets
 		if len(windowSizePresets) == 0 {
 			windowSizePresets = dashboardServer.GetPlatformConfiguration().GetDefaultWindowSizePresets()
 		}
+		autoScaleMetricsMode := dashboardServer.GetPlatformConfiguration().AutoScaleMetricsMode
+		customMetricsEnabled = autoScaleMetricsMode == platformconfig.AutoScaleMetricsModeCustom
 	}
 
 	return map[string]interface{}{
-		"metricPresets":     supportedAutoScaleMetrics,
-		"windowSizePresets": windowSizePresets,
+		"customMetricsEnabled": customMetricsEnabled,
+		"metricPresets":        supportedAutoScaleMetrics,
+		"windowSizePresets":    windowSizePresets,
 	}
 }
 

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -3488,6 +3488,7 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
 		"basicAuth"
 	],
 	"autoScaleMetrics": {
+        "customMetricsEnabled": false,
 		"metricPresets": [
 			{
 				"metricName": "cpu",

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2426,12 +2426,18 @@ func (lc *lazyClient) deleteFunctionEvents(ctx context.Context, functionName str
 
 func (lc *lazyClient) GetFunctionMetricSpecs(function *nuclioio.NuclioFunction) ([]autosv2.MetricSpec, error) {
 
-	metricSpecs, err := lc.resolveMetricSpecs(function)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to resolve metric specs")
-	}
-	if len(metricSpecs) > 0 {
-		return metricSpecs, nil
+	var metricSpecs []autosv2.MetricSpec
+
+	if lc.platformConfigurationProvider.GetPlatformConfiguration().AutoScaleMetricsMode ==
+		platformconfig.AutoScaleMetricsModeCustom {
+
+		metricSpecs, err := lc.resolveMetricSpecs(function)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to resolve metric specs")
+		}
+		if len(metricSpecs) > 0 {
+			return metricSpecs, nil
+		}
 	}
 
 	// for backwards compatibility, if no custom metrics are specified, use targetCPU and default metric

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -44,6 +44,7 @@ type Config struct {
 	ScaleToZero               ScaleToZero                      `json:"scaleToZero,omitempty"`
 	AutoScale                 AutoScale                        `json:"autoScale,omitempty"`
 	SupportedAutoScaleMetrics []functionconfig.AutoScaleMetric `json:"supportedAutoScaleMetrics,omitempty"`
+	AutoScaleMetricsMode      AutoScaleMetricsMode             `json:"autoScaleMetricsMode,omitempty"`
 	CronTriggerCreationMode   CronTriggerCreationMode          `json:"cronTriggerCreationMode,omitempty"`
 	FunctionAugmentedConfigs  []LabelSelectorAndConfig         `json:"functionAugmentedConfigs,omitempty"`
 	FunctionReadinessTimeout  *string                          `json:"functionReadinessTimeout,omitempty"`
@@ -124,6 +125,11 @@ func NewPlatformConfig(configurationPath string) (*Config, error) {
 
 	if config.ScaleToZero.MultiTargetStrategy == "" {
 		config.ScaleToZero.MultiTargetStrategy = scalertypes.MultiTargetStrategyRandom
+	}
+
+	// fall back to legacy default
+	if !AutoScaleMetricsModeIsValid(config.AutoScaleMetricsMode) {
+		config.AutoScaleMetricsMode = AutoScaleMetricsModeLegacy
 	}
 
 	if config.StreamMonitoring.WebapiURL == "" {

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -105,6 +105,29 @@ const (
 	DisabledScaleToZeroMode ScaleToZeroMode = "disabled"
 )
 
+type AutoScaleMetricsMode string
+
+const (
+
+	// AutoScaleMetricsModeLegacy is the legacy mode, where CPU usage is used for scaling
+	AutoScaleMetricsModeLegacy AutoScaleMetricsMode = "legacy"
+
+	// AutoScaleMetricsModeCustom uses custom metrics for scaling
+	AutoScaleMetricsModeCustom AutoScaleMetricsMode = "custom"
+)
+
+func AutoScaleMetricsModeIsValid(autoScaleMode AutoScaleMetricsMode) bool {
+	for _, mode := range []AutoScaleMetricsMode{
+		AutoScaleMetricsModeLegacy,
+		AutoScaleMetricsModeCustom,
+	} {
+		if autoScaleMode == mode {
+			return true
+		}
+	}
+	return false
+}
+
 type AutoScale struct {
 	MetricName  string `json:"metricName,omitempty"`
 	TargetValue string `json:"targetValue,omitempty"`


### PR DESCRIPTION
Add `AutoScaleMetricsMode` to the platform config, which supports 2 options:

- `legacy` - scale functions according to CPU usage only.
- `custom` - scale function according to user selected metrics.

Also, add a feature flag to the frontend spec specifying whether to show the custom scaling selection fields, or the previous `Target CPU` slider. 
Feature flag is `frontendSpec.autoScaleMetrics.customMetricsEnabled == true/false`.