### PR TITLE
[Docs] Remove rebalance section from v3iostream trigger

### DIFF
--- a/docs/reference/triggers/v3iostream.md
+++ b/docs/reference/triggers/v3iostream.md
@@ -112,11 +112,6 @@ qualified_offset = nuclio.QualifiedOffset.from_event(event)
 await context.platform.explicit_ack(qualified_offset)
 ```
 
-During [rebalance](#rebalancing), the function can still be processing events. We can register a callback to drop or commit events being handled when the rebalancing is about to happen, using the following method:
-```py
-context.platform.on_signal(callback)
-```
-
 **NOTES**:
 * Currently, the explicit ack feature is only available for python runtime and functions that have a stream trigger (kafka/v3io).
 * The explicit ack feature can be enabled only when using a static worker allocation mode. Meaning that the function metadata must have the following annotation: `"nuclio.io/v3iostream-worker-allocation-mode":"static"`.


### PR DESCRIPTION
V3IO stream trigger doesn't support rebalace, this `on_signal` is irrelevent for it.

Resolves https://jira.iguazeng.com/browse/IG-21820 