### PR TITLE
[Nuctl] Fix report path in nuctl tests

### DIFF
--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1591,7 +1591,11 @@ func (suite *functionExportImportTestSuite) TestImportWithReport() {
 	}()
 
 	// generate report path
-	reportPath := suite.tempDir + "/nuctl-import-report.json"
+	reportPath := path.Join(suite.GetImportsDir(),
+		fmt.Sprintf("import-project-report-%s.json",
+			common.GenerateRandomString(5, common.LettersAndNumbers),
+		),
+	)
 	err := suite.ExecuteNuctl([]string{"import", "project", "--verbose", "--save-report", "--report-file-path", reportPath, functionConfigPath}, nil)
 	suite.Require().NotNil(err)
 

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1591,7 +1591,7 @@ func (suite *functionExportImportTestSuite) TestImportWithReport() {
 	}()
 
 	// generate report path
-	reportPath := path.Join(suite.GetImportsDir(),
+	reportPath := path.Join(suite.tempDir,
 		fmt.Sprintf("import-project-report-%s.json",
 			common.GenerateRandomString(5, common.LettersAndNumbers),
 		),

--- a/pkg/nuctl/test/project_test.go
+++ b/pkg/nuctl/test/project_test.go
@@ -159,11 +159,7 @@ func (suite *projectGetTestSuite) TestDeleteWithFunctions() {
 
 func (suite *projectExportImportTestSuite) TestParseReport() {
 	outputPath := path.Join(suite.tempDir, "nuctl-parsed-report.txt")
-	reportPath := path.Join(suite.GetImportsDir(),
-		fmt.Sprintf("import-project-report-%s.json",
-			common.GenerateRandomString(5, common.LettersAndNumbers),
-		),
-	)
+	reportPath := path.Join(suite.GetImportsDir(), "import-project-report.json")
 	err := suite.ExecuteNuctl([]string{"parse", "--report-file-path", reportPath, "--output-path", outputPath}, nil)
 	suite.Require().NoError(err)
 

--- a/pkg/nuctl/test/project_test.go
+++ b/pkg/nuctl/test/project_test.go
@@ -159,7 +159,11 @@ func (suite *projectGetTestSuite) TestDeleteWithFunctions() {
 
 func (suite *projectExportImportTestSuite) TestParseReport() {
 	outputPath := path.Join(suite.tempDir, "nuctl-parsed-report.txt")
-	reportPath := path.Join(suite.GetImportsDir(), "import-project-report.json")
+	reportPath := path.Join(suite.GetImportsDir(),
+		fmt.Sprintf("import-project-report-%s.json",
+			common.GenerateRandomString(5, common.LettersAndNumbers),
+		),
+	)
 	err := suite.ExecuteNuctl([]string{"parse", "--report-file-path", reportPath, "--output-path", outputPath}, nil)
 	suite.Require().NoError(err)
 


### PR DESCRIPTION
In order to avoid using the same file in two tests at the same time, suffix was added to report file path.