### PR TITLE
[Nuctl] Ensure that report path exists

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -607,3 +607,17 @@ func PopulateFieldsFromValues[T string | bool | int](fieldsToValues map[*T]T) {
 		}
 	}
 }
+
+// EnsureDirExists checks if the directory exists, creates it if it doesn't
+func EnsureDirExists(ctx context.Context, loggerInstance logger.Logger, dir string) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		loggerInstance.DebugWithCtx(ctx,
+			"Creating directory as it does not exist",
+			"directory", dir)
+
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -73,6 +73,20 @@ func FileExists(path string) bool {
 	return err == nil
 }
 
+// EnsureDirExists checks if the directory exists, creates it if it doesn't
+func EnsureDirExists(ctx context.Context, loggerInstance logger.Logger, dir string) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		loggerInstance.DebugWithCtx(ctx,
+			"Creating directory as it does not exist",
+			"directory", dir)
+
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // StringSliceToIntSlice converts slices of strings to slices of int. e.g. ["1", "3"] -> [1, 3]
 func StringSliceToIntSlice(stringSlice []string) ([]int, error) {
 	var result []int
@@ -606,18 +620,4 @@ func PopulateFieldsFromValues[T string | bool | int](fieldsToValues map[*T]T) {
 			*field = value
 		}
 	}
-}
-
-// EnsureDirExists checks if the directory exists, creates it if it doesn't
-func EnsureDirExists(ctx context.Context, loggerInstance logger.Logger, dir string) error {
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		loggerInstance.DebugWithCtx(ctx,
-			"Creating directory as it does not exist",
-			"directory", dir)
-
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/pkg/nuctl/command/common/helpers.go
+++ b/pkg/nuctl/command/common/helpers.go
@@ -112,10 +112,10 @@ func saveReportToFile(ctx context.Context, loggerInstance logger.Logger, report 
 			"err", err,
 			"path", path)
 	}
-	// Get the directory path from the file path
+	// get the directory path from the file path
 	dir := filepath.Dir(path)
 
-	// Check if the directory exists, create it if it doesn't
+	// check if the directory exists, create it if it doesn't
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		loggerInstance.DebugWithCtx(ctx,
 			"Creating directory for report as it does not exist",

--- a/pkg/nuctl/command/common/helpers.go
+++ b/pkg/nuctl/command/common/helpers.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 
 	"github.com/nuclio/errors"
@@ -116,17 +117,11 @@ func saveReportToFile(ctx context.Context, loggerInstance logger.Logger, report 
 	dir := filepath.Dir(path)
 
 	// check if the directory exists, create it if it doesn't
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		loggerInstance.DebugWithCtx(ctx,
-			"Creating directory for report as it does not exist",
-			"directory", dir)
-
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			loggerInstance.ErrorWithCtx(ctx,
-				"Failed to create directory for report",
-				"directory", dir,
-				"error", err)
-		}
+	if err := common.EnsureDirExists(ctx, loggerInstance, dir); err != nil {
+		loggerInstance.ErrorWithCtx(ctx,
+			"Failed to create a directory",
+			"directory", dir,
+			"error", err)
 	}
 
 	if err := os.WriteFile(path, content, 0644); err != nil {

--- a/pkg/nuctl/command/common/helpers.go
+++ b/pkg/nuctl/command/common/helpers.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 
@@ -111,6 +112,23 @@ func saveReportToFile(ctx context.Context, loggerInstance logger.Logger, report 
 			"err", err,
 			"path", path)
 	}
+	// Get the directory path from the file path
+	dir := filepath.Dir(path)
+
+	// Check if the directory exists, create it if it doesn't
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		loggerInstance.DebugWithCtx(ctx,
+			"Creating directory for report as it does not exist",
+			"directory", dir)
+
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			loggerInstance.ErrorWithCtx(ctx,
+				"Failed to create directory for report",
+				"directory", dir,
+				"error", err)
+		}
+	}
+
 	if err := os.WriteFile(path, content, 0644); err != nil {
 		loggerInstance.ErrorWithCtx(ctx,
 			"Failed to write report to file",

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1592,7 +1592,7 @@ func (suite *functionExportImportTestSuite) TestImportWithReport() {
 
 	// generate report path
 	reportPath := path.Join(suite.tempDir,
-		fmt.Sprintf("import-project-report-%s.json",
+		fmt.Sprintf("/subdir/import-project-report-%s.json",
 			common.GenerateRandomString(5, common.LettersAndNumbers),
 		),
 	)


### PR DESCRIPTION
This PR resolves the issue where an error occurred if a user attempted to create a report file directory that did not exist.

Jira - https://jira.iguazeng.com/browse/NUC-137