### PR TITLE
[Helm] Fix creation of ClusterRoleBinding for namespace access mode

### DIFF
--- a/hack/k8s/helm/nuclio/templates/rolebinding/crd-admin.yaml
+++ b/hack/k8s/helm/nuclio/templates/rolebinding/crd-admin.yaml
@@ -28,9 +28,9 @@ roleRef:
   kind: ClusterRole
   name: {{ template "nuclio.crdAdminName" . }}-clusterrole
 subjects:
-  - kind: ServiceAccount
-    name: {{ template "nuclio.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: {{ template "nuclio.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- if eq .Values.rbac.crdAccessMode "namespaced" }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/k8s/helm/nuclio/templates/rolebinding/crd-admin.yaml
+++ b/hack/k8s/helm/nuclio/templates/rolebinding/crd-admin.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 {{- if .Values.rbac.create }}
+{{- if eq .Values.rbac.crdAccessMode "cluster" }}
 # Bind the service account (used by controller / dashboard) to the crd-admin role,
 # allowing them to create / delete custom resource definitions in the appropriate namespace
 apiVersion: rbac.authorization.k8s.io/v1
@@ -27,13 +28,11 @@ roleRef:
   kind: ClusterRole
   name: {{ template "nuclio.crdAdminName" . }}-clusterrole
 subjects:
-- kind: ServiceAccount
-  name: {{ template "nuclio.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
-
+  - kind: ServiceAccount
+    name: {{ template "nuclio.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- if eq .Values.rbac.crdAccessMode "namespaced" }}
-
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION
Jira: IG-22043

In the Nuclio helm chart, we define the value of rbac.crdAccessMode to be either "cluster" or "namespaced".

If set to "namespaced" - all RBAC resources are created in the given namespace (e.g Roles, Rolebindings)
If set to "cluster" - all RBAC resources are created cluster-wide (e.g ClusterRoles, ClusterRolebindings)

It has been seen that for RoleBindings, a ClusterRoleBinding is created regardless of the
crdAccessMode value. This can cause issues when installing Nuclio without cluster admin permissions, and when the relevant ClusterRole doesn't exist.

Re-implement https://github.com/nuclio/nuclio/pull/2986 to fix commit mess