### PR TITLE
[Function / Nuctl] Support patching imported functions only

### DIFF
--- a/pkg/common/headers/headers.go
+++ b/pkg/common/headers/headers.go
@@ -29,6 +29,7 @@ const (
 	DeleteFunctionIgnoreStateValidation = "X-Nuclio-Delete-Function-Ignore-State-Validation"
 	CreationStateUpdatedTimeout         = "X-Nuclio-Creation-State-Updated-Timeout"
 	FunctionEnrichApiGateways           = "X-Nuclio-Function-Enrich-Apigateways"
+	ImportedFunctionOnly                = "X-Nuclio-Imported-Function-Only"
 
 	// Project headers
 	ProjectName           = "X-Nuclio-Project-Name"

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -509,6 +509,12 @@ func (fr *functionResource) redeployFunction(request *http.Request,
 	}
 
 	waitForFunction := fr.headerValueIsTrue(request, headers.WaitFunctionAction)
+	importedOnly := fr.headerValueIsTrue(request, headers.ImportedFunctionOnly)
+
+	if importedOnly && function.GetStatus().State != functionconfig.FunctionStateImported {
+		fr.Logger.DebugWithCtx(request.Context(), "Function is not imported, skipping redeploy", "functionName", id, "functionState", function.GetStatus().State)
+		return nil
+	}
 
 	fr.Logger.DebugWith("Redeploying function", "functionName", id)
 

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1105,7 +1105,7 @@ func (suite *functionTestSuite) TestPatchFunctionInvalidDesiredState() {
 	}
 
 	requestBody := `{
-	"desiredState": "ready"
+	"desiredState": "unhealthy"
 }`
 
 	suite.sendRequest("PATCH",

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1040,7 +1040,7 @@ func (suite *functionTestSuite) TestPatchSuccessful() {
 
 	// send request
 	expectedStatusCode := http.StatusNoContent
-	headers := map[string]string{
+	requestHeaders := map[string]string{
 		headers.WaitFunctionAction: "true",
 		headers.FunctionNamespace:  namespace,
 	}
@@ -1051,7 +1051,7 @@ func (suite *functionTestSuite) TestPatchSuccessful() {
 
 	suite.sendRequest("PATCH",
 		fmt.Sprintf("/api/functions/%s", functionName),
-		headers,
+		requestHeaders,
 		bytes.NewBufferString(requestBody),
 		&expectedStatusCode,
 		nil)
@@ -1076,7 +1076,7 @@ func (suite *functionTestSuite) TestPatchFunctionNotFound() {
 
 	// send request
 	expectedStatusCode := http.StatusNotFound
-	headers := map[string]string{
+	requestHeaders := map[string]string{
 		headers.WaitFunctionAction: "true",
 		headers.FunctionNamespace:  namespace,
 	}
@@ -1087,7 +1087,7 @@ func (suite *functionTestSuite) TestPatchFunctionNotFound() {
 
 	suite.sendRequest("PATCH",
 		fmt.Sprintf("/api/functions/%s", functionName),
-		headers,
+		requestHeaders,
 		bytes.NewBufferString(requestBody),
 		&expectedStatusCode,
 		nil)
@@ -1099,21 +1099,96 @@ func (suite *functionTestSuite) TestPatchFunctionInvalidDesiredState() {
 
 	// send request
 	expectedStatusCode := http.StatusBadRequest
-	headers := map[string]string{
+	requestHeaders := map[string]string{
 		headers.WaitFunctionAction: "true",
 		headers.FunctionNamespace:  namespace,
 	}
 
 	requestBody := `{
-	"desiredState": "unhealthy"
+	"desiredState": "ready"
 }`
 
 	suite.sendRequest("PATCH",
 		fmt.Sprintf("/api/functions/%s", functionName),
-		headers,
+		requestHeaders,
 		bytes.NewBufferString(requestBody),
 		&expectedStatusCode,
 		nil)
+}
+
+func (suite *functionTestSuite) TestPatchFunctionImportedOnly() {
+	namespace := "some-namespace"
+
+	for _, testCase := range []struct {
+		name                 string
+		functionName         string
+		functionState        functionconfig.FunctionState
+		expectedCreateCalled bool
+	}{
+		{
+			name:                 "importedFunction",
+			functionName:         "imported-func",
+			functionState:        functionconfig.FunctionStateImported,
+			expectedCreateCalled: true,
+		},
+		{
+			name:                 "readyFunction",
+			functionName:         "ready-func",
+			functionState:        functionconfig.FunctionStateReady,
+			expectedCreateCalled: false,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			function := platform.AbstractFunction{}
+			function.Config.Meta.Name = testCase.functionName
+			function.Config.Meta.Namespace = namespace
+			function.Status.State = testCase.functionState
+
+			// verifications
+			verifyGetFunctionsOptions := func(getFunctionsOptions *platform.GetFunctionsOptions) bool {
+				suite.Require().Equal(testCase.functionName, getFunctionsOptions.Name)
+				suite.Require().Equal(namespace, getFunctionsOptions.Namespace)
+				return true
+			}
+			verifyCreateFunctionOptions := func(createFunctionOptions *platform.CreateFunctionOptions) bool {
+				suite.Require().Equal(testCase.functionName, createFunctionOptions.FunctionConfig.Meta.Name)
+				suite.Require().Equal(namespace, createFunctionOptions.FunctionConfig.Meta.Namespace)
+				return true
+			}
+
+			// mock
+			suite.mockPlatform.
+				On("GetFunctions", mock.Anything, mock.MatchedBy(verifyGetFunctionsOptions)).
+				Return([]platform.Function{&function}, nil).
+				Once()
+
+			if testCase.expectedCreateCalled {
+				suite.mockPlatform.
+					On("CreateFunction", mock.Anything, mock.MatchedBy(verifyCreateFunctionOptions)).
+					Return(&platform.CreateFunctionResult{}, nil).
+					Once()
+			}
+
+			// send request
+			expectedStatusCode := http.StatusNoContent
+			requestHeaders := map[string]string{
+				headers.WaitFunctionAction:   "true",
+				headers.FunctionNamespace:    namespace,
+				headers.ImportedFunctionOnly: "true",
+			}
+
+			requestBody := `{
+	"desiredState": "ready"
+}`
+
+			suite.sendRequest("PATCH",
+				fmt.Sprintf("/api/functions/%s", testCase.functionName),
+				requestHeaders,
+				bytes.NewBufferString(requestBody),
+				&expectedStatusCode,
+				nil)
+		})
+	}
 }
 
 func (suite *functionTestSuite) sendRequestNoMetadata(method string) {


### PR DESCRIPTION
When redeploying functions, support redeploying only imported functions by passing the following header:
```
"X-Nuclio-Imported-Function-Only": "true"
```

To do it in nuctl, pass the `--imported-only` flag to the `nuctl beta deploy --no-build` command.