### PR TITLE
[Nuctl] Render multiple resources properly in json and yaml outputs

### DIFF
--- a/pkg/nuctl/command/get.go
+++ b/pkg/nuctl/command/get.go
@@ -123,15 +123,27 @@ func newGetFunctionCommandeer(ctx context.Context, getCommandeer *getCommandeer)
 
 func (g *getFunctionCommandeer) renderFunctionConfigWithStatus(functions []platform.Function,
 	renderer func(interface{}) error) error {
+	configsWithStatus := make([]functionconfig.ConfigWithStatus, 0, len(functions))
 	for _, function := range functions {
 		functionConfigWithStatus := functionconfig.ConfigWithStatus{
 			Config: *function.GetConfig(),
 			Status: *function.GetStatus(),
 		}
-		if err := renderer(functionConfigWithStatus); err != nil {
+		configsWithStatus = append(configsWithStatus, functionConfigWithStatus)
+	}
+	if len(configsWithStatus) == 1 {
+		if err := renderer(configsWithStatus[0]); err != nil {
 			return errors.Wrap(err, "Failed to render function config with status")
 		}
+		return nil
 	}
+	items := map[string]interface{}{
+		"functions": configsWithStatus,
+	}
+	if err := renderer(items); err != nil {
+		return errors.Wrap(err, "Failed to render function config with status")
+	}
+
 	return nil
 }
 
@@ -197,12 +209,23 @@ func newGetProjectCommandeer(ctx context.Context, getCommandeer *getCommandeer) 
 }
 
 func (g *getProjectCommandeer) renderProjectConfig(ctx context.Context, projects []platform.Project, renderer func(interface{}) error) error {
-	for _, project := range projects {
-		if err := renderer(project.GetConfig()); err != nil {
+	if len(projects) == 1 {
+		if err := renderer(projects[0].GetConfig()); err != nil {
 			return errors.Wrap(err, "Failed to render project config")
 		}
+		return nil
 	}
 
+	projectConfigs := make([]platform.ProjectConfig, 0, len(projects))
+	for _, project := range projects {
+		projectConfigs = append(projectConfigs, *project.GetConfig())
+	}
+	items := map[string]interface{}{
+		"projects": projectConfigs,
+	}
+	if err := renderer(items); err != nil {
+		return errors.Wrap(err, "Failed to render project config")
+	}
 	return nil
 }
 
@@ -263,10 +286,22 @@ func newGetAPIGatewayCommandeer(ctx context.Context, getCommandeer *getCommandee
 }
 
 func (g *getAPIGatewayCommandeer) renderAPIGatewayConfig(apiGateways []platform.APIGateway, renderer func(interface{}) error) error {
-	for _, apiGateway := range apiGateways {
-		if err := renderer(apiGateway.GetConfig()); err != nil {
+	if len(apiGateways) == 1 {
+		if err := renderer(apiGateways[0].GetConfig()); err != nil {
 			return errors.Wrap(err, "Failed to render api gateway config")
 		}
+		return nil
+	}
+
+	apiGatewayConfigs := make([]platform.APIGatewayConfig, 0, len(apiGateways))
+	for _, apiGateway := range apiGateways {
+		apiGatewayConfigs = append(apiGatewayConfigs, *apiGateway.GetConfig())
+	}
+	items := map[string]interface{}{
+		"apiGateways": apiGatewayConfigs,
+	}
+	if err := renderer(items); err != nil {
+		return errors.Wrap(err, "Failed to render api gateway config")
 	}
 
 	return nil
@@ -338,10 +373,22 @@ func newGetFunctionEventCommandeer(ctx context.Context, getCommandeer *getComman
 }
 
 func (g *getFunctionEventCommandeer) renderFunctionEventConfig(functionEvents []platform.FunctionEvent, renderer func(interface{}) error) error {
-	for _, functionEvent := range functionEvents {
-		if err := renderer(functionEvent.GetConfig()); err != nil {
+	if len(functionEvents) == 1 {
+		if err := renderer(functionEvents[0].GetConfig()); err != nil {
 			return errors.Wrap(err, "Failed to render function event config")
 		}
+		return nil
+	}
+
+	functionEventConfigs := make([]platform.FunctionEventConfig, 0, len(functionEvents))
+	for _, functionEvent := range functionEvents {
+		functionEventConfigs = append(functionEventConfigs, *functionEvent.GetConfig())
+	}
+	items := map[string]interface{}{
+		"functionEvents": functionEventConfigs,
+	}
+	if err := renderer(items); err != nil {
+		return errors.Wrap(err, "Failed to render function event config")
 	}
 
 	return nil


### PR DESCRIPTION
When GET-ting multiple resource with nuctl, it didn't format them correctly as a list of items, making it difficult to use in code, etc.

Change is relevant to the following resources:

- Functions
- Function events
- Projects
- API Gateways

Example:
```
nuctl get function -o json
```

Before PR:
```
{
	"metadata": {
		"name": function-1,
                 ...
        },
        "spec": {
                 ...
        }
}
{
	"metadata": {
		"name": function-2,
                 ...
        },
        "spec": {
                 ...
        }
}
```

After PR:
```
{
        "functions": [
                {
	                "metadata": {
		                "name": function-1,
                                 ...
                        },
                        "spec": {
                                 ...
                        }
                },
                {
	                "metadata": {
		                "name": function-2,
                                 ...
                        },
                        "spec": {
                                 ...
                        }
                }
        ]
}
```
Same with yaml outpu.