### PR TITLE
[Git] Fix resolving Azure repository URL

### DIFF
--- a/pkg/common/git/git.go
+++ b/pkg/common/git/git.go
@@ -120,11 +120,21 @@ func (agc *AbstractClient) cloneFromAzureDevops(outputDir string,
 	// compile repository URL with git auth credentials
 	if gitAuth != nil {
 		splitFunctionPath := strings.Split(repositoryURL, "://")
+		prefix := splitFunctionPath[0]
+		projectPath := splitFunctionPath[1]
+
+		// when getting a git URL from azure, the project name might appear in the URL, so we need to remove it
+		// as we comprise the URL with the credentials instead.
+		if strings.Contains(splitFunctionPath[1], "@") {
+			splitProjectPath := strings.Split(splitFunctionPath[1], "@")
+			projectPath = splitProjectPath[1]
+		}
+
 		repositoryURL = fmt.Sprintf("%s://%s:%s@%s",
-			splitFunctionPath[0],
+			prefix,
 			gitAuth.Username,
 			gitAuth.Password,
-			splitFunctionPath[1])
+			projectPath)
 
 		// redact username and password (so it won't be logged)
 		runOptions = &cmdrunner.RunOptions{

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -687,6 +687,17 @@ func (suite *testSuite) TestResolveFunctionPathGitCodeEntry() {
 				},
 			},
 		},
+		{
+			Name: "AzureDevopsBranchWithDuplicatedProjectName",
+			BuildConfiguration: functionconfig.Build{
+				CodeEntryType: GitEntryType,
+				Path:          "https://sahar920089@dev.azure.com/sahar920089/test-nuclio-cet/_git/test-nuclio-cet",
+				CodeEntryAttributes: map[string]interface{}{
+					"workDir": "go-function",
+					"branch":  "go-func",
+				},
+			},
+		},
 	} {
 		suite.Run(testCase.Name, func() {
 			err := suite.builder.createTempDir()


### PR DESCRIPTION
When getting a git URL from azure, the project name might appear in the URL, so we need to remove it, as we comprise the URL with the credentials instead.

Meaning, we now support both these url formats:
```
https://dev.azure.com/<project-name>/<repo-name>/_git/<repo-name>
https://<project-name>@dev.azure.com/<project-name>/<repo-name>/_git/<repo-name>
```