### PR TITLE
[RPC] Fix testRuntime drain failures

### DIFF
--- a/pkg/processor/runtime/rpc/abstract_test.go
+++ b/pkg/processor/runtime/rpc/abstract_test.go
@@ -64,6 +64,9 @@ func newTestRuntime(parentLogger logger.Logger, configuration *runtime.Configura
 
 	newTestRuntime.AbstractRuntime.ControlMessageBroker = NewRpcControlMessageBroker(nil, parentLogger, nil)
 
+	// set the runtime's isDrained to true, so it won't send a signal to the wrapper process
+	newTestRuntime.isDrained = true
+
 	return newTestRuntime, nil
 }
 
@@ -205,9 +208,6 @@ func (suite *RuntimeSuite) TestReadControlMessage() {
 }
 
 func (suite *RuntimeSuite) TearDownTest() {
-	// set the runtime's isDrained to true, so it won't send a signal to the wrapper process
-	suite.testRuntimeInstance.isDrained = true
-
 	if suite.testRuntimeInstance != nil && suite.testRuntimeInstance.wrapperProcess != nil {
 		suite.testRuntimeInstance.Stop() // nolint: errcheck
 	}


### PR DESCRIPTION
In the abstract runtime tests we use the runtime's `Stop` function, this in turn signals the runtime to drain using `SIGUSR1`.
Since the test runtime doesn't register to this signal, it causes tests to fail.

We should skip the signaling by default by setting `isDrained` to true.