### PR TITLE
[Nuctl] Poll function status when waiting for function redeployment

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -529,7 +529,7 @@ func (fr *functionResource) redeployFunction(request *http.Request,
 		return responseErr
 	}
 
-	return nuclio.ErrNoContent
+	return nuclio.ErrAccepted
 }
 
 func (fr *functionResource) functionToAttributes(function platform.Function) restful.Attributes {

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1039,7 +1039,7 @@ func (suite *functionTestSuite) TestPatchSuccessful() {
 		Once()
 
 	// send request
-	expectedStatusCode := http.StatusNoContent
+	expectedStatusCode := http.StatusAccepted
 	requestHeaders := map[string]string{
 		headers.WaitFunctionAction: "true",
 		headers.FunctionNamespace:  namespace,
@@ -1170,7 +1170,7 @@ func (suite *functionTestSuite) TestPatchFunctionImportedOnly() {
 			}
 
 			// send request
-			expectedStatusCode := http.StatusNoContent
+			expectedStatusCode := http.StatusAccepted
 			requestHeaders := map[string]string{
 				headers.WaitFunctionAction:   "true",
 				headers.FunctionNamespace:    namespace,

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1124,18 +1124,21 @@ func (suite *functionTestSuite) TestPatchFunctionImportedOnly() {
 		functionName         string
 		functionState        functionconfig.FunctionState
 		expectedCreateCalled bool
+		expectedStatusCode   int
 	}{
 		{
 			name:                 "importedFunction",
 			functionName:         "imported-func",
 			functionState:        functionconfig.FunctionStateImported,
 			expectedCreateCalled: true,
+			expectedStatusCode:   http.StatusAccepted,
 		},
 		{
 			name:                 "readyFunction",
 			functionName:         "ready-func",
 			functionState:        functionconfig.FunctionStateReady,
 			expectedCreateCalled: false,
+			expectedStatusCode:   http.StatusNoContent,
 		},
 	} {
 		suite.Run(testCase.name, func() {
@@ -1170,7 +1173,6 @@ func (suite *functionTestSuite) TestPatchFunctionImportedOnly() {
 			}
 
 			// send request
-			expectedStatusCode := http.StatusAccepted
 			requestHeaders := map[string]string{
 				headers.WaitFunctionAction:   "true",
 				headers.FunctionNamespace:    namespace,
@@ -1185,7 +1187,7 @@ func (suite *functionTestSuite) TestPatchFunctionImportedOnly() {
 				fmt.Sprintf("/api/functions/%s", testCase.functionName),
 				requestHeaders,
 				bytes.NewBufferString(requestBody),
-				&expectedStatusCode,
+				&testCase.expectedStatusCode,
 				nil)
 		})
 	}

--- a/pkg/nuctl/client/api.go
+++ b/pkg/nuctl/client/api.go
@@ -135,7 +135,7 @@ func (c *NuclioAPIClient) GetFunctions(ctx context.Context, namespace string) (m
 	return functions, nil
 }
 
-// GetFunction a single function with the given name and namespace
+// GetFunction returns a single function with the given name and namespace
 func (c *NuclioAPIClient) GetFunction(ctx context.Context, name, namespace string) (*functionconfig.ConfigWithStatus, error) {
 
 	url := fmt.Sprintf("%s/%s/%s", c.apiURL, FunctionsEndpoint, name)

--- a/pkg/nuctl/client/types.go
+++ b/pkg/nuctl/client/types.go
@@ -25,7 +25,9 @@ import (
 type APIClient interface {
 
 	// GetFunctions returns a map of function name to function config for all functions in the given namespace
-	GetFunctions(ctx context.Context, namespace string) (map[string]functionconfig.Config, error)
+	GetFunctions(ctx context.Context, namespace string) (map[string]*functionconfig.ConfigWithStatus, error)
+
+	GetFunction(ctx context.Context, name, namespace string) (*functionconfig.ConfigWithStatus, error)
 
 	// PatchFunction patches a single function with the given options
 	PatchFunction(ctx context.Context,

--- a/pkg/nuctl/command/common/helpers.go
+++ b/pkg/nuctl/command/common/helpers.go
@@ -81,20 +81,20 @@ func GetUnmarshalFunc(bytes []byte) (func(data []byte, v interface{}) error, err
 	return nil, errors.New("Input is neither json nor yaml")
 }
 
-// ConvertMapToFunctionConfig converts a map to a function config
-func ConvertMapToFunctionConfig(functionMap map[string]interface{}) (functionconfig.Config, error) {
-	var functionConfig functionconfig.Config
+// ConvertMapToFunctionConfigWithStatus converts a map to a function config with status
+func ConvertMapToFunctionConfigWithStatus(functionMap map[string]interface{}) (*functionconfig.ConfigWithStatus, error) {
+	var functionConfigWithStatus *functionconfig.ConfigWithStatus
 
 	// convert to json
 	functionConfigJSON, err := json.Marshal(functionMap)
 	if err != nil {
-		return functionConfig, errors.Wrap(err, "Failed to marshal function config")
+		return functionConfigWithStatus, errors.Wrap(err, "Failed to marshal function config")
 	}
 
-	// convert to function config
-	if err := json.Unmarshal(functionConfigJSON, &functionConfig); err != nil {
-		return functionConfig, errors.Wrap(err, "Failed to unmarshal function config")
+	// convert to function config with status
+	if err := json.Unmarshal(functionConfigJSON, &functionConfigWithStatus); err != nil {
+		return functionConfigWithStatus, errors.Wrap(err, "Failed to unmarshal function config")
 	}
 
-	return functionConfig, nil
+	return functionConfigWithStatus, nil
 }

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -806,11 +806,15 @@ func (d *deployCommandeer) waitForFunctionDeployment(ctx context.Context, functi
 		case <-time.After(d.waitTimeout):
 			return errors.New(fmt.Sprintf("Timed out waiting for function '%s' to be ready", functionName))
 		case <-ticker.C:
-			isReady, err := d.functionIsInTerminalState(ctx, functionName)
-			if !isReady {
+			isTerminal, err := d.functionIsInTerminalState(ctx, functionName)
+			if !isTerminal {
+
+				// function isn't in terminal state yet, retry
 				continue
 			}
 			if err != nil {
+
+				// function is terminal, but not ready, return error
 				return err
 			}
 

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/common/headers"
@@ -93,6 +94,7 @@ type deployCommandeer struct {
 	excludedFunctions      []string
 	excludeFunctionWithGPU bool
 	importedOnly           bool
+	waitTimeout            time.Duration
 }
 
 func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, betaCommandeer *betaCommandeer) *deployCommandeer {
@@ -271,6 +273,7 @@ func addBetaDeployFlags(cmd *cobra.Command,
 	cmd.PersistentFlags().StringSliceVar(&commandeer.excludedFunctions, "exclude-functions", []string{}, "Exclude functions to patch")
 	cmd.PersistentFlags().BoolVar(&commandeer.excludeFunctionWithGPU, "exclude-functions-with-gpu", false, "Skip functions with GPU")
 	cmd.PersistentFlags().BoolVar(&commandeer.importedOnly, "imported-only", false, "Deploy only imported functions")
+	cmd.PersistentFlags().DurationVar(&commandeer.waitTimeout, "wait-timeout", 15*time.Minute, "Wait timeout duration for the function deployment (default 15m)")
 }
 
 func parseResourceAllocations(values stringSliceFlag, resources *v1.ResourceList) error {
@@ -718,10 +721,10 @@ func (d *deployCommandeer) getFunctionNames(ctx context.Context) ([]string, erro
 	}
 
 	functionNames := make([]string, 0)
-	for functionName, functionConfig := range functionConfigs {
+	for functionName, functionConfigWithStatus := range functionConfigs {
 
 		// filter excluded functions
-		if d.shouldSkipFunction(functionConfig) {
+		if d.shouldSkipFunction(functionConfigWithStatus.Config) {
 			d.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Excluding function", "function", functionName)
 			d.outputManifest.AddSkipped(functionName)
 			continue
@@ -761,9 +764,9 @@ func (d *deployCommandeer) redeployFunctions(ctx context.Context, functionNames 
 }
 
 // patchFunction patches a single function
-func (d *deployCommandeer) patchFunction(ctx context.Context, function string) error {
+func (d *deployCommandeer) patchFunction(ctx context.Context, functionName string) error {
 
-	d.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Redeploying function", "function", function)
+	d.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Redeploying function", "function", functionName)
 
 	// patch function
 	patchOptions := map[string]string{
@@ -778,11 +781,42 @@ func (d *deployCommandeer) patchFunction(ctx context.Context, function string) e
 	requestHeaders := d.resolveRequestHeaders()
 
 	if err := d.betaCommandeer.apiClient.PatchFunction(ctx,
-		function,
+		functionName,
 		d.rootCommandeer.namespace,
 		payload,
 		requestHeaders); err != nil {
 		return errors.Wrap(err, "Failed to patch function")
+	}
+
+	d.rootCommandeer.loggerInstance.InfoWithCtx(ctx,
+		"Function redeploy request sent successfully",
+		"function", functionName)
+
+	if d.waitForFunction {
+		ticker := time.NewTicker(5 * time.Second)
+		for {
+			select {
+			case <-time.After(d.waitTimeout):
+				return errors.New(fmt.Sprintf("Timed out waiting for function '%s' to be ready", functionName))
+			case <-ticker.C:
+
+				// get function and poll its status
+				function, err := d.betaCommandeer.apiClient.GetFunction(ctx, functionName, d.rootCommandeer.namespace)
+				if err != nil {
+					d.rootCommandeer.loggerInstance.WarnWithCtx(ctx, "Failed to get function", "functionName", functionName)
+				}
+				if function.Status.State == functionconfig.FunctionStateReady {
+					d.rootCommandeer.loggerInstance.InfoWithCtx(ctx,
+						"Function redeployed successfully",
+						"functionName", functionName)
+					return nil
+				}
+				d.rootCommandeer.loggerInstance.DebugWithCtx(ctx,
+					"Function not ready yet",
+					"functionName", functionName,
+					"functionState", function.Status.State)
+			}
+		}
 	}
 
 	return nil
@@ -805,11 +839,6 @@ func (d *deployCommandeer) shouldSkipFunction(functionConfig functionconfig.Conf
 
 func (d *deployCommandeer) resolveRequestHeaders() map[string]string {
 	requestHeaders := map[string]string{}
-	if d.waitForFunction {
-
-		// add a header that will tell the API to wait for the function to be ready after patching
-		requestHeaders[headers.WaitFunctionAction] = "true"
-	}
 	if d.importedOnly {
 
 		// add a header that will tell the API to only deploy imported functions


### PR DESCRIPTION
When redeploying functions with the `--wait` flag, poll the function status to make sure function is redeployed instead of letting the server (dashboard) wait for the deployment to complete.

Added a flag `--wait-timeout` to modify the timeout when waiting for the function redeployment to complete. Defaults to 15 minutes.

Also, PATCH function will return status 202 (Accepted) as the redeployment is async.

Resolves https://jira.iguazeng.com/browse/IG-21931