### PR TITLE
[CI] Free space in Test K8s Nuctl job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,6 +175,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Freeing up disk space
+        run: "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
+
       - uses: azure/setup-helm@v3
         with:
           version: "v3.6.3"

--- a/hack/scripts/ci/free-space.sh
+++ b/hack/scripts/ci/free-space.sh
@@ -22,14 +22,18 @@ print_free_space() {
 print_free_space
 
 # clean unneeded os packages and misc
+sudo apt-get remove -y '^ghc-8.*'
 sudo apt-get remove -y '^dotnet-.*'
+sudo apt-get remove -y '^llvm-.*'
 sudo apt-get remove -y 'php.*'
 sudo apt-get remove -y \
   azure-cli \
   google-cloud-sdk \
   google-chrome-stable \
   firefox \
-  powershell
+  powershell \
+  monodoc-http \
+  mono-devel
 
 sudo apt-get autoremove --yes
 sudo apt clean
@@ -39,7 +43,10 @@ sudo rm --recursive --force \
     /usr/local/lib/android \
     /usr/share/dotnet \
     /usr/share/miniconda \
-    /usr/share/swift
+    /usr/share/swift \
+    /opt/ghc \
+    /usr/local/share/boost \
+    "$AGENT_TOOLSDIRECTORY"
 
 # clean unneeded docker images
 docker system prune --all --force


### PR DESCRIPTION
Test K8s Nuctl job fails intermittently in CI with `Error: No space left on device` from docker.
To fix this, we run the `free_space.sh` step in the job as well.

Also - I removed some more stuff in the free space script to hopefully free more space.