### PR TITLE
[Nuctl] Change error handling logic for function import

### DIFF
--- a/pkg/nuctl/command/beta.go
+++ b/pkg/nuctl/command/beta.go
@@ -32,7 +32,6 @@ type betaCommandeer struct {
 	cmd            *cobra.Command
 	rootCommandeer *RootCommandeer
 	apiClient      client.APIClient
-	concurrency    int
 	apiURL         string
 	username       string
 	accessKey      string
@@ -56,7 +55,6 @@ func newBetaCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *bet
 	cmd.PersistentFlags().StringVar(&commandeer.accessKey, "access-key", "", "Access Key of a user with permissions to the nuclio API")
 	cmd.PersistentFlags().StringVar(&commandeer.requestTimeout, "request-timeout", "60s", "Request timeout")
 	cmd.PersistentFlags().BoolVar(&commandeer.skipTLSVerify, "skip-tls-verify", false, "Skip TLS verification")
-	cmd.PersistentFlags().IntVar(&commandeer.concurrency, "concurrency", DefaultConcurrency, "Max number of parallel patches")
 
 	cmd.MarkPersistentFlagRequired("api-url") // nolint: errcheck
 

--- a/pkg/nuctl/command/beta.go
+++ b/pkg/nuctl/command/beta.go
@@ -25,8 +25,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const DefaultConcurrency = 10
-
 // betaCommandeer is the BETA version of nuctl as an API client
 type betaCommandeer struct {
 	cmd            *cobra.Command

--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -134,7 +134,7 @@ func (i *importCommandeer) importFunctions(ctx context.Context,
 					"project", project.Meta.Name,
 					"error", err)
 			} else {
-				i.rootCommandeer.loggerInstance.ErrorWithCtx(ctx, "Function has been successfully imported",
+				i.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Function has been successfully imported",
 					"function", function.Meta.Name,
 					"project", project.Meta.Name)
 			}

--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -117,24 +117,30 @@ func (i *importCommandeer) importFunctions(ctx context.Context,
 	functionConfigs map[string]*functionconfig.Config,
 	project *platform.ProjectConfig) error {
 	importFailed := atomic.Bool{}
-	i.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Importing functions", "functions", functionConfigs)
+	i.rootCommandeer.loggerInstance.DebugWithCtx(ctx,
+		"Importing functions",
+		"functions", functionConfigs)
 	wg := sync.WaitGroup{}
 	for _, functionConfig := range functionConfigs {
 		wg.Add(1)
 		go func(function *functionconfig.Config) {
-			i.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Importing function",
+			i.rootCommandeer.loggerInstance.DebugWithCtx(ctx,
+				"Importing function",
 				"function", function.Meta.Name,
 				"project", project.Meta.Name)
+
 			if err := i.importFunction(ctx, function, project); err != nil {
 				if !importFailed.Load() {
 					importFailed.Store(true)
 				}
-				i.rootCommandeer.loggerInstance.ErrorWithCtx(ctx, "Failed to import function",
+				i.rootCommandeer.loggerInstance.ErrorWithCtx(ctx,
+					"Failed to import function",
 					"function", function.Meta.Name,
 					"project", project.Meta.Name,
 					"error", err)
 			} else {
-				i.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Function was imported successfully",
+				i.rootCommandeer.loggerInstance.DebugWithCtx(ctx,
+					"Function was imported successfully",
 					"function", function.Meta.Name,
 					"project", project.Meta.Name)
 			}

--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -18,7 +18,6 @@ package command
 
 import (
 	"context"
-	"golang.org/x/sync/semaphore"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -33,6 +32,7 @@ import (
 	"github.com/nuclio/errors"
 	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/semaphore"
 )
 
 type importCommandeer struct {
@@ -126,7 +126,7 @@ func (i *importCommandeer) importFunctions(ctx context.Context,
 	var sem = semaphore.NewWeighted(int64(runtime.NumCPU()))
 	for _, functionConfig := range functionConfigs {
 		wg.Add(1)
-		sem.Acquire(ctx, 1)
+		_ = sem.Acquire(ctx, 1)
 		go func(function *functionconfig.Config) {
 			i.rootCommandeer.loggerInstance.DebugWithCtx(ctx,
 				"Importing function",

--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -122,7 +122,7 @@ func (i *importCommandeer) importFunctions(ctx context.Context,
 	for _, functionConfig := range functionConfigs {
 		wg.Add(1)
 		go func(function *functionconfig.Config) {
-			i.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Import function",
+			i.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Importing function",
 				"function", function.Meta.Name,
 				"project", project.Meta.Name)
 			if err := i.importFunction(ctx, function, project); err != nil {
@@ -134,7 +134,7 @@ func (i *importCommandeer) importFunctions(ctx context.Context,
 					"project", project.Meta.Name,
 					"error", err)
 			} else {
-				i.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Function has been successfully imported",
+				i.rootCommandeer.loggerInstance.DebugWithCtx(ctx, "Function was imported successfully",
 					"function", function.Meta.Name,
 					"project", project.Meta.Name)
 			}
@@ -144,7 +144,7 @@ func (i *importCommandeer) importFunctions(ctx context.Context,
 	wg.Wait()
 
 	if importFailed.Load() {
-		return errors.New("Import was failed for some of the functions")
+		return errors.New("Import failed for some of the functions")
 	}
 	return nil
 }

--- a/pkg/nuctl/command/nuctl.go
+++ b/pkg/nuctl/command/nuctl.go
@@ -43,6 +43,7 @@ type RootCommandeer struct {
 	namespace      string
 	verbose        bool
 	KubeconfigPath string
+	concurrency    int
 
 	platformConfiguration *platformconfig.Config
 }
@@ -64,6 +65,7 @@ func NewRootCommandeer() *RootCommandeer {
 	cmd.PersistentFlags().BoolVarP(&commandeer.verbose, "verbose", "v", false, "Verbose output")
 	cmd.PersistentFlags().StringVarP(&commandeer.platformName, "platform", "", defaultPlatformType, "Platform identifier - \"kube\", \"local\", or \"auto\"")
 	cmd.PersistentFlags().StringVarP(&commandeer.namespace, "namespace", "n", defaultNamespace, "Namespace")
+	cmd.PersistentFlags().IntVar(&commandeer.concurrency, "concurrency", DefaultConcurrency, "Max number of parallel patches")
 
 	// platform specific
 	cmd.PersistentFlags().StringVarP(&commandeer.KubeconfigPath, "kubeconfig", "k", "", "Path to a Kubernetes configuration file (admin.conf)")

--- a/pkg/nuctl/command/nuctl.go
+++ b/pkg/nuctl/command/nuctl.go
@@ -19,6 +19,7 @@ package command
 import (
 	"context"
 	"os"
+	"runtime"
 
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/platform"
@@ -65,7 +66,7 @@ func NewRootCommandeer() *RootCommandeer {
 	cmd.PersistentFlags().BoolVarP(&commandeer.verbose, "verbose", "v", false, "Verbose output")
 	cmd.PersistentFlags().StringVarP(&commandeer.platformName, "platform", "", defaultPlatformType, "Platform identifier - \"kube\", \"local\", or \"auto\"")
 	cmd.PersistentFlags().StringVarP(&commandeer.namespace, "namespace", "n", defaultNamespace, "Namespace")
-	cmd.PersistentFlags().IntVar(&commandeer.concurrency, "concurrency", DefaultConcurrency, "Max number of parallel patches")
+	cmd.PersistentFlags().IntVar(&commandeer.concurrency, "concurrency", runtime.NumCPU(), "Max number of parallel patches. The default value is equal to the number of CPUs.")
 
 	// platform specific
 	cmd.PersistentFlags().StringVarP(&commandeer.KubeconfigPath, "kubeconfig", "k", "", "Path to a Kubernetes configuration file (admin.conf)")

--- a/pkg/nuctl/command/redeploy.go
+++ b/pkg/nuctl/command/redeploy.go
@@ -199,7 +199,7 @@ func (d *redeployCommandeer) redeployFunctions(ctx context.Context, functionName
 		return errors.New(fmt.Sprintf("Desired state %s is not supported", d.desiredState))
 	}
 
-	patchErrGroup, _ := errgroup.WithContextSemaphore(ctx, d.rootCommandeer.loggerInstance, uint(d.betaCommandeer.concurrency))
+	patchErrGroup, _ := errgroup.WithContextSemaphore(ctx, d.rootCommandeer.loggerInstance, uint(d.rootCommandeer.concurrency))
 	for _, function := range functionNames {
 		function := function
 		patchErrGroup.Go("patch function", func() error {


### PR DESCRIPTION
Jira - https://jira.iguazeng.com/browse/NUC-118
It's just a first iteration of upcoming changes in nuctl import logic. 
In this PR, we introduce error logging for each function import process.

We are moving away from using errgroup to enable the tracking of errors for each import individually. This change will enable us to generate a finely-grained report (in following PR) for each failed import, complete with a detailed description and recommendations.