### PR TITLE
[Build] Fix source code population test

### DIFF
--- a/pkg/processor/build/test/build_test.go
+++ b/pkg/processor/build/test/build_test.go
@@ -235,6 +235,7 @@ func (suite *testSuite) TestBuildFunctionFromFileExpectSourceCodePopulated() {
 
 	createFunctionOptions.FunctionConfig.Spec.Runtime = "python"
 	createFunctionOptions.FunctionConfig.Spec.Handler = "reverser:handler"
+	createFunctionOptions.FunctionConfig.Spec.Build.CodeEntryType = "sourceCode"
 
 	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
 


### PR DESCRIPTION
Following #3088 , source code is populated only if `codeEntryType` is set to `sourceCode`.