### PR TITLE
[Nuctl][Dashboard] Add flag to ensure external registry when redeploying functions

### DIFF
--- a/pkg/common/headers/headers.go
+++ b/pkg/common/headers/headers.go
@@ -31,6 +31,7 @@ const (
 	FunctionEnrichApiGateways           = "X-Nuclio-Function-Enrich-Apigateways"
 	ImportedFunctionOnly                = "X-Nuclio-Imported-Function-Only"
 	SkipSpecCleanup                     = "X-Nuclio-Skip-Spec-Cleanup"
+	VerifyExternalRegistry              = "X-Nuclio-Verify-External-Registry"
 
 	// Project headers
 	ProjectName           = "X-Nuclio-Project-Name"

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -193,13 +193,13 @@ func (fr *functionResource) Patch(request *http.Request, id string) error {
 	// get the desired state of the function from the request body
 	patchOptionsInstance, err := fr.getPatchFunctionOptionsFromRequest(request)
 	if err != nil {
-		return nuclio.NewErrPreconditionFailed("Failed to get patch options")
+		return errors.Wrap(err, "Failed to get patch options")
 	}
 
 	// get the authentication configuration for the request
 	authConfig, err := fr.getRequestAuthConfig(request)
 	if err != nil {
-		return nuclio.NewErrPreconditionFailed("Failed to get auth config")
+		return errors.Wrap(err, "Failed to get auth config")
 	}
 
 	if patchOptionsInstance.DesiredState != nil {

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -888,6 +888,7 @@ func (d *deployCommandeer) resolveRequestHeaders() map[string]string {
 		// add a header that will tell the API to only deploy imported functions
 		requestHeaders[headers.ImportedFunctionOnly] = "true"
 	}
+	requestHeaders[headers.VerifyExternalRegistry] = "true"
 	return requestHeaders
 }
 


### PR DESCRIPTION
Jira: `IG-22044`, `IG-22084`

When redeploying function post-upgrade, the redeployment will work only if Nuclio uses an external registry and the function images are persisted.

If Nuclio uses the internal app node registry, the images will be deleted during the cluster re-installation as the app-node registry is volatile.

 
This can be configured using a header to the PATCH request:
`x-nuclio-verify-external-registry` - Only redeploy functions if the registry is external.
If the header is given and the registry is internal, return 412 status code (PreconditionFailed).