### PR TITLE
[Nuctl] Do not init platform in nuctl parse

### DIFF
--- a/pkg/nuctl/command/beta.go
+++ b/pkg/nuctl/command/beta.go
@@ -69,7 +69,7 @@ func (b *betaCommandeer) initialize() error {
 	var err error
 
 	// initialize root
-	if err := b.rootCommandeer.initialize(); err != nil {
+	if err := b.rootCommandeer.initialize(true); err != nil {
 		return errors.Wrap(err, "Failed to initialize root")
 	}
 

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -59,7 +59,7 @@ func newBuildCommandeer(rootCommandeer *RootCommandeer) *buildCommandeer {
 			}
 
 			// initialize root
-			if err := rootCommandeer.initialize(); err != nil {
+			if err := rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 

--- a/pkg/nuctl/command/create.go
+++ b/pkg/nuctl/command/create.go
@@ -82,7 +82,7 @@ func newCreateProjectCommandeer(ctx context.Context, createCommandeer *createCom
 			}
 
 			// initialize root
-			if err := createCommandeer.rootCommandeer.initialize(); err != nil {
+			if err := createCommandeer.rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 
@@ -146,7 +146,7 @@ func newCreateAPIGatewayCommandeer(ctx context.Context, createCommandeer *create
 			}
 
 			// initialize root
-			if err := createCommandeer.rootCommandeer.initialize(); err != nil {
+			if err := createCommandeer.rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 
@@ -305,7 +305,7 @@ func newCreateFunctionEventCommandeer(ctx context.Context, createCommandeer *cre
 			}
 
 			// initialize root
-			if err := createCommandeer.rootCommandeer.initialize(); err != nil {
+			if err := createCommandeer.rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 

--- a/pkg/nuctl/command/delete.go
+++ b/pkg/nuctl/command/delete.go
@@ -86,7 +86,7 @@ func newDeleteFunctionCommandeer(ctx context.Context, deleteCommandeer *deleteCo
 			}
 
 			// initialize root
-			if err := deleteCommandeer.rootCommandeer.initialize(); err != nil {
+			if err := deleteCommandeer.rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 
@@ -134,7 +134,7 @@ func newDeleteProjectCommandeer(ctx context.Context, deleteCommandeer *deleteCom
 			}
 
 			// initialize root
-			if err := deleteCommandeer.rootCommandeer.initialize(); err != nil {
+			if err := deleteCommandeer.rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 
@@ -187,7 +187,7 @@ func newDeleteAPIGatewayCommandeer(ctx context.Context, deleteCommandeer *delete
 			}
 
 			// initialize root
-			if err := deleteCommandeer.rootCommandeer.initialize(); err != nil {
+			if err := deleteCommandeer.rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 
@@ -227,7 +227,7 @@ func newDeleteFunctionEventCommandeer(ctx context.Context, deleteCommandeer *del
 			}
 
 			// initialize root
-			if err := deleteCommandeer.rootCommandeer.initialize(); err != nil {
+			if err := deleteCommandeer.rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 

--- a/pkg/nuctl/command/deploy.go
+++ b/pkg/nuctl/command/deploy.go
@@ -95,7 +95,7 @@ func newDeployCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *d
 			var err error
 
 			// initialize root
-			if err := rootCommandeer.initialize(); err != nil {
+			if err := rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 

--- a/pkg/nuctl/command/export.go
+++ b/pkg/nuctl/command/export.go
@@ -101,7 +101,7 @@ Arguments:
 			}
 
 			// initialize root
-			if err := exportCommandeer.rootCommandeer.initialize(); err != nil {
+			if err := exportCommandeer.rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 
@@ -229,7 +229,7 @@ Arguments:
 			}
 
 			// initialize root
-			if err := exportCommandeer.rootCommandeer.initialize(); err != nil {
+			if err := exportCommandeer.rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 

--- a/pkg/nuctl/command/get.go
+++ b/pkg/nuctl/command/get.go
@@ -86,7 +86,7 @@ func newGetFunctionCommandeer(ctx context.Context, getCommandeer *getCommandeer)
 			}
 
 			// initialize root
-			if err := getCommandeer.rootCommandeer.initialize(); err != nil {
+			if err := getCommandeer.rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 
@@ -170,7 +170,7 @@ func newGetProjectCommandeer(ctx context.Context, getCommandeer *getCommandeer) 
 			}
 
 			// initialize root
-			if err := getCommandeer.rootCommandeer.initialize(); err != nil {
+			if err := getCommandeer.rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 
@@ -250,7 +250,7 @@ func newGetAPIGatewayCommandeer(ctx context.Context, getCommandeer *getCommandee
 			}
 
 			// initialize root
-			if err := getCommandeer.rootCommandeer.initialize(); err != nil {
+			if err := getCommandeer.rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 
@@ -326,7 +326,7 @@ func newGetFunctionEventCommandeer(ctx context.Context, getCommandeer *getComman
 			}
 
 			// initialize root
-			if err := getCommandeer.rootCommandeer.initialize(); err != nil {
+			if err := getCommandeer.rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 

--- a/pkg/nuctl/command/import.go
+++ b/pkg/nuctl/command/import.go
@@ -210,7 +210,7 @@ Arguments:
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// initialize root
-			if err := importCommandeer.rootCommandeer.initialize(); err != nil {
+			if err := importCommandeer.rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 
@@ -318,7 +318,7 @@ Arguments:
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// initialize root
-			if err := importCommandeer.rootCommandeer.initialize(); err != nil {
+			if err := importCommandeer.rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 

--- a/pkg/nuctl/command/invoke.go
+++ b/pkg/nuctl/command/invoke.go
@@ -72,7 +72,7 @@ func newInvokeCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *i
 			}
 
 			// initialize root
-			if err := rootCommandeer.initialize(); err != nil {
+			if err := rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 

--- a/pkg/nuctl/command/nuctl.go
+++ b/pkg/nuctl/command/nuctl.go
@@ -108,12 +108,15 @@ func (rc *RootCommandeer) CreateMarkdown(path string) error {
 	return doc.GenMarkdownTree(rc.cmd, path)
 }
 
-func (rc *RootCommandeer) initialize() error {
+func (rc *RootCommandeer) initialize(initPlatform bool) error {
 	var err error
 
 	rc.loggerInstance, err = rc.createLogger()
 	if err != nil {
 		return errors.Wrap(err, "Failed to create logger")
+	}
+	if !initPlatform {
+		return nil
 	}
 
 	// TODO: accept platform config path as arg

--- a/pkg/nuctl/command/parse.go
+++ b/pkg/nuctl/command/parse.go
@@ -48,7 +48,7 @@ func newParseCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *pa
 		Short:   "Parse report",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// initialize root
-			if err := rootCommandeer.initialize(); err != nil {
+			if err := rootCommandeer.initialize(false); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 

--- a/pkg/nuctl/command/redeploy.go
+++ b/pkg/nuctl/command/redeploy.go
@@ -75,7 +75,7 @@ Arguments:
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// initialize root
-			if err := rootCommandeer.initialize(); err != nil {
+			if err := rootCommandeer.initialize(true); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 			if err := commandeer.betaCommandeer.initialize(); err != nil {

--- a/pkg/nuctl/command/update.go
+++ b/pkg/nuctl/command/update.go
@@ -82,7 +82,7 @@ func newUpdateFunctionCommandeer(ctx context.Context, updateCommandeer *updateCo
 			}
 
 			// initialize root
-			if err := updateCommandeer.rootCommandeer.initialize(); err != nil {
+			if err := updateCommandeer.rootCommandeer.initialize(false); err != nil {
 				return errors.Wrap(err, "Failed to initialize root")
 			}
 


### PR DESCRIPTION
This PR introduces the ability to configure the initialization of the platform during the initialization of the nuctl root command. Previously, platform initialization was required in every command before the addition of nuctl parse. However, when using nuctl parse, users do not expect to specify any namespace (or other) parameters. That's why there was a need for this functionality to be implemented.

Jira - https://jira.iguazeng.com/browse/NUC-136