### PR TITLE
[Processor] [Python runtime][Docs] Split drain and termination flows

### DIFF
--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -662,8 +662,8 @@ func (p *Processor) terminateAllTriggers(signal os.Signal) {
 		// drains all workers in trigger (for each trigger in parallel)
 		go func(triggerInstance trigger.Trigger, wg *sync.WaitGroup) {
 			defer wg.Done()
-			if err := triggerInstance.SignalWorkerDraining(); err != nil {
-				p.logger.WarnWith("Failed to signal worker draining",
+			if err := triggerInstance.SignalWorkerTermination(); err != nil {
+				p.logger.WarnWith("Failed to signal worker termination",
 					"triggerKind", triggerInstance.GetKind(),
 					"triggerName", triggerInstance.GetName(),
 					"err", err.Error())

--- a/cmd/processor/app/processor_test.go
+++ b/cmd/processor/app/processor_test.go
@@ -236,6 +236,11 @@ func (t *testTrigger) SignalWorkerDraining() error {
 	return nil
 }
 
+func (t *testTrigger) SignalWorkerTermination() error {
+	t.Called()
+	return nil
+}
+
 func TestTriggerTestSuite(t *testing.T) {
 	suite.Run(t, new(TriggerTestSuite))
 }

--- a/docs/reference/runtimes/python/python-reference.md
+++ b/docs/reference/runtimes/python/python-reference.md
@@ -214,3 +214,16 @@ docker run \
 
 That way, you can build your function once, deploy it as much as desired, 
 without being needed to volumize the function configuration upon each deployment.
+
+## Termination callback
+
+As of now, this feature is exclusively supported in the Python runtime. It enables the definition of a termination callback within user code through the following:
+```py
+context.platform.set_drain_termination(callback)  # where 'callback' is a user-defined function
+```
+Termination callback is triggered by processor when processor is about to stop working. 
+The termination callback serves the purpose of facilitating a graceful shutdown.
+
+Additionally, we offer a [drain callback](../../triggers/kafka.md#drain-callback) option for stream triggers.
+
+

--- a/docs/reference/runtimes/python/python-reference.md
+++ b/docs/reference/runtimes/python/python-reference.md
@@ -221,8 +221,8 @@ As of now, this feature is exclusively supported in the Python runtime. It enabl
 ```py
 context.platform.set_drain_termination(callback)  # where 'callback' is a user-defined function
 ```
-Termination callback is triggered by processor when processor is about to stop working. 
-The termination callback serves the purpose of facilitating a graceful shutdown.
+Termination callback is triggered by the processor when it is about to exit.
+The termination callback facilitates a graceful shutdown.
 
 Additionally, we offer a [drain callback](../../triggers/kafka.md#drain-callback) option for stream triggers.
 

--- a/docs/reference/triggers/kafka.md
+++ b/docs/reference/triggers/kafka.md
@@ -307,7 +307,7 @@ using the following method (Note that the registered callback is a nullary callb
 context.platform.set_drain_callback(callback)
 ```
 
-Also, as part of this feature, a new customizable timeout `WaitExplicitAckDuringRebalanceTimeout` was added. Its main purpose is to help avoid processing the same message twice.
+This feature includes a customizable timeout  `WaitExplicitAckDuringRebalanceTimeout`. Its purpose is to prevent processing the same message twice.
 This timeout allows to configure the waiting time for a control message from runtime after a rebalance happened and before we unsubscribe from control messages from runtime and completely disconnect.
 Default value is `100ms`. It can be also set via function annotation `nuclio.io/wait-explicit-ack-during-rebalance-timeout`.
 

--- a/docs/reference/triggers/kafka.md
+++ b/docs/reference/triggers/kafka.md
@@ -299,11 +299,12 @@ qualified_offset = nuclio.QualifiedOffset.from_event(event)
 await context.platform.explicit_ack(qualified_offset)
 ```
 
+### Drain callback
 During [rebalance](#rebalancing), the function can still be processing events. 
-We can register a callback to run before the workers are terminated, e.g. to drop or commit events being handled when the rebalancing is about to happen, 
+We can register a callback to run before the workers are drained, e.g. to drop or commit events being handled when the rebalancing is about to happen, 
 using the following method (Note that the registered callback is a nullary callback (doesn't accept arguments)):
 ```py
-context.platform.set_termination_callback(callback)
+context.platform.set_drain_callback(callback)
 ```
 
 Also, as part of this feature, a new customizable timeout `WaitExplicitAckDuringRebalanceTimeout` was added. Its main purpose is to help avoid processing the same message twice.

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -214,7 +214,7 @@ class Wrapper(object):
                 raise
 
     def _register_to_signal(self):
-        signal.signal(signal.SIGUSR1, self._on_sigterm)
+        signal.signal(signal.SIGUSR1, self._on_termination_signal)
         signal.signal(signal.SIGUSR2, self._on_drain_signal)
 
     def _on_drain_signal(self, signal_number, frame):
@@ -232,7 +232,7 @@ class Wrapper(object):
             # after the current event is handled
             self._is_drain_needed = True
 
-    def _on_sigterm(self, signal_number, frame):
+    def _on_termination_signal(self, signal_number, frame):
         self._logger.debug_with('Received signal, calling termination callback', signal=signal_number)
 
         if self._is_waiting_for_event:

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -239,7 +239,7 @@ class Wrapper(object):
             self._logger.debug('Wrapper is waiting for an event, calling terminate handler')
 
             # call the drain handler here as the event loop is stuck waiting for an event
-            self._call_drain_handler()
+            self._call_termination_handler()
         else:
             self._logger.debug('Wrapper is handling an event, setting drain flag to true')
 

--- a/pkg/processor/runtime/python/py/requirements/common.txt
+++ b/pkg/processor/runtime/python/py/requirements/common.txt
@@ -1,3 +1,3 @@
 mock==2.0.0
-nuclio-sdk==0.5.6
+nuclio-sdk==0.5.8
 pip==23.3.1

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -236,7 +236,22 @@ func (r *AbstractRuntime) Drain() error {
 	}
 	r.isDrained = true
 
-	// we use SIGUSR1 to signal the wrapper process to drain events
+	// we use SIGUSR2 to signal the wrapper process to drain events
+	if err := r.signal(syscall.SIGUSR2); err != nil {
+		return errors.Wrap(err, "Failed to signal wrapper process")
+	}
+
+	// wait for process to finish event handling or timeout
+	// TODO: replace the following function with one that waits for a control communication message or timeout
+	r.waitForProcessTermination(r.configuration.WorkerTerminationTimeout)
+
+	return nil
+}
+
+// Terminate signals to the runtime process that processor is about to stop working
+func (r *AbstractRuntime) Terminate() error {
+
+	// we use SIGUSR1 to signal the wrapper process to terminate
 	if err := r.signal(syscall.SIGUSR1); err != nil {
 		return errors.Wrap(err, "Failed to signal wrapper process")
 	}

--- a/pkg/processor/runtime/runtime.go
+++ b/pkg/processor/runtime/runtime.go
@@ -65,6 +65,9 @@ type Runtime interface {
 	// Drain signals to the runtime process to drain its accumulated events and waits for it to finish
 	Drain() error
 
+	// Terminate signals to the runtime process that processor is about to stop working
+	Terminate() error
+
 	// GetControlMessageBroker returns the control message broker
 	GetControlMessageBroker() controlcommunication.ControlMessageBroker
 }
@@ -254,5 +257,9 @@ func (ar *AbstractRuntime) Stop() error {
 }
 
 func (ar *AbstractRuntime) Drain() error {
+	return nil
+}
+
+func (ar *AbstractRuntime) Terminate() error {
 	return nil
 }

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -86,6 +86,9 @@ type Trigger interface {
 
 	// SignalWorkerDraining drains all workers
 	SignalWorkerDraining() error
+
+	// SignalWorkerTermination signal to all workers that the processor is about to stop working
+	SignalWorkerTermination() error
 }
 
 // AbstractTrigger implements common trigger operations
@@ -364,6 +367,13 @@ func (at *AbstractTrigger) UnsubscribeFromControlMessageKind(kind controlcommuni
 func (at *AbstractTrigger) SignalWorkerDraining() error {
 	if err := at.WorkerAllocator.SignalDraining(); err != nil {
 		return errors.Wrap(err, "Failed to signal all workers to drain events")
+	}
+	return nil
+}
+
+func (at *AbstractTrigger) SignalWorkerTermination() error {
+	if err := at.WorkerAllocator.SignalTermination(); err != nil {
+		return errors.Wrap(err, "Failed to signal all workers to terminate")
 	}
 	return nil
 }

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -151,6 +151,14 @@ func (w *Worker) SupportsRestart() bool {
 	return w.runtime.SupportsRestart()
 }
 
+func (w *Worker) Terminate() error {
+	if err := w.runtime.Terminate(); err != nil {
+		return err
+	}
+	w.logger.DebugWith("Successfully terminated worker", "workerIndex", w.index)
+	return nil
+}
+
 func (w *Worker) Drain() error {
 	w.drainedLock.Lock()
 	defer w.drainedLock.Unlock()

--- a/pkg/processor/worker/worker_test.go
+++ b/pkg/processor/worker/worker_test.go
@@ -81,6 +81,11 @@ func (mr *MockRuntime) Drain() error {
 	return args.Error(0)
 }
 
+func (mr *MockRuntime) Terminate() error {
+	args := mr.Called()
+	return args.Error(0)
+}
+
 func (mr *MockRuntime) SupportsControlCommunication() bool {
 	args := mr.Called()
 	return args.Bool(0)

--- a/test/_functions/python/drain-hook/drain-hook.py
+++ b/test/_functions/python/drain-hook/drain-hook.py
@@ -15,8 +15,8 @@ import time
 import os
 
 
-class TerminationHandler:
-    file_path_template = '/tmp/nuclio/termination-hook-{}.txt'
+class DrainHandler:
+    file_path_template = '/tmp/nuclio/drain-hook-{}.txt'
 
     def __init__(self, worker_id, logger):
         self.worker_id = worker_id
@@ -38,10 +38,10 @@ class TerminationHandler:
 
 def init_context(context):
     context.logger.info_with('Initializing', worker_id=context.worker_id)
-    termination_handler = TerminationHandler(context.worker_id, logger=context.logger)
+    drain_handler = DrainHandler(context.worker_id, logger=context.logger)
 
-    # register a callback to be called when the function is terminated
-    context.platform.set_termination_callback(termination_handler.write_results)
+    # register a callback to be called when the function is drained
+    context.platform.set_drain_callback(drain_handler.write_results)
 
 
 def handler(context, event):


### PR DESCRIPTION
Jira - [NUC-107](https://jira.iguazeng.com/browse/NUC-107)

In this PR, we have separated the drain and termination flows to enhance flexibility for users. Here's a breakdown of each flow:

**Drain**:
* applicable for functions with stream triggers only
* being called on rebalance by sending the `SIGUSR2` signal to runtime

**Termination**:
* applicable for functions with all trigger types
* being called when the processor terminates by sending the `SIGUSR1` signal to runtime
