### PR TITLE
[CI] Run tests with long execution time in parallel with the fast ones

### DIFF
--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -15,15 +15,8 @@
 name: Periodic
 
 on:
-  pull_request:
-    branches:
-      - development
-      - "[0-9]+.[0-9]+.x"
-
-  # Run CI also on push to master
-  push:
-    branches:
-      - master
+  schedule:
+  - cron:  '0 */12 * * *'
 
 env:
   DOCKER_BUILDKIT: 1

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -15,8 +15,15 @@
 name: Periodic
 
 on:
-  schedule:
-  - cron:  '0 */12 * * *'
+  pull_request:
+    branches:
+      - development
+      - "[0-9]+.[0-9]+.x"
+
+  # Run CI also on push to master
+  push:
+    branches:
+      - master
 
 env:
   DOCKER_BUILDKIT: 1
@@ -28,8 +35,12 @@ jobs:
     # https://github.com/actions/runner-images/discussions/7188
     runs-on: ubuntu-20.04
 
+    strategy:
+      fail-fast: false
+      matrix:
+        command: [nuctl-tests,dotnet-tests,golang-tests,java-tests,python-tests,python-runtime-tests,fast-tests]
+
     # let's not run this on every fork, comment this out when developing periodic on your fork
-    if: github.repository == 'nuclio/nuclio'
 
     steps:
     - uses: actions/checkout@v3
@@ -48,6 +59,6 @@ jobs:
         NUCLIO_NUCTL_CREATE_SYMLINK: false
 
     - name: Test
-      run: make test
+      run: LIST_TESTS_MAKE_COMMAND=${{ matrix.command }} make test
       env:
         NUCLIO_CI_SKIP_STRESS_TEST: true

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -34,6 +34,7 @@ jobs:
         command: [nuctl-tests,dotnet-tests,golang-tests,java-tests,python-tests,python-runtime-tests,fast-tests]
 
     # let's not run this on every fork, comment this out when developing periodic on your fork
+    if: github.repository == 'nuclio/nuclio'
 
     steps:
     - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ GO_VERSION := $(shell go version | cut -d " " -f 3)
 GOPATH ?= $(shell go env GOPATH)
 OS_NAME = $(shell uname)
 KUBECONFIG := $(if $(KUBECONFIG),$(KUBECONFIG),$(HOME)/.kube/config)
+SHELL:=/bin/bash
 
 # upstream repo
 NUCLIO_DOCKER_REPO ?= quay.io/nuclio
@@ -73,6 +74,9 @@ GO_LINK_FLAGS_INJECT_VERSION := $(GO_LINK_FLAGS) \
 
 # Nuclio test timeout
 NUCLIO_GO_TEST_TIMEOUT ?= "30m"
+
+NUCLIO_DEFAULT_LIST_TESTS_MAKE_COMMAND=list-all-dirs-with-tests
+LIST_TESTS_MAKE_COMMAND := $(if $(LIST_TESTS_MAKE_COMMAND),$(LIST_TESTS_MAKE_COMMAND),$(NUCLIO_DEFAULT_LIST_TESTS_MAKE_COMMAND))
 
 # Docker client cli to be used
 NUCLIO_DOCKER_CLIENT_VERSION ?= 23.0.1
@@ -695,12 +699,13 @@ test-docker-nuctl:
 
 .PHONY: test-undockerized
 test-undockerized: ensure-gopath
-	go test \
+	${eval LIST=${shell make --no-print-directory $(LIST_TESTS_MAKE_COMMAND)}}
+	go test  \
 		-tags="test_integration,test_local" \
 		-v \
 		-p 1 \
 		--timeout $(NUCLIO_GO_TEST_TIMEOUT) \
-		./cmd/... ./pkg/...
+		${LIST}
 
 .PHONY: test-k8s-undockerized
 test-k8s-undockerized: ensure-gopath
@@ -714,16 +719,19 @@ test-k8s-undockerized: ensure-gopath
 
 .PHONY: test-broken-undockerized
 test-broken-undockerized: ensure-gopath
-	go test \
+	${eval LIST=${shell make --no-print-directory $(LIST_TESTS_MAKE_COMMAND)}}
+	go test  \
 		-tags="test_integration,test_broken" \
 		-v \
 		-p 1 \
 		--timeout $(NUCLIO_GO_TEST_TIMEOUT) \
-		./cmd/... ./pkg/...
+		${LIST}
 
 .PHONY: test
 test: build-test
-	$(eval NUCLIO_TEST_MAKE_TARGET ?= $(if $(NUCLIO_TEST_BROKEN),"test-broken-undockerized","test-undockerized"))
+	$(eval NUCLIO_TEST_MAKE_TARGET ?= $(if $(NUCLIO_TEST_BROKEN),test-broken-undockerized,test-undockerized))
+	$(eval RUN=make $(NUCLIO_TEST_MAKE_TARGET) LIST_TESTS_MAKE_COMMAND=${LIST_TESTS_MAKE_COMMAND})
+
 	@docker run \
 		--rm \
 		--volume /var/run/docker.sock:/var/run/docker.sock \
@@ -740,8 +748,7 @@ test: build-test
 		--env NUCLIO_TEST_HOST_PATH=$(NUCLIO_PATH) \
 		--env NUCLIO_CI_SKIP_STRESS_TEST \
 		$(NUCLIO_DOCKER_TEST_TAG) \
-		/bin/bash -c "make $(NUCLIO_TEST_MAKE_TARGET)"
-
+		/bin/bash -c "git config --global --add safe.directory /nuclio && LIST_TESTS_MAKE_COMMAND=${LIST_TESTS_MAKE_COMMAND} make ${NUCLIO_TEST_MAKE_TARGET}"
 .PHONY: test-k8s
 test-k8s: build-test
 	NUCLIO_TEST_KUBECONFIG=$(if $(NUCLIO_TEST_KUBECONFIG),$(NUCLIO_TEST_KUBECONFIG),$(KUBECONFIG)) \
@@ -818,6 +825,53 @@ test-python:
 			--file pkg/processor/runtime/python/test/Dockerfile \
 			. ;\
 	done
+
+# list of tests which run for a long time, so it makes sense to run each of those in parallel
+TEST_LIST_RUN_EACH_IN_PARALLEL = pkg/nuctl/test \
+ 								 pkg/processor/build/runtime/dotnetcore/test \
+								 pkg/processor/build/runtime/golang/test  \
+								 pkg/processor/build/runtime/java/test  \
+								 pkg/processor/build/runtime/python/test  \
+								 pkg/processor/runtime/python/test
+
+.PHONY: list-all-dirs-with-tests
+list-all-dirs-with-tests:
+	@go list -f '{{ if .TestGoFiles }}{{.ImportPath }}{{ end }}' -tags="test_integration,test_local" ./cmd/... ./pkg/...  #| sed -r 's/github.com\/nuclio\/nuclio/./g'
+
+.PHONY: list-tests-with-long-execution-time
+list-tests-with-long-execution-time:
+	@(for value in $(TEST_LIST_RUN_EACH_IN_PARALLEL); do pattern+="-e $$value "; done; make list-all-dirs-with-tests | grep $$pattern)
+
+.PHONY: fast-tests
+fast-tests:
+	@for value in $(TEST_LIST_RUN_EACH_IN_PARALLEL); do pattern+="-v -e $$value "; done; make list-all-dirs-with-tests | grep $$pattern
+
+.PHONY: nuctl-tests
+nuctl-tests:
+	@make list-all-dirs-with-tests | grep "pkg/nuctl/test"
+
+.PHONY: dotnet-tests
+dotnet-tests:
+	@make list-all-dirs-with-tests | grep "pkg/processor/build/runtime/dotnetcore/test"
+
+.PHONY: golang-tests
+golang-tests:
+	@make list-all-dirs-with-tests | grep "pkg/processor/build/runtime/golang/test"
+
+.PHONY: java-tests
+java-tests:
+	@make list-all-dirs-with-tests | grep "pkg/processor/build/runtime/java/test"
+
+.PHONY: python-tests
+python-tests:
+	@make list-all-dirs-with-tests | grep "pkg/processor/build/runtime/python/test"
+
+.PHONY: python-runtime-tests
+python-runtime-tests:
+	@make list-all-dirs-with-tests | grep "pkg/processor/runtime/python/test"
+
+.PHONY: run-long-test
+run-long-test:
 
 
 #

--- a/Makefile
+++ b/Makefile
@@ -868,10 +868,6 @@ python-tests:
 python-runtime-tests:
 	@make list-all-dirs-with-tests | grep "pkg/processor/runtime/python/test"
 
-.PHONY: run-long-test
-run-long-test:
-
-
 #
 # Go env
 #

--- a/Makefile
+++ b/Makefile
@@ -730,8 +730,6 @@ test-broken-undockerized: ensure-gopath
 .PHONY: test
 test: build-test
 	$(eval NUCLIO_TEST_MAKE_TARGET ?= $(if $(NUCLIO_TEST_BROKEN),test-broken-undockerized,test-undockerized))
-	$(eval RUN=make $(NUCLIO_TEST_MAKE_TARGET) LIST_TESTS_MAKE_COMMAND=${LIST_TESTS_MAKE_COMMAND})
-
 	@docker run \
 		--rm \
 		--volume /var/run/docker.sock:/var/run/docker.sock \

--- a/pkg/platform/local/test/platform_test.go
+++ b/pkg/platform/local/test/platform_test.go
@@ -49,6 +49,14 @@ func (suite *TestSuite) SetupSuite() {
 
 	// we will work on the first one
 	suite.namespace = namespaces[0]
+
+	getProjectsOptions := &platform.CreateProjectOptions{
+		ProjectConfig: &platform.ProjectConfig{Meta: platform.ProjectMeta{Name: platform.DefaultProjectName, Namespace: suite.namespace}, Spec: platform.ProjectSpec{
+			Description: "just a description",
+		}},
+	}
+	err = suite.Platform.CreateProject(suite.ctx, getProjectsOptions)
+	suite.Require().NoError(err, "Failed to create project")
 }
 
 // Test function containers healthiness validation
@@ -101,6 +109,7 @@ func (suite *TestSuite) TestValidateFunctionContainersHealthiness() {
 	createFunctionOptions.FunctionConfig.Meta.Namespace = suite.namespace
 	suite.DeployFunction(createFunctionOptions,
 		func(deployResult *platform.CreateFunctionResult) bool {
+			suite.NotEmpty(deployResult, "Function hasn't been deployed")
 			functionName := deployResult.UpdatedFunctionConfig.Meta.Name
 
 			// Ensure function state is ready

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -427,7 +427,6 @@ func (b *Builder) initializeSupportedRuntimes() {
 	b.runtimeInfo["shell"] = runtimeInfo{"sh", poundParser, 0}
 	b.runtimeInfo["golang"] = runtimeInfo{"go", slashSlashParser, 0}
 	b.runtimeInfo["python"] = runtimeInfo{"py", poundParser, 10}
-	b.runtimeInfo["python:3.6"] = runtimeInfo{"py", poundParser, 5}
 	b.runtimeInfo["python:3.7"] = runtimeInfo{"py", poundParser, 5}
 	b.runtimeInfo["python:3.8"] = runtimeInfo{"py", poundParser, 5}
 	b.runtimeInfo["python:3.9"] = runtimeInfo{"py", poundParser, 5}

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -619,6 +619,12 @@ func (suite *TestSuite) deployFunction(createFunctionOptions *platform.CreateFun
 	// deploy the function
 	deployResult, deployErr := suite.Platform.CreateFunction(suite.ctx, createFunctionOptions)
 
+	if deployErr != nil {
+		suite.Logger.DebugWith("Function was not created",
+			"deploy result", deployResult,
+			"deploy err", deployErr.Error())
+	}
+
 	// give the container some time - after 10 seconds, give up
 	deadline := time.Now().Add(10 * time.Second)
 


### PR DESCRIPTION

Jira - [NUC-34](https://jira.iguazeng.com/browse/NUC-34)

Within this PR:

* split periodic CI into 7 parallel jobs using matrix
* removed python3.6 usage from builder
* fixed platform test so they can be run independently from other tests

Here is run example: https://github.com/nuclio/nuclio/actions/runs/6637257969
Instead of ~2h30min execution, whole tests run takes ~1hour