### PR TITLE
[Helm] Fix creation of ClusterRoleBinding for namespace access mode

### DIFF
--- a/hack/k8s/helm/nuclio/templates/rolebinding/crd-admin.yaml
+++ b/hack/k8s/helm/nuclio/templates/rolebinding/crd-admin.yaml
@@ -33,8 +33,6 @@ subjects:
   namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- if eq .Values.rbac.crdAccessMode "namespaced" }}
-
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/hack/k8s/helm/nuclio/templates/rolebinding/crd-admin.yaml
+++ b/hack/k8s/helm/nuclio/templates/rolebinding/crd-admin.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 {{- if .Values.rbac.create }}
+{{- if eq .Values.rbac.crdAccessMode "cluster" }}
 # Bind the service account (used by controller / dashboard) to the crd-admin role,
 # allowing them to create / delete custom resource definitions in the appropriate namespace
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +31,7 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "nuclio.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-
+{{- end }}
 {{- if eq .Values.rbac.crdAccessMode "namespaced" }}
 
 ---

--- a/pkg/processor/runtime/rpc/abstract_test.go
+++ b/pkg/processor/runtime/rpc/abstract_test.go
@@ -64,6 +64,9 @@ func newTestRuntime(parentLogger logger.Logger, configuration *runtime.Configura
 
 	newTestRuntime.AbstractRuntime.ControlMessageBroker = NewRpcControlMessageBroker(nil, parentLogger, nil)
 
+	// set the runtime's isDrained to true, so it won't send a signal to the wrapper process
+	newTestRuntime.isDrained = true
+
 	return newTestRuntime, nil
 }
 
@@ -205,9 +208,6 @@ func (suite *RuntimeSuite) TestReadControlMessage() {
 }
 
 func (suite *RuntimeSuite) TearDownTest() {
-	// set the runtime's isDrained to true, so it won't send a signal to the wrapper process
-	suite.testRuntimeInstance.isDrained = true
-
 	if suite.testRuntimeInstance != nil && suite.testRuntimeInstance.wrapperProcess != nil {
 		suite.testRuntimeInstance.Stop() // nolint: errcheck
 	}

--- a/pkg/processor/runtime/rpc/abstract_test.go
+++ b/pkg/processor/runtime/rpc/abstract_test.go
@@ -64,9 +64,6 @@ func newTestRuntime(parentLogger logger.Logger, configuration *runtime.Configura
 
 	newTestRuntime.AbstractRuntime.ControlMessageBroker = NewRpcControlMessageBroker(nil, parentLogger, nil)
 
-	// set the runtime's isDrained to true, so it won't send a signal to the wrapper process
-	newTestRuntime.isDrained = true
-
 	return newTestRuntime, nil
 }
 
@@ -208,6 +205,9 @@ func (suite *RuntimeSuite) TestReadControlMessage() {
 }
 
 func (suite *RuntimeSuite) TearDownTest() {
+	// set the runtime's isDrained to true, so it won't send a signal to the wrapper process
+	suite.testRuntimeInstance.isDrained = true
+
 	if suite.testRuntimeInstance != nil && suite.testRuntimeInstance.wrapperProcess != nil {
 		suite.testRuntimeInstance.Stop() // nolint: errcheck
 	}


### PR DESCRIPTION
Jira: `IG-22043`

In the Nuclio helm chart, we define the value of `rbac.crdAccessMode` to be either "cluster" or "namespaced".

If set to "namespaced" - all RBAC resources are created in the given namespace (e.g Roles, Rolebindings)
If set to "cluster" - all RBAC resources are created cluster-wide (e.g ClusterRoles, ClusterRolebindings)

It has been seen that for RoleBindings, a ClusterRoleBinding is created regardless of the 
crdAccessMode value. This can cause issues when installing Nuclio without cluster admin permissions, and when the relevant ClusterRole doesn't exist.