### PR TITLE
[Processor] Fix duplicated event processing

### DIFF
--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -78,7 +78,6 @@ type AbstractRuntime struct {
 	cancelHandlerChan chan struct{}
 	socketType        SocketType
 	processWaiter     *processwaiter.ProcessWaiter
-	isDrained         bool
 }
 
 type rpcLogRecord struct {
@@ -231,11 +230,6 @@ func (r *AbstractRuntime) SupportsControlCommunication() bool {
 
 // Drain signals to the runtime to drain its accumulated events and waits for it to finish
 func (r *AbstractRuntime) Drain() error {
-	if r.isDrained {
-		return nil
-	}
-	r.isDrained = true
-
 	// we use SIGUSR2 to signal the wrapper process to drain events
 	if err := r.signal(syscall.SIGUSR2); err != nil {
 		return errors.Wrap(err, "Failed to signal wrapper process")

--- a/pkg/processor/runtime/rpc/abstract_test.go
+++ b/pkg/processor/runtime/rpc/abstract_test.go
@@ -64,9 +64,6 @@ func newTestRuntime(parentLogger logger.Logger, configuration *runtime.Configura
 
 	newTestRuntime.AbstractRuntime.ControlMessageBroker = NewRpcControlMessageBroker(nil, parentLogger, nil)
 
-	// set the runtime's isDrained to true, so it won't send a signal to the wrapper process
-	newTestRuntime.isDrained = true
-
 	return newTestRuntime, nil
 }
 

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -415,7 +415,7 @@ func (k *kafka) eventSubmitter(claim sarama.ConsumerGroupClaim, submittedEventCh
 		if processErr != nil {
 			k.Logger.DebugWith("Process error",
 				"partition", submittedEvent.event.kafkaMessage.Partition,
-				"err", processErr)
+				"err", processErr.Error())
 		}
 
 		switch k.configuration.ExplicitAckMode {

--- a/pkg/processor/worker/allocator.go
+++ b/pkg/processor/worker/allocator.go
@@ -30,6 +30,8 @@ import (
 
 var ErrNoAvailableWorkers = errors.New("No available workers")
 var ErrAllWorkersAreTerminated = errors.New("All workers are terminated")
+var ErrWorkerIsDrained = errors.New("Worker is drained")
+var ErrWorkerIsTerminated = errors.New("Worker is terminated")
 
 type Allocator interface {
 
@@ -124,7 +126,7 @@ func (s *singleton) SignalTermination() error {
 }
 
 func (s *singleton) ResetDrainState() {
-	s.worker.setDrained(false)
+	s.worker.setState(StateAvailable)
 }
 
 func (s *singleton) IsTerminated() bool {
@@ -278,7 +280,7 @@ func (fp *fixedPool) SignalTermination() error {
 
 func (fp *fixedPool) ResetDrainState() {
 	for _, workerInstance := range fp.GetWorkers() {
-		workerInstance.setDrained(false)
+		workerInstance.setState(StateAvailable)
 	}
 }
 

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -183,6 +183,7 @@ func (w *Worker) Terminate() error {
 	if err := w.runtime.Terminate(); err != nil {
 		return err
 	}
+	w.state.State = StateTerminated
 	w.logger.DebugWith("Successfully terminated worker", "workerIndex", w.index)
 	return nil
 }

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -40,6 +40,11 @@ const (
 	StateTerminated State = "terminated"
 )
 
+type StateWithLock struct {
+	State
+	sync.Mutex
+}
+
 // Worker holds all the required state and context to handle a single request
 type Worker struct {
 
@@ -53,11 +58,6 @@ type Worker struct {
 	binaryCloudEvent     cloudevent.Binary
 	eventTime            *time.Time
 	state                StateWithLock
-}
-
-type StateWithLock struct {
-	State
-	sync.Mutex
 }
 
 // NewWorker creates a new worker

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -192,10 +192,13 @@ func (w *Worker) Drain() error {
 	w.state.Lock()
 	defer w.state.Unlock()
 
-	if err := w.runtime.Drain(); err == nil {
-		w.logger.DebugWith("Successfully drained worker", "workerIndex", w.index)
-		w.state.State = StateDrained
-		return err
+	// drain if is not drained yet
+	if w.state.State != StateDrained {
+		if err := w.runtime.Drain(); err == nil {
+			w.logger.DebugWith("Successfully drained worker", "workerIndex", w.index)
+			w.state.State = StateDrained
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Jira - https://jira.iguazeng.com/browse/NUC-119

This pull request addresses a recently discovered bug related to the repeated event processing that occurs after scaling the function up. It was decided to fix this bug by defining a new `State` attribute in the `Worker` entity. 

`State` can be one of the following:
* available
* drained
* terminated

The `Worker.State` entity contains a mutex, which we block during worker draining and event processing to prevent them from happening concurrently. 
Additionally, before processing an event, we check if the worker is in the 'available' state. If not, we return an error and halt the consumption process.