### PR TITLE
[Build] Update go build commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -443,7 +443,7 @@ NUCLIO_DOCKER_HANDLER_BUILDER_GOLANG_ONBUILD_ALPINE_IMAGE_NAME_CACHE=\
  $(NUCLIO_CACHE_REPO)/handler-builder-golang-onbuild:$(NUCLIO_DOCKER_IMAGE_CACHE_ALPINE_TAG)
 
 .PHONY: handler-builder-golang-onbuild-alpine
-handler-builder-golang-onbuild-alpine: processor
+handler-builder-golang-onbuild-alpine: build-builder
 	docker build \
 		--build-arg NUCLIO_ARCH=$(NUCLIO_ARCH) \
 		--build-arg NUCLIO_GO_LINK_FLAGS_INJECT_VERSION="$(GO_LINK_FLAGS_INJECT_VERSION)" \
@@ -456,7 +456,7 @@ handler-builder-golang-onbuild-alpine: processor
 		.
 
 .PHONY: handler-builder-golang-onbuild
-handler-builder-golang-onbuild: processor
+handler-builder-golang-onbuild: build-builder
 ifndef SKIP_BUILD_GOLANG_ONBUILD_ALPINE
 handler-builder-golang-onbuild: handler-builder-golang-onbuild-alpine
 endif

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ helm-publish:
 
 # tools get built with the specified OS/arch and inject version
 GO_BUILD_TOOL_WORKDIR = /nuclio
-GO_BUILD_NUCTL = go build -ldflags="$(GO_LINK_FLAGS_INJECT_VERSION)"
+GO_BUILD_CMD = go build -ldflags="$(GO_LINK_FLAGS_INJECT_VERSION)"
 
 #
 # Rules
@@ -249,7 +249,7 @@ nuctl: ensure-gopath build-builder
 		--env GOOS=$(NUCLIO_OS) \
 		--env GOARCH=$(NUCLIO_ARCH) \
 		$(NUCLIO_DOCKER_REPO)/nuclio-builder:$(NUCLIO_DOCKER_IMAGE_TAG) \
-		$(GO_BUILD_NUCTL) -o /go/bin/$(NUCTL_BIN_NAME) cmd/nuctl/main.go
+		$(GO_BUILD_CMD) -o /go/bin/$(NUCTL_BIN_NAME) cmd/nuctl/main.go
 ifeq ($(NUCLIO_NUCTL_CREATE_SYMLINK), true)
 	@rm -f $(NUCTL_TARGET)
 	@ln -sF $(GOPATH)/bin/$(NUCTL_BIN_NAME) $(NUCTL_TARGET)
@@ -257,7 +257,7 @@ endif
 
 .PHONY: nuctl-bin
 nuctl-bin: ensure-gopath
-	CGO_ENABLED=0 $(GO_BUILD_NUCTL) -o $(NUCLIO_PATH)/$(NUCTL_BIN_NAME) cmd/nuctl/main.go
+	CGO_ENABLED=0 $(GO_BUILD_CMD) -o $(NUCLIO_PATH)/$(NUCTL_BIN_NAME) cmd/nuctl/main.go
 
 NUCLIO_DOCKER_PROCESSOR_IMAGE_NAME=$(NUCLIO_DOCKER_REPO)/processor:$(NUCLIO_DOCKER_IMAGE_TAG)
 NUCLIO_DOCKER_PROCESSOR_IMAGE_NAME_CACHE=$(NUCLIO_CACHE_REPO)/processor:$(NUCLIO_DOCKER_IMAGE_CACHE_TAG)
@@ -270,8 +270,7 @@ processor: modules
 	@# this is done to avoid trying compiling the processor binary on the image
 	@# while using virtualization / emulation to match the desired architecture
 	@mkdir -p ./.bin
-	GOARCH=$(NUCLIO_ARCH) CGO_ENABLED=0 go build \
-        -ldflags="$(GO_LINK_FLAGS_INJECT_VERSION)" \
+	GOARCH=$(NUCLIO_ARCH) CGO_ENABLED=0 $(GO_BUILD_CMD) \
         -o ./.bin/processor-$(NUCLIO_ARCH) \
         cmd/processor/main.go
 

--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ processor: modules
 	@# this is done to avoid trying compiling the processor binary on the image
 	@# while using virtualization / emulation to match the desired architecture
 	@mkdir -p ./.bin
-	GOARCH=$(NUCLIO_ARCH) CGO_ENABLED=0 $(GO_BUILD_CMD) \
+	GOARCH=$(NUCLIO_ARCH) GOOS=linux CGO_ENABLED=0 $(GO_BUILD_CMD) \
         -o ./.bin/processor-$(NUCLIO_ARCH) \
         cmd/processor/main.go
 

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ helm-publish:
 
 # tools get built with the specified OS/arch and inject version
 GO_BUILD_TOOL_WORKDIR = /nuclio
-GO_BUILD_NUCTL = go build -a -installsuffix cgo -ldflags="$(GO_LINK_FLAGS_INJECT_VERSION)"
+GO_BUILD_NUCTL = go build -ldflags="$(GO_LINK_FLAGS_INJECT_VERSION)"
 
 #
 # Rules
@@ -271,8 +271,6 @@ processor: modules
 	@# while using virtualization / emulation to match the desired architecture
 	@mkdir -p ./.bin
 	GOARCH=$(NUCLIO_ARCH) CGO_ENABLED=0 go build \
-        -a \
-        -installsuffix cgo \
         -ldflags="$(GO_LINK_FLAGS_INJECT_VERSION)" \
         -o ./.bin/processor-$(NUCLIO_ARCH) \
         cmd/processor/main.go

--- a/Makefile
+++ b/Makefile
@@ -89,14 +89,17 @@ ifeq ($(NUCLIO_ARCH), armhf)
 	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/arm32v7/alpine:3.17
 	NUCLIO_BASE_IMAGE_NAME 			?= gcr.io/iguazio/arm32v7/golang
 	NUCLIO_DOCKER_JAVA_OPENJDK		?= gcr.io/iguazio/openjdk:11-slim
+	NODE_IMAGE_NAME 				?= gcr.io/iguazio/arm32v7/node:14.21
 else ifeq ($(NUCLIO_ARCH), arm64)
 	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/arm64v8/alpine:3.17
 	NUCLIO_BASE_IMAGE_NAME 			?= gcr.io/iguazio/arm64v8/golang
 	NUCLIO_DOCKER_JAVA_OPENJDK 		?= gcr.io/iguazio/arm64v8/openjdk:11-slim
+	NODE_IMAGE_NAME 				?= gcr.io/iguazio/arm64v8/node:14.21
 else
 	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/alpine:3.17
 	NUCLIO_BASE_IMAGE_NAME 			?= gcr.io/iguazio/golang
 	NUCLIO_DOCKER_JAVA_OPENJDK		?= gcr.io/iguazio/openjdk:11-slim
+	NODE_IMAGE_NAME 				?= gcr.io/iguazio/node:14.21
 endif
 
 NUCLIO_BASE_IMAGE_TAG ?= 1.19
@@ -336,6 +339,8 @@ dashboard: build-builder
 		--build-arg NGINX_IMAGE=$(NUCLIO_DOCKER_DASHBOARD_NGINX_BASE_IMAGE) \
 		--build-arg NUCLIO_DOCKER_ALPINE_IMAGE=$(NUCLIO_DOCKER_ALPINE_IMAGE) \
 		--build-arg NUCLIO_GO_LINK_FLAGS_INJECT_VERSION="$(GO_LINK_FLAGS_INJECT_VERSION)" \
+		--build-arg UHTTPC_ARCH="$(NUCLIO_DOCKER_DASHBOARD_UHTTPC_ARCH)" \
+		--build-arg NODE_IMAGE_NAME=$(NODE_IMAGE_NAME) \
 		--build-arg NUCLIO_DOCKER_REPO=$(NUCLIO_DOCKER_REPO) \
 		--build-arg NUCLIO_DOCKER_IMAGE_TAG=$(NUCLIO_DOCKER_IMAGE_TAG) \
 		--build-arg BUILDKIT_INLINE_CACHE=1 \
@@ -438,8 +443,9 @@ NUCLIO_DOCKER_HANDLER_BUILDER_GOLANG_ONBUILD_ALPINE_IMAGE_NAME_CACHE=\
  $(NUCLIO_CACHE_REPO)/handler-builder-golang-onbuild:$(NUCLIO_DOCKER_IMAGE_CACHE_ALPINE_TAG)
 
 .PHONY: handler-builder-golang-onbuild-alpine
-handler-builder-golang-onbuild-alpine: build-builder
+handler-builder-golang-onbuild-alpine: processor
 	docker build \
+		--build-arg NUCLIO_ARCH=$(NUCLIO_ARCH) \
 		--build-arg NUCLIO_GO_LINK_FLAGS_INJECT_VERSION="$(GO_LINK_FLAGS_INJECT_VERSION)" \
 		--build-arg NUCLIO_BASE_IMAGE_NAME=$(NUCLIO_BASE_IMAGE_NAME) \
 		--build-arg NUCLIO_BASE_ALPINE_IMAGE_TAG=$(NUCLIO_BASE_ALPINE_IMAGE_TAG) \
@@ -450,12 +456,13 @@ handler-builder-golang-onbuild-alpine: build-builder
 		.
 
 .PHONY: handler-builder-golang-onbuild
-handler-builder-golang-onbuild: build-builder
+handler-builder-golang-onbuild: processor
 ifndef SKIP_BUILD_GOLANG_ONBUILD_ALPINE
 handler-builder-golang-onbuild: handler-builder-golang-onbuild-alpine
 endif
 handler-builder-golang-onbuild:
 	docker build \
+		--build-arg NUCLIO_ARCH=$(NUCLIO_ARCH) \
 		--build-arg NUCLIO_DOCKER_IMAGE_TAG=$(NUCLIO_DOCKER_IMAGE_TAG) \
 		--build-arg NUCLIO_GO_LINK_FLAGS_INJECT_VERSION="$(GO_LINK_FLAGS_INJECT_VERSION)" \
 		--build-arg NUCLIO_BASE_IMAGE_NAME=$(NUCLIO_BASE_IMAGE_NAME) \

--- a/cmd/autoscaler/Dockerfile
+++ b/cmd/autoscaler/Dockerfile
@@ -25,8 +25,6 @@ FROM $NUCLIO_DOCKER_REPO/nuclio-builder:$NUCLIO_DOCKER_IMAGE_TAG as build-autosc
 ARG NUCLIO_GO_LINK_FLAGS_INJECT_VERSION
 
 RUN go build \
-    -a \
-    -installsuffix cgo \
     -ldflags="${NUCLIO_GO_LINK_FLAGS_INJECT_VERSION}" \
     -o autoscaler cmd/autoscaler/main.go
 

--- a/cmd/controller/Dockerfile
+++ b/cmd/controller/Dockerfile
@@ -25,8 +25,6 @@ FROM $NUCLIO_DOCKER_REPO/nuclio-builder:$NUCLIO_DOCKER_IMAGE_TAG as build-contro
 ARG NUCLIO_GO_LINK_FLAGS_INJECT_VERSION
 
 RUN go build \
-    -a \
-    -installsuffix cgo \
     -ldflags="${NUCLIO_GO_LINK_FLAGS_INJECT_VERSION}" \
     -o controller cmd/controller/main.go
 

--- a/cmd/dashboard/docker/Dockerfile
+++ b/cmd/dashboard/docker/Dockerfile
@@ -20,8 +20,9 @@ ARG NUCLIO_DOCKER_IMAGE_TAG
 ARG UHTTPC_ARCH=amd64
 ARG NUCLIO_DOCKER_ALPINE_IMAGE
 ARG NUCLIO_DOCKER_REPO
+ARG NODE_IMAGE_NAME
 
-FROM gcr.io/iguazio/node:14.21 as build-static
+FROM $NODE_IMAGE_NAME as build-static
 
 # copy source tree
 COPY ./pkg/dashboard/ui /home/nuclio/dashboard/src

--- a/cmd/dashboard/docker/Dockerfile
+++ b/cmd/dashboard/docker/Dockerfile
@@ -42,8 +42,6 @@ FROM $NUCLIO_DOCKER_REPO/nuclio-builder:$NUCLIO_DOCKER_IMAGE_TAG as build-binary
 ARG NUCLIO_GO_LINK_FLAGS_INJECT_VERSION
 
 RUN go build \
-    -a \
-    -installsuffix cgo \
     -ldflags="${NUCLIO_GO_LINK_FLAGS_INJECT_VERSION}" \
     -o dashboard cmd/dashboard/main.go
 

--- a/cmd/dlx/Dockerfile
+++ b/cmd/dlx/Dockerfile
@@ -26,8 +26,6 @@ ARG NUCLIO_GO_LINK_FLAGS_INJECT_VERSION
 
 # build dlx
 RUN go build \
-    -a \
-    -installsuffix cgo \
     -ldflags="${NUCLIO_GO_LINK_FLAGS_INJECT_VERSION}" \
     -o dlx cmd/dlx/main.go
 

--- a/pkg/platform/factory/factory.go
+++ b/pkg/platform/factory/factory.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
+	"github.com/v3io/version-go"
 )
 
 // CreatePlatform creates a platform based on a requested type (platformType) and configuration it receives
@@ -71,6 +72,7 @@ func CreatePlatform(ctx context.Context,
 
 	parentLogger.DebugWithCtx(ctx,
 		"Initializing platform",
+		"version", version.Get().String(),
 		"platformName", newPlatform.GetName())
 	if err = newPlatform.Initialize(ctx); err != nil {
 		return nil, errors.Wrap(err, "Failed to initialize platform")

--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -51,15 +51,18 @@ type Store struct {
 	logger       logger.Logger
 	dockerClient dockerclient.Client
 	platform     platform.Platform
+	imageName    string
 }
 
 func NewStore(parentLogger logger.Logger,
 	platform platform.Platform,
-	dockerClient dockerclient.Client) (*Store, error) {
+	dockerClient dockerclient.Client,
+	imageName string) (*Store, error) {
 	return &Store{
 		logger:       parentLogger.GetChild("store"),
 		dockerClient: dockerClient,
 		platform:     platform,
+		imageName:    imageName,
 	}, nil
 }
 
@@ -414,7 +417,7 @@ func (s *Store) runCommand(env map[string]string, format string, args ...interfa
 
 		// run a container that simply volumizes the volume with the storage and sleeps for 6 hours
 		// using alpine mirrored to gcr.io/iguazio for stability
-		if _, err := s.dockerClient.RunContainer("gcr.io/iguazio/alpine:3.17", &dockerclient.RunOptions{
+		if _, err := s.dockerClient.RunContainer(s.imageName, &dockerclient.RunOptions{
 			Volumes:          map[string]string{volumeName: baseDir},
 			Remove:           true,
 			Command:          `/bin/sh -c "/bin/sleep 6h"`,

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -106,7 +106,7 @@ func NewPlatform(ctx context.Context,
 
 	newPlatform.storeImageName = "gcr.io/iguazio/alpine:3.17"
 	if version.Get().Arch == "arm64" {
-		newPlatform.storeImageName += fmt.Sprintf("-%s", version.Get().Arch)
+		newPlatform.storeImageName = "gcr.io/iguazio/arm64v8/alpine:3.17"
 	}
 
 	if newPlatform.ContainerBuilder, err = containerimagebuilderpusher.NewDocker(newPlatform.Logger,

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -49,6 +49,7 @@ import (
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
 	nucliozap "github.com/nuclio/zap"
+	"github.com/v3io/version-go"
 	"sigs.k8s.io/yaml"
 )
 
@@ -58,6 +59,8 @@ type Platform struct {
 	dockerClient   dockerclient.Client
 	localStore     *client.Store
 	projectsClient project.Client
+
+	storeImageName string
 }
 
 const Mib = 1048576
@@ -101,9 +104,14 @@ func NewPlatform(ctx context.Context,
 		return nil, errors.Wrap(err, "Failed to create a command runner")
 	}
 
+	newPlatform.storeImageName = "gcr.io/iguazio/alpine:3.17"
+	if version.Get().Arch == "arm64" {
+		newPlatform.storeImageName += fmt.Sprintf("-%s", version.Get().Arch)
+	}
+
 	if newPlatform.ContainerBuilder, err = containerimagebuilderpusher.NewDocker(newPlatform.Logger,
 		platformConfiguration.ContainerBuilderConfiguration); err != nil {
-		return nil, errors.Wrap(err, "Failed to create containerimagebuilderpusher")
+		return nil, errors.Wrap(err, "Failed to create container image builder pusher")
 	}
 
 	// create a docker client
@@ -112,7 +120,10 @@ func NewPlatform(ctx context.Context,
 	}
 
 	// create a local store for configs and stuff
-	if newPlatform.localStore, err = client.NewStore(parentLogger, newPlatform, newPlatform.dockerClient); err != nil {
+	if newPlatform.localStore, err = client.NewStore(parentLogger,
+		newPlatform,
+		newPlatform.dockerClient,
+		newPlatform.storeImageName); err != nil {
 		return nil, errors.Wrap(err, "Failed to create a local store")
 	}
 
@@ -1198,7 +1209,7 @@ func (p *Platform) prepareFunctionVolumeMount(createFunctionOptions *platform.Cr
 	}
 
 	// dumping contents to volume's processor path
-	if _, err := p.dockerClient.RunContainer("gcr.io/iguazio/alpine:3.17",
+	if _, err := p.dockerClient.RunContainer(p.storeImageName,
 		&dockerclient.RunOptions{
 			Remove:           true,
 			ImageMayNotExist: true,

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -49,7 +50,6 @@ import (
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
 	nucliozap "github.com/nuclio/zap"
-	"github.com/v3io/version-go"
 	"sigs.k8s.io/yaml"
 )
 
@@ -104,9 +104,13 @@ func NewPlatform(ctx context.Context,
 		return nil, errors.Wrap(err, "Failed to create a command runner")
 	}
 
-	newPlatform.storeImageName = "gcr.io/iguazio/alpine:3.17"
-	if version.Get().Arch == "arm64" {
+	switch runtime.GOARCH {
+	case "arm64":
 		newPlatform.storeImageName = "gcr.io/iguazio/arm64v8/alpine:3.17"
+	case "arm":
+		newPlatform.storeImageName = "gcr.io/iguazio/arm32v7/alpine:3.17"
+	default:
+		newPlatform.storeImageName = "gcr.io/iguazio/alpine:3.17"
 	}
 
 	if newPlatform.ContainerBuilder, err = containerimagebuilderpusher.NewDocker(newPlatform.Logger,

--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
@@ -24,8 +24,6 @@ ARG NUCLIO_GO_LINK_FLAGS_INJECT_VERSION
 
 # Build the processor
 RUN go build \
-    -a \
-    -installsuffix cgo \
     -ldflags="${NUCLIO_GO_LINK_FLAGS_INJECT_VERSION}" \
     -o /home/nuclio/bin/processor cmd/processor/main.go
 

--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile.alpine
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile.alpine
@@ -35,8 +35,6 @@ COPY . .
 
 # Build the processor
 RUN go build \
-    -a \
-    -installsuffix cgo \
     -ldflags="${NUCLIO_GO_LINK_FLAGS_INJECT_VERSION}" \
     -o /tmp/processor cmd/processor/main.go
 


### PR DESCRIPTION
1. no need `-a --installsuffix cgo` when `CGO_ENABLED=0`
2. fix building processor on mac (missing target os)
3. print nuclio version upon platform initialization
4. pick store image according to go arch (runtime)
5. pick node image according to go arch (buildtime)