### PR TITLE
[Dashboard][Controller][Nuctl] Redeploy to desired state

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -531,10 +531,8 @@ func (fr *functionResource) redeployFunction(request *http.Request,
 	}
 
 	fr.Logger.DebugWith("Redeploying function",
-		"functionName",
-		id,
-		"desiredState",
-		*options.DesiredState)
+		"functionName", id,
+		"desiredState", *options.DesiredState)
 
 	if err := fr.getPlatform().RedeployFunction(ctx, &platform.RedeployFunctionOptions{
 		FunctionMeta:               &function.GetConfig().Meta,

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -518,6 +518,11 @@ func (fr *functionResource) redeployFunction(request *http.Request,
 		return nuclio.NewErrPreconditionFailed("No image field in function config spec, unable to redeploy")
 	}
 
+	if *options.DesiredState == functionconfig.FunctionStateScaledToZero &&
+		*function.GetConfig().Spec.MinReplicas > 0 {
+		return nuclio.NewErrPreconditionFailed("Cannot scale to zero a function with non-zero min replicas")
+	}
+
 	importedOnly := fr.headerValueIsTrue(request, headers.ImportedFunctionOnly)
 
 	if importedOnly && function.GetStatus().State != functionconfig.FunctionStateImported {

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -530,7 +530,11 @@ func (fr *functionResource) redeployFunction(request *http.Request,
 		return nil
 	}
 
-	fr.Logger.DebugWith("Redeploying function", "functionName", id)
+	fr.Logger.DebugWith("Redeploying function",
+		"functionName",
+		id,
+		"desiredState",
+		*options.DesiredState)
 
 	if err := fr.getPlatform().RedeployFunction(ctx, &platform.RedeployFunctionOptions{
 		FunctionMeta:               &function.GetConfig().Meta,

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -494,9 +494,7 @@ func (fr *functionResource) patchFunctionDesiredState(request *http.Request,
 	authConfig *platform.AuthConfig) error {
 
 	switch *options.DesiredState {
-	case functionconfig.FunctionStateReady:
-		return fr.redeployFunction(request, id, authConfig, options)
-	case functionconfig.FunctionStateScaledToZero:
+	case functionconfig.FunctionStateReady, functionconfig.FunctionStateScaledToZero:
 		return fr.redeployFunction(request, id, authConfig, options)
 	default:
 		return nuclio.NewErrBadRequest(fmt.Sprintf("Unsupported desired state in patch request: %s",

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1136,6 +1136,7 @@ func (suite *functionTestSuite) TestPatchFunction() {
 		expectedStatusCode int
 		importedOnly       string
 		desiredState       string
+		minReplicas        int
 	}{
 		{
 			name:               "importedFunction",
@@ -1144,6 +1145,7 @@ func (suite *functionTestSuite) TestPatchFunction() {
 			expectedStatusCode: http.StatusAccepted,
 			importedOnly:       "true",
 			desiredState:       "ready",
+			minReplicas:        1,
 		},
 		{
 			name:               "readyFunction",
@@ -1152,6 +1154,7 @@ func (suite *functionTestSuite) TestPatchFunction() {
 			expectedStatusCode: http.StatusNoContent,
 			importedOnly:       "true",
 			desiredState:       "ready",
+			minReplicas:        1,
 		},
 		{
 			name:               "readyFunctionToScaledToZero",
@@ -1160,12 +1163,23 @@ func (suite *functionTestSuite) TestPatchFunction() {
 			expectedStatusCode: http.StatusAccepted,
 			importedOnly:       "false",
 			desiredState:       "scaledToZero",
+			minReplicas:        0,
+		},
+		{
+			name:               "readyFunctionToScaledToZero",
+			functionName:       "scale-to-zero",
+			functionState:      functionconfig.FunctionStateReady,
+			expectedStatusCode: http.StatusPreconditionFailed,
+			importedOnly:       "false",
+			desiredState:       "scaledToZero",
+			minReplicas:        1,
 		},
 	} {
 		suite.Run(testCase.name, func() {
 			function := platform.AbstractFunction{}
 			function.Config.Meta.Name = testCase.functionName
 			function.Config.Meta.Namespace = namespace
+			function.GetConfig().Spec.MinReplicas = &testCase.minReplicas
 			function.Status.State = testCase.functionState
 			function.Config.Spec.Image = "image"
 

--- a/pkg/nuctl/command/redeploy.go
+++ b/pkg/nuctl/command/redeploy.go
@@ -108,7 +108,7 @@ func addRedeployFlags(cmd *cobra.Command,
 	cmd.Flags().BoolVar(&commandeer.importedOnly, "imported-only", false, "Deploy only imported functions")
 	cmd.Flags().BoolVarP(&commandeer.waitForFunction, "wait", "w", false, "Wait for function deployment to complete")
 	cmd.Flags().DurationVar(&commandeer.waitTimeout, "wait-timeout", 15*time.Minute, "Wait timeout duration for the function deployment, e.g 30s, 5m")
-	cmd.Flags().StringVar(&commandeer.desiredState, "desired-state", "ready", "Desired function state")
+	cmd.Flags().StringVar(&commandeer.desiredState, "desired-state", "ready", "Desired function state [\"ready\", \"scaledToZero\"]")
 }
 
 func (d *redeployCommandeer) redeploy(ctx context.Context, args []string) error {
@@ -190,7 +190,7 @@ func (d *redeployCommandeer) redeployFunctions(ctx context.Context, functionName
 			functionconfig.FunctionStateReady,
 			functionconfig.FunctionStateScaledToZero,
 		}) {
-		return errors.New("Desired status is not allowed to be set")
+		return errors.New(fmt.Sprintf("Desired state %s is not supported", d.desiredState))
 	}
 
 	patchErrGroup, _ := errgroup.WithContextSemaphore(ctx, d.rootCommandeer.loggerInstance, uint(d.betaCommandeer.concurrency))

--- a/pkg/nuctl/command/redeploy.go
+++ b/pkg/nuctl/command/redeploy.go
@@ -224,7 +224,10 @@ func (d *redeployCommandeer) redeployFunctions(ctx context.Context, functionName
 // patchFunction patches a single function
 func (d *redeployCommandeer) patchFunction(ctx context.Context, functionName string, desiredState string) error {
 
-	d.rootCommandeer.loggerInstance.InfoWithCtx(ctx, "Redeploying function", "function", functionName)
+	d.rootCommandeer.loggerInstance.InfoWithCtx(ctx,
+		"Redeploying function",
+		"function", functionName,
+		"desiredState", desiredState)
 
 	// patch function
 	patchOptions := map[string]string{

--- a/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
+++ b/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
@@ -43,13 +43,6 @@ func (nf *NuclioFunction) GetComputedReplicas() *int32 {
 		nf.Status.State == functionconfig.FunctionStateImported ||
 		nf.Status.State == functionconfig.FunctionStateScaledToZero ||
 		nf.Status.State == functionconfig.FunctionStateWaitingForScaleResourcesToZero {
-
-		if (nf.Status.State == functionconfig.FunctionStateWaitingForScaleResourcesToZero ||
-			nf.Status.State == functionconfig.FunctionStateScaledToZero) && nf.Spec.MinReplicas != nil && *nf.Spec.MinReplicas > 0 {
-			minReplicas := int32(*nf.Spec.MinReplicas)
-			return &minReplicas
-		}
-
 		return &zero
 	} else if nf.Spec.Replicas != nil {
 

--- a/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
+++ b/pkg/platform/kube/apis/nuclio.io/v1beta1/types.go
@@ -43,6 +43,13 @@ func (nf *NuclioFunction) GetComputedReplicas() *int32 {
 		nf.Status.State == functionconfig.FunctionStateImported ||
 		nf.Status.State == functionconfig.FunctionStateScaledToZero ||
 		nf.Status.State == functionconfig.FunctionStateWaitingForScaleResourcesToZero {
+
+		if (nf.Status.State == functionconfig.FunctionStateWaitingForScaleResourcesToZero ||
+			nf.Status.State == functionconfig.FunctionStateScaledToZero) && nf.Spec.MinReplicas != nil && *nf.Spec.MinReplicas > 0 {
+			minReplicas := int32(*nf.Spec.MinReplicas)
+			return &minReplicas
+		}
+
 		return &zero
 	} else if nf.Spec.Replicas != nil {
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -564,6 +564,7 @@ func (p *Platform) RedeployFunction(ctx context.Context, redeployFunctionOptions
 	case functionconfig.FunctionStateScaledToZero:
 		state = functionconfig.FunctionStateWaitingForScaleResourcesToZero
 	default:
+		// setting a different function state is not supported so we fallback to ready
 		state = functionconfig.FunctionStateWaitingForResourceConfiguration
 	}
 

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -96,6 +96,7 @@ type RedeployFunctionOptions struct {
 	AuthSession                 auth.Session
 	PermissionOptions           opa.PermissionOptions
 	CreationStateUpdatedTimeout time.Duration
+	DesiredState                functionconfig.FunctionState
 }
 
 // CreateFunctionBuildResult holds information detected/generated as a result of a build process


### PR DESCRIPTION
Jira: [NUC-67](https://jira.iguazeng.com/browse/NUC-67)

Since we currently support function deployment not only as `ready`, but also as `scaledToZero`, we decided to allow the user to specify the `desired-state` parameter in the redeploy command. We currently only support `scaledToZero` and `ready` states. Default desired state is `ready`