### PR TITLE
[Controller] Consider scaling when monitoring function state

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -45,7 +45,8 @@ func Run(kubeconfigPath string,
 	platformConfigurationName string,
 	functionOperatorNumWorkersStr string,
 	resyncIntervalStr string,
-	functionMonitorIntervalStr,
+	functionMonitorIntervalStr string,
+	scalingGracePeriodStr string,
 	cronJobStaleResourcesCleanupIntervalStr string,
 	evictedPodsCleanupIntervalStr string,
 	functionEventOperatorNumWorkersStr string,
@@ -60,6 +61,7 @@ func Run(kubeconfigPath string,
 		functionOperatorNumWorkersStr,
 		resyncIntervalStr,
 		functionMonitorIntervalStr,
+		scalingGracePeriodStr,
 		cronJobStaleResourcesCleanupIntervalStr,
 		evictedPodsCleanupIntervalStr,
 		functionEventOperatorNumWorkersStr,
@@ -86,6 +88,7 @@ func createController(kubeconfigPath string,
 	functionOperatorNumWorkersStr string,
 	resyncIntervalStr string,
 	functionMonitorIntervalStr string,
+	scalingGracePeriodStr string,
 	cronJobStaleResourcesCleanupIntervalStr string,
 	evictedPodsCleanupIntervalStr string,
 	functionEventOperatorNumWorkersStr string,
@@ -110,6 +113,11 @@ func createController(kubeconfigPath string,
 	functionMonitorInterval, err := time.ParseDuration(functionMonitorIntervalStr)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to parse function monitor interval")
+	}
+
+	scalingGracePeriod, err := time.ParseDuration(scalingGracePeriodStr)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to parse function scaling grace period")
 	}
 
 	cronJobStaleResourcesCleanupInterval, err := time.ParseDuration(cronJobStaleResourcesCleanupIntervalStr)
@@ -194,6 +202,7 @@ func createController(kubeconfigPath string,
 		apigatewayresClient,
 		resyncInterval,
 		functionMonitorInterval,
+		scalingGracePeriod,
 		cronJobStaleResourcesCleanupInterval,
 		evictedPodsCleanupInterval,
 		platformConfiguration,

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -53,6 +53,7 @@ func main() {
 	}
 
 	functionMonitorIntervalStr := flag.String("function-monitor-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_MONITOR_INTERVAL", "3m"), "Set function monitor interval (optional)")
+	scalingGracePeriodStr := flag.String("scaling-grace-period", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_SCALING_GRACE_PERIOD", "3m"), "Set function scaling grace period (optional)")
 	cronJobStaleResourcesCleanupIntervalStr := flag.String("cron-job-stale-resources-cleanup-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_CRON_JOB_STALE_RESOURCES_CLEANUP_INTERVAL", "1m"), "Set interval for the cleanup of stale cron job resources (optional)")
 	evictedPodsCleanupIntervalStr := flag.String("evicted-pods-cleanup-interval", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_EVICTED_PODS_CLEANUP_INTERVAL", "30m"), "Set interval for the cleanup of evicted function pods (optional)")
 	functionEventOperatorNumWorkersStr := flag.String("function-event-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_EVENT_OPERATOR_NUM_WORKERS", "2"), "Set number of workers for the function event operator (optional)")
@@ -72,6 +73,7 @@ func main() {
 		*functionOperatorNumWorkersStr,
 		*resyncIntervalStr,
 		*functionMonitorIntervalStr,
+		*scalingGracePeriodStr,
 		*cronJobStaleResourcesCleanupIntervalStr,
 		*evictedPodsCleanupIntervalStr,
 		*functionEventOperatorNumWorkersStr,

--- a/pkg/platform/kube/controller/controller.go
+++ b/pkg/platform/kube/controller/controller.go
@@ -69,6 +69,7 @@ func NewController(parentLogger logger.Logger,
 	apigatewayresClient apigatewayres.Client,
 	resyncInterval time.Duration,
 	functionMonitoringInterval time.Duration,
+	scalingGracePeriod time.Duration,
 	cronJobStaleResourcesCleanupInterval time.Duration,
 	evictedPodsCleanupInterval time.Duration,
 	platformConfiguration *platformconfig.Config,
@@ -156,7 +157,8 @@ func NewController(parentLogger logger.Logger,
 		namespace,
 		kubeClientSet,
 		nuclioClientSet,
-		functionMonitoringInterval)
+		functionMonitoringInterval,
+		scalingGracePeriod)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create function monitor")
 	}

--- a/pkg/platform/kube/controller/controller.go
+++ b/pkg/platform/kube/controller/controller.go
@@ -158,7 +158,8 @@ func NewController(parentLogger logger.Logger,
 		kubeClientSet,
 		nuclioClientSet,
 		functionMonitoringInterval,
-		scalingGracePeriod)
+		scalingGracePeriod,
+		platformConfiguration.GetDefaultFunctionReadinessTimeout())
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create function monitor")
 	}

--- a/pkg/platform/kube/controller/controller_test.go
+++ b/pkg/platform/kube/controller/controller_test.go
@@ -49,6 +49,7 @@ func (suite *ControllerTestSuite) SetupTest() {
 	var err error
 	resyncInterval := 0 * time.Second
 	functionMonitoringInterval := 10 * time.Second
+	scalingGracePeriod := 2 * time.Minute
 	evictedPodsCleanupInterval := 30 * time.Minute
 	cronJobInterval := 10 * time.Second
 	defaultNumWorkers := 1
@@ -80,6 +81,7 @@ func (suite *ControllerTestSuite) SetupTest() {
 		nil,
 		resyncInterval,
 		functionMonitoringInterval,
+		scalingGracePeriod,
 		evictedPodsCleanupInterval,
 		cronJobInterval,
 		platformConfig,

--- a/pkg/platform/kube/controller/nucliofunction_test.go
+++ b/pkg/platform/kube/controller/nucliofunction_test.go
@@ -51,6 +51,7 @@ func (suite *NuclioFunctionTestSuite) SetupTest() {
 	var err error
 	resyncInterval := 0 * time.Second
 	functionMonitoringInterval := 10 * time.Second
+	scalingGracePeriod := 2 * time.Minute
 	evictedPodsCleanupInterval := 30 * time.Minute
 	cronJobInterval := 10 * time.Second
 	defaultNumWorkers := 1
@@ -80,6 +81,7 @@ func (suite *NuclioFunctionTestSuite) SetupTest() {
 		nil,
 		resyncInterval,
 		functionMonitoringInterval,
+		scalingGracePeriod,
 		evictedPodsCleanupInterval,
 		cronJobInterval,
 		platformConfig,

--- a/pkg/platform/kube/monitoring/function_test.go
+++ b/pkg/platform/kube/monitoring/function_test.go
@@ -69,7 +69,8 @@ func (suite *FunctionMonitoringTestSuite) SetupTest() {
 		suite.kubeClientSet,
 		suite.nuclioioClientSet,
 		time.Second,
-		suite.scalingGracePeriod)
+		suite.scalingGracePeriod,
+		2*time.Minute)
 	suite.Require().NoError(err)
 }
 

--- a/pkg/platform/kube/monitoring/function_test.go
+++ b/pkg/platform/kube/monitoring/function_test.go
@@ -25,24 +25,29 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platform/kube"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	nuclioiofake "github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/versioned/fake"
 
 	"github.com/nuclio/logger"
 	"github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+	autosv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
 type FunctionMonitoringTestSuite struct {
 	suite.Suite
-	nuclioioClientSet *nuclioiofake.Clientset
-	kubeClientSet     *fake.Clientset
-	Namespace         string
-	Logger            logger.Logger
-	functionMonitor   *FunctionMonitor
-	ctx               context.Context
+	nuclioioClientSet  *nuclioiofake.Clientset
+	kubeClientSet      *fake.Clientset
+	Namespace          string
+	Logger             logger.Logger
+	functionMonitor    *FunctionMonitor
+	scalingGracePeriod time.Duration
+	ctx                context.Context
 }
 
 func (suite *FunctionMonitoringTestSuite) SetupSuite() {
@@ -57,12 +62,14 @@ func (suite *FunctionMonitoringTestSuite) SetupTest() {
 	var err error
 	suite.kubeClientSet = fake.NewSimpleClientset()
 	suite.nuclioioClientSet = nuclioiofake.NewSimpleClientset()
+	suite.scalingGracePeriod = 20 * time.Second
 	suite.functionMonitor, err = NewFunctionMonitor(suite.ctx,
 		suite.Logger,
 		suite.Namespace,
 		suite.kubeClientSet,
 		suite.nuclioioClientSet,
-		time.Second)
+		time.Second,
+		suite.scalingGracePeriod)
 	suite.Require().NoError(err)
 }
 
@@ -89,6 +96,124 @@ func (suite *FunctionMonitoringTestSuite) TestBulkCheckFunctionStatuses() {
 
 	err := suite.functionMonitor.checkFunctionStatuses(suite.ctx)
 	suite.Require().NoError(err)
+}
+
+func (suite *FunctionMonitoringTestSuite) TestStatusNotChangeWhileScaling() {
+
+	minReplicas := 0
+	minReplicasInt32 := int32(minReplicas)
+	maxReplicas := 4
+	maxReplicasInt32 := int32(maxReplicas)
+
+	// create a dummy function in ready state
+	functionSpec := functionconfig.Spec{
+		MinReplicas: &minReplicas,
+		MaxReplicas: &maxReplicas,
+	}
+	function, err := suite.nuclioioClientSet.NuclioV1beta1().
+		NuclioFunctions(suite.Namespace).
+		Create(suite.ctx,
+			&nuclioio.NuclioFunction{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "func",
+					Namespace: suite.Namespace,
+				},
+				Spec: functionSpec,
+				Status: functionconfig.Status{
+					State: functionconfig.FunctionStateReady,
+				},
+			}, metav1.CreateOptions{})
+	suite.Require().NoError(err)
+	suite.Require().NotNil(function)
+
+	// create a deployment for the function, with status not ready
+	deploymentSpec := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kube.DeploymentNameFromFunctionName(function.Name),
+			Namespace: suite.Namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      kube.PodNameFromFunctionName(function.Name),
+					Namespace: suite.Namespace,
+				},
+				Spec: corev1.PodSpec{},
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            4,
+			AvailableReplicas:   1,
+			UnavailableReplicas: 3,
+			Conditions: []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentAvailable,
+					Status: corev1.ConditionFalse,
+				},
+			},
+		},
+	}
+
+	deployment, err := suite.kubeClientSet.AppsV1().
+		Deployments(function.Namespace).
+		Create(suite.ctx, &deploymentSpec, metav1.CreateOptions{})
+	suite.Require().NoError(err)
+	suite.Require().NotNil(deployment)
+
+	// mock an HPA for the function, with current replicas < desired replicas
+	now := metav1.Now()
+	hpaSpec := autosv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kube.HPANameFromFunctionName(function.Name),
+			Namespace: suite.Namespace,
+		},
+		Spec: autosv2.HorizontalPodAutoscalerSpec{
+			MinReplicas: &minReplicasInt32,
+			MaxReplicas: maxReplicasInt32,
+			ScaleTargetRef: autosv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       kube.DeploymentNameFromFunctionName(function.Name),
+			},
+		},
+		Status: autosv2.HorizontalPodAutoscalerStatus{
+			LastScaleTime:   &now,
+			CurrentReplicas: 1,
+			DesiredReplicas: 4,
+		},
+	}
+	hpa, err := suite.kubeClientSet.AutoscalingV2().
+		HorizontalPodAutoscalers(suite.Namespace).
+		Create(suite.ctx, &hpaSpec, metav1.CreateOptions{})
+	suite.Require().NoError(err)
+	suite.Require().NotNil(hpa)
+
+	// invoke the function monitor and make sure the function status is not changed
+	err = suite.functionMonitor.checkFunctionStatuses(suite.ctx)
+	suite.Require().NoError(err)
+
+	// get the function and make sure its status is still ready
+	function, err = suite.nuclioioClientSet.NuclioV1beta1().
+		NuclioFunctions(suite.Namespace).
+		Get(suite.ctx, function.Name, metav1.GetOptions{})
+	suite.Require().NoError(err)
+	suite.Require().NotNil(function)
+	suite.Require().Equal(functionconfig.FunctionStateReady, function.Status.State)
+
+	// wait for the scaling grace period to pass
+	time.Sleep(suite.scalingGracePeriod)
+
+	// invoke the function monitor and make sure the function status is now changed to unhealthy
+	err = suite.functionMonitor.checkFunctionStatuses(suite.ctx)
+	suite.Require().NoError(err)
+
+	// get the function and make sure its status is now unhealthy
+	function, err = suite.nuclioioClientSet.NuclioV1beta1().
+		NuclioFunctions(suite.Namespace).
+		Get(suite.ctx, function.Name, metav1.GetOptions{})
+	suite.Require().NoError(err)
+	suite.Require().NotNil(function)
+	suite.Require().Equal(functionconfig.FunctionStateUnhealthy, function.Status.State)
 }
 
 func TestFunctionMonitoringTestSuite(t *testing.T) {

--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -222,7 +222,7 @@ func (suite *FunctionMonitoringTestSuite) TestRecoverErrorStateFunctionWhenResou
 	functionName := "function-recovery"
 	createFunctionOptions := suite.CompileCreateFunctionOptions(functionName)
 
-	// for some reasons, some time minikube misses resource quota limitation of 0 pods while there's a single replica
+	// for some reason, sometimes minikube misses resource quota limitation of 0 pods while there's a single replica
 	two := 2
 	createFunctionOptions.FunctionConfig.Spec.Replicas = &two
 	getFunctionOptions := &platform.GetFunctionsOptions{
@@ -230,7 +230,7 @@ func (suite *FunctionMonitoringTestSuite) TestRecoverErrorStateFunctionWhenResou
 		Namespace: createFunctionOptions.FunctionConfig.Meta.Namespace,
 	}
 
-	functionMonitoringSleepTimeout := 2*suite.Controller.GetFunctionMonitoringInterval() +
+	functionMonitoringSleepTimeout := 3*suite.Controller.GetFunctionMonitoringInterval() +
 		monitoring.PostDeploymentMonitoringBlockingInterval
 	suite.DeployFunction(createFunctionOptions, func(deployResults *platform.CreateFunctionResult) bool {
 

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -1313,7 +1313,7 @@ func (suite *DeployFunctionTestSuite) TestDeployFunctionWithSidecarSanity() {
 	commands := []string{
 		"sh",
 		"-c",
-		"for i in {1..10}; do echo $i; sleep 1; done; echo 'Done'",
+		"for i in {1..10}; do echo $i; sleep 10; done; echo 'Done'",
 	}
 
 	// create a busybox sidecar
@@ -1341,7 +1341,7 @@ func (suite *DeployFunctionTestSuite) TestDeployFunctionWithSidecarSanity() {
 		podLogOpts := v1.PodLogOptions{
 			Container: sidecarContainerName,
 		}
-		err := common.RetryUntilSuccessful(10*time.Second, 1*time.Second, func() bool {
+		err := common.RetryUntilSuccessful(20*time.Second, 1*time.Second, func() bool {
 			return suite.validatePodLogsContainData(pod.Name, &podLogOpts, []string{"Done"})
 		})
 		suite.Require().NoError(err)

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -213,7 +213,7 @@ func (suite *KubeTestSuite) CompileCreateFunctionOptions(functionName string) *p
 		},
 	}
 	createFunctionOptions.FunctionConfig.Spec.Handler = "main:handler"
-	createFunctionOptions.FunctionConfig.Spec.Runtime = "python:3.8"
+	createFunctionOptions.FunctionConfig.Spec.Runtime = "python:3.9"
 	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = base64.StdEncoding.EncodeToString([]byte(`
 def handler(context, event):
   return "hello world"
@@ -653,6 +653,7 @@ func (suite *KubeTestSuite) createController() *controller.Controller {
 		apigatewayresClient,
 		0,              // disable resync interval
 		time.Second*5,  // monitor interval
+		time.Minute*2,  // scaling grace period
 		time.Second*30, // cronjob stale duration
 		time.Minute*30, // evicted pods cleanup duration
 		suite.PlatformConfiguration,


### PR DESCRIPTION
We have seen some cases where a function with minReplicas != maxReplicas is set as `Unhealthy` state while it's being scaled up.
This is because the way the function monitor decides wether a function is available or not is based on the function deployment's `Available` condition. However - this condition can be set to `False` while scaling up, due to `MinimumReplicasUnavailable`.

In this PR, I have added another check if the function deployment is unavailable, where we check if the function's HPA is actively scaling the function. If so - we give it a "grace period" (configurable, and defaults to 3m), in which if it is still scaling the function we do not set its state to `Unhealthy`.
If the grace period passed and the HPA is still working - set it to `Unhealthy` anyways.

It is important to note that while the function is scaling up, although the deployment might not be `Available` - the function can still be invoked and perform its tasks.


Resolves https://jira.iguazeng.com/browse/NUC-70