### PR TITLE
[Docs] Fix title for SEO

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Overview 
+# Documentation 
 Learn how to use Nuclio to quickly develop "serverless" applications.
 
 To download Nuclio and view full product release notes, visit the Nuclio GitHub [Releases](https://github.com/nuclio/nuclio/releases) page.


### PR DESCRIPTION
update the meta title of the new website from "Nuclio Overview" to "Nuclio Documentation" to be the same as the old website - 