### PR TITLE
[Nuctl] Rename beta's `password` flag to `access-key`

### DIFF
--- a/pkg/nuctl/client/api.go
+++ b/pkg/nuctl/client/api.go
@@ -45,7 +45,7 @@ type NuclioAPIClient struct {
 	apiURL         string
 	requestTimeout string
 	username       string
-	password       string
+	accessKey      string
 	skipTLSVerify  bool
 	authHeaders    map[string]string
 }
@@ -61,7 +61,7 @@ func NewNuclioAPIClient(parentLogger logger.Logger,
 		apiURL:         apiURL,
 		requestTimeout: requestTimeout,
 		username:       username,
-		password:       password,
+		accessKey:      password,
 		skipTLSVerify:  skipTLSVerify,
 	}
 
@@ -214,19 +214,19 @@ func (c *NuclioAPIClient) createAuthorizationHeaders(ctx context.Context) (map[s
 	if c.username == "" {
 		c.username = common.GetEnvOrDefaultString("NUCLIO_USERNAME", "")
 	}
-	if c.password == "" {
-		c.password = common.GetEnvOrDefaultString("NUCLIO_PASSWORD", "")
+	if c.accessKey == "" {
+		c.accessKey = common.GetEnvOrDefaultString("NUCLIO_ACCESS_KEY", "")
 	}
 
 	// if username and password are still empty, fail
-	if c.username == "" || c.password == "" {
+	if c.username == "" || c.accessKey == "" {
 		return nil, errors.New("Username and password must be provided")
 	}
 
 	// cache the auth headers
 	c.authHeaders = map[string]string{
 		"x-v3io-username": c.username,
-		"Authorization":   "Basic " + base64.StdEncoding.EncodeToString([]byte(c.username+":"+c.password)),
+		"Authorization":   "Basic " + base64.StdEncoding.EncodeToString([]byte(c.username+":"+c.accessKey)),
 	}
 
 	return c.authHeaders, nil

--- a/pkg/nuctl/client/api.go
+++ b/pkg/nuctl/client/api.go
@@ -210,7 +210,7 @@ func (c *NuclioAPIClient) createAuthorizationHeaders(ctx context.Context) (map[s
 		return c.authHeaders, nil
 	}
 
-	// resolve username and password from env vars if not provided
+	// resolve username and access key from env vars if not provided
 	if c.username == "" {
 		c.username = common.GetEnvOrDefaultString("NUCLIO_USERNAME", "")
 	}
@@ -218,9 +218,11 @@ func (c *NuclioAPIClient) createAuthorizationHeaders(ctx context.Context) (map[s
 		c.accessKey = common.GetEnvOrDefaultString("NUCLIO_ACCESS_KEY", "")
 	}
 
-	// if username and password are still empty, fail
-	if c.username == "" || c.accessKey == "" {
-		return nil, errors.New("Username and password must be provided")
+	// access key is still empty, fail
+	if c.accessKey == "" {
+		message := "Access key must be provided"
+		c.logger.Error(message)
+		return nil, errors.New(message)
 	}
 
 	// cache the auth headers

--- a/pkg/nuctl/command/beta.go
+++ b/pkg/nuctl/command/beta.go
@@ -35,7 +35,7 @@ type betaCommandeer struct {
 	concurrency    int
 	apiURL         string
 	username       string
-	password       string
+	accessKey      string
 	requestTimeout string
 	skipTLSVerify  bool
 }
@@ -52,7 +52,7 @@ func newBetaCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *bet
 
 	cmd.PersistentFlags().StringVar(&commandeer.apiURL, "api-url", "", "URL of the nuclio API (e.g. https://nuclio.io:8070)")
 	cmd.PersistentFlags().StringVar(&commandeer.username, "username", "", "Username of a user with permissions to the nuclio API")
-	cmd.PersistentFlags().StringVar(&commandeer.password, "password", "", "Password/Access Key of a user with permissions to the nuclio API")
+	cmd.PersistentFlags().StringVar(&commandeer.accessKey, "access-key", "", "Access Key of a user with permissions to the nuclio API")
 	cmd.PersistentFlags().StringVar(&commandeer.requestTimeout, "request-timeout", "60s", "Request timeout")
 	cmd.PersistentFlags().BoolVar(&commandeer.skipTLSVerify, "skip-tls-verify", false, "Skip TLS verification")
 	cmd.PersistentFlags().IntVar(&commandeer.concurrency, "concurrency", DefaultConcurrency, "Max number of parallel patches")
@@ -80,7 +80,7 @@ func (b *betaCommandeer) initialize() error {
 		b.apiURL,
 		b.requestTimeout,
 		b.username,
-		b.password,
+		b.accessKey,
 		b.skipTLSVerify)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create API client")

--- a/pkg/nuctl/command/beta.go
+++ b/pkg/nuctl/command/beta.go
@@ -52,6 +52,7 @@ func newBetaCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *bet
 
 	cmd.PersistentFlags().StringVar(&commandeer.apiURL, "api-url", "", "URL of the nuclio API (e.g. https://nuclio.io:8070)")
 	cmd.PersistentFlags().StringVar(&commandeer.username, "username", "", "Username of a user with permissions to the nuclio API")
+	cmd.PersistentFlags().StringVar(&commandeer.accessKey, "password", "", "Access Key of a user with permissions to the nuclio API [Deprecated: use --access-key]")
 	cmd.PersistentFlags().StringVar(&commandeer.accessKey, "access-key", "", "Access Key of a user with permissions to the nuclio API")
 	cmd.PersistentFlags().StringVar(&commandeer.requestTimeout, "request-timeout", "60s", "Request timeout")
 	cmd.PersistentFlags().BoolVar(&commandeer.skipTLSVerify, "skip-tls-verify", false, "Skip TLS verification")

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -123,7 +123,6 @@ func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, be
 				}
 				commandeer.rootCommandeer.loggerInstance.Debug("In BETA mode")
 				if commandeer.noBuild {
-					commandeer.rootCommandeer.loggerInstance.Debug("BETA redeployment called")
 					if err := commandeer.betaDeploy(ctx, args); err != nil {
 						return errors.Wrap(err, "Failed to deploy function")
 					}
@@ -260,7 +259,6 @@ func addDeployFlags(cmd *cobra.Command,
 	cmd.Flags().StringVar(&commandeer.loggerLevel, "logger-level", "", "One of debug, info, warn, error. By default, uses platform configuration")
 
 	addBetaDeployFlags(cmd, commandeer)
-
 }
 
 func addBetaDeployFlags(cmd *cobra.Command,


### PR DESCRIPTION
For making requests to the nuclio api, nuctl uses a basic authentication header.
This authentication method only works with a username and an access key, an not password.

Thus, to use the `beta` deploy command, pass the `--access-key` flag.

Also, removed username requirement.

Resolves https://jira.iguazeng.com/browse/IG-21894 