### PR TITLE
[Kafka] Explicit ack enhancements

### DIFF
--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -677,7 +677,12 @@ func (p *Processor) terminateAllTriggers(signal os.Signal) {
 		// drains all workers in trigger (for each trigger in parallel)
 		go func(triggerInstance trigger.Trigger, wg *sync.WaitGroup) {
 			defer wg.Done()
-			triggerInstance.SignalWorkerDraining()
+			if err := triggerInstance.SignalWorkerDraining(); err != nil {
+				p.logger.WarnWith("Failed to signal worker draining",
+					"triggerKind", triggerInstance.GetKind(),
+					"triggerName", triggerInstance.GetName(),
+					"err", err.Error())
+			}
 		}(triggerInstance, wg)
 	}
 	wg.Wait()

--- a/cmd/processor/app/processor_test.go
+++ b/cmd/processor/app/processor_test.go
@@ -231,8 +231,9 @@ func (t *testTrigger) TimeoutWorker(worker *worker.Worker) error {
 	return nil
 }
 
-func (t *testTrigger) SignalWorkerDraining() {
+func (t *testTrigger) SignalWorkerDraining() error {
 	t.Called()
+	return nil
 }
 
 func TestTriggerTestSuite(t *testing.T) {

--- a/pkg/common/status/status.go
+++ b/pkg/common/status/status.go
@@ -21,7 +21,7 @@ import "fmt"
 // Provider is an interface for entities that have a reportable status
 type Provider interface {
 
-	// Returns the entity's status
+	// GetStatus Returns the entity's status
 	GetStatus() Status
 }
 

--- a/pkg/nuctl/command/export.go
+++ b/pkg/nuctl/command/export.go
@@ -33,11 +33,10 @@ import (
 )
 
 type exportCommandeer struct {
-	cmd             *cobra.Command
-	rootCommandeer  *RootCommandeer
-	scrubber        *functionconfig.Scrubber
-	noScrub         bool
-	skipSpecCleanup bool
+	cmd            *cobra.Command
+	rootCommandeer *RootCommandeer
+	scrubber       *functionconfig.Scrubber
+	noScrub        bool
 }
 
 func newExportCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *exportCommandeer {
@@ -74,6 +73,7 @@ type exportFunctionCommandeer struct {
 	*exportCommandeer
 	getFunctionsOptions platform.GetFunctionsOptions
 	output              string
+	skipSpecCleanup     bool
 }
 
 func newExportFunctionCommandeer(ctx context.Context, exportCommandeer *exportCommandeer) *exportFunctionCommandeer {
@@ -196,6 +196,7 @@ type exportProjectCommandeer struct {
 	*exportCommandeer
 	getProjectsOptions platform.GetProjectsOptions
 	output             string
+	skipSpecCleanup    bool
 }
 
 func newExportProjectCommandeer(ctx context.Context, exportCommandeer *exportCommandeer) *exportProjectCommandeer {

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -85,7 +85,7 @@ type Trigger interface {
 	TimeoutWorker(worker *worker.Worker) error
 
 	// SignalWorkerDraining drains all workers
-	SignalWorkerDraining()
+	SignalWorkerDraining() error
 }
 
 // AbstractTrigger implements common trigger operations

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -361,12 +361,11 @@ func (at *AbstractTrigger) UnsubscribeFromControlMessageKind(kind controlcommuni
 
 // SignalWorkerDraining sends a signal to all workers, telling them to drop or ack events
 // that are currently being processed
-func (at *AbstractTrigger) SignalWorkerDraining() {
-
-	// signal all workers to drain
+func (at *AbstractTrigger) SignalWorkerDraining() error {
 	if err := at.WorkerAllocator.SignalDraining(); err != nil {
-		at.Logger.WarnWith("Failed to signal all workers to drain events", "err", err.Error())
+		return errors.Wrap(err, "Failed to signal all workers to drain events")
 	}
+	return nil
 }
 
 // ResetWorkerTerminationState resets the worker termination state

--- a/pkg/processor/worker/allocator.go
+++ b/pkg/processor/worker/allocator.go
@@ -224,7 +224,6 @@ func (fp *fixedPool) SignalDraining() error {
 	}
 
 	if err := errGroup.Wait(); err != nil {
-		fp.logger.WarnWith("At least one worker failed to stop", "err", err.Error())
 		return errors.Wrap(err, "At least one worker failed to drain")
 	}
 

--- a/pkg/processor/worker/allocator.go
+++ b/pkg/processor/worker/allocator.go
@@ -219,14 +219,13 @@ func (fp *fixedPool) SignalDraining() error {
 			if err := workerInstance.Drain(); err != nil {
 				return errors.Wrapf(err, "Failed to signal worker %d to drain events", workerInstance.GetIndex())
 			}
-			fp.logger.DebugWith("Worker has drained events after signaling",
-				"workerIndex", workerInstance.GetIndex())
 			return nil
 		})
 	}
 
 	if err := errGroup.Wait(); err != nil {
 		fp.logger.WarnWith("At least one worker failed to stop", "err", err.Error())
+		return errors.Wrap(err, "At least one worker failed to drain")
 	}
 
 	return nil

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -44,7 +44,7 @@ type Worker struct {
 	structuredCloudEvent cloudevent.Structured
 	binaryCloudEvent     cloudevent.Binary
 	eventTime            *time.Time
-	isDrained            bool
+	isDrained            atomic.Bool
 	drainedLock          sync.Mutex
 }
 
@@ -155,11 +155,11 @@ func (w *Worker) Drain() error {
 	w.drainedLock.Lock()
 	defer w.drainedLock.Unlock()
 
-	if !w.isDrained {
+	if !w.isDrained.Load() {
 		err := w.runtime.Drain()
 		if err == nil {
 			w.logger.DebugWith("Successfully drained worker", "workerIndex", w.index)
-			w.isDrained = true
+			w.isDrained.Store(true)
 		}
 		return err
 	}
@@ -170,7 +170,7 @@ func (w *Worker) setDrained(isDrained bool) {
 	w.drainedLock.Lock()
 	defer w.drainedLock.Unlock()
 
-	w.isDrained = isDrained
+	w.isDrained.Store(isDrained)
 }
 
 // Subscribe subscribes to a control message kind

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -158,6 +158,7 @@ func (w *Worker) Drain() error {
 	if !w.isDrained {
 		err := w.runtime.Drain()
 		if err == nil {
+			w.logger.DebugWith("Successfully drained worker", "workerIndex", w.index)
 			w.isDrained = true
 		}
 		return err


### PR DESCRIPTION
Reduce spammy log lines
Fixed potential race condition where a drained-worker would be reset while another partition will now try to drain it again
Improve some log lines with relevant kwargs
