### PR TITLE
[Release] Only run release job on main fork

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,7 @@ permissions:
 
 jobs:
   release:
+    if: github.repository == 'nuclio/nuclio'
     name: Release ${{ matrix.arch }}
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
On forks some credentials might be missing and releases constantly fail.
Anyways, no need to release from forks at all.