### PR TITLE
[Nuctl] Make it possible to run nuctl in the pod without kubeconfig propagation

### DIFF
--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -101,7 +101,9 @@ func NewPlatform(ctx context.Context,
 
 	// init platform
 	newPlatform.Platform = newAbstractPlatform
-	newPlatform.kubeconfigPath = common.GetKubeconfigPath(platformConfiguration.Kube.KubeConfigPath)
+	if _, err := common.GetKubeConfigClientCmdByKubeconfigPath(platformConfiguration.Kube.KubeConfigPath); err == nil {
+		newPlatform.kubeconfigPath = common.GetKubeconfigPath(platformConfiguration.Kube.KubeConfigPath)
+	}
 
 	// create consumer
 	newPlatform.consumer, err = client.NewConsumer(ctx, newPlatform.Logger, newPlatform.kubeconfigPath)

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -101,6 +101,10 @@ func NewPlatform(ctx context.Context,
 
 	// init platform
 	newPlatform.Platform = newAbstractPlatform
+
+	// we run GetKubeConfigClientCmdByKubeconfigPath in order to check if we are running in k8s
+	// empty error means that the kubeconfig path was found, the configuration at this path exists and can be loaded successfully
+	// if error is not nil, we leave kubeconfigPath empty and use the in-cluster k8s configuration when creating the consumer below
 	if _, err := common.GetKubeConfigClientCmdByKubeconfigPath(platformConfiguration.Kube.KubeConfigPath); err == nil {
 		newPlatform.kubeconfigPath = common.GetKubeconfigPath(platformConfiguration.Kube.KubeConfigPath)
 	}


### PR DESCRIPTION
Jira - https://jira.iguazeng.com/browse/NUC-78


The idea of this PR is to make it possible to run nuctl in the pod without kubeconfig propagation. We need this to unblock cluster backup/restore feature so it could backup and restore all nuclio staff