### PR TITLE
[Nuctl] Add previous state annotation when export function

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -233,9 +233,9 @@ func (fr *functionResource) GetCustomRoutes() ([]restful.CustomRoute, error) {
 func (fr *functionResource) export(ctx context.Context, function platform.Function) restful.Attributes {
 
 	functionConfig := function.GetConfig()
-
 	fr.Logger.DebugWithCtx(ctx, "Preparing function for export", "functionName", functionConfig.Meta.Name)
-	functionConfig.PrepareFunctionForExport(false)
+	state := string(function.GetStatus().State)
+	functionConfig.PrepareFunctionForExport(false, state)
 
 	fr.Logger.DebugWithCtx(ctx, "Exporting function", "functionName", functionConfig.Meta.Name)
 

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -878,6 +878,7 @@ func (suite *functionTestSuite) TestExportFunctionSuccessful() {
 	returnedFunction.Config.Meta.Name = "f1"
 	returnedFunction.Config.Meta.Namespace = "f1-namespace"
 	returnedFunction.Config.Spec.Replicas = &replicas
+	returnedFunction.Status.State = functionconfig.FunctionStateReady
 	returnedFunction.Config.Spec.Build.CodeEntryAttributes = map[string]interface{}{
 		"password": passwordReference,
 	}
@@ -904,6 +905,7 @@ func (suite *functionTestSuite) TestExportFunctionSuccessful() {
 	"metadata": {
 		"name": "f1",
 		"annotations": {
+			"nuclio.io/previous-state": "ready",
 			"skip-build": "true",
 			"skip-deploy": "true"
 		}
@@ -937,11 +939,13 @@ func (suite *functionTestSuite) TestExportFunctionListSuccessful() {
 	returnedFunction1.Config.Meta.Name = "f1"
 	returnedFunction1.Config.Meta.Namespace = "f-namespace"
 	returnedFunction1.Config.Spec.Replicas = &replicas
+	returnedFunction1.Status.State = functionconfig.FunctionStateReady
 
 	returnedFunction2 := platform.AbstractFunction{}
 	returnedFunction2.Config.Meta.Name = "f2"
 	returnedFunction2.Config.Meta.Namespace = "f-namespace"
 	returnedFunction2.Config.Spec.Replicas = &replicas
+	returnedFunction2.Status.State = functionconfig.FunctionStateScaledToZero
 
 	// verify
 	verifyGetFunctionsOptions := func(getFunctionsOptions *platform.GetFunctionsOptions) bool {
@@ -966,6 +970,7 @@ func (suite *functionTestSuite) TestExportFunctionListSuccessful() {
 		"metadata": {
 			"name": "f1",
 			"annotations": {
+                "nuclio.io/previous-state": "ready",
 				"skip-build": "true",
 				"skip-deploy": "true"
 			}
@@ -982,6 +987,7 @@ func (suite *functionTestSuite) TestExportFunctionListSuccessful() {
 		"metadata": {
 			"name": "f2",
 			"annotations": {
+                "nuclio.io/previous-state": "scaledToZero",
 				"skip-build": "true",
 				"skip-deploy": "true"
 			}
@@ -1444,6 +1450,7 @@ func (suite *projectTestSuite) TestExportProjectSuccessful() {
 	returnedFunction1.Config.Meta.Name = "f1"
 	returnedFunction1.Config.Meta.Namespace = "f-namespace"
 	returnedFunction1.Config.Spec.Runtime = "r1"
+	returnedFunction1.Status.State = functionconfig.FunctionStateReady
 
 	returnedFunctionEvent := platform.AbstractFunctionEvent{}
 	returnedFunctionEvent.FunctionEventConfig.Meta.Name = "fe1"
@@ -1458,6 +1465,7 @@ func (suite *projectTestSuite) TestExportProjectSuccessful() {
 	returnedFunction2.Config.Meta.Name = "f2"
 	returnedFunction2.Config.Meta.Namespace = "f-namespace"
 	returnedFunction2.Config.Spec.Runtime = "r2"
+	returnedFunction2.Status.State = functionconfig.FunctionStateReady
 
 	returnedProject1 := platform.AbstractProject{}
 	returnedProject1.ProjectConfig.Meta.Name = "p1"
@@ -1560,6 +1568,7 @@ func (suite *projectTestSuite) TestExportProjectSuccessful() {
       "metadata": {
         "name": "f1",
         "annotations": {
+          "nuclio.io/previous-state": "ready",
           "skip-build": "true",
           "skip-deploy": "true"
         }
@@ -1576,6 +1585,7 @@ func (suite *projectTestSuite) TestExportProjectSuccessful() {
       "metadata": {
         "name": "f2",
         "annotations": {
+          "nuclio.io/previous-state": "ready",
           "skip-build": "true",
           "skip-deploy": "true"
         }
@@ -1613,11 +1623,13 @@ func (suite *projectTestSuite) TestExportProjectListSuccessful() {
 	returnedFunction1.Config.Meta.Name = "f1"
 	returnedFunction1.Config.Meta.Namespace = "f-namespace"
 	returnedFunction1.Config.Spec.Runtime = "r1"
+	returnedFunction1.Status.State = functionconfig.FunctionStateReady
 
 	returnedFunction2 := platform.AbstractFunction{}
 	returnedFunction2.Config.Meta.Name = "f2"
 	returnedFunction2.Config.Meta.Namespace = "f-namespace"
 	returnedFunction2.Config.Spec.Runtime = "r2"
+	returnedFunction2.Status.State = functionconfig.FunctionStateReady
 
 	returnedProject1 := platform.AbstractProject{}
 	returnedProject1.ProjectConfig.Meta.Name = "p1"
@@ -1711,6 +1723,7 @@ func (suite *projectTestSuite) TestExportProjectListSuccessful() {
         "metadata": {
           "name": "f1",
           "annotations": {
+			"nuclio.io/previous-state": "ready",
             "skip-build": "true",
             "skip-deploy": "true"
           }
@@ -1747,6 +1760,7 @@ func (suite *projectTestSuite) TestExportProjectListSuccessful() {
         "metadata": {
           "name": "f2",
           "annotations": {
+			"nuclio.io/previous-state": "ready",
             "skip-build": "true",
             "skip-deploy": "true"
           }

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -501,6 +501,7 @@ func (s *Spec) PositiveGPUResourceLimit() bool {
 const (
 	FunctionAnnotationSkipBuild  = "skip-build"
 	FunctionAnnotationSkipDeploy = "skip-deploy"
+	FunctionAnnotationPrevState  = "nuclio.io/previous-state"
 )
 
 // Meta identifies a function
@@ -577,7 +578,7 @@ func (c *Config) CleanFunctionSpec() {
 	}
 }
 
-func (c *Config) PrepareFunctionForExport(noScrub bool) {
+func (c *Config) PrepareFunctionForExport(noScrub bool, state string) {
 	if !noScrub {
 		c.scrubFunctionData()
 	}
@@ -586,6 +587,7 @@ func (c *Config) PrepareFunctionForExport(noScrub bool) {
 	c.Meta.ResourceVersion = ""
 
 	c.AddSkipAnnotations()
+	c.AddPrevStateAnnotation(state)
 }
 
 func (c *Config) AddSkipAnnotations() {
@@ -597,6 +599,13 @@ func (c *Config) AddSkipAnnotations() {
 	// add annotations for not deploying or building on import
 	c.Meta.AddSkipBuildAnnotation()
 	c.Meta.AddSkipDeployAnnotation()
+}
+
+func (c *Config) AddPrevStateAnnotation(status string) {
+	if c.Meta.Annotations == nil {
+		c.Meta.Annotations = map[string]string{}
+	}
+	c.Meta.Annotations[FunctionAnnotationPrevState] = status
 }
 
 func (c *Config) scrubFunctionData() {

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -601,11 +601,11 @@ func (c *Config) AddSkipAnnotations() {
 	c.Meta.AddSkipDeployAnnotation()
 }
 
-func (c *Config) AddPrevStateAnnotation(status string) {
+func (c *Config) AddPrevStateAnnotation(state string) {
 	if c.Meta.Annotations == nil {
 		c.Meta.Annotations = map[string]string{}
 	}
-	c.Meta.Annotations[FunctionAnnotationPrevState] = status
+	c.Meta.Annotations[FunctionAnnotationPrevState] = state
 }
 
 func (c *Config) scrubFunctionData() {

--- a/pkg/nuctl/command/export.go
+++ b/pkg/nuctl/command/export.go
@@ -337,7 +337,7 @@ func (e *exportProjectCommandeer) exportProjectFunctionsAndFunctionEvents(ctx co
 			functionEventMap[functionEventConfig.Meta.Name] = functionEventConfig
 		}
 		state := string(function.GetStatus().State)
-		functionConfig.PrepareFunctionForExport(e.noScrub, skipSpecCleanup,state)
+		functionConfig.PrepareFunctionForExport(e.noScrub, skipSpecCleanup, state)
 		functionMap[functionConfig.Meta.Name] = functionConfig
 	}
 

--- a/pkg/nuctl/command/export.go
+++ b/pkg/nuctl/command/export.go
@@ -161,7 +161,8 @@ func (e *exportFunctionCommandeer) renderFunctionConfig(functions []platform.Fun
 			} else if err != nil {
 				return errors.Wrap(err, "Failed to check if function config is scrubbed")
 			}
-			functionConfig.PrepareFunctionForExport(e.noScrub)
+			state := string(function.GetStatus().State)
+			functionConfig.PrepareFunctionForExport(e.noScrub, state)
 			lock.Lock()
 			functionConfigs[functionConfig.Meta.Name] = functionConfig
 			lock.Unlock()
@@ -330,8 +331,8 @@ func (e *exportProjectCommandeer) exportProjectFunctionsAndFunctionEvents(ctx co
 			functionEventConfig.Meta.Namespace = ""
 			functionEventMap[functionEventConfig.Meta.Name] = functionEventConfig
 		}
-
-		functionConfig.PrepareFunctionForExport(e.noScrub)
+		state := string(function.GetStatus().State)
+		functionConfig.PrepareFunctionForExport(e.noScrub, state)
 		functionMap[functionConfig.Meta.Name] = functionConfig
 	}
 


### PR DESCRIPTION
Jira: `IG-22051`

When exporting a function, add its current state as an annotation "nuclio.io/previous-state".
The state should be taken from the function status, and should be one of the available options of "FunctionState".
This will later be used when importing and redeploying function to determine the desired state.