### PR TITLE
[Nuctl] Allow force-deleting resources

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -123,6 +123,23 @@ func StringSliceContainsStringCaseInsensitive(slice []string, str string) bool {
 	return false
 }
 
+// PrependStringToStringSlice prepends a string to a string slice
+func PrependStringToStringSlice(slice []string, str string) []string {
+	slice = append(slice, "")
+	copy(slice[1:], slice)
+	slice[0] = str
+	return slice
+}
+
+// PrependStringsToStringSlice prepends multiple strings to a string slice
+func PrependStringsToStringSlice(slice []string, strs ...string) []string {
+	totalLen := len(slice) + len(strs)
+	slice = append(slice, make([]string, len(strs))...)
+	copy(slice[len(strs):], slice)
+	copy(slice, strs)
+	return slice[:totalLen]
+}
+
 // RemoveANSIColorsFromString strips out ANSI Colors chars from string
 // example: "\u001b[31mHelloWorld" -> "HelloWorld"
 func RemoveANSIColorsFromString(s string) string {

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1465,7 +1465,51 @@ func (suite *functionGetTestSuite) TestDelete() {
 	err = suite.ExecuteNuctl([]string{"delete", "fu", functionName}, nil)
 	suite.Require().NoError(err)
 
-	// try invoke, it should failed
+	// try invoking, it should fail
+	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"invoke", functionName},
+		map[string]string{
+			"method": "POST",
+			"body":   "-reverse this string+",
+			"via":    "external-ip",
+		},
+		true)
+	suite.Require().NoError(err, "Function was suppose to be deleted!")
+}
+
+func (suite *functionGetTestSuite) TestForceDelete() {
+	var err error
+
+	uniqueSuffix := "-" + xid.New().String()
+	functionName := "reverser" + uniqueSuffix
+	imageName := "nuclio/processor-" + functionName
+
+	namedArgs := map[string]string{
+		"path":    path.Join(suite.GetFunctionsDir(), "common", "reverser", "golang"),
+		"runtime": "golang",
+		"handler": "main:Reverse",
+	}
+
+	// deploy function in goroutine
+	go func() {
+		err = suite.ExecuteNuctl([]string{
+			"deploy",
+			functionName,
+			"--verbose",
+			"--no-pull",
+		}, namedArgs)
+		suite.Require().Error(err)
+	}()
+
+	// wait for function deployment to start, then force delete the function
+	time.Sleep(3 * time.Second)
+	// function removed
+	err = suite.ExecuteNuctl([]string{"delete", "fu", functionName, "--force"}, nil)
+	suite.Require().NoError(err)
+
+	// cleanup
+	defer suite.dockerClient.RemoveImage(imageName) // nolint: errcheck
+
+	// try invoking, it should fail
 	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"invoke", functionName},
 		map[string]string{
 			"method": "POST",

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -379,7 +379,7 @@ func (c *Config) enrichContainerResources(ctx context.Context,
 
 	logger.DebugWithCtx(ctx,
 		"Populated resources with default values",
-		"resources", resources)
+		"resources", resources.String())
 }
 
 func (c *Config) getMetricSinks(metricSinkNames []string) (map[string]MetricSink, error) {


### PR DESCRIPTION
Allow deleting functions that are in a provisioning state, and projects with resources by using the `--force` flag.
This is already possible from the API, adding support in `nuctl` as well. 

Resolves #3059 