### PR TITLE
[Nuctl] Lowercase report fields and report error cause

### DIFF
--- a/pkg/nuctl/command/common/importreport.go
+++ b/pkg/nuctl/command/common/importreport.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 )
 
 type ProjectReports struct {
-	Reports map[string]*ProjectReport
+	Reports map[string]*ProjectReport `json:"reports,omitempty"`
 }
 
 func NewProjectReports() *ProjectReports {
@@ -56,11 +57,11 @@ func (pr *ProjectReports) SprintfError() string {
 }
 
 type ProjectReport struct {
-	Name            string
-	Skipped         bool
-	Success         bool
-	Failed          *FailReport
-	FunctionReports *FunctionReports
+	Name            string           `json:"name,omitempty"`
+	Skipped         bool             `json:"skipped,omitempty"`
+	Success         bool             `json:"success,omitempty"`
+	Failed          *FailReport      `json:"failed,omitempty"`
+	FunctionReports *FunctionReports `json:"functionReports,omitempty"`
 }
 
 func NewProjectReport(name string) *ProjectReport {
@@ -89,8 +90,8 @@ func (pr *ProjectReport) SprintfError() string {
 }
 
 type FunctionReports struct {
-	Success []string
-	Failed  map[string]*FailReport
+	Success []string               `json:"success,omitempty"`
+	Failed  map[string]*FailReport `json:"failed,omitempty"`
 
 	mutex sync.Mutex
 }
@@ -119,8 +120,10 @@ func (fr *FunctionReports) AddFailure(name string, err error) {
 	fr.mutex.Lock()
 	defer fr.mutex.Unlock()
 
+	typedErr := err.(*errors.Error)
+
 	fr.Failed[name] = &FailReport{
-		FailReason: err.Error(),
+		FailReason: typedErr.Cause().Error(),
 	}
 }
 
@@ -132,6 +135,6 @@ func (fr *FunctionReports) AddSuccess(name string) {
 }
 
 type FailReport struct {
-	FailReason     string
-	CanBeAutoFixed bool
+	FailReason     string `json:"failReason,omitempty"`
+	CanBeAutoFixed bool   `json:"canBeAutoFixed,omitempty"`
 }

--- a/pkg/nuctl/command/common/importreport.go
+++ b/pkg/nuctl/command/common/importreport.go
@@ -120,10 +120,8 @@ func (fr *FunctionReports) AddFailure(name string, err error) {
 	fr.mutex.Lock()
 	defer fr.mutex.Unlock()
 
-	typedErr := err.(*errors.Error)
-
 	fr.Failed[name] = &FailReport{
-		FailReason: typedErr.Cause().Error(),
+		FailReason: errors.RootCause(err).Error(),
 	}
 }
 

--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -276,7 +276,11 @@ Use --help for more information`)
 				},
 			}
 
-			return commandeer.importFunctions(ctx, functionConfigs, platformConfig, commandeer.report)
+			err = commandeer.importFunctions(ctx, functionConfigs, platformConfig, commandeer.report)
+			if commandeer.saveReport {
+				commandeer.report.SaveToFile(ctx, commandeer.rootCommandeer.loggerInstance, commandeer.reportFilePath)
+			}
+			return err
 		},
 	}
 

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1612,7 +1612,7 @@ func (suite *functionExportImportTestSuite) TestImportWithReport() {
 	suite.Require().Contains(projectReport.FunctionReports.Success, "incorrect-fixable-test-function")
 
 	suite.Require().Contains(projectReport.FunctionReports.Failed, "incorrect-not-fixable-test-function")
-	suite.Require().Equal("If image is passed, runtime must be specified", projectReport.FunctionReports.Failed["incorrect-not-fixable-test-function"].FailReason)
+	suite.Require().Equal("There's more than one http trigger (unsupported)", projectReport.FunctionReports.Failed["incorrect-not-fixable-test-function"].FailReason)
 	suite.Require().Equal(false, projectReport.FunctionReports.Failed["incorrect-not-fixable-test-function"].CanBeAutoFixed)
 }
 

--- a/test/_imports/project_with_wrong_conf.yaml
+++ b/test/_imports/project_with_wrong_conf.yaml
@@ -72,6 +72,13 @@ functions:
         skip-deploy: "true"
       name: incorrect-not-fixable-test-function
     spec:
+      triggers:
+        myHttpTrigger:
+          maxWorkers: 1
+          kind: "http"
+        anotherHTTP:
+          maxWorkers: 1
+          kind: "http"
       alias: latest
       build:
         codeEntryType: sourceCode


### PR DESCRIPTION
[No ticket]

This PR provides following `nuctl import` improvements:

* Save import report with fields in lowercase
* Print error cause instead of wrapped error
* Save report for functions as well