### PR TITLE
[HTTP] Handle internal healthcheck before request validation

### DIFF
--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -389,18 +389,18 @@ func (h *http) handleRequest(ctx *fasthttp.RequestCtx) {
 	var functionLogger logger.Logger
 	var bufferLogger *nucliozap.BufferLogger
 
+	// internal endpoint to allow clients the information whether the http server is taking requests in
+	// this is an internal endpoint, we do not want to update statistics here
+	if bytes.HasPrefix(ctx.URI().Path(), h.internalHealthPath) {
+		ctx.Response.SetStatusCode(nethttp.StatusOK)
+		return
+	}
+
 	// perform pre request handling validation
 	if !h.preHandleRequestValidation(ctx) {
 
 		// in case validation failed, stop here
 		h.UpdateStatistics(false)
-		return
-	}
-
-	// internal endpoint to allow clients the information whether the http server is taking requests in
-	// this is an internal endpoint, we do not want to update statistics here
-	if bytes.HasPrefix(ctx.URI().Path(), h.internalHealthPath) {
-		ctx.Response.SetStatusCode(nethttp.StatusOK)
 		return
 	}
 


### PR DESCRIPTION
Kubernetes health check requests do not have any headers (specifically - no `Origin` header), and are very frequent.
When CORS is enabled, these checks fail CORS origin validation and keep the trigger constantly busy so every request gets redirected.

Fixes https://jira.iguazeng.com/projects/NUC/issues/NUC-5