### PR TITLE
[Assets] Install nginx ingress controller using helm

### DIFF
--- a/test/k8s/ci_assets/install_nginx_ingress_controller.sh
+++ b/test/k8s/ci_assets/install_nginx_ingress_controller.sh
@@ -14,4 +14,6 @@
 # limitations under the License.
 #
 
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.34.1/deploy/static/provider/cloud/deploy.yaml
+helm upgrade --install ingress-nginx ingress-nginx \
+  --repo https://kubernetes.github.io/ingress-nginx \
+  --namespace ingress-nginx --create-namespace


### PR DESCRIPTION
Replace the nginx ingress controller installation script from `kubectl apply` to `helm upgrade` to be aligned with the latest nginx versions and being able to upgrade easily.