### PR TITLE
[Function] Redeploy using crd state update

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -521,7 +521,6 @@ func (fr *functionResource) redeployFunction(request *http.Request,
 	if err := fr.getPlatform().RedeployFunction(ctx, &platform.RedeployFunctionOptions{
 		FunctionMeta:               &function.GetConfig().Meta,
 		FunctionSpec:               &function.GetConfig().Spec,
-		FunctionStatus:             function.GetStatus(),
 		AuthConfig:                 authConfig,
 		DependantImagesRegistryURL: fr.GetServer().(*dashboard.Server).GetDependantImagesRegistryURL(),
 		AuthSession:                fr.getCtxSession(ctx),

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -526,7 +526,7 @@ func (fr *functionResource) redeployFunction(request *http.Request,
 		return errors.Wrap(err, "Failed to update function CRD state")
 	}
 
-	return nuclio.ErrNoContent
+	return nuclio.ErrAccepted
 }
 
 func (fr *functionResource) functionToAttributes(function platform.Function) restful.Attributes {

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1021,9 +1021,10 @@ func (suite *functionTestSuite) TestPatchSuccessful() {
 		suite.Require().Equal(namespace, getFunctionsOptions.Namespace)
 		return true
 	}
-	verifyUpdateFunctionsOptions := func(updateFunctionsOptions *platform.UpdateFunctionOptions) bool {
-		suite.Require().Equal(functionName, updateFunctionsOptions.FunctionMeta.Name)
-		suite.Require().Equal(namespace, updateFunctionsOptions.FunctionMeta.Namespace)
+	verifyRedeployFunctionsOptions := func(redeployFunctionsOptions *platform.RedeployFunctionOptions) bool {
+		suite.Require().Equal(functionName, redeployFunctionsOptions.FunctionMeta.Name)
+		suite.Require().Equal(namespace, redeployFunctionsOptions.FunctionMeta.Namespace)
+		suite.Require().Equal(1*time.Minute, redeployFunctionsOptions.CreationStateUpdatedTimeout)
 		return true
 	}
 
@@ -1034,10 +1035,9 @@ func (suite *functionTestSuite) TestPatchSuccessful() {
 		Once()
 
 	suite.mockPlatform.
-		On("UpdateFunctionState",
+		On("RedeployFunction",
 			mock.Anything,
-			mock.MatchedBy(verifyUpdateFunctionsOptions),
-			functionconfig.FunctionStateWaitingForResourceConfiguration).
+			mock.MatchedBy(verifyRedeployFunctionsOptions)).
 		Return(nil).
 		Once()
 
@@ -1123,25 +1123,22 @@ func (suite *functionTestSuite) TestPatchFunctionImportedOnly() {
 	namespace := "some-namespace"
 
 	for _, testCase := range []struct {
-		name                 string
-		functionName         string
-		functionState        functionconfig.FunctionState
-		expectedCreateCalled bool
-		expectedStatusCode   int
+		name               string
+		functionName       string
+		functionState      functionconfig.FunctionState
+		expectedStatusCode int
 	}{
 		{
-			name:                 "importedFunction",
-			functionName:         "imported-func",
-			functionState:        functionconfig.FunctionStateImported,
-			expectedCreateCalled: true,
-			expectedStatusCode:   http.StatusAccepted,
+			name:               "importedFunction",
+			functionName:       "imported-func",
+			functionState:      functionconfig.FunctionStateImported,
+			expectedStatusCode: http.StatusAccepted,
 		},
 		{
-			name:                 "readyFunction",
-			functionName:         "ready-func",
-			functionState:        functionconfig.FunctionStateReady,
-			expectedCreateCalled: false,
-			expectedStatusCode:   http.StatusNoContent,
+			name:               "readyFunction",
+			functionName:       "ready-func",
+			functionState:      functionconfig.FunctionStateReady,
+			expectedStatusCode: http.StatusNoContent,
 		},
 	} {
 		suite.Run(testCase.name, func() {
@@ -1156,9 +1153,10 @@ func (suite *functionTestSuite) TestPatchFunctionImportedOnly() {
 				suite.Require().Equal(namespace, getFunctionsOptions.Namespace)
 				return true
 			}
-			verifyUpdateFunctionsOptions := func(updateFunctionsOptions *platform.UpdateFunctionOptions) bool {
-				suite.Require().Equal(testCase.functionName, updateFunctionsOptions.FunctionMeta.Name)
-				suite.Require().Equal(namespace, updateFunctionsOptions.FunctionMeta.Namespace)
+			verifyRedeployFunctionsOptions := func(redeployFunctionsOptions *platform.RedeployFunctionOptions) bool {
+				suite.Require().Equal(testCase.functionName, redeployFunctionsOptions.FunctionMeta.Name)
+				suite.Require().Equal(namespace, redeployFunctionsOptions.FunctionMeta.Namespace)
+				suite.Require().Equal(1*time.Minute, redeployFunctionsOptions.CreationStateUpdatedTimeout)
 				return true
 			}
 
@@ -1169,10 +1167,9 @@ func (suite *functionTestSuite) TestPatchFunctionImportedOnly() {
 				Once()
 
 			suite.mockPlatform.
-				On("UpdateFunctionState",
+				On("RedeployFunction",
 					mock.Anything,
-					mock.MatchedBy(verifyUpdateFunctionsOptions),
-					functionconfig.FunctionStateWaitingForResourceConfiguration).
+					mock.MatchedBy(verifyRedeployFunctionsOptions)).
 				Return(nil).
 				Once()
 

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1021,9 +1021,9 @@ func (suite *functionTestSuite) TestPatchSuccessful() {
 		suite.Require().Equal(namespace, getFunctionsOptions.Namespace)
 		return true
 	}
-	verifyCreateFunction := func(createFunctionOptions *platform.CreateFunctionOptions) bool {
-		suite.Require().Equal(functionName, createFunctionOptions.FunctionConfig.Meta.Name)
-		suite.Require().Equal(namespace, createFunctionOptions.FunctionConfig.Meta.Namespace)
+	verifyUpdateFunctionsOptions := func(updateFunctionsOptions *platform.UpdateFunctionOptions) bool {
+		suite.Require().Equal(functionName, updateFunctionsOptions.FunctionMeta.Name)
+		suite.Require().Equal(namespace, updateFunctionsOptions.FunctionMeta.Namespace)
 		return true
 	}
 
@@ -1034,8 +1034,11 @@ func (suite *functionTestSuite) TestPatchSuccessful() {
 		Once()
 
 	suite.mockPlatform.
-		On("CreateFunction", mock.Anything, mock.MatchedBy(verifyCreateFunction)).
-		Return(&platform.CreateFunctionResult{}, nil).
+		On("UpdateFunctionState",
+			mock.Anything,
+			mock.MatchedBy(verifyUpdateFunctionsOptions),
+			functionconfig.FunctionStateWaitingForResourceConfiguration).
+		Return(nil).
 		Once()
 
 	// send request
@@ -1150,9 +1153,9 @@ func (suite *functionTestSuite) TestPatchFunctionImportedOnly() {
 				suite.Require().Equal(namespace, getFunctionsOptions.Namespace)
 				return true
 			}
-			verifyCreateFunctionOptions := func(createFunctionOptions *platform.CreateFunctionOptions) bool {
-				suite.Require().Equal(testCase.functionName, createFunctionOptions.FunctionConfig.Meta.Name)
-				suite.Require().Equal(namespace, createFunctionOptions.FunctionConfig.Meta.Namespace)
+			verifyUpdateFunctionsOptions := func(updateFunctionsOptions *platform.UpdateFunctionOptions) bool {
+				suite.Require().Equal(testCase.functionName, updateFunctionsOptions.FunctionMeta.Name)
+				suite.Require().Equal(namespace, updateFunctionsOptions.FunctionMeta.Namespace)
 				return true
 			}
 
@@ -1162,12 +1165,13 @@ func (suite *functionTestSuite) TestPatchFunctionImportedOnly() {
 				Return([]platform.Function{&function}, nil).
 				Once()
 
-			if testCase.expectedCreateCalled {
-				suite.mockPlatform.
-					On("CreateFunction", mock.Anything, mock.MatchedBy(verifyCreateFunctionOptions)).
-					Return(&platform.CreateFunctionResult{}, nil).
-					Once()
-			}
+			suite.mockPlatform.
+				On("UpdateFunctionState",
+					mock.Anything,
+					mock.MatchedBy(verifyUpdateFunctionsOptions),
+					functionconfig.FunctionStateWaitingForResourceConfiguration).
+				Return(nil).
+				Once()
 
 			// send request
 			expectedStatusCode := http.StatusNoContent

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1042,7 +1042,7 @@ func (suite *functionTestSuite) TestPatchSuccessful() {
 		Once()
 
 	// send request
-	expectedStatusCode := http.StatusNoContent
+	expectedStatusCode := http.StatusAccepted
 	requestHeaders := map[string]string{
 		headers.WaitFunctionAction: "true",
 		headers.FunctionNamespace:  namespace,

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -843,8 +843,13 @@ func (d *deployCommandeer) functionIsInTerminalState(ctx context.Context, functi
 		return true, nil
 	}
 
-	// we use this function to check if the function is in terminal state, as we already checked that it's ready
-	if functionconfig.FunctionStateProvisioned(function.Status.State) {
+	// we use this function to check if the function is in terminal state, as we already checked if it's ready
+	if functionconfig.FunctionStateInSlice(function.Status.State,
+		[]functionconfig.FunctionState{
+			functionconfig.FunctionStateError,
+			functionconfig.FunctionStateUnhealthy,
+			functionconfig.FunctionStateScaledToZero,
+		}) {
 		return true, errors.New(fmt.Sprintf("Function '%s' is in terminal state '%s' but not ready",
 			functionName, function.Status.State))
 	}

--- a/pkg/platform/kube/client/updater.go
+++ b/pkg/platform/kube/client/updater.go
@@ -122,14 +122,14 @@ func (u *Updater) Update(ctx context.Context, updateFunctionOptions *platform.Up
 
 // UpdateState will update a function CRD state
 // we don't require permissions for this operation because it's used internally by the platform
-func (u *Updater) UpdateState(ctx context.Context, updateFunctionOptions *platform.UpdateFunctionOptions, state functionconfig.FunctionState) error {
+func (u *Updater) UpdateState(ctx context.Context, functionName, namespace string, authConfig *platform.AuthConfig, state functionconfig.FunctionState) error {
 	u.logger.InfoWithCtx(ctx,
 		"Updating function state",
-		"name", updateFunctionOptions.FunctionMeta.Name,
+		"name", functionName,
 		"state", state)
 
 	// get clientset
-	nuclioClientSet, err := u.consumer.getNuclioClientSet(updateFunctionOptions.AuthConfig)
+	nuclioClientSet, err := u.consumer.getNuclioClientSet(authConfig)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get nuclio clientset")
 	}
@@ -137,8 +137,8 @@ func (u *Updater) UpdateState(ctx context.Context, updateFunctionOptions *platfo
 	// get specific function CR
 	function, err := nuclioClientSet.
 		NuclioV1beta1().
-		NuclioFunctions(updateFunctionOptions.FunctionMeta.Namespace).
-		Get(ctx, updateFunctionOptions.FunctionMeta.Name, metav1.GetOptions{})
+		NuclioFunctions(namespace).
+		Get(ctx, functionName, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "Failed to get function")
 	}
@@ -159,7 +159,7 @@ func (u *Updater) UpdateState(ctx context.Context, updateFunctionOptions *platfo
 	// trigger an update
 	updatedFunction, err := nuclioClientSet.
 		NuclioV1beta1().
-		NuclioFunctions(updateFunctionOptions.FunctionMeta.Namespace).
+		NuclioFunctions(namespace).
 		Update(ctx, function, metav1.UpdateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "Failed to update function CR")

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -522,6 +522,11 @@ func (p *Platform) UpdateFunction(ctx context.Context, updateFunctionOptions *pl
 	return p.updater.Update(ctx, updateFunctionOptions)
 }
 
+// UpdateFunctionState will update a function's state
+func (p *Platform) UpdateFunctionState(ctx context.Context, updateFunctionOptions *platform.UpdateFunctionOptions, state functionconfig.FunctionState) error {
+	return p.updater.UpdateState(ctx, updateFunctionOptions, state)
+}
+
 // DeleteFunction will delete a previously deployed function
 func (p *Platform) DeleteFunction(ctx context.Context, deleteFunctionOptions *platform.DeleteFunctionOptions) error {
 	p.Logger.DebugWithCtx(ctx, "Deleting function",

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -390,6 +390,11 @@ func (p *Platform) UpdateFunction(ctx context.Context, updateFunctionOptions *pl
 	return nil
 }
 
+// UpdateFunctionState will update a function's state
+func (p *Platform) UpdateFunctionState(ctx context.Context, updateFunctionOptions *platform.UpdateFunctionOptions, state functionconfig.FunctionState) error {
+	return nil
+}
+
 // DeleteFunction will delete a previously deployed function
 func (p *Platform) DeleteFunction(ctx context.Context, deleteFunctionOptions *platform.DeleteFunctionOptions) error {
 

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -410,6 +410,10 @@ func (p *Platform) DeleteFunction(ctx context.Context, deleteFunctionOptions *pl
 
 func (p *Platform) RedeployFunction(ctx context.Context, redeployFunctionOptions *platform.RedeployFunctionOptions) error {
 
+	p.Logger.InfoWithCtx(ctx,
+		"Redeploying function",
+		"functionName", redeployFunctionOptions.FunctionMeta.Name)
+
 	// delete existing function containers
 	previousHTTPPort, err := p.deleteOrStopFunctionContainers(&platform.CreateFunctionOptions{
 		Logger: p.Logger,

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -98,15 +98,14 @@ func (mp *Platform) UpdateFunction(ctx context.Context, updateFunctionOptions *p
 	return args.Error(0)
 }
 
-// UpdateFunctionState will update a function's state
-func (mp *Platform) UpdateFunctionState(ctx context.Context, updateFunctionOptions *platform.UpdateFunctionOptions, state functionconfig.FunctionState) error {
-	args := mp.Called(ctx, updateFunctionOptions, state)
-	return args.Error(0)
-}
-
 // DeleteFunction will delete a previously deployed function
 func (mp *Platform) DeleteFunction(ctx context.Context, deleteFunctionOptions *platform.DeleteFunctionOptions) error {
 	args := mp.Called(ctx, deleteFunctionOptions)
+	return args.Error(0)
+}
+
+func (mp *Platform) RedeployFunction(ctx context.Context, redeployFunctionOptions *platform.RedeployFunctionOptions) error {
+	args := mp.Called(ctx, redeployFunctionOptions)
 	return args.Error(0)
 }
 

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -98,6 +98,12 @@ func (mp *Platform) UpdateFunction(ctx context.Context, updateFunctionOptions *p
 	return args.Error(0)
 }
 
+// UpdateFunctionState will update a function's state
+func (mp *Platform) UpdateFunctionState(ctx context.Context, updateFunctionOptions *platform.UpdateFunctionOptions, state functionconfig.FunctionState) error {
+	args := mp.Called(ctx, updateFunctionOptions, state)
+	return args.Error(0)
+}
+
 // DeleteFunction will delete a previously deployed function
 func (mp *Platform) DeleteFunction(ctx context.Context, deleteFunctionOptions *platform.DeleteFunctionOptions) error {
 	args := mp.Called(ctx, deleteFunctionOptions)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -68,6 +68,9 @@ type Platform interface {
 	// DeleteFunction will delete a previously deployed function
 	DeleteFunction(ctx context.Context, deleteFunctionOptions *DeleteFunctionOptions) error
 
+	// UpdateFunctionState will update a previously deployed function
+	UpdateFunctionState(ctx context.Context, updateFunctionOptions *UpdateFunctionOptions, state functionconfig.FunctionState) error
+
 	// CreateFunctionInvocation will invoke a previously deployed function
 	CreateFunctionInvocation(ctx context.Context, createFunctionInvocationOptions *CreateFunctionInvocationOptions) (*CreateFunctionInvocationResult, error)
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -68,8 +68,8 @@ type Platform interface {
 	// DeleteFunction will delete a previously deployed function
 	DeleteFunction(ctx context.Context, deleteFunctionOptions *DeleteFunctionOptions) error
 
-	// UpdateFunctionState will update a previously deployed function
-	UpdateFunctionState(ctx context.Context, updateFunctionOptions *UpdateFunctionOptions, state functionconfig.FunctionState) error
+	// RedeployFunction will redeploy a previously deployed function
+	RedeployFunction(ctx context.Context, redeployFunctionOptions *RedeployFunctionOptions) error
 
 	// CreateFunctionInvocation will invoke a previously deployed function
 	CreateFunctionInvocation(ctx context.Context, createFunctionInvocationOptions *CreateFunctionInvocationOptions) (*CreateFunctionInvocationResult, error)

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -91,7 +91,6 @@ type DeleteFunctionOptions struct {
 type RedeployFunctionOptions struct {
 	FunctionMeta                *functionconfig.Meta
 	FunctionSpec                *functionconfig.Spec
-	FunctionStatus              *functionconfig.Status
 	AuthConfig                  *AuthConfig
 	DependantImagesRegistryURL  string
 	AuthSession                 auth.Session

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -88,6 +88,17 @@ type DeleteFunctionOptions struct {
 	IgnoreFunctionStateValidation bool
 }
 
+type RedeployFunctionOptions struct {
+	FunctionMeta                *functionconfig.Meta
+	FunctionSpec                *functionconfig.Spec
+	FunctionStatus              *functionconfig.Status
+	AuthConfig                  *AuthConfig
+	DependantImagesRegistryURL  string
+	AuthSession                 auth.Session
+	PermissionOptions           opa.PermissionOptions
+	CreationStateUpdatedTimeout time.Duration
+}
+
 // CreateFunctionBuildResult holds information detected/generated as a result of a build process
 type CreateFunctionBuildResult struct {
 	Image string


### PR DESCRIPTION
When redeploy functions, instead of recreating the function (enriching, building etc) we change the function CRD status to "waitingForResourceConfiguration", and add an annotation.
This triggers the controller to update all related resources, and bring the function to a ready state.

Related jira ticket: https://jira.iguazeng.com/browse/IG-21931 