### PR TITLE
[CI] Skip building dotnet for arm64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,6 +88,12 @@ jobs:
         - arm64
         - amd64
         docker_image_rule: ${{ fromJson(needs.image_matrix_prep.outputs.matrix) }}
+        exclude:
+
+
+          # issues with building on qemu
+          - arch: arm64
+            docker_image_rule: handler-builder-dotnetcore-onbuild
     steps:
     - name: Prepare envs
       run: |


### PR DESCRIPTION
There are some issues with building dotnet on qemu for arm64