### PR TITLE
[Local] Support providing function cpu and memory

### DIFF
--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -166,12 +166,22 @@ spec:
       - apk --update --no-cache add curl
       - pip install simplejson
   resources:
+
+    # Kubernetes Limits & Requests for the function's CPU and memory usage.
+    # For more information, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    # Leave empty to use the default values.
+    # Note: This is mostly relevant for Kubernetes platform only.
+    # For local platform (Docker), only the `limits` section is relevant.
+    #   When nvidia gpu limit is set, the function will be deployed with "--gpus all"
+    #   When cpu limit set, the function will be deployed with "--cpus <cpu limit>"
+    #   When memory limit set, the function will be deployed with "--memory <memory limit>"
     requests:
       cpu: 1
       memory: 128M
     limits:
       cpu: 2
       memory: 256M
+      nvidia.com/gpu: 1
   securityContext:
     runAsUser: 1000
     runAsGroup: 2000

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -243,6 +243,14 @@ func (c *ShellClient) RunContainer(imageName string, runOptions *RunOptions) (st
 		dockerArguments = append(dockerArguments, fmt.Sprintf("--gpus %s", runOptions.GPUs))
 	}
 
+	if runOptions.Memory != "" {
+		dockerArguments = append(dockerArguments, fmt.Sprintf("--memory %s", runOptions.Memory))
+	}
+
+	if runOptions.CPUs != "" {
+		dockerArguments = append(dockerArguments, fmt.Sprintf("--cpus %s", runOptions.CPUs))
+	}
+
 	if runOptions.Remove {
 		dockerArguments = append(dockerArguments, "--rm")
 	}

--- a/pkg/dockerclient/types.go
+++ b/pkg/dockerclient/types.go
@@ -65,6 +65,8 @@ type RunOptions struct {
 	Network          string
 	RestartPolicy    *RestartPolicy
 	GPUs             string
+	CPUs             string
+	Memory           string
 	MountPoints      []MountPoint
 	RunAsUser        *int64
 	RunAsGroup       *int64
@@ -87,7 +89,7 @@ type GetContainerOptions struct {
 	ID      string
 }
 
-// ContainerJSONBase contains response of Engine API:
+// Container contains response of Engine API:
 // GET "/containers/{name:.*}/json"
 type Container struct {
 	ID              string `json:"Id"`

--- a/pkg/platform/local/platform_test.go
+++ b/pkg/platform/local/platform_test.go
@@ -20,14 +20,12 @@ package local
 
 import (
 	"context"
-	"github.com/nuclio/nuclio/pkg/cmdrunner"
-	"github.com/nuclio/nuclio/pkg/dockerclient"
-	"github.com/nuclio/nuclio/pkg/functionconfig"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"testing"
 
+	"github.com/nuclio/nuclio/pkg/cmdrunner"
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/dockerclient"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform/abstract"
 	mockplatform "github.com/nuclio/nuclio/pkg/platform/mock"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
@@ -35,6 +33,8 @@ import (
 	"github.com/nuclio/logger"
 	"github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 type localPlatformTestSuite struct {

--- a/pkg/platform/local/platform_test.go
+++ b/pkg/platform/local/platform_test.go
@@ -1,0 +1,171 @@
+//go:build test_unit
+
+/*
+Copyright 2017 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local
+
+import (
+	"context"
+	"github.com/nuclio/nuclio/pkg/cmdrunner"
+	"github.com/nuclio/nuclio/pkg/dockerclient"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/platform/abstract"
+	mockplatform "github.com/nuclio/nuclio/pkg/platform/mock"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type localPlatformTestSuite struct {
+	suite.Suite
+	abstractPlatform *abstract.Platform
+	logger           logger.Logger
+	mockedPlatform   *mockplatform.Platform
+	cmdRunner        *cmdrunner.MockRunner
+	dockerClient     *dockerclient.MockDockerClient
+	platform         *Platform
+	ctx              context.Context
+}
+
+func (suite *localPlatformTestSuite) SetupSuite() {
+	var err error
+	common.SetVersionFromEnv()
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err, "Logger should create successfully")
+	suite.ctx = context.Background()
+}
+
+func (suite *localPlatformTestSuite) SetupTest() {
+	var err error
+	platformConfig := &platformconfig.Config{}
+	suite.mockedPlatform = &mockplatform.Platform{}
+	abstractPlatform, err := abstract.NewPlatform(suite.logger, suite.mockedPlatform, platformConfig, "")
+	suite.Require().NoError(err, "Could not create platform")
+
+	suite.abstractPlatform = abstractPlatform
+	suite.cmdRunner = cmdrunner.NewMockRunner()
+	suite.dockerClient = dockerclient.NewMockDockerClient()
+	suite.platform, err = NewPlatform(suite.ctx, suite.logger, platformConfig, "")
+	suite.Require().NoError(err, "Could not create platform")
+	suite.platform.cmdRunner = suite.cmdRunner
+	suite.platform.dockerClient = suite.dockerClient
+}
+
+func (suite *localPlatformTestSuite) TearDownTest() {
+	suite.cmdRunner.AssertExpectations(suite.T())
+	suite.dockerClient.AssertExpectations(suite.T())
+}
+
+func (suite *localPlatformTestSuite) TestResolveFunctionSpecRequestCPUs() {
+	for _, testCase := range []struct {
+		name         string
+		cpus         string
+		expectedCPUs string
+	}{
+		{
+			name:         "CPU - empty",
+			cpus:         "",
+			expectedCPUs: "",
+		},
+		{
+			name:         "CPU - integer",
+			cpus:         "1",
+			expectedCPUs: "1.0",
+		},
+		{
+			name:         "CPU - float",
+			cpus:         "1.5",
+			expectedCPUs: "1.5",
+		},
+		{
+			name:         "CPU - float 2",
+			cpus:         ".5",
+			expectedCPUs: "0.5",
+		},
+		{
+			// support up to 5 digits after the decimal point
+			name:         "CPU - float 3",
+			cpus:         "3.14159265",
+			expectedCPUs: "3.141593",
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			resourceLimits := v1.ResourceList{}
+			if testCase.cpus != "" {
+				quantity, err := resource.ParseQuantity(testCase.cpus)
+				suite.Require().NoError(err, "Could not parse quantity")
+				resourceLimits[v1.ResourceCPU] = quantity
+			}
+			cpus := suite.platform.resolveFunctionSpecRequestCPUs(functionconfig.Spec{
+				Resources: v1.ResourceRequirements{
+					Limits: resourceLimits,
+				},
+			})
+			suite.Require().Equal(testCase.expectedCPUs, cpus)
+		})
+	}
+}
+
+func (suite *localPlatformTestSuite) TestResolveFunctionSpecRequestMemory() {
+	for _, testCase := range []struct {
+		name           string
+		memory         string
+		expectedMemory string
+	}{
+		{
+			name:           "Memory - empty",
+			memory:         "",
+			expectedMemory: "",
+		},
+		{
+			name:           "Memory - 1Gi",
+			memory:         "1Gi",
+			expectedMemory: "1073741824b",
+		},
+		{
+			name:           "Memory - 1G",
+			memory:         "1G",
+			expectedMemory: "1000000000b",
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			resourceLimits := v1.ResourceList{}
+			if testCase.memory != "" {
+				quantity, err := resource.ParseQuantity(testCase.memory)
+				suite.Require().NoError(err, "Could not parse quantity")
+				resourceLimits[v1.ResourceMemory] = quantity
+			}
+			cpus := suite.platform.resolveFunctionSpecRequestMemory(functionconfig.Spec{
+				Resources: v1.ResourceRequirements{
+					Limits: resourceLimits,
+				},
+			})
+			suite.Require().Equal(testCase.expectedMemory, cpus)
+		})
+	}
+}
+
+func TestKubePlatformTestSuite(t *testing.T) {
+	suite.Run(t, new(localPlatformTestSuite))
+}


### PR DESCRIPTION
Idea is to support local platform functions memory and cpu resource management.  We do support that for kubernetes, using kubernetes sdk, we will use it and translate the "kubernetes" resource unit sizes and provide it as docker-compatible unit sizes for both cpu and memory.


