### PR TITLE
[Scrubber] Convert function config to map when restoring

### DIFF
--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -420,7 +420,7 @@ func (p *Platform) CreateFunction(ctx context.Context, createFunctionOptions *pl
 		return createFunctionResult, nil
 	}
 
-	// do the deploy in the abstract base class
+	// do the deploying in the abstract base class
 	return p.HandleDeployFunction(ctx, existingFunctionConfig, createFunctionOptions, onAfterConfigUpdated, onAfterBuild)
 }
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -322,12 +322,12 @@ func (c *Config) EnrichContainerResources(ctx context.Context,
 		resources.Requests = make(v1.ResourceList)
 	}
 
-	if _, exists := resources.Requests["cpu"]; !exists {
+	if cpuRequest, exists := resources.Requests["cpu"]; !exists || cpuRequest.IsZero() {
 		resources.Requests["cpu"] = common.ParseQuantityOrDefault(defaultFunctionPodResources.Requests.CPU,
 			"25m",
 			logger)
 	}
-	if _, exists := resources.Requests["memory"]; !exists {
+	if memoryRequest, exists := resources.Requests["memory"]; !exists || memoryRequest.IsZero() {
 		resources.Requests["memory"] = common.ParseQuantityOrDefault(defaultFunctionPodResources.Requests.Memory,
 			"1Mi",
 			logger)
@@ -336,13 +336,13 @@ func (c *Config) EnrichContainerResources(ctx context.Context,
 	if resources.Limits == nil {
 		resources.Limits = make(v1.ResourceList)
 	}
-	if _, exists := resources.Limits["cpu"]; !exists {
+	if cpuLimit, exists := resources.Limits["cpu"]; !exists || cpuLimit.IsZero() {
 		cpuQuantity, err := apiresource.ParseQuantity(defaultFunctionPodResources.Limits.CPU)
 		if err == nil {
 			resources.Limits["cpu"] = cpuQuantity
 		}
 	}
-	if _, exists := resources.Limits["memory"]; !exists {
+	if memoryLimit, exists := resources.Limits["memory"]; !exists || memoryLimit.IsZero() {
 		memoryQuantity, err := apiresource.ParseQuantity(defaultFunctionPodResources.Limits.Memory)
 		if err == nil {
 			resources.Limits["memory"] = memoryQuantity


### PR DESCRIPTION
Gosecretive's restore sometimes altars complex objects inside the function config.
To avoid it, we convert the config to map before restoring, and convert back to function config object afterwards, same as we do when scrubbing it.

Fixes https://jira.iguazeng.com/browse/IG-21726 