### PR TITLE
[CI] Add token to slack notification step

### DIFF
--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -61,6 +61,7 @@ jobs:
       if: always()
       uses: ravsamhq/notify-slack-action@v2
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         status: ${{ job.status }}
         notify_when: "failure"
         notification_title: "{workflow} has failed"


### PR DESCRIPTION
According to [notify-slack-action docs](https://github.com/marketplace/actions/notify-slack-action#:~:text=In%20order%20to%20use%20%7Bworkflow_url%7D%2C%20specify%20the%20token%20input%20as%20token%3A%20%24%7B%7B%20secrets.GITHUB_TOKEN%20%7D%7D.) - add the github token to allow using the {workflow_url} link.