### PR TITLE
[Ingress] Set default TLS secret in iguazio systems [1.10.x]

### DIFF
--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -123,6 +123,14 @@ func NewPlatformConfig(configurationPath string) (*Config, error) {
 		config.ScaleToZero.MultiTargetStrategy = scalertypes.MultiTargetStrategyRandom
 	}
 
+	// if we're running on iguazio, set the default ingress config
+	if config.IngressConfig.IguazioAuthURL != "" {
+		if config.IngressConfig.TLSSecret == "" {
+			config.IngressConfig.TLSSecret = DefaultIguazioIngressTLSSecretName
+		}
+		config.IngressConfig.EnableSSLRedirect = true
+	}
+
 	if config.StreamMonitoring.WebapiURL == "" {
 		config.StreamMonitoring.WebapiURL = DefaultStreamMonitoringWebapiURL
 	}

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -223,6 +223,8 @@ type ImageRegistryOverridesConfig struct {
 	OnbuildImageRegistries map[string]string `json:"onbuildImageRegistries,omitempty"`
 }
 
+const DefaultIguazioIngressTLSSecretName = "ingress-tls"
+
 // IngressConfig holds the default values for created ingresses
 type IngressConfig struct {
 	EnableSSLRedirect          bool     `json:"enableSSLRedirect,omitempty"`


### PR DESCRIPTION
In iguazio systems, the communication goes through secure connections, and each ingress has a tls secret.

In this PR, we enrich function ingresses with the iguazio system's tls secret, and enable nginx ssl redirection by default.