### PR TITLE
[OPA] Add redeploy function permission check

### DIFF
--- a/pkg/opa/opa.go
+++ b/pkg/opa/opa.go
@@ -67,6 +67,10 @@ func GenerateFunctionResourceString(projectName, functionName string) string {
 	return fmt.Sprintf("/projects/%s/functions/%s", projectName, functionName)
 }
 
+func GenerateFunctionRedeployResourceString(projectName, functionName string) string {
+	return fmt.Sprintf("/projects/%s/functions/%s/redeploy", projectName, functionName)
+}
+
 func GenerateFunctionEventResourceString(projectName, functionName, functionEventName string) string {
 	return fmt.Sprintf("/projects/%s/functions/%s/function-events/%s", projectName, functionName, functionEventName)
 }

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1182,6 +1182,20 @@ func (ap *Platform) QueryOPAFunctionPermissions(projectName,
 		permissionOptions)
 }
 
+func (ap *Platform) QueryOPAFunctionRedeployPermissions(projectName,
+	functionName string,
+	permissionOptions *opa.PermissionOptions) (bool, error) {
+	if projectName == "" {
+		projectName = "*"
+	}
+	if functionName == "" {
+		functionName = "*"
+	}
+	return ap.queryOPAPermissions(opa.GenerateFunctionRedeployResourceString(projectName, functionName),
+		opa.ActionCreate,
+		permissionOptions)
+}
+
 func (ap *Platform) QueryOPAFunctionEventPermissions(projectName,
 	functionName,
 	functionEventName string,

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -410,6 +410,16 @@ func (p *Platform) DeleteFunction(ctx context.Context, deleteFunctionOptions *pl
 
 func (p *Platform) RedeployFunction(ctx context.Context, redeployFunctionOptions *platform.RedeployFunctionOptions) error {
 
+	// Check OPA permissions
+	permissionOptions := redeployFunctionOptions.PermissionOptions
+	permissionOptions.RaiseForbidden = true
+	if _, err := p.QueryOPAFunctionRedeployPermissions(
+		redeployFunctionOptions.FunctionMeta.Labels[common.NuclioResourceLabelKeyProjectName],
+		redeployFunctionOptions.FunctionMeta.Name,
+		&permissionOptions); err != nil {
+		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
+	}
+
 	p.Logger.InfoWithCtx(ctx,
 		"Redeploying function",
 		"functionName", redeployFunctionOptions.FunctionMeta.Name)


### PR DESCRIPTION
Add opa permissions check when patching a function for redeployment.

The check is for the `create` action, for the following resource:
```
/projects/<project-name>/functions/<function-name>/redeploy
```

Resolves https://jira.iguazeng.com/browse/IG-22061
Related to https://github.com/iguazio/zebo/pull/6309