### PR TITLE
[Platform] Move function name validation from resource to platform

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"net/http"
 	"runtime/debug"
-	"strings"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/auth"
@@ -37,7 +36,6 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/nuclio-sdk-go"
-	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 type functionResource struct {
@@ -681,23 +679,15 @@ func (fr *functionResource) processFunctionInfo(functionInfoInstance *functionIn
 	// validate for missing / malformed fields
 	//
 
-	// name must exists
+	// name must exist
 	if functionInfoInstance.Meta.Name == "" {
 		return nil, nuclio.NewErrBadRequest("Function name must be provided in metadata")
 	}
 
-	// namespace must exists (sanity)
+	// namespace must exist (sanity)
 	// TODO: is this really possible considering the fact namespace was enriched beforehand?
 	if functionInfoInstance.Meta.Namespace == "" {
 		return nil, nuclio.NewErrBadRequest("Function namespace must be provided in metadata")
-	}
-
-	// validate function name is according to k8s convention
-	errorMessages := validation.IsQualifiedName(functionInfoInstance.Meta.Name)
-	if len(errorMessages) != 0 {
-		joinedErrorMessage := strings.Join(errorMessages, ", ")
-		return nil, nuclio.NewErrBadRequest("Function name doesn't conform to k8s naming convention. Errors: " +
-			joinedErrorMessage)
 	}
 
 	return functionInfoInstance, nil

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -534,37 +534,6 @@ func (suite *functionTestSuite) TestCreateWithExistingName() {
 	suite.sendRequestWithExistingName("POST")
 }
 
-func (suite *functionTestSuite) TestCreateFunctionWithInvalidName() {
-	body := `{
-	"metadata": {
-		"namespace": "f1-namespace",
-		"name": "!funcmylif&"
-	},
-	"spec": {
-		"resources": {},
-		"build": {},
-		"platform": {},
-		"runtime": "r1"
-	}
-}`
-	headers := map[string]string{
-		headers.WaitFunctionAction: "true",
-	}
-
-	expectedStatusCode := http.StatusBadRequest
-	ecv := restful.NewErrorContainsVerifier(suite.logger, []string{"Function name doesn't conform to k8s naming convention"})
-	requestBody := body
-
-	suite.sendRequest("POST",
-		"/api/functions",
-		headers,
-		bytes.NewBufferString(requestBody),
-		&expectedStatusCode,
-		ecv.Verify)
-
-	suite.mockPlatform.AssertExpectations(suite.T())
-}
-
 func (suite *functionTestSuite) TestUpdateSuccessful() {
 	suite.T().Skip("Update not supported")
 

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -529,6 +529,14 @@ func (suite *functionDeployTestSuite) TestDeployFailsOnShellMissingPathAndHandle
 	suite.Require().Error(err, "Function code must be provided either in the path or inline in a spec file; alternatively, an image or handler may be provided")
 }
 
+func (suite *functionDeployTestSuite) TestDeployFailsOnInvalidFunctionName() {
+	functionName := "invalid function name"
+
+	err := suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"}, nil)
+	suite.Require().Error(err, "Function name should not have been deployed")
+	suite.Require().Contains(errors.RootCause(err).Error(), "Function name doesn't conform to k8s naming convention")
+}
+
 func (suite *functionDeployTestSuite) TestDeployShellViaHandler() {
 	uniqueSuffix := "-" + xid.New().String()
 	functionName := "shell-handler" + uniqueSuffix


### PR DESCRIPTION
Function name validation was happening only on the `resource` side, when parsing the function information on `Create` / `Update` / `Delete` requests.
This allowed deploying functions with invalid names via Nuctl - The deployment would eventually fail, but the error message was not as clear as it should be.
This also caused errors when trying to delete the already erroneous function because delete request failed function validation.

Thus, we move the function name validation to the platform, so it will be appplied both when deploying via the dashboard and via nuctl.

Resolves #3045