### PR TITLE
[Release] Fix building images for arm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,6 +85,8 @@ jobs:
     - name: Install QEMU
       if: matrix.arch != 'amd64'
       uses: docker/setup-qemu-action@v2
+      with:
+        platforms: ${{ matrix.arch }}
 
     - name: Login to Quay.io
       uses: docker/login-action@v2
@@ -158,6 +160,8 @@ jobs:
     - name: Install QEMU
       if: matrix.arch != 'amd64'
       uses: docker/setup-qemu-action@v2
+      with:
+        platforms: ${{ matrix.arch }}
 
     - name: Build binaries
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,17 +82,9 @@ jobs:
         cache: true
         go-version-file: go.mod
 
-    # for none x86_64 platforms
     - name: Install QEMU
       if: matrix.arch != 'amd64'
-      run: |
-
-        # install os packages
-        sudo apt update -qqy && sudo apt -qqy install qemu qemu-user-static
-
-        # enabled non arm64 docker containers executables
-        # mirrored to gcr.io/iguazio from multiarch/qemu-user-static:latest for availability reasons
-        docker run --rm --privileged gcr.io/iguazio/multiarch/qemu-user-static:latest --reset -p yes
+      uses: docker/setup-qemu-action@v2
 
     - name: Login to Quay.io
       uses: docker/login-action@v2
@@ -112,6 +104,8 @@ jobs:
       run: |
         make pull-docker-images-cache || true
         make docker-images
+      env:
+        DOCKER_DEFAULT_PLATFORM: linux/${{ matrix.arch }}
 
     - name: Push cache images
       if: env.NUCLIO_LABEL == 'unstable'
@@ -163,14 +157,7 @@ jobs:
 
     - name: Install QEMU
       if: matrix.arch != 'amd64'
-      run: |
-
-        # install os packages
-        sudo apt update -qqy && sudo apt -qqy install qemu qemu-user-static
-
-        # enabled non arm64 docker containers executables
-        # mirrored to gcr.io/iguazio from multiarch/qemu-user-static:latest for availability reasons
-        docker run --rm --privileged gcr.io/iguazio/multiarch/qemu-user-static:latest --reset -p yes
+      uses: docker/setup-qemu-action@v2
 
     - name: Build binaries
       run: |
@@ -182,6 +169,7 @@ jobs:
       env:
         NUCLIO_NUCTL_CREATE_SYMLINK: false
         GOPATH: /home/runner/go
+        DOCKER_DEFAULT_PLATFORM: linux/${{ matrix.arch }}
 
     - name: Upload binaries
       uses: AButler/upload-release-assets@v2.0.2


### PR DESCRIPTION
export `DOCKER_DEFAULT_PLATFORM ` to ensure all docker builds command passes are targeted to right architecture
in addition, use docker qemu install script, for simplicitness
