### PR TITLE
[Python] Revert python wrapper changes

### DIFF
--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -255,8 +255,9 @@ class Wrapper(object):
             # after the current event is handled
             self._is_termination_needed = True
 
-    def _on_continue_signal(self, signal_name, frame):
-        self._logger.debug_with('Received signal', signal=signal_name)
+    def _on_continue_signal(self, signal_number, frame):
+        self._logger.debug_with('Received continue signal',
+                                signal=signal.Signals(signal_number).name)
 
         # set this flag to False, so continue normal event processing flow
         self._discard_events = False

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -14,7 +14,6 @@
 
 import argparse
 import asyncio
-import functools
 import json
 import logging
 import re
@@ -127,21 +126,19 @@ class Wrapper(object):
         self._is_drain_needed = False
         self._is_termination_needed = False
         self._discard_events = False
-
-        self._event_message_length_task = None
+        self._is_waiting_for_event = False
 
     async def serve_requests(self, num_requests=None):
         """Read event from socket, send out reply"""
 
         while True:
             try:
-                # resolve event message length
-                self._event_message_length_task = asyncio.create_task(
-                    self._resolve_event_message_length(self._event_sock)
-                )
-                event_message_length = await self._event_message_length_task
+                self._is_waiting_for_event = True
 
-                self._event_message_length_task = None
+                # resolve event message length
+                event_message_length = await self._resolve_event_message_length(self._event_sock)
+
+                self._is_waiting_for_event = False
 
                 # resolve event message
                 event = await self._resolve_event(self._event_sock, event_message_length)
@@ -169,23 +166,14 @@ class Wrapper(object):
                 self._unpacker = self._resolve_unpacker()
                 await self._on_serving_error(exc)
 
-            except asyncio.CancelledError:
-                self._logger.debug('Waiting for event message was interrupted by a signal')
-
             except Exception as exc:
                 await self._on_serving_error(exc)
 
             finally:
                 if self._is_drain_needed:
-                    result = self._call_drain_handler()
-                    if asyncio.iscoroutine(result):
-                        await result
-
+                    self._call_drain_handler()
                 if self._is_termination_needed:
-                    result = self._call_termination_handler()
-                    if asyncio.iscoroutine(result):
-                        await result
-                    break
+                    self._call_termination_handler()
 
             # for testing, we can ask wrapper to only read a set number of requests
             if num_requests is not None:
@@ -231,38 +219,43 @@ class Wrapper(object):
                 raise
 
     def _register_to_signal(self):
-        on_termination_signal = functools.partial(self._on_termination_signal, Constants.termination_signal.name)
-        on_drain_signal = functools.partial(self._on_drain_signal, Constants.drain_signal.name)
-        on_continue_signal = functools.partial(self._on_continue_signal, Constants.continue_signal.name)
+        signal.signal(signal.SIGUSR1, self._on_termination_signal)
+        signal.signal(signal.SIGUSR2, self._on_drain_signal)
+        signal.signal(signal.SIGCONT, self._on_continue_signal)
 
-        asyncio.get_running_loop().add_signal_handler(Constants.termination_signal, on_termination_signal)
-        asyncio.get_running_loop().add_signal_handler(Constants.drain_signal, on_drain_signal)
-        asyncio.get_running_loop().add_signal_handler(Constants.continue_signal, on_continue_signal)
+    def _on_drain_signal(self, signal_number, frame):
+        self._logger.debug_with('Received signal, calling draining callback',
+                                signal=signal.Signals(signal_number).name)
 
-    def _on_drain_signal(self, signal_name):
-        # do not perform draining if discarding events
-        if self._discard_events:
-            self._logger.debug('Draining signal is received, but it will be ignored as the worker is already drained')
-            return
+        if self._is_waiting_for_event:
+            self._logger.debug('Wrapper is waiting for an event, calling drain handler')
 
-        self._logger.debug_with('Received signal', signal=signal_name)
-        self._is_drain_needed = True
+            # call the drain handler here as the event loop is stuck waiting for an event
+            self._call_drain_handler()
+        else:
+            self._logger.debug('Wrapper is handling an event, setting drain flag to true')
 
-        # set the flag to True to stop processing events which are received after draining
-        self._discard_events = True
+            # set the flag to true so the event loop will call the drain handler
+            # after the current event is handled
+            self._is_drain_needed = True
 
-        # if serving loop is waiting for an event, unblock this operation to allow the drain callback to be called
-        if self._event_message_length_task:
-            self._event_message_length_task.cancel()
+    def _on_termination_signal(self, signal_number, frame):
+        self._logger.debug_with('Received signal, calling termination callback',
+                                signal=signal.Signals(signal_number).name)
 
-    def _on_termination_signal(self, signal_name):
-        self._logger.debug_with('Received signal', signal=signal_name)
-        self._is_termination_needed = True
-        # if serving loop is waiting for an event, unblock this operation to allow the termination callback to be called
-        if self._event_message_length_task:
-            self._event_message_length_task.cancel()
+        if self._is_waiting_for_event:
+            self._logger.debug('Wrapper is waiting for an event, calling termination handler')
 
-    def _on_continue_signal(self, signal_name):
+            # call the termination handler here as the event loop is stuck waiting for an event
+            self._call_termination_handler()
+        else:
+            self._logger.debug('Wrapper is handling an event, setting termination flag to true')
+
+            # set the flag to true so the event loop will call the termination handler
+            # after the current event is handled
+            self._is_termination_needed = True
+
+    def _on_continue_signal(self, signal_name, frame):
         self._logger.debug_with('Received signal', signal=signal_name)
 
         # set this flag to False, so continue normal event processing flow
@@ -273,7 +266,7 @@ class Wrapper(object):
 
         # set the flag to False so the drain handler will not be called more than once
         self._is_drain_needed = False
-        return self._platform._on_signal(callback_type="drain")
+        self._platform._on_signal(callback_type="drain")
 
     def _call_termination_handler(self):
         self._logger.debug('Calling platform termination handler')
@@ -284,7 +277,7 @@ class Wrapper(object):
         # call termination handler
         # TODO: send a control message to the processor after this line,
         # to indicate that the termination handler has finished, and the processor can exit early
-        return self._platform._on_signal(callback_type="termination")
+        self._platform._on_signal(callback_type="termination")
 
     async def _send_data_on_control_socket(self, data):
         self._logger.debug_with('Sending data on control socket', data_length=len(data))


### PR DESCRIPTION
Revert this commit https://github.com/nuclio/nuclio/commit/5100ad3606a2f5206245985805e40c99fd10c2a7 with some additional changes to continue support continue signalling

We observed that it disrupted our CI and initiated an investigation, during which we discovered that, for some reason, asyncio task cancellation doesn't function as expected. It doesn't exit from the await, leading to skipping draining in some cases.

P.S. TestDrainHook is fixed (I've checked locally)