### PR TITLE
[Kafka/V3ioStream] Allow setting explicit ack mode via annotations

### DIFF
--- a/pkg/processor/trigger/types.go
+++ b/pkg/processor/trigger/types.go
@@ -126,6 +126,23 @@ func (c *Configuration) ParseDurationOrDefault(durationConfigField *DurationConf
 	return nil
 }
 
+func (c *Configuration) PopulateExplicitAckMode(explicitAckModeValue string,
+	triggerConfigurationExplicitAckMode functionconfig.ExplicitAckMode) error {
+	switch explicitAckModeValue {
+	case string(functionconfig.ExplicitAckModeEnable):
+		c.ExplicitAckMode = functionconfig.ExplicitAckModeEnable
+	case string(functionconfig.ExplicitAckModeExplicitOnly):
+		c.ExplicitAckMode = functionconfig.ExplicitAckModeExplicitOnly
+	default:
+
+		// default explicit ack mode to 'disable'
+		if triggerConfigurationExplicitAckMode == "" {
+			c.ExplicitAckMode = functionconfig.ExplicitAckModeDisable
+		}
+	}
+	return nil
+}
+
 type Statistics struct {
 	EventsHandledSuccessTotal uint64
 	EventsHandledFailureTotal uint64


### PR DESCRIPTION
To add an option to enable the explicit ack feature via UI, allow setting explicit ack mode in annotations for kafka and v3io stream triggers.

Supported modes: `enable`, `disable`, `explicitOnly`.

**Usage example:** add the following annotations:
kafka:
```
"nuclio.io/kafka-explicit-ack-mode": "enable"
```
v3io stream:
```
"nuclio.io/v3iostream-explicit-ack-mode": "enable"
```