### PR TITLE
[RPC Runtime] Return event process error to trigger

### DIFF
--- a/pkg/processor/runtime/python/py/requirements/common.txt
+++ b/pkg/processor/runtime/python/py/requirements/common.txt
@@ -1,2 +1,2 @@
 mock==2.0.0
-nuclio-sdk==0.5.1
+nuclio-sdk==0.5.5

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -441,7 +441,8 @@ func (r *AbstractRuntime) eventWrapperOutputHandler(conn io.Reader, resultChan c
 			data, unmarshalledResult.err = outReader.ReadBytes('\n')
 
 			if unmarshalledResult.err != nil {
-				r.Logger.WarnWith(string(common.FailedReadFromEventConnection), "err", unmarshalledResult.err)
+				r.Logger.WarnWith(string(common.FailedReadFromEventConnection),
+					"err", unmarshalledResult.err.Error())
 				resultChan <- unmarshalledResult
 				continue
 			}
@@ -451,7 +452,7 @@ func (r *AbstractRuntime) eventWrapperOutputHandler(conn io.Reader, resultChan c
 
 				// try to unmarshall the result
 				if unmarshalledResult.err = json.Unmarshal(data[1:], unmarshalledResult); unmarshalledResult.err != nil {
-					r.Logger.WarnWith("Failed to unmarshal result", "err", unmarshalledResult.err)
+					r.Logger.WarnWith("Failed to unmarshal result", "err", unmarshalledResult.err.Error())
 					r.resultChan <- unmarshalledResult
 					continue
 				}

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -149,7 +149,7 @@ func (r *AbstractRuntime) ProcessEvent(event nuclio.Event, functionLogger logger
 		ContentType: result.ContentType,
 		Headers:     result.Headers,
 		StatusCode:  result.StatusCode,
-	}, nil
+	}, result.err
 }
 
 // Stop stops the runtime
@@ -451,6 +451,7 @@ func (r *AbstractRuntime) eventWrapperOutputHandler(conn io.Reader, resultChan c
 
 				// try to unmarshall the result
 				if unmarshalledResult.err = json.Unmarshal(data[1:], unmarshalledResult); unmarshalledResult.err != nil {
+					r.Logger.WarnWith("Failed to unmarshal result", "err", unmarshalledResult.err)
 					r.resultChan <- unmarshalledResult
 					continue
 				}


### PR DESCRIPTION
When an error occurs during event processing, the the rpc runtime just ignores it, and a successful empty response is returned.

In this PR we return the error, resulting with a 500 response with the error message in the body.

Plus, bump nuclio-sdk-py to v0.5.5, which contains a fix on handler return values - https://github.com/nuclio/nuclio-sdk-py/pull/52 

Resolves https://jira.iguazeng.com/browse/IG-21912