### PR TITLE
[Build] Fix building java & go runtimes for arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,14 +86,17 @@ endif
 
 # alpine is commonly used by controller / dlx / autoscaler
 ifeq ($(NUCLIO_ARCH), armhf)
-	NUCLIO_DOCKER_ALPINE_IMAGE ?= gcr.io/iguazio/arm32v7/alpine:3.17
-	NUCLIO_BASE_IMAGE_NAME ?= gcr.io/iguazio/arm32v7/golang
+	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/arm32v7/alpine:3.17
+	NUCLIO_BASE_IMAGE_NAME 			?= gcr.io/iguazio/arm32v7/golang
+	NUCLIO_DOCKER_JAVA_OPENJDK		?= gcr.io/iguazio/openjdk:11-slim
 else ifeq ($(NUCLIO_ARCH), arm64)
-	NUCLIO_DOCKER_ALPINE_IMAGE ?= gcr.io/iguazio/arm64v8/alpine:3.17
-	NUCLIO_BASE_IMAGE_NAME ?= gcr.io/iguazio/arm64v8/golang
+	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/arm64v8/alpine:3.17
+	NUCLIO_BASE_IMAGE_NAME 			?= gcr.io/iguazio/arm64v8/golang
+	NUCLIO_DOCKER_JAVA_OPENJDK 		?= gcr.io/iguazio/arm64v8/openjdk:11-slim
 else
-	NUCLIO_DOCKER_ALPINE_IMAGE ?= gcr.io/iguazio/alpine:3.17
-	NUCLIO_BASE_IMAGE_NAME ?= gcr.io/iguazio/golang
+	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/alpine:3.17
+	NUCLIO_BASE_IMAGE_NAME 			?= gcr.io/iguazio/golang
+	NUCLIO_DOCKER_JAVA_OPENJDK		?= gcr.io/iguazio/openjdk:11-slim
 endif
 
 NUCLIO_BASE_IMAGE_TAG ?= 1.19
@@ -549,6 +552,7 @@ handler-builder-java-onbuild:
 	docker build \
 		--build-arg NUCLIO_DOCKER_IMAGE_TAG=$(NUCLIO_DOCKER_IMAGE_TAG) \
 		--build-arg NUCLIO_DOCKER_REPO=$(NUCLIO_DOCKER_REPO) \
+		--build-arg NUCLIO_DOCKER_JAVA_OPENJDK=$(NUCLIO_DOCKER_JAVA_OPENJDK) \
 		--cache-from $(NUCLIO_DOCKER_HANDLER_BUILDER_JAVA_ONBUILD_IMAGE_NAME_CACHE) \
 		--file pkg/processor/build/runtime/java/docker/onbuild/Dockerfile \
 		--tag $(NUCLIO_DOCKER_HANDLER_BUILDER_JAVA_ONBUILD_IMAGE_NAME) \

--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile.alpine
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile.alpine
@@ -46,8 +46,9 @@ ARG NUCLIO_BASE_ALPINE_IMAGE_TAG
 FROM ${NUCLIO_BASE_IMAGE_NAME}:${NUCLIO_BASE_ALPINE_IMAGE_TAG}
 
 # Download required packages for plugin compilation
+# binutils-gold for arm64 handling of "collect2: fatal error: cannot find 'ld'"
 RUN apk upgrade --no-cache \
-    && apk add --no-cache git gcc musl-dev file
+    && apk add --no-cache git gcc musl-dev file binutils-gold
 
 # Store processor binary
 COPY --from=build-processor /tmp/processor /home/nuclio/bin/processor

--- a/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 ARG NUCLIO_DOCKER_IMAGE_TAG
+ARG NUCLIO_DOCKER_JAVA_OPENJDK
 ARG NUCLIO_DOCKER_REPO=quay.io/nuclio
 
 # Supplies processor
 FROM ${NUCLIO_DOCKER_REPO}/processor:${NUCLIO_DOCKER_IMAGE_TAG} as processor
 
-FROM gcr.io/iguazio/openjdk:11-slim as user-handler-builder
+FROM ${NUCLIO_DOCKER_JAVA_OPENJDK} as user-handler-builder
 
 ENV GRADLEVERSION=5.6.4
 


### PR DESCRIPTION
compiling go on alpine failed due to missing `ld` - added `binutils-gold` os package
compiling java failed due to usage of non-arm image - injected suitable arm image for java sdk