### PR TITLE
[Nuctl] Add flag to leave image info in function config 

### DIFF
--- a/pkg/common/headers/headers.go
+++ b/pkg/common/headers/headers.go
@@ -30,7 +30,7 @@ const (
 	CreationStateUpdatedTimeout         = "X-Nuclio-Creation-State-Updated-Timeout"
 	FunctionEnrichApiGateways           = "X-Nuclio-Function-Enrich-Apigateways"
 	ImportedFunctionOnly                = "X-Nuclio-Imported-Function-Only"
-	ExportWithImage                     = "X-Nuclio-Export-With-Image"
+	SkipSpecCleanup                     = "X-Nuclio-Skip-Spec-Cleanup"
 
 	// Project headers
 	ProjectName           = "X-Nuclio-Project-Name"

--- a/pkg/common/headers/headers.go
+++ b/pkg/common/headers/headers.go
@@ -30,6 +30,7 @@ const (
 	CreationStateUpdatedTimeout         = "X-Nuclio-Creation-State-Updated-Timeout"
 	FunctionEnrichApiGateways           = "X-Nuclio-Function-Enrich-Apigateways"
 	ImportedFunctionOnly                = "X-Nuclio-Imported-Function-Only"
+	WithImageFlag                       = "X-Nuclio-Export-With-Image"
 
 	// Project headers
 	ProjectName           = "X-Nuclio-Project-Name"

--- a/pkg/common/headers/headers.go
+++ b/pkg/common/headers/headers.go
@@ -30,7 +30,7 @@ const (
 	CreationStateUpdatedTimeout         = "X-Nuclio-Creation-State-Updated-Timeout"
 	FunctionEnrichApiGateways           = "X-Nuclio-Function-Enrich-Apigateways"
 	ImportedFunctionOnly                = "X-Nuclio-Imported-Function-Only"
-	WithImageFlag                       = "X-Nuclio-Export-With-Image"
+	ExportWithImage                     = "X-Nuclio-Export-With-Image"
 
 	// Project headers
 	ProjectName           = "X-Nuclio-Project-Name"

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -564,10 +564,7 @@ func (fr *functionResource) getWithImageFlagFromRequest(request *http.Request) b
 
 	// get the flag to export with/without image
 	providedHeader := request.Header.Get(headers.WithImageFlag)
-	if providedHeader == "" {
-		return false
-	}
-	return true
+	return providedHeader != ""
 }
 
 func (fr *functionResource) getFunctionInfoFromRequest(request *http.Request) (*functionInfo, error) {

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -560,13 +560,6 @@ func (fr *functionResource) getNamespaceFromRequest(request *http.Request) strin
 	return fr.getNamespaceOrDefault(request.Header.Get(headers.FunctionNamespace))
 }
 
-func (fr *functionResource) getWithImageFlagFromRequest(request *http.Request) bool {
-
-	// get the flag to export with/without image
-	providedHeader := request.Header.Get(headers.WithImageFlag)
-	return providedHeader != ""
-}
-
 func (fr *functionResource) getFunctionInfoFromRequest(request *http.Request) (*functionInfo, error) {
 
 	// read body

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -79,13 +79,13 @@ func (fr *functionResource) GetAll(request *http.Request) (map[string]restful.At
 	}
 
 	exportFunction := fr.GetURLParamBoolOrDefault(request, restful.ParamExport, false)
-
+	withImage := fr.getWithImageFlagFromRequest(request)
 	// create a map of attributes keyed by the function id (name)
 	for _, function := range functions {
 		if exportFunction {
-			response[function.GetConfig().Meta.Name] = fr.export(ctx, function)
+			response[function.GetConfig().Meta.Name] = fr.export(ctx, function, withImage)
 		} else {
-			response[function.GetConfig().Meta.Name] = fr.functionToAttributes(function)
+			response[function.GetConfig().Meta.Name] = fr.functionToAttributes(function, withImage)
 		}
 	}
 
@@ -107,12 +107,12 @@ func (fr *functionResource) GetByID(request *http.Request, id string) (restful.A
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get get function")
 	}
-
+	withImage := fr.getWithImageFlagFromRequest(request)
 	if fr.GetURLParamBoolOrDefault(request, restful.ParamExport, false) {
-		return fr.export(ctx, function), nil
+		return fr.export(ctx, function, withImage), nil
 	}
 
-	return fr.functionToAttributes(function), nil
+	return fr.functionToAttributes(function, withImage), nil
 }
 
 // Create and deploy a function
@@ -230,12 +230,12 @@ func (fr *functionResource) GetCustomRoutes() ([]restful.CustomRoute, error) {
 	}, nil
 }
 
-func (fr *functionResource) export(ctx context.Context, function platform.Function) restful.Attributes {
+func (fr *functionResource) export(ctx context.Context, function platform.Function, withImage bool) restful.Attributes {
 
 	functionConfig := function.GetConfig()
 
 	fr.Logger.DebugWithCtx(ctx, "Preparing function for export", "functionName", functionConfig.Meta.Name)
-	functionConfig.PrepareFunctionForExport(false)
+	functionConfig.PrepareFunctionForExport(false, withImage)
 
 	fr.Logger.DebugWithCtx(ctx, "Exporting function", "functionName", functionConfig.Meta.Name)
 
@@ -536,9 +536,11 @@ func (fr *functionResource) redeployFunction(request *http.Request,
 	return nuclio.ErrAccepted
 }
 
-func (fr *functionResource) functionToAttributes(function platform.Function) restful.Attributes {
+func (fr *functionResource) functionToAttributes(function platform.Function, withImage bool) restful.Attributes {
 	functionConfig := function.GetConfig()
-	functionConfig.CleanFunctionSpec()
+	if !withImage {
+		functionConfig.CleanFunctionSpec()
+	}
 
 	attributes := restful.Attributes{
 		"metadata": functionConfig.Meta,
@@ -556,6 +558,16 @@ func (fr *functionResource) getNamespaceFromRequest(request *http.Request) strin
 
 	// get the namespace provided by the user or the default namespace
 	return fr.getNamespaceOrDefault(request.Header.Get(headers.FunctionNamespace))
+}
+
+func (fr *functionResource) getWithImageFlagFromRequest(request *http.Request) bool {
+
+	// get the flag to export with/without image
+	providedHeader := request.Header.Get(headers.WithImageFlag)
+	if providedHeader == "" {
+		return false
+	}
+	return true
 }
 
 func (fr *functionResource) getFunctionInfoFromRequest(request *http.Request) (*functionInfo, error) {

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -297,7 +297,8 @@ func (pr *projectResource) getFunctionsAndFunctionEventsMap(request *http.Reques
 
 	// create a map of attributes keyed by the function id (name)
 	for _, function := range functions {
-		functionsMap[function.GetConfig().Meta.Name] = functionResourceInstance.export(ctx, function)
+		withImage := pr.getWithImageFlagFromRequest(request)
+		functionsMap[function.GetConfig().Meta.Name] = functionResourceInstance.export(ctx, function, withImage)
 
 		functionEvents := functionEventResourceInstance.getFunctionEvents(request, function, namespace)
 		for _, functionEvent := range functionEvents {

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -297,8 +297,8 @@ func (pr *projectResource) getFunctionsAndFunctionEventsMap(request *http.Reques
 
 	// create a map of attributes keyed by the function id (name)
 	for _, function := range functions {
-		withImage := pr.getWithImageFlagFromRequest(request)
-		functionsMap[function.GetConfig().Meta.Name] = functionResourceInstance.export(ctx, function, withImage)
+		skipSpecCleanup := pr.getSkipSpecCleanupFlagFromRequest(request)
+		functionsMap[function.GetConfig().Meta.Name] = functionResourceInstance.export(ctx, function, skipSpecCleanup)
 
 		functionEvents := functionEventResourceInstance.getFunctionEvents(request, function, namespace)
 		for _, functionEvent := range functionEvents {

--- a/pkg/dashboard/resource/resource.go
+++ b/pkg/dashboard/resource/resource.go
@@ -18,11 +18,11 @@ package resource
 
 import (
 	"context"
-	"github.com/nuclio/nuclio/pkg/common/headers"
 	"net/http"
 	"strings"
 
 	"github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/common/headers"
 	"github.com/nuclio/nuclio/pkg/dashboard"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/restful"

--- a/pkg/dashboard/resource/resource.go
+++ b/pkg/dashboard/resource/resource.go
@@ -18,6 +18,7 @@ package resource
 
 import (
 	"context"
+	"github.com/nuclio/nuclio/pkg/common/headers"
 	"net/http"
 	"strings"
 
@@ -53,6 +54,14 @@ func (r *resource) getNamespaceOrDefault(providedNamespace string) string {
 
 	// get the default namespace we were created with
 	return r.getDashboard().GetDefaultNamespace()
+}
+
+func (r *resource) getWithImageFlagFromRequest(request *http.Request) bool {
+	providedHeader := request.Header.Get(headers.WithImageFlag)
+	if providedHeader == "" {
+		return false
+	}
+	return true
 }
 
 func (r *resource) getRequestAuthConfig(request *http.Request) (*platform.AuthConfig, error) {

--- a/pkg/dashboard/resource/resource.go
+++ b/pkg/dashboard/resource/resource.go
@@ -57,11 +57,9 @@ func (r *resource) getNamespaceOrDefault(providedNamespace string) string {
 }
 
 func (r *resource) getWithImageFlagFromRequest(request *http.Request) bool {
-	providedHeader := request.Header.Get(headers.WithImageFlag)
-	if providedHeader == "" {
-		return false
-	}
-	return true
+	// get the flag to export with/without image
+	providedHeader := request.Header.Get(headers.ExportWithImage)
+	return providedHeader != ""
 }
 
 func (r *resource) getRequestAuthConfig(request *http.Request) (*platform.AuthConfig, error) {

--- a/pkg/dashboard/resource/resource.go
+++ b/pkg/dashboard/resource/resource.go
@@ -56,9 +56,9 @@ func (r *resource) getNamespaceOrDefault(providedNamespace string) string {
 	return r.getDashboard().GetDefaultNamespace()
 }
 
-func (r *resource) getWithImageFlagFromRequest(request *http.Request) bool {
+func (r *resource) getSkipSpecCleanupFlagFromRequest(request *http.Request) bool {
 	// get the flag to export with/without image
-	providedHeader := request.Header.Get(headers.ExportWithImage)
+	providedHeader := request.Header.Get(headers.SkipSpecCleanup)
 	return providedHeader != ""
 }
 

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -577,9 +577,13 @@ func (c *Config) CleanFunctionSpec() {
 	}
 }
 
-func (c *Config) PrepareFunctionForExport(noScrub bool) {
+func (c *Config) PrepareFunctionForExport(noScrub, withImage bool) {
 	if !noScrub {
 		c.scrubFunctionData()
+	}
+
+	if !withImage {
+		c.CleanFunctionSpec()
 	}
 
 	// resource version should not be exported anyway, as it's a k8s thing
@@ -600,8 +604,6 @@ func (c *Config) AddSkipAnnotations() {
 }
 
 func (c *Config) scrubFunctionData() {
-	c.CleanFunctionSpec()
-
 	// scrub namespace from function meta
 	c.Meta.Namespace = ""
 

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -577,12 +577,12 @@ func (c *Config) CleanFunctionSpec() {
 	}
 }
 
-func (c *Config) PrepareFunctionForExport(noScrub, withImage bool) {
+func (c *Config) PrepareFunctionForExport(noScrub, skipSpecCleanup bool) {
 	if !noScrub {
 		c.scrubFunctionData()
 	}
 
-	if !withImage {
+	if !skipSpecCleanup {
 		c.CleanFunctionSpec()
 	}
 

--- a/pkg/nuctl/command/common/renderers.go
+++ b/pkg/nuctl/command/common/renderers.go
@@ -185,7 +185,8 @@ func RenderFunctionEvents(functionEvents []platform.FunctionEvent,
 
 func RenderProjects(ctx context.Context,
 	projects []platform.Project,
-	format string, writer io.Writer,
+	format string, 
+	writer io.Writer,
 	renderCallback func(ctx context.Context, functions []platform.Project, renderer func(interface{}) error) error,
 	skipSpecCleanup bool) error {
 

--- a/pkg/nuctl/command/common/renderers.go
+++ b/pkg/nuctl/command/common/renderers.go
@@ -44,8 +44,8 @@ func RenderFunctions(ctx context.Context,
 	logger logger.Logger,
 	functions []platform.Function,
 	format string, writer io.Writer,
-	renderCallback func(functions []platform.Function, renderer func(interface{}) error, withImage bool) error,
-	withImage bool) error {
+	renderCallback func(functions []platform.Function, renderer func(interface{}) error, skipSpecCleanup bool) error,
+	skipSpecCleanup bool) error {
 
 	errGroup, errGroupCtx := errgroup.WithContext(ctx, logger)
 	var renderNodePort bool
@@ -123,9 +123,9 @@ func RenderFunctions(ctx context.Context,
 
 		rendererInstance.RenderTable(header, functionRecords)
 	case OutputFormatYAML:
-		return renderCallback(functions, rendererInstance.RenderYAML, withImage)
+		return renderCallback(functions, rendererInstance.RenderYAML, skipSpecCleanup)
 	case OutputFormatJSON:
-		return renderCallback(functions, rendererInstance.RenderJSON, withImage)
+		return renderCallback(functions, rendererInstance.RenderJSON, skipSpecCleanup)
 	}
 
 	return nil
@@ -187,7 +187,7 @@ func RenderProjects(ctx context.Context,
 	projects []platform.Project,
 	format string, writer io.Writer,
 	renderCallback func(ctx context.Context, functions []platform.Project, renderer func(interface{}) error) error,
-	withImage bool) error {
+	skipSpecCleanup bool) error {
 
 	rendererInstance := renderer.NewRenderer(writer)
 

--- a/pkg/nuctl/command/common/renderers.go
+++ b/pkg/nuctl/command/common/renderers.go
@@ -43,7 +43,8 @@ const (
 func RenderFunctions(ctx context.Context,
 	logger logger.Logger,
 	functions []platform.Function,
-	format string, writer io.Writer,
+	format string,
+	writer io.Writer,
 	renderCallback func(functions []platform.Function, renderer func(interface{}) error, skipSpecCleanup bool) error,
 	skipSpecCleanup bool) error {
 
@@ -185,7 +186,7 @@ func RenderFunctionEvents(functionEvents []platform.FunctionEvent,
 
 func RenderProjects(ctx context.Context,
 	projects []platform.Project,
-	format string, 
+	format string,
 	writer io.Writer,
 	renderCallback func(ctx context.Context, functions []platform.Project, renderer func(interface{}) error) error,
 	skipSpecCleanup bool) error {

--- a/pkg/nuctl/command/common/renderers.go
+++ b/pkg/nuctl/command/common/renderers.go
@@ -40,12 +40,7 @@ const (
 	OutputFormatYAML = "yaml"
 )
 
-func RenderFunctions(ctx context.Context,
-	logger logger.Logger,
-	functions []platform.Function,
-	format string,
-	writer io.Writer,
-	renderCallback func(functions []platform.Function, renderer func(interface{}) error) error) error {
+func RenderFunctions(ctx context.Context, logger logger.Logger, functions []platform.Function, format string, writer io.Writer, renderCallback func(functions []platform.Function, renderer func(interface{}) error, withImage bool) error, withImage bool) error {
 
 	errGroup, errGroupCtx := errgroup.WithContext(ctx, logger)
 	var renderNodePort bool
@@ -123,9 +118,9 @@ func RenderFunctions(ctx context.Context,
 
 		rendererInstance.RenderTable(header, functionRecords)
 	case OutputFormatYAML:
-		return renderCallback(functions, rendererInstance.RenderYAML)
+		return renderCallback(functions, rendererInstance.RenderYAML, withImage)
 	case OutputFormatJSON:
-		return renderCallback(functions, rendererInstance.RenderJSON)
+		return renderCallback(functions, rendererInstance.RenderJSON, withImage)
 	}
 
 	return nil
@@ -183,11 +178,7 @@ func RenderFunctionEvents(functionEvents []platform.FunctionEvent,
 	return nil
 }
 
-func RenderProjects(ctx context.Context,
-	projects []platform.Project,
-	format string,
-	writer io.Writer,
-	renderCallback func(ctx context.Context, functions []platform.Project, renderer func(interface{}) error) error) error {
+func RenderProjects(ctx context.Context, projects []platform.Project, format string, writer io.Writer, renderCallback func(ctx context.Context, functions []platform.Project, renderer func(interface{}) error) error, withImage bool) error {
 
 	rendererInstance := renderer.NewRenderer(writer)
 

--- a/pkg/nuctl/command/common/renderers.go
+++ b/pkg/nuctl/command/common/renderers.go
@@ -40,7 +40,12 @@ const (
 	OutputFormatYAML = "yaml"
 )
 
-func RenderFunctions(ctx context.Context, logger logger.Logger, functions []platform.Function, format string, writer io.Writer, renderCallback func(functions []platform.Function, renderer func(interface{}) error, withImage bool) error, withImage bool) error {
+func RenderFunctions(ctx context.Context,
+	logger logger.Logger,
+	functions []platform.Function,
+	format string, writer io.Writer,
+	renderCallback func(functions []platform.Function, renderer func(interface{}) error, withImage bool) error,
+	withImage bool) error {
 
 	errGroup, errGroupCtx := errgroup.WithContext(ctx, logger)
 	var renderNodePort bool
@@ -178,7 +183,11 @@ func RenderFunctionEvents(functionEvents []platform.FunctionEvent,
 	return nil
 }
 
-func RenderProjects(ctx context.Context, projects []platform.Project, format string, writer io.Writer, renderCallback func(ctx context.Context, functions []platform.Project, renderer func(interface{}) error) error, withImage bool) error {
+func RenderProjects(ctx context.Context,
+	projects []platform.Project,
+	format string, writer io.Writer,
+	renderCallback func(ctx context.Context, functions []platform.Project, renderer func(interface{}) error) error,
+	withImage bool) error {
 
 	rendererInstance := renderer.NewRenderer(writer)
 

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -89,6 +89,7 @@ type deployCommandeer struct {
 	noBuild                bool
 	deployAll              bool
 	waitForFunction        bool
+	withImage              bool
 	outputManifest         *nuctlcommon.PatchOutputManifest
 	excludedProjects       []string
 	excludedFunctions      []string
@@ -144,7 +145,7 @@ func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, be
 				}
 				if importedFunction != nil {
 					commandeer.rootCommandeer.loggerInstance.Debug("Function was already imported, deploying it")
-					commandeer.functionConfig = commandeer.prepareFunctionConfigForRedeploy(importedFunction)
+					commandeer.functionConfig = commandeer.prepareFunctionConfigForRedeploy(importedFunction, commandeer.withImage)
 				}
 			}
 
@@ -218,6 +219,7 @@ func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, be
 	}
 
 	addDeployFlags(cmd, commandeer)
+	cmd.Flags().BoolVarP(&commandeer.withImage, "with-image", "i", false, "Flag to leave image value in function config")
 	cmd.Flags().StringVarP(&commandeer.inputImageFile, "input-image-file", "", "", "Path to an input function-image Docker archive file")
 
 	commandeer.cmd = cmd
@@ -372,11 +374,13 @@ func (d *deployCommandeer) getImportedFunction(ctx context.Context, functionName
 	return nil, nil
 }
 
-func (d *deployCommandeer) prepareFunctionConfigForRedeploy(importedFunction platform.Function) functionconfig.Config {
+func (d *deployCommandeer) prepareFunctionConfigForRedeploy(importedFunction platform.Function, withImage bool) functionconfig.Config {
 	functionConfig := importedFunction.GetConfig()
 
 	// Ensure RunRegistry is taken from the commandeer config
-	functionConfig.CleanFunctionSpec()
+	if !withImage {
+		functionConfig.CleanFunctionSpec()
+	}
 	functionConfig.Spec.RunRegistry = d.functionConfig.Spec.RunRegistry
 
 	return *functionConfig
@@ -883,6 +887,11 @@ func (d *deployCommandeer) resolveRequestHeaders() map[string]string {
 
 		// add a header that will tell the API to only deploy imported functions
 		requestHeaders[headers.ImportedFunctionOnly] = "true"
+	}
+	if d.withImage {
+
+		// add a header that will signal that we want to leave image info in function config
+		requestHeaders[headers.WithImageFlag] = "true"
 	}
 	return requestHeaders
 }

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -891,7 +891,7 @@ func (d *deployCommandeer) resolveRequestHeaders() map[string]string {
 	if d.skipSpecCleanup {
 
 		// add a header that will signal that we want to leave image info in function config
-		requestHeaders[headers.WithImageFlag] = "true"
+		requestHeaders[headers.ExportWithImage] = "true"
 	}
 	return requestHeaders
 }

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -888,11 +888,6 @@ func (d *deployCommandeer) resolveRequestHeaders() map[string]string {
 		// add a header that will tell the API to only deploy imported functions
 		requestHeaders[headers.ImportedFunctionOnly] = "true"
 	}
-	if d.skipSpecCleanup {
-
-		// add a header that will signal that we want to leave image info in function config
-		requestHeaders[headers.ExportWithImage] = "true"
-	}
 	return requestHeaders
 }
 

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -219,7 +219,7 @@ func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, be
 	}
 
 	addDeployFlags(cmd, commandeer)
-	cmd.Flags().BoolVarP(&commandeer.skipSpecCleanup, "skip-spec-cleanup", "s", false, "Do not clean up spec in function configs")
+	cmd.Flags().BoolVarP(&commandeer.skipSpecCleanup, "skip-spec-cleanup", "", false, "Do not clean up spec in function configs")
 	cmd.Flags().StringVarP(&commandeer.inputImageFile, "input-image-file", "", "", "Path to an input function-image Docker archive file")
 
 	commandeer.cmd = cmd
@@ -374,11 +374,11 @@ func (d *deployCommandeer) getImportedFunction(ctx context.Context, functionName
 	return nil, nil
 }
 
-func (d *deployCommandeer) prepareFunctionConfigForRedeploy(importedFunction platform.Function, withImage bool) functionconfig.Config {
+func (d *deployCommandeer) prepareFunctionConfigForRedeploy(importedFunction platform.Function, skipSpecCleanup bool) functionconfig.Config {
 	functionConfig := importedFunction.GetConfig()
 
 	// Ensure RunRegistry is taken from the commandeer config
-	if !withImage {
+	if !skipSpecCleanup {
 		functionConfig.CleanFunctionSpec()
 	}
 	functionConfig.Spec.RunRegistry = d.functionConfig.Spec.RunRegistry

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -89,7 +89,7 @@ type deployCommandeer struct {
 	noBuild                bool
 	deployAll              bool
 	waitForFunction        bool
-	withImage              bool
+	skipSpecCleanup        bool
 	outputManifest         *nuctlcommon.PatchOutputManifest
 	excludedProjects       []string
 	excludedFunctions      []string
@@ -145,7 +145,7 @@ func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, be
 				}
 				if importedFunction != nil {
 					commandeer.rootCommandeer.loggerInstance.Debug("Function was already imported, deploying it")
-					commandeer.functionConfig = commandeer.prepareFunctionConfigForRedeploy(importedFunction, commandeer.withImage)
+					commandeer.functionConfig = commandeer.prepareFunctionConfigForRedeploy(importedFunction, commandeer.skipSpecCleanup)
 				}
 			}
 
@@ -219,7 +219,7 @@ func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, be
 	}
 
 	addDeployFlags(cmd, commandeer)
-	cmd.Flags().BoolVarP(&commandeer.withImage, "with-image", "i", false, "Flag to leave image value in function config")
+	cmd.Flags().BoolVarP(&commandeer.skipSpecCleanup, "skip-spec-cleanup", "s", false, "Do not clean up spec in function configs")
 	cmd.Flags().StringVarP(&commandeer.inputImageFile, "input-image-file", "", "", "Path to an input function-image Docker archive file")
 
 	commandeer.cmd = cmd
@@ -888,7 +888,7 @@ func (d *deployCommandeer) resolveRequestHeaders() map[string]string {
 		// add a header that will tell the API to only deploy imported functions
 		requestHeaders[headers.ImportedFunctionOnly] = "true"
 	}
-	if d.withImage {
+	if d.skipSpecCleanup {
 
 		// add a header that will signal that we want to leave image info in function config
 		requestHeaders[headers.WithImageFlag] = "true"

--- a/pkg/nuctl/command/export.go
+++ b/pkg/nuctl/command/export.go
@@ -54,7 +54,7 @@ func newExportCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *e
 to the standard output, in JSON or YAML format`,
 	}
 
-	cmd.PersistentFlags().BoolVar(&commandeer.noScrub, "no-scrub", true, "Export all function data, including sensitive and unnecessary data")
+	cmd.PersistentFlags().BoolVar(&commandeer.noScrub, "no-scrub", false, "Export all function data, including sensitive and unnecessary data")
 
 	exportFunctionCommand := newExportFunctionCommandeer(ctx, commandeer).cmd
 	exportProjectCommand := newExportProjectCommandeer(ctx, commandeer).cmd
@@ -132,7 +132,7 @@ Arguments:
 		},
 	}
 
-	cmd.Flags().BoolVarP(&commandeer.withImage, "with-image", "i", false, "Flag to export with image info")
+	cmd.Flags().BoolVarP(&commandeer.withImage, "with-image", "i", false, "Do not clear the image info from the function spec")
 	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", nuctlcommon.OutputFormatYAML, "Output format - \"json\" or \"yaml\"")
 
 	commandeer.cmd = cmd
@@ -249,7 +249,7 @@ Arguments:
 		},
 	}
 
-	cmd.Flags().BoolVarP(&commandeer.withImage, "with-image", "i", false, "Flag to export with image info")
+	cmd.Flags().BoolVarP(&commandeer.withImage, "with-image", "i", false, "Do not clear the image info from the function spec")
 	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", nuctlcommon.OutputFormatYAML, "Output format - \"json\" or \"yaml\"")
 	commandeer.cmd = cmd
 

--- a/pkg/nuctl/command/export.go
+++ b/pkg/nuctl/command/export.go
@@ -54,7 +54,7 @@ func newExportCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *e
 to the standard output, in JSON or YAML format`,
 	}
 
-	cmd.PersistentFlags().BoolVar(&commandeer.noScrub, "no-scrub", false, "Export all function data, including sensitive and unnecessary data")
+	cmd.PersistentFlags().BoolVar(&commandeer.noScrub, "no-scrub", true, "Export all function data, including sensitive and unnecessary data")
 
 	exportFunctionCommand := newExportFunctionCommandeer(ctx, commandeer).cmd
 	exportProjectCommand := newExportProjectCommandeer(ctx, commandeer).cmd
@@ -72,6 +72,7 @@ to the standard output, in JSON or YAML format`,
 type exportFunctionCommandeer struct {
 	*exportCommandeer
 	getFunctionsOptions platform.GetFunctionsOptions
+	withImage           bool
 	output              string
 }
 
@@ -88,7 +89,8 @@ func newExportFunctionCommandeer(ctx context.Context, exportCommandeer *exportCo
 to the standard output, in JSON or YAML format (see -o|--output)
 
 Arguments:
-  <function> (string) The name of a function to export`,
+  <function> (string) The name of a function to export
+  <with-image> (flag) With this flag function will be exported with image info`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// if we got positional arguments
@@ -125,10 +127,13 @@ Arguments:
 				functions,
 				commandeer.output,
 				cmd.OutOrStdout(),
-				commandeer.renderFunctionConfig)
+				commandeer.renderFunctionConfig,
+				commandeer.withImage,
+			)
 		},
 	}
 
+	cmd.Flags().BoolVarP(&commandeer.withImage, "with-image", "i", false, "Flag to export with image info")
 	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", nuctlcommon.OutputFormatYAML, "Output format - \"json\" or \"yaml\"")
 
 	commandeer.cmd = cmd
@@ -136,7 +141,7 @@ Arguments:
 	return commandeer
 }
 
-func (e *exportFunctionCommandeer) renderFunctionConfig(functions []platform.Function, renderer func(interface{}) error) error {
+func (e *exportFunctionCommandeer) renderFunctionConfig(functions []platform.Function, renderer func(interface{}) error, withImage bool) error {
 	functionConfigs := map[string]*functionconfig.Config{}
 	lock := sync.Mutex{}
 	errGroup, errGroupCtx := errgroup.WithContextSemaphore(context.Background(),
@@ -161,7 +166,7 @@ func (e *exportFunctionCommandeer) renderFunctionConfig(functions []platform.Fun
 			} else if err != nil {
 				return errors.Wrap(err, "Failed to check if function config is scrubbed")
 			}
-			functionConfig.PrepareFunctionForExport(e.noScrub)
+			functionConfig.PrepareFunctionForExport(e.noScrub, withImage)
 			lock.Lock()
 			functionConfigs[functionConfig.Meta.Name] = functionConfig
 			lock.Unlock()
@@ -190,6 +195,7 @@ func (e *exportFunctionCommandeer) renderFunctionConfig(functions []platform.Fun
 type exportProjectCommandeer struct {
 	*exportCommandeer
 	getProjectsOptions platform.GetProjectsOptions
+	withImage          bool
 	output             string
 }
 
@@ -207,7 +213,8 @@ all its functions, function events, and API gateways) or of all projects (defaul
 to the standard output, in JSON or YAML format (see -o|--output)
 
 Arguments:
-  <project> (string) The name of a project to export`,
+  <project> (string) The name of a project to export
+  <with-image> (flag) With this flag functions will be exported with image info`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// if we got positional arguments
@@ -240,10 +247,11 @@ Arguments:
 			}
 
 			// render the projects
-			return nuctlcommon.RenderProjects(ctx, projects, commandeer.output, cmd.OutOrStdout(), commandeer.renderProjectConfig)
+			return nuctlcommon.RenderProjects(ctx, projects, commandeer.output, cmd.OutOrStdout(), commandeer.renderProjectConfig, commandeer.withImage)
 		},
 	}
 
+	cmd.Flags().BoolVarP(&commandeer.withImage, "with-image", "i", false, "Flag to export with image info")
 	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", nuctlcommon.OutputFormatYAML, "Output format - \"json\" or \"yaml\"")
 	commandeer.cmd = cmd
 
@@ -294,7 +302,7 @@ func (e *exportProjectCommandeer) exportAPIGateways(ctx context.Context, project
 	return apiGatewaysMap, nil
 }
 
-func (e *exportProjectCommandeer) exportProjectFunctionsAndFunctionEvents(ctx context.Context, projectConfig *platform.ProjectConfig) (
+func (e *exportProjectCommandeer) exportProjectFunctionsAndFunctionEvents(ctx context.Context, projectConfig *platform.ProjectConfig, withImage bool) (
 	map[string]*functionconfig.Config, map[string]*platform.FunctionEventConfig, error) {
 	getFunctionOptions := &platform.GetFunctionsOptions{
 		Namespace: projectConfig.Meta.Namespace,
@@ -331,7 +339,7 @@ func (e *exportProjectCommandeer) exportProjectFunctionsAndFunctionEvents(ctx co
 			functionEventMap[functionEventConfig.Meta.Name] = functionEventConfig
 		}
 
-		functionConfig.PrepareFunctionForExport(e.noScrub)
+		functionConfig.PrepareFunctionForExport(e.noScrub, withImage)
 		functionMap[functionConfig.Meta.Name] = functionConfig
 	}
 
@@ -339,7 +347,7 @@ func (e *exportProjectCommandeer) exportProjectFunctionsAndFunctionEvents(ctx co
 }
 
 func (e *exportProjectCommandeer) exportProject(ctx context.Context, projectConfig *platform.ProjectConfig) (map[string]interface{}, error) {
-	functions, functionEvents, err := e.exportProjectFunctionsAndFunctionEvents(ctx, projectConfig)
+	functions, functionEvents, err := e.exportProjectFunctionsAndFunctionEvents(ctx, projectConfig, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/nuctl/command/export.go
+++ b/pkg/nuctl/command/export.go
@@ -37,6 +37,7 @@ type exportCommandeer struct {
 	rootCommandeer *RootCommandeer
 	scrubber       *functionconfig.Scrubber
 	noScrub        bool
+	withImage      bool
 }
 
 func newExportCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *exportCommandeer {
@@ -72,7 +73,6 @@ to the standard output, in JSON or YAML format`,
 type exportFunctionCommandeer struct {
 	*exportCommandeer
 	getFunctionsOptions platform.GetFunctionsOptions
-	withImage           bool
 	output              string
 }
 
@@ -194,7 +194,6 @@ func (e *exportFunctionCommandeer) renderFunctionConfig(functions []platform.Fun
 type exportProjectCommandeer struct {
 	*exportCommandeer
 	getProjectsOptions platform.GetProjectsOptions
-	withImage          bool
 	output             string
 }
 

--- a/pkg/nuctl/command/export.go
+++ b/pkg/nuctl/command/export.go
@@ -33,11 +33,11 @@ import (
 )
 
 type exportCommandeer struct {
-	cmd            *cobra.Command
-	rootCommandeer *RootCommandeer
-	scrubber       *functionconfig.Scrubber
-	noScrub        bool
-	withImage      bool
+	cmd             *cobra.Command
+	rootCommandeer  *RootCommandeer
+	scrubber        *functionconfig.Scrubber
+	noScrub         bool
+	skipSpecCleanup bool
 }
 
 func newExportCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *exportCommandeer {
@@ -127,12 +127,12 @@ Arguments:
 				commandeer.output,
 				cmd.OutOrStdout(),
 				commandeer.renderFunctionConfig,
-				commandeer.withImage,
+				commandeer.skipSpecCleanup,
 			)
 		},
 	}
 
-	cmd.Flags().BoolVarP(&commandeer.withImage, "with-image", "i", false, "Do not clear the image info from the function spec")
+	cmd.Flags().BoolVarP(&commandeer.skipSpecCleanup, "skip-spec-cleanup", "", false, "Do not clear the image info from the function spec")
 	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", nuctlcommon.OutputFormatYAML, "Output format - \"json\" or \"yaml\"")
 
 	commandeer.cmd = cmd
@@ -140,7 +140,7 @@ Arguments:
 	return commandeer
 }
 
-func (e *exportFunctionCommandeer) renderFunctionConfig(functions []platform.Function, renderer func(interface{}) error, withImage bool) error {
+func (e *exportFunctionCommandeer) renderFunctionConfig(functions []platform.Function, renderer func(interface{}) error, skipSpecCleanup bool) error {
 	functionConfigs := map[string]*functionconfig.Config{}
 	lock := sync.Mutex{}
 	errGroup, errGroupCtx := errgroup.WithContextSemaphore(context.Background(),
@@ -165,7 +165,7 @@ func (e *exportFunctionCommandeer) renderFunctionConfig(functions []platform.Fun
 			} else if err != nil {
 				return errors.Wrap(err, "Failed to check if function config is scrubbed")
 			}
-			functionConfig.PrepareFunctionForExport(e.noScrub, withImage)
+			functionConfig.PrepareFunctionForExport(e.noScrub, skipSpecCleanup)
 			lock.Lock()
 			functionConfigs[functionConfig.Meta.Name] = functionConfig
 			lock.Unlock()
@@ -244,11 +244,11 @@ Arguments:
 			}
 
 			// render the projects
-			return nuctlcommon.RenderProjects(ctx, projects, commandeer.output, cmd.OutOrStdout(), commandeer.renderProjectConfig, commandeer.withImage)
+			return nuctlcommon.RenderProjects(ctx, projects, commandeer.output, cmd.OutOrStdout(), commandeer.renderProjectConfig, commandeer.skipSpecCleanup)
 		},
 	}
 
-	cmd.Flags().BoolVarP(&commandeer.withImage, "with-image", "i", false, "Do not clear the image info from the function spec")
+	cmd.Flags().BoolVarP(&commandeer.skipSpecCleanup, "skip-spec-cleanup", "", false, "Do not clear the image info from the function spec")
 	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", nuctlcommon.OutputFormatYAML, "Output format - \"json\" or \"yaml\"")
 	commandeer.cmd = cmd
 
@@ -299,7 +299,7 @@ func (e *exportProjectCommandeer) exportAPIGateways(ctx context.Context, project
 	return apiGatewaysMap, nil
 }
 
-func (e *exportProjectCommandeer) exportProjectFunctionsAndFunctionEvents(ctx context.Context, projectConfig *platform.ProjectConfig, withImage bool) (
+func (e *exportProjectCommandeer) exportProjectFunctionsAndFunctionEvents(ctx context.Context, projectConfig *platform.ProjectConfig, skipSpecCleanup bool) (
 	map[string]*functionconfig.Config, map[string]*platform.FunctionEventConfig, error) {
 	getFunctionOptions := &platform.GetFunctionsOptions{
 		Namespace: projectConfig.Meta.Namespace,
@@ -336,7 +336,7 @@ func (e *exportProjectCommandeer) exportProjectFunctionsAndFunctionEvents(ctx co
 			functionEventMap[functionEventConfig.Meta.Name] = functionEventConfig
 		}
 
-		functionConfig.PrepareFunctionForExport(e.noScrub, withImage)
+		functionConfig.PrepareFunctionForExport(e.noScrub, skipSpecCleanup)
 		functionMap[functionConfig.Meta.Name] = functionConfig
 	}
 

--- a/pkg/nuctl/command/export.go
+++ b/pkg/nuctl/command/export.go
@@ -89,8 +89,7 @@ func newExportFunctionCommandeer(ctx context.Context, exportCommandeer *exportCo
 to the standard output, in JSON or YAML format (see -o|--output)
 
 Arguments:
-  <function> (string) The name of a function to export
-  <with-image> (flag) With this flag function will be exported with image info`,
+  <function> (string) The name of a function to export`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// if we got positional arguments
@@ -213,8 +212,7 @@ all its functions, function events, and API gateways) or of all projects (defaul
 to the standard output, in JSON or YAML format (see -o|--output)
 
 Arguments:
-  <project> (string) The name of a project to export
-  <with-image> (flag) With this flag functions will be exported with image info`,
+  <project> (string) The name of a project to export`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// if we got positional arguments

--- a/pkg/nuctl/command/get.go
+++ b/pkg/nuctl/command/get.go
@@ -190,7 +190,12 @@ func newGetProjectCommandeer(ctx context.Context, getCommandeer *getCommandeer) 
 			}
 
 			// render the projects
-			return common.RenderProjects(ctx, projects, commandeer.output, cmd.OutOrStdout(), commandeer.renderProjectConfig, false)
+			return common.RenderProjects(ctx,
+				projects,
+				commandeer.output,
+				cmd.OutOrStdout(),
+				commandeer.renderProjectConfig,
+				false)
 		},
 	}
 

--- a/pkg/nuctl/command/get.go
+++ b/pkg/nuctl/command/get.go
@@ -110,10 +110,10 @@ func newGetFunctionCommandeer(ctx context.Context, getCommandeer *getCommandeer)
 				functions,
 				commandeer.output,
 				cmd.OutOrStdout(),
-				commandeer.renderFunctionConfigWithStatus)
+				commandeer.renderFunctionConfigWithStatus,
+				false)
 		},
 	}
-
 	cmd.PersistentFlags().StringVarP(&commandeer.getFunctionsOptions.Labels, "labels", "l", "", "Function labels (lbl1=val1[,lbl2=val2,...])")
 	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", common.OutputFormatText, "Output format - \"text\", \"wide\", \"yaml\", or \"json\"")
 	commandeer.cmd = cmd
@@ -122,7 +122,7 @@ func newGetFunctionCommandeer(ctx context.Context, getCommandeer *getCommandeer)
 }
 
 func (g *getFunctionCommandeer) renderFunctionConfigWithStatus(functions []platform.Function,
-	renderer func(interface{}) error) error {
+	renderer func(interface{}) error, withImage bool) error {
 	configsWithStatus := make([]functionconfig.ConfigWithStatus, 0, len(functions))
 	for _, function := range functions {
 		functionConfigWithStatus := functionconfig.ConfigWithStatus{
@@ -190,11 +190,7 @@ func newGetProjectCommandeer(ctx context.Context, getCommandeer *getCommandeer) 
 			}
 
 			// render the projects
-			return common.RenderProjects(ctx,
-				projects,
-				commandeer.output,
-				cmd.OutOrStdout(),
-				commandeer.renderProjectConfig)
+			return common.RenderProjects(ctx, projects, commandeer.output, cmd.OutOrStdout(), commandeer.renderProjectConfig, false)
 		},
 	}
 

--- a/pkg/nuctl/command/get.go
+++ b/pkg/nuctl/command/get.go
@@ -122,7 +122,7 @@ func newGetFunctionCommandeer(ctx context.Context, getCommandeer *getCommandeer)
 }
 
 func (g *getFunctionCommandeer) renderFunctionConfigWithStatus(functions []platform.Function,
-	renderer func(interface{}) error, withImage bool) error {
+	renderer func(interface{}) error, skipSpecCleanup bool) error {
 	configsWithStatus := make([]functionconfig.ConfigWithStatus, 0, len(functions))
 	for _, function := range functions {
 		functionConfigWithStatus := functionconfig.ConfigWithStatus{


### PR DESCRIPTION
Jira:`IG-22067`

When redeploying an imported function, the dashboard updates the CRD status and the controller creates the relevant resources.
However - when exporting the function in the first place, the image in `spec.image` is cleared. This results with the controller creating a deployment with an empty image name, although it might already exist in the registry.

To overcome this, we should add an option to keep the image name in the spec, so when the deployment is created it will use the same image.

If the image won't exist in the registry - the redeployment will still fail, and a regular deployment will be required.