### PR TITLE
[Lint] Replace impi with gci import linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,7 @@ linters:
     - typecheck
     - gocritic
     - unused
+    - gci
 
 run:
 
@@ -59,6 +60,16 @@ linters-settings:
   gocritic:
     disabled-checks:
       - commentFormatting # we dont want to enforce space before the comment text
+
+  gci:
+    sections:
+      - standard
+      - prefix(github.com/nuclio/nuclio/)
+      - default
+      - blank
+      - dot
+
+    custom-order: true
 
 issues:
 

--- a/Makefile
+++ b/Makefile
@@ -619,25 +619,8 @@ fmt:
 .PHONY: lint
 lint: modules ensure-test-files-annotated
 	@echo Installing linters...
-	@test -e $(GOPATH)/bin/impi || \
-		(mkdir -p $(GOPATH)/bin && \
-		curl -s https://api.github.com/repos/pavius/impi/releases/latest \
-		| grep -i "browser_download_url.*impi.*$(OS_NAME)" \
-		| cut -d : -f 2,3 \
-		| tr -d \" \
-		| wget -O $(GOPATH)/bin/impi -qi - \
-		&& chmod +x $(GOPATH)/bin/impi)
-
 	@test -e $(GOPATH)/bin/golangci-lint || \
 	  	(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.54.2)
-
-	@echo Verifying imports...
-	$(GOPATH)/bin/impi \
-		--local github.com/nuclio/nuclio/ \
-		--scheme stdLocalThirdParty \
-		--skip pkg/platform/kube/apis \
-		--skip pkg/platform/kube/client \
-		./cmd/... ./pkg/... ./hack/...
 
 	@echo Linting...
 	$(GOPATH)/bin/golangci-lint run -v

--- a/cmd/autoscaler/app/autoscaler.go
+++ b/cmd/autoscaler/app/autoscaler.go
@@ -22,8 +22,6 @@ import (
 	nuclioioclient "github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/versioned"
 	"github.com/nuclio/nuclio/pkg/platform/kube/resourcescaler"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
-	// load all sinks
-	_ "github.com/nuclio/nuclio/pkg/sinks"
 
 	"github.com/nuclio/errors"
 	"github.com/v3io/scaler/pkg/autoscaler"
@@ -32,6 +30,9 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/metrics/pkg/client/custom_metrics"
+
+	// load all sinks
+	_ "github.com/nuclio/nuclio/pkg/sinks"
 )
 
 func Run(platformConfigurationPath string, namespace string, kubeconfigPath string) error {

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -30,12 +30,13 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform/kube/functionres"
 	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
-	// load all sinks
-	_ "github.com/nuclio/nuclio/pkg/sinks"
 
 	"github.com/nuclio/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	// load all sinks
+	_ "github.com/nuclio/nuclio/pkg/sinks"
 )
 
 func Run(kubeconfigPath string,

--- a/cmd/dashboard/app/run.go
+++ b/cmd/dashboard/app/run.go
@@ -35,13 +35,14 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform/factory"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/restful"
-	// load all sinks
-	_ "github.com/nuclio/nuclio/pkg/sinks"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/v3io/version-go"
 	"k8s.io/client-go/rest"
+
+	// load all sinks
+	_ "github.com/nuclio/nuclio/pkg/sinks"
 )
 
 func Run(listenAddress string,

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -22,9 +22,10 @@ import (
 
 	"github.com/nuclio/nuclio/cmd/dashboard/app"
 	"github.com/nuclio/nuclio/pkg/common"
-	_ "github.com/nuclio/nuclio/pkg/dashboard/resource"
 
 	"github.com/nuclio/errors"
+
+	_ "github.com/nuclio/nuclio/pkg/dashboard/resource"
 )
 
 func main() {

--- a/cmd/dlx/app/dlx.go
+++ b/cmd/dlx/app/dlx.go
@@ -22,12 +22,13 @@ import (
 	nuclioioclient "github.com/nuclio/nuclio/pkg/platform/kube/client/clientset/versioned"
 	"github.com/nuclio/nuclio/pkg/platform/kube/resourcescaler"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
-	// load all sinks
-	_ "github.com/nuclio/nuclio/pkg/sinks"
 
 	"github.com/nuclio/errors"
 	"github.com/v3io/scaler/pkg/dlx"
 	"k8s.io/client-go/rest"
+
+	// load all sinks
+	_ "github.com/nuclio/nuclio/pkg/sinks"
 )
 
 func Run(platformConfigurationPath string,

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -42,6 +42,17 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/healthcheck"
 	"github.com/nuclio/nuclio/pkg/processor/metricsink"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/timeout"
+	"github.com/nuclio/nuclio/pkg/processor/trigger"
+	httpnuclio "github.com/nuclio/nuclio/pkg/processor/trigger/http"
+	"github.com/nuclio/nuclio/pkg/processor/util/clock"
+	"github.com/nuclio/nuclio/pkg/processor/webadmin"
+	"github.com/nuclio/nuclio/pkg/processor/worker"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+	"github.com/v3io/version-go"
+
 	// load all runtimes
 	_ "github.com/nuclio/nuclio/pkg/processor/runtime/dotnetcore"
 	_ "github.com/nuclio/nuclio/pkg/processor/runtime/golang"
@@ -50,11 +61,8 @@ import (
 	_ "github.com/nuclio/nuclio/pkg/processor/runtime/python"
 	_ "github.com/nuclio/nuclio/pkg/processor/runtime/ruby"
 	_ "github.com/nuclio/nuclio/pkg/processor/runtime/shell"
-	"github.com/nuclio/nuclio/pkg/processor/timeout"
-	"github.com/nuclio/nuclio/pkg/processor/trigger"
 	// load all triggers
 	_ "github.com/nuclio/nuclio/pkg/processor/trigger/cron"
-	httpnuclio "github.com/nuclio/nuclio/pkg/processor/trigger/http"
 	_ "github.com/nuclio/nuclio/pkg/processor/trigger/kafka"
 	_ "github.com/nuclio/nuclio/pkg/processor/trigger/kickstart"
 	_ "github.com/nuclio/nuclio/pkg/processor/trigger/kinesis"
@@ -66,15 +74,8 @@ import (
 	_ "github.com/nuclio/nuclio/pkg/processor/trigger/pubsub"
 	_ "github.com/nuclio/nuclio/pkg/processor/trigger/rabbitmq"
 	_ "github.com/nuclio/nuclio/pkg/processor/trigger/v3iostream"
-	"github.com/nuclio/nuclio/pkg/processor/util/clock"
-	"github.com/nuclio/nuclio/pkg/processor/webadmin"
-	"github.com/nuclio/nuclio/pkg/processor/worker"
 	// load all sinks
 	_ "github.com/nuclio/nuclio/pkg/sinks"
-
-	"github.com/nuclio/errors"
-	"github.com/nuclio/logger"
-	"github.com/v3io/version-go"
 )
 
 // Processor is responsible to process events

--- a/cmd/processor/app/processor_test.go
+++ b/cmd/processor/app/processor_test.go
@@ -29,14 +29,15 @@ import (
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/processor"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
-	// load cron trigger for tests purposes
-	_ "github.com/nuclio/nuclio/pkg/processor/trigger/cron"
 	"github.com/nuclio/nuclio/pkg/processor/worker"
 
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+
+	// load cron trigger for tests purposes
+	_ "github.com/nuclio/nuclio/pkg/processor/trigger/cron"
 )
 
 type TriggerTestSuite struct {

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -24,10 +24,11 @@ import (
 
 	"github.com/nuclio/nuclio/cmd/processor/app"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
-	_ "github.com/nuclio/nuclio/pkg/processor/webadmin/resource"
 
 	"github.com/nuclio/errors"
 	"github.com/v3io/version-go"
+
+	_ "github.com/nuclio/nuclio/pkg/processor/webadmin/resource"
 )
 
 func run() error {

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/common/headers"
 	"github.com/nuclio/nuclio/pkg/dashboard"
 	"github.com/nuclio/nuclio/pkg/dashboard/functiontemplates"
-	_ "github.com/nuclio/nuclio/pkg/dashboard/resource"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
@@ -56,6 +55,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/api/core/v1"
+
+	_ "github.com/nuclio/nuclio/pkg/dashboard/resource"
 )
 
 type dashboardTestSuite struct {

--- a/pkg/nuctl/command/nuctl.go
+++ b/pkg/nuctl/command/nuctl.go
@@ -31,6 +31,7 @@ import (
 	"github.com/nuclio/zap"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
+
 	// load authentication modes
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"

--- a/pkg/platform/kube/apis/nuclio.io/v1beta1/register.go
+++ b/pkg/platform/kube/apis/nuclio.io/v1beta1/register.go
@@ -17,11 +17,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	"github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io"
 )
 
 // SchemeGroupVersion is group version used to register these objects

--- a/pkg/platform/kube/client/consumer.go
+++ b/pkg/platform/kube/client/consumer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"k8s.io/client-go/kubernetes"
+
 	// enable OIDC plugin
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )

--- a/pkg/platform/kube/client/deleter.go
+++ b/pkg/platform/kube/client/deleter.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+
 	"github.com/nuclio/nuclio/pkg/nuctl"
 	"github.com/nuclio/nuclio/pkg/platform"
 

--- a/pkg/platform/kube/client/getter.go
+++ b/pkg/platform/kube/client/getter.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+
 	"github.com/nuclio/nuclio/pkg/platform"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -38,14 +38,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/processor/build/inlineparser"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
-	// load runtimes so that they register to runtime registry
-	_ "github.com/nuclio/nuclio/pkg/processor/build/runtime/dotnetcore"
-	_ "github.com/nuclio/nuclio/pkg/processor/build/runtime/golang"
-	_ "github.com/nuclio/nuclio/pkg/processor/build/runtime/java"
-	_ "github.com/nuclio/nuclio/pkg/processor/build/runtime/nodejs"
-	_ "github.com/nuclio/nuclio/pkg/processor/build/runtime/python"
-	_ "github.com/nuclio/nuclio/pkg/processor/build/runtime/ruby"
-	_ "github.com/nuclio/nuclio/pkg/processor/build/runtime/shell"
 	"github.com/nuclio/nuclio/pkg/processor/build/util"
 
 	"github.com/mholt/archiver/v3"
@@ -55,6 +47,15 @@ import (
 	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/v3io/version-go"
 	"gopkg.in/yaml.v3"
+
+	// load runtimes so that they register to runtime registry
+	_ "github.com/nuclio/nuclio/pkg/processor/build/runtime/dotnetcore"
+	_ "github.com/nuclio/nuclio/pkg/processor/build/runtime/golang"
+	_ "github.com/nuclio/nuclio/pkg/processor/build/runtime/java"
+	_ "github.com/nuclio/nuclio/pkg/processor/build/runtime/nodejs"
+	_ "github.com/nuclio/nuclio/pkg/processor/build/runtime/python"
+	_ "github.com/nuclio/nuclio/pkg/processor/build/runtime/ruby"
+	_ "github.com/nuclio/nuclio/pkg/processor/build/runtime/shell"
 )
 
 const (


### PR DESCRIPTION
Introduce the [gci](https://golangci-lint.run/usage/linters/#gci) import linter which is a part of the golangci linters.
It is able to validate **and fix** the imports according to the set rules.

The import order is as follows:
- Standard go libraries
- Nuclio in-house packages (`github.com/nuclio/nuclio/`)
- External packages
- Black imports (`_`)
- Relatice (dot) imports

See more at https://github.com/daixiang0/gci