### PR TITLE
[CI] Skip python stress tests

### DIFF
--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -49,3 +49,5 @@ jobs:
 
     - name: Test
       run: make test
+      env:
+        NUCLIO_CI_SKIP_STRESS_TEST: true

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"path"
 	"regexp"
 	"runtime"
@@ -102,6 +103,9 @@ func (suite *TestSuite) TestAsyncHandler() {
 }
 
 func (suite *TestSuite) TestStress() {
+	if os.Getenv("NUCLIO_CI_SKIP_STRESS_TEST") == "true" {
+		suite.T().Skip("Skipping stress test")
+	}
 
 	// Create blastConfiguration using default configurations + changes for python specification
 	blastConfiguration := suite.NewBlastConfiguration()


### PR DESCRIPTION
Our python stress tests keep failing the periodic CI with exit code 137 - OOM Killer!
Until a fix is found, disable the stress test in the CI environment.