### PR TITLE
[Platform] Support configurable default function invocation timeout

### DIFF
--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -480,6 +480,7 @@ platform: {}
 #     onbuildImageRegistries:
 #       "golang": "myregistry"
 #   functionReadinessTimeout: 120s
+#   functionInvocationTimeout: 60s
 #   opa:
 #
 #     # set to 10 for extra verbosity on top of nuclio logger

--- a/pkg/dashboard/resource/invocation.go
+++ b/pkg/dashboard/resource/invocation.go
@@ -144,7 +144,7 @@ func (tr *invocationResource) writeErrorMessage(responseWriter io.Writer, messag
 
 func (tr *invocationResource) resolveInvokeTimeout(invokeTimeout string) (time.Duration, error) {
 	if invokeTimeout == "" {
-		return platform.FunctionInvocationDefaultTimeout, nil
+		return tr.getPlatform().GetConfig().GetDefaultFunctionInvocationTimeout(), nil
 	}
 	parsedDuration, err := time.ParseDuration(invokeTimeout)
 	if err != nil {

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -734,6 +734,11 @@ func (suite *functionTestSuite) TestInvokeUnSuccessful() {
 		Return(&expectedInvokeResult, nuclio.NewErrBadRequest(errMessage)).
 		Once()
 
+	suite.mockPlatform.
+		On("GetConfig").
+		Return(&platformconfig.Config{}).
+		Once()
+
 	expectedStatusCode := http.StatusBadRequest
 	ecv := restful.NewErrorContainsVerifier(suite.logger, []string{errMessage})
 

--- a/pkg/nuctl/command/invoke.go
+++ b/pkg/nuctl/command/invoke.go
@@ -32,6 +32,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common"
 	nuctlcommon "github.com/nuclio/nuclio/pkg/nuctl/command/common"
 	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
 
 	"github.com/fatih/color"
 	"github.com/nuclio/errors"
@@ -168,7 +169,7 @@ func newInvokeCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *i
 	cmd.Flags().StringVarP(&commandeer.invokeVia, "via", "", "any", "Invoke the function via - \"any\": a load balancer or an external IP; \"loadbalancer\": a load balancer; \"external-ip\": an external IP")
 	cmd.Flags().StringVarP(&commandeer.createFunctionInvocationOptions.LogLevelName, "log-level", "l", "info", "Log level - \"none\", \"debug\", \"info\", \"warn\", or \"error\"")
 	cmd.Flags().StringVarP(&commandeer.externalIPAddresses, "external-ips", "", os.Getenv("NUCTL_EXTERNAL_IP_ADDRESSES"), "External IP addresses (comma-delimited) with which to invoke the function")
-	cmd.Flags().DurationVarP(&commandeer.timeout, "timeout", "t", platform.FunctionInvocationDefaultTimeout, "Invocation request timeout")
+	cmd.Flags().DurationVarP(&commandeer.timeout, "timeout", "t", platformconfig.DefaultFunctionInvocationTimeoutSeconds*time.Second, "Invocation request timeout")
 	commandeer.cmd = cmd
 
 	return commandeer

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -34,9 +34,9 @@ import (
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	nuctlcommon "github.com/nuclio/nuclio/pkg/nuctl/command/common"
-	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/kube"
 	"github.com/nuclio/nuclio/pkg/platform/kube/client"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/processor/build"
 
 	"github.com/ghodss/yaml"
@@ -250,7 +250,7 @@ func (suite *functionDeployTestSuite) TestInvokeWithTimeout() {
 		map[string]string{
 			"method":  "POST",
 			"via":     "external-ip",
-			"timeout": platform.FunctionInvocationDefaultTimeout.String(),
+			"timeout": (platformconfig.DefaultFunctionInvocationTimeoutSeconds * time.Second).String(),
 		},
 		false)
 	suite.Require().NoError(err)

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -31,7 +31,10 @@ import (
 	machinarymetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const DefaultFunctionReadinessTimeoutSeconds = 120
+const (
+	DefaultFunctionReadinessTimeoutSeconds  = 120
+	DefaultFunctionInvocationTimeoutSeconds = 60
+)
 
 type LoggerSinkKind string
 


### PR DESCRIPTION
When nuclio is used via third party application (e.g. CVAT), invoking functions does not always support adding custom headers such as `X-Nuclio-Invoke-Timeout`.

In this PR we enable changing the default function invocation timeout via the platform configuration, which can be set in the helm chart at `platform.functionInvocationTimeout` as a string, e.g `180s`.

Resolves #2814  