### PR TITLE
[Controller] Remove internal annotations from function deployment

### DIFF
--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -499,8 +499,9 @@ func (s *Spec) PositiveGPUResourceLimit() bool {
 }
 
 const (
-	FunctionAnnotationSkipBuild  = "skip-build"
-	FunctionAnnotationSkipDeploy = "skip-deploy"
+	FunctionAnnotationSkipBuild   = "skip-build"
+	FunctionAnnotationSkipDeploy  = "skip-deploy"
+	FunctionAnnotationForceUpdate = "nuclio.io/force-update"
 )
 
 // Meta identifies a function

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -501,6 +501,7 @@ func (s *Spec) PositiveGPUResourceLimit() bool {
 const (
 	FunctionAnnotationSkipBuild   = "skip-build"
 	FunctionAnnotationSkipDeploy  = "skip-deploy"
+	FunctionAnnotationPrevState   = "nuclio.io/previous-state"
 	FunctionAnnotationForceUpdate = "nuclio.io/force-update"
 )
 

--- a/pkg/platform/kube/client/updater.go
+++ b/pkg/platform/kube/client/updater.go
@@ -154,7 +154,7 @@ func (u *Updater) UpdateState(ctx context.Context, functionName, namespace strin
 	if function.Annotations == nil {
 		function.Annotations = map[string]string{}
 	}
-	function.Annotations["nuclio.io/force-update"] = strconv.Itoa(int(time.Now().UnixNano()))
+	function.Annotations[functionconfig.FunctionAnnotationForceUpdate] = strconv.Itoa(int(time.Now().UnixNano()))
 	delete(function.Annotations, functionconfig.FunctionAnnotationSkipDeploy)
 	delete(function.Annotations, functionconfig.FunctionAnnotationSkipBuild)
 

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -116,6 +116,18 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 		return errors.New("Function name doesn't conform to k8s naming convention. Errors: " + joinedErrorMessage)
 	}
 
+	annotationsToClean := []string{
+		functionconfig.FunctionAnnotationForceUpdate,
+		"nuclio.io/previous-state",
+	}
+
+	// cleaning
+	if function.ObjectMeta.Annotations != nil {
+		for _, annotation := range annotationsToClean {
+			delete(function.ObjectMeta.Annotations, annotation)
+		}
+	}
+
 	// ready functions as part of controller resyncs, where we verify that a given function CRD has its resources
 	// properly configured
 	statesToRespond := []functionconfig.FunctionState{

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -118,7 +118,7 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 
 	annotationsToClean := []string{
 		functionconfig.FunctionAnnotationForceUpdate,
-		"nuclio.io/previous-state",
+		functionconfig.FunctionAnnotationPrevState,
 	}
 
 	// cleaning

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -121,7 +121,7 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 		functionconfig.FunctionAnnotationPrevState,
 	}
 
-	// cleaning
+	// clean the irrelevant annotations from the CRD before adding resources
 	if function.ObjectMeta.Annotations != nil {
 		for _, annotation := range annotationsToClean {
 			delete(function.ObjectMeta.Annotations, annotation)


### PR DESCRIPTION
Jira: `IG-22050`

There are some annotations added to the Nuclio function CRD that are being used only to communicate some details from the dashboard to the controller.These annotations are then put on the function deployment itself, although they are not needed there and can confuse and distract the users. The controller should clean the irrelevant annotations from the CRD before adding them the the resources it creates (only if they exist).