### PR TITLE
[Controller] Allow redeploying function as Scaled To Zero

### DIFF
--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -816,18 +816,13 @@ func FunctionStateProvisioning(functionState FunctionState) bool {
 	return !FunctionStateProvisioned(functionState)
 }
 
-func IsPreviousFunctionStateAllowedToBeSet(prevState string) bool {
-	allowedPreviousStates := []string{
-		string(FunctionStateScaledToZero),
-		string(FunctionStateReady),
-		string(FunctionStateImported),
+func IsPreviousFunctionStateAllowedToBeSet(prevState FunctionState) bool {
+	allowedPreviousStates := []FunctionState{
+		FunctionStateScaledToZero,
+		FunctionStateReady,
+		FunctionStateImported,
 	}
-	for _, state := range allowedPreviousStates {
-		if state == prevState {
-			return true
-		}
-	}
-	return false
+	return FunctionStateInSlice(prevState, allowedPreviousStates)
 }
 
 // Status holds the status of the function

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -816,6 +816,20 @@ func FunctionStateProvisioning(functionState FunctionState) bool {
 	return !FunctionStateProvisioned(functionState)
 }
 
+func IsPreviousFunctionStateAllowedToBeSet(prevState string) bool {
+	allowedPreviousStates := []string{
+		string(FunctionStateScaledToZero),
+		string(FunctionStateReady),
+		string(FunctionStateImported),
+	}
+	for _, state := range allowedPreviousStates {
+		if state == prevState {
+			return true
+		}
+	}
+	return false
+}
+
 // Status holds the status of the function
 type Status struct {
 	State       FunctionState            `json:"state,omitempty"`

--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -563,6 +563,8 @@ func waitForFunctionReadiness(ctx context.Context,
 		}
 
 		switch function.Status.State {
+		case functionconfig.FunctionStateScaledToZero:
+			return true, nil
 		case functionconfig.FunctionStateReady:
 			return true, nil
 		case functionconfig.FunctionStateError, functionconfig.FunctionStateUnhealthy:

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -115,13 +115,16 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 		return errors.New("Function name doesn't conform to k8s naming convention. Errors: " + joinedErrorMessage)
 	}
 
-	annotationsToClean := []string{
-		functionconfig.FunctionAnnotationForceUpdate,
-		functionconfig.FunctionAnnotationPrevState,
-	}
+	var prevState string
 
 	// clean the irrelevant annotations from the CRD before adding resources
 	if function.ObjectMeta.Annotations != nil {
+		prevState = function.ObjectMeta.Annotations[functionconfig.FunctionAnnotationPrevState]
+		annotationsToClean := []string{
+			functionconfig.FunctionAnnotationForceUpdate,
+			functionconfig.FunctionAnnotationPrevState,
+			functionconfig.FunctionAnnotationSkipDeploy,
+		}
 		for _, annotation := range annotationsToClean {
 			delete(function.ObjectMeta.Annotations, annotation)
 		}
@@ -153,6 +156,12 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 		return nil
 	}
 
+	if prevState == string(functionconfig.FunctionStateScaledToZero) {
+		fo.logger.InfoWith("Previous status of function is set to ScaledToZero, so function will be deployed in this state",
+			"function", function.Name)
+		function.Status.State = functionconfig.FunctionStateWaitingForScaleResourcesToZero
+	}
+
 	// imported functions have skip deploy annotation, set its state and bail
 	if functionconfig.ShouldSkipDeploy(function.Annotations) {
 		fo.logger.InfoWithCtx(ctx,
@@ -168,7 +177,7 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 
 	//we respond to ready to complete the scale from zero flow. we want to skip flows where once the function
 	// has created or updated and marked as ready, so it will not needlessly run the create or update flow.
-	if functionconfig.FunctionStateInSlice(function.Status.State,
+	if prevState == "" && functionconfig.FunctionStateInSlice(function.Status.State,
 		[]functionconfig.FunctionState{
 			functionconfig.FunctionStateReady,
 			functionconfig.FunctionStateScaledToZero,
@@ -254,6 +263,7 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 
 		var scaleEvent scalertypes.ScaleEvent
 		var finalState functionconfig.FunctionState
+
 		switch function.Status.State {
 		case functionconfig.FunctionStateWaitingForScaleResourcesToZero:
 			scaleEvent = scalertypes.ScaleToZeroCompletedScaleEvent

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -169,9 +169,12 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 		}
 	}
 
+	// prevState annotation presents in the function config after function being imported and redeployed
+	// this allows to deploy function right to the state which function had before it was exported
 	if functionconfig.IsPreviousFunctionStateAllowedToBeSet(functionconfig.FunctionState(prevState)) {
 		fo.logger.InfoWith("Previous status of function is set in annotation, so function will be moved to this state.",
-			"function", function.Name, "prevState", prevState)
+			"function", function.Name,
+			"prevState", prevState)
 		switch prevState {
 		case string(functionconfig.FunctionStateScaledToZero):
 			function.Status.State = functionconfig.FunctionStateWaitingForScaleResourcesToZero

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -1267,6 +1267,24 @@ func (suite *DeployFunctionTestSuite) TestRedeployWithReplicasAndValidateResourc
 	})
 }
 
+func (suite *DeployFunctionTestSuite) TestDeployImportedFunctionAsScaledToZero() {
+	zero := 0
+	one := 1
+	functionName := "func-scale-to-zero"
+	createFunctionOptions := suite.CompileCreateFunctionOptions(functionName)
+	createFunctionOptions.FunctionConfig.Spec.MinReplicas = &zero
+	createFunctionOptions.FunctionConfig.Spec.MaxReplicas = &one
+	createFunctionOptions.FunctionConfig.AddPrevStateAnnotation(string(functionconfig.FunctionStateScaledToZero))
+	result, deployErr := suite.Platform.CreateFunction(suite.Ctx, createFunctionOptions)
+
+	suite.Require().Equal(result.FunctionStatus.State, functionconfig.FunctionStateScaledToZero)
+	suite.NoError(deployErr)
+
+	deployment, err := suite.KubeClientSet.AppsV1().Deployments("default").Get(suite.Ctx, "nuclio-func-scale-to-zero", metav1.GetOptions{})
+	suite.NoError(err)
+	suite.Require().Equal(int(*deployment.Spec.Replicas), 0)
+}
+
 func (suite *DeployFunctionTestSuite) TestCreateFunctionWithCustomScalingMetrics() {
 	one := 1
 	four := 4

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -1276,9 +1276,8 @@ func (suite *DeployFunctionTestSuite) TestDeployImportedFunctionAsScaledToZero()
 	createFunctionOptions.FunctionConfig.Spec.MaxReplicas = &one
 	createFunctionOptions.FunctionConfig.AddPrevStateAnnotation(string(functionconfig.FunctionStateScaledToZero))
 	result, deployErr := suite.Platform.CreateFunction(suite.Ctx, createFunctionOptions)
-
-	suite.Require().Equal(result.FunctionStatus.State, functionconfig.FunctionStateScaledToZero)
 	suite.NoError(deployErr)
+	suite.Require().Equal(result.FunctionStatus.State, functionconfig.FunctionStateScaledToZero)
 
 	deployment, err := suite.KubeClientSet.AppsV1().Deployments("default").Get(suite.Ctx, "nuclio-func-scale-to-zero", metav1.GetOptions{})
 	suite.NoError(err)


### PR DESCRIPTION
https://jira.iguazeng.com/browse/NUC-31

When redploying functions post-upgrade, there is a risk of trying to create many pods at once and failing to get all resources.
Furthermore, if a function was scaled-to-zero before upgrading, it should remain scaled-to-zero post upgrade as well. To deploy it - the user should just invoke it. Within this PR the ability of redeploying function right to the status which function had before being imported is added.