### PR TITLE
[Nuctl] Move redeploying functionality to a new command

### DIFF
--- a/pkg/nuctl/command/beta.go
+++ b/pkg/nuctl/command/beta.go
@@ -61,7 +61,7 @@ func newBetaCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *bet
 	cmd.MarkPersistentFlagRequired("api-url") // nolint: errcheck
 
 	cmd.AddCommand(
-		newDeployCommandeer(ctx, rootCommandeer, commandeer).cmd,
+		newRedeployCommandeer(ctx, rootCommandeer, commandeer).cmd,
 	)
 
 	commandeer.cmd = cmd

--- a/pkg/nuctl/command/beta.go
+++ b/pkg/nuctl/command/beta.go
@@ -86,6 +86,6 @@ func (b *betaCommandeer) initialize() error {
 	if err != nil {
 		return errors.Wrap(err, "Failed to create API client")
 	}
-
+	b.rootCommandeer.loggerInstance.Debug("In BETA mode")
 	return nil
 }

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -185,7 +185,6 @@ func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *d
 	}
 
 	addDeployFlags(cmd, commandeer)
-	cmd.Flags().StringVarP(&commandeer.inputImageFile, "input-image-file", "", "", "Path to an input function-image Docker archive file")
 
 	commandeer.cmd = cmd
 
@@ -226,6 +225,7 @@ func addDeployFlags(cmd *cobra.Command,
 	cmd.Flags().Var(&commandeer.resourceLimits, "resource-limit", "Resource restrictions of the format '<resource name>=<quantity>' (for example, 'cpu=3')")
 	cmd.Flags().Var(&commandeer.resourceRequests, "resource-request", "Requested resources of the format '<resource name>=<quantity>' (for example, 'cpu=3')")
 	cmd.Flags().StringVar(&commandeer.loggerLevel, "logger-level", "", "One of debug, info, warn, error. By default, uses platform configuration")
+	cmd.Flags().StringVarP(&commandeer.inputImageFile, "input-image-file", "", "", "Path to an input function-image Docker archive file")
 }
 func parseResourceAllocations(values stringSliceFlag, resources *v1.ResourceList) error {
 	for _, value := range values {

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,7 +32,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform/abstract"
 
 	"github.com/nuclio/errors"
-	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/spf13/cobra"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -643,17 +641,6 @@ func (d *deployCommandeer) resolveFunctionName() (string, error) {
 	}
 
 	return "", errors.New("Function name is not provided")
-}
-
-func (d *deployCommandeer) isRedeploymentRetryable(err error) bool {
-	switch typedError := err.(type) {
-	case *nuclio.ErrorWithStatusCode:
-		// if the status code is 412, then another redeployment will not help because there is something wrong with the configuration
-		return typedError.StatusCode() != http.StatusPreconditionFailed
-	case error:
-		return true
-	}
-	return true
 }
 
 func (d *deployCommandeer) resolveFunctionNameFromPath() (string, error) {

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -111,6 +111,7 @@ func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *d
 				}
 				if importedFunction != nil {
 					commandeer.rootCommandeer.loggerInstance.Debug("Function was already imported, deploying it")
+					commandeer.functionConfig = commandeer.prepareFunctionConfigForRedeploy(importedFunction)
 				}
 			}
 
@@ -320,6 +321,16 @@ func (d *deployCommandeer) getImportedFunction(ctx context.Context, functionName
 	}
 
 	return nil, nil
+}
+
+func (d *deployCommandeer) prepareFunctionConfigForRedeploy(importedFunction platform.Function) functionconfig.Config {
+	functionConfig := importedFunction.GetConfig()
+
+	// Ensure RunRegistry is taken from the commandeer config
+	functionConfig.CleanFunctionSpec()
+	functionConfig.Spec.RunRegistry = d.functionConfig.Spec.RunRegistry
+
+	return *functionConfig
 }
 
 func (d *deployCommandeer) populateDeploymentDefaults() {

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -25,11 +25,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
-	"github.com/nuclio/nuclio/pkg/common/headers"
-	"github.com/nuclio/nuclio/pkg/errgroup"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	nuctlcommon "github.com/nuclio/nuclio/pkg/nuctl/command/common"
 	"github.com/nuclio/nuclio/pkg/platform"
@@ -85,35 +82,12 @@ type deployCommandeer struct {
 	runAsGroup                      int64
 	fsGroup                         int64
 	overrideHTTPTriggerServiceType  string
-
-	// beta - api client
-	betaCommandeer         *betaCommandeer
-	noBuild                bool
-	redeployFromReportFile bool
-	deployAll              bool
-	waitForFunction        bool
-	skipSpecCleanup        bool
-	verifyExternalRegistry bool
-	outputManifest         *nuctlcommon.PatchManifest
-	inputManifest          *nuctlcommon.PatchManifest
-	saveReport             bool
-	reportFilePath         string
-	excludedProjects       []string
-	excludedFunctions      []string
-	excludeFunctionWithGPU bool
-	importedOnly           bool
-	waitTimeout            time.Duration
 }
 
-func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, betaCommandeer *betaCommandeer) *deployCommandeer {
+func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *deployCommandeer {
 	commandeer := &deployCommandeer{
 		rootCommandeer: rootCommandeer,
 		functionConfig: *functionconfig.NewConfig(),
-		outputManifest: nuctlcommon.NewPatchManifest(),
-	}
-
-	if betaCommandeer != nil {
-		commandeer.betaCommandeer = betaCommandeer
 	}
 
 	cmd := &cobra.Command{
@@ -125,19 +99,6 @@ func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, be
 			// initialize root
 			if err := rootCommandeer.initialize(); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
-			}
-
-			if commandeer.betaCommandeer != nil {
-				if err := commandeer.betaCommandeer.initialize(); err != nil {
-					return errors.Wrap(err, "Failed to initialize beta commandeer")
-				}
-				commandeer.rootCommandeer.loggerInstance.Debug("In BETA mode")
-				if commandeer.noBuild {
-					if err := commandeer.betaDeploy(ctx, args); err != nil {
-						return errors.Wrap(err, "Failed to deploy function")
-					}
-					return nil
-				}
 			}
 
 			var importedFunction platform.Function
@@ -152,7 +113,6 @@ func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, be
 				}
 				if importedFunction != nil {
 					commandeer.rootCommandeer.loggerInstance.Debug("Function was already imported, deploying it")
-					commandeer.functionConfig = commandeer.prepareFunctionConfigForRedeploy(importedFunction, commandeer.skipSpecCleanup)
 				}
 			}
 
@@ -226,7 +186,6 @@ func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, be
 	}
 
 	addDeployFlags(cmd, commandeer)
-	cmd.Flags().BoolVarP(&commandeer.skipSpecCleanup, "skip-spec-cleanup", "", false, "Do not clean up spec in function configs")
 	cmd.Flags().StringVarP(&commandeer.inputImageFile, "input-image-file", "", "", "Path to an input function-image Docker archive file")
 
 	commandeer.cmd = cmd
@@ -268,27 +227,7 @@ func addDeployFlags(cmd *cobra.Command,
 	cmd.Flags().Var(&commandeer.resourceLimits, "resource-limit", "Resource restrictions of the format '<resource name>=<quantity>' (for example, 'cpu=3')")
 	cmd.Flags().Var(&commandeer.resourceRequests, "resource-request", "Requested resources of the format '<resource name>=<quantity>' (for example, 'cpu=3')")
 	cmd.Flags().StringVar(&commandeer.loggerLevel, "logger-level", "", "One of debug, info, warn, error. By default, uses platform configuration")
-
-	addBetaDeployFlags(cmd, commandeer)
 }
-
-func addBetaDeployFlags(cmd *cobra.Command,
-	commandeer *deployCommandeer) {
-
-	cmd.Flags().BoolVar(&commandeer.noBuild, "no-build", false, "Don't build the function, only deploy it")
-	cmd.Flags().BoolVar(&commandeer.deployAll, "deploy-all", false, "Deploy all functions in the namespace")
-	cmd.PersistentFlags().BoolVarP(&commandeer.waitForFunction, "wait", "w", false, "Wait for function deployment to complete")
-	cmd.PersistentFlags().StringSliceVar(&commandeer.excludedProjects, "exclude-projects", []string{}, "Exclude projects to patch")
-	cmd.PersistentFlags().StringSliceVar(&commandeer.excludedFunctions, "exclude-functions", []string{}, "Exclude functions to patch")
-	cmd.PersistentFlags().BoolVar(&commandeer.excludeFunctionWithGPU, "exclude-functions-with-gpu", false, "Skip functions with GPU")
-	cmd.PersistentFlags().BoolVar(&commandeer.importedOnly, "imported-only", false, "Deploy only imported functions")
-	cmd.PersistentFlags().DurationVar(&commandeer.waitTimeout, "wait-timeout", 15*time.Minute, "Wait timeout duration for the function deployment (default 15m)")
-	cmd.Flags().BoolVarP(&commandeer.redeployFromReportFile, "redeploy-from-report-file", "", false, "Redeploy failed and retryable functions from the given report file")
-	cmd.Flags().BoolVarP(&commandeer.saveReport, "save-report", "", false, "Save redeployment report to a file")
-	cmd.Flags().BoolVarP(&commandeer.verifyExternalRegistry, "verify-external-registry", "", false, "verify registry is external")
-	cmd.Flags().StringVarP(&commandeer.reportFilePath, "report-file-path", "", "nuctl-redeployment-report.json", "Path to redeployment report")
-}
-
 func parseResourceAllocations(values stringSliceFlag, resources *v1.ResourceList) error {
 	for _, value := range values {
 
@@ -383,18 +322,6 @@ func (d *deployCommandeer) getImportedFunction(ctx context.Context, functionName
 	}
 
 	return nil, nil
-}
-
-func (d *deployCommandeer) prepareFunctionConfigForRedeploy(importedFunction platform.Function, skipSpecCleanup bool) functionconfig.Config {
-	functionConfig := importedFunction.GetConfig()
-
-	// Ensure RunRegistry is taken from the commandeer config
-	if !skipSpecCleanup {
-		functionConfig.CleanFunctionSpec()
-	}
-	functionConfig.Spec.RunRegistry = d.functionConfig.Spec.RunRegistry
-
-	return *functionConfig
 }
 
 func (d *deployCommandeer) populateDeploymentDefaults() {
@@ -694,241 +621,6 @@ func (d *deployCommandeer) enrichBuildConfigWithArgs() {
 	if len(d.commands) > 0 {
 		d.functionConfig.Spec.Build.Commands = d.commands
 	}
-}
-
-func (d *deployCommandeer) betaDeploy(ctx context.Context, args []string) error {
-
-	if d.redeployFromReportFile {
-		manifest, err := nuctlcommon.NewPatchManifestFromFile(d.reportFilePath)
-		if err != nil {
-			return errors.Wrap(err, "Problem with reading report file")
-		}
-		d.inputManifest = manifest
-		retryableFunctions := d.inputManifest.GetRetryableFunctionNames()
-		d.rootCommandeer.loggerInstance.InfoWith("Redeploying failed functions from report file",
-			"report file", d.reportFilePath,
-			"functions", retryableFunctions)
-		args = append(args, retryableFunctions...)
-	}
-
-	if len(args) == 0 {
-
-		if d.redeployFromReportFile {
-			d.rootCommandeer.loggerInstance.Info("No retryable functions to redeploy")
-			return nil
-		}
-
-		// redeploy all functions in the namespace
-		if err := d.redeployAllFunctions(ctx); err != nil {
-			return errors.Wrap(err, "Failed to redeploy all functions")
-		}
-	} else {
-
-		// redeploy the given functions
-		if err := d.redeployFunctions(ctx, args); err != nil {
-			return errors.Wrap(err, "Failed to redeploy functions")
-		}
-	}
-
-	return nil
-}
-
-func (d *deployCommandeer) redeployAllFunctions(ctx context.Context) error {
-	d.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Redeploying all functions")
-
-	// get function names to redeploy
-	functionNames, err := d.getFunctionNames(ctx)
-	if err != nil {
-		return errors.Wrap(err, "Failed to get functions")
-	}
-
-	return d.redeployFunctions(ctx, functionNames)
-}
-
-func (d *deployCommandeer) getFunctionNames(ctx context.Context) ([]string, error) {
-	d.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Getting function names")
-
-	functionConfigs, err := d.betaCommandeer.apiClient.GetFunctions(ctx, d.rootCommandeer.namespace)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get functions")
-	}
-
-	functionNames := make([]string, 0)
-	for functionName, functionConfigWithStatus := range functionConfigs {
-
-		// filter excluded functions
-		if d.shouldSkipFunction(functionConfigWithStatus.Config) {
-			d.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Excluding function", "function", functionName)
-			d.outputManifest.AddSkipped(functionName)
-			continue
-		}
-		functionNames = append(functionNames, functionName)
-	}
-
-	return functionNames, nil
-}
-
-func (d *deployCommandeer) redeployFunctions(ctx context.Context, functionNames []string) error {
-	d.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Redeploying functions", "functionNames", functionNames)
-
-	patchErrGroup, _ := errgroup.WithContextSemaphore(ctx, d.rootCommandeer.loggerInstance, uint(d.betaCommandeer.concurrency))
-	for _, function := range functionNames {
-		function := function
-		patchErrGroup.Go("patch function", func() error {
-			if err := d.patchFunction(ctx, function); err != nil {
-				d.outputManifest.AddFailure(function, err, d.isRedeploymentRetryable(err))
-				return errors.Wrap(err, "Failed to patch function")
-			}
-			d.outputManifest.AddSuccess(function)
-			return nil
-		})
-	}
-
-	if err := patchErrGroup.Wait(); err != nil {
-
-		// Functions that failed to patch are included in the output manifest,
-		// so we don't need to fail the entire operation here
-		d.rootCommandeer.loggerInstance.WarnWithCtx(ctx, "Failed to patch functions", "err", err)
-	}
-
-	d.outputManifest.LogOutput(ctx, d.rootCommandeer.loggerInstance)
-	if d.saveReport {
-		d.outputManifest.SaveToFile(ctx, d.rootCommandeer.loggerInstance, d.reportFilePath)
-	}
-
-	return nil
-}
-
-// patchFunction patches a single function
-func (d *deployCommandeer) patchFunction(ctx context.Context, functionName string) error {
-
-	d.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Redeploying function", "function", functionName)
-
-	// patch function
-	patchOptions := map[string]string{
-		"desiredState": "ready",
-	}
-
-	payload, err := json.Marshal(patchOptions)
-	if err != nil {
-		return errors.Wrap(err, "Failed to marshal payload")
-	}
-
-	requestHeaders := d.resolveRequestHeaders()
-
-	if err := d.betaCommandeer.apiClient.PatchFunction(ctx,
-		functionName,
-		d.rootCommandeer.namespace,
-		payload,
-		requestHeaders); err != nil {
-		switch typedError := err.(type) {
-		case *nuclio.ErrorWithStatusCode:
-			return nuclio.GetWrapByStatusCode(typedError.StatusCode())(errors.Wrap(err, "Failed to patch function"))
-		default:
-			return errors.Wrap(typedError, "Failed to patch function")
-		}
-	}
-
-	d.rootCommandeer.loggerInstance.InfoWithCtx(ctx,
-		"Function redeploy request sent successfully",
-		"function", functionName)
-
-	if d.waitForFunction {
-		return d.waitForFunctionDeployment(ctx, functionName)
-	}
-
-	return nil
-}
-
-func (d *deployCommandeer) waitForFunctionDeployment(ctx context.Context, functionName string) error {
-	ticker := time.NewTicker(5 * time.Second)
-	for {
-		select {
-		case <-time.After(d.waitTimeout):
-			return errors.New(fmt.Sprintf("Timed out waiting for function '%s' to be ready", functionName))
-		case <-ticker.C:
-			isTerminal, err := d.functionIsInTerminalState(ctx, functionName)
-			if !isTerminal {
-
-				// function isn't in terminal state yet, retry
-				continue
-			}
-			if err != nil {
-
-				// function is terminal, but not ready, return error
-				return err
-			}
-
-			// function is ready
-			return nil
-		}
-	}
-}
-
-// functionIsInTerminalState checks if the function is in terminal state
-// if the function is ready, it returns true and no error
-// if the function is in another terminal state, it returns true and an error
-// else it returns false
-func (d *deployCommandeer) functionIsInTerminalState(ctx context.Context, functionName string) (bool, error) {
-
-	// get function and poll its status
-	function, err := d.betaCommandeer.apiClient.GetFunction(ctx, functionName, d.rootCommandeer.namespace)
-	if err != nil {
-		d.rootCommandeer.loggerInstance.WarnWithCtx(ctx, "Failed to get function", "functionName", functionName)
-		return false, err
-	}
-	if function.Status.State == functionconfig.FunctionStateReady {
-		d.rootCommandeer.loggerInstance.InfoWithCtx(ctx,
-			"Function redeployed successfully",
-			"functionName", functionName)
-		return true, nil
-	}
-
-	// we use this function to check if the function is in terminal state, as we already checked if it's ready
-	if functionconfig.FunctionStateInSlice(function.Status.State,
-		[]functionconfig.FunctionState{
-			functionconfig.FunctionStateError,
-			functionconfig.FunctionStateUnhealthy,
-			functionconfig.FunctionStateScaledToZero,
-		}) {
-		return true, errors.New(fmt.Sprintf("Function '%s' is in terminal state '%s' but not ready",
-			functionName, function.Status.State))
-	}
-
-	d.rootCommandeer.loggerInstance.DebugWithCtx(ctx,
-		"Function not ready yet",
-		"functionName", functionName,
-		"functionState", function.Status.State)
-
-	return false, nil
-}
-
-// shouldSkipFunction returns true if the function patch should be skipped
-func (d *deployCommandeer) shouldSkipFunction(functionConfig functionconfig.Config) bool {
-	functionName := functionConfig.Meta.Name
-	projectName := functionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName]
-
-	// skip if function is excluded or if it has a positive GPU resource limit
-	if common.StringSliceContainsString(d.excludedFunctions, functionName) ||
-		common.StringSliceContainsString(d.excludedProjects, projectName) ||
-		(d.excludeFunctionWithGPU && functionConfig.Spec.PositiveGPUResourceLimit()) {
-		return true
-	}
-
-	return false
-}
-
-func (d *deployCommandeer) resolveRequestHeaders() map[string]string {
-	requestHeaders := map[string]string{}
-	if d.importedOnly {
-
-		// add a header that will tell the API to only deploy imported functions
-		requestHeaders[headers.ImportedFunctionOnly] = "true"
-	}
-	if d.verifyExternalRegistry {
-		requestHeaders[headers.VerifyExternalRegistry] = "true"
-	}
-	return requestHeaders
 }
 
 func (d *deployCommandeer) resolveFunctionName() (string, error) {

--- a/pkg/nuctl/command/nuctl.go
+++ b/pkg/nuctl/command/nuctl.go
@@ -71,7 +71,7 @@ func NewRootCommandeer() *RootCommandeer {
 	// add children
 	cmd.AddCommand(
 		newBuildCommandeer(commandeer).cmd,
-		newDeployCommandeer(ctx, commandeer, nil).cmd,
+		newDeployCommandeer(ctx, commandeer).cmd,
 		newInvokeCommandeer(ctx, commandeer).cmd,
 		newGetCommandeer(ctx, commandeer).cmd,
 		newDeleteCommandeer(ctx, commandeer).cmd,

--- a/pkg/nuctl/command/redeploy.go
+++ b/pkg/nuctl/command/redeploy.go
@@ -1,0 +1,356 @@
+/*
+Copyright 2023 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/common/headers"
+	"github.com/nuclio/nuclio/pkg/errgroup"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	nuctlcommon "github.com/nuclio/nuclio/pkg/nuctl/command/common"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/nuclio-sdk-go"
+	"github.com/spf13/cobra"
+)
+
+type redeployCommandeer struct {
+	cmd            *cobra.Command
+	rootCommandeer *RootCommandeer
+
+	betaCommandeer         *betaCommandeer
+	redeployFromReportFile bool
+	deployAll              bool
+	waitForFunction        bool
+	skipSpecCleanup        bool
+	verifyExternalRegistry bool
+	outputManifest         *nuctlcommon.PatchManifest
+	inputManifest          *nuctlcommon.PatchManifest
+	saveReport             bool
+	reportFilePath         string
+	excludedProjects       []string
+	excludedFunctions      []string
+	excludeFunctionWithGPU bool
+	importedOnly           bool
+	waitTimeout            time.Duration
+}
+
+func newRedeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, betaCommandeer *betaCommandeer) *redeployCommandeer {
+	commandeer := &redeployCommandeer{
+		rootCommandeer: rootCommandeer,
+		outputManifest: nuctlcommon.NewPatchManifest(),
+		betaCommandeer: betaCommandeer,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "redeploy function-name",
+		Short: "Redeploy a function",
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			// initialize root
+			if err := rootCommandeer.initialize(); err != nil {
+				return errors.Wrap(err, "Failed to initialize root")
+			}
+
+			if commandeer.betaCommandeer != nil {
+				if err := commandeer.betaCommandeer.initialize(); err != nil {
+					return errors.Wrap(err, "Failed to initialize beta commandeer")
+				}
+				commandeer.rootCommandeer.loggerInstance.Debug("In BETA mode")
+				if err := commandeer.betaRedeploy(ctx, args); err != nil {
+					return errors.Wrap(err, "Failed to deploy function")
+				}
+				return nil
+			}
+			return nil
+		},
+	}
+
+	addRedeployFlags(cmd, commandeer)
+	cmd.Flags().BoolVarP(&commandeer.skipSpecCleanup, "skip-spec-cleanup", "", false, "Do not clean up spec in function configs")
+
+	commandeer.cmd = cmd
+
+	return commandeer
+}
+
+func addRedeployFlags(cmd *cobra.Command,
+	commandeer *redeployCommandeer) {
+	cmd.Flags().BoolVar(&commandeer.deployAll, "deploy-all", false, "Deploy all functions in the namespace")
+	cmd.PersistentFlags().BoolVarP(&commandeer.waitForFunction, "wait", "w", false, "Wait for function deployment to complete")
+	cmd.PersistentFlags().StringSliceVar(&commandeer.excludedProjects, "exclude-projects", []string{}, "Exclude projects to patch")
+	cmd.PersistentFlags().StringSliceVar(&commandeer.excludedFunctions, "exclude-functions", []string{}, "Exclude functions to patch")
+	cmd.PersistentFlags().BoolVar(&commandeer.excludeFunctionWithGPU, "exclude-functions-with-gpu", false, "Skip functions with GPU")
+	cmd.PersistentFlags().BoolVar(&commandeer.importedOnly, "imported-only", false, "Deploy only imported functions")
+	cmd.PersistentFlags().DurationVar(&commandeer.waitTimeout, "wait-timeout", 15*time.Minute, "Wait timeout duration for the function deployment (default 15m)")
+	cmd.Flags().BoolVarP(&commandeer.redeployFromReportFile, "redeploy-from-report-file", "", false, "Redeploy failed and retryable functions from the given report file")
+	cmd.Flags().BoolVarP(&commandeer.saveReport, "save-report", "", false, "Save redeployment report to a file")
+	cmd.Flags().BoolVarP(&commandeer.verifyExternalRegistry, "verify-external-registry", "", false, "verify registry is external")
+	cmd.Flags().StringVarP(&commandeer.reportFilePath, "report-file-path", "", "nuctl-redeployment-report.json", "Path to redeployment report")
+}
+
+func (d *redeployCommandeer) betaRedeploy(ctx context.Context, args []string) error {
+
+	if d.redeployFromReportFile {
+		manifest, err := nuctlcommon.NewPatchManifestFromFile(d.reportFilePath)
+		if err != nil {
+			return errors.Wrap(err, "Problem with reading report file")
+		}
+		d.inputManifest = manifest
+		retryableFunctions := d.inputManifest.GetRetryableFunctionNames()
+		d.rootCommandeer.loggerInstance.InfoWith("Redeploying failed functions from report file",
+			"report file", d.reportFilePath,
+			"functions", retryableFunctions)
+		args = append(args, retryableFunctions...)
+	}
+
+	if len(args) == 0 {
+
+		if d.redeployFromReportFile {
+			d.rootCommandeer.loggerInstance.Info("No retryable functions to redeploy")
+			return nil
+		}
+
+		// redeploy all functions in the namespace
+		if err := d.redeployAllFunctions(ctx); err != nil {
+			return errors.Wrap(err, "Failed to redeploy all functions")
+		}
+	} else {
+
+		// redeploy the given functions
+		if err := d.redeployFunctions(ctx, args); err != nil {
+			return errors.Wrap(err, "Failed to redeploy functions")
+		}
+	}
+
+	return nil
+}
+
+func (d *redeployCommandeer) redeployAllFunctions(ctx context.Context) error {
+	d.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Redeploying all functions")
+
+	// get function names to redeploy
+	functionNames, err := d.getFunctionNames(ctx)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get functions")
+	}
+
+	return d.redeployFunctions(ctx, functionNames)
+}
+
+func (d *redeployCommandeer) getFunctionNames(ctx context.Context) ([]string, error) {
+	d.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Getting function names")
+
+	functionConfigs, err := d.betaCommandeer.apiClient.GetFunctions(ctx, d.rootCommandeer.namespace)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get functions")
+	}
+
+	functionNames := make([]string, 0)
+	for functionName, functionConfigWithStatus := range functionConfigs {
+
+		// filter excluded functions
+		if d.shouldSkipFunction(functionConfigWithStatus.Config) {
+			d.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Excluding function", "function", functionName)
+			d.outputManifest.AddSkipped(functionName)
+			continue
+		}
+		functionNames = append(functionNames, functionName)
+	}
+
+	return functionNames, nil
+}
+
+func (d *redeployCommandeer) redeployFunctions(ctx context.Context, functionNames []string) error {
+	d.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Redeploying functions", "functionNames", functionNames)
+
+	patchErrGroup, _ := errgroup.WithContextSemaphore(ctx, d.rootCommandeer.loggerInstance, uint(d.betaCommandeer.concurrency))
+	for _, function := range functionNames {
+		function := function
+		patchErrGroup.Go("patch function", func() error {
+			if err := d.patchFunction(ctx, function); err != nil {
+				d.outputManifest.AddFailure(function, err, d.isRedeploymentRetryable(err))
+				return errors.Wrap(err, "Failed to patch function")
+			}
+			d.outputManifest.AddSuccess(function)
+			return nil
+		})
+	}
+
+	if err := patchErrGroup.Wait(); err != nil {
+
+		// Functions that failed to patch are included in the output manifest,
+		// so we don't need to fail the entire operation here
+		d.rootCommandeer.loggerInstance.WarnWithCtx(ctx, "Failed to patch functions", "err", err)
+	}
+
+	d.outputManifest.LogOutput(ctx, d.rootCommandeer.loggerInstance)
+	if d.saveReport {
+		d.outputManifest.SaveToFile(ctx, d.rootCommandeer.loggerInstance, d.reportFilePath)
+	}
+
+	return nil
+}
+
+// patchFunction patches a single function
+func (d *redeployCommandeer) patchFunction(ctx context.Context, functionName string) error {
+
+	d.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Redeploying function", "function", functionName)
+
+	// patch function
+	patchOptions := map[string]string{
+		"desiredState": "ready",
+	}
+
+	payload, err := json.Marshal(patchOptions)
+	if err != nil {
+		return errors.Wrap(err, "Failed to marshal payload")
+	}
+
+	requestHeaders := d.resolveRequestHeaders()
+
+	if err := d.betaCommandeer.apiClient.PatchFunction(ctx,
+		functionName,
+		d.rootCommandeer.namespace,
+		payload,
+		requestHeaders); err != nil {
+		switch typedError := err.(type) {
+		case *nuclio.ErrorWithStatusCode:
+			return nuclio.GetWrapByStatusCode(typedError.StatusCode())(errors.Wrap(err, "Failed to patch function"))
+		default:
+			return errors.Wrap(typedError, "Failed to patch function")
+		}
+	}
+
+	d.rootCommandeer.loggerInstance.InfoWithCtx(ctx,
+		"Function redeploy request sent successfully",
+		"function", functionName)
+
+	if d.waitForFunction {
+		return d.waitForFunctionDeployment(ctx, functionName)
+	}
+
+	return nil
+}
+
+func (d *redeployCommandeer) waitForFunctionDeployment(ctx context.Context, functionName string) error {
+	ticker := time.NewTicker(5 * time.Second)
+	for {
+		select {
+		case <-time.After(d.waitTimeout):
+			return errors.New(fmt.Sprintf("Timed out waiting for function '%s' to be ready", functionName))
+		case <-ticker.C:
+			isTerminal, err := d.functionIsInTerminalState(ctx, functionName)
+			if !isTerminal {
+
+				// function isn't in terminal state yet, retry
+				continue
+			}
+			if err != nil {
+
+				// function is terminal, but not ready, return error
+				return err
+			}
+
+			// function is ready
+			return nil
+		}
+	}
+}
+
+// functionIsInTerminalState checks if the function is in terminal state
+// if the function is ready, it returns true and no error
+// if the function is in another terminal state, it returns true and an error
+// else it returns false
+func (d *redeployCommandeer) functionIsInTerminalState(ctx context.Context, functionName string) (bool, error) {
+
+	// get function and poll its status
+	function, err := d.betaCommandeer.apiClient.GetFunction(ctx, functionName, d.rootCommandeer.namespace)
+	if err != nil {
+		d.rootCommandeer.loggerInstance.WarnWithCtx(ctx, "Failed to get function", "functionName", functionName)
+		return false, err
+	}
+	if function.Status.State == functionconfig.FunctionStateReady {
+		d.rootCommandeer.loggerInstance.InfoWithCtx(ctx,
+			"Function redeployed successfully",
+			"functionName", functionName)
+		return true, nil
+	}
+
+	// we use this function to check if the function is in terminal state, as we already checked if it's ready
+	if functionconfig.FunctionStateInSlice(function.Status.State,
+		[]functionconfig.FunctionState{
+			functionconfig.FunctionStateError,
+			functionconfig.FunctionStateUnhealthy,
+			functionconfig.FunctionStateScaledToZero,
+		}) {
+		return true, errors.New(fmt.Sprintf("Function '%s' is in terminal state '%s' but not ready",
+			functionName, function.Status.State))
+	}
+
+	d.rootCommandeer.loggerInstance.DebugWithCtx(ctx,
+		"Function not ready yet",
+		"functionName", functionName,
+		"functionState", function.Status.State)
+
+	return false, nil
+}
+
+// shouldSkipFunction returns true if the function patch should be skipped
+func (d *redeployCommandeer) shouldSkipFunction(functionConfig functionconfig.Config) bool {
+	functionName := functionConfig.Meta.Name
+	projectName := functionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName]
+
+	// skip if function is excluded or if it has a positive GPU resource limit
+	if common.StringSliceContainsString(d.excludedFunctions, functionName) ||
+		common.StringSliceContainsString(d.excludedProjects, projectName) ||
+		(d.excludeFunctionWithGPU && functionConfig.Spec.PositiveGPUResourceLimit()) {
+		return true
+	}
+
+	return false
+}
+
+func (d *redeployCommandeer) resolveRequestHeaders() map[string]string {
+	requestHeaders := map[string]string{}
+	if d.importedOnly {
+
+		// add a header that will tell the API to only deploy imported functions
+		requestHeaders[headers.ImportedFunctionOnly] = "true"
+	}
+	if d.verifyExternalRegistry {
+		requestHeaders[headers.VerifyExternalRegistry] = "true"
+	}
+	return requestHeaders
+}
+
+func (d *redeployCommandeer) isRedeploymentRetryable(err error) bool {
+	switch typedError := err.(type) {
+	case *nuclio.ErrorWithStatusCode:
+		// if the status code is 412, then another redeployment will not help because there is something wrong with the configuration
+		return typedError.StatusCode() != http.StatusPreconditionFailed
+	case error:
+		return true
+	}
+	return true
+}

--- a/pkg/nuctl/command/redeploy.go
+++ b/pkg/nuctl/command/redeploy.go
@@ -87,12 +87,12 @@ func newRedeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer, 
 
 func addRedeployFlags(cmd *cobra.Command,
 	commandeer *redeployCommandeer) {
-	cmd.PersistentFlags().BoolVarP(&commandeer.waitForFunction, "wait", "w", false, "Wait for function deployment to complete")
-	cmd.PersistentFlags().StringSliceVar(&commandeer.excludedProjects, "exclude-projects", []string{}, "Exclude projects to patch")
-	cmd.PersistentFlags().StringSliceVar(&commandeer.excludedFunctions, "exclude-functions", []string{}, "Exclude functions to patch")
-	cmd.PersistentFlags().BoolVar(&commandeer.excludeFunctionWithGPU, "exclude-functions-with-gpu", false, "Skip functions with GPU")
-	cmd.PersistentFlags().BoolVar(&commandeer.importedOnly, "imported-only", false, "Deploy only imported functions")
-	cmd.PersistentFlags().DurationVar(&commandeer.waitTimeout, "wait-timeout", 15*time.Minute, "Wait timeout duration for the function deployment (default 15m)")
+	cmd.Flags().BoolVarP(&commandeer.waitForFunction, "wait", "w", false, "Wait for function deployment to complete")
+	cmd.Flags().StringSliceVar(&commandeer.excludedProjects, "exclude-projects", []string{}, "Exclude projects to patch")
+	cmd.Flags().StringSliceVar(&commandeer.excludedFunctions, "exclude-functions", []string{}, "Exclude functions to patch")
+	cmd.Flags().BoolVar(&commandeer.excludeFunctionWithGPU, "exclude-functions-with-gpu", false, "Skip functions with GPU")
+	cmd.Flags().BoolVar(&commandeer.importedOnly, "imported-only", false, "Deploy only imported functions")
+	cmd.Flags().DurationVar(&commandeer.waitTimeout, "wait-timeout", 15*time.Minute, "Wait timeout duration for the function deployment (default 15m)")
 	cmd.Flags().BoolVarP(&commandeer.redeployFromReportFile, "redeploy-from-report-file", "", false, "Redeploy failed and retryable functions from the given report file")
 	cmd.Flags().BoolVarP(&commandeer.saveReport, "save-report", "", false, "Save redeployment report to a file")
 	cmd.Flags().BoolVarP(&commandeer.verifyExternalRegistry, "verify-external-registry", "", false, "verify registry is external")

--- a/pkg/nuctl/command/redeploy.go
+++ b/pkg/nuctl/command/redeploy.go
@@ -43,7 +43,6 @@ type redeployCommandeer struct {
 	waitForFunction        bool
 	verifyExternalRegistry bool
 	outputManifest         *nuctlcommon.PatchManifest
-	inputManifest          *nuctlcommon.PatchManifest
 	saveReport             bool
 	reportFilePath         string
 	excludedProjects       []string


### PR DESCRIPTION
Jira: `IG-22145`


As part of this task, we are transferring part of the functionality of the `deploy` command to a separate `redeploy` command. That part of the functionality in the `deploy` that worked in beta mode with the flag `--no-build` will now be in `redeploy`. 
Beta Commander will only contain `redeploy` command for now, because following our concept that everything that uses the api is beta, this is the only command that uses the api. That is, the `redeploy` command will be available only in beta mode. 

In turn, the `deploy` command will contain only that part of the functionality that was in the main mode.

In other words, `deploy=build+deploy from scratch` and `redeploy=deploy without build`