### PR TITLE
[Trigger] Fix trigger initialization race condition

### DIFF
--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -350,6 +350,13 @@ func (p *Processor) createTriggers(processorConfiguration *processor.Configurati
 	lock := sync.Mutex{}
 
 	platformKind := processorConfiguration.PlatformConfig.Kind
+	if processorConfiguration.Meta.Labels == nil {
+
+		// backwards compatibility, for function created before labels were introduced
+		processorConfiguration.Meta.Labels = map[string]string{
+			common.NuclioResourceLabelKeyProjectName: "",
+		}
+	}
 
 	for triggerName, triggerConfiguration := range processorConfiguration.Spec.Triggers {
 		triggerName, triggerConfiguration := triggerName, triggerConfiguration

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -122,14 +122,6 @@ func NewAbstractTrigger(logger logger.Logger,
 		configuration.WorkerAvailabilityTimeoutMilliseconds = &defaultWorkerAvailabilityTimeoutMilliseconds
 	}
 
-	if configuration.RuntimeConfiguration.Meta.Labels == nil {
-
-		// backwards compatibility
-		configuration.RuntimeConfiguration.Meta.Labels = map[string]string{
-			common.NuclioResourceLabelKeyProjectName: "",
-		}
-	}
-
 	return AbstractTrigger{
 		Logger:          logger,
 		ID:              configuration.ID,


### PR DESCRIPTION
Triggers are created in parallel, initializing the labels within each go routine would end up in a race condition. Fixed by moving the map initialization before go routine starts.