### PR TITLE
[Processor] Add workers draining on processor termination

### DIFF
--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -666,7 +666,7 @@ func (p *Processor) handleSignals() {
 }
 
 func (p *Processor) actOnSignal(signal os.Signal) {
-	p.logger.WarnWith("Got system signal", signal.String())
+	p.logger.WarnWith("", "Got system signal", signal.String())
 	p.terminateAllTriggers()
 	os.Exit(0)
 }
@@ -682,10 +682,10 @@ func (p *Processor) terminateAllTriggers() {
 		atomic.AddInt32(&tasksCounter, 1)
 
 		// goroutine to drain trigger, decrements counter when it's done
-		go func(triggerInstance trigger.Trigger, counter int32) {
-			defer atomic.AddInt32(&counter, -1)
+		go func(triggerInstance trigger.Trigger, counter *int32) {
+			defer atomic.AddInt32(counter, -1)
 			triggerInstance.SignalWorkerDraining()
-		}(triggerInstance, tasksCounter)
+		}(triggerInstance, &tasksCounter)
 	}
 
 	tasksCounterCheckTicker := time.NewTicker(time.Second)

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -669,13 +669,12 @@ func (p *Processor) terminateAllTriggers(signal os.Signal) {
 	wg := &sync.WaitGroup{}
 
 	for _, triggerInstance := range p.triggers {
-
+		wg.Add(1)
 		// goroutine to drain trigger
-		go func(triggerInstance trigger.Trigger) {
+		go func(triggerInstance trigger.Trigger, wg *sync.WaitGroup) {
 			defer wg.Done()
-			wg.Add(1)
 			triggerInstance.SignalWorkerDraining()
-		}(triggerInstance)
+		}(triggerInstance, wg)
 	}
 	wg.Wait()
 	p.logger.Info("All triggers are terminated")

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -690,6 +690,7 @@ func (p *Processor) terminateAllTriggers() {
 
 	tasksCounterCheckTicker := time.NewTicker(time.Second)
 
+	// waits for all triggers to be drainer
 	for {
 		select {
 		case <-tasksCounterCheckTicker.C:

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -24,7 +24,6 @@ import (
 	"os/signal"
 	"path"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -76,8 +75,6 @@ import (
 	"github.com/nuclio/logger"
 	"github.com/v3io/version-go"
 )
-
-const defaultGracefulShutdownTimeout = 30 * time.Second
 
 // Processor is responsible to process events
 type Processor struct {
@@ -658,48 +655,28 @@ func (p *Processor) setWorkersStatus(triggerInstance trigger.Trigger, status sta
 	return nil
 }
 
-// creates a signal handler, so on signal processor gracefully terminated
+// handleSignals creates a signal handler, so on signal processor gracefully terminated
 func (p *Processor) handleSignals() {
 	var captureSignal = make(chan os.Signal, 1)
 	signal.Notify(captureSignal, syscall.SIGTERM, syscall.SIGABRT, syscall.SIGINT)
-	p.actOnSignal(<-captureSignal)
+	p.terminateAllTriggers(<-captureSignal)
+	p.Stop()
 }
 
-func (p *Processor) actOnSignal(signal os.Signal) {
-	p.logger.WarnWith("", "Got system signal", signal.String())
-	p.terminateAllTriggers()
-	os.Exit(0)
-}
+func (p *Processor) terminateAllTriggers(signal os.Signal) {
+	p.logger.WarnWith("Got system signal", "signal", signal.String())
 
-func (p *Processor) terminateAllTriggers() {
-	// counter to control trigger termination
-	gracefulShutdownTimeout := time.NewTicker(defaultGracefulShutdownTimeout)
-	tasksCounter := int32(0)
+	wg := &sync.WaitGroup{}
 
 	for _, triggerInstance := range p.triggers {
 
-		// adding new task
-		atomic.AddInt32(&tasksCounter, 1)
-
-		// goroutine to drain trigger, decrements counter when it's done
-		go func(triggerInstance trigger.Trigger, counter *int32) {
-			defer atomic.AddInt32(counter, -1)
+		// goroutine to drain trigger
+		go func(triggerInstance trigger.Trigger) {
+			defer wg.Done()
+			wg.Add(1)
 			triggerInstance.SignalWorkerDraining()
-		}(triggerInstance, &tasksCounter)
+		}(triggerInstance)
 	}
-
-	tasksCounterCheckTicker := time.NewTicker(time.Second)
-
-	// waits for all triggers to be drainer
-	for {
-		select {
-		case <-tasksCounterCheckTicker.C:
-			if atomic.LoadInt32(&tasksCounter) == 0 {
-				p.logger.Info("All triggers are terminated")
-				os.Exit(0)
-			}
-		case <-gracefulShutdownTimeout.C:
-			p.logger.Warn("Processor is about to terminate, but some triggers are not drained")
-		}
-	}
+	wg.Wait()
+	p.logger.Info("All triggers are terminated")
 }

--- a/cmd/processor/app/processor_test.go
+++ b/cmd/processor/app/processor_test.go
@@ -231,6 +231,10 @@ func (t *testTrigger) TimeoutWorker(worker *worker.Worker) error {
 	return nil
 }
 
+func (t *testTrigger) SignalWorkerDraining() {
+	t.Called()
+}
+
 func TestTriggerTestSuite(t *testing.T) {
 	suite.Run(t, new(TriggerTestSuite))
 }

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -1398,6 +1398,22 @@ def handler(context, event):
 	suite.DeployFunctionAndRedeploy(createFunctionOptions, afterFirstDeploy, afterSecondDeploy)
 }
 
+func (suite *DeleteFunctionTestSuite) TestProcessorShutdown() {
+	functionName := "func-to-test-processor-shutdown"
+	createFunctionOptions := suite.CompileCreateFunctionOptions(functionName)
+
+	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+		pods := suite.GetFunctionPods(functionName)
+		firstPod := pods[0]
+		sigtermTime := metav1.Now()
+		suite.KubeClientSet.CoreV1().Pods(firstPod.Namespace).Delete(suite.Ctx, firstPod.Name, metav1.DeleteOptions{})
+		logs := suite.KubeClientSet.CoreV1().Pods(firstPod.Namespace).GetLogs(firstPod.Name, &v1.PodLogOptions{SinceTime: &sigtermTime})
+		suite.Require().Containsf(logs, "All triggers are terminated", "triggers were not drained")
+		return true
+	})
+
+}
+
 type UpdateFunctionTestSuite struct {
 	KubeTestSuite
 }

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -1406,13 +1406,14 @@ func (suite *DeleteFunctionTestSuite) TestProcessorShutdown() {
 		suite.Require().NotEmpty(deployResult)
 		pods := suite.GetFunctionPods(functionName)
 		firstPod := pods[0]
-
-		suite.WaitMessageInPodLog(firstPod.Namespace, firstPod.Name, "Processor started", &v1.PodLogOptions{}, 10)
-		err := suite.KubeClientSet.CoreV1().Pods(firstPod.Namespace).Delete(suite.Ctx, firstPod.Name, metav1.DeleteOptions{})
+		err := suite.WaitMessageInPodLog(firstPod.Namespace, firstPod.Name, "Processor started", &v1.PodLogOptions{}, 20*time.Second)
 		suite.Require().NoError(err)
 
-		triggersTerminated := suite.WaitMessageInPodLog(firstPod.Namespace, firstPod.Name, "All triggers are terminated", &v1.PodLogOptions{}, 10)
-		suite.Require().Equal(triggersTerminated, true, "triggers were not drained")
+		err = suite.KubeClientSet.CoreV1().Pods(firstPod.Namespace).Delete(suite.Ctx, firstPod.Name, metav1.DeleteOptions{})
+		suite.Require().NoError(err)
+
+		err = suite.WaitMessageInPodLog(firstPod.Namespace, firstPod.Name, "All triggers are terminated", &v1.PodLogOptions{}, 30*time.Second)
+		suite.Require().NoError(err, "triggers were not drained")
 		return true
 	})
 

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -717,3 +717,24 @@ func (suite *KubeTestSuite) CompileCreateAPIGatewayOptions(apiGatewayName string
 		},
 	}
 }
+
+func (suite *KubeTestSuite) GetPodLogs(namespace, name string, opts *v1.PodLogOptions) string {
+
+	req := suite.KubeClientSet.CoreV1().Pods(namespace).GetLogs(name, opts)
+	podLogs, err := req.Do(suite.Ctx).Raw()
+	if err != nil {
+		return ""
+	}
+	return string(podLogs[:])
+}
+
+func (suite *KubeTestSuite) WaitMessageInPodLog(namespace, name, message string, opts *v1.PodLogOptions, numberOfRetries int) bool {
+	for i := 0; i < numberOfRetries; i++ {
+		logs := suite.GetPodLogs(namespace, name, opts)
+		if strings.Contains(logs, message) {
+			return true
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return false
+}

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -731,9 +731,6 @@ func (suite *KubeTestSuite) GetPodLogs(namespace, name string, opts *v1.PodLogOp
 func (suite *KubeTestSuite) WaitMessageInPodLog(namespace, name, message string, opts *v1.PodLogOptions, maxDuration time.Duration) error {
 	return common.RetryUntilSuccessful(maxDuration, time.Second, func() bool {
 		logs := suite.GetPodLogs(namespace, name, opts)
-		if strings.Contains(logs, message) {
-			return true
-		}
-		return false
+		return strings.Contains(logs, message)
 	})
 }

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -728,13 +728,12 @@ func (suite *KubeTestSuite) GetPodLogs(namespace, name string, opts *v1.PodLogOp
 	return string(podLogs)
 }
 
-func (suite *KubeTestSuite) WaitMessageInPodLog(namespace, name, message string, opts *v1.PodLogOptions, numberOfRetries int) bool {
-	for i := 0; i < numberOfRetries; i++ {
+func (suite *KubeTestSuite) WaitMessageInPodLog(namespace, name, message string, opts *v1.PodLogOptions, maxDuration time.Duration) error {
+	return common.RetryUntilSuccessful(maxDuration, time.Second, func() bool {
 		logs := suite.GetPodLogs(namespace, name, opts)
 		if strings.Contains(logs, message) {
 			return true
 		}
-		time.Sleep(1 * time.Second)
-	}
-	return false
+		return false
+	})
 }

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -725,7 +725,7 @@ func (suite *KubeTestSuite) GetPodLogs(namespace, name string, opts *v1.PodLogOp
 	if err != nil {
 		return ""
 	}
-	return string(podLogs[:])
+	return string(podLogs)
 }
 
 func (suite *KubeTestSuite) WaitMessageInPodLog(namespace, name, message string, opts *v1.PodLogOptions, numberOfRetries int) bool {

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -661,7 +661,7 @@ func (r *AbstractRuntime) waitForProcessTermination(timeout time.Duration) {
 	r.Logger.DebugWith("Waiting for process termination",
 		"wid", r.Context.WorkerID,
 		"process", r.wrapperProcess,
-		"timeout", timeout)
+		"timeout", timeout.String())
 
 	for {
 		select {

--- a/pkg/processor/trigger/cron/types.go
+++ b/pkg/processor/trigger/cron/types.go
@@ -40,7 +40,7 @@ func NewConfiguration(id string,
 	// create base
 	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to create trigger configuration")
 	}
 	newConfiguration.Configuration = *baseConfiguration
 

--- a/pkg/processor/trigger/cron/types.go
+++ b/pkg/processor/trigger/cron/types.go
@@ -38,7 +38,11 @@ func NewConfiguration(id string,
 	newConfiguration := Configuration{}
 
 	// create base
-	newConfiguration.Configuration = *trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	if err != nil {
+		return nil, err
+	}
+	newConfiguration.Configuration = *baseConfiguration
 
 	// parse attributes
 	if err := mapstructure.Decode(newConfiguration.Configuration.Attributes, &newConfiguration); err != nil {

--- a/pkg/processor/trigger/http/types.go
+++ b/pkg/processor/trigger/http/types.go
@@ -50,7 +50,7 @@ func NewConfiguration(id string,
 	// create base
 	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to create trigger configuration")
 	}
 	newConfiguration.Configuration = *baseConfiguration
 

--- a/pkg/processor/trigger/http/types.go
+++ b/pkg/processor/trigger/http/types.go
@@ -48,7 +48,11 @@ func NewConfiguration(id string,
 	newConfiguration := Configuration{}
 
 	// create base
-	newConfiguration.Configuration = *trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	if err != nil {
+		return nil, err
+	}
+	newConfiguration.Configuration = *baseConfiguration
 
 	// parse attributes
 	if err := mapstructure.Decode(newConfiguration.Configuration.Attributes, &newConfiguration); err != nil {

--- a/pkg/processor/trigger/kafka/kafka_test.go
+++ b/pkg/processor/trigger/kafka/kafka_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor"
@@ -170,6 +171,64 @@ func (suite *TestSuite) TestExplicitAckModeWithWorkerAllocationModes() {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
+			}
+		})
+	}
+}
+
+func (suite *TestSuite) TestWorkerTimeoutConfiguration() {
+	for _, testCase := range []struct {
+		name                   string
+		timeout                string
+		expectedRuntimeTimeout time.Duration
+		expectedFailure        bool
+	}{
+		{
+			name:                   "Timeout specified",
+			timeout:                "2s",
+			expectedRuntimeTimeout: 2 * time.Second,
+			expectedFailure:        false,
+		},
+		{
+			name:                   "Timeout not specified",
+			timeout:                "",
+			expectedRuntimeTimeout: 10 * time.Second,
+			expectedFailure:        false,
+		},
+		{
+			name:            "Wrong timeout value",
+			timeout:         "timeout",
+			expectedFailure: true,
+		},
+	} {
+		triggerInstance := &functionconfig.Trigger{
+			WorkerTerminationTimeout: testCase.timeout,
+			Attributes: map[string]interface{}{
+				"topics": []string{
+					"some-topic",
+				},
+				"consumerGroup":            "some-cg",
+				"initialOffset":            "earliest",
+				"workerTerminationTimeout": testCase.timeout,
+				"brokers": []string{
+					"some-broker",
+				},
+			},
+		}
+		suite.Run(testCase.name, func() {
+			configuration, err := NewConfiguration(testCase.name,
+				triggerInstance,
+				&runtime.Configuration{
+					Configuration: &processor.Configuration{
+						Config: functionconfig.Config{},
+					},
+				},
+				suite.logger)
+			if testCase.expectedFailure {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(testCase.expectedRuntimeTimeout, configuration.RuntimeConfiguration.WorkerTerminationTimeout, "Bad timeout value")
 			}
 		})
 	}

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -72,12 +72,12 @@ func newTrigger(parentLogger logger.Logger,
 
 	sarama.Logger = NewSaramaLogger(loggerInstance)
 
-	newTrigger := &kafka{
+	kafkaTrigger := &kafka{
 		configuration:       configuration,
 		stopConsumptionChan: make(chan struct{}, 1),
 	}
 
-	newTrigger.AbstractTrigger, err = trigger.NewAbstractTrigger(loggerInstance,
+	kafkaTrigger.AbstractTrigger, err = trigger.NewAbstractTrigger(loggerInstance,
 		workerAllocator,
 		&configuration.Configuration,
 		"async",
@@ -88,9 +88,9 @@ func newTrigger(parentLogger logger.Logger,
 		return nil, errors.New("Failed to create abstract trigger")
 	}
 
-	newTrigger.AbstractTrigger.Trigger = newTrigger
+	kafkaTrigger.AbstractTrigger.Trigger = kafkaTrigger
 
-	newTrigger.Logger.DebugWith("Creating consumer",
+	kafkaTrigger.Logger.DebugWith("Creating consumer",
 		"brokers", configuration.brokers,
 		"workerAllocationMode", configuration.WorkerAllocationMode,
 		"sessionTimeout", configuration.sessionTimeout,
@@ -107,12 +107,12 @@ func newTrigger(parentLogger logger.Logger,
 		"maxWaitHandlerDuringRebalance", configuration.maxWaitHandlerDuringRebalance,
 		"logLevel", configuration.LogLevel)
 
-	newTrigger.kafkaConfig, err = newTrigger.newKafkaConfig()
+	kafkaTrigger.kafkaConfig, err = kafkaTrigger.newKafkaConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create configuration")
 	}
 
-	return newTrigger, nil
+	return kafkaTrigger, nil
 }
 
 func (k *kafka) Start(checkpoint functionconfig.Checkpoint) error {
@@ -269,9 +269,6 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 			// don't consume any more messages
 			consumeMessages = false
 
-			// signal the worker to drain its accumulated events and wait for it to finish its work
-			go k.SignalWorkerDraining(workerDrainingCompleteChan)
-
 			// trigger is ready for rebalance if both the handler is done and
 			// the workers are finished draining events
 			go func() {
@@ -283,7 +280,7 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 					wg.Done()
 				}()
 				go func() {
-					<-workerDrainingCompleteChan
+					k.SignalWorkerDraining()
 					k.Logger.DebugWith("Workers drained", "partition", claim.Partition())
 					wg.Done()
 				}()

--- a/pkg/processor/trigger/kafka/types.go
+++ b/pkg/processor/trigger/kafka/types.go
@@ -112,7 +112,7 @@ func NewConfiguration(id string,
 	// create base
 	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to create trigger configuration")
 	}
 	newConfiguration.Configuration = *baseConfiguration
 

--- a/pkg/processor/trigger/kafka/types.go
+++ b/pkg/processor/trigger/kafka/types.go
@@ -110,12 +110,16 @@ func NewConfiguration(id string,
 	newConfiguration := Configuration{}
 
 	// create base
-	newConfiguration.Configuration = *trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	if err != nil {
+		return nil, err
+	}
+	newConfiguration.Configuration = *baseConfiguration
 
 	workerAllocationModeValue := ""
 	explicitAckModeValue := ""
 
-	err := newConfiguration.PopulateConfigurationFromAnnotations([]trigger.AnnotationConfigField{
+	err = newConfiguration.PopulateConfigurationFromAnnotations([]trigger.AnnotationConfigField{
 		{Key: "nuclio.io/kafka-session-timeout", ValueString: &newConfiguration.SessionTimeout},
 		{Key: "nuclio.io/kafka-heartbeat-interval", ValueString: &newConfiguration.HeartbeatInterval},
 		{Key: "nuclio.io/kafka-max-processing-time", ValueString: &newConfiguration.MaxProcessingTime},
@@ -299,22 +303,10 @@ func NewConfiguration(id string,
 		}
 	}
 
-	if triggerConfiguration.WorkerTerminationTimeout == "" {
-		triggerConfiguration.WorkerTerminationTimeout = functionconfig.DefaultWorkerTerminationTimeout
-	}
-
-	workerTerminationTimeout, err := time.ParseDuration(triggerConfiguration.WorkerTerminationTimeout)
-	if err != nil {
-		return nil, errors.New("Failed to parse worker termination timeout from trigger configuration")
-	}
-
 	// on rebalance, we want to wait the max timeout so the workers can exit gracefully before killing them
-	if newConfiguration.maxWaitHandlerDuringRebalance < workerTerminationTimeout {
-		newConfiguration.maxWaitHandlerDuringRebalance = workerTerminationTimeout + 3*time.Second
+	if newConfiguration.maxWaitHandlerDuringRebalance < runtimeConfiguration.WorkerTerminationTimeout {
+		newConfiguration.maxWaitHandlerDuringRebalance = runtimeConfiguration.WorkerTerminationTimeout + 3*time.Second
 	}
-
-	// enrich runtime configuration with worker termination timeout
-	runtimeConfiguration.WorkerTerminationTimeout = workerTerminationTimeout
 
 	newConfiguration.WorkerAllocationMode = newConfiguration.ResolveWorkerAllocationMode(newConfiguration.WorkerAllocationMode,
 		partitionworker.AllocationMode(workerAllocationModeValue))

--- a/pkg/processor/trigger/kickstart/types.go
+++ b/pkg/processor/trigger/kickstart/types.go
@@ -37,7 +37,11 @@ func NewConfiguration(id string,
 	newConfiguration := Configuration{}
 
 	// create base
-	newConfiguration.Configuration = *trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	if err != nil {
+		return nil, err
+	}
+	newConfiguration.Configuration = *baseConfiguration
 
 	// parse attributes
 	if err := mapstructure.Decode(newConfiguration.Configuration.Attributes, &newConfiguration); err != nil {

--- a/pkg/processor/trigger/kickstart/types.go
+++ b/pkg/processor/trigger/kickstart/types.go
@@ -39,7 +39,7 @@ func NewConfiguration(id string,
 	// create base
 	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to create trigger configuration")
 	}
 	newConfiguration.Configuration = *baseConfiguration
 

--- a/pkg/processor/trigger/kinesis/types.go
+++ b/pkg/processor/trigger/kinesis/types.go
@@ -46,7 +46,11 @@ func NewConfiguration(id string,
 	newConfiguration := Configuration{}
 
 	// create base
-	newConfiguration.Configuration = *trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	if err != nil {
+		return nil, err
+	}
+	newConfiguration.Configuration = *baseConfiguration
 
 	// parse attributes
 	if err := mapstructure.Decode(newConfiguration.Configuration.Attributes, &newConfiguration); err != nil {

--- a/pkg/processor/trigger/kinesis/types.go
+++ b/pkg/processor/trigger/kinesis/types.go
@@ -48,7 +48,7 @@ func NewConfiguration(id string,
 	// create base
 	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to create trigger configuration")
 	}
 	newConfiguration.Configuration = *baseConfiguration
 

--- a/pkg/processor/trigger/mqtt/types.go
+++ b/pkg/processor/trigger/mqtt/types.go
@@ -43,7 +43,11 @@ func NewConfiguration(id string,
 	newConfiguration := Configuration{}
 
 	// create base
-	newConfiguration.Configuration = *trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	if err != nil {
+		return nil, err
+	}
+	newConfiguration.Configuration = *baseConfiguration
 
 	// parse attributes
 	if err := mapstructure.Decode(newConfiguration.Configuration.Attributes, &newConfiguration); err != nil {

--- a/pkg/processor/trigger/mqtt/types.go
+++ b/pkg/processor/trigger/mqtt/types.go
@@ -45,7 +45,7 @@ func NewConfiguration(id string,
 	// create base
 	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to create trigger configuration")
 	}
 	newConfiguration.Configuration = *baseConfiguration
 

--- a/pkg/processor/trigger/nats/types.go
+++ b/pkg/processor/trigger/nats/types.go
@@ -37,7 +37,11 @@ func NewConfiguration(id string,
 	newConfiguration := Configuration{}
 
 	// create base
-	newConfiguration.Configuration = *trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	if err != nil {
+		return nil, err
+	}
+	newConfiguration.Configuration = *baseConfiguration
 
 	// parse attributes
 	if err := mapstructure.Decode(newConfiguration.Configuration.Attributes, &newConfiguration); err != nil {

--- a/pkg/processor/trigger/nats/types.go
+++ b/pkg/processor/trigger/nats/types.go
@@ -39,7 +39,7 @@ func NewConfiguration(id string,
 	// create base
 	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to create trigger configuration")
 	}
 	newConfiguration.Configuration = *baseConfiguration
 

--- a/pkg/processor/trigger/partitioned/eventhub/types.go
+++ b/pkg/processor/trigger/partitioned/eventhub/types.go
@@ -41,7 +41,11 @@ func NewConfiguration(id string,
 	newConfiguration := Configuration{}
 
 	// create base
-	newConfiguration.Configuration = *partitioned.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	baseConfiguration, err := partitioned.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	if err != nil {
+		return nil, err
+	}
+	newConfiguration.Configuration = *baseConfiguration
 
 	// parse attributes
 	if err := mapstructure.Decode(newConfiguration.Configuration.Attributes, &newConfiguration); err != nil {

--- a/pkg/processor/trigger/partitioned/eventhub/types.go
+++ b/pkg/processor/trigger/partitioned/eventhub/types.go
@@ -43,7 +43,7 @@ func NewConfiguration(id string,
 	// create base
 	baseConfiguration, err := partitioned.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to create trigger configuration")
 	}
 	newConfiguration.Configuration = *baseConfiguration
 

--- a/pkg/processor/trigger/partitioned/types.go
+++ b/pkg/processor/trigger/partitioned/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package partitioned
 
 import (
+	"github.com/nuclio/errors"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
@@ -34,7 +35,7 @@ func NewConfiguration(id string,
 	// create base
 	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to create trigger configuration")
 	}
 	newConfiguration.Configuration = *baseConfiguration
 

--- a/pkg/processor/trigger/partitioned/types.go
+++ b/pkg/processor/trigger/partitioned/types.go
@@ -28,11 +28,15 @@ type Configuration struct {
 
 func NewConfiguration(id string,
 	triggerConfiguration *functionconfig.Trigger,
-	runtimeConfiguration *runtime.Configuration) *Configuration {
+	runtimeConfiguration *runtime.Configuration) (*Configuration, error) {
 	newConfiguration := Configuration{}
 
 	// create base
-	newConfiguration.Configuration = *trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	if err != nil {
+		return nil, err
+	}
+	newConfiguration.Configuration = *baseConfiguration
 
-	return &newConfiguration
+	return &newConfiguration, nil
 }

--- a/pkg/processor/trigger/partitioned/types.go
+++ b/pkg/processor/trigger/partitioned/types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package partitioned
 
 import (
-	"github.com/nuclio/errors"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
@@ -35,7 +34,7 @@ func NewConfiguration(id string,
 	// create base
 	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create trigger configuration")
+		return nil, err
 	}
 	newConfiguration.Configuration = *baseConfiguration
 

--- a/pkg/processor/trigger/poller/types.go
+++ b/pkg/processor/trigger/poller/types.go
@@ -39,7 +39,11 @@ func NewConfiguration(id string,
 	newConfiguration := Configuration{}
 
 	// create base
-	newConfiguration.Configuration = *trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	if err != nil {
+		return nil, err
+	}
+	newConfiguration.Configuration = *baseConfiguration
 
 	// parse attributes
 	if err := mapstructure.Decode(newConfiguration.Configuration.Attributes, &newConfiguration); err != nil {

--- a/pkg/processor/trigger/poller/types.go
+++ b/pkg/processor/trigger/poller/types.go
@@ -41,7 +41,7 @@ func NewConfiguration(id string,
 	// create base
 	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to create trigger configuration")
 	}
 	newConfiguration.Configuration = *baseConfiguration
 

--- a/pkg/processor/trigger/pubsub/types.go
+++ b/pkg/processor/trigger/pubsub/types.go
@@ -56,7 +56,7 @@ func NewConfiguration(id string,
 	// create base
 	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to create trigger configuration")
 	}
 	newConfiguration.Configuration = *baseConfiguration
 

--- a/pkg/processor/trigger/pubsub/types.go
+++ b/pkg/processor/trigger/pubsub/types.go
@@ -54,7 +54,11 @@ func NewConfiguration(id string,
 	newConfiguration := Configuration{}
 
 	// create base
-	newConfiguration.Configuration = *trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	if err != nil {
+		return nil, err
+	}
+	newConfiguration.Configuration = *baseConfiguration
 
 	// parse attributes
 	if err := mapstructure.Decode(newConfiguration.Configuration.Attributes, &newConfiguration); err != nil {

--- a/pkg/processor/trigger/rabbitmq/types.go
+++ b/pkg/processor/trigger/rabbitmq/types.go
@@ -49,7 +49,11 @@ func NewConfiguration(id string,
 	newConfiguration := Configuration{}
 
 	// create base
-	newConfiguration.Configuration = *trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	if err != nil {
+		return nil, err
+	}
+	newConfiguration.Configuration = *baseConfiguration
 
 	// parse attributes
 	if err := mapstructure.Decode(newConfiguration.Configuration.Attributes, &newConfiguration); err != nil {

--- a/pkg/processor/trigger/rabbitmq/types.go
+++ b/pkg/processor/trigger/rabbitmq/types.go
@@ -51,7 +51,7 @@ func NewConfiguration(id string,
 	// create base
 	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to create trigger configuration")
 	}
 	newConfiguration.Configuration = *baseConfiguration
 

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -83,6 +83,8 @@ type Trigger interface {
 
 	// TimeoutWorker times out a worker
 	TimeoutWorker(worker *worker.Worker) error
+
+	SignalWorkerDraining()
 }
 
 // AbstractTrigger implements common trigger operations
@@ -358,15 +360,12 @@ func (at *AbstractTrigger) UnsubscribeFromControlMessageKind(kind controlcommuni
 
 // SignalWorkerDraining sends a signal to all workers, telling them to drop or ack events
 // that are currently being processed
-func (at *AbstractTrigger) SignalWorkerDraining(workerDrainingCompleteChan chan bool) {
+func (at *AbstractTrigger) SignalWorkerDraining() {
 
 	// signal all workers to drain
 	if err := at.WorkerAllocator.SignalDraining(); err != nil {
 		at.Logger.WarnWith("Failed to signal all workers to drain events", "err", err.Error())
 	}
-
-	// signal draining complete
-	workerDrainingCompleteChan <- true
 }
 
 // ResetWorkerTerminationState resets the worker termination state

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -84,6 +84,7 @@ type Trigger interface {
 	// TimeoutWorker times out a worker
 	TimeoutWorker(worker *worker.Worker) error
 
+	// SignalWorkerDraining drains all workers
 	SignalWorkerDraining()
 }
 

--- a/pkg/processor/trigger/types.go
+++ b/pkg/processor/trigger/types.go
@@ -58,7 +58,7 @@ type Configuration struct {
 
 func NewConfiguration(id string,
 	triggerConfiguration *functionconfig.Trigger,
-	runtimeConfiguration *runtime.Configuration) *Configuration {
+	runtimeConfiguration *runtime.Configuration) (*Configuration, error) {
 
 	configuration := &Configuration{
 		Trigger:              *triggerConfiguration,
@@ -71,7 +71,17 @@ func NewConfiguration(id string,
 		configuration.MaxWorkers = 1
 	}
 
-	return configuration
+	if triggerConfiguration.WorkerTerminationTimeout == "" {
+		triggerConfiguration.WorkerTerminationTimeout = functionconfig.DefaultWorkerTerminationTimeout
+	}
+
+	workerTerminationTimeout, err := time.ParseDuration(triggerConfiguration.WorkerTerminationTimeout)
+	if err != nil {
+		return nil, errors.New("Failed to parse worker termination timeout from trigger configuration")
+	}
+	runtimeConfiguration.WorkerTerminationTimeout = workerTerminationTimeout
+
+	return configuration, nil
 }
 
 // PopulateConfigurationFromAnnotations allows setting configuration via annotations, for experimental settings

--- a/pkg/processor/trigger/v3iostream/types.go
+++ b/pkg/processor/trigger/v3iostream/types.go
@@ -63,7 +63,11 @@ func NewConfiguration(id string, triggerConfiguration *functionconfig.Trigger,
 	newConfiguration := Configuration{}
 
 	// create base
-	newConfiguration.Configuration = *trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	if err != nil {
+		return nil, err
+	}
+	newConfiguration.Configuration = *baseConfiguration
 
 	workerAllocationModeValue := ""
 	explicitAckModeValue := ""

--- a/pkg/processor/trigger/v3iostream/types.go
+++ b/pkg/processor/trigger/v3iostream/types.go
@@ -65,7 +65,7 @@ func NewConfiguration(id string, triggerConfiguration *functionconfig.Trigger,
 	// create base
 	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to create trigger configuration")
 	}
 	newConfiguration.Configuration = *baseConfiguration
 


### PR DESCRIPTION
Jira: `IG-22036`

When a pod is deleted, k8s signals the main process with a SIGTERM, and after a certain grace period (30 seconds) it kills the process with SIGKILL. (https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)

We want to use this grace period to drain the workers properly, and allow them to execute their termination callback (if it exists).