### PR TITLE
[Dashboard] Add trigger existence validation

### DIFF
--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -577,6 +577,13 @@ func NewConfig() *Config {
 		Meta: Meta{
 			Namespace: "default",
 		},
+		Spec: Spec{Triggers: map[string]Trigger{
+			"some-trigger": {
+				Kind:       "http",
+				MaxWorkers: 1,
+				Name:       "some-trigger",
+			},
+		}},
 	}
 }
 

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -577,13 +577,6 @@ func NewConfig() *Config {
 		Meta: Meta{
 			Namespace: "default",
 		},
-		Spec: Spec{Triggers: map[string]Trigger{
-			"some-trigger": {
-				Kind:       "http",
-				MaxWorkers: 1,
-				Name:       "some-trigger",
-			},
-		}},
 	}
 }
 

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1572,8 +1572,7 @@ func (ap *Platform) validateTriggers(functionConfig *functionconfig.Config) erro
 
 	// validate that at least one trigger exists
 	if len(functionConfig.Spec.Triggers) == 0 {
-		return nuclio.NewErrBadRequest("Function must contain at least one trigger, " +
-			"but no triggers were found in the function configuration")
+		return nuclio.NewErrBadRequest("Function must have at least one trigger")
 	}
 
 	// validate ingresses structure correctness

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1570,6 +1570,12 @@ func (ap *Platform) validateProjectExists(ctx context.Context, functionConfig *f
 func (ap *Platform) validateTriggers(functionConfig *functionconfig.Config) error {
 	var httpTriggerExists bool
 
+	// validate that at least one trigger exists
+	if len(functionConfig.Spec.Triggers) == 0 {
+		return nuclio.NewErrBadRequest("Function must contain at least one trigger, " +
+			"but no triggers were found in the function configuration")
+	}
+
 	// validate ingresses structure correctness
 	if err := ap.validateIngresses(functionConfig.Spec.Triggers); err != nil {
 		return errors.Wrap(err, "Ingresses validation failed")

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -291,6 +291,9 @@ func (suite *AbstractPlatformTestSuite) TestValidationFailOnMalformedIngressesSt
 }
 
 func (suite *AbstractPlatformTestSuite) TestEnrichDefaultHttpTrigger() {
+	defer func() {
+		suite.Platform.Config.DisableDefaultHTTPTrigger = false
+	}()
 	functionConfig := functionconfig.NewConfig()
 	functionConfig.Meta.Name = "f1"
 	functionConfig.Meta.Namespace = "default"
@@ -1209,7 +1212,10 @@ func (suite *AbstractPlatformTestSuite) TestValidateFunctionConfigDockerImagesFi
 			Return([]platform.Project{&platform.AbstractProject{}}, nil).
 			Once()
 
-		err := suite.Platform.ValidateFunctionConfig(suite.ctx, &functionConfig)
+		err := suite.Platform.enrichTriggers(suite.ctx, &functionConfig)
+		suite.Require().NoError(err)
+
+		err = suite.Platform.ValidateFunctionConfig(suite.ctx, &functionConfig)
 		if !testCase.valid {
 			suite.Require().Error(err, "Validation passed unexpectedly")
 			suite.Logger.InfoWith("Expected error received", "err", err, "functionConfig", functionConfig)

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -1212,10 +1212,7 @@ func (suite *AbstractPlatformTestSuite) TestValidateFunctionConfigDockerImagesFi
 			Return([]platform.Project{&platform.AbstractProject{}}, nil).
 			Once()
 
-		err := suite.Platform.enrichTriggers(suite.ctx, &functionConfig)
-		suite.Require().NoError(err)
-
-		err = suite.Platform.ValidateFunctionConfig(suite.ctx, &functionConfig)
+		err := suite.Platform.ValidateFunctionConfig(suite.ctx, &functionConfig)
 		if !testCase.valid {
 			suite.Require().Error(err, "Validation passed unexpectedly")
 			suite.Logger.InfoWith("Expected error received", "err", err, "functionConfig", functionConfig)

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -1211,8 +1211,10 @@ func (suite *AbstractPlatformTestSuite) TestValidateFunctionConfigDockerImagesFi
 			}).
 			Return([]platform.Project{&platform.AbstractProject{}}, nil).
 			Once()
+		err := suite.Platform.enrichTriggers(suite.ctx, &functionConfig)
+		suite.Require().NoError(err)
 
-		err := suite.Platform.ValidateFunctionConfig(suite.ctx, &functionConfig)
+		err = suite.Platform.ValidateFunctionConfig(suite.ctx, &functionConfig)
 		if !testCase.valid {
 			suite.Require().Error(err, "Validation passed unexpectedly")
 			suite.Logger.InfoWith("Expected error received", "err", err, "functionConfig", functionConfig)

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -306,7 +306,7 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateServiceType() {
 				Return([]platform.Project{
 					&platform.AbstractProject{},
 				}, nil).
-				Once()
+				Twice()
 
 			// name it with index and shift with 65 to get A as first letter
 			functionName := string(rune(idx + 65))
@@ -322,8 +322,10 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateServiceType() {
 				"nuclio.io/project-name": platform.DefaultProjectName,
 			}
 			suite.Logger.DebugWith("Checking function ", "functionName", functionName)
+			err := suite.platform.EnrichFunctionConfig(suite.ctx, &createFunctionOptions.FunctionConfig)
+			suite.Require().NoError(err)
 
-			err := suite.platform.ValidateFunctionConfig(suite.ctx, &createFunctionOptions.FunctionConfig)
+			err = suite.platform.ValidateFunctionConfig(suite.ctx, &createFunctionOptions.FunctionConfig)
 			if testCase.shouldFailValidation {
 				suite.Require().Error(err, "Validation passed unexpectedly")
 			} else {


### PR DESCRIPTION
In this pull request, existence validation for triggers has been added. This validation is performed within the validateTriggers method, which is part of the function validation flow occurring after the enrichment flow. This is crucial because the default HTTP trigger is added during the enrichment phase. Therefore, we aim to raise an error only if there is no trigger (either default or custom).