### PR TITLE
[Nuctl] Export with previous status annotations by default

### DIFF
--- a/pkg/common/headers/headers.go
+++ b/pkg/common/headers/headers.go
@@ -31,7 +31,6 @@ const (
 	FunctionEnrichApiGateways           = "X-Nuclio-Function-Enrich-Apigateways"
 	ImportedFunctionOnly                = "X-Nuclio-Imported-Function-Only"
 	SkipSpecCleanup                     = "X-Nuclio-Skip-Spec-Cleanup"
-	WithPrevState                       = "X-Nuclio-With-Prev-State"
 	VerifyExternalRegistry              = "X-Nuclio-Verify-External-Registry"
 
 	// Project headers

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -24,6 +24,5 @@ type CatchAndLogPanicOptions struct {
 type ExportFunctionOptions struct {
 	NoScrub         bool
 	SkipSpecCleanup bool
-	WithPrevState   bool
 	PrevState       string
 }

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -237,9 +237,7 @@ func (fr *functionResource) export(ctx context.Context, function platform.Functi
 
 	functionConfig := function.GetConfig()
 	fr.Logger.DebugWithCtx(ctx, "Preparing function for export", "functionName", functionConfig.Meta.Name)
-	if exportOptions.WithPrevState {
-		exportOptions.PrevState = string(function.GetStatus().State)
-	}
+	exportOptions.PrevState = string(function.GetStatus().State)
 	functionConfig.PrepareFunctionForExport(exportOptions)
 
 	fr.Logger.DebugWithCtx(ctx, "Exporting function", "functionName", functionConfig.Meta.Name)

--- a/pkg/dashboard/resource/resource.go
+++ b/pkg/dashboard/resource/resource.go
@@ -60,7 +60,6 @@ func (r *resource) getNamespaceOrDefault(providedNamespace string) string {
 func (r *resource) getExportOptionsFromRequest(request *http.Request) *common.ExportFunctionOptions {
 	return &common.ExportFunctionOptions{
 		SkipSpecCleanup: request.Header.Get(headers.SkipSpecCleanup) != "",
-		WithPrevState:   request.Header.Get(headers.WithPrevState) != "",
 	}
 }
 

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -939,11 +939,13 @@ func (suite *functionTestSuite) TestExportFunctionListSuccessful() {
 	returnedFunction1.Config.Meta.Name = "f1"
 	returnedFunction1.Config.Meta.Namespace = "f-namespace"
 	returnedFunction1.Config.Spec.Replicas = &replicas
+	returnedFunction1.Status.State = functionconfig.FunctionStateReady
 
 	returnedFunction2 := platform.AbstractFunction{}
 	returnedFunction2.Config.Meta.Name = "f2"
 	returnedFunction2.Config.Meta.Namespace = "f-namespace"
 	returnedFunction2.Config.Spec.Replicas = &replicas
+	returnedFunction2.Status.State = functionconfig.FunctionStateScaledToZero
 
 	// verify
 	verifyGetFunctionsOptions := func(getFunctionsOptions *platform.GetFunctionsOptions) bool {
@@ -968,6 +970,7 @@ func (suite *functionTestSuite) TestExportFunctionListSuccessful() {
 		"metadata": {
 			"name": "f1",
 			"annotations": {
+				"nuclio.io/previous-state": "ready",
 				"skip-build": "true",
 				"skip-deploy": "true"
 			}
@@ -984,6 +987,7 @@ func (suite *functionTestSuite) TestExportFunctionListSuccessful() {
 		"metadata": {
 			"name": "f2",
 			"annotations": {
+				"nuclio.io/previous-state": "scaledToZero",
 				"skip-build": "true",
 				"skip-deploy": "true"
 			}
@@ -1566,6 +1570,7 @@ func (suite *projectTestSuite) TestExportProjectSuccessful() {
       "metadata": {
         "name": "f1",
         "annotations": {
+          "nuclio.io/previous-state": "ready",
           "skip-build": "true",
           "skip-deploy": "true"
         }
@@ -1582,6 +1587,7 @@ func (suite *projectTestSuite) TestExportProjectSuccessful() {
       "metadata": {
         "name": "f2",
         "annotations": {
+          "nuclio.io/previous-state": "ready",
           "skip-build": "true",
           "skip-deploy": "true"
         }
@@ -1719,6 +1725,7 @@ func (suite *projectTestSuite) TestExportProjectListSuccessful() {
         "metadata": {
           "name": "f1",
           "annotations": {
+            "nuclio.io/previous-state": "ready",
             "skip-build": "true",
             "skip-deploy": "true"
           }
@@ -1755,6 +1762,7 @@ func (suite *projectTestSuite) TestExportProjectListSuccessful() {
         "metadata": {
           "name": "f2",
           "annotations": {
+            "nuclio.io/previous-state": "ready",
             "skip-build": "true",
             "skip-deploy": "true"
           }

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -898,7 +898,6 @@ func (suite *functionTestSuite) TestExportFunctionSuccessful() {
 
 	headers := map[string]string{
 		headers.FunctionNamespace: "f1-namespace",
-		headers.WithPrevState:     "true",
 	}
 
 	expectedStatusCode := http.StatusOK

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -593,11 +593,7 @@ func (c *Config) PrepareFunctionForExport(exportOptions *common.ExportFunctionOp
 	c.Meta.ResourceVersion = ""
 
 	c.AddSkipAnnotations()
-
-	if exportOptions.WithPrevState {
-		c.AddPrevStateAnnotation(exportOptions.PrevState)
-	}
-
+	c.AddPrevStateAnnotation(exportOptions.PrevState)
 }
 
 func (c *Config) AddSkipAnnotations() {


### PR DESCRIPTION
Reverts part of https://github.com/nuclio/nuclio/pull/3028 , while keeping the `ExportFunctionOptions` struct.

After some discussion it was decided to revert the default behavior, so older clients that run export without the newly added nuctl flag `--with-previous-status` will still export functions with it, and the redeployment will consider the previous state.