### PR TITLE
[Processor] Rework kafka stream processing logic 

### DIFF
--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -106,10 +106,6 @@ const (
 
 	// DefaultWorkerTerminationTimeout wait time for workers to drop or ack events before rebalance initiates
 	DefaultWorkerTerminationTimeout string = "10s"
-
-	// DefaultWaitExplicitAckDuringRebalanceTimeout wait time for ExplicitAck before unsubscribing
-	// from control messages in explicitAck mode
-	DefaultWaitExplicitAckDuringRebalanceTimeout = "0s"
 )
 
 func ExplicitAckModeInSlice(ackMode ExplicitAckMode, ackModes []ExplicitAckMode) bool {

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -80,6 +80,7 @@ type Trigger struct {
 	WorkerAvailabilityTimeoutMilliseconds *int              `json:"workerAvailabilityTimeoutMilliseconds,omitempty"`
 	WorkerAllocatorName                   string            `json:"workerAllocatorName,omitempty"`
 	ExplicitAckMode                       ExplicitAckMode   `json:"explicitAckMode,omitempty"`
+	WaitExplicitAckDuringRebalanceTimeout string            `json:"waitExplicitAckDuringRebalanceTimeout,omitempty"`
 	WorkerTerminationTimeout              string            `json:"workerTerminationTimeout,omitempty"`
 
 	// Dealer Information
@@ -105,6 +106,10 @@ const (
 
 	// DefaultWorkerTerminationTimeout wait time for workers to drop or ack events before rebalance initiates
 	DefaultWorkerTerminationTimeout string = "10s"
+
+	// DefaultWaitExplicitAckDuringRebalanceTimeout wait time for ExplicitAck before unsubscribing
+	// from control messages in explicitAck mode
+	DefaultWaitExplicitAckDuringRebalanceTimeout = "0s"
 )
 
 func ExplicitAckModeInSlice(ackMode ExplicitAckMode, ackModes []ExplicitAckMode) bool {

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1690,6 +1690,10 @@ func (ap *Platform) enrichExplicitAckParams(ctx context.Context, functionConfig 
 			triggerInstance.WorkerTerminationTimeout = functionconfig.DefaultWorkerTerminationTimeout
 		}
 
+		if triggerInstance.WaitExplicitAckDuringRebalanceTimeout == "" {
+			triggerInstance.WaitExplicitAckDuringRebalanceTimeout = functionconfig.DefaultWaitExplicitAckDuringRebalanceTimeout
+		}
+
 		functionConfig.Spec.Triggers[triggerName] = triggerInstance
 	}
 

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1690,10 +1690,6 @@ func (ap *Platform) enrichExplicitAckParams(ctx context.Context, functionConfig 
 			triggerInstance.WorkerTerminationTimeout = functionconfig.DefaultWorkerTerminationTimeout
 		}
 
-		if triggerInstance.WaitExplicitAckDuringRebalanceTimeout == "" {
-			triggerInstance.WaitExplicitAckDuringRebalanceTimeout = functionconfig.DefaultWaitExplicitAckDuringRebalanceTimeout
-		}
-
 		functionConfig.Spec.Triggers[triggerName] = triggerInstance
 	}
 

--- a/pkg/processor/trigger/kafka/event.go
+++ b/pkg/processor/trigger/kafka/event.go
@@ -60,6 +60,10 @@ func (e *Event) GetHeader(key string) interface{} {
 func (e *Event) getHeadersAsMap() map[string]interface{} {
 	headersMap := map[string]interface{}{}
 
+	if e.kafkaMessage == nil {
+		return headersMap
+	}
+
 	if e.kafkaMessage.Headers == nil {
 		return headersMap
 	}

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -105,6 +105,7 @@ func newTrigger(parentLogger logger.Logger,
 		"fetchMax", configuration.FetchMax,
 		"channelBufferSize", configuration.ChannelBufferSize,
 		"maxWaitHandlerDuringRebalance", configuration.maxWaitHandlerDuringRebalance,
+		"waitExplicitAckDuringRebalanceTimeout", configuration.waitExplicitAckDuringRebalanceTimeout,
 		"logLevel", configuration.LogLevel)
 
 	kafkaTrigger.kafkaConfig, err = kafkaTrigger.newKafkaConfig()
@@ -192,9 +193,6 @@ func (k *kafka) Cleanup(session sarama.ConsumerGroupSession) error {
 func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
 	var submitError error
 
-	// cleared when the consumption should stop
-	consumeMessages := true
-
 	submittedEventInstance := submittedEvent{
 		done: make(chan error),
 	}
@@ -203,12 +201,6 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 	submittedEventChan := make(chan *submittedEvent)
 	explicitAckControlMessageChan := make(chan *controlcommunication.ControlMessage)
 	workerDrainingCompleteChan := make(chan bool)
-	readyForRebalanceChan := make(chan bool)
-
-	// indicate whether this partition worker was drained
-	// this is used to avoid race condition where 2 different partitions sharing the same worker
-	// will both try to reset the drain flag needlessly
-	var drainedWorker bool
 
 	// submit the events in a goroutine so that we can unblock immediately
 	go k.eventSubmitter(claim, submittedEventChan)
@@ -228,132 +220,52 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 	k.Logger.DebugWith("Starting claim consumption",
 		"partition", claim.Partition(),
 		"ackWindowSize", ackWindowSize)
-
-	// the exit condition is that (a) the Messages() channel was closed and (b) we got a signal telling us
-	// to stop consumption
-	for message := range claim.Messages() {
-		if !consumeMessages {
-			k.Logger.DebugWith("Stopping message consumption", "partition", claim.Partition())
-			break
-		}
-
-		// allocate a worker for this topic/partition
-		workerInstance, cookie, err := k.partitionWorkerAllocator.AllocateWorker(claim.Topic(),
-			int(claim.Partition()),
-			nil)
-		if err != nil {
-			return errors.Wrap(err, "Failed to allocate worker")
-		}
-
-		submittedEventInstance.event.kafkaMessage = message
-		submittedEventInstance.worker = workerInstance
-
-		// handle in the goroutine so we don't block
-		submittedEventChan <- &submittedEventInstance
-
-		// wait for handling done or indication to stop
+loop:
+	for {
 		select {
-		case err := <-submittedEventInstance.done:
+		case message := <-claim.Messages():
 
-			// we successfully submitted the message to the handler. mark it
-			if err == nil {
-				session.MarkOffset(
-					message.Topic,
-					message.Partition,
-					message.Offset+1-ackWindowSize,
-					"",
-				)
+			// allocate a worker for this topic/partition
+			workerInstance, cookie, err := k.partitionWorkerAllocator.AllocateWorker(claim.Topic(),
+				int(claim.Partition()),
+				nil)
+			if err != nil {
+				return errors.Wrap(err, "Failed to allocate worker")
+			}
+
+			submittedEventInstance.event.kafkaMessage = message
+			submittedEventInstance.worker = workerInstance
+
+			// handle in the goroutine so we don't block
+			submittedEventChan <- &submittedEventInstance
+
+			select {
+			case err := <-submittedEventInstance.done:
+
+				// we successfully submitted the message to the handler. mark it
+				if err == nil {
+					session.MarkOffset(
+						message.Topic,
+						message.Partition,
+						message.Offset+1-ackWindowSize,
+						"",
+					)
+				}
+			case <-session.Context().Done():
+				k.drainOnRebalance(session, claim, workerInstance, &submittedEventInstance, message, true)
+			}
+
+			if err := k.partitionWorkerAllocator.ReleaseWorker(cookie, workerInstance); err != nil {
+				return errors.Wrap(err, "Failed to release worker")
 			}
 
 		case <-session.Context().Done():
-			k.Logger.DebugWith("Got signal to stop consumption",
-				"wait", k.configuration.maxWaitHandlerDuringRebalance.String(),
-				"partition", claim.Partition())
-
-			// don't consume any more messages
-			consumeMessages = false
-
-			// trigger is ready for rebalance if both the handler is done and
-			// the workers are finished draining events
-			go func() {
-				defer common.CatchAndLogPanicWithOptions(k.ctx, // nolint: errcheck
-					k.Logger,
-					"Recover from panic after trying to write into channel, which was closed because of wait for rebalance timeout",
-					&common.CatchAndLogPanicOptions{
-						Args:          []interface{}{"partition", claim.Partition()},
-						CustomHandler: nil,
-					})
-				var wg sync.WaitGroup
-				wg.Add(2)
-				go func() {
-					err := <-submittedEventInstance.done
-
-					// we successfully submitted the message to the handler. mark it
-					if err == nil {
-						session.MarkOffset(
-							message.Topic,
-							message.Partition,
-							message.Offset+1-ackWindowSize,
-							"",
-						)
-					}
-					k.Logger.DebugWith("Handler done", "partition", claim.Partition())
-					wg.Done()
-				}()
-				go func() {
-
-					// this needs to occur once. the reason is that this specific function (ConsumeClaim)
-					// runs in parallel for each partition, and we want to make sure that we only
-					// drain the workers once.
-					if err := k.SignalWorkerDraining(); err != nil {
-						k.Logger.DebugWith("Failed to signal worker draining",
-							"err", err.Error(),
-							"partition", claim.Partition())
-					} else {
-						drainedWorker = true
-					}
-					wg.Done()
-				}()
-
-				wg.Wait()
-				readyForRebalanceChan <- true
-			}()
-
-			// wait a for rebalance readiness or max timeout
-			select {
-			case <-readyForRebalanceChan:
-				k.Logger.DebugWith("Handler done, rebalancing will commence",
-					"partition", claim.Partition())
-
-			case <-time.After(k.configuration.maxWaitHandlerDuringRebalance):
-				k.Logger.DebugWith("Timed out waiting for handler to complete",
-					"partition", claim.Partition())
-
-				// mark this as a failure, metric-wise
-				k.UpdateStatistics(false)
-
-				// restart the worker, and having failed that shut down
-				if err := k.cancelEventHandling(workerInstance, claim); err != nil {
-					k.Logger.DebugWith("Failed to cancel event handling",
-						"err", err.Error(),
-						"partition", claim.Partition())
-
-					panic("Failed to cancel event handling")
-				}
-			}
-		}
-
-		// release the worker from whence it came
-		if err := k.partitionWorkerAllocator.ReleaseWorker(cookie, workerInstance); err != nil {
-			return errors.Wrap(err, "Failed to release worker")
+			k.drainOnRebalance(session, claim, nil, nil, nil, false)
+			break loop
 		}
 	}
 
 	k.Logger.DebugWith("Claim consumption stopped", "partition", claim.Partition())
-
-	if drainedWorker {
-		k.ResetWorkerTerminationState()
-	}
 
 	// unsubscribe channel from the streamAck control message kind before closing it
 	if err := k.UnsubscribeFromControlMessageKind(controlcommunication.StreamMessageAckKind, explicitAckControlMessageChan); err != nil {
@@ -364,9 +276,111 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 	close(submittedEventChan)
 	close(explicitAckControlMessageChan)
 	close(workerDrainingCompleteChan)
-	close(readyForRebalanceChan)
 
 	return submitError
+}
+
+func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
+	claim sarama.ConsumerGroupClaim,
+	workerInstance *worker.Worker,
+	submittedEventInstance *submittedEvent,
+	message *sarama.ConsumerMessage,
+	handlingMessage bool) {
+
+	k.Logger.DebugWith("Got signal to stop consumption",
+		"wait", k.configuration.maxWaitHandlerDuringRebalance.String(),
+		"partition", claim.Partition())
+
+	readyForRebalanceChan := make(chan bool)
+	defer close(readyForRebalanceChan)
+
+	// indicate whether this partition worker was drained
+	// this is used to avoid race condition where 2 different partitions sharing the same worker
+	// will both try to reset the drain flag needlessly
+	var drainedWorker bool
+
+	go func() {
+		defer common.CatchAndLogPanicWithOptions(k.ctx, // nolint: errcheck
+			k.Logger,
+			"Recover from panic after trying to write into channel, which was closed because of wait for rebalance timeout",
+			&common.CatchAndLogPanicOptions{
+				Args:          []interface{}{"partition", claim.Partition()},
+				CustomHandler: nil,
+			})
+		var wg sync.WaitGroup
+		if handlingMessage {
+			wg.Add(2)
+			go func() {
+				err := <-submittedEventInstance.done
+
+				// we successfully submitted the message to the handler. mark it
+				if err == nil {
+					session.MarkOffset(
+						message.Topic,
+						message.Partition,
+						message.Offset+1-int64(k.configuration.ackWindowSize),
+						"",
+					)
+				}
+				k.Logger.DebugWith("Handler done", "partition", claim.Partition())
+				wg.Done()
+			}()
+		} else {
+			wg.Add(1)
+		}
+
+		go func() {
+			// this needs to occur once. the reason is that this specific function (ConsumeClaim)
+			// runs in parallel for each partition, and we want to make sure that we only
+			// drain the workers once.
+			if err := k.SignalWorkerDraining(); err != nil {
+				k.Logger.DebugWith("Failed to signal worker draining",
+					"err", err.Error(),
+					"partition", claim.Partition())
+			} else {
+				drainedWorker = true
+			}
+			wg.Done()
+		}()
+
+		wg.Wait()
+		readyForRebalanceChan <- true
+	}()
+
+	// wait a for rebalance readiness or max timeout
+	select {
+	case <-readyForRebalanceChan:
+		k.Logger.DebugWith("Handler done, rebalancing will commence",
+			"partition", claim.Partition())
+		if functionconfig.ExplicitAckEnabled(k.configuration.ExplicitAckMode) {
+			k.Logger.DebugWith("Wait for control messages from runtime before rebalance",
+				"wait time", k.configuration.waitExplicitAckDuringRebalanceTimeout)
+
+			time.Sleep(k.configuration.waitExplicitAckDuringRebalanceTimeout)
+		}
+
+	case <-time.After(k.configuration.maxWaitHandlerDuringRebalance):
+		k.Logger.DebugWith("Timed out waiting for handler to complete",
+			"partition", claim.Partition())
+
+		// mark this as a failure, metric-wise
+		k.UpdateStatistics(false)
+
+		if handlingMessage {
+			// restart the worker, and having failed that shut down
+			if err := k.cancelEventHandling(workerInstance, claim); err != nil {
+				k.Logger.DebugWith("Failed to cancel event handling",
+					"err", err.Error(),
+					"partition", claim.Partition())
+
+				panic("Failed to cancel event handling")
+			}
+		}
+	}
+
+	if drainedWorker {
+		k.ResetWorkerTerminationState()
+	}
 }
 
 func (k *kafka) eventSubmitter(claim sarama.ConsumerGroupClaim, submittedEventChan chan *submittedEvent) {
@@ -632,7 +646,8 @@ func (k *kafka) explicitAckHandler(session sarama.ConsumerGroupSession,
 		)
 	}
 
-	k.Logger.InfoWith("Stopped listening for explicit ack control messages")
+	k.Logger.InfoWith("Stopped listening for explicit ack control messages",
+		"partition", partitionNumber)
 }
 
 func (k *kafka) resolveNoAckMessage(response interface{}, submittedEvent *submittedEvent) error {

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -106,7 +106,6 @@ func newTrigger(parentLogger logger.Logger,
 		"channelBufferSize", configuration.ChannelBufferSize,
 		"maxWaitHandlerDuringRebalance", configuration.maxWaitHandlerDuringRebalance,
 		"waitExplicitAckDuringRebalanceTimeout", configuration.waitExplicitAckDuringRebalanceTimeout,
-		"WaitExplicitAckDuringRebalanceTimeout", configuration.WaitExplicitAckDuringRebalanceTimeout,
 		"logLevel", configuration.LogLevel)
 
 	kafkaTrigger.kafkaConfig, err = kafkaTrigger.newKafkaConfig()

--- a/pkg/processor/trigger/kafka/types.go
+++ b/pkg/processor/trigger/kafka/types.go
@@ -119,7 +119,6 @@ func NewConfiguration(id string,
 
 	workerAllocationModeValue := ""
 	explicitAckModeValue := ""
-	waitExplicitAckDuringRebalanceTimeout := ""
 
 	err = newConfiguration.PopulateConfigurationFromAnnotations([]trigger.AnnotationConfigField{
 		{Key: "nuclio.io/kafka-session-timeout", ValueString: &newConfiguration.SessionTimeout},
@@ -174,7 +173,7 @@ func NewConfiguration(id string,
 		{Key: "nuclio.io/kafka-explicit-ack-mode", ValueString: &explicitAckModeValue},
 
 		// allow changing explicit ack mode via annotation
-		{Key: "nuclio.io/wait-explicit-ack-during-rebalance-timeout", ValueString: &waitExplicitAckDuringRebalanceTimeout},
+		{Key: "nuclio.io/wait-explicit-ack-during-rebalance-timeout", ValueString: &triggerConfiguration.WaitExplicitAckDuringRebalanceTimeout},
 	})
 
 	if err != nil {
@@ -189,8 +188,6 @@ func NewConfiguration(id string,
 		triggerConfiguration.ExplicitAckMode); err != nil {
 		return nil, errors.Wrap(err, "Failed to populate explicit ack mode")
 	}
-
-	triggerConfiguration.WaitExplicitAckDuringRebalanceTimeout = waitExplicitAckDuringRebalanceTimeout
 
 	if ackWindowSizeInterface, ok := newConfiguration.Attributes["ackWindowSize"]; ok {
 		var ackWindowSize int
@@ -305,10 +302,10 @@ func NewConfiguration(id string,
 			Default: 5 * time.Second,
 		},
 		{
-			Name:    "",
+			Name:    "wait explicit ack during rebalance timeout",
 			Value:   newConfiguration.WaitExplicitAckDuringRebalanceTimeout,
 			Field:   &newConfiguration.waitExplicitAckDuringRebalanceTimeout,
-			Default: 0 * time.Second,
+			Default: 1 * time.Millisecond,
 		},
 	} {
 		if err = newConfiguration.ParseDurationOrDefault(&durationConfigField); err != nil {


### PR DESCRIPTION
Jira - https://jira.iguazeng.com/browse/NUC-62

Within this PR:

* Logic of processing kafka event has been reworked so we can faster handle session closing
* Configurable timeout to wait for ExplicitAck from runtime-side before rebalance added