### PR TITLE
[Invoke] Add option to skip tls verification

### DIFF
--- a/cmd/dashboard/README.md
+++ b/cmd/dashboard/README.md
@@ -228,6 +228,7 @@ you `DELETE /api/function_invocations`, the HTTP method in the event as received
     * `x-nuclio-invoke-url`: Function invocation url to use (required)
     * `x-nuclio-path`: The path to invoke the function with (can be empty to invoke with `/`)
     * `x-nuclio-invoke-timeout`: Function invocation request timeout (e.g.: `1s`)
+    * `x-nuclio-skip-tls-verification`: Skip TLS verification when invoking the function (e.g.: `true`)
     * Any other header is passed transparently to the function
 * Body: Raw body passed as is to the function
 

--- a/pkg/dashboard/resource/invocation.go
+++ b/pkg/dashboard/resource/invocation.go
@@ -91,16 +91,19 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 		tr.writeErrorMessage(responseWriter, errors.RootCause(err).Error())
 	}
 
+	skipTLSVerification := strings.ToLower(request.Header.Get("x-nuclio-skip-tls-verification")) == "true"
+
 	// resolve the function host
 	invocationResult, err := tr.getPlatform().CreateFunctionInvocation(ctx, &platform.CreateFunctionInvocationOptions{
-		Name:      functionName,
-		Namespace: functionNamespace,
-		Path:      path,
-		Method:    request.Method,
-		Headers:   request.Header,
-		Body:      requestBody,
-		URL:       invokeURL,
-		Timeout:   invokeTimeout,
+		Name:                functionName,
+		Namespace:           functionNamespace,
+		Path:                path,
+		Method:              request.Method,
+		Headers:             request.Header,
+		Body:                requestBody,
+		URL:                 invokeURL,
+		Timeout:             invokeTimeout,
+		SkipTLSVerification: skipTLSVerification,
 
 		// auth & permissions
 		AuthSession: tr.getCtxSession(ctx),

--- a/pkg/nuctl/command/invoke.go
+++ b/pkg/nuctl/command/invoke.go
@@ -170,6 +170,7 @@ func newInvokeCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *i
 	cmd.Flags().StringVarP(&commandeer.createFunctionInvocationOptions.LogLevelName, "log-level", "l", "info", "Log level - \"none\", \"debug\", \"info\", \"warn\", or \"error\"")
 	cmd.Flags().StringVarP(&commandeer.externalIPAddresses, "external-ips", "", os.Getenv("NUCTL_EXTERNAL_IP_ADDRESSES"), "External IP addresses (comma-delimited) with which to invoke the function")
 	cmd.Flags().DurationVarP(&commandeer.timeout, "timeout", "t", platformconfig.DefaultFunctionInvocationTimeoutSeconds*time.Second, "Invocation request timeout")
+	cmd.Flags().BoolVarP(&commandeer.createFunctionInvocationOptions.SkipTLSVerification, "skip-tls", "", false, "Skip TLS verification")
 	commandeer.cmd = cmd
 
 	return commandeer

--- a/pkg/platform/abstract/invoker.go
+++ b/pkg/platform/abstract/invoker.go
@@ -19,6 +19,7 @@ package abstract
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -78,6 +79,14 @@ func (i *invoker) invoke(ctx context.Context,
 	client := &http.Client{
 		Timeout: createFunctionInvocationOptions.Timeout,
 	}
+
+	// if tls verification is disabled, skip verification
+	if createFunctionInvocationOptions.SkipTLSVerification {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	}
+
 	var req *http.Request
 	var body io.Reader = http.NoBody
 

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -139,6 +139,9 @@ type CreateFunctionInvocationOptions struct {
 	// used from nuctl, to avoid validating the input url, which might be overridden when
 	// user provides explicit external ip address
 	SkipURLValidation bool
+
+	// skip tls verification when invoking a function
+	SkipTLSVerification bool
 }
 
 func (c *CreateFunctionInvocationOptions) EnrichFunction(ctx context.Context, p Platform) error {


### PR DESCRIPTION
Support skipping tls verification when invoking a function via:

1. `/function_invocations` endpoint - send a request with the following header:
```
X-nuclio-skip-tls-verification: true
```
2. nuctl - add the `--skip-tls` flag to the `invoke` command.

followup to #2839