### PR TITLE
Replace `github.com/ghodss/yaml` with `sigs.k8s.io/yaml`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/eclipse/paho.mqtt.golang v1.4.2
 	github.com/fatih/color v1.13.0
 	github.com/fatih/structs v1.1.0
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-chi/cors v1.2.1
 	github.com/go-git/go-git/v5 v5.4.2

--- a/go.sum
+++ b/go.sum
@@ -147,7 +147,6 @@ github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=

--- a/pkg/dashboard/functiontemplates/basefunctiontemplatefetcher.go
+++ b/pkg/dashboard/functiontemplates/basefunctiontemplatefetcher.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 
-	"github.com/ghodss/yaml"
 	"github.com/icza/dyno"
 	"github.com/nuclio/errors"
 	"github.com/rs/xid"
+	"sigs.k8s.io/yaml"
 )
 
 type BaseFunctionTemplateFetcher struct {

--- a/pkg/dashboard/functiontemplates/generated.go
+++ b/pkg/dashboard/functiontemplates/generated.go
@@ -17,7 +17,7 @@ package functiontemplates
 import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 var GeneratedFunctionTemplates = []*generatedFunctionTemplate{

--- a/pkg/dashboard/functiontemplates/generatedfunctiontemplatefetcher.go
+++ b/pkg/dashboard/functiontemplates/generatedfunctiontemplatefetcher.go
@@ -19,9 +19,9 @@ package functiontemplates
 import (
 	"encoding/base64"
 
-	"github.com/ghodss/yaml"
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
+	"sigs.k8s.io/yaml"
 )
 
 type GeneratedFunctionTemplateFetcher struct {

--- a/pkg/dashboard/functiontemplates/generator/generator.go
+++ b/pkg/dashboard/functiontemplates/generator/generator.go
@@ -35,12 +35,12 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/build"
 	"github.com/nuclio/nuclio/pkg/processor/build/inlineparser"
 
-	"github.com/ghodss/yaml"
 	"github.com/gobuffalo/flect"
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
-	"github.com/nuclio/zap"
+	nucliozap "github.com/nuclio/zap"
 	yamlv3 "gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 )
 
 var funcMap = template.FuncMap{
@@ -82,7 +82,7 @@ package functiontemplates
 import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 var GeneratedFunctionTemplates = []*generatedFunctionTemplate{

--- a/pkg/dashboard/functiontemplates/render.go
+++ b/pkg/dashboard/functiontemplates/render.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 
-	"github.com/ghodss/yaml"
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
+	"sigs.k8s.io/yaml"
 )
 
 type FunctionTemplateRenderer struct {

--- a/pkg/functionconfig/reader.go
+++ b/pkg/functionconfig/reader.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/common"
 
-	"github.com/ghodss/yaml"
 	"github.com/imdario/mergo"
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
+	"sigs.k8s.io/yaml"
 )
 
 type Reader struct {

--- a/pkg/functionconfig/reader_test.go
+++ b/pkg/functionconfig/reader_test.go
@@ -22,11 +22,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 )
 
 type ReaderTestSuite struct {

--- a/pkg/nuctl/command/common/helpers.go
+++ b/pkg/nuctl/command/common/helpers.go
@@ -71,7 +71,9 @@ func GetUnmarshalFunc(bytes []byte) (func(data []byte, v interface{}) error, err
 	}
 
 	if err = yaml.Unmarshal(bytes, &obj); err == nil {
-		return yaml.Unmarshal, nil
+		return func(data []byte, v interface{}) error {
+			return yaml.Unmarshal(data, v)
+		}, nil
 	}
 
 	return nil, errors.New("Input is neither json nor yaml")

--- a/pkg/nuctl/command/common/helpers.go
+++ b/pkg/nuctl/command/common/helpers.go
@@ -21,8 +21,8 @@ import (
 	"io"
 	"os"
 
-	"github.com/ghodss/yaml"
 	"github.com/nuclio/errors"
+	"sigs.k8s.io/yaml"
 )
 
 func ReadFromInOrStdin(r io.Reader) ([]byte, error) {

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -38,13 +38,13 @@ import (
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/processor/build"
 
-	"github.com/ghodss/yaml"
 	"github.com/gobuffalo/flect"
 	"github.com/nuclio/errors"
 	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 )
 
 type functionBuildTestSuite struct {

--- a/pkg/nuctl/test/project_test.go
+++ b/pkg/nuctl/test/project_test.go
@@ -31,10 +31,10 @@ import (
 	nuctlCommon "github.com/nuclio/nuclio/pkg/nuctl/command/common"
 	"github.com/nuclio/nuclio/pkg/platform"
 
-	"github.com/ghodss/yaml"
 	"github.com/nuclio/errors"
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/suite"
+	"sigs.k8s.io/yaml"
 )
 
 type projectGetTestSuite struct {

--- a/pkg/nuctl/test/suite.go
+++ b/pkg/nuctl/test/suite.go
@@ -38,11 +38,11 @@ import (
 	nuctlcommon "github.com/nuclio/nuclio/pkg/nuctl/command/common"
 	"github.com/nuclio/nuclio/pkg/platform"
 
-	"github.com/ghodss/yaml"
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
-	"github.com/nuclio/zap"
+	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -42,7 +42,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/trigger/cron"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http"
 
-	"github.com/ghodss/yaml"
 	"github.com/imdario/mergo"
 	"github.com/mitchellh/mapstructure"
 	"github.com/nuclio/errors"
@@ -62,6 +61,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -44,7 +44,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	processorsuite "github.com/nuclio/nuclio/pkg/processor/test/suite"
 
-	"github.com/ghodss/yaml"
 	"github.com/nuclio/errors"
 	"github.com/rs/xid"
 	appsv1 "k8s.io/api/apps/v1"
@@ -54,6 +53,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/yaml"
 )
 
 type OnAfterIngressCreated func(*networkingv1.Ingress)

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -45,11 +45,11 @@ import (
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/processor"
 
-	"github.com/ghodss/yaml"
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
-	"github.com/nuclio/zap"
+	nucliozap "github.com/nuclio/zap"
+	"sigs.k8s.io/yaml"
 )
 
 type Platform struct {

--- a/pkg/platformconfig/reader.go
+++ b/pkg/platformconfig/reader.go
@@ -20,8 +20,8 @@ import (
 	"io"
 	"os"
 
-	"github.com/ghodss/yaml"
 	"github.com/nuclio/errors"
+	"sigs.k8s.io/yaml"
 )
 
 type Reader struct{}

--- a/pkg/processor/build/runtime/java/types.go
+++ b/pkg/processor/build/runtime/java/types.go
@@ -19,9 +19,9 @@ package java
 import (
 	"fmt"
 
-	"github.com/ghodss/yaml"
 	"github.com/mitchellh/mapstructure"
 	"github.com/nuclio/errors"
+	"sigs.k8s.io/yaml"
 )
 
 type dependency struct {

--- a/pkg/processor/config/reader.go
+++ b/pkg/processor/config/reader.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/processor"
 
-	"github.com/ghodss/yaml"
 	"github.com/nuclio/errors"
+	"sigs.k8s.io/yaml"
 )
 
 // Reader is processor configuration reader

--- a/pkg/processor/config/writer.go
+++ b/pkg/processor/config/writer.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/processor"
 
-	"github.com/ghodss/yaml"
 	"github.com/nuclio/errors"
+	"sigs.k8s.io/yaml"
 )
 
 type Writer struct{}


### PR DESCRIPTION
The package `github.com/ghodss/yaml` is no longer actively maintained. [`sigs.k8s.io/yaml`](https://github.com/kubernetes-sigs/yaml) is a permanent fork of `github.com/ghodss/yaml`. It is actively maintained by Kubernetes SIG, and also widely used in K8s projects.

The notable change is that `github.com/ghodss/yaml` uses `gopkg.in/yaml.v2 v2.2.2`, but `sigs.k8s.io/yaml` uses `gopkg.in/yaml.v2 v2.4.0`. Changes can be seen here [v2.2.2...v2.4.0](https://github.com/go-yaml/yaml/compare/v2.2.2...v2.4.0), mostly bug fixes.