### PR TITLE
[Dashboard] Merge sidecar's and container's environmental variables

### DIFF
--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -45,7 +45,7 @@ func MergeEnvSlices(primaryEnv []v1.EnvVar, secondaryEnv []v1.EnvVar) []v1.EnvVa
 		envMap[env.Name] = env
 	}
 
-	// add environment variables from the primary list to the map with priority
+	// add environment variables from the primary list to the map, overriding secondary list variables if the keys are the same
 	for _, env := range primaryEnv {
 		envMap[env.Name] = env
 	}

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -40,7 +40,7 @@ func RemoveEnvFromSlice(env v1.EnvVar, slice []v1.EnvVar) []v1.EnvVar {
 func MergeEnvSlices(primaryEnv []v1.EnvVar, secondaryEnv []v1.EnvVar) []v1.EnvVar {
 	envMap := make(map[string]v1.EnvVar)
 
-	// add environment variables from the secondary list to the map only if they don't already exist
+	// add environment variables from the secondary list to the map
 	for _, env := range secondaryEnv {
 		envMap[env.Name] = env
 	}

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -35,3 +35,28 @@ func RemoveEnvFromSlice(env v1.EnvVar, slice []v1.EnvVar) []v1.EnvVar {
 	}
 	return slice
 }
+
+// MergeEnvSlices merges two lists of environment variables, giving priority to variables from the primary list
+func MergeEnvSlices(primaryEnv []v1.EnvVar, secondaryEnv []v1.EnvVar) []v1.EnvVar {
+	envMap := make(map[string]v1.EnvVar)
+
+	// Add environment variables from the primary list to the map with priority
+	for _, env := range primaryEnv {
+		envMap[env.Name] = env
+	}
+
+	// Add environment variables from the secondary list to the map only if they don't already exist
+	for _, env := range secondaryEnv {
+		if _, exists := envMap[env.Name]; !exists {
+			envMap[env.Name] = env
+		}
+	}
+
+	// Convert the map back to a slice of EnvVar
+	mergedEnv := make([]v1.EnvVar, 0, len(envMap))
+	for _, env := range envMap {
+		mergedEnv = append(mergedEnv, env)
+	}
+
+	return mergedEnv
+}

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -40,19 +40,19 @@ func RemoveEnvFromSlice(env v1.EnvVar, slice []v1.EnvVar) []v1.EnvVar {
 func MergeEnvSlices(primaryEnv []v1.EnvVar, secondaryEnv []v1.EnvVar) []v1.EnvVar {
 	envMap := make(map[string]v1.EnvVar)
 
-	// Add environment variables from the primary list to the map with priority
+	// add environment variables from the primary list to the map with priority
 	for _, env := range primaryEnv {
 		envMap[env.Name] = env
 	}
 
-	// Add environment variables from the secondary list to the map only if they don't already exist
+	// add environment variables from the secondary list to the map only if they don't already exist
 	for _, env := range secondaryEnv {
 		if _, exists := envMap[env.Name]; !exists {
 			envMap[env.Name] = env
 		}
 	}
 
-	// Convert the map back to a slice of EnvVar
+	// convert the map back to a slice of EnvVar
 	mergedEnv := make([]v1.EnvVar, 0, len(envMap))
 	for _, env := range envMap {
 		mergedEnv = append(mergedEnv, env)

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -40,16 +40,14 @@ func RemoveEnvFromSlice(env v1.EnvVar, slice []v1.EnvVar) []v1.EnvVar {
 func MergeEnvSlices(primaryEnv []v1.EnvVar, secondaryEnv []v1.EnvVar) []v1.EnvVar {
 	envMap := make(map[string]v1.EnvVar)
 
-	// add environment variables from the primary list to the map with priority
-	for _, env := range primaryEnv {
+	// add environment variables from the secondary list to the map only if they don't already exist
+	for _, env := range secondaryEnv {
 		envMap[env.Name] = env
 	}
 
-	// add environment variables from the secondary list to the map only if they don't already exist
-	for _, env := range secondaryEnv {
-		if _, exists := envMap[env.Name]; !exists {
-			envMap[env.Name] = env
-		}
+	// add environment variables from the primary list to the map with priority
+	for _, env := range primaryEnv {
+		envMap[env.Name] = env
 	}
 
 	// convert the map back to a slice of EnvVar

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -62,7 +62,7 @@ func (cts *ConfigTestSuite) TestMergeEnvSlices() {
 
 			// since order can be different, check that each element of the expected list is in the actual slice
 			for _, envVar := range mergedEnvs {
-				expectedEnvVarValue, _ := testCase.expectedMergedEnvs[envVar.Name]
+				expectedEnvVarValue := testCase.expectedMergedEnvs[envVar.Name]
 				cts.Require().Equal(expectedEnvVarValue, envVar.Value)
 			}
 		})

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -19,10 +19,10 @@ limitations under the License.
 package common
 
 import (
-	v1 "k8s.io/api/core/v1"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/core/v1"
 )
 
 type ConfigTestSuite struct {

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -1,0 +1,74 @@
+//go:build test_unit
+
+/*
+Copyright 2023 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ConfigTestSuite struct {
+	suite.Suite
+}
+
+func (cts *ConfigTestSuite) TestMergeEnvSlices() {
+	for _, testCase := range []struct {
+		name               string
+		primaryEnvs        []v1.EnvVar
+		secondaryEnvs      []v1.EnvVar
+		expectedMergedEnvs map[string]string
+	}{
+
+		{
+			name:               "same-key-different-value",
+			primaryEnvs:        []v1.EnvVar{{Name: "test1", Value: "a"}, {Name: "test2", Value: "c"}},
+			secondaryEnvs:      []v1.EnvVar{{Name: "test1", Value: "b"}, {Name: "test3", Value: "d"}},
+			expectedMergedEnvs: map[string]string{"test1": "a", "test2": "c", "test3": "d"},
+		},
+		{
+			name:               "empty-secondary",
+			primaryEnvs:        []v1.EnvVar{{Name: "test1", Value: "a"}},
+			expectedMergedEnvs: map[string]string{"test1": "a"},
+		},
+		{
+			name:               "empty-primary",
+			primaryEnvs:        []v1.EnvVar{{Name: "test1", Value: "a"}},
+			expectedMergedEnvs: map[string]string{"test1": "a"},
+		},
+	} {
+		cts.Run(testCase.name, func() {
+			mergedEnvs := MergeEnvSlices(testCase.primaryEnvs, testCase.secondaryEnvs)
+
+			// check that slices are of the same length
+			cts.Require().Equal(len(testCase.expectedMergedEnvs), len(mergedEnvs))
+
+			// since order can be different, check that each element of the expected list is in the actual slice
+			for _, envVar := range mergedEnvs {
+				expectedEnvVarValue, _ := testCase.expectedMergedEnvs[envVar.Name]
+				cts.Require().Equal(expectedEnvVarValue, envVar.Value)
+			}
+		})
+	}
+}
+
+func TestConfigTestSuite(t *testing.T) {
+	suite.Run(t, new(ConfigTestSuite))
+}

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -29,7 +29,7 @@ type ConfigTestSuite struct {
 	suite.Suite
 }
 
-func (cts *ConfigTestSuite) TestMergeEnvSlices() {
+func (suite *ConfigTestSuite) TestMergeEnvSlices() {
 	for _, testCase := range []struct {
 		name               string
 		primaryEnvs        []v1.EnvVar
@@ -54,16 +54,16 @@ func (cts *ConfigTestSuite) TestMergeEnvSlices() {
 			expectedMergedEnvs: map[string]string{"test1": "a"},
 		},
 	} {
-		cts.Run(testCase.name, func() {
+		suite.Run(testCase.name, func() {
 			mergedEnvs := MergeEnvSlices(testCase.primaryEnvs, testCase.secondaryEnvs)
 
 			// check that slices are of the same length
-			cts.Require().Equal(len(testCase.expectedMergedEnvs), len(mergedEnvs))
+			suite.Require().Len(mergedEnvs, len(testCase.expectedMergedEnvs))
 
 			// since order can be different, check that each element of the expected list is in the actual slice
 			for _, envVar := range mergedEnvs {
 				expectedEnvVarValue := testCase.expectedMergedEnvs[envVar.Name]
-				cts.Require().Equal(expectedEnvVarValue, envVar.Value)
+				suite.Require().Equal(expectedEnvVarValue, envVar.Value)
 			}
 		})
 	}

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1527,7 +1527,7 @@ func (p *Platform) enrichContainerSpec(container *v1.Container, functionConfig *
 	if container.Env == nil {
 		container.Env = make([]v1.EnvVar, 0)
 	}
-	container.Env = append(container.Env, functionConfig.Spec.Env...)
+	container.Env = common.MergeEnvSlices(container.Env, functionConfig.Spec.Env)
 
 	// image pull policy
 	if container.ImagePullPolicy == "" {


### PR DESCRIPTION
Recently, the bug was discovered where the sidecar's environment variables were being updated with the function's environment variables during each function deployment, resulting in numerous duplications of the same key in the sidecar's spec. This PR addresses the issue by implementing merging functionality.

Jira - https://jira.iguazeng.com/browse/NUC-134