### PR TITLE
[Lint] Add `unused` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
     - govet
     - typecheck
     - gocritic
+    - unused
 
 run:
 

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -444,16 +444,6 @@ func (p *Processor) createTriggers(processorConfiguration *processor.Configurati
 	return triggers, nil
 }
 
-func (p *Processor) hasHTTPTrigger(triggers []trigger.Trigger) bool {
-	for _, existingTrigger := range triggers {
-		if existingTrigger.GetKind() == "http" {
-			return true
-		}
-	}
-
-	return false
-}
-
 func (p *Processor) createWebAdminServer(platformConfiguration *platformconfig.Config) (*webadmin.Server, error) {
 
 	// if enabled not passed, default to true

--- a/hack/scripts/releaser/releaser.go
+++ b/hack/scripts/releaser/releaser.go
@@ -391,40 +391,6 @@ func (r *Release) getGithubWorkflowsReleaseStatus() (string, error) {
 	return status, nil
 }
 
-func (r *Release) getTravisReleaseStatus() (string, error) {
-	travisBuildsURL := fmt.Sprintf("%s/repos/nuclio/%s/builds", travisAPIURL, r.repositoryOwnerName)
-	request, err := http.NewRequest(http.MethodGet, travisBuildsURL, nil)
-	if err != nil {
-		return "", errors.Wrap(err, "Failed to create new request")
-	}
-	request.Header.Set("Content-Type", "application/vnd.travis-ci.2.1+json")
-	response, err := http.DefaultClient.Do(request)
-	if err != nil {
-		return "", errors.Wrap(err, "Failed to perform request")
-	}
-	responseBody, err := io.ReadAll(response.Body)
-	if err != nil {
-		return "", errors.Wrap(err, "Failed to read all response body")
-	}
-
-	type Build struct {
-		Branch string `json:"branch,omitempty"`
-		State  string `json:"state,omitempty"`
-	}
-	var BuildsResponse []Build
-	if err := json.Unmarshal(responseBody, &BuildsResponse); err != nil {
-		return "", errors.Wrap(err, "Failed to unmarshal builds response")
-	}
-	releaseBuildState := ""
-	for _, buildResponse := range BuildsResponse {
-		if buildResponse.Branch == r.targetVersion.String() {
-			releaseBuildState = buildResponse.State
-			break
-		}
-	}
-	return releaseBuildState, nil
-}
-
 func (r *Release) compileGithubAPIURL() string {
 	return fmt.Sprintf("%s/repos/%s/nuclio", githubAPIURL, r.repositoryOwnerName)
 }

--- a/pkg/dashboard/resource/resource.go
+++ b/pkg/dashboard/resource/resource.go
@@ -87,10 +87,6 @@ func (r *resource) getRequestAuthConfig(request *http.Request) (*platform.AuthCo
 	return nil, nil
 }
 
-func (r *resource) getListenAddress() string {
-	return r.getDashboard().ListenAddress
-}
-
 func (r *resource) headerValueIsTrue(request *http.Request, headerName string) bool {
 	return strings.ToLower(request.Header.Get(headerName)) == "true"
 }

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -3425,21 +3425,6 @@ func (suite *apiGatewayTestSuite) TestDeleteSuccessful() {
 	suite.mockPlatform.AssertExpectations(suite.T())
 }
 
-func (suite *apiGatewayTestSuite) sendRequestWithInvalidBody(method string, body string, expectedError string) {
-	expectedStatusCode := http.StatusBadRequest
-	ecv := restful.NewErrorContainsVerifier(suite.logger, []string{expectedError})
-	requestBody := body
-
-	suite.sendRequest(method,
-		"/api/api_gateways",
-		nil,
-		bytes.NewBufferString(requestBody),
-		&expectedStatusCode,
-		ecv.Verify)
-
-	suite.mockPlatform.AssertExpectations(suite.T())
-}
-
 //
 // Stream
 //

--- a/pkg/functionconfig/scrubber.go
+++ b/pkg/functionconfig/scrubber.go
@@ -397,15 +397,6 @@ func (s *Scrubber) validateReference(functionConfig *Config,
 	return errors.New(fmt.Sprintf("Config data in path %s is already masked, but secret does not exist.", fieldPath))
 }
 
-func (s *Scrubber) validateSecretName(secretName string) string {
-	if len(secretName) > common.KubernetesDomainLevelMaxLength {
-		secretName = secretName[:common.KubernetesDomainLevelMaxLength]
-	}
-
-	// remove trailing non-alphanumeric characters
-	return strings.TrimRight(secretName, "-_")
-}
-
 func (s *Scrubber) convertMapToConfig(mapConfig interface{}) (*Config, error) {
 
 	// marshal and unmarshal the map object back to function config

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1618,14 +1618,6 @@ func (p *Platform) getFunctionInstanceAndConfig(ctx context.Context,
 	return nil, nil, nil
 }
 
-func (p *Platform) platformProjectToProject(platformProject *platform.ProjectConfig, project *nuclioio.NuclioProject) {
-	project.Name = platformProject.Meta.Name
-	project.Namespace = platformProject.Meta.Namespace
-	project.Labels = platformProject.Meta.Labels
-	project.Annotations = platformProject.Meta.Annotations
-	project.Spec = platformProject.Spec
-}
-
 func (p *Platform) platformAPIGatewayToAPIGateway(platformAPIGateway *platform.APIGatewayConfig, apiGateway *nuclioio.NuclioAPIGateway) {
 	apiGateway.Name = platformAPIGateway.Meta.Name
 	apiGateway.Namespace = platformAPIGateway.Meta.Namespace

--- a/pkg/platform/kube/test/functional/platform_test.go
+++ b/pkg/platform/kube/test/functional/platform_test.go
@@ -212,7 +212,7 @@ func (suite *PlatformTestSuite) executeHelm(runOptions *cmdrunner.RunOptions,
 	return results.Output
 }
 
-func (suite *PlatformTestSuite) executeMinikube(positionalArgs []string,
+func (suite *PlatformTestSuite) executeMinikube(positionalArgs []string, // nolint: unused
 	namedArgs map[string]string) string {
 
 	if len(positionalArgs) == 0 {

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -815,40 +815,6 @@ func (b *Builder) resolveUserSpecifiedWorkdir(mainDir string) (string, error) {
 	return mainDir, nil
 }
 
-func (b *Builder) readFunctionConfigFile(functionConfigPath string) error {
-
-	// read the file once for logging
-	functionConfigContents, err := os.ReadFile(functionConfigPath)
-	if err != nil {
-		return errors.Wrap(err, "Failed to read function configuration file")
-	}
-
-	// log
-	b.logger.DebugWith("Read function configuration file", "contents", string(functionConfigContents))
-
-	functionConfigFile, err := os.Open(functionConfigPath)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to open function configuration file: %s", functionConfigPath)
-	}
-
-	defer functionConfigFile.Close() // nolint: errcheck
-
-	functionconfigReader, err := functionconfig.NewReader(b.logger)
-	if err != nil {
-		return errors.Wrap(err, "Failed to create functionconfig reader")
-	}
-
-	// read the configuration
-	if err := functionconfigReader.Read(functionConfigFile,
-		"yaml",
-		&b.options.FunctionConfig); err != nil {
-
-		return errors.Wrap(err, "Failed to read function configuration file")
-	}
-
-	return nil
-}
-
 func (b *Builder) createRuntime() (runtime.Runtime, error) {
 	runtimeName, err := b.getRuntimeName()
 	if err != nil {
@@ -1670,21 +1636,6 @@ func (b *Builder) getS3FunctionItemKey() (string, error) {
 	}
 
 	return s3Attributes["s3ItemKey"], nil
-}
-
-func (b *Builder) resolveCodeEntryAttributeAsString(attribute string) string {
-	if value, found := b.options.FunctionConfig.Spec.Build.CodeEntryAttributes[attribute]; found {
-		switch typedValue := value.(type) {
-		case string:
-			return typedValue
-		case int, int8, int16, int32, int64:
-			return fmt.Sprintf("%d", typedValue)
-		case float32, float64:
-			return fmt.Sprintf("%f", typedValue)
-		}
-	}
-
-	return ""
 }
 
 func (b *Builder) parseGitAttributes() (*gitcommon.Attributes, error) {

--- a/pkg/processor/build/runtime/java/test/java_test.go
+++ b/pkg/processor/build/runtime/java/test/java_test.go
@@ -19,10 +19,8 @@ limitations under the License.
 package test
 
 import (
-	"path"
 	"testing"
 
-	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime/test/suite"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
 
@@ -121,22 +119,6 @@ func (suite *TestSuite) TestBuildWithJarFromURL() {
 		RequestBody:          "abcd",
 		ExpectedResponseBody: "dcba",
 	})
-}
-
-func (suite *TestSuite) getDeployOptions(functionName string) *platform.CreateFunctionOptions {
-	functionInfo := suite.RuntimeSuite.GetFunctionInfo(functionName)
-
-	if functionInfo.Skip {
-		suite.T().Skip()
-	}
-
-	createFunctionOptions := suite.GetDeployOptions(functionName,
-		path.Join(functionInfo.Path...))
-
-	createFunctionOptions.FunctionConfig.Spec.Handler = functionInfo.Handler
-	createFunctionOptions.FunctionConfig.Spec.Runtime = functionInfo.Runtime
-
-	return createFunctionOptions
 }
 
 func TestIntegrationSuite(t *testing.T) {

--- a/pkg/processor/runtime/golang/test/timeout_test.go
+++ b/pkg/processor/runtime/golang/test/timeout_test.go
@@ -19,9 +19,7 @@ limitations under the License.
 package test
 
 import (
-	"bytes"
 	"encoding/json"
-	"io"
 	"net/http"
 	"path"
 	"testing"
@@ -73,17 +71,6 @@ func (suite *TimeoutTestSuite) TestTimeout() {
 			ExpectedResponseStatusCode: &timeoutStatusCode,
 		},
 	})
-}
-
-func (suite *TimeoutTestSuite) createRequest(timeout time.Duration) io.Reader {
-	var buf bytes.Buffer
-	request := map[string]string{
-		"timeout": timeout.String(),
-	}
-
-	err := json.NewEncoder(&buf).Encode(request)
-	suite.Require().NoError(err, "Can't encode request")
-	return &buf
 }
 
 func (suite *TimeoutTestSuite) genTimeoutRequest(timeout time.Duration) string {

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -621,12 +621,6 @@ func (r *AbstractRuntime) resolveFunctionLogger(functionLogger logger.Logger) lo
 	return functionLogger
 }
 
-func (r *AbstractRuntime) newResultChan() {
-
-	// We create the channel buffered so we won't block on sending
-	r.resultChan = make(chan *result, 1)
-}
-
 func (r *AbstractRuntime) watchWrapperProcess() {
 
 	// whatever happens, clear wrapper process

--- a/pkg/processor/runtime/rpc/rpc_test.go
+++ b/pkg/processor/runtime/rpc/rpc_test.go
@@ -23,8 +23,6 @@ import (
 	"encoding/json"
 	"io"
 	"net"
-	"os"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -78,14 +76,6 @@ func (suite *RPCSuite) emitLog(message string, conn io.Writer) {
 	suite.Require().NoError(err, "Can't encode log record")
 	_, err = io.Copy(conn, &buf)
 	suite.Require().NoError(err)
-}
-
-func (suite *RPCSuite) dummyProcess() *os.Process {
-	var buf bytes.Buffer
-	cmd := exec.Command("ls")
-	cmd.Stdout = &buf
-	suite.Require().NoError(cmd.Run(), "Can't run")
-	return cmd.Process
 }
 
 func (suite *RPCSuite) runtimeConfiguration(loggerInstance logger.Logger) *runtime.Configuration {

--- a/pkg/processor/trigger/kafka/test/kafka_test.go
+++ b/pkg/processor/trigger/kafka/test/kafka_test.go
@@ -679,7 +679,7 @@ func (suite *testSuite) publishMessageToTopicOnSpecificShard(topic string, body 
 	return nil
 }
 
-func (suite *testSuite) resolveReceivedEventBodies(deployResult *platform.CreateFunctionResult) []string {
+func (suite *testSuite) resolveReceivedEventBodies(deployResult *platform.CreateFunctionResult) []string { // nolint: unused
 
 	receivedEvents, err := triggertest.GetEventRecorderReceivedEvents(suite.Logger, suite.BrokerHost, deployResult.Port)
 	suite.Require().NoError(err)

--- a/pkg/processor/trigger/poller/trigger.go
+++ b/pkg/processor/trigger/poller/trigger.go
@@ -166,7 +166,3 @@ func (ap *AbstractPoller) waitForEventBatch(eventsChan chan nuclio.Event,
 
 	return events, eventCycleCompleted, nil
 }
-
-func (ap *AbstractPoller) onV3ioLog(formattedRecord string) {
-	ap.Logger.Debug(formattedRecord)
-}

--- a/pkg/processor/trigger/poller/v3ioitempoller/trigger.go
+++ b/pkg/processor/trigger/poller/v3ioitempoller/trigger.go
@@ -286,21 +286,3 @@ func (vip *v3ioItemPoller) encloseStrings(inputStrings []string, start string, e
 
 	return enclosedStrings
 }
-
-func (vip *v3ioItemPoller) createEventsFromItems(path string,
-	items []interface{},
-	eventsChan chan nuclio.Event) {
-
-	//for _, item := range items {
-	//	name := item["__name"].(string)
-	//
-	//	event := Event{
-	//		item: &item,
-	//		url:  vip.v3ioClient.URL + "/" + path + "/" + name,
-	//		path: path + "/" + name,
-	//	}
-	//
-	//	// shove event to channe
-	//	eventsChan <- &event
-	//}
-}

--- a/pkg/restful/resource_test.go
+++ b/pkg/restful/resource_test.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -168,15 +167,6 @@ func (suite *resourceTestSuite) sendRequest(method string,
 	}
 
 	return response, decodedResponseBody
-}
-
-// remove tabs and newlines
-func (suite *resourceTestSuite) cleanJSONstring(input string) string {
-	for _, char := range []string{"\n", "\t"} {
-		input = strings.ReplaceAll(input, char, "")
-	}
-
-	return input
 }
 
 // send error triggering requests


### PR DESCRIPTION
Removed all unused functions except for 2:
- `resolveReceivedEventBodies` in kafka suite - it is being called from a currently commented out test. 
In a followup PR it will be removed if the test is stale.
- `executeMinikube` in platform test - I can see benefits for it in the future.