### PR TITLE
[Processor] Stop processing events on draining and send signal to continue processing

### DIFF
--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -653,7 +653,7 @@ func (p *Processor) terminateAllTriggers(signal os.Signal) {
 		// drains all workers in trigger (for each trigger in parallel)
 		go func(triggerInstance trigger.Trigger, wg *sync.WaitGroup) {
 			defer wg.Done()
-			if err := triggerInstance.SignalWorkerTermination(); err != nil {
+			if err := triggerInstance.SignalWorkersToTerminate(); err != nil {
 				p.logger.WarnWith("Failed to signal worker termination",
 					"triggerKind", triggerInstance.GetKind(),
 					"triggerName", triggerInstance.GetName(),

--- a/cmd/processor/app/processor_test.go
+++ b/cmd/processor/app/processor_test.go
@@ -232,12 +232,17 @@ func (t *testTrigger) TimeoutWorker(worker *worker.Worker) error {
 	return nil
 }
 
-func (t *testTrigger) SignalWorkerDraining() error {
+func (t *testTrigger) SignalWorkersToDrain() error {
 	t.Called()
 	return nil
 }
 
-func (t *testTrigger) SignalWorkerTermination() error {
+func (t *testTrigger) SignalWorkersToTerminate() error {
+	t.Called()
+	return nil
+}
+
+func (t *testTrigger) SignalWorkersToContinue() error {
 	t.Called()
 	return nil
 }

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -251,9 +251,8 @@ class Wrapper(object):
         if self._event_message_length_task:
             self._event_message_length_task.cancel()
 
-    def _on_continue_signal(self, signal_number, frame):
-        self._logger.debug_with('Received continue signal',
-                                signal=signal.Signals(signal_number).name)
+    def _on_continue_signal(self, signal_name):
+        self._logger.debug_with('Received continue signal', signal=signal_name)
 
         # set this flag to False, so continue normal event processing flow
         self._discard_events = False

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -174,7 +174,7 @@ class Wrapper(object):
                 await self._on_serving_error(exc)
 
             finally:
-                if self._is_drain_needed and not self._discard_events:
+                if self._is_drain_needed:
                     result = self._call_drain_handler()
                     if asyncio.iscoroutine(result):
                         await result
@@ -242,7 +242,7 @@ class Wrapper(object):
         if self._discard_events:
             return
 
-        self._logger.debug_with('Received signal, calling draining callback', signal=signal_name)
+        self._logger.debug_with('Received signal', signal=signal_name)
         self._is_drain_needed = True
 
         # set the flag to True to stop processing events which are received after draining
@@ -253,7 +253,7 @@ class Wrapper(object):
             self._event_message_length_task.cancel()
 
     def _on_termination_signal(self, signal_name):
-        self._logger.debug_with('Received signal, calling termination callback', signal=signal_name)
+        self._logger.debug_with('Received signal', signal=signal_name)
         self._is_termination_needed = True
         # if serving loop is waiting for an event, unblock this operation to allow the termination callback to be called
         if self._event_message_length_task:

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -244,9 +244,11 @@ class Wrapper(object):
 
         self._logger.debug_with('Received signal, calling draining callback', signal=signal_name)
         self._is_drain_needed = True
-        # if serving loop is waiting for an event, unblock this operation to allow the drain callback to be called
+
         # set the flag to True to stop processing events which are received after draining
         self._discard_events = True
+
+        # if serving loop is waiting for an event, unblock this operation to allow the drain callback to be called
         if self._event_message_length_task:
             self._event_message_length_task.cancel()
 

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -174,11 +174,12 @@ class Wrapper(object):
                 await self._on_serving_error(exc)
 
             finally:
-                if self._is_drain_needed:
+                if self._is_drain_needed and not self._discard_events:
                     result = self._call_drain_handler()
                     if asyncio.iscoroutine(result):
                         await result
                     self._discard_events = True
+                self._is_drain_needed = False
 
                 if self._is_termination_needed:
                     result = self._call_termination_handler()
@@ -233,6 +234,7 @@ class Wrapper(object):
         on_termination_signal = functools.partial(self._on_termination_signal, Constants.termination_signal.name)
         on_drain_signal = functools.partial(self._on_drain_signal, Constants.drain_signal.name)
         on_continue_signal = functools.partial(self._on_continue_signal, Constants.continue_signal.name)
+
         asyncio.get_running_loop().add_signal_handler(Constants.termination_signal, on_termination_signal)
         asyncio.get_running_loop().add_signal_handler(Constants.drain_signal, on_drain_signal)
         asyncio.get_running_loop().add_signal_handler(Constants.continue_signal, on_continue_signal)

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -176,7 +176,6 @@ class Wrapper(object):
             finally:
                 if self._is_drain_needed and not self._discard_events:
                     result = self._call_drain_handler()
-                    self._discard_events = True
                     if asyncio.iscoroutine(result):
                         await result
                 self._is_drain_needed = False
@@ -264,6 +263,9 @@ class Wrapper(object):
 
         # set the flag to False so the drain handler will not be called more than once
         self._is_drain_needed = False
+
+        # set the flag to True to stop processing events which are received after draining
+        self._discard_events = True
         return self._platform._on_signal(callback_type="drain")
 
     def _call_termination_handler(self):

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -143,16 +143,14 @@ class Wrapper(object):
 
                 self._event_message_length_task = None
 
-                # do not process event if worker is drained
+                # resolve event message
+                event = await self._resolve_event(self._event_sock, event_message_length)
+
+                # do not handle an event if a worker is drained
                 if not self._discard_events:
-                    # resolve event message
-                    event = await self._resolve_event(self._event_sock, event_message_length)
-
                     try:
-
                         # handle event
                         await self._handle_event(event)
-
                     except BaseException as exc:
                         await self._on_handle_event_error(exc)
 

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -176,9 +176,9 @@ class Wrapper(object):
             finally:
                 if self._is_drain_needed and not self._discard_events:
                     result = self._call_drain_handler()
+                    self._discard_events = True
                     if asyncio.iscoroutine(result):
                         await result
-                    self._discard_events = True
                 self._is_drain_needed = False
 
                 if self._is_termination_needed:

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -242,6 +242,16 @@ func (r *AbstractRuntime) Drain() error {
 	return nil
 }
 
+// Continue signals to the runtime to continue event processing
+func (r *AbstractRuntime) Continue() error {
+	// we use SIGCONT to signal the wrapper process to continue event processing
+	if err := r.signal(syscall.SIGCONT); err != nil {
+		return errors.Wrap(err, "Failed to signal wrapper process")
+	}
+
+	return nil
+}
+
 // Terminate signals to the runtime process that processor is about to stop working
 func (r *AbstractRuntime) Terminate() error {
 

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -232,7 +232,7 @@ func (r *AbstractRuntime) SupportsControlCommunication() bool {
 func (r *AbstractRuntime) Drain() error {
 	// we use SIGUSR2 to signal the wrapper process to drain events
 	if err := r.signal(syscall.SIGUSR2); err != nil {
-		return errors.Wrap(err, "Failed to signal wrapper process")
+		return errors.Wrap(err, "Failed to signal wrapper process to drain")
 	}
 
 	// wait for process to finish event handling or timeout
@@ -246,7 +246,7 @@ func (r *AbstractRuntime) Drain() error {
 func (r *AbstractRuntime) Continue() error {
 	// we use SIGCONT to signal the wrapper process to continue event processing
 	if err := r.signal(syscall.SIGCONT); err != nil {
-		return errors.Wrap(err, "Failed to signal wrapper process")
+		return errors.Wrap(err, "Failed to signal wrapper process to continue")
 	}
 
 	return nil
@@ -257,7 +257,7 @@ func (r *AbstractRuntime) Terminate() error {
 
 	// we use SIGUSR1 to signal the wrapper process to terminate
 	if err := r.signal(syscall.SIGUSR1); err != nil {
-		return errors.Wrap(err, "Failed to signal wrapper process")
+		return errors.Wrap(err, "Failed to signal wrapper process to terminate")
 	}
 
 	// wait for process to finish event handling or timeout

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -242,7 +242,7 @@ func (r *AbstractRuntime) Drain() error {
 	return nil
 }
 
-// Continue signals to the runtime to continue event processing
+// Continue signals the runtime to continue event processing
 func (r *AbstractRuntime) Continue() error {
 	// we use SIGCONT to signal the wrapper process to continue event processing
 	if err := r.signal(syscall.SIGCONT); err != nil {

--- a/pkg/processor/runtime/runtime.go
+++ b/pkg/processor/runtime/runtime.go
@@ -65,7 +65,7 @@ type Runtime interface {
 	// Drain signals to the runtime process to drain its accumulated events and waits for it to finish
 	Drain() error
 
-	// Continue signals to the runtime process to continue event processing
+	// Continue signals the runtime process to continue event processing
 	Continue() error
 
 	// Terminate signals to the runtime process that processor is about to stop working

--- a/pkg/processor/runtime/runtime.go
+++ b/pkg/processor/runtime/runtime.go
@@ -65,6 +65,9 @@ type Runtime interface {
 	// Drain signals to the runtime process to drain its accumulated events and waits for it to finish
 	Drain() error
 
+	// Continue signals to the runtime process to continue event processing
+	Continue() error
+
 	// Terminate signals to the runtime process that processor is about to stop working
 	Terminate() error
 
@@ -261,5 +264,9 @@ func (ar *AbstractRuntime) Drain() error {
 }
 
 func (ar *AbstractRuntime) Terminate() error {
+	return nil
+}
+
+func (ar *AbstractRuntime) Continue() error {
 	return nil
 }

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -136,7 +136,6 @@ func (k *kafka) Start(checkpoint functionconfig.Checkpoint) error {
 			if err = k.SignalWorkerContinue(); err != nil {
 				k.Logger.WarnWith("Failed to signal worker to continue event processing",
 					"err", err)
-				time.Sleep(1 * time.Second)
 				continue
 			}
 

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -133,7 +133,7 @@ func (k *kafka) Start(checkpoint functionconfig.Checkpoint) error {
 			k.Logger.DebugWith("Starting to consume from broker", "topics", k.configuration.Topics)
 
 			// signal workers to continue event processing
-			if err = k.SignalWorkerContinue(); err != nil {
+			if err = k.SignalWorkersToContinue(); err != nil {
 				k.Logger.WarnWith("Failed to signal worker to continue event processing",
 					"err", err)
 				continue
@@ -350,7 +350,7 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 			// this needs to occur once. the reason is that this specific function (ConsumeClaim)
 			// runs in parallel for each partition, and we want to make sure that we only
 			// drain the workers once.
-			if err := k.SignalWorkerDraining(); err != nil {
+			if err := k.SignalWorkersToDrain(); err != nil {
 				k.Logger.DebugWith("Failed to signal worker draining",
 					"err", err.Error(),
 					"partition", claim.Partition())

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -371,10 +371,10 @@ func (at *AbstractTrigger) SignalWorkerDraining() error {
 	return nil
 }
 
-// SignalWorkerContinue sends a signal to all workers, telling them to resume event processing
+// SignalWorkerContinue sends a signal to all workers, telling them to continue event processing
 func (at *AbstractTrigger) SignalWorkerContinue() error {
 	if err := at.WorkerAllocator.SignalContinue(); err != nil {
-		return errors.Wrap(err, "Failed to signal all workers to drain events")
+		return errors.Wrap(err, "Failed to signal all workers to continue event processing")
 	}
 	return nil
 }

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -84,11 +84,14 @@ type Trigger interface {
 	// TimeoutWorker times out a worker
 	TimeoutWorker(worker *worker.Worker) error
 
-	// SignalWorkerDraining drains all workers
-	SignalWorkerDraining() error
+	// SignalWorkersToDrain drains all workers
+	SignalWorkersToDrain() error
 
-	// SignalWorkerTermination signal to all workers that the processor is about to stop working
-	SignalWorkerTermination() error
+	// SignalWorkersToContinue signal all workers to continue processing
+	SignalWorkersToContinue() error
+
+	// SignalWorkersToTerminate signal to all workers that the processor is about to stop working
+	SignalWorkersToTerminate() error
 }
 
 // AbstractTrigger implements common trigger operations
@@ -362,24 +365,24 @@ func (at *AbstractTrigger) UnsubscribeFromControlMessageKind(kind controlcommuni
 	return nil
 }
 
-// SignalWorkerDraining sends a signal to all workers, telling them to drop or ack events
+// SignalWorkersToDrain sends a signal to all workers, telling them to drop or ack events
 // that are currently being processed
-func (at *AbstractTrigger) SignalWorkerDraining() error {
+func (at *AbstractTrigger) SignalWorkersToDrain() error {
 	if err := at.WorkerAllocator.SignalDraining(); err != nil {
 		return errors.Wrap(err, "Failed to signal all workers to drain events")
 	}
 	return nil
 }
 
-// SignalWorkerContinue sends a signal to all workers, telling them to continue event processing
-func (at *AbstractTrigger) SignalWorkerContinue() error {
+// SignalWorkersToContinue sends a signal to all workers, telling them to continue event processing
+func (at *AbstractTrigger) SignalWorkersToContinue() error {
 	if err := at.WorkerAllocator.SignalContinue(); err != nil {
 		return errors.Wrap(err, "Failed to signal all workers to continue event processing")
 	}
 	return nil
 }
 
-func (at *AbstractTrigger) SignalWorkerTermination() error {
+func (at *AbstractTrigger) SignalWorkersToTerminate() error {
 	if err := at.WorkerAllocator.SignalTermination(); err != nil {
 		return errors.Wrap(err, "Failed to signal all workers to terminate")
 	}

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -371,16 +371,19 @@ func (at *AbstractTrigger) SignalWorkerDraining() error {
 	return nil
 }
 
+// SignalWorkerContinue sends a signal to all workers, telling them to resume event processing
+func (at *AbstractTrigger) SignalWorkerContinue() error {
+	if err := at.WorkerAllocator.SignalContinue(); err != nil {
+		return errors.Wrap(err, "Failed to signal all workers to drain events")
+	}
+	return nil
+}
+
 func (at *AbstractTrigger) SignalWorkerTermination() error {
 	if err := at.WorkerAllocator.SignalTermination(); err != nil {
 		return errors.Wrap(err, "Failed to signal all workers to terminate")
 	}
 	return nil
-}
-
-// ResetWorkerDrainState resets the worker draining state
-func (at *AbstractTrigger) ResetWorkerDrainState() {
-	at.WorkerAllocator.ResetDrainState()
 }
 
 func (at *AbstractTrigger) prepareEvent(event nuclio.Event, workerInstance *worker.Worker) (nuclio.Event, error) {

--- a/pkg/processor/worker/worker_test.go
+++ b/pkg/processor/worker/worker_test.go
@@ -86,6 +86,11 @@ func (mr *MockRuntime) Terminate() error {
 	return args.Error(0)
 }
 
+func (mr *MockRuntime) Continue() error {
+	args := mr.Called()
+	return args.Error(0)
+}
+
 func (mr *MockRuntime) SupportsControlCommunication() bool {
 	args := mr.Called()
 	return args.Bool(0)


### PR DESCRIPTION
Jira - https://jira.iguazeng.com/browse/NUC-119

This pull request addresses an issue where the processor sent events to the runtime after draining and before reconnection. Now, the wrapper will skip all events received after draining and wait for the `SIGCONT` signal to resume event processing.
These changes also allow us to get rid of `isDrained` checks on processor side.