### PR TITLE
[Trigger] Fix explicit ack mode population

### DIFF
--- a/pkg/processor/trigger/types.go
+++ b/pkg/processor/trigger/types.go
@@ -146,8 +146,10 @@ func (c *Configuration) PopulateExplicitAckMode(explicitAckModeValue string,
 		c.ExplicitAckMode = functionconfig.ExplicitAckModeExplicitOnly
 	default:
 
-		// default explicit ack mode to 'disable'
-		if triggerConfigurationExplicitAckMode == "" {
+		// default explicit ack mode to 'disable' if not set
+		if triggerConfigurationExplicitAckMode != "" {
+			c.ExplicitAckMode = triggerConfigurationExplicitAckMode
+		} else {
 			c.ExplicitAckMode = functionconfig.ExplicitAckModeDisable
 		}
 	}


### PR DESCRIPTION
When populating explicit ack mode on the trigger configuration, the value from `spec.trigger[<name>].explicitAckMode` was ignored and the default `disable` mode was used, unless given in the annotations.