### PR TITLE
[Python] Delete reference to event as soon as possible

### DIFF
--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -154,6 +154,9 @@ class Wrapper(object):
                 else:
                     self._logger.debug_with('Event has been discarded', event=event)
 
+                # allow event to be garbage collected by deleting the reference
+                del event
+
             except WrapperFatalException as exc:
                 await self._on_serving_error(exc)
 


### PR DESCRIPTION
Currently, it's retained until the next event arrives, preventing the event from being garbage collected before then.

Needed to resolve [ML-4421](https://jira.iguazeng.com/browse/ML-4421).