### PR TITLE
[Nuctl] Deploy - fix build commands support

### DIFF
--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -673,8 +673,8 @@ func (d *deployCommandeer) enrichBuildConfigWithArgs() {
 	})
 
 	// enrich build commands
-	if len(d.functionBuild.Commands) > 0 {
-		d.functionConfig.Spec.Build.Commands = d.functionBuild.Commands
+	if len(d.commands) > 0 {
+		d.functionConfig.Spec.Build.Commands = d.commands
 	}
 }
 

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -671,6 +671,11 @@ func (d *deployCommandeer) enrichBuildConfigWithArgs() {
 		&d.functionConfig.Spec.Build.NoCleanup:        d.functionBuild.NoCleanup,
 		&d.functionConfig.Spec.Build.Offline:          d.functionBuild.Offline,
 	})
+
+	// enrich build commands
+	if len(d.functionBuild.Commands) > 0 {
+		d.functionConfig.Spec.Build.Commands = d.functionBuild.Commands
+	}
 }
 
 func (d *deployCommandeer) betaDeploy(ctx context.Context, args []string) error {


### PR DESCRIPTION
The build commands were mistakenly ignored in the deploy refactor https://github.com/nuclio/nuclio/pull/2935.
Brought back in this PR.