### PR TITLE
[CI] Refine release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -144,6 +144,10 @@ jobs:
         DOCKER_DEFAULT_PLATFORM: linux/${{ matrix.arch }}
         DOCKER_IMAGES_RULES: ${{ matrix.docker_image_rule }}
 
+        # this only applies when target is `handler-builder-golang-onbuild`
+        # not applied when target is `handler-builder-golang-onbuild-alpine`
+        SKIP_BUILD_GOLANG_ONBUILD_ALPINE: true
+
     - name: Push cache images
       if: env.NUCLIO_LABEL == 'unstable'
       run: make push-docker-images-cache

--- a/Makefile
+++ b/Makefile
@@ -453,7 +453,11 @@ handler-builder-golang-onbuild-alpine: build-builder
 		.
 
 .PHONY: handler-builder-golang-onbuild
-handler-builder-golang-onbuild: build-builder handler-builder-golang-onbuild-alpine
+handler-builder-golang-onbuild: build-builder
+ifndef SKIP_BUILD_GOLANG_ONBUILD_ALPINE
+handler-builder-golang-onbuild: handler-builder-golang-onbuild-alpine
+endif
+handler-builder-golang-onbuild:
 	docker build \
 		--build-arg NUCLIO_DOCKER_IMAGE_TAG=$(NUCLIO_DOCKER_IMAGE_TAG) \
 		--build-arg NUCLIO_GO_LINK_FLAGS_INJECT_VERSION="$(GO_LINK_FLAGS_INJECT_VERSION)" \


### PR DESCRIPTION
When making onbuild golang  it builds alpine image as well as go function defaultto alpine images. for development it is handy, for release it runs the build twice while not needed. this PR ensure when building alpine / regular onbuild go, it builds them only