### PR TITLE
[Python] Fix duplicate event on drain callback

### DIFF
--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -36,6 +36,9 @@ class Constants:
     # in msgpack protoctol, binary messages' length is 4 bytes long
     msgpack_message_length_bytes = 4
 
+    drain_signal = signal.SIGUSR1
+    termination_signal = signal.SIGUSR1
+
 
 class WrapperFatalException(Exception):
     """
@@ -223,11 +226,11 @@ class Wrapper(object):
                 raise
 
     def _register_to_signal(self):
-        on_termination_signal = functools.partial(self._on_termination_signal, "SIGUSR1")
-        on_drain_signal = functools.partial(self._on_drain_signal, "SIGUSR2")
+        on_termination_signal = functools.partial(self._on_termination_signal, Constants.termination_signal.name)
+        on_drain_signal = functools.partial(self._on_drain_signal, Constants.drain_signal.name)
 
-        asyncio.get_running_loop().add_signal_handler(signal.SIGUSR1, on_termination_signal)
-        asyncio.get_running_loop().add_signal_handler(signal.SIGUSR2, on_drain_signal)
+        asyncio.get_running_loop().add_signal_handler(Constants.termination_signal, on_termination_signal)
+        asyncio.get_running_loop().add_signal_handler(Constants.drain_signal, on_drain_signal)
 
     def _on_drain_signal(self, signal_name):
         self._logger.debug_with('Received signal, calling draining callback', signal=signal_name)

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -166,7 +166,7 @@ class Wrapper(object):
                 await self._on_serving_error(exc)
 
             except asyncio.CancelledError:
-                self._logger.debug(f'Waiting for event message was interrupted by a signal')
+                self._logger.debug('Waiting for event message was interrupted by a signal')
 
             except Exception as exc:
                 await self._on_serving_error(exc)

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -36,8 +36,8 @@ class Constants:
     # in msgpack protoctol, binary messages' length is 4 bytes long
     msgpack_message_length_bytes = 4
 
-    drain_signal = signal.SIGUSR1
     termination_signal = signal.SIGUSR1
+    drain_signal = signal.SIGUSR2
 
 
 class WrapperFatalException(Exception):

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -232,12 +232,14 @@ class Wrapper(object):
     def _on_drain_signal(self, signal_name):
         self._logger.debug_with('Received signal, calling draining callback', signal=signal_name)
         self._is_drain_needed = True
+        # if serving loop is waiting for an event, unblock this operation to allow the drain callback to be called
         if self._event_message_length_task:
             self._event_message_length_task.cancel()
 
     def _on_termination_signal(self, signal_name):
         self._logger.debug_with('Received signal, calling termination callback', signal=signal_name)
         self._is_termination_needed = True
+        # if serving loop is waiting for an event, unblock this operation to allow the termination callback to be called
         if self._event_message_length_task:
             self._event_message_length_task.cancel()
 


### PR DESCRIPTION
[NUC-119](https://jira.iguazeng.com/browse/NUC-119)

Also:
* Exit python wrapper following a termination signal.
* Await a coroutine if returned by drain or termination callback (relates to https://github.com/nuclio/nuclio-sdk-py/pull/60). This unblocks [ML-4421](https://jira.iguazeng.com/browse/ML-4421), because it allows for drain/termination callbacks to call `explicit_ack()` without having to start a separate thread. E.g.:
```python
    async def drain_callback():
        for qualified_offset in context.qualified_offsets.values():
            await context.platform.explicit_ack(qualified_offset)
```
instead of
```python
    def drain_callback():
        for qualified_offset in context.qualified_offsets.values():
            def commit():
                asyncio.run(context.platform.explicit_ack(qualified_offset))
            thread = threading.Thread(target=commit)
            thread.start()
            thread.join()
```