### PR TITLE
[Secrets] Reuse secret names, delete secrets only on function deletion

### DIFF
--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -120,13 +120,6 @@ func NewProcessor(configurationPath string, platformConfigurationPath string) (*
 		return nil, errors.Wrap(err, "Failed to create logger")
 	}
 
-	// restore function configuration from secret
-	restoredFunctionConfig, err := newProcessor.restoreFunctionConfig(&processorConfiguration.Config)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to restore function configuration")
-	}
-	processorConfiguration.Config = *restoredFunctionConfig
-
 	// for now, use the same logger for both the processor and user handler
 	newProcessor.functionLogger = newProcessor.logger
 	newProcessor.logger.InfoWith("Starting processor", "version", version.Get())
@@ -135,6 +128,13 @@ func NewProcessor(configurationPath string, platformConfigurationPath string) (*
 
 	newProcessor.logger.DebugWith("Read configuration",
 		"config", string(indentedProcessorConfiguration))
+
+	// restore function configuration from secret
+	restoredFunctionConfig, err := newProcessor.restoreFunctionConfig(&processorConfiguration.Config)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to restore function configuration")
+	}
+	processorConfiguration.Config = *restoredFunctionConfig
 
 	// save platform configuration in process configuration
 	processorConfiguration.PlatformConfig = platformConfiguration

--- a/pkg/functionconfig/scrubber.go
+++ b/pkg/functionconfig/scrubber.go
@@ -38,7 +38,6 @@ import (
 const (
 	ReferencePrefix                  = "$ref:"
 	ReferenceToEnvVarPrefix          = "NUCLIO_B64_"
-	NuclioSecretNamePrefix           = "nuclio-secret"
 	NuclioFlexVolumeSecretNamePrefix = "nuclio-flexvolume"
 	SecretTypeFunctionConfig         = "nuclio.io/functionconfig"
 	SecretTypeV3ioFuse               = "v3io/fuse"
@@ -232,8 +231,8 @@ func (s *Scrubber) DecodeSecretData(secretData map[string][]byte) (map[string]st
 
 // GenerateFunctionSecretName generates a secret name for a function, in the form of:
 // `nuclio-secret-<project-name>-<function-name>-<unique-id>`
-func (s *Scrubber) GenerateFunctionSecretName(functionName, projectName string) string {
-	secretName := fmt.Sprintf("%s-%s-%s", NuclioSecretNamePrefix, projectName, functionName)
+func (s *Scrubber) GenerateFunctionSecretName(functionName string) string {
+	secretName := fmt.Sprintf("%s-%s", "nuclio", functionName)
 	if len(secretName) > common.KubernetesDomainLevelMaxLength-8 {
 		secretName = secretName[:common.KubernetesDomainLevelMaxLength-8]
 	}
@@ -249,8 +248,8 @@ func (s *Scrubber) GenerateFunctionSecretName(functionName, projectName string) 
 
 // GenerateFlexVolumeSecretName generates a secret name for a flex volume, in the form of:
 // `nuclio-flex-volume-<volume-name>-<unique-id>`
-func (s *Scrubber) GenerateFlexVolumeSecretName(functionName, projectName, volumeName string) string {
-	secretName := fmt.Sprintf("%s-%s-%s-%s", NuclioFlexVolumeSecretNamePrefix, projectName, functionName, volumeName)
+func (s *Scrubber) GenerateFlexVolumeSecretName(functionName, volumeName string) string {
+	secretName := fmt.Sprintf("%s-%s-%s", NuclioFlexVolumeSecretNamePrefix, functionName, volumeName)
 
 	// if the secret name is too long, drop the function and project name
 	if len(secretName) > common.KubernetesDomainLevelMaxLength {

--- a/pkg/functionconfig/scrubber_test.go
+++ b/pkg/functionconfig/scrubber_test.go
@@ -350,7 +350,6 @@ func (suite *ScrubberTestSuite) TestGenerateFunctionSecretName() {
 	for _, testCase := range []struct {
 		name                 string
 		functionName         string
-		projectName          string
 		volumeName           string
 		expectedResultPrefix string
 	}{
@@ -358,48 +357,41 @@ func (suite *ScrubberTestSuite) TestGenerateFunctionSecretName() {
 		{
 			name:                 "FunctionSecret-Sanity",
 			functionName:         "my-function",
-			projectName:          "my-project",
-			expectedResultPrefix: "nuclio-secret-my-project-my-function",
+			expectedResultPrefix: "nuclio-my-function",
 		},
 		{
 			name:                 "FunctionSecret-FunctionNameWithTrailingDashes",
 			functionName:         "my-function-_",
-			projectName:          "my-project",
-			expectedResultPrefix: "nuclio-secret-my-project-my-function",
+			expectedResultPrefix: "nuclio-my-function",
 		},
 		{
 			name:                 "FunctionSecret-LongFunctionName",
 			functionName:         "my-function-with-a-very-long-name-which-is-more-than-63-characters-long",
-			projectName:          "my-project",
-			expectedResultPrefix: "nuclio-secret-my-project-my-function-with-a-very-long-n", // nolint: misspell
+			expectedResultPrefix: "nuclio-my-function-with-a-very-long-name-which-is-more", // nolint: misspell
 		},
 
 		// Flex volume secret names
 		{
 			name:                 "VolumeSecret-Sanity",
 			functionName:         "my-function",
-			projectName:          "my-project",
 			volumeName:           "my-volume",
-			expectedResultPrefix: "nuclio-flexvolume-my-project-my-function-my-volume",
+			expectedResultPrefix: "nuclio-flexvolume-my-function-my-volume",
 		},
 		{
 			name:                 "VolumeSecret-VolumeNameWithTrailingDashes",
 			functionName:         "my-function",
-			projectName:          "my-project",
 			volumeName:           "my-volume----",
-			expectedResultPrefix: "nuclio-flexvolume-my-project-my-function-my-volume",
+			expectedResultPrefix: "nuclio-flexvolume-my-function-my-volume",
 		},
 		{
 			name:                 "VolumeSecret-LongFunctionName",
 			functionName:         "my-function-with-a-very-long-name-which-is-more-than-63-characters-long",
-			projectName:          "my-project",
 			volumeName:           "my-volume",
 			expectedResultPrefix: "nuclio-flexvolume-my-volume",
 		},
 		{
 			name:                 "VolumeSecret-LongVolumeName",
 			functionName:         "my-function",
-			projectName:          "my-project",
 			volumeName:           "my-volume-name-which-is-more-than-63-characters-long",
 			expectedResultPrefix: "nuclio-flexvolume-my-volume-name-which-is-more-than-63",
 		},
@@ -407,9 +399,9 @@ func (suite *ScrubberTestSuite) TestGenerateFunctionSecretName() {
 		suite.Run(testCase.name, func() {
 			var secretName string
 			if testCase.volumeName == "" {
-				secretName = suite.scrubber.GenerateFunctionSecretName(testCase.functionName, testCase.projectName)
+				secretName = suite.scrubber.GenerateFunctionSecretName(testCase.functionName)
 			} else {
-				secretName = suite.scrubber.GenerateFlexVolumeSecretName(testCase.functionName, testCase.projectName, testCase.volumeName)
+				secretName = suite.scrubber.GenerateFlexVolumeSecretName(testCase.functionName, testCase.volumeName)
 			}
 			suite.logger.DebugWith("Generated secret name", "secretName", secretName)
 			suite.Require().True(strings.HasPrefix(secretName, testCase.expectedResultPrefix))

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -163,7 +163,7 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 			functionconfig.FunctionStateScaledToZero,
 		}) {
 
-		// make sure this cycle isnt happening after a long run. we want to avoid another "create or update"
+		// make sure this cycle isn't happening after a long run. we want to avoid another "create or update"
 		// that happen as a side effect for updating the function status
 		if function.Status.ScaleToZero != nil &&
 			function.Status.ScaleToZero.LastScaleEventTime != nil &&

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -278,6 +278,9 @@ func (suite *lazyTestSuite) TestNoChanges() {
 				common.NuclioResourceLabelKeyProjectName:  function.Labels["nuclio.io/project-name"],
 				common.NuclioResourceLabelKeyVolumeName:   volumeName,
 			},
+			CreationTimestamp: metav1.Time{
+				Time: time.Now(),
+			},
 		},
 	}, metav1.CreateOptions{})
 	suite.Require().NoError(err)

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -847,7 +847,7 @@ func (suite *DeployFunctionTestSuite) TestFunctionSecretCreation() {
 
 		for _, secret := range secrets {
 			secret := secret.Kubernetes
-			if strings.HasPrefix(secret.Name, functionconfig.NuclioSecretNamePrefix) {
+			if !strings.HasPrefix(secret.Name, functionconfig.NuclioFlexVolumeSecretNamePrefix) {
 
 				// decode data from secret
 				decodedSecretData, err := scrubber.DecodeSecretData(secret.Data)
@@ -878,7 +878,7 @@ func (suite *DeployFunctionTestSuite) TestFunctionSecretCreation() {
 					"Got unknown secret",
 					"secretName", secret.Name,
 					"secretData", secret.Data)
-				suite.Failf("Got unknown secret. Secret name: %s\n", secret.Name)
+				suite.Failf("Got unknown secret", "Secret name: %s", secret.Name)
 			}
 
 		}
@@ -955,7 +955,7 @@ func (suite *DeployFunctionTestSuite) TestMultipleVolumeSecrets() {
 		for _, secret := range secrets {
 			kubeSecret := secret.Kubernetes
 			switch {
-			case strings.HasPrefix(kubeSecret.Name, functionconfig.NuclioSecretNamePrefix):
+			case !strings.HasPrefix(kubeSecret.Name, functionconfig.NuclioFlexVolumeSecretNamePrefix):
 				functionSecretCounter++
 
 				// decode data from secret
@@ -992,7 +992,7 @@ func (suite *DeployFunctionTestSuite) TestMultipleVolumeSecrets() {
 					"Got unknown secret",
 					"secretName", kubeSecret.Name,
 					"secretData", kubeSecret.Data)
-				suite.Failf("Got unknown secret. Secret name: %s\n", kubeSecret.Name)
+				suite.Failf("Got unknown secret.", "Secret name: %s", kubeSecret.Name)
 			}
 
 		}


### PR DESCRIPTION
A few fixes regarding function secrets:

- Re-use the function's existing secret when updating a function - Instead of creating a new secret for every redeployment, and possibly deleting secrets that are currently volumed to the running function, the existing secret will be updated on redeploy.
- Remove project name from secret name - a function name is unique in a namespace, and the project is specified in the annotations. 
- Do not delete stale secrets in dashboard - secrets will be deleted by the controller on function deletion.
- When the controller is volumizing the function / volume secret, use the most recently created secret.
- On processor startup - log function config before restoring.

This PR also fixes https://jira.iguazeng.com/browse/IG-21557