### PR TITLE
[Build] `apk update` before adding alpine packages in Go runtime

### DIFF
--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile.alpine
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile.alpine
@@ -45,7 +45,7 @@ FROM ${NUCLIO_BASE_IMAGE_NAME}:${NUCLIO_BASE_ALPINE_IMAGE_TAG}
 
 # Download required packages for plugin compilation
 # binutils-gold for arm64 handling of "collect2: fatal error: cannot find 'ld'"
-RUN apk upgrade --no-cache \
+RUN apk update && apk upgrade --no-cache \
     && apk add --no-cache git gcc musl-dev file binutils-gold
 
 # Store processor binary


### PR DESCRIPTION
Building docker images for the `handler-builder-golang-onbuild` target intermittently fails the following step in the Dockerfile:
```sh
RUN apk upgrade --no-cache     && apk add --no-cache git gcc musl-dev file binutils-gold
```
With the following errors:
```
ERROR: libstdc++-12.2.1_git20220924-r4: remote server returned error (try 'apk update')
ERROR: binutils-gold-2.39-r2: remote server returned error (try 'apk update')
...
```

So adding apk update before the RUN command.