### PR TITLE
[RabbitMQ] Use prefetch from configuration

### DIFF
--- a/docs/reference/triggers/rabbitmq.md
+++ b/docs/reference/triggers/rabbitmq.md
@@ -11,6 +11,7 @@ Reads messages from [RabbitMQ](https://www.rabbitmq.com/) queues.
 | topics            | list of strings    | If specified, the trigger creates a queue with a unique name and subscribes it to these topics |
 | reconnectDuration | string of duration | The duration to wait before reconnecting to RabbitMQ. Default is 5 minutes.                    |
 | reconnectInterval | string of duration | The interval to wait before reconnecting to RabbitMQ. Default is 11 seconds.                   |
+| prefetchCount     | int                | The prefetch count of the broker channel. Default is 0.                                        |
 
 > **Note:** `topics` and `queueName` are mutually exclusive.
 > The trigger can either create to an existing queue specified by `queueName` or create its own queue, subscribing it to `topics` 
@@ -30,5 +31,6 @@ triggers:
       exchangeName: "myExchangeName"
       queueName: "myQueueNameName"
       reconnectDuration: "10m"
-      reconnectInterval: "60s"  
+      reconnectInterval: "60s"
+      prefetchCount: 1
 ```

--- a/pkg/processor/trigger/rabbitmq/trigger.go
+++ b/pkg/processor/trigger/rabbitmq/trigger.go
@@ -243,8 +243,7 @@ func (rmq *rabbitMq) createTopics() error {
 	// TODO: move to ui and add feature flag
 
 	if rmq.configuration.PrefetchCount != 0 {
-		err := rmq.brokerChannel.Qos(rmq.configuration.PrefetchCount, 0, true)
-		if err != nil {
+		if err := rmq.brokerChannel.Qos(rmq.configuration.PrefetchCount, 0, true); err != nil {
 			return errors.Wrap(err, "Failed to setup prefetch on channel")
 		}
 	}

--- a/pkg/processor/trigger/rabbitmq/trigger.go
+++ b/pkg/processor/trigger/rabbitmq/trigger.go
@@ -241,6 +241,13 @@ func (rmq *rabbitMq) createTopics() error {
 	// create exchange and queue only if user provided topics, else assuming the user did all the necessary configuration
 	// to support listening on the provided exchange and queue
 
+	if rmq.configuration.PrefetchCount != 0 {
+		err := rmq.brokerChannel.Qos(rmq.configuration.PrefetchCount, 0, true)
+		if err != nil {
+			return errors.Wrap(err, "Failed to setup prefetch on channel")
+		}
+	}
+
 	// create the exchange
 	if err := rmq.brokerChannel.ExchangeDeclare(rmq.configuration.ExchangeName,
 		"topic",

--- a/pkg/processor/trigger/rabbitmq/types.go
+++ b/pkg/processor/trigger/rabbitmq/types.go
@@ -34,6 +34,7 @@ type Configuration struct {
 	Topics            []string
 	ReconnectDuration string
 	ReconnectInterval string
+	PrefetchCount     int
 
 	reconnectDuration time.Duration
 	reconnectInterval time.Duration


### PR DESCRIPTION
When configuring the rabbit broker channel a value called prefetch is determined which selects how many events will be fetched even before it's time to ingest them. When the `prefetch` value isn't configured correctly (for example takes all) it can mess with the scaling of the Nuclio since the new pods will not have any messages to ingest (already found in another pod).

Added the ability to configure the prefetch using attributes from the rabbit trigger, if not configured (or 0) will act as before (rabbit default). example:
```yaml
    rabbit-example:
      class: ""
      kind: rabbit-mq
      name: rabbit-example
      url: "amqp://rmq-host:5672"
      attributes:
        prefetchCount: 1
        exchangeName: exchangeName
        topics:
          - someKey
```

Tested manually on a Nuclio cluster using MLRun community edition 

https://www.rabbitmq.com/consumer-prefetch.html
