### PR TITLE
[CI] Security Scan - use grype instead of trivy and print results

### DIFF
--- a/.github/workflows/security_scan.yaml
+++ b/.github/workflows/security_scan.yaml
@@ -26,6 +26,33 @@ on:
         description: 'Image rules override (comma separated)'
         required: false
         default: ''
+      publish_results:
+        description: 'Whether to publish results to Github or not (default "false")'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+      severity_threshold:
+        description: 'The minimum severity of vulnerabilities to report ("negligible", "low", "medium", "high" and "critical".)'
+        required: false
+        default: 'low'
+        type: choice
+        options:
+          - 'negligible'
+          - 'low'
+          - 'medium'
+          - 'high'
+          - 'critical'
+      only_fixed:
+        description: 'Whether to only report vulnerabilities that have a fix available ("true" or "false")'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
 
 env:
   NUCLIO_LABEL: latest
@@ -105,37 +132,32 @@ jobs:
           PRINT_FIRST_IMAGE: true
 
       - name: Define output format
-        id: trivy-output-format
+        id: output-format
         run: |
-          if [[ -z "${{ github.event.inputs.pr_number }}" ]]; then \
+          if [[ -n "${{ github.event.inputs.publish_results }}" ]]; then \
             echo "format=sarif" >> $GITHUB_OUTPUT; \
-            echo "output=trivy-results.sarif" >> $GITHUB_OUTPUT; \
-            echo "exit_code=0" >> $GITHUB_OUTPUT; \
+            echo "fail_build=false" >> $GITHUB_OUTPUT; \
           else \
             echo "format=table" >> $GITHUB_OUTPUT; \
-            echo "output=" >> $GITHUB_OUTPUT; \
-            echo "exit_code=1" >> $GITHUB_OUTPUT; \
+            echo "fail_build=true" >> $GITHUB_OUTPUT; \
           fi
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+      - name: Scan image
+        uses: anchore/scan-action@v3
+        id: scan
         with:
-          scan-type: image
-          image-ref: ${{ env.image_name }}
-          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
-          ignore-unfixed: true
-          output: ${{ steps.trivy-output-format.outputs.output }}
-          format: ${{ steps.trivy-output-format.outputs.format }}
-          exit-code: ${{ steps.trivy-output-format.outputs.exit_code }}
+          image: ${{ env.image_name }}
+          only-fixed: ${{ github.event.inputs.only_fixed }}
+          output-format: ${{ steps.output-format.outputs.format }}
+          fail-build: ${{ steps.output-format.outputs.fail_build }}
+          severity-cutoff: ${{ github.event.inputs.severity_threshold }}
 
-      - name: Upload Trivy scan results to GitHub Security tab
-        # upload results if not running against pr.
-        # we do not want to manipulate our security reports
-        # with work-in-progress.
-        if: github.event.inputs.pr_number == ''
+      - name: Upload scan results
+        # by default we don't upload results to github
+        if: github.event.inputs.publish_results != ''
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: ${{ steps.scan.outputs.sarif }}
           category: ${{ matrix.image_rule }}
 
   scale_fs:
@@ -155,32 +177,29 @@ jobs:
           ref: refs/pull/${{ github.event.inputs.pr_number }}/merge
 
       - name: Define output format
-        id: trivy-output-format
+        id: output-format
         run: |
-          if [[ -z "${{ github.event.inputs.pr_number }}" ]]; then \
+          if [[ -n "${{ github.event.inputs.publish_results }}" ]]; then \
             echo "format=sarif" >> $GITHUB_OUTPUT; \
-            echo "output=trivy-results.sarif" >> $GITHUB_OUTPUT; \
-            echo "exit_code=0" >> $GITHUB_OUTPUT; \
+            echo "fail_build=false" >> $GITHUB_OUTPUT; \
           else \
             echo "format=table" >> $GITHUB_OUTPUT; \
-            echo "output=" >> $GITHUB_OUTPUT; \
-            echo "exit_code=1" >> $GITHUB_OUTPUT; \
+            echo "fail_build=true" >> $GITHUB_OUTPUT; \
           fi
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+      - name: Scan fs
+        uses: anchore/scan-action@v3
+        id: scan
         with:
-          scan-type: fs
-          output: ${{ steps.trivy-output-format.outputs.output }}
-          format: ${{ steps.trivy-output-format.outputs.format }}
-          exit-code: ${{ steps.trivy-output-format.outputs.exit_code }}
+          path: "."
+          only-fixed: ${{ github.event.inputs.only_fixed }}
+          output-format: ${{ steps.output-format.outputs.format }}
+          fail-build: ${{ steps.output-format.outputs.fail_build }}
+          severity-cutoff: ${{ github.event.inputs.severity_threshold }}
 
-      - name: Upload Trivy scan results
-        # upload results if not running against pr.
-        # we do not want to manipulate our security reports
-        # with work-in-progress.
-        if: github.event.inputs.pr_number == ''
+      - name: Upload scan results
+        if: github.event.inputs.publish_results != ''
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: ${{ steps.scan.outputs.sarif }}
           category: filesystem

--- a/.github/workflows/security_scan.yaml
+++ b/.github/workflows/security_scan.yaml
@@ -27,13 +27,9 @@ on:
         required: false
         default: ''
       publish_results:
-        description: 'Whether to publish results to Github or not (default "false")'
+        description: 'Whether to publish results to Github or not (default empty - no publish)'
         required: false
-        default: 'false'
-        type: choice
-        options:
-          - 'true'
-          - 'false'
+        default: ''
       severity_threshold:
         description: 'The minimum severity of vulnerabilities to report ("negligible", "low", "medium", "high" and "critical".)'
         required: false


### PR DESCRIPTION
The current security scan publishes the results to github actions by default when running on `development` branch, and it is not easy to identify the vulnerabilities.
In this PR I improved the workflow by:

1. Replace Trivy scan with Grype scan
2. Print report by default instead of publish report to Github
3. Add workflow options