### PR TITLE
[Function] Ignore current function state when patching a function

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -508,11 +508,6 @@ func (fr *functionResource) redeployFunction(request *http.Request,
 		return errors.Wrap(err, "Failed to get get function")
 	}
 
-	// if function is already in ready state, return
-	if function.GetStatus().State == functionconfig.FunctionStateReady {
-		return nil
-	}
-
 	waitForFunction := fr.headerValueIsTrue(request, headers.WaitFunctionAction)
 
 	// Deploy function


### PR DESCRIPTION
Allow redeploying a function regardless of its current state.

Relates to https://github.com/nuclio/nuclio/issues/2685 