### PR TITLE
[CI] Added release of nuctl darwin arm64 binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -213,8 +213,8 @@ jobs:
     - name: Build binaries
       run: |
         NUCLIO_OS=linux make tools
+        NUCLIO_OS=darwin make tools
         if [ $NUCLIO_ARCH == "amd64" ]; then \
-          NUCLIO_OS=darwin make tools; \
           NUCLIO_OS=windows make tools; \
         fi;
       env:


### PR DESCRIPTION
Currently, we release the nuctl binary in the following OS/Architecture matrix:

linux / amd64 + arm64
darwin (macOS) / amd64
windows / amd64
 

We need to add  darwin / arm64 to the binary releases.

