### PR TITLE
[Nuctl] Deploy - Fix config enrichment

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -574,13 +574,3 @@ func RemoveStringSliceItemsFromStringSlice(slice []string, itemsToRemove []strin
 	}
 	return list
 }
-
-// PopulateFieldsFromValues populates fields with values if the value is not nil, according to the isNotNilFunc.
-// the given fieldsToValues map is a map of pointers to fields to populate and values.
-func PopulateFieldsFromValues[T string | bool | int](fieldsToValues map[*T]T, isNotNilFunc func(T) bool) {
-	for field, value := range fieldsToValues {
-		if isNotNilFunc(value) {
-			*field = value
-		}
-	}
-}

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -574,3 +574,14 @@ func RemoveStringSliceItemsFromStringSlice(slice []string, itemsToRemove []strin
 	}
 	return list
 }
+
+// PopulateFieldsFromValues populates fields with values if the value is not nil, according to the isNotNilFunc.
+// the given fieldsToValues map is a map of pointers to fields to populate and values.
+func PopulateFieldsFromValues[T string | bool | int](fieldsToValues map[*T]T) {
+	var zeroValue T
+	for field, value := range fieldsToValues {
+		if value != zeroValue {
+			*field = value
+		}
+	}
+}

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -574,3 +574,13 @@ func RemoveStringSliceItemsFromStringSlice(slice []string, itemsToRemove []strin
 	}
 	return list
 }
+
+// PopulateFieldsFromValues populates fields with values if the value is not nil, according to the isNotNilFunc.
+// the given fieldsToValues map is a map of pointers to fields to populate and values.
+func PopulateFieldsFromValues[T string | bool | int](fieldsToValues map[*T]T, isNotNilFunc func(T) bool) {
+	for field, value := range fieldsToValues {
+		if isNotNilFunc(value) {
+			*field = value
+		}
+	}
+}

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -180,12 +180,9 @@ func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, be
 			commandeer.populateHTTPServiceType()
 
 			// Override basic fields from the config
-			commandeer.functionConfig.Meta.Name = commandeer.functionName
-			commandeer.functionConfig.Meta.Namespace = rootCommandeer.namespace
-
-			commandeer.functionConfig.Spec.Build = commandeer.functionBuild
-			commandeer.functionConfig.Spec.Build.Commands = commandeer.commands
-			commandeer.functionConfig.Spec.Build.FunctionConfigPath = commandeer.functionConfigPath
+			if err := commandeer.overrideBasicConfigFields(rootCommandeer); err != nil {
+				return errors.Wrap(err, "Failed overriding basic config fields")
+			}
 
 			// Enrich function config with args
 			commandeer.enrichConfigWithStringArgs()
@@ -416,6 +413,53 @@ func (d *deployCommandeer) populateHTTPServiceType() {
 	if overridingHTTPServiceType != "" {
 		d.rootCommandeer.platformConfiguration.Kube.DefaultServiceType = overridingHTTPServiceType
 	}
+}
+
+// overrideBasicConfigFields overrides basic fields in the function config with the values from the commandeer,
+// if they are given explicitly
+func (d *deployCommandeer) overrideBasicConfigFields(rootCommandeer *RootCommandeer) error {
+
+	// don't override name if it came from a config file
+	if d.functionConfig.Meta.Name == "" {
+		if d.functionName != "" {
+			d.functionConfig.Meta.Name = d.functionName
+		}
+		return errors.New("Function name cannot be empty")
+	} else {
+		if d.functionName != "" && d.functionName != d.functionConfig.Meta.Name {
+			return errors.Errorf("Function name %s is different from the name in the config file %s", d.functionName, d.functionConfig.Meta.Name)
+		}
+		d.functionName = d.functionConfig.Meta.Name
+	}
+
+	if d.functionConfig.Meta.Namespace == "" {
+		d.functionConfig.Meta.Namespace = rootCommandeer.namespace
+	}
+
+	if len(d.commands) != 0 {
+		d.functionConfig.Spec.Build.Commands = d.commands
+	}
+
+	if d.functionConfigPath != "" {
+		d.functionConfig.Spec.Build.FunctionConfigPath = d.functionConfigPath
+	}
+
+	// override build fields if they are given explicitly
+	for flagValue, fieldInFunctionConfig := range map[string]*string{
+		d.functionBuild.Path:               &d.functionConfig.Spec.Build.Path,
+		d.functionBuild.FunctionSourceCode: &d.functionConfig.Spec.Build.FunctionSourceCode,
+		d.functionBuild.Image:              &d.functionConfig.Spec.Build.Image,
+		d.functionBuild.Registry:           &d.functionConfig.Spec.Build.Registry,
+		d.functionBuild.BaseImage:          &d.functionConfig.Spec.Build.BaseImage,
+		d.functionBuild.OnbuildImage:       &d.functionConfig.Spec.Build.OnbuildImage,
+		d.functionBuild.CodeEntryType:      &d.functionConfig.Spec.Build.CodeEntryType,
+	} {
+		if flagValue != "" {
+			*fieldInFunctionConfig = flagValue
+		}
+	}
+
+	return nil
 }
 
 func (d *deployCommandeer) enrichConfigWithStringArgs() {

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -657,31 +657,23 @@ func (d *deployCommandeer) enrichConfigWithComplexArgs() error {
 func (d *deployCommandeer) enrichBuildConfigWithArgs() {
 
 	// enrich string fields in function config with flags
-	for flagValue, fieldInFunctionConfig := range map[string]*string{
-		d.functionConfigPath:               &d.functionConfig.Spec.Build.FunctionConfigPath,
-		d.functionBuild.Path:               &d.functionConfig.Spec.Build.Path,
-		d.functionBuild.FunctionSourceCode: &d.functionConfig.Spec.Build.FunctionSourceCode,
-		d.functionBuild.Image:              &d.functionConfig.Spec.Build.Image,
-		d.functionBuild.Registry:           &d.functionConfig.Spec.Build.Registry,
-		d.functionBuild.BaseImage:          &d.functionConfig.Spec.Build.BaseImage,
-		d.functionBuild.OnbuildImage:       &d.functionConfig.Spec.Build.OnbuildImage,
-		d.functionBuild.CodeEntryType:      &d.functionConfig.Spec.Build.CodeEntryType,
-	} {
-		if flagValue != "" {
-			*fieldInFunctionConfig = flagValue
-		}
-	}
+	common.PopulateFieldsFromValues(map[*string]string{
+		&d.functionConfig.Spec.Build.FunctionConfigPath: d.functionConfigPath,
+		&d.functionConfig.Spec.Build.Path:               d.functionBuild.Path,
+		&d.functionConfig.Spec.Build.FunctionSourceCode: d.functionBuild.FunctionSourceCode,
+		&d.functionConfig.Spec.Build.Image:              d.functionBuild.Image,
+		&d.functionConfig.Spec.Build.Registry:           d.functionBuild.Registry,
+		&d.functionConfig.Spec.Build.BaseImage:          d.functionBuild.BaseImage,
+		&d.functionConfig.Spec.Build.OnbuildImage:       d.functionBuild.OnbuildImage,
+		&d.functionConfig.Spec.Build.CodeEntryType:      d.functionBuild.CodeEntryType,
+	})
 
 	// enrich bool fields in function config with flags
-	for flagValue, fieldInFunctionConfig := range map[bool]*bool{
-		d.functionBuild.NoBaseImagesPull: &d.functionConfig.Spec.Build.NoBaseImagesPull,
-		d.functionBuild.NoCleanup:        &d.functionConfig.Spec.Build.NoCleanup,
-		d.functionBuild.Offline:          &d.functionConfig.Spec.Build.Offline,
-	} {
-		if flagValue {
-			*fieldInFunctionConfig = flagValue
-		}
-	}
+	common.PopulateFieldsFromValues(map[*bool]bool{
+		&d.functionConfig.Spec.Build.NoBaseImagesPull: d.functionBuild.NoBaseImagesPull,
+		&d.functionConfig.Spec.Build.NoCleanup:        d.functionBuild.NoCleanup,
+		&d.functionConfig.Spec.Build.Offline:          d.functionBuild.Offline,
+	})
 }
 
 func (d *deployCommandeer) betaDeploy(ctx context.Context, args []string) error {

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -657,27 +657,31 @@ func (d *deployCommandeer) enrichConfigWithComplexArgs() error {
 func (d *deployCommandeer) enrichBuildConfigWithArgs() {
 
 	// enrich string fields in function config with flags
-	common.PopulateFieldsFromValues(map[*string]string{
-		&d.functionConfig.Spec.Build.FunctionConfigPath: d.functionConfigPath,
-		&d.functionConfig.Spec.Build.Path:               d.functionBuild.Path,
-		&d.functionConfig.Spec.Build.FunctionSourceCode: d.functionBuild.FunctionSourceCode,
-		&d.functionConfig.Spec.Build.Image:              d.functionBuild.Image,
-		&d.functionConfig.Spec.Build.Registry:           d.functionBuild.Registry,
-		&d.functionConfig.Spec.Build.BaseImage:          d.functionBuild.BaseImage,
-		&d.functionConfig.Spec.Build.OnbuildImage:       d.functionBuild.OnbuildImage,
-		&d.functionConfig.Spec.Build.CodeEntryType:      d.functionBuild.CodeEntryType,
-	}, func(s string) bool {
-		return s != ""
-	})
+	for flagValue, fieldInFunctionConfig := range map[string]*string{
+		d.functionConfigPath:               &d.functionConfig.Spec.Build.FunctionConfigPath,
+		d.functionBuild.Path:               &d.functionConfig.Spec.Build.Path,
+		d.functionBuild.FunctionSourceCode: &d.functionConfig.Spec.Build.FunctionSourceCode,
+		d.functionBuild.Image:              &d.functionConfig.Spec.Build.Image,
+		d.functionBuild.Registry:           &d.functionConfig.Spec.Build.Registry,
+		d.functionBuild.BaseImage:          &d.functionConfig.Spec.Build.BaseImage,
+		d.functionBuild.OnbuildImage:       &d.functionConfig.Spec.Build.OnbuildImage,
+		d.functionBuild.CodeEntryType:      &d.functionConfig.Spec.Build.CodeEntryType,
+	} {
+		if flagValue != "" {
+			*fieldInFunctionConfig = flagValue
+		}
+	}
 
 	// enrich bool fields in function config with flags
-	common.PopulateFieldsFromValues(map[*bool]bool{
-		&d.functionConfig.Spec.Build.NoBaseImagesPull: d.functionBuild.NoBaseImagesPull,
-		&d.functionConfig.Spec.Build.NoCleanup:        d.functionBuild.NoCleanup,
-		&d.functionConfig.Spec.Build.Offline:          d.functionBuild.Offline,
-	}, func(b bool) bool {
-		return b
-	})
+	for flagValue, fieldInFunctionConfig := range map[bool]*bool{
+		d.functionBuild.NoBaseImagesPull: &d.functionConfig.Spec.Build.NoBaseImagesPull,
+		d.functionBuild.NoCleanup:        &d.functionConfig.Spec.Build.NoCleanup,
+		d.functionBuild.Offline:          &d.functionConfig.Spec.Build.Offline,
+	} {
+		if flagValue {
+			*fieldInFunctionConfig = flagValue
+		}
+	}
 }
 
 func (d *deployCommandeer) betaDeploy(ctx context.Context, args []string) error {

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -421,10 +421,10 @@ func (d *deployCommandeer) overrideBasicConfigFields(rootCommandeer *RootCommand
 
 	// don't override name if it came from a config file
 	if d.functionConfig.Meta.Name == "" {
-		if d.functionName != "" {
-			d.functionConfig.Meta.Name = d.functionName
+		if d.functionName == "" {
+			return errors.New("Function name cannot be empty")
 		}
-		return errors.New("Function name cannot be empty")
+		d.functionConfig.Meta.Name = d.functionName
 	} else {
 		if d.functionName != "" && d.functionName != d.functionConfig.Meta.Name {
 			return errors.Errorf("Function name %s is different from the name in the config file %s", d.functionName, d.functionConfig.Meta.Name)

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -474,7 +474,6 @@ func (d *deployCommandeer) enrichConfigWithStringArgs() {
 	if d.priorityClassName != "" {
 		d.functionConfig.Spec.PriorityClassName = d.priorityClassName
 	}
-
 }
 
 func (d *deployCommandeer) enrichConfigWithBoolArgs() {
@@ -658,31 +657,27 @@ func (d *deployCommandeer) enrichConfigWithComplexArgs() error {
 func (d *deployCommandeer) enrichBuildConfigWithArgs() {
 
 	// enrich string fields in function config with flags
-	for flagValue, fieldInFunctionConfig := range map[string]*string{
-		d.functionConfigPath:               &d.functionConfig.Spec.Build.FunctionConfigPath,
-		d.functionBuild.Path:               &d.functionConfig.Spec.Build.Path,
-		d.functionBuild.FunctionSourceCode: &d.functionConfig.Spec.Build.FunctionSourceCode,
-		d.functionBuild.Image:              &d.functionConfig.Spec.Build.Image,
-		d.functionBuild.Registry:           &d.functionConfig.Spec.Build.Registry,
-		d.functionBuild.BaseImage:          &d.functionConfig.Spec.Build.BaseImage,
-		d.functionBuild.OnbuildImage:       &d.functionConfig.Spec.Build.OnbuildImage,
-		d.functionBuild.CodeEntryType:      &d.functionConfig.Spec.Build.CodeEntryType,
-	} {
-		if flagValue != "" {
-			*fieldInFunctionConfig = flagValue
-		}
-	}
+	common.PopulateFieldsFromValues(map[*string]string{
+		&d.functionConfig.Spec.Build.FunctionConfigPath: d.functionConfigPath,
+		&d.functionConfig.Spec.Build.Path:               d.functionBuild.Path,
+		&d.functionConfig.Spec.Build.FunctionSourceCode: d.functionBuild.FunctionSourceCode,
+		&d.functionConfig.Spec.Build.Image:              d.functionBuild.Image,
+		&d.functionConfig.Spec.Build.Registry:           d.functionBuild.Registry,
+		&d.functionConfig.Spec.Build.BaseImage:          d.functionBuild.BaseImage,
+		&d.functionConfig.Spec.Build.OnbuildImage:       d.functionBuild.OnbuildImage,
+		&d.functionConfig.Spec.Build.CodeEntryType:      d.functionBuild.CodeEntryType,
+	}, func(s string) bool {
+		return s != ""
+	})
 
 	// enrich bool fields in function config with flags
-	for flagValue, fieldInFunctionConfig := range map[bool]*bool{
-		d.functionBuild.NoBaseImagesPull: &d.functionConfig.Spec.Build.NoBaseImagesPull,
-		d.functionBuild.NoCleanup:        &d.functionConfig.Spec.Build.NoCleanup,
-		d.functionBuild.Offline:          &d.functionConfig.Spec.Build.Offline,
-	} {
-		if flagValue {
-			*fieldInFunctionConfig = flagValue
-		}
-	}
+	common.PopulateFieldsFromValues(map[*bool]bool{
+		&d.functionConfig.Spec.Build.NoBaseImagesPull: d.functionBuild.NoBaseImagesPull,
+		&d.functionConfig.Spec.Build.NoCleanup:        d.functionBuild.NoCleanup,
+		&d.functionConfig.Spec.Build.Offline:          d.functionBuild.Offline,
+	}, func(b bool) bool {
+		return b
+	})
 }
 
 func (d *deployCommandeer) betaDeploy(ctx context.Context, args []string) error {

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -313,7 +313,7 @@ func (suite *functionDeployTestSuite) TestDeployFromFunctionConfig() {
 	functionName := functionConfig.Meta.Name
 	imageName := "nuclio/processor-" + functionName
 
-	err = suite.ExecuteNuctl([]string{"deploy", "", "--verbose", "--no-pull"},
+	err = suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"},
 		map[string]string{
 			"path":  path.Join(suite.GetFunctionsDir(), "common", "json-parser-with-function-config", "python"),
 			"image": imageName,


### PR DESCRIPTION
When deploying a function with nuctl and passing a function yaml file, the function name was overridden with an different value and caused some issues, such as the updater updating the wrong function.

In this PR I did some organization regarding overrides:
1. Validate that a function name is indeed given.
3. If flag args are given as well as a function config file, give precedence to the flag arguments and override them.

Fixes https://github.com/nuclio/nuclio/issues/2934 