### PR TITLE
[Scaling] Don't ignore explicit custom scaling metrics in "legacy" AutoScaleMetricsMode

### DIFF
--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -1291,9 +1291,6 @@ func (suite *DeployFunctionTestSuite) TestCreateFunctionWithCustomScalingMetrics
 			},
 		},
 	}
-	/*
-		is invalid: spec.metrics[0].pods.target.averageValue: Required value: must specify a positive target averageValue
-	*/
 
 	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
 		suite.Require().NotNil(deployResult)

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autosv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -546,7 +545,7 @@ func (suite *DeployFunctionTestSuite) TestMinMaxReplicas() {
 	createFunctionOptions.FunctionConfig.Spec.MinReplicas = &two
 	createFunctionOptions.FunctionConfig.Spec.MaxReplicas = &three
 	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
-		hpaInstance := &autoscalingv1.HorizontalPodAutoscaler{}
+		hpaInstance := &autosv2.HorizontalPodAutoscaler{}
 		suite.GetResourceAndUnmarshal("hpa", kube.HPANameFromFunctionName(functionName), hpaInstance)
 		suite.Require().Equal(two, int(*hpaInstance.Spec.MinReplicas))
 		suite.Require().Equal(three, int(hpaInstance.Spec.MaxReplicas))


### PR DESCRIPTION
The `AutoScaleMetricsMode` was introduced as a prep for supporting different auto scale metrics.

However, this mode is still not exposed to the users properly, and we still want to let the user set explicit kubernetes-y custom auto scale metrics.

So in this PR we don't ignore the given custom scaling metrics, regardless of the `AutoScaleMetricsMode` value.