### PR TITLE
[Nuctl] Increase http client's default timeout

### DIFF
--- a/pkg/nuctl/client/api.go
+++ b/pkg/nuctl/client/api.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-const DefaultRequestTimeout = "60s"
+const DefaultRequestTimeout = "5m"
 
 type NuclioAPIClient struct {
 	logger         logger.Logger


### PR DESCRIPTION
Increase default timeout to 5 minutes, as 1 minute is too short for some of the actions.

Resolves https://jira.iguazeng.com/browse/IG-21931