### PR TITLE
[Nuctl] Add skip-external-registry-verify option to nuctl beta deploy

### DIFF
--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -132,7 +132,7 @@ func (d *Docker) buildContainerImage(ctx context.Context, buildOptions *BuildOpt
 		NoCache:        buildOptions.NoCache,
 		Pull:           buildOptions.Pull,
 		BuildArgs:      buildOptions.BuildArgs,
-		BuildFlags:     buildOptions.BuildFLags,
+		BuildFlags:     buildOptions.BuildFlags,
 	})
 
 }

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -266,16 +266,16 @@ func (k *Kaniko) compileJobSpec(ctx context.Context,
 		buildArgs = append(buildArgs, "--cache=true")
 	}
 
-	if _, ok := buildOptions.BuildFLags["--insecure"]; !ok && k.builderConfiguration.InsecurePushRegistry {
+	if _, ok := buildOptions.BuildFlags["--insecure"]; !ok && k.builderConfiguration.InsecurePushRegistry {
 		buildArgs = append(buildArgs, "--insecure")
 	}
 
-	if _, ok := buildOptions.BuildFLags["--insecure-pull"]; !ok && k.builderConfiguration.InsecurePullRegistry {
+	if _, ok := buildOptions.BuildFlags["--insecure-pull"]; !ok && k.builderConfiguration.InsecurePullRegistry {
 		buildArgs = append(buildArgs, "--insecure-pull")
 	}
 
 	// Add user's custom flags
-	for flag := range buildOptions.BuildFLags {
+	for flag := range buildOptions.BuildFlags {
 		buildArgs = append(buildArgs, flag)
 	}
 

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -36,7 +36,7 @@ type BuildOptions struct {
 	NoCache                 bool
 	Pull                    bool
 	NoBaseImagePull         bool
-	BuildFLags              map[string]bool
+	BuildFlags              map[string]bool
 	BuildArgs               map[string]string
 	RegistryURL             string
 	RepoName                string

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -108,8 +108,8 @@ func (c *ShellClient) Build(buildOptions *BuildOptions) error {
 	}
 
 	buildArgs := ""
-	for buildFLag := range buildOptions.BuildFlags {
-		buildArgs += fmt.Sprintf(buildFLag + " ")
+	for buildFlag := range buildOptions.BuildFlags {
+		buildArgs += fmt.Sprintf(buildFlag + " ")
 	}
 	for buildArgName, buildArgValue := range buildOptions.BuildArgs {
 		buildArgs += fmt.Sprintf("--build-arg %s=%s ", buildArgName, buildArgValue)

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -85,18 +85,18 @@ type deployCommandeer struct {
 	overrideHTTPTriggerServiceType  string
 
 	// beta - api client
-	betaCommandeer             *betaCommandeer
-	noBuild                    bool
-	deployAll                  bool
-	waitForFunction            bool
-	skipSpecCleanup            bool
-	skipExternalRegistryVerify bool
-	outputManifest             *nuctlcommon.PatchOutputManifest
-	excludedProjects           []string
-	excludedFunctions          []string
-	excludeFunctionWithGPU     bool
-	importedOnly               bool
-	waitTimeout                time.Duration
+	betaCommandeer         *betaCommandeer
+	noBuild                bool
+	deployAll              bool
+	waitForFunction        bool
+	skipSpecCleanup        bool
+	verifyExternalRegistry bool
+	outputManifest         *nuctlcommon.PatchOutputManifest
+	excludedProjects       []string
+	excludedFunctions      []string
+	excludeFunctionWithGPU bool
+	importedOnly           bool
+	waitTimeout            time.Duration
 }
 
 func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, betaCommandeer *betaCommandeer) *deployCommandeer {
@@ -221,7 +221,7 @@ func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, be
 
 	addDeployFlags(cmd, commandeer)
 	cmd.Flags().BoolVarP(&commandeer.skipSpecCleanup, "skip-spec-cleanup", "", false, "Do not clean up spec in function configs")
-	cmd.Flags().BoolVarP(&commandeer.skipExternalRegistryVerify, "skip-external-registry-verify", "", false, "Do not verify if registry is external")
+	cmd.Flags().BoolVarP(&commandeer.verifyExternalRegistry, "verify-external-registry", "", false, "verify registry is external")
 	cmd.Flags().StringVarP(&commandeer.inputImageFile, "input-image-file", "", "", "Path to an input function-image Docker archive file")
 
 	commandeer.cmd = cmd
@@ -890,7 +890,7 @@ func (d *deployCommandeer) resolveRequestHeaders() map[string]string {
 		// add a header that will tell the API to only deploy imported functions
 		requestHeaders[headers.ImportedFunctionOnly] = "true"
 	}
-	if !d.skipExternalRegistryVerify {
+	if d.verifyExternalRegistry {
 		requestHeaders[headers.VerifyExternalRegistry] = "true"
 	}
 	return requestHeaders

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -85,17 +85,18 @@ type deployCommandeer struct {
 	overrideHTTPTriggerServiceType  string
 
 	// beta - api client
-	betaCommandeer         *betaCommandeer
-	noBuild                bool
-	deployAll              bool
-	waitForFunction        bool
-	skipSpecCleanup        bool
-	outputManifest         *nuctlcommon.PatchOutputManifest
-	excludedProjects       []string
-	excludedFunctions      []string
-	excludeFunctionWithGPU bool
-	importedOnly           bool
-	waitTimeout            time.Duration
+	betaCommandeer             *betaCommandeer
+	noBuild                    bool
+	deployAll                  bool
+	waitForFunction            bool
+	skipSpecCleanup            bool
+	skipExternalRegistryVerify bool
+	outputManifest             *nuctlcommon.PatchOutputManifest
+	excludedProjects           []string
+	excludedFunctions          []string
+	excludeFunctionWithGPU     bool
+	importedOnly               bool
+	waitTimeout                time.Duration
 }
 
 func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, betaCommandeer *betaCommandeer) *deployCommandeer {
@@ -220,6 +221,7 @@ func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, be
 
 	addDeployFlags(cmd, commandeer)
 	cmd.Flags().BoolVarP(&commandeer.skipSpecCleanup, "skip-spec-cleanup", "", false, "Do not clean up spec in function configs")
+	cmd.Flags().BoolVarP(&commandeer.skipExternalRegistryVerify, "skip-external-registry-verify", "", false, "Do not verify if registry is external")
 	cmd.Flags().StringVarP(&commandeer.inputImageFile, "input-image-file", "", "", "Path to an input function-image Docker archive file")
 
 	commandeer.cmd = cmd
@@ -888,7 +890,9 @@ func (d *deployCommandeer) resolveRequestHeaders() map[string]string {
 		// add a header that will tell the API to only deploy imported functions
 		requestHeaders[headers.ImportedFunctionOnly] = "true"
 	}
-	requestHeaders[headers.VerifyExternalRegistry] = "true"
+	if !d.skipExternalRegistryVerify {
+		requestHeaders[headers.VerifyExternalRegistry] = "true"
+	}
 	return requestHeaders
 }
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1078,7 +1078,7 @@ func (b *Builder) buildProcessorImage(ctx context.Context) (string, error) {
 			Pull:                b.options.FunctionConfig.Spec.Build.NoCache,
 			NoCache:             b.options.FunctionConfig.Spec.Build.NoCache,
 			NoBaseImagePull:     b.GetNoBaseImagePull(),
-			BuildFLags:          buildFlags,
+			BuildFlags:          buildFlags,
 			BuildArgs:           buildArgs,
 			RegistryURL:         registryURL,
 			RepoName:            b.resolveRepoName(registryURL),


### PR DESCRIPTION
Added skip-external-registry-verify option to nuctl beta deploy and fixed typo in BuildFlags