### PR TITLE
[Nuctl] Deploy - Resolve function name from path

### DIFF
--- a/pkg/common/consts.go
+++ b/pkg/common/consts.go
@@ -50,3 +50,5 @@ const (
 )
 
 const RestoreConfigFromSecretEnvVar = "NUCLIO_RESTORE_FUNCTION_CONFIG_FROM_SECRET"
+
+const FunctionConfigFileName = "function.yaml"

--- a/pkg/dashboard/functiontemplates/generator/generator.go
+++ b/pkg/dashboard/functiontemplates/generator/generator.go
@@ -32,7 +32,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/dashboard/functiontemplates"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
-	"github.com/nuclio/nuclio/pkg/processor/build"
 	"github.com/nuclio/nuclio/pkg/processor/build/inlineparser"
 
 	"github.com/gobuffalo/flect"
@@ -216,7 +215,7 @@ func (g *Generator) isFunctionDir(runtime *Runtime, functionDirFiles []os.DirEnt
 	for _, file := range functionDirFiles {
 
 		// directory has at least one file related to function's runtime or a function.yaml
-		if strings.HasSuffix(file.Name(), runtime.FileExtension) || file.Name() == build.FunctionConfigFileName {
+		if strings.HasSuffix(file.Name(), runtime.FileExtension) || file.Name() == common.FunctionConfigFileName {
 			return true
 		}
 	}
@@ -317,7 +316,7 @@ func (g *Generator) getFunctionConfigAndSource(functionDir string) (*functioncon
 	configFileExists := false
 
 	// first, look for a function.yaml file. parse it if found
-	configPath := filepath.Join(functionDir, build.FunctionConfigFileName)
+	configPath := filepath.Join(functionDir, common.FunctionConfigFileName)
 
 	if common.IsFile(configPath) {
 		configFileExists = true
@@ -340,7 +339,7 @@ func (g *Generator) getFunctionConfigAndSource(functionDir string) (*functioncon
 	}
 
 	for _, file := range files {
-		if file.Name() != build.FunctionConfigFileName {
+		if file.Name() != common.FunctionConfigFileName {
 
 			// we found our source code, read it
 			sourcePath := filepath.Join(functionDir, file.Name())
@@ -400,7 +399,7 @@ func (g *Generator) parseInlineConfiguration(sourcePath string,
 		return nil
 	}
 
-	unmarshalledInlineConfigYAML, found := configureBlock.Contents[build.FunctionConfigFileName]
+	unmarshalledInlineConfigYAML, found := configureBlock.Contents[common.FunctionConfigFileName]
 	if !found {
 		return errors.Errorf("No function.yaml file found inside configure block at %s", sourcePath)
 	}

--- a/pkg/functionconfig/reader.go
+++ b/pkg/functionconfig/reader.go
@@ -19,6 +19,7 @@ package functionconfig
 import (
 	"encoding/json"
 	"io"
+	"os"
 
 	"github.com/nuclio/nuclio/pkg/common"
 
@@ -99,6 +100,35 @@ func (r *Reader) Read(reader io.Reader, configType string, config *Config) error
 	}
 
 	r.enrichPostMergeConfig(config, &codeEntryConfig)
+
+	return nil
+}
+
+func (r *Reader) ReadFunctionConfigFile(functionConfigPath string, config *Config) error {
+
+	// read the file once for logging
+	functionConfigContents, err := os.ReadFile(functionConfigPath)
+	if err != nil {
+		return errors.Wrap(err, "Failed to read function configuration file")
+	}
+
+	// log
+	r.logger.DebugWith("Read function configuration file", "contents", string(functionConfigContents))
+
+	functionConfigFile, err := os.Open(functionConfigPath)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to open function configuration file: %s", functionConfigPath)
+	}
+
+	defer functionConfigFile.Close() // nolint: errcheck
+
+	// read the configuration
+	if err := r.Read(functionConfigFile,
+		"yaml",
+		config); err != nil {
+
+		return errors.Wrap(err, "Failed to read function configuration file")
+	}
 
 	return nil
 }

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/nuclio/nuclio/pkg/common"
@@ -417,16 +418,14 @@ func (d *deployCommandeer) populateHTTPServiceType() {
 // if they are given explicitly
 func (d *deployCommandeer) enrichConfigMetadata(rootCommandeer *RootCommandeer) error {
 
-	if d.functionName == "" {
-		if d.functionConfig.Meta.Name == "" {
-			return errors.New("Function name cannot be empty")
-		}
-		d.functionName = d.functionConfig.Meta.Name
-	} else {
-
-		// override the name in the config with the name from the command line
-		d.functionConfig.Meta.Name = d.functionName
+	functionName, err := d.resolveFunctionName()
+	if err != nil {
+		return errors.Wrap(err, "Failed to resolve function name")
 	}
+
+	// set the resolved function name
+	d.functionConfig.Meta.Name = functionName
+	d.functionName = functionName
 
 	// override the namespace in the config with the namespace from the command line (must be set)
 	d.functionConfig.Meta.Namespace = rootCommandeer.namespace
@@ -814,4 +813,73 @@ func (d *deployCommandeer) resolveRequestHeaders() map[string]string {
 		requestHeaders[headers.ImportedFunctionOnly] = "true"
 	}
 	return requestHeaders
+}
+
+func (d *deployCommandeer) resolveFunctionName() (string, error) {
+	if d.functionName != "" {
+		return d.functionName, nil
+	}
+
+	// if function name is not provided, use the name from the config
+	if d.functionConfig.Meta.Name != "" {
+		return d.functionConfig.Meta.Name, nil
+	}
+
+	// if a path is provided, read the function config from the path and use the name from the config
+	if d.functionBuild.Path != "" {
+		functionName, err := d.resolveFunctionNameFromPath()
+		if err != nil {
+			return "", errors.Wrap(err, "Failed to resolve function name from path")
+		}
+		return functionName, nil
+	}
+
+	return "", errors.New("Function name is not provided")
+}
+
+func (d *deployCommandeer) resolveFunctionNameFromPath() (string, error) {
+
+	functionConfigPath := d.resolveFunctionConfigPath()
+	if functionConfigPath == "" {
+		return "", errors.New("Failed to resolve function config path")
+	}
+
+	config := &functionconfig.Config{}
+
+	functionconfigReader, err := functionconfig.NewReader(d.rootCommandeer.loggerInstance)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to create functionconfig reader")
+	}
+	if err := functionconfigReader.ReadFunctionConfigFile(functionConfigPath, config); err != nil {
+		return "", errors.Wrap(err, "Failed to read function configuration")
+	}
+
+	return config.Meta.Name, nil
+}
+
+func (d *deployCommandeer) resolveFunctionConfigPath() string {
+
+	// if the user provided a configuration path, use that
+	if d.functionBuild.FunctionConfigPath != "" {
+		return d.functionBuild.FunctionConfigPath
+	}
+
+	// if the path is a file, check if it is a yaml file
+	if common.IsFile(d.functionBuild.Path) {
+		cleanPath := filepath.Clean(d.functionBuild.Path)
+		if filepath.Ext(cleanPath) == ".yaml" || filepath.Ext(cleanPath) == ".yml" {
+			return cleanPath
+		}
+
+		// it's a file, but not a config file
+		return ""
+	}
+
+	functionConfigPath := filepath.Join(d.functionBuild.Path, common.FunctionConfigFileName)
+
+	if !common.FileExists(functionConfigPath) {
+		return ""
+	}
+
+	return functionConfigPath
 }

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform/kube"
 	"github.com/nuclio/nuclio/pkg/platform/kube/client"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
-	"github.com/nuclio/nuclio/pkg/processor/build"
 
 	"github.com/gobuffalo/flect"
 	"github.com/nuclio/errors"
@@ -306,14 +305,14 @@ func (suite *functionDeployTestSuite) TestDeployFromFunctionConfig() {
 
 	functionPath := path.Join(suite.GetFunctionsDir(), "common", "json-parser-with-function-config", "python")
 	functionConfig := functionconfig.Config{}
-	functionBody, err := os.ReadFile(filepath.Join(functionPath, build.FunctionConfigFileName))
+	functionBody, err := os.ReadFile(filepath.Join(functionPath, common.FunctionConfigFileName))
 	suite.Require().NoError(err)
 	err = yaml.Unmarshal(functionBody, &functionConfig)
 	suite.Require().NoError(err)
 	functionName := functionConfig.Meta.Name
 	imageName := "nuclio/processor-" + functionName
 
-	err = suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"},
+	err = suite.ExecuteNuctl([]string{"deploy", "--verbose", "--no-pull"},
 		map[string]string{
 			"path":  path.Join(suite.GetFunctionsDir(), "common", "json-parser-with-function-config", "python"),
 			"image": imageName,
@@ -672,7 +671,7 @@ func (suite *functionDeployTestSuite) TestBuildAndDeployFromFile() {
 	uniqueSuffix := "-" + xid.New().String()
 	functionPath := path.Join(suite.GetFunctionsDir(), "common", "json-parser-with-function-config", "python")
 	functionConfig := functionconfig.Config{}
-	functionBody, err := os.ReadFile(filepath.Join(functionPath, build.FunctionConfigFileName))
+	functionBody, err := os.ReadFile(filepath.Join(functionPath, common.FunctionConfigFileName))
 	suite.Require().NoError(err)
 	err = yaml.Unmarshal(functionBody, &functionConfig)
 	suite.Require().NoError(err)
@@ -741,7 +740,7 @@ func (suite *functionDeployTestSuite) TestBuildAndDeployFromFileWithOverriddenAr
 	uniqueSuffix := "-" + xid.New().String()
 	functionPath := path.Join(suite.GetFunctionsDir(), "common", "json-parser-with-function-config", "python")
 	functionConfig := functionconfig.Config{}
-	functionBody, err := os.ReadFile(filepath.Join(functionPath, build.FunctionConfigFileName))
+	functionBody, err := os.ReadFile(filepath.Join(functionPath, common.FunctionConfigFileName))
 	suite.Require().NoError(err)
 	err = yaml.Unmarshal(functionBody, &functionConfig)
 	suite.Require().NoError(err)
@@ -819,7 +818,7 @@ func (suite *functionDeployTestSuite) TestDeployWithResourceVersion() {
 	functionConfig := functionconfig.Config{}
 	uniqueSuffix := "-" + xid.New().String()
 	functionPath := path.Join(suite.GetFunctionsDir(), "common", "json-parser-with-function-config", "python")
-	functionBody, err := os.ReadFile(filepath.Join(functionPath, build.FunctionConfigFileName))
+	functionBody, err := os.ReadFile(filepath.Join(functionPath, common.FunctionConfigFileName))
 	suite.Require().NoError(err)
 	err = yaml.Unmarshal(functionBody, &functionConfig)
 	suite.Require().NoError(err)


### PR DESCRIPTION
When deploying a function resolve function name accordingly:
- if an explicit name was given - use it
- else, if a function config was given (`--file`) - extract the name from the config
- else, if a path was given (`--path`):
  - if the path contains a function config file (`function.yaml`) - extract the name from it
  - otherwise fail.

This changes the previous nuctl behavior where you could deploy a function with only a `path` to a source code, but the change is a side affect of https://github.com/nuclio/nuclio/issues/2934 's fix, where the function crd was updated wrongly due to a missing function name.