### PR TITLE
Revert "[Helm] Fix creation of ClusterRoleBinding for namespace access mode"

### DIFF
--- a/hack/k8s/helm/nuclio/templates/rolebinding/crd-admin.yaml
+++ b/hack/k8s/helm/nuclio/templates/rolebinding/crd-admin.yaml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 {{- if .Values.rbac.create }}
-{{- if eq .Values.rbac.crdAccessMode "cluster" }}
 # Bind the service account (used by controller / dashboard) to the crd-admin role,
 # allowing them to create / delete custom resource definitions in the appropriate namespace
 apiVersion: rbac.authorization.k8s.io/v1
@@ -31,8 +30,10 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "nuclio.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-{{- end }}
+
 {{- if eq .Values.rbac.crdAccessMode "namespaced" }}
+
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/pkg/processor/runtime/rpc/abstract_test.go
+++ b/pkg/processor/runtime/rpc/abstract_test.go
@@ -64,6 +64,9 @@ func newTestRuntime(parentLogger logger.Logger, configuration *runtime.Configura
 
 	newTestRuntime.AbstractRuntime.ControlMessageBroker = NewRpcControlMessageBroker(nil, parentLogger, nil)
 
+	// set the runtime's isDrained to true, so it won't send a signal to the wrapper process
+	newTestRuntime.isDrained = true
+
 	return newTestRuntime, nil
 }
 
@@ -205,9 +208,6 @@ func (suite *RuntimeSuite) TestReadControlMessage() {
 }
 
 func (suite *RuntimeSuite) TearDownTest() {
-	// set the runtime's isDrained to true, so it won't send a signal to the wrapper process
-	suite.testRuntimeInstance.isDrained = true
-
 	if suite.testRuntimeInstance != nil && suite.testRuntimeInstance.wrapperProcess != nil {
 		suite.testRuntimeInstance.Stop() // nolint: errcheck
 	}


### PR DESCRIPTION
Reverts nuclio/nuclio#2986, since it caused other issues reverting https://github.com/nuclio/nuclio/pull/2987 