### PR TITLE
[Dashboard] Support email in username label

### DIFF
--- a/cmd/dashboard/app/run.go
+++ b/cmd/dashboard/app/run.go
@@ -214,7 +214,7 @@ func enrichAuthConfig(authConfig *auth.Config,
 		authConfig.Iguazio.VerificationDataEnrichmentURL = authConfigIguazioVerificationDataEnrichmentURL
 	} else {
 		authConfig.Iguazio.VerificationDataEnrichmentURL =
-			authConfigIguazioVerificationURL + iguazio.IguzioVerificationAndDataEnrichmentURLSuffix
+			authConfigIguazioVerificationURL + iguazio.IguazioVerificationAndDataEnrichmentURLSuffix
 	}
 
 	if authConfigIguazioTimeout != "" {

--- a/pkg/auth/iguazio/auth.go
+++ b/pkg/auth/iguazio/auth.go
@@ -38,8 +38,9 @@ import (
 )
 
 const (
-	IguzioUsernameLabel                          string = "iguazio.com/username"
-	IguzioVerificationAndDataEnrichmentURLSuffix string = "_enrich_data"
+	IguazioUsernameLabel                          string = "iguazio.com/username"
+	IguazioDomainLabel                            string = "iguazio.com/domain"
+	IguazioVerificationAndDataEnrichmentURLSuffix string = "_enrich_data"
 )
 
 type Auth struct {

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -317,8 +317,7 @@ func (ap *Platform) enrichUsernameAndDomainLabels(ctx context.Context, labels ma
 		if value, exist := labels[iguazio.IguazioUsernameLabel]; !exist || value == "" {
 			fullUsername := authSession.GetUsername()
 
-			// If the username contains '@' (email) then parse the username into two labels: "iguazio.com/username", "iguazio.com/domain"
-			// If it doesn't contain '@' then put the full username into the "iguazio.com/username" label
+			// split email usernames to name and domain because '@' is an invalid character in kubernetes labels
 			if strings.Contains(fullUsername, "@") {
 				split := strings.Split(fullUsername, "@")
 				labels[iguazio.IguazioUsernameLabel] = split[0]

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -1493,10 +1493,10 @@ func (suite *FunctionKubePlatformTestSuite) TestUsernameLabelsEnrichment() {
 			labels := make(map[string]string)
 			suite.platform.EnrichLabels(testContext, labels)
 
-			usernameLabel, _ := labels[iguazio.IguazioUsernameLabel]
+			usernameLabel := labels[iguazio.IguazioUsernameLabel]
 			suite.Require().Equal(testCase.expectedUsernameLabel, usernameLabel)
 
-			domainLabel, _ := labels[iguazio.IguazioDomainLabel]
+			domainLabel := labels[iguazio.IguazioDomainLabel]
 			suite.Require().Equal(testCase.expectedDomainLabel, domainLabel)
 		})
 	}


### PR DESCRIPTION
When creating a Nuclio function in Iguazio, a function label is created:

`iguazio.com/username: <username> `

Following the SSO effort, we need to allow usernames that looks like an email, e.g:`name@nuclio.com `

The issue is that the `@` sign is an invalid character in a kubernetes label.
To resolve this issue, in case we encounter an email-like username, we will split it into 2 labels, e.g.:
```
iguazio.com/username: name
iguazio.com/domain: nuclio.com 
```

Jira - https://jira.iguazeng.com/browse/NUC-133