### PR TITLE
[Processor] Fix event timing out

### DIFF
--- a/pkg/common/version.go
+++ b/pkg/common/version.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package common
 
-import "github.com/v3io/version-go"
+import (
+	"runtime"
+
+	"github.com/v3io/version-go"
+)
 
 // SetVersionFromEnv is being used by tests to override linker injected values
 func SetVersionFromEnv() {
@@ -24,7 +28,7 @@ func SetVersionFromEnv() {
 		Label:     GetEnvOrDefaultString("NUCLIO_LABEL", version.Get().Label),
 		GitCommit: "c",
 		OS:        GetEnvOrDefaultString("NUCLIO_OS", "linux"),
-		Arch:      GetEnvOrDefaultString("NUCLIO_ARCH", "amd64"),
+		Arch:      GetEnvOrDefaultString("NUCLIO_ARCH", runtime.GOARCH),
 		GoVersion: version.Get().GoVersion,
 	})
 }

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -161,12 +161,6 @@ func (r *AbstractRuntime) Stop() error {
 
 	if r.wrapperProcess != nil {
 
-		// signal the wrapper process to drain events before killing it
-		// TODO: notify the process that this drain is called before killing it (and not before rebalance)
-		if err := r.Drain(); err != nil {
-			return errors.Wrap(err, "Failed to drain wrapper process")
-		}
-
 		// stop waiting for process
 		if err := r.processWaiter.Cancel(); err != nil {
 			r.Logger.WarnWith("Failed to cancel process waiting")

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -93,6 +93,7 @@ type BlastConfiguration struct {
 // SetupSuite is called for suite setup
 func (suite *TestSuite) SetupSuite() {
 	var err error
+	common.SetVersionFromEnv()
 
 	if suite.RuntimeDir == "" {
 		suite.RuntimeDir = suite.Runtime

--- a/pkg/processor/timeout/timeout.go
+++ b/pkg/processor/timeout/timeout.go
@@ -136,7 +136,7 @@ func (w EventTimeoutWatcher) gracefulShutdown(ctx context.Context, timedoutWorke
 	w.logger.WarnWithCtx(ctx, "Stopping triggers")
 	runningWorkers := w.stopTriggers(ctx, timedoutWorker)
 
-	w.logger.WarnWithCtx(ctx, "waiting for workers termination")
+	w.logger.WarnWithCtx(ctx, "Waiting for workers termination")
 	w.waitForWorkers(ctx, runningWorkers)
 
 	w.logger.WarnWithCtx(ctx, "Stopping processor")
@@ -157,7 +157,10 @@ func (w EventTimeoutWatcher) stopTriggers(ctx context.Context, timedoutWorker *w
 		triggerErrGroup.Go("Stop trigger", func() error {
 
 			if checkpoint, err := triggerInstance.Stop(false); err != nil {
-				w.logger.ErrorWithCtx(triggerErrGroupCtx, "Can't stop trigger", "triggerIdx", triggerIdx, "error", err)
+				w.logger.ErrorWithCtx(triggerErrGroupCtx,
+					"Can't stop trigger",
+					"triggerIdx", triggerIdx,
+					"error", err)
 			} else {
 				checkpointValue := ""
 				if checkpoint != nil {

--- a/pkg/processor/timeout/timeout.go
+++ b/pkg/processor/timeout/timeout.go
@@ -68,7 +68,6 @@ func (w EventTimeoutWatcher) watch() {
 		// create error group
 		triggerErrGroup, triggerErrGroupCtx := errgroup.WithContext(context.Background(), w.logger)
 
-		// TODO: Run in parallel
 		for triggerName, triggerInstance := range w.processor.GetTriggers() {
 			triggerName, triggerInstance := triggerName, triggerInstance
 
@@ -107,9 +106,11 @@ func (w EventTimeoutWatcher) watch() {
 							}
 						} else {
 							if err := triggerInstance.TimeoutWorker(workerInstance); err != nil {
-								w.logger.WarnWithCtx(workerErrGroupCtx, "Error timing out a worker", "worker", workerInstance.GetIndex(), "trigger", triggerName)
+								w.logger.WarnWithCtx(workerErrGroupCtx,
+									"Error timing out a worker",
+									with...)
 							}
-							w.gracefulShutdown(workerInstance)
+							w.gracefulShutdown(triggerErrGroupCtx, workerInstance)
 						}
 
 						return nil
@@ -126,21 +127,28 @@ func (w EventTimeoutWatcher) watch() {
 	}
 }
 
-func (w EventTimeoutWatcher) gracefulShutdown(timedoutWorker *worker.Worker) {
-	w.logger.WarnWith("Staring graceful shutdown")
+func (w EventTimeoutWatcher) gracefulShutdown(ctx context.Context, timedoutWorker *worker.Worker) {
+	w.logger.WarnWithCtx(ctx, "Staring graceful shutdown")
 
 	w.shuttingDown = true
 
-	runningWorkers := w.stopTriggers(timedoutWorker)
-	w.waitForWorkers(runningWorkers)
+	w.logger.WarnWithCtx(ctx, "Stopping triggers")
+	runningWorkers := w.stopTriggers(ctx, timedoutWorker)
+
+	w.logger.WarnWithCtx(ctx, "waiting for workers termination")
+	w.waitForWorkers(ctx, runningWorkers)
+
+	w.logger.WarnWithCtx(ctx, "Stopping processor")
 	w.processor.Stop()
+
+	w.logger.WarnWithCtx(ctx, "Graceful shutdown completed")
 }
 
-func (w EventTimeoutWatcher) stopTriggers(timedoutWorker *worker.Worker) map[string]*worker.Worker {
+func (w EventTimeoutWatcher) stopTriggers(ctx context.Context, timedoutWorker *worker.Worker) map[string]*worker.Worker {
 	runningWorkers := make(map[string]*worker.Worker)
 
 	// create error group
-	triggerErrGroup, triggerErrGroupCtx := errgroup.WithContext(context.Background(), w.logger)
+	triggerErrGroup, triggerErrGroupCtx := errgroup.WithContext(ctx, w.logger)
 
 	for triggerIdx, triggerInstance := range w.processor.GetTriggers() {
 		triggerIdx, triggerInstance := triggerIdx, triggerInstance
@@ -178,25 +186,31 @@ func (w EventTimeoutWatcher) stopTriggers(timedoutWorker *worker.Worker) map[str
 	}
 
 	if err := triggerErrGroup.Wait(); err != nil {
-		w.logger.WarnWithCtx(triggerErrGroupCtx, "Failed to wait for triggers", "err", errors.GetErrorStackString(err, 10))
+		w.logger.WarnWithCtx(triggerErrGroupCtx,
+			"Failed to wait for triggers",
+			"err", errors.GetErrorStackString(err, 10))
 	}
 
 	return runningWorkers
 }
 
-func (w EventTimeoutWatcher) waitForWorkers(runningWorkers map[string]*worker.Worker) {
+func (w EventTimeoutWatcher) waitForWorkers(ctx context.Context, runningWorkers map[string]*worker.Worker) {
 	// TODO: Find a better deadline
 	shutdownDuration := 10 * w.timeout
 	deadline := time.Now().Add(shutdownDuration)
 
 	for {
+
+		// we're done
 		if len(runningWorkers) == 0 {
 			return
 		}
 
 		now := time.Now()
 		if now.After(deadline) {
-			w.logger.WarnWith("Graceful shutdown deadline reached", "duration", shutdownDuration)
+			w.logger.WarnWithCtx(ctx,
+				"Graceful shutdown deadline reached",
+				"duration", shutdownDuration)
 			return
 		}
 
@@ -208,7 +222,9 @@ func (w EventTimeoutWatcher) waitForWorkers(runningWorkers map[string]*worker.Wo
 			}
 
 			if now.Sub(*eventTime) > w.timeout {
-				w.logger.WarnWith("Worker timed out", "worker", key)
+				w.logger.WarnWithCtx(ctx,
+					"Worker timed out",
+					"worker", key)
 				delete(runningWorkers, key)
 				continue
 			}

--- a/pkg/processor/trigger/http/test/suite/suite.go
+++ b/pkg/processor/trigger/http/test/suite/suite.go
@@ -35,6 +35,7 @@ import (
 	"github.com/nuclio/nuclio/test/compare"
 
 	"github.com/nuclio/nuclio-sdk-go"
+	"github.com/stretchr/testify/assert"
 )
 
 // EventFields for events
@@ -76,6 +77,8 @@ type Request struct {
 	RetryUntilSuccessfulStatusCode *int
 	RetryUntilSuccessfulDuration   time.Duration
 	RetryUntilSuccessfulInterval   time.Duration
+
+	containerID string
 }
 
 func (r *Request) Enrich(deployResult *platform.CreateFunctionResult) {
@@ -95,6 +98,8 @@ func (r *Request) Enrich(deployResult *platform.CreateFunctionResult) {
 	if r.RequestMethod == "" {
 		r.RequestMethod = "POST"
 	}
+
+	r.containerID = deployResult.ContainerID
 }
 
 // TestSuite is an HTTP test suite
@@ -136,7 +141,7 @@ func (suite *TestSuite) DeployFunctionAndRequests(createFunctionOptions *platfor
 	requests []*Request) *platform.CreateFunctionResult {
 
 	return suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
-		suite.Require().NotNil(deployResult)
+		suite.Require().NotNil(deployResult, "Failed to deploy function")
 		for _, request := range requests {
 			request.Enrich(deployResult)
 			suite.Logger.DebugWith("Sending request",
@@ -188,17 +193,36 @@ func (suite *TestSuite) SendRequestVerifyResponse(request *Request) bool {
 		return false
 	}
 
+	suite.Logger.DebugWith("Got response", "statusCode", httpResponse.StatusCode)
+
 	suite.Require().NoError(err, "Failed to send request")
 
 	body, err := io.ReadAll(httpResponse.Body)
 	suite.Require().NoError(err)
 
 	if request.ExpectedResponseStatusCode != nil {
-		suite.Require().Equal(*request.ExpectedResponseStatusCode,
+		if !assert.New(suite.T()).Equal(*request.ExpectedResponseStatusCode,
 			httpResponse.StatusCode,
-			"Got unexpected status code with request body (%s) and response body (%s)",
+			"Got unexpected status code %d with request body (%s) and response body (%s)",
+			httpResponse.StatusCode,
 			request.RequestBody,
-			body)
+			body) {
+
+			// value is not equal, print the container logs
+			suite.Logger.DebugWith("Failed to send request, fetching container logs",
+				"containerID", request.containerID)
+			functionContainerLogs, err := suite.DockerClient.GetContainerLogs(request.containerID)
+			if err != nil {
+				suite.Logger.WarnWith("Failed to get container logs", "err", err.Error())
+			} else {
+				suite.Logger.DebugWith("Fetched container logs",
+					"containerID", request.containerID,
+					"logs", functionContainerLogs)
+			}
+
+			// if the status code is not as expected, fail the test
+			suite.T().FailNow()
+		}
 	}
 
 	// verify header correctness

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -404,6 +404,13 @@ func (k *kafka) eventSubmitter(claim sarama.ConsumerGroupClaim, submittedEventCh
 func (k *kafka) cancelEventHandling(workerInstance *worker.Worker,
 	claim sarama.ConsumerGroupClaim) error {
 	if workerInstance.SupportsRestart() {
+
+		k.Logger.WarnWith("Cancelling event handling",
+			"topic", claim.Topic(),
+			"partition", claim.Partition())
+		if err := workerInstance.Drain(); err != nil {
+			return errors.Wrap(err, "Failed to drain worker")
+		}
 		return workerInstance.Restart()
 	}
 

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -404,13 +404,9 @@ func (k *kafka) eventSubmitter(claim sarama.ConsumerGroupClaim, submittedEventCh
 func (k *kafka) cancelEventHandling(workerInstance *worker.Worker,
 	claim sarama.ConsumerGroupClaim) error {
 	if workerInstance.SupportsRestart() {
-
 		k.Logger.WarnWith("Cancelling event handling",
 			"topic", claim.Topic(),
 			"partition", claim.Partition())
-		if err := workerInstance.Drain(); err != nil {
-			return errors.Wrap(err, "Failed to drain worker")
-		}
 		return workerInstance.Restart()
 	}
 


### PR DESCRIPTION
Various of changes were made, all of them together are part of my investigation and fixing of the "Timeout" integ test that has raised a regression on how python handles event timeout


Processor:
- Moved trigger timeout before restart to ensure 408 is returned (for http trigger specifically) prior to (hard / soft) restart.
- Added some logs to when workers / triggers are being stopped
- Removed the draining call from `Stop()` to force explicit call to `Drain()` prior to `Stop()`. The reason of it is to speed up the `stop` flow when it is required. if there is any need to `Drain()`, then it is up to the callee to invoke it first.
- Drain single worker as well

Tests:
- Log container logs upon request failure
- Added `common.SetVersionFromEnv()` to suite to allow using envvars (such as `NUCLIO_LABEL=x` on runtime tests)
- Fixed default ARCH so ARM64 would be used if needed
