### PR TITLE
[Release] Faster processor build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,8 @@
 !cmd
 !test
 
+!.bin
+
 !go.mod
 !go.sum
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,11 @@ jobs:
       - name: Freeing up disk space
         run: "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
 
+      - uses: actions/setup-go@v3
+        with:
+          cache: true
+          go-version-file: go.mod
+
       - name: Build
         run: |
           make docker-images

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,11 @@ on:
     - development
 
   workflow_dispatch:
+    inputs:
+      docker_image_rule:
+        description: 'Docker image rule to build and release (space separated)'
+        required: false
+        default: ''
 
 env:
   REPO: quay.io
@@ -51,9 +56,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: print targets
+      - name: define targets
         id: set-matrix
         run: |
+
+          # if custom image is given, use it
+          if [ -n "${{ github.event.inputs.docker_image_rule }}" ]; then \
+            export DOCKER_IMAGES_RULES="${{ github.event.inputs.docker_image_rule }}" \
+          fi
+
           docker_image_rules_json=$(make print-docker-image-rules-json)
           
           # if "handler-builder-golang-onbuild" is in the matrix
@@ -64,7 +75,7 @@ jobs:
           echo "matrix=$(echo $docker_image_rules_json | jq -c '[.[].image_rule]')" >> $GITHUB_OUTPUT
 
   release:
-    if: github.repository == 'mlrun/mlrun' || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'nuclio/nuclio' || github.event_name == 'workflow_dispatch'
     name: Release image (${{ matrix.docker_image_rule }}-${{ matrix.arch }})
     runs-on: ubuntu-latest
     needs: image_matrix_prep

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,7 +63,7 @@ jobs:
           # if custom image is given, use it
           if [ -n "${{ github.event.inputs.docker_image_rule }}" ]; then \
             export DOCKER_IMAGES_RULES="${{ github.event.inputs.docker_image_rule }}" \
-          fi
+          fi;
 
           docker_image_rules_json=$(make print-docker-image-rules-json)
           

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,9 @@ jobs:
           docker_image_rules_json=$(echo $docker_image_rules_json | \
             jq -c 'select(.[].image_rule=="handler-builder-golang-onbuild") += [{"image_rule":"handler-builder-golang-onbuild-alpine"}]')
           
+          echo $docker_image_rules_json
           echo "matrix=$(echo $docker_image_rules_json | jq -c '[.[].image_rule]')" >> $GITHUB_OUTPUT
+          
 
   release:
     if: github.repository == 'nuclio/nuclio' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,8 +61,8 @@ jobs:
         run: |
 
           # if custom image is given, use it
-          if [ -n "${{ github.event.inputs.docker_image_rule }}" ]; then \
-            export DOCKER_IMAGES_RULES="${{ github.event.inputs.docker_image_rule }}" \
+          if [[ -n "${{ github.event.inputs.docker_image_rule }}" ]]; then \
+            export DOCKER_IMAGES_RULES="${{ github.event.inputs.docker_image_rule }}"; \
           fi;
 
           docker_image_rules_json=$(make print-docker-image-rules-json)
@@ -108,9 +108,6 @@ jobs:
       run: echo "NUCLIO_LABEL=${{ steps.release_info.outputs.REF_TAG }}" >> $GITHUB_ENV
 
     - uses: actions/checkout@v3
-
-    - name: Freeing up disk space
-      run: "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
 
     - uses: actions/setup-go@v3
       with:

--- a/.github/workflows/security_scan.yaml
+++ b/.github/workflows/security_scan.yaml
@@ -86,6 +86,11 @@ jobs:
           fetch-depth: 0
           ref: refs/pull/${{ github.event.inputs.pr_number }}/merge
 
+      - uses: actions/setup-go@v3
+        with:
+          cache: true
+          go-version-file: go.mod
+
       - name: Build ${{ matrix.image_rule }} image
         run: make docker-images
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ pkg/processor/runtime/python/py/whl
 # act files (https://github.com/nektos/act)
 .github/act
 
+# build artifacts
+.bin
+
 vendor
 
 # general

--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ processor: modules
 	@# this is done to avoid trying compiling the processor binary on the image
 	@# while using virtualization / emulation to match the desired architecture
 	@mkdir -p ./.bin
-	GOARCH=$(NUCLIO_ARCH) go build \
+	GOARCH=$(NUCLIO_ARCH) CGO_ENABLED=0 go build \
         -a \
         -installsuffix cgo \
         -ldflags="$(GO_LINK_FLAGS_INJECT_VERSION)" \

--- a/Makefile
+++ b/Makefile
@@ -263,11 +263,22 @@ NUCLIO_DOCKER_PROCESSOR_IMAGE_NAME=$(NUCLIO_DOCKER_REPO)/processor:$(NUCLIO_DOCK
 NUCLIO_DOCKER_PROCESSOR_IMAGE_NAME_CACHE=$(NUCLIO_CACHE_REPO)/processor:$(NUCLIO_DOCKER_IMAGE_CACHE_TAG)
 
 .PHONY: processor
-processor: build-builder
+processor: modules
+
+	@# build processor locally
+	@# build its image and copy from host to image
+	@# this is done to avoid trying compiling the processor binary on the image
+	@# while using virtualization / emulation to match the desired architecture
+	@mkdir -p ./.bin
+	GOARCH=$(NUCLIO_ARCH) go build \
+        -a \
+        -installsuffix cgo \
+        -ldflags="$(GO_LINK_FLAGS_INJECT_VERSION)" \
+        -o ./.bin/processor-$(NUCLIO_ARCH) \
+        cmd/processor/main.go
+
 	docker build \
-		--build-arg NUCLIO_GO_LINK_FLAGS_INJECT_VERSION="$(GO_LINK_FLAGS_INJECT_VERSION)" \
-		--build-arg NUCLIO_DOCKER_IMAGE_TAG=$(NUCLIO_DOCKER_IMAGE_TAG) \
-		--build-arg NUCLIO_DOCKER_REPO=$(NUCLIO_DOCKER_REPO) \
+		--build-arg NUCLIO_ARCH=$(NUCLIO_ARCH) \
 		--build-arg BUILDKIT_INLINE_CACHE=1 \
 		--cache-from $(NUCLIO_DOCKER_PROCESSOR_IMAGE_NAME_CACHE) \
 		--file cmd/processor/Dockerfile \
@@ -814,7 +825,6 @@ endif
 
 .PHONY: modules
 modules: ensure-gopath
-	@echo Getting go modules
 	@go mod download
 
 .PHONY: targets

--- a/cmd/processor/Dockerfile
+++ b/cmd/processor/Dockerfile
@@ -12,20 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG NUCLIO_DOCKER_IMAGE_TAG
-ARG NUCLIO_DOCKER_REPO
-
-FROM $NUCLIO_DOCKER_REPO/nuclio-builder:$NUCLIO_DOCKER_IMAGE_TAG as build-processor
-
-ARG NUCLIO_GO_LINK_FLAGS_INJECT_VERSION
-
-# build the processor
-RUN go build \
-    -a \
-    -installsuffix cgo \
-    -ldflags="${NUCLIO_GO_LINK_FLAGS_INJECT_VERSION}" \
-    -o processor cmd/processor/main.go
-
 FROM scratch
 
-COPY --from=build-processor  /nuclio/processor /home/nuclio/bin/processor
+ARG NUCLIO_ARCH=amd64
+
+ADD .bin/processor-$NUCLIO_ARCH /home/nuclio/bin/processor


### PR DESCRIPTION
When compiling processor under different architecture than host, the emulation layer of qemu/docker makes build process takes forever.
In order to reduce it, we will compile processor binary on host while injecting the "architecture" to go, allowing it to compile it natively to its desired arch and the processor image will simply load it. that way, we reduce the compilation of processor on image from ~30m to ~3m for arm64