### PR TITLE
[Nuctl] Log how to redeploy from report if functions failed redeployment

### DIFF
--- a/pkg/nuctl/command/common/patchmanifest.go
+++ b/pkg/nuctl/command/common/patchmanifest.go
@@ -155,6 +155,11 @@ func (m *PatchManifest) SaveToFile(ctx context.Context, loggerInstance logger.Lo
 			"err", err,
 			"path", path)
 	}
+
+	if len(m.GetFailed()) > 0 {
+		loggerInstance.WarnWithCtx(ctx,
+			"Some functions failed to patch. To retry redeploying retryable functions, rerun the command with the \"--from-report\" flag")
+	}
 }
 
 func readManifestFromFile(path string) (*patchManifest, error) {

--- a/pkg/nuctl/command/common/patchmanifest.go
+++ b/pkg/nuctl/command/common/patchmanifest.go
@@ -156,9 +156,9 @@ func (m *PatchManifest) SaveToFile(ctx context.Context, loggerInstance logger.Lo
 			"path", path)
 	}
 
-	if len(m.GetFailed()) > 0 {
+	if len(m.GetRetryableFunctionNames()) > 0 {
 		loggerInstance.WarnWithCtx(ctx,
-			"Some functions failed to patch. To retry redeploying retryable functions, rerun the command with the \"--from-report\" flag")
+			"Some functions failed to patch. To retry redeploying them, rerun the command with the \"--from-report\" flag")
 	}
 }
 

--- a/pkg/nuctl/command/redeploy.go
+++ b/pkg/nuctl/command/redeploy.go
@@ -131,6 +131,12 @@ func (d *redeployCommandeer) redeploy(ctx context.Context, args []string) error 
 	}
 
 	if len(args) == 0 {
+		if d.fromReport {
+			// this means that no explicit function names were given, and we don't have any retryable functions
+			// from the report file, so we can exit
+			d.rootCommandeer.loggerInstance.Info("No functions to redeploy")
+			return nil
+		}
 
 		// redeploy all functions in the namespace
 		if err := d.redeployAllFunctions(ctx); err != nil {


### PR DESCRIPTION
When some function fail to redeploy and the redeployment report is saved, log that it is possible to redeploy retryable functions from the report.