### PR TITLE
[Controller] Set default logs container when sidecars are set

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1575,9 +1575,9 @@ func (lc *lazyClient) getPodAnnotations(function *nuclioio.NuclioFunction) (map[
 		annotations[annotationKey] = annotationValue
 	}
 
-	// if a sidecar is defined, configure the processor container as default for logging
+	// if a sidecar is defined, configure the processor container as default
 	if len(function.Spec.Sidecars) > 0 {
-		annotations["kubectl.kubernetes.io/default-logs-container"] = client.FunctionContainerName
+		annotations["kubectl.kubernetes.io/default-container"] = client.FunctionContainerName
 	}
 
 	return annotations, nil

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1575,6 +1575,11 @@ func (lc *lazyClient) getPodAnnotations(function *nuclioio.NuclioFunction) (map[
 		annotations[annotationKey] = annotationValue
 	}
 
+	// if a sidecar is defined, configure the processor container as default for logging
+	if len(function.Spec.Sidecars) > 0 {
+		annotations["kubectl.kubernetes.io/default-logs-container"] = client.FunctionContainerName
+	}
+
 	return annotations, nil
 }
 


### PR DESCRIPTION
When a pod has multiple containers, getting logs require specifying the container name.
When sidecars are set for a function, this can cause error when a deployment fails and the dashboard tries getting the pod logs, resulting with the following output:
```
Failed to read logs: a container name must be specified for pod <pod-name>, choose one of: [nuclio sidecar-container]
```

In this PR we set the default logs container to the nuclio function container when sidecars are set.
see https://text.superbrothers.dev/en/201123-allow-to-preselect-interesting-container-in-logs/ 