### PR TITLE
CI - fix workflow breakage

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -35,15 +35,6 @@ jobs:
     name: Function HTTP Load Benchmarking
     runs-on: ubuntu-latest
     steps:
-      - name: Dump github context
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-
-      - name: Dump runner context
-        run: echo "$RUNNER_CONTEXT"
-        env:
-          RUNNER_CONTEXT: ${{ toJson(runner) }}
 
       # checkout from development
       - uses: actions/checkout@v3
@@ -85,6 +76,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.8'
+
+      - uses: actions/setup-go@v3
+        with:
+          cache: true
 
       - name: Install vegeta
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,16 +38,6 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Dump github context
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-
-      - name: Dump runner context
-        run: echo "$RUNNER_CONTEXT"
-        env:
-          RUNNER_CONTEXT: ${{ toJson(runner) }}
-
       - uses: actions/checkout@v3
 
       - uses: actions/setup-go@v3
@@ -132,27 +122,10 @@ jobs:
     name: Build docker images
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-
-      - name: Dump runner context
-        run: echo "$RUNNER_CONTEXT"
-        env:
-          RUNNER_CONTEXT: ${{ toJson(runner) }}
-
-      - name: Dump github ref
-        run: echo "$GITHUB_REF"
-
       - uses: actions/checkout@v3
 
-      # since github-actions gives us 14G only, and fills it up with some garbage
-      # we will free up some space for us (~2GB)
       - name: Freeing up disk space
-        run: |
-          chmod +x "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
-          "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
+        run: "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
 
       - name: Extract git branch
         id: git_info

--- a/.github/workflows/long_ci.yaml
+++ b/.github/workflows/long_ci.yaml
@@ -38,22 +38,12 @@ jobs:
           fetch-depth: 0
           ref: refs/pull/${{ github.event.inputs.pr_number }}/merge
 
-      - name: Dump github context
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-
-      - name: Dump runner context
-        run: echo "$RUNNER_CONTEXT"
-        env:
-          RUNNER_CONTEXT: ${{ toJson(runner) }}
-
-      # since github-actions gives us 14G only, and fills it up with some garbage
-      # we will free up some space for us (~2GB)
       - name: Freeing up disk space
-        run: |
-          chmod +x "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
-          "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
+        run: "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
+
+      - uses: actions/setup-go@v3
+        with:
+          cache: true
 
       - name: Set labels
         uses: actions/github-script@v3

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -27,24 +27,14 @@ jobs:
     if: github.repository == 'nuclio/nuclio'
 
     steps:
-    - name: Dump github context
-      run: echo "$GITHUB_CONTEXT"
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-
-    - name: Dump runner context
-      run: echo "$RUNNER_CONTEXT"
-      env:
-        RUNNER_CONTEXT: ${{ toJson(runner) }}
-
     - uses: actions/checkout@v3
 
-    # since github-actions gives us 14G only, and fills it up with some garbage
-    # we will free up some space for us (~2GB)
     - name: Freeing up disk space
-      run: |
-        chmod +x "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
-        "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
+      run: "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
+
+    - uses: actions/setup-go@v3
+      with:
+        cache: true
 
     - name: Build
       run: make build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,24 +38,11 @@ jobs:
       matrix:
         arch: [ arm64, amd64 ]
     steps:
-    - name: Dump github context
-      run: echo "$GITHUB_CONTEXT"
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-
-    - name: Dump runner context
-      run: echo "$RUNNER_CONTEXT"
-      env:
-        RUNNER_CONTEXT: ${{ toJson(runner) }}
-
-    - name: Dump github ref
-      run: echo "$GITHUB_REF"
-
     - name: Extract ref info
       id: release_info
       run: |
-        echo ::set-output name=REF_BRANCH::${GITHUB_REF#refs/heads/}
-        echo ::set-output name=REF_TAG::${GITHUB_REF#refs/tags/}
+        echo "REF_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+        echo "REF_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
     - name: Set NUCLIO_LABEL to unstable
       if: github.event_name == 'push' && steps.release_info.outputs.REF_BRANCH == 'development'
@@ -66,6 +53,9 @@ jobs:
       if: github.event_name == 'release'
       run: |
         echo "NUCLIO_LABEL=${{ steps.release_info.outputs.REF_TAG }}" >> $GITHUB_ENV
+
+    - name: Freeing up disk space
+      run: "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
 
     - uses: actions/checkout@v3
 
@@ -84,13 +74,6 @@ jobs:
         export version_suffix=$(echo "${{ steps.git_info.outputs.branch }}" | grep -E "^[0-9]+\.[0-9]+\.x$" | tr -d '.')
         export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
         echo "name=tag::$(echo $unstable_tag)" >> $GITHUB_OUTPUT
-
-    # since github-actions gives us 14G only, and fills it up with some garbage
-    # we will free up some space for us (~2GB)
-    - name: Freeing up disk space
-      run: |
-        chmod +x "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
-        "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
 
     - uses: azure/docker-login@v1
       with:


### PR DESCRIPTION
Cleanup script was updated and removed `go` binary that was installed prior to that.
Update some of the CI steps and ensure running cleanup script *prior* to go installation so that it wont remove it.
