### PR TITLE
[CI] Downgrade periodic runner to ubuntu-20.04

### DIFF
--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -24,6 +24,8 @@ env:
 jobs:
   periodic:
     name: Periodic Regression
+    # TODO: update this to ubuntu-latest when the runner issue is fixed:
+    # https://github.com/actions/runner-images/discussions/7188
     runs-on: ubuntu-20.04
 
     # let's not run this on every fork, comment this out when developing periodic on your fork

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -24,7 +24,7 @@ env:
 jobs:
   periodic:
     name: Periodic Regression
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # let's not run this on every fork, comment this out when developing periodic on your fork
     if: github.repository == 'nuclio/nuclio'


### PR DESCRIPTION
Periodic CI fails lately with the following errors:
```
The operation was canceled.
```
```
The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.
```

This is an issue with the github runners, and as suggested in https://github.com/actions/runner-images/discussions/7188 - downgrading the runners to `ubuntu-20.04` should fix the issue.