### PR TITLE
[Stream] Fix validation of explicit ack mode with worker pool mode

### DIFF
--- a/pkg/processor/trigger/kafka/types.go
+++ b/pkg/processor/trigger/kafka/types.go
@@ -185,7 +185,7 @@ func NewConfiguration(id string,
 
 	// explicit ack is only allowed for Static Allocation mode
 	if newConfiguration.WorkerAllocationMode != partitionworker.AllocationModeStatic &&
-		functionconfig.ExplicitAckEnabled(triggerConfiguration.ExplicitAckMode) {
+		functionconfig.ExplicitAckEnabled(newConfiguration.ExplicitAckMode) {
 		return nil, errors.New("Explicit ack mode is not allowed when using worker pool allocation mode")
 	}
 

--- a/pkg/processor/trigger/v3iostream/types.go
+++ b/pkg/processor/trigger/v3iostream/types.go
@@ -92,7 +92,7 @@ func NewConfiguration(id string, triggerConfiguration *functionconfig.Trigger,
 
 	// explicit ack is only allowed for Static Allocation mode
 	if newConfiguration.WorkerAllocationMode != partitionworker.AllocationModeStatic &&
-		functionconfig.ExplicitAckEnabled(triggerConfiguration.ExplicitAckMode) {
+		functionconfig.ExplicitAckEnabled(newConfiguration.ExplicitAckMode) {
 		return nil, errors.New("Explicit ack mode is not allowed when using worker pool allocation mode")
 	}
 

--- a/pkg/processor/trigger/v3iostream/types.go
+++ b/pkg/processor/trigger/v3iostream/types.go
@@ -85,11 +85,6 @@ func NewConfiguration(id string, triggerConfiguration *functionconfig.Trigger,
 		return nil, errors.Wrap(err, "Failed to populate explicit ack mode")
 	}
 
-	// default explicit ack mode to 'disable'
-	if triggerConfiguration.ExplicitAckMode == "" {
-		newConfiguration.ExplicitAckMode = functionconfig.ExplicitAckModeDisable
-	}
-
 	// explicit ack is only allowed for Static Allocation mode
 	if newConfiguration.WorkerAllocationMode != partitionworker.AllocationModeStatic &&
 		functionconfig.ExplicitAckEnabled(newConfiguration.ExplicitAckMode) {


### PR DESCRIPTION
Validate the new configuration's explicit ack mode against the worker allocation mode after it is populated from annotations, instead of validating against the trigger configuration.

Fixes https://jira.iguazeng.com/browse/IG-21815