### PR TITLE
Revert "[Platform] Move function name validation from resource to platform"

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/auth"
@@ -36,6 +37,7 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/nuclio-sdk-go"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 type functionResource struct {
@@ -679,15 +681,23 @@ func (fr *functionResource) processFunctionInfo(functionInfoInstance *functionIn
 	// validate for missing / malformed fields
 	//
 
-	// name must exist
+	// name must exists
 	if functionInfoInstance.Meta.Name == "" {
 		return nil, nuclio.NewErrBadRequest("Function name must be provided in metadata")
 	}
 
-	// namespace must exist (sanity)
+	// namespace must exists (sanity)
 	// TODO: is this really possible considering the fact namespace was enriched beforehand?
 	if functionInfoInstance.Meta.Namespace == "" {
 		return nil, nuclio.NewErrBadRequest("Function namespace must be provided in metadata")
+	}
+
+	// validate function name is according to k8s convention
+	errorMessages := validation.IsQualifiedName(functionInfoInstance.Meta.Name)
+	if len(errorMessages) != 0 {
+		joinedErrorMessage := strings.Join(errorMessages, ", ")
+		return nil, nuclio.NewErrBadRequest("Function name doesn't conform to k8s naming convention. Errors: " +
+			joinedErrorMessage)
 	}
 
 	return functionInfoInstance, nil

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -534,6 +534,37 @@ func (suite *functionTestSuite) TestCreateWithExistingName() {
 	suite.sendRequestWithExistingName("POST")
 }
 
+func (suite *functionTestSuite) TestCreateFunctionWithInvalidName() {
+	body := `{
+	"metadata": {
+		"namespace": "f1-namespace",
+		"name": "!funcmylif&"
+	},
+	"spec": {
+		"resources": {},
+		"build": {},
+		"platform": {},
+		"runtime": "r1"
+	}
+}`
+	headers := map[string]string{
+		headers.WaitFunctionAction: "true",
+	}
+
+	expectedStatusCode := http.StatusBadRequest
+	ecv := restful.NewErrorContainsVerifier(suite.logger, []string{"Function name doesn't conform to k8s naming convention"})
+	requestBody := body
+
+	suite.sendRequest("POST",
+		"/api/functions",
+		headers,
+		bytes.NewBufferString(requestBody),
+		&expectedStatusCode,
+		ecv.Verify)
+
+	suite.mockPlatform.AssertExpectations(suite.T())
+}
+
 func (suite *functionTestSuite) TestUpdateSuccessful() {
 	suite.T().Skip("Update not supported")
 

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -529,14 +529,6 @@ func (suite *functionDeployTestSuite) TestDeployFailsOnShellMissingPathAndHandle
 	suite.Require().Error(err, "Function code must be provided either in the path or inline in a spec file; alternatively, an image or handler may be provided")
 }
 
-func (suite *functionDeployTestSuite) TestDeployFailsOnInvalidFunctionName() {
-	functionName := "invalid function name"
-
-	err := suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"}, nil)
-	suite.Require().Error(err, "Function name should not have been deployed")
-	suite.Require().Contains(errors.RootCause(err).Error(), "Function name doesn't conform to k8s naming convention")
-}
-
 func (suite *functionDeployTestSuite) TestDeployShellViaHandler() {
 	uniqueSuffix := "-" + xid.New().String()
 	functionName := "shell-handler" + uniqueSuffix

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -420,8 +420,9 @@ func (ap *Platform) EnrichFunctionsWithDeployLogStream(functions []platform.Func
 // ValidateFunctionConfig validates and enforces of required function creation logic
 func (ap *Platform) ValidateFunctionConfig(ctx context.Context, functionConfig *functionconfig.Config) error {
 
-	if err := ap.validateFunctionName(functionConfig); err != nil {
-		return errors.Wrap(err, "Function name validation failed")
+	if common.StringInSlice(functionConfig.Meta.Name, ap.ResolveReservedResourceNames()) {
+		return nuclio.NewErrPreconditionFailed(fmt.Sprintf("Function name %s is reserved and cannot be used.",
+			functionConfig.Meta.Name))
 	}
 
 	// check function config for possible malicious content
@@ -461,23 +462,6 @@ func (ap *Platform) ValidateFunctionConfig(ctx context.Context, functionConfig *
 		return errors.Wrap(err, "Auto scale metrics validation failed")
 	}
 
-	return nil
-}
-
-func (ap *Platform) validateFunctionName(functionConfig *functionconfig.Config) error {
-
-	// validate function name against k8s naming conventions
-	errorMessages := validation.IsQualifiedName(functionConfig.Meta.Name)
-	if len(errorMessages) != 0 {
-		joinedErrorMessage := strings.Join(errorMessages, ", ")
-		return nuclio.NewErrBadRequest("Function name doesn't conform to k8s naming convention. Errors: " +
-			joinedErrorMessage)
-	}
-
-	if common.StringInSlice(functionConfig.Meta.Name, ap.ResolveReservedResourceNames()) {
-		return nuclio.NewErrPreconditionFailed(fmt.Sprintf("Function name %s is reserved and cannot be used.",
-			functionConfig.Meta.Name))
-	}
 	return nil
 }
 

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -1196,7 +1196,6 @@ func (suite *AbstractPlatformTestSuite) TestValidateFunctionConfigDockerImagesFi
 	} {
 
 		functionConfig := *functionconfig.NewConfig()
-		functionConfig.Meta.Name = "some-function-name"
 		functionConfig.Spec.Build.Image = testCase.buildImage
 
 		suite.Logger.InfoWith("Running function spec sanitization case",
@@ -1836,62 +1835,6 @@ func (suite *AbstractPlatformTestSuite) TestValidateFunctionConfigAutoScaleMetri
 				suite.Require().Error(err, "Validation passed unexpectedly")
 			} else {
 				suite.Require().NoError(err, "Validation failed unexpectedly")
-			}
-		})
-	}
-}
-
-func (suite *AbstractPlatformTestSuite) TestValidateFunctionName() {
-	for _, testCase := range []struct {
-		name         string
-		functionName string
-		valid        bool
-	}{
-		{
-			name:         "ValidFunctionName",
-			functionName: "valid-function-name",
-			valid:        true,
-		},
-		{
-			name:         "FunctionNameWithUnderscore",
-			functionName: "function_name_with_underscore",
-			valid:        true,
-		},
-		{
-			name:         "FunctionNameWithDot",
-			functionName: "function.name.with.dot",
-			valid:        true,
-		},
-		{
-			name:         "FunctionNameWithSpaces",
-			functionName: "function name with spaces",
-		},
-		{
-			name:         "FunctionNameWithInvalidChars",
-			functionName: "function-name&with%invalid-chars!",
-		},
-	} {
-		suite.Run(testCase.name, func() {
-			suite.mockedPlatform.On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
-				Meta: platform.ProjectMeta{
-					Name:      platform.DefaultProjectName,
-					Namespace: "default",
-				},
-			}).Return([]platform.Project{
-				&platform.AbstractProject{},
-			}, nil).Once()
-
-			functionConfig := functionconfig.NewConfig()
-			functionConfig.Meta.Name = testCase.functionName
-			functionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
-			}
-
-			err := suite.Platform.ValidateFunctionConfig(suite.ctx, functionConfig)
-			if testCase.valid {
-				suite.Require().NoError(err, "Validation failed unexpectedly")
-			} else {
-				suite.Require().Error(err, "Validation passed unexpectedly")
 			}
 		})
 	}


### PR DESCRIPTION
Reverts nuclio/nuclio#3130

This failed the CI on several tests, and the reason being that if a function is deployed from a function configuration file (or URL), the config is read in the `Build` part of the deployment which happens after the enrichment/validation.
Until we move the configuration reading earlier, I'm reverting this change.