### PR TITLE
[Kafka] Commit the offset when handler is done on rebalance

### DIFF
--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -278,7 +278,17 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 				var wg sync.WaitGroup
 				wg.Add(2)
 				go func() {
-					<-submittedEventInstance.done
+					err := <-submittedEventInstance.done
+
+					// we successfully submitted the message to the handler. mark it
+					if err == nil {
+						session.MarkOffset(
+							message.Topic,
+							message.Partition,
+							message.Offset+1-ackWindowSize,
+							"",
+						)
+					}
 					k.Logger.DebugWith("Handler done", "partition", claim.Partition())
 					wg.Done()
 				}()


### PR DESCRIPTION
It has been seen that when a rebalance occurs, the last event before the rebalance is handled twice, regardless of the timeout configurations described in https://github.com/nuclio/nuclio/blob/development/docs/reference/triggers/kafka.md#rebalancing-config-choice .

We noticed that while the kafka trigger does wait for the worker to finish handling the last event, when it is done the event offset is not committed on the stream, and thus at least a single event will be handled twice.
In this PR we commit event in such cases. 

JIRA: https://jira.iguazeng.com/browse/IG-22040