### PR TITLE
[Ingress] Set default TLS secret in iguazio systems [1.9.x]

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1910,10 +1910,9 @@ func (lc *lazyClient) populateIngressConfig(ctx context.Context,
 		function.Status.State != functionconfig.FunctionStateImported &&
 		function.GetComputedMinReplicas() == 0 &&
 		function.GetComputedMaxReplicas() > 0 {
-		platformConfiguration := lc.platformConfigurationProvider.GetPlatformConfiguration()
 
 		// enrich if not exists
-		for key, value := range platformConfiguration.ScaleToZero.HTTPTriggerIngressAnnotations {
+		for key, value := range platformConfig.ScaleToZero.HTTPTriggerIngressAnnotations {
 			if _, ok := meta.Annotations[key]; !ok {
 				meta.Annotations[key] = value
 			}
@@ -1929,12 +1928,21 @@ func (lc *lazyClient) populateIngressConfig(ctx context.Context,
 		}
 	}
 
+	if platformConfig.IngressConfig.EnableSSLRedirect {
+		meta.Annotations["nginx.ingress.kubernetes.io/ssl-redirect"] = "true"
+	}
+
 	// clear out existing so that we don't keep adding rules
 	spec.Rules = []networkingv1.IngressRule{}
 	spec.TLS = []networkingv1.IngressTLS{}
 
 	ingresses := functionconfig.GetFunctionIngresses(client.NuclioioToFunctionConfig(function))
 	for _, ingress := range ingresses {
+
+		if err := lc.enrichIngressWithDefaultValues(&ingress); err != nil {
+			return errors.Wrap(err, "Failed to enrich ingress with default values")
+		}
+
 		if err := lc.addIngressToSpec(ctx, &ingress, functionLabels, function, spec); err != nil {
 			return errors.Wrap(err, "Failed to add ingress to spec")
 		}
@@ -2483,6 +2491,19 @@ func (lc *lazyClient) isPodAutoScaledUp(ctx context.Context, pod v1.Pod) (bool, 
 		}
 	}
 	return false, nil
+}
+
+func (lc *lazyClient) enrichIngressWithDefaultValues(ingress *functionconfig.Ingress) error {
+
+	platformConfig := lc.platformConfigurationProvider.GetPlatformConfiguration()
+
+	// enrich with default ingress tls if exists
+	if ingress.TLS.SecretName == "" && platformConfig.IngressConfig.TLSSecret != "" {
+		ingress.TLS.Hosts = []string{ingress.Host}
+		ingress.TLS.SecretName = platformConfig.IngressConfig.TLSSecret
+	}
+
+	return nil
 }
 
 //

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -222,6 +222,7 @@ func (suite *lazyTestSuite) TestEnrichIngressWithDefaultAnnotations() {
 
 func (suite *lazyTestSuite) TestEnrichIngressWithDefaultTLSSecret() {
 	tlsSecretName := "my-secret"
+	hostName := "something.com"
 	suite.client.SetPlatformConfigurationProvider(&mockedPlatformConfigurationProvider{
 		platformConfiguration: &platformconfig.Config{
 			IngressConfig: platformconfig.IngressConfig{
@@ -235,7 +236,7 @@ func (suite *lazyTestSuite) TestEnrichIngressWithDefaultTLSSecret() {
 	defaultHTTPTrigger.Attributes = map[string]interface{}{
 		"ingresses": map[string]interface{}{
 			"0": map[string]interface{}{
-				"host":  "something.com",
+				"host":  hostName,
 				"paths": []string{"/"},
 			},
 		},
@@ -261,6 +262,7 @@ func (suite *lazyTestSuite) TestEnrichIngressWithDefaultTLSSecret() {
 	suite.Require().Equal(ingressInstance.Spec.TLS[0].SecretName, tlsSecretName)
 	suite.Require().Contains(ingressInstance.Annotations, sslRedirectAnnotation)
 	suite.Require().Equal("true", ingressInstance.Annotations[sslRedirectAnnotation])
+	suite.Require().Contains(ingressInstance.Spec.TLS[0].Hosts, hostName)
 }
 
 func (suite *lazyTestSuite) TestNoChanges() {

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -114,6 +114,14 @@ func NewPlatformConfig(configurationPath string) (*Config, error) {
 		config.ScaleToZero.MultiTargetStrategy = scalertypes.MultiTargetStrategyRandom
 	}
 
+	// if we're running on iguazio, set the default ingress config
+	if config.IngressConfig.IguazioAuthURL != "" {
+		if config.IngressConfig.TLSSecret == "" {
+			config.IngressConfig.TLSSecret = DefaultIguazioIngressTLSSecretName
+		}
+		config.IngressConfig.EnableSSLRedirect = true
+	}
+
 	if config.StreamMonitoring.WebapiURL == "" {
 		config.StreamMonitoring.WebapiURL = DefaultStreamMonitoringWebapiURL
 	}

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -218,6 +218,8 @@ type ImageRegistryOverridesConfig struct {
 	OnbuildImageRegistries map[string]string `json:"onbuildImageRegistries,omitempty"`
 }
 
+const DefaultIguazioIngressTLSSecretName = "ingress-tls"
+
 // IngressConfig holds the default values for created ingresses
 type IngressConfig struct {
 	EnableSSLRedirect          bool     `json:"enableSSLRedirect,omitempty"`

--- a/pkg/processor/build/runtime/shell/runtime.go
+++ b/pkg/processor/build/runtime/shell/runtime.go
@@ -60,7 +60,7 @@ func (s *shell) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, 
 	return &processorDockerfileInfo, nil
 }
 
-// GetProcessorImageObjectPaths returns the paths of all objects that should reside in the handler
+// GetHandlerDirObjectPaths returns the paths of all objects that should reside in the handler
 // directory
 func (s *shell) GetHandlerDirObjectPaths() []string {
 	if s.FunctionConfig.Spec.Build.Path != "/dev/null" {


### PR DESCRIPTION
In iguazio systems, the communication goes through secure connections, and each ingress has a tls secret.

In this PR, we enrich function ingresses with the iguazio system's tls secret, and enable nginx ssl redirection by default.