### PR TITLE
[Processor] Fix panic on try to write to closed channel 

### DIFF
--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -272,6 +272,12 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 			// trigger is ready for rebalance if both the handler is done and
 			// the workers are finished draining events
 			go func() {
+				defer func() {
+					if err := recover(); err != nil {
+						k.Logger.DebugWith("Recover from panic after trying to write into channel, "+
+							"which was closed because of wait for rebalance timeout", "partition", claim.Partition())
+					}
+				}()
 				var wg sync.WaitGroup
 				wg.Add(2)
 				go func() {

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -272,12 +272,13 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 			// trigger is ready for rebalance if both the handler is done and
 			// the workers are finished draining events
 			go func() {
-				defer func() {
-					if err := recover(); err != nil {
-						k.Logger.DebugWith("Recover from panic after trying to write into channel, "+
-							"which was closed because of wait for rebalance timeout", "partition", claim.Partition())
-					}
-				}()
+				defer common.CatchAndLogPanicWithOptions(k.ctx, // nolint: errcheck
+					k.Logger,
+					"Recover from panic after trying to write into channel, which was closed because of wait for rebalance timeout",
+					&common.CatchAndLogPanicOptions{
+						Args:          nil,
+						CustomHandler: nil,
+					})
 				var wg sync.WaitGroup
 				wg.Add(2)
 				go func() {


### PR DESCRIPTION
Jira: `IG-22062`

We got a panic:

```
panic: send on closed channel

goroutine 1530 [running]:
github.com/nuclio/nuclio/pkg/processor/trigger/kafka.(*kafka).ConsumeClaim.func1()
        /home/runner/work/nuclio/nuclio/pkg/processor/trigger/kafka/trigger.go:302 +0x22a
created by github.com/nuclio/nuclio/pkg/processor/trigger/kafka.(*kafka).ConsumeClaim
        /home/runner/work/nuclio/nuclio/pkg/processor/trigger/kafka/trigger.go:277 +0xaa5
```

The reason for this panic was an attempt to record in an already closed channel. We closed this channel due to the timeout waiting for the completion of two goroutines, so we just exited. After discussing with @TomerShor various options for solving the problem of synchronizing the closing of the channel and writing to it, it was decided to simply add panic recover to the goroutine.