### PR TITLE
[nuctl] move nuctl executable to binary

### DIFF
--- a/docs/reference/nuctl/nuctl.md
+++ b/docs/reference/nuctl/nuctl.md
@@ -19,7 +19,7 @@
 
 To install `nuctl`, simply visit the Nuclio [releases page](https://github.com/nuclio/nuclio/releases) and download the appropriate CLI binary for your environment (for example, **nuctl-&lt;version&gt;-darwin-amd64** for a machine running macOS).
 
-You can use the following command to download the latest `nuctl` release:
+You can use the following script to download the latest `nuctl` release:
 ```sh
 mkdir -p $HOME/bin
 cd $HOME/bin

--- a/docs/reference/nuctl/nuctl.md
+++ b/docs/reference/nuctl/nuctl.md
@@ -21,11 +21,14 @@ To install `nuctl`, simply visit the Nuclio [releases page](https://github.com/n
 
 You can use the following command to download the latest `nuctl` release:
 ```sh
+mkdir -p $HOME/bin
+cd $HOME/bin
 curl -s https://api.github.com/repos/nuclio/nuclio/releases/latest \
 			| grep -i "browser_download_url.*nuctl.*$(uname)" \
 			| cut -d : -f 2,3 \
 			| tr -d \" \
 			| wget -O nuctl -qi - && chmod +x nuctl
+cd -
 ```
 
 <a id="usage"></a>


### PR DESCRIPTION
Small fix to make the rest of the guide work w/o further change.
We're cd'ing into a dir that's in env PATH by default, running our CURL there to make it accessible as an exec without ./ prefix and cd'ing back