### PR TITLE
[Kube] Initialize container image builder pusher only when needed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -240,6 +240,25 @@ jobs:
           # run test
           make test-k8s-nuctl
 
+      - name: Output some logs in case of failure
+        if: ${{ failure() }}
+        # add set -x to print commands before executing to make logs reading easier
+        run: |
+          set -x
+          minikube ip
+          minikube logs
+          minikube kubectl -- --namespace ${NAMESPACE} logs -l app=nuclio,release=nuclio --tail=-1
+          minikube kubectl -- --namespace ${NAMESPACE} get all
+          minikube kubectl -- --namespace ${NAMESPACE} get all -o yaml
+          minikube kubectl -- --namespace ${NAMESPACE} describe pods
+          minikube kubectl -- --namespace ${NAMESPACE} get cm
+          minikube kubectl -- --namespace ${NAMESPACE} get cm -o yaml
+          minikube kubectl -- --namespace ${NAMESPACE} get secrets
+          minikube kubectl -- --namespace ${NAMESPACE} get secrets -o yaml
+          minikube kubectl -- --namespace ${NAMESPACE} get pvc
+          minikube kubectl -- --namespace ${NAMESPACE} get pv
+          set +x
+
   test_docker_nuctl:
     name: Test Docker nuctl
     runs-on: ubuntu-latest

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -83,7 +83,7 @@ func (fsr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restfu
 	defaultHTTPIngressHostTemplate := fsr.getDefaultHTTPIngressHostTemplate()
 	validFunctionPriorityClassNames := fsr.resolveValidFunctionPriorityClassNames()
 	defaultFunctionPodResources := fsr.resolveDefaultFunctionPodResources()
-	AutoScaleMetrics := fsr.resolveAutoScaleMetrics(inactivityWindowPresets)
+	autoScaleMetrics := fsr.resolveAutoScaleMetrics(inactivityWindowPresets)
 
 	frontendSpec := map[string]restful.Attributes{
 		"frontendSpec": { // frontendSpec is the ID of this singleton resource
@@ -97,7 +97,7 @@ func (fsr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restfu
 			"allowedAuthenticationModes":      allowedAuthenticationModes,
 			"validFunctionPriorityClassNames": validFunctionPriorityClassNames,
 			"defaultFunctionPodResources":     defaultFunctionPodResources,
-			"autoScaleMetrics":                AutoScaleMetrics,
+			"autoScaleMetrics":                autoScaleMetrics,
 		},
 	}
 

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -116,6 +116,12 @@ func (ap *Platform) CreateFunctionBuild(ctx context.Context,
 	createFunctionBuildOptions *platform.CreateFunctionBuildOptions) (
 	*platform.CreateFunctionBuildResult, error) {
 
+	// ensure container builder is initialized (idempotent).
+	// it is called here as well for cases where this function was not called from the dashboard
+	if err := ap.platform.InitializeContainerBuilder(); err != nil {
+		return nil, errors.Wrap(err, "Failed to initialize container builder")
+	}
+
 	// execute a build
 	builder, err := build.NewBuilder(createFunctionBuildOptions.Logger, ap.platform, &common.AbstractS3Client{})
 	if err != nil {

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -955,6 +955,9 @@ func (ap *Platform) GetDefaultRegistryCredentialsSecretName() string {
 
 // GetContainerBuilderKind returns the container-builder kind
 func (ap *Platform) GetContainerBuilderKind() string {
+	if ap.ContainerBuilder == nil {
+		return ap.GetConfig().ContainerBuilderConfiguration.Kind
+	}
 	return ap.ContainerBuilder.GetKind()
 }
 

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -955,10 +955,10 @@ func (ap *Platform) GetDefaultRegistryCredentialsSecretName() string {
 
 // GetContainerBuilderKind returns the container-builder kind
 func (ap *Platform) GetContainerBuilderKind() string {
-	if ap.ContainerBuilder == nil {
-		return ap.GetConfig().ContainerBuilderConfiguration.Kind
+	if ap.ContainerBuilder != nil {
+		return ap.ContainerBuilder.GetKind()
 	}
-	return ap.ContainerBuilder.GetKind()
+	return ap.GetConfig().ContainerBuilderConfiguration.Kind
 }
 
 // GetRuntimeBuildArgs returns the runtime specific build arguments

--- a/pkg/platform/kube/controller/test/controller_test.go
+++ b/pkg/platform/kube/controller/test/controller_test.go
@@ -85,8 +85,12 @@ func (suite *ControllerTestSuite) buildTestFunction() *functionconfig.Config {
 	// create function options
 	createFunctionOptions := suite.CompileCreateFunctionOptions(fmt.Sprintf("test-%s", suite.TestID))
 
+	// ensure platform's container builder is initialized
+	err := suite.Platform.InitializeContainerBuilder()
+	suite.Require().NoError(err)
+
 	// enrich with defaults
-	err := suite.Platform.EnrichFunctionConfig(suite.KubeTestSuite.Ctx, &createFunctionOptions.FunctionConfig)
+	err = suite.Platform.EnrichFunctionConfig(suite.KubeTestSuite.Ctx, &createFunctionOptions.FunctionConfig)
 	suite.Require().NoError(err)
 
 	// build function

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1227,7 +1227,14 @@ func (p *Platform) ValidateFunctionConfig(ctx context.Context, functionConfig *f
 	return p.validateFunctionIngresses(ctx, functionConfig)
 }
 
+// InitializeContainerBuilder initializes the container builder, if not already initialized
 func (p *Platform) InitializeContainerBuilder() error {
+
+	// if container builder is already initialized, return
+	if p.ContainerBuilder != nil {
+		return nil
+	}
+
 	var err error
 
 	containerBuilderConfiguration := p.GetConfig().ContainerBuilderConfiguration

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -818,6 +818,10 @@ func (p *Platform) GetFunctionSecretData(ctx context.Context, functionName, func
 	return nil, nil
 }
 
+func (p *Platform) InitializeContainerBuilder() error {
+	return nil
+}
+
 func (p *Platform) deployFunction(createFunctionOptions *platform.CreateFunctionOptions,
 	previousHTTPPort int) (*platform.CreateFunctionResult, error) {
 

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -295,6 +295,10 @@ func (mp *Platform) GetDefaultInvokeIPAddresses() ([]string, error) {
 	return args.Get(0).([]string), args.Error(1)
 }
 
+func (mp *Platform) InitializeContainerBuilder() error {
+	return nil
+}
+
 func (mp *Platform) BuildAndPushContainerImage(ctx context.Context, buildOptions *containerimagebuilderpusher.BuildOptions) error {
 	return nil
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -177,7 +177,7 @@ type Platform interface {
 	// GetName returns the platform name
 	GetName() string
 
-	// InitializeContainerBuilder initializes the container builder
+	// InitializeContainerBuilder initializes the container builder, if not already initialized
 	InitializeContainerBuilder() error
 
 	// BuildAndPushContainerImage builds container image and pushes it into container registry

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -177,6 +177,9 @@ type Platform interface {
 	// GetName returns the platform name
 	GetName() string
 
+	// InitializeContainerBuilder initializes the container builder
+	InitializeContainerBuilder() error
+
 	// BuildAndPushContainerImage builds container image and pushes it into container registry
 	BuildAndPushContainerImage(ctx context.Context, buildOptions *containerimagebuilderpusher.BuildOptions) error
 


### PR DESCRIPTION
In a kube platform, the container builder is only needed when creating a new function.
Initializing it only when needed allows other operations to run with a platform without it.

This resolves issues that occur when nuctl, for example, wants to perform operations without docker being installed on the system.

In docker platform it is still initialized when creating a new platform, as docker is needed anyways to perform all operations.

Resolves https://github.com/nuclio/nuclio/issues/2854