### PR TITLE
[Trigger] Fix resolving worker allocation mode

### DIFF
--- a/pkg/processor/trigger/kafka/kafka_test.go
+++ b/pkg/processor/trigger/kafka/kafka_test.go
@@ -151,6 +151,7 @@ func (suite *TestSuite) TestExplicitAckModeWithWorkerAllocationModes() {
 						"brokers": []string{
 							"some-broker",
 						},
+						"workerAllocationMode": string(testCase.workerAllocationMode),
 					},
 				},
 				&runtime.Configuration{
@@ -158,8 +159,7 @@ func (suite *TestSuite) TestExplicitAckModeWithWorkerAllocationModes() {
 						Config: functionconfig.Config{
 							Meta: functionconfig.Meta{
 								Annotations: map[string]string{
-									"nuclio.io/kafka-explicit-ack-mode":      string(testCase.explicitAckMode),
-									"nuclio.io/kafka-worker-allocation-mode": string(testCase.workerAllocationMode),
+									"nuclio.io/kafka-explicit-ack-mode": string(testCase.explicitAckMode),
 								},
 							},
 						},

--- a/pkg/processor/trigger/kafka/test/kafka_test.go
+++ b/pkg/processor/trigger/kafka/test/kafka_test.go
@@ -227,9 +227,10 @@ func (suite *testSuite) TestExplicitAck() {
 					Kind: "kafka-cluster",
 					URL:  fmt.Sprintf("%s:9090", suite.brokerContainerName),
 					Attributes: map[string]interface{}{
-						"topics":        []string{topic},
-						"consumerGroup": functionName,
-						"initialOffset": suite.initialOffset,
+						"topics":               []string{topic},
+						"consumerGroup":        functionName,
+						"initialOffset":        suite.initialOffset,
+						"workerAllocationMode": string(partitionworker.AllocationModeStatic),
 					},
 					WorkerTerminationTimeout: "5s",
 					ExplicitAckMode:          functionconfig.ExplicitAckModeEnable,
@@ -238,11 +239,6 @@ func (suite *testSuite) TestExplicitAck() {
 					Kind:       "http",
 					Attributes: map[string]interface{}{},
 				},
-			}
-
-			// set worker allocation mode to static
-			createFunctionOptions.FunctionConfig.Meta.Annotations = map[string]string{
-				"nuclio.io/kafka-worker-allocation-mode": string(partitionworker.AllocationModeStatic),
 			}
 
 			// deploy function

--- a/pkg/processor/trigger/types.go
+++ b/pkg/processor/trigger/types.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/util/partitionworker"
 	"github.com/nuclio/nuclio/pkg/processor/worker"
 
 	"github.com/nuclio/errors"
@@ -141,6 +142,20 @@ func (c *Configuration) PopulateExplicitAckMode(explicitAckModeValue string,
 		}
 	}
 	return nil
+}
+
+func (c *Configuration) ResolveWorkerAllocationMode(modeFromAttributes, modeFromAnnotation partitionworker.AllocationMode) partitionworker.AllocationMode {
+
+	// prioritize attribute over annotation
+	if modeFromAttributes != "" {
+		return modeFromAttributes
+	}
+	if modeFromAnnotation != "" {
+		return modeFromAnnotation
+	}
+
+	// default to pool
+	return partitionworker.AllocationModePool
 }
 
 type Statistics struct {

--- a/pkg/processor/trigger/v3iostream/v3iostream_test.go
+++ b/pkg/processor/trigger/v3iostream/v3iostream_test.go
@@ -97,10 +97,11 @@ func (suite *TestSuite) TestExplicitAckModeWithWorkerAllocationModes() {
 				&functionconfig.Trigger{
 					// populate some dummy values
 					Attributes: map[string]interface{}{
-						"containerName": "my-container",
-						"streamPath":    "/my-stream",
-						"consumerGroup": "some-cg",
-						"password":      "some-password",
+						"containerName":        "my-container",
+						"streamPath":           "/my-stream",
+						"consumerGroup":        "some-cg",
+						"password":             "some-password",
+						"workerAllocationMode": string(testCase.workerAllocationMode),
 					},
 				},
 				&runtime.Configuration{
@@ -108,8 +109,7 @@ func (suite *TestSuite) TestExplicitAckModeWithWorkerAllocationModes() {
 						Config: functionconfig.Config{
 							Meta: functionconfig.Meta{
 								Annotations: map[string]string{
-									"nuclio.io/v3iostream-explicit-ack-mode":      string(testCase.explicitAckMode),
-									"nuclio.io/v3iostream-worker-allocation-mode": string(testCase.workerAllocationMode),
+									"nuclio.io/v3iostream-explicit-ack-mode": string(testCase.explicitAckMode),
 								},
 							},
 						},


### PR DESCRIPTION
In stream triggers (kafka/v3io) setting worker allocation mode via annotations is supported, however in most cases it is set in the trigger attributes (e.g. in the UI).
Unorganized code caused the annotation value to always override the attribute, and populate the default in case no annotation was given.

In this PR I added a common function to resolve the worker allocation mode, where the attribute has priority over the annotation, as annotations are mostly used for tech-previewing functionalities.

Fixes https://jira.iguazeng.com/browse/IG-21823