### PR TITLE
[Builder] Log runtime is ignored when custom base image is set

### DIFF
--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1375,16 +1375,18 @@ func (b *Builder) getProcessorDockerfileBaseImage(runtimeDefaultBaseImage string
 			return runtimeDefaultBaseImage
 		}
 
-		// if a non empty baseImageRegistry was passed, use it as a registry prefix for the default base image
+		// if a non-empty baseImageRegistry was passed, use it as a registry prefix for the default base image
 		sepIndex := strings.Index(runtimeDefaultBaseImage, "/")
 		if sepIndex != -1 {
 			runtimeDefaultBaseImage = runtimeDefaultBaseImage[sepIndex+1:]
 		}
 		return strings.Join([]string{baseImageRegistry, runtimeDefaultBaseImage}, "/")
 
-	// if user specified something - use that, as is
+	// if user specified something - use that, as is.
 	// see description on https://github.com/nuclio/nuclio/pull/1544 - we don't implicitly mutate the given baseimage
 	default:
+		b.logger.WarnWith("Using user provided base image, runtime configuration will be ignored",
+			"baseImage", b.options.FunctionConfig.Spec.Build.BaseImage)
 		return b.options.FunctionConfig.Spec.Build.BaseImage
 	}
 }

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1382,7 +1382,7 @@ func (b *Builder) getProcessorDockerfileBaseImage(runtimeDefaultBaseImage string
 		}
 		return strings.Join([]string{baseImageRegistry, runtimeDefaultBaseImage}, "/")
 
-	// if user specified something - use that, as is.
+	// if user specified something - use that, as is
 	// see description on https://github.com/nuclio/nuclio/pull/1544 - we don't implicitly mutate the given baseimage
 	default:
 		b.logger.WarnWith("Using user provided base image, runtime interpreter version is provided by the base image",

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1385,7 +1385,7 @@ func (b *Builder) getProcessorDockerfileBaseImage(runtimeDefaultBaseImage string
 	// if user specified something - use that, as is.
 	// see description on https://github.com/nuclio/nuclio/pull/1544 - we don't implicitly mutate the given baseimage
 	default:
-		b.logger.WarnWith("Using user provided base image, runtime configuration will be ignored",
+		b.logger.WarnWith("Using user provided base image, runtime interpreter version is provided by the base image",
 			"baseImage", b.options.FunctionConfig.Spec.Build.BaseImage)
 		return b.options.FunctionConfig.Spec.Build.BaseImage
 	}


### PR DESCRIPTION
When passing a custom base image in the function spec, this overrides the base image of the specified runtime, meaning that the value in `spec.runtime` is ignored.

This means that if the function is set to use a specific programming language and it is not pre-installed in the given base image, the function will fail.

Relates to #3095