### PR TITLE
[FunctionConfig] Fix checking replica values instead of pointers

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1547,7 +1547,7 @@ func (ap *Platform) validateTriggers(functionConfig *functionconfig.Config) erro
 		if lo.Contains[string]([]string{"v3io-stream", "v3ioStream"}, triggerInstance.Kind) {
 
 			// V3IO stream trigger does not support autoscaling, so min and max replicas must be equal
-			if functionConfig.Spec.MinReplicas != functionConfig.Spec.MaxReplicas {
+			if *functionConfig.Spec.MinReplicas != *functionConfig.Spec.MaxReplicas {
 				return nuclio.NewErrBadRequest("V3IO Stream trigger does not support autoscaling")
 			}
 		}


### PR DESCRIPTION
When validating min/max replicas in v3io stream trigger, check the values instead of pointer addresses.

Fixes https://jira.iguazeng.com/browse/IG-21639 