### PR TITLE
[Nuctl] Add flag to import with previousState

### DIFF
--- a/pkg/common/headers/headers.go
+++ b/pkg/common/headers/headers.go
@@ -31,6 +31,7 @@ const (
 	FunctionEnrichApiGateways           = "X-Nuclio-Function-Enrich-Apigateways"
 	ImportedFunctionOnly                = "X-Nuclio-Imported-Function-Only"
 	SkipSpecCleanup                     = "X-Nuclio-Skip-Spec-Cleanup"
+	AddPrevState                        = "X-Nuclio-Add-Prev-State"
 	VerifyExternalRegistry              = "X-Nuclio-Verify-External-Registry"
 
 	// Project headers

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -54,6 +54,13 @@ type PatchOptions struct {
 	DesiredState *functionconfig.FunctionState `json:"desiredState,omitempty"`
 }
 
+type ExportOptions struct {
+	SkipSpecCleanUp bool
+	AddPrevState    bool
+	NoScrub         bool
+	PrevState       string
+}
+
 func (fr *functionResource) ExtendMiddlewares() error {
 	fr.resource.addAuthMiddleware(nil)
 	return nil
@@ -78,13 +85,13 @@ func (fr *functionResource) GetAll(request *http.Request) (map[string]restful.At
 	}
 
 	exportFunction := fr.GetURLParamBoolOrDefault(request, restful.ParamExport, false)
-	skipSpecCleanup := fr.getSkipSpecCleanupFlagFromRequest(request)
+	exportOptions := fr.getExportOptions(request)
 	// create a map of attributes keyed by the function id (name)
 	for _, function := range functions {
 		if exportFunction {
-			response[function.GetConfig().Meta.Name] = fr.export(ctx, function, skipSpecCleanup)
+			response[function.GetConfig().Meta.Name] = fr.export(ctx, function, exportOptions)
 		} else {
-			response[function.GetConfig().Meta.Name] = fr.functionToAttributes(function, skipSpecCleanup)
+			response[function.GetConfig().Meta.Name] = fr.functionToAttributes(function, exportOptions.SkipSpecCleanUp)
 		}
 	}
 
@@ -106,12 +113,12 @@ func (fr *functionResource) GetByID(request *http.Request, id string) (restful.A
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get get function")
 	}
-	skipSpecCleanup := fr.getSkipSpecCleanupFlagFromRequest(request)
+	exportOptions := fr.getExportOptions(request)
 	if fr.GetURLParamBoolOrDefault(request, restful.ParamExport, false) {
-		return fr.export(ctx, function, skipSpecCleanup), nil
+		return fr.export(ctx, function, exportOptions), nil
 	}
 
-	return fr.functionToAttributes(function, skipSpecCleanup), nil
+	return fr.functionToAttributes(function, exportOptions.SkipSpecCleanUp), nil
 }
 
 // Create and deploy a function
@@ -233,12 +240,12 @@ func (fr *functionResource) GetCustomRoutes() ([]restful.CustomRoute, error) {
 	}, nil
 }
 
-func (fr *functionResource) export(ctx context.Context, function platform.Function, skipSpecCleanup bool) restful.Attributes {
+func (fr *functionResource) export(ctx context.Context, function platform.Function, exportOptions *ExportOptions) restful.Attributes {
 
 	functionConfig := function.GetConfig()
 	fr.Logger.DebugWithCtx(ctx, "Preparing function for export", "functionName", functionConfig.Meta.Name)
-	state := string(function.GetStatus().State)
-	functionConfig.PrepareFunctionForExport(false, skipSpecCleanup, state)
+	exportOptions.PrevState = string(function.GetStatus().State)
+	functionConfig.PrepareFunctionForExport(exportOptions)
 
 	fr.Logger.DebugWithCtx(ctx, "Exporting function", "functionName", functionConfig.Meta.Name)
 

--- a/pkg/dashboard/resource/resource.go
+++ b/pkg/dashboard/resource/resource.go
@@ -62,6 +62,19 @@ func (r *resource) getSkipSpecCleanupFlagFromRequest(request *http.Request) bool
 	return providedHeader != ""
 }
 
+func (r *resource) getAddPrevStatusFromRequest(request *http.Request) bool {
+	// get the flag to export with/without image
+	providedHeader := request.Header.Get(headers.AddPrevState)
+	return providedHeader != ""
+}
+
+func (r *resource) getExportOptions(request *http.Request) *ExportOptions {
+	return &ExportOptions{
+		AddPrevState:    r.getAddPrevStatusFromRequest(request),
+		SkipSpecCleanUp: r.getSkipSpecCleanupFlagFromRequest(request),
+	}
+}
+
 func (r *resource) getRequestAuthConfig(request *http.Request) (*platform.AuthConfig, error) {
 
 	// TODO: move as a middleware for specific routes

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -18,12 +18,12 @@ package functionconfig
 
 import (
 	"fmt"
-	"github.com/nuclio/nuclio/pkg/dashboard/resource"
 	"reflect"
 	"strconv"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/dashboard/resource"
 
 	"github.com/v3io/scaler/pkg/scalertypes"
 	appsv1 "k8s.io/api/apps/v1"

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -18,6 +18,7 @@ package functionconfig
 
 import (
 	"fmt"
+	"github.com/nuclio/nuclio/pkg/dashboard/resource"
 	"reflect"
 	"strconv"
 	"time"
@@ -580,12 +581,12 @@ func (c *Config) CleanFunctionSpec() {
 	}
 }
 
-func (c *Config) PrepareFunctionForExport(noScrub, skipSpecCleanup bool, state string) {
-	if !noScrub {
+func (c *Config) PrepareFunctionForExport(exportOptions *resource.ExportOptions) {
+	if !exportOptions.NoScrub {
 		c.scrubFunctionData()
 	}
 
-	if !skipSpecCleanup {
+	if !exportOptions.SkipSpecCleanUp {
 		c.CleanFunctionSpec()
 	}
 
@@ -593,7 +594,10 @@ func (c *Config) PrepareFunctionForExport(noScrub, skipSpecCleanup bool, state s
 	c.Meta.ResourceVersion = ""
 
 	c.AddSkipAnnotations()
-	c.AddPrevStateAnnotation(state)
+
+	if exportOptions.AddPrevState {
+		c.AddPrevStateAnnotation(exportOptions.PrevState)
+	}
 }
 
 func (c *Config) AddSkipAnnotations() {

--- a/pkg/nuctl/command/common/renderers.go
+++ b/pkg/nuctl/command/common/renderers.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/dashboard/resource"
 	"github.com/nuclio/nuclio/pkg/errgroup"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
@@ -45,8 +46,8 @@ func RenderFunctions(ctx context.Context,
 	functions []platform.Function,
 	format string,
 	writer io.Writer,
-	renderCallback func(functions []platform.Function, renderer func(interface{}) error, skipSpecCleanup bool) error,
-	skipSpecCleanup bool) error {
+	renderCallback func(functions []platform.Function, renderer func(interface{}) error, options *resource.ExportOptions) error,
+	options *resource.ExportOptions) error {
 
 	errGroup, errGroupCtx := errgroup.WithContext(ctx, logger)
 	var renderNodePort bool
@@ -124,9 +125,9 @@ func RenderFunctions(ctx context.Context,
 
 		rendererInstance.RenderTable(header, functionRecords)
 	case OutputFormatYAML:
-		return renderCallback(functions, rendererInstance.RenderYAML, skipSpecCleanup)
+		return renderCallback(functions, rendererInstance.RenderYAML, options)
 	case OutputFormatJSON:
-		return renderCallback(functions, rendererInstance.RenderJSON, skipSpecCleanup)
+		return renderCallback(functions, rendererInstance.RenderJSON, options)
 	}
 
 	return nil

--- a/pkg/nuctl/command/export.go
+++ b/pkg/nuctl/command/export.go
@@ -19,10 +19,10 @@ package command
 import (
 	"context"
 	"fmt"
-	"github.com/nuclio/nuclio/pkg/dashboard/resource"
 	"sync"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/dashboard/resource"
 	"github.com/nuclio/nuclio/pkg/errgroup"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	nuctlcommon "github.com/nuclio/nuclio/pkg/nuctl/command/common"


### PR DESCRIPTION
Jira - https://jira.iguazeng.com/browse/NUC-66
Subtask of https://jira.iguazeng.com/browse/NUC-63

Import functions nuctl command supports new flag  `--with-previous-state`. By default, import happens without keeping prevState annotation.