### PR TITLE
[NATS] Submit events to workers concurrently

### DIFF
--- a/pkg/processor/trigger/nats/test/nats_test.go
+++ b/pkg/processor/trigger/nats/test/nats_test.go
@@ -67,7 +67,7 @@ func (suite *testSuite) TestPostEvent() {
 		suite.BrokerHost,
 		suite.getDeployOptions(),
 		map[string]triggertest.TopicMessages{
-			suite.topicName: {NumMessages: 3},
+			suite.topicName: {NumMessages: 20},
 		},
 		nil,
 		suite.publishMessageToTopic)
@@ -86,6 +86,7 @@ func (suite *testSuite) getDeployOptions() *platform.CreateFunctionOptions {
 		Attributes: map[string]interface{}{
 			"topic": suite.topicName,
 		},
+		MaxWorkers: 10,
 	}
 
 	return createFunctionOptions

--- a/pkg/processor/trigger/nats/test/nats_test.go
+++ b/pkg/processor/trigger/nats/test/nats_test.go
@@ -86,7 +86,7 @@ func (suite *testSuite) getDeployOptions() *platform.CreateFunctionOptions {
 		Attributes: map[string]interface{}{
 			"topic": suite.topicName,
 		},
-		MaxWorkers: 10,
+		MaxWorkers: 3,
 	}
 
 	return createFunctionOptions

--- a/pkg/processor/trigger/test/eventrecorder.go
+++ b/pkg/processor/trigger/test/eventrecorder.go
@@ -85,7 +85,6 @@ func InvokeEventRecorder(suite *processorsuite.TestSuite,
 			}
 		}
 
-		// TODO: retry until successful
 		var receivedEvents []Event
 		var getEventErr error
 		err := common.RetryUntilSuccessful(10*time.Second,


### PR DESCRIPTION
In the current implementation of the NATS trigger, even when multiple workers are configured, the event is submitted to the event, and the next event will only be submitted once the previous event is done processing.
Since we do not do anything after an event is processed, we can better utilize the multiple workers by processing the events concurrently.

Resolves #2955 