### PR TITLE
[Processor] Delete isDrained flag from runtime

### DIFF
--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -78,7 +78,6 @@ type AbstractRuntime struct {
 	cancelHandlerChan chan struct{}
 	socketType        SocketType
 	processWaiter     *processwaiter.ProcessWaiter
-	isDrained         bool
 }
 
 type rpcLogRecord struct {
@@ -231,11 +230,6 @@ func (r *AbstractRuntime) SupportsControlCommunication() bool {
 
 // Drain signals to the runtime to drain its accumulated events and waits for it to finish
 func (r *AbstractRuntime) Drain() error {
-	if r.isDrained {
-		return nil
-	}
-	r.isDrained = true
-
 	// we use SIGUSR2 to signal the wrapper process to drain events
 	if err := r.signal(syscall.SIGUSR2); err != nil {
 		return errors.Wrap(err, "Failed to signal wrapper process")

--- a/pkg/processor/runtime/rpc/abstract_test.go
+++ b/pkg/processor/runtime/rpc/abstract_test.go
@@ -64,9 +64,6 @@ func newTestRuntime(parentLogger logger.Logger, configuration *runtime.Configura
 
 	newTestRuntime.AbstractRuntime.ControlMessageBroker = NewRpcControlMessageBroker(nil, parentLogger, nil)
 
-	// set the runtime's isDrained to true, so it won't send a signal to the wrapper process
-	newTestRuntime.isDrained = true
-
 	return newTestRuntime, nil
 }
 


### PR DESCRIPTION
[No ticket]

Deleted `isDrained` flag from runtime. It caused a bug when we drain only on 1st happened rebalance.