### PR TITLE
[Event Encoder] Add `offset` filed when encoding events

### DIFF
--- a/pkg/platform/kube/controller/controller.go
+++ b/pkg/platform/kube/controller/controller.go
@@ -169,7 +169,7 @@ func NewController(parentLogger logger.Logger,
 			&cronJobStaleResourcesCleanupInterval)
 	}
 
-	// creat evicted pods cleanup monitoring
+	// create evicted pods cleanup monitoring
 	newController.evictedPodsMonitoring = NewEvictedPodsMonitoring(ctx,
 		parentLogger,
 		newController,

--- a/pkg/processor/runtime/rpc/encode.go
+++ b/pkg/processor/runtime/rpc/encode.go
@@ -46,6 +46,7 @@ func eventAsMap(event nuclio.Event) map[string]interface{} {
 		"type":         event.GetType(),
 		"type_version": event.GetTypeVersion(),
 		"version":      event.GetVersion(),
+		"offset":       event.GetOffset(),
 	}
 	return eventToEncode
 }

--- a/pkg/processor/runtime/rpc/encode_msgpack.go
+++ b/pkg/processor/runtime/rpc/encode_msgpack.go
@@ -58,10 +58,12 @@ func (e *EventMsgPackEncoder) Encode(event nuclio.Event) error {
 		return errors.Wrap(err, "Failed to encode message")
 	}
 
+	// write the encoded size message to the socket
 	if err := binary.Write(e.writer, binary.BigEndian, int32(e.buf.Len())); err != nil {
 		return errors.Wrap(err, "Failed to write message size to socket")
 	}
 
+	// write the encoded message content to the socket
 	bs := e.buf.Bytes()
 	if _, err := e.writer.Write(bs); err != nil {
 		return errors.Wrap(err, "Failed to write message to socket")


### PR DESCRIPTION
For some reason, the `offset` event field was ignored by the event encoder while transforming the event to a map.
This caused issues with explicit acks, as the offset value was always set to zero.

Resolves https://jira.iguazeng.com/browse/IG-21839 along with https://github.com/nuclio/nuclio-sdk-py/pull/47