### PR TITLE
[Processor] Fix unexpected consumption stop 

### DIFF
--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -263,7 +263,7 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 
 		case <-session.Context().Done():
 			k.Logger.DebugWith("Got signal to stop consumption",
-				"wait", k.configuration.maxWaitHandlerDuringRebalance,
+				"wait", k.configuration.maxWaitHandlerDuringRebalance.String(),
 				"partition", claim.Partition())
 
 			// don't consume any more messages
@@ -297,6 +297,10 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 					wg.Done()
 				}()
 				go func() {
+
+					// this needs to occur once. the reason is that this specific function (ConsumeClaim)
+					// would run in parallel for each partition, and we want to make sure that we only
+					// drain the workers once.
 					k.SignalWorkerDraining()
 					k.Logger.DebugWith("Workers drained", "partition", claim.Partition())
 					wg.Done()

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -299,7 +299,7 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 				go func() {
 
 					// this needs to occur once. the reason is that this specific function (ConsumeClaim)
-					// would run in parallel for each partition, and we want to make sure that we only
+					// runs in parallel for each partition, and we want to make sure that we only
 					// drain the workers once.
 					k.SignalWorkerDraining()
 					k.Logger.DebugWith("Workers drained", "partition", claim.Partition())

--- a/pkg/processor/worker/allocator.go
+++ b/pkg/processor/worker/allocator.go
@@ -216,7 +216,7 @@ func (fp *fixedPool) SignalDraining() error {
 
 		errGroup.Go(fmt.Sprintf("Drain worker %d", workerInstance.GetIndex()), func() error {
 			// if worker is not already drained, signal it to drain events
-			err := workerInstance.DrainIfNotDrained()
+			err := workerInstance.Drain()
 			if err != nil {
 				return errors.Wrapf(err, "Failed to signal worker %d to drain events", workerInstance.GetIndex())
 			}

--- a/pkg/processor/worker/allocator.go
+++ b/pkg/processor/worker/allocator.go
@@ -216,8 +216,7 @@ func (fp *fixedPool) SignalDraining() error {
 
 		errGroup.Go(fmt.Sprintf("Drain worker %d", workerInstance.GetIndex()), func() error {
 			// if worker is not already drained, signal it to drain events
-			err := workerInstance.Drain()
-			if err != nil {
+			if err := workerInstance.Drain(); err != nil {
 				return errors.Wrapf(err, "Failed to signal worker %d to drain events", workerInstance.GetIndex())
 			}
 			fp.logger.DebugWith("Worker has drained events after signaling",

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -167,6 +167,20 @@ func (w *Worker) IsDrained() bool {
 	return w.isDrained
 }
 
+func (w *Worker) DrainIfNotDrained() error {
+	w.drainedLock.Lock()
+	defer w.drainedLock.Unlock()
+
+	if !w.isDrained {
+		err := w.runtime.Drain()
+		if err == nil {
+			w.isDrained = true
+		}
+		return err
+	}
+	return nil
+}
+
 func (w *Worker) setDrained(isDrained bool) {
 	w.drainedLock.Lock()
 	defer w.drainedLock.Unlock()

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -151,15 +151,6 @@ func (w *Worker) SupportsRestart() bool {
 	return w.runtime.SupportsRestart()
 }
 
-func (w *Worker) Drain() error {
-	err := w.runtime.Drain()
-	if err == nil {
-
-		w.setDrained(true)
-	}
-	return err
-}
-
 func (w *Worker) IsDrained() bool {
 	w.drainedLock.Lock()
 	defer w.drainedLock.Unlock()
@@ -167,7 +158,7 @@ func (w *Worker) IsDrained() bool {
 	return w.isDrained
 }
 
-func (w *Worker) DrainIfNotDrained() error {
+func (w *Worker) Drain() error {
 	w.drainedLock.Lock()
 	defer w.drainedLock.Unlock()
 

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -151,13 +151,6 @@ func (w *Worker) SupportsRestart() bool {
 	return w.runtime.SupportsRestart()
 }
 
-func (w *Worker) IsDrained() bool {
-	w.drainedLock.Lock()
-	defer w.drainedLock.Unlock()
-
-	return w.isDrained
-}
-
 func (w *Worker) Drain() error {
 	w.drainedLock.Lock()
 	defer w.drainedLock.Unlock()


### PR DESCRIPTION
Jira: `IG-22088`

Recently nuclio function with explicitAck kafka trigger stopped consumption on certain partition for some reason.

The thing is that `ConsumeClaim` is a go routine spawned by sarama for each partition, so basically, the `SignalWorkerDraining` is invoked N times (as the amount of the partitions we get, so each worker drains itself over and over again while crashing and left in zombie state. The solution is to synchronise workers draining with blocking each worker state during draining process.