### PR TITLE
[Env] Remove restore secret env var from function spec

### DIFF
--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -26,3 +26,12 @@ func EnvInSlice(env v1.EnvVar, slice []v1.EnvVar) bool {
 	}
 	return false
 }
+
+func RemoveEnvFromSlice(env v1.EnvVar, slice []v1.EnvVar) []v1.EnvVar {
+	for i, envVar := range slice {
+		if envVar.Name == env.Name {
+			return append(slice[:i], slice[i+1:]...)
+		}
+	}
+	return slice
+}

--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -218,23 +218,6 @@ func (d *Deployer) ScrubFunctionConfig(ctx context.Context,
 		return nil, errors.Wrap(err, "Failed to create or update function secret")
 	}
 
-	// set an env var to tell the processor to restore the function config from the mounted secret
-	restoreFunctionConfigFromSecretEnvVar := v1.EnvVar{
-		Name:  common.RestoreConfigFromSecretEnvVar,
-		Value: "true",
-	}
-	if !common.EnvInSlice(restoreFunctionConfigFromSecretEnvVar, scrubbedFunctionConfig.Spec.Env) {
-		scrubbedFunctionConfig.Spec.Env = append(scrubbedFunctionConfig.Spec.Env, restoreFunctionConfigFromSecretEnvVar)
-	} else {
-
-		// set the value to true
-		for envIndex, envVar := range scrubbedFunctionConfig.Spec.Env {
-			if envVar.Name == restoreFunctionConfigFromSecretEnvVar.Name {
-				scrubbedFunctionConfig.Spec.Env[envIndex].Value = restoreFunctionConfigFromSecretEnvVar.Value
-			}
-		}
-	}
-
 	return scrubbedFunctionConfig, nil
 }
 

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2308,6 +2308,23 @@ func (lc *lazyClient) getFunctionVolumeAndMounts(ctx context.Context,
 			MountPath: functionconfig.FunctionSecretMountPath,
 			ReadOnly:  true,
 		})
+
+		// set an env var to tell the processor to restore the function config from the mounted secret
+		restoreFunctionConfigFromSecretEnvVar := v1.EnvVar{
+			Name:  common.RestoreConfigFromSecretEnvVar,
+			Value: "true",
+		}
+		if !common.EnvInSlice(restoreFunctionConfigFromSecretEnvVar, function.Spec.Env) {
+			function.Spec.Env = append(function.Spec.Env, restoreFunctionConfigFromSecretEnvVar)
+		} else {
+
+			// set the value to true
+			for envIndex, envVar := range function.Spec.Env {
+				if envVar.Name == restoreFunctionConfigFromSecretEnvVar.Name {
+					function.Spec.Env[envIndex].Value = restoreFunctionConfigFromSecretEnvVar.Value
+				}
+			}
+		}
 	}
 
 	for _, volume := range volumeNameToVolume {

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1608,6 +1608,16 @@ func (lc *lazyClient) getFunctionEnvironment(functionLabels labels.Set,
 		},
 	})
 
+	// remove internal env vars from the function spec env
+	for _, internalEnvVar := range []v1.EnvVar{
+		{
+			Name:  common.RestoreConfigFromSecretEnvVar,
+			Value: "true",
+		},
+	} {
+		function.Spec.Env = common.RemoveEnvFromSlice(internalEnvVar, function.Spec.Env)
+	}
+
 	return env
 }
 


### PR DESCRIPTION
The `"NUCLIO_RESTORE_FUNCTION_CONFIG_FROM_SECRET"` env var is for internal use, as the nuclio controller signals the processor that a secret is mounted to the function.

This secret should not appear in the function config (when GET-ting the function or the UI), so we remove it from the spec after populating the deployment's container env vars.

Fixes https://jira.iguazeng.com/browse/IG-21724