### PR TITLE
[Worker] Check if worker allocator is terminated in static allocation mode

### DIFF
--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -307,7 +307,6 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 	waitForHandler bool) {
 
 	readyForRebalanceChan := make(chan bool)
-	defer close(readyForRebalanceChan)
 
 	// indicate whether this partition worker was drained
 	// this is used to avoid race condition where 2 different partitions sharing the same worker
@@ -360,6 +359,7 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 
 		wg.Wait()
 		readyForRebalanceChan <- true
+		close(readyForRebalanceChan)
 	}()
 
 	// wait a for rebalance readiness or max timeout
@@ -398,7 +398,7 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 	}
 
 	if drainedWorker {
-		k.ResetWorkerTerminationState()
+		k.ResetWorkerDrainState()
 	}
 }
 

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -378,9 +378,9 @@ func (at *AbstractTrigger) SignalWorkerTermination() error {
 	return nil
 }
 
-// ResetWorkerTerminationState resets the worker termination state
-func (at *AbstractTrigger) ResetWorkerTerminationState() {
-	at.WorkerAllocator.ResetTerminationState()
+// ResetWorkerDrainState resets the worker draining state
+func (at *AbstractTrigger) ResetWorkerDrainState() {
+	at.WorkerAllocator.ResetDrainState()
 }
 
 func (at *AbstractTrigger) prepareEvent(event nuclio.Event, workerInstance *worker.Worker) (nuclio.Event, error) {

--- a/pkg/processor/worker/allocator.go
+++ b/pkg/processor/worker/allocator.go
@@ -57,7 +57,7 @@ type Allocator interface {
 	// SignalTermination signals all workers to terminate
 	SignalTermination() error
 
-	// ResetDrainState resets draining state of all workers
+	// ResetDrainState resets drain state of all workers
 	ResetDrainState()
 
 	// IsTerminated returns true if all workers are terminated

--- a/pkg/processor/worker/allocator.go
+++ b/pkg/processor/worker/allocator.go
@@ -57,8 +57,11 @@ type Allocator interface {
 	// SignalTermination signals all workers to terminate
 	SignalTermination() error
 
-	// ResetTerminationState resets termination state of all workers
-	ResetTerminationState()
+	// ResetDrainState resets draining state of all workers
+	ResetDrainState()
+
+	// IsTerminated returns true if all workers are terminated
+	IsTerminated() bool
 }
 
 //
@@ -116,11 +119,16 @@ func (s *singleton) SignalDraining() error {
 }
 
 func (s *singleton) SignalTermination() error {
-	return s.worker.Drain()
+	s.isTerminated = true
+	return s.worker.Terminate()
 }
 
-func (s *singleton) ResetTerminationState() {
+func (s *singleton) ResetDrainState() {
 	s.worker.setDrained(false)
+}
+
+func (s *singleton) IsTerminated() bool {
+	return s.isTerminated
 }
 
 //
@@ -268,8 +276,12 @@ func (fp *fixedPool) SignalTermination() error {
 	return nil
 }
 
-func (fp *fixedPool) ResetTerminationState() {
+func (fp *fixedPool) ResetDrainState() {
 	for _, workerInstance := range fp.GetWorkers() {
 		workerInstance.setDrained(false)
 	}
+}
+
+func (fp *fixedPool) IsTerminated() bool {
+	return fp.isTerminated
 }


### PR DESCRIPTION
Followup to https://github.com/nuclio/nuclio/pull/3092 , where we are blocking worker allocation if a the workers are terminated:
- Add termination check to the static worker allocator mode. It was missing from https://github.com/nuclio/nuclio/pull/3092 because the static allocator allocates all workers on startup, instead of per event.
- Rename termination state related methods to "drain state".
- In Kafka's `drainOnRebalance` - close the `readyForRebalanceChan` after sending a value on it. This will help cases where the `maxWaitHandlerDuringRebalance` times out before the drain handler finishes, and then the channel is closed before the drain invoking goroutine passes a value on it.