### PR TITLE
[Issues] Update slack invite link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -15,5 +15,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Try Us @ Slack
-    url: https://lit-oasis-83353.herokuapp.com/
+    url: https://go.iguazio.com/nuclio/joincommunity
     about: "If you have any other questions, please join the Nuclio community on Slack."


### PR DESCRIPTION
The old link no longer exists, use the new one: https://go.iguazio.com/nuclio/joincommunity