### PR TITLE
[Nuctl] Keep image in spec by default when exporting

### DIFF
--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -22,7 +22,7 @@ type CatchAndLogPanicOptions struct {
 }
 
 type ExportFunctionOptions struct {
-	NoScrub         bool
-	SkipSpecCleanup bool
-	PrevState       string
+	NoScrub     bool
+	CleanupSpec bool
+	PrevState   string
 }

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -84,7 +84,7 @@ func (fr *functionResource) GetAll(request *http.Request) (map[string]restful.At
 		if exportFunction {
 			response[function.GetConfig().Meta.Name] = fr.export(ctx, function, exportOptions)
 		} else {
-			response[function.GetConfig().Meta.Name] = fr.functionToAttributes(function, exportOptions.SkipSpecCleanup)
+			response[function.GetConfig().Meta.Name] = fr.functionToAttributes(function, exportOptions.CleanupSpec)
 		}
 	}
 
@@ -111,7 +111,7 @@ func (fr *functionResource) GetByID(request *http.Request, id string) (restful.A
 		return fr.export(ctx, function, exportOptions), nil
 	}
 
-	return fr.functionToAttributes(function, exportOptions.SkipSpecCleanup), nil
+	return fr.functionToAttributes(function, exportOptions.CleanupSpec), nil
 }
 
 // Create and deploy a function
@@ -553,9 +553,9 @@ func (fr *functionResource) redeployFunction(request *http.Request,
 	return nuclio.ErrAccepted
 }
 
-func (fr *functionResource) functionToAttributes(function platform.Function, skipSpecCleanup bool) restful.Attributes {
+func (fr *functionResource) functionToAttributes(function platform.Function, cleanupSpec bool) restful.Attributes {
 	functionConfig := function.GetConfig()
-	if !skipSpecCleanup {
+	if cleanupSpec {
 		functionConfig.CleanFunctionSpec()
 	}
 

--- a/pkg/dashboard/resource/resource.go
+++ b/pkg/dashboard/resource/resource.go
@@ -59,7 +59,7 @@ func (r *resource) getNamespaceOrDefault(providedNamespace string) string {
 
 func (r *resource) getExportOptionsFromRequest(request *http.Request) *common.ExportFunctionOptions {
 	return &common.ExportFunctionOptions{
-		SkipSpecCleanup: request.Header.Get(headers.SkipSpecCleanup) != "",
+		CleanupSpec: request.Header.Get(headers.SkipSpecCleanup) != "",
 	}
 }
 

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -585,7 +585,7 @@ func (c *Config) PrepareFunctionForExport(exportOptions *common.ExportFunctionOp
 		c.scrubFunctionData()
 	}
 
-	if !exportOptions.SkipSpecCleanup {
+	if exportOptions.CleanupSpec {
 		c.CleanFunctionSpec()
 	}
 

--- a/pkg/nuctl/command/export.go
+++ b/pkg/nuctl/command/export.go
@@ -33,11 +33,11 @@ import (
 )
 
 type exportCommandeer struct {
-	cmd             *cobra.Command
-	rootCommandeer  *RootCommandeer
-	scrubber        *functionconfig.Scrubber
-	noScrub         bool
-	skipSpecCleanup bool
+	cmd            *cobra.Command
+	rootCommandeer *RootCommandeer
+	scrubber       *functionconfig.Scrubber
+	noScrub        bool
+	cleanupSpec    bool
 }
 
 func newExportCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *exportCommandeer {
@@ -56,7 +56,7 @@ to the standard output, in JSON or YAML format`,
 	}
 
 	cmd.PersistentFlags().BoolVar(&commandeer.noScrub, "no-scrub", false, "Export all function data, including sensitive and unnecessary data")
-	cmd.PersistentFlags().BoolVar(&commandeer.skipSpecCleanup, "skip-spec-cleanup", false, "Do not clear the image info from the function spec")
+	cmd.PersistentFlags().BoolVar(&commandeer.cleanupSpec, "cleanup-spec", false, "Clean up the image info from the function spec")
 
 	exportFunctionCommand := newExportFunctionCommandeer(ctx, commandeer).cmd
 	exportProjectCommand := newExportProjectCommandeer(ctx, commandeer).cmd
@@ -121,7 +121,7 @@ Arguments:
 				return nil
 			}
 			exportOptions := &common.ExportFunctionOptions{
-				SkipSpecCleanup: commandeer.skipSpecCleanup,
+				CleanupSpec: commandeer.cleanupSpec,
 			}
 
 			// render the functions
@@ -249,7 +249,7 @@ Arguments:
 			}
 
 			// render the projects
-			return nuctlcommon.RenderProjects(ctx, projects, commandeer.output, cmd.OutOrStdout(), commandeer.renderProjectConfig, commandeer.skipSpecCleanup)
+			return nuctlcommon.RenderProjects(ctx, projects, commandeer.output, cmd.OutOrStdout(), commandeer.renderProjectConfig, commandeer.cleanupSpec)
 		},
 	}
 
@@ -352,8 +352,8 @@ func (e *exportProjectCommandeer) exportProject(ctx context.Context, projectConf
 	functions, functionEvents, err := e.exportProjectFunctionsAndFunctionEvents(ctx,
 		projectConfig,
 		&common.ExportFunctionOptions{
-			SkipSpecCleanup: e.skipSpecCleanup,
-			NoScrub:         e.noScrub})
+			CleanupSpec: e.cleanupSpec,
+			NoScrub:     e.noScrub})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It was decided to keep the image spec by default when we export function