### PR TITLE
[Nuctl] Improve `redeploy` user experience

### DIFF
--- a/pkg/nuctl/command/common/patchmanifest.go
+++ b/pkg/nuctl/command/common/patchmanifest.go
@@ -139,6 +139,9 @@ func (m *PatchManifest) LogOutput(ctx context.Context, loggerInstance logger.Log
 }
 
 func (m *PatchManifest) SaveToFile(ctx context.Context, loggerInstance logger.Logger, path string) {
+	loggerInstance.InfoWithCtx(ctx, "Saving redeploy report to file",
+		"path", path)
+
 	file, err := json.Marshal(m.patchManifest)
 	if err != nil {
 		loggerInstance.ErrorWithCtx(ctx,

--- a/pkg/nuctl/command/common/patchmanifest_test.go
+++ b/pkg/nuctl/command/common/patchmanifest_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
+	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -37,13 +38,14 @@ type PatchManifestTestSuite struct {
 
 func (suite *PatchManifestTestSuite) SetupSuite() {
 	var err error
-
+	suite.ctx = context.Background()
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
 	suite.tempDir, err = os.MkdirTemp("", "patchManifest-test")
 	suite.Require().NoError(err)
 }
 
 func (suite *PatchManifestTestSuite) TearDownSuite() {
-	defer os.RemoveAll(suite.tempDir)
+	defer os.RemoveAll(suite.tempDir) // nolint: errcheck
 }
 
 func (suite *PatchManifestTestSuite) TestNewPatchManifestFromFile() {

--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -140,8 +140,8 @@ func newImportFunctionCommandeer(ctx context.Context, importCommandeer *importCo
 		Use:     "functions [<config file>]",
 		Aliases: []string{"function", "fn", "fu"},
 		Short:   "(or function) Import functions",
-		Long: `(or function) Import the configurations of one or more functions
-from a configurations file or from standard input (default)
+		Long: `Import the configurations of one or more functions from
+a configurations file or from standard input (default)
 
 Note: The command doesn't deploy the imported functions.
       To deploy an imported function, use the 'deploy' command.
@@ -241,8 +241,8 @@ func newImportProjectCommandeer(ctx context.Context, importCommandeer *importCom
 		Use:     "projects [<config file>]",
 		Aliases: []string{"project", "prj", "proj"},
 		Short:   "(or project) Import projects (including all functions, function events, and API gateways)",
-		Long: `(or project) Import the configurations of one or more projects (including
-all project functions, function events, and API gateways) from a configurations file
+		Long: `Import the configurations of one or more projects (including all project 
+functions, function events, and API gateways) from a configurations file
 or from standard input (default)
 
 Note: The command doesn't deploy the functions in the  imported projects.

--- a/pkg/nuctl/command/redeploy.go
+++ b/pkg/nuctl/command/redeploy.go
@@ -49,7 +49,6 @@ type redeployCommandeer struct {
 	excludeFunctionWithGPU bool
 	importedOnly           bool
 	waitForFunction        bool
-	waitTimeoutStr         string
 	waitTimeout            time.Duration
 }
 
@@ -82,13 +81,6 @@ Arguments:
 				return errors.Wrap(err, "Failed to initialize beta commandeer")
 			}
 
-			// parse the wait timeout duration
-			waitTimoutDuration, err := time.ParseDuration(commandeer.waitTimeoutStr)
-			if err != nil {
-				return errors.Wrap(err, "Failed to parse wait timeout")
-			}
-			commandeer.waitTimeout = waitTimoutDuration
-
 			if err := commandeer.redeploy(ctx, args); err != nil {
 				return errors.Wrap(err, "Failed to deploy function")
 			}
@@ -114,7 +106,7 @@ func addRedeployFlags(cmd *cobra.Command,
 	cmd.Flags().BoolVar(&commandeer.excludeFunctionWithGPU, "exclude-functions-with-gpu", false, "Skip functions with GPU")
 	cmd.Flags().BoolVar(&commandeer.importedOnly, "imported-only", false, "Deploy only imported functions")
 	cmd.Flags().BoolVarP(&commandeer.waitForFunction, "wait", "w", false, "Wait for function deployment to complete")
-	cmd.Flags().StringVar(&commandeer.waitTimeoutStr, "wait-timeout", "15m", "Wait timeout duration for the function deployment (default 15m)")
+	cmd.Flags().DurationVar(&commandeer.waitTimeout, "wait-timeout", 15*time.Minute, "Wait timeout duration for the function deployment, e.g 30s, 5m")
 }
 
 func (d *redeployCommandeer) redeploy(ctx context.Context, args []string) error {


### PR DESCRIPTION
While using the new `redeploy` nuctl command I noticed several thing that are fixed in this PR: 
- Replace Info and Debug logs so that the default logs will be more informative
- Expand and fix help messages for `redeploy` and `import`, and for some flags
- Allow redeploying from file and passing function names as arguments (merge them)
- Use `RetryUntilSuccessful` when waiting for function deployment

Example usage of command:
```bash
nuctl --namespace <namespace> beta redeploy --api-url <api-url> --access-key <access-key> --save-report --report-file-path temp/nuctl-redeploy-report.json --skip-tls-verify --wait --wait-timeout 10m --verbose
```