### PR TITLE
[FunctionConfig] Validate autoscaling is supported by trigger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -138,6 +138,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/samber/lo v1.37.0 // indirect
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
@@ -153,6 +154,7 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	golang.org/x/crypto v0.5.0 // indirect
+	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/image v0.5.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -533,6 +533,8 @@ github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/samber/lo v1.37.0 h1:XjVcB8g6tgUp8rsPsJ2CvhClfImrpL04YpQHXeHPhRw=
+github.com/samber/lo v1.37.0/go.mod h1:9vaz2O4o8oOnK23pd2TrXufcbdbJIa3b6cstBWKpopA=
 github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybLANtM3mBXNUtOfsCFXeTsnBqCsx1KM=
 github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sendgridlabs/go-kinesis v0.0.0-20190306160747-8de9069567f6 h1:DKamRgrd28Ll7sUN5RIEJ5POTxluIBStXYAHQaH6W04=
@@ -654,6 +656,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 h1:3MTrJm4PyNL9NBqvYDSj3DHl46qQakyfqfWo4jgfaEM=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -46,6 +46,7 @@ import (
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
+	"github.com/samber/lo"
 	autosv2 "k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1539,6 +1540,13 @@ func (ap *Platform) validateTriggers(functionConfig *functionconfig.Config) erro
 					functionconfig.ExplicitAckEnabled(triggerInstance.ExplicitAckMode) {
 					return nuclio.NewErrBadRequest("Explicit ack mode is not allowed when using worker pool allocation mode")
 				}
+			}
+		}
+
+		// validate trigger supports autoscaling
+		if lo.Contains[string]([]string{"v3io-stream", "v3ioStream"}, triggerInstance.Kind) {
+			if functionConfig.Spec.MinReplicas != functionConfig.Spec.MaxReplicas {
+				return nuclio.NewErrBadRequest("V3IO Stream trigger does not support autoscaling")
 			}
 		}
 	}

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1545,6 +1545,8 @@ func (ap *Platform) validateTriggers(functionConfig *functionconfig.Config) erro
 
 		// validate trigger supports autoscaling
 		if lo.Contains[string]([]string{"v3io-stream", "v3ioStream"}, triggerInstance.Kind) {
+
+			// V3IO stream trigger does not support autoscaling, so min and max replicas must be equal
 			if functionConfig.Spec.MinReplicas != functionConfig.Spec.MaxReplicas {
 				return nuclio.NewErrBadRequest("V3IO Stream trigger does not support autoscaling")
 			}

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -829,6 +829,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 	for idx, testCase := range []struct {
 		triggers                 map[string]functionconfig.Trigger
 		functionMetaAnnotations  map[string]string
+		supportAutoScale         bool
 		expectedEnrichedTriggers map[string]functionconfig.Trigger
 		shouldFailValidation     bool
 	}{
@@ -939,6 +940,16 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 			},
 			shouldFailValidation: false,
 		},
+		{
+			triggers: map[string]functionconfig.Trigger{
+				"v3ioStream": {
+					Kind: "v3ioStream",
+					Name: "v3ioStream",
+				},
+			},
+			supportAutoScale:     true,
+			shouldFailValidation: true,
+		},
 	} {
 
 		suite.mockedPlatform.On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
@@ -967,6 +978,12 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 
 		if testCase.functionMetaAnnotations != nil {
 			createFunctionOptions.FunctionConfig.Meta.Annotations = testCase.functionMetaAnnotations
+		}
+
+		if testCase.supportAutoScale {
+			one, five := 1, 5
+			createFunctionOptions.FunctionConfig.Spec.MinReplicas = &one
+			createFunctionOptions.FunctionConfig.Spec.MaxReplicas = &five
 		}
 
 		err := suite.Platform.EnrichFunctionConfig(suite.ctx, &createFunctionOptions.FunctionConfig)


### PR DESCRIPTION
V3io stream trigger doesn't support autoscaling.
If the function spec has `minReplicas != maxReplicas`, and a v3io-stream trigger - fail validation.

Fixes https://jira.iguazeng.com/browse/IG-21633