### PR TITLE
[Function] Add PATCH method to change function state

### DIFF
--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -217,7 +217,7 @@ func (s *Server) InstallMiddleware(router chi.Router) error {
 
 	corsOptions := cors.Options{
 		AllowedOrigins: []string{"*"},
-		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"},
 		AllowedHeaders: []string{
 			"Accept",
 			"Authorization",

--- a/pkg/processor/trigger/http/cors/cors.go
+++ b/pkg/processor/trigger/http/cors/cors.go
@@ -60,6 +60,7 @@ func NewCORS() *CORS {
 			fasthttp.MethodPut,
 			fasthttp.MethodDelete,
 			fasthttp.MethodOptions,
+			fasthttp.MethodPatch,
 		},
 		AllowHeaders: []string{
 			fasthttp.HeaderAccept,


### PR DESCRIPTION
Patching a function allows changing a function state, by setting `desiredState` in the request body.
Currently, it only supports setting the desired state as `ready`, which essentially redeploys the function.

Usage:
`PATCH /functions/<function-name>`
Request body:
```
{
    "desiredState": "ready"
}
```

In the future, this feature will be supported via nuctl as well.
Test manually against a live cluster, along with the attached unit tests