### PR TITLE
[Build] Don't populate function source code for all code entry types

### DIFF
--- a/pkg/nuctl/command/export.go
+++ b/pkg/nuctl/command/export.go
@@ -155,6 +155,7 @@ func (e *exportFunctionCommandeer) renderFunctionConfig(functions []platform.Fun
 
 			functionConfig := function.GetConfig()
 
+			// restore the function config, if it was scrubbed
 			if scrubbed, err := e.scrubber.HasScrubbedConfig(functionConfig,
 				e.rootCommandeer.platform.GetConfig().SensitiveFields.CompileSensitiveFieldsRegex()); err == nil && scrubbed {
 				var restoreErr error
@@ -168,6 +169,7 @@ func (e *exportFunctionCommandeer) renderFunctionConfig(functions []platform.Fun
 			} else if err != nil {
 				return errors.Wrap(err, "Failed to check if function config is scrubbed")
 			}
+
 			exportOptions.PrevState = string(function.GetStatus().State)
 			exportOptions.NoScrub = e.noScrub
 			functionConfig.PrepareFunctionForExport(exportOptions)

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -206,14 +206,16 @@ func (b *Builder) Build(ctx context.Context, options *platform.CreateFunctionBui
 		// see if there are any inline blocks in the code. ignore errors during parse / load / whatever
 		b.parseInlineBlocks() // nolint: errcheck
 
-		// dont fail on parseInlineBlocks so that if the parser fails on something we won't block deployments. the only
+		// don't fail on parseInlineBlocks so that if the parser fails on something we won't block deployments. the only
 		// exception is if the user provided a block with improper contents
 		if b.inlineConfigurationBlock.Error != nil {
 			return nil, errors.Wrap(b.inlineConfigurationBlock.Error, "Failed to parse inline configuration")
 		}
 
-		// populate function source code
-		b.populateFunctionSourceCodeFromFilePath()
+		// populate function source code only if needed
+		if b.options.FunctionConfig.Spec.Build.CodeEntryType == SourceCodeEntryType {
+			b.populateFunctionSourceCodeFromFilePath()
+		}
 	}
 
 	// prepare configuration from both configuration files and things builder infers


### PR DESCRIPTION
When building a function from a file path, the file contents are copied to the `functionSourceCode` attribute so it can be used when building an image.

In cases where the `codeEntryType` is not `sourceCode` , e.g when deploying a function from git, the source code is not needed in the function spec for the image to be built properly, and it is better for security and privacy to not expose the source code in such cases.

Resolves https://github.com/nuclio/nuclio/issues/3084