### PR TITLE
[Python] Bump pip for all python versions

### DIFF
--- a/pkg/processor/runtime/python/py/requirements/common.txt
+++ b/pkg/processor/runtime/python/py/requirements/common.txt
@@ -1,2 +1,3 @@
 mock==2.0.0
 nuclio-sdk==0.5.6
+pip==23.3.1

--- a/pkg/processor/runtime/python/py/requirements/python3_10.txt
+++ b/pkg/processor/runtime/python/py/requirements/python3_10.txt
@@ -1,3 +1,2 @@
 -r common.txt
 msgpack==1.0.7
-pip==23.3.1

--- a/pkg/processor/runtime/python/py/requirements/python3_11.txt
+++ b/pkg/processor/runtime/python/py/requirements/python3_11.txt
@@ -1,3 +1,2 @@
 -r common.txt
 msgpack==1.0.7
-pip==23.3.1

--- a/pkg/processor/runtime/python/py/requirements/python3_7.txt
+++ b/pkg/processor/runtime/python/py/requirements/python3_7.txt
@@ -1,3 +1,2 @@
 -r common.txt
-pip==21.1.3
 msgpack==1.0.2 --no-binary=msgpack

--- a/pkg/processor/runtime/python/py/requirements/python3_8.txt
+++ b/pkg/processor/runtime/python/py/requirements/python3_8.txt
@@ -1,3 +1,2 @@
 -r common.txt
-pip==21.1.3
 msgpack==1.0.2 --no-binary=msgpack

--- a/pkg/processor/runtime/python/py/requirements/python3_9.txt
+++ b/pkg/processor/runtime/python/py/requirements/python3_9.txt
@@ -1,3 +1,2 @@
 -r common.txt
-pip==21.1.3
 msgpack==1.0.2 --no-binary=msgpack


### PR DESCRIPTION
Bump pip to the latest version for all python version, following some security threats: https://github.com/nuclio/nuclio/security/dependabot 