### PR TITLE
[Processor] Do not close kafka connection if workers are terminated

### DIFF
--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -249,6 +249,11 @@ consumptionLoop:
 				int(claim.Partition()),
 				nil)
 			if err != nil {
+				// If all workers are terminated, we don't want to stop consumption to avoid Kafka reconnection
+				// and give some time to the explicitAckHandler to process the last control messages.
+				if errors.Is(err, worker.ErrAllWorkersAreTerminated) {
+					continue
+				}
 				return errors.Wrap(err, "Failed to allocate worker")
 			}
 


### PR DESCRIPTION
This PR addresses a bug where some messages were processed twice after a function restart. The issue arose because, after sending a termination signal, all workers were marked as terminated. Subsequently, when the `ConsumeClaim` function attempted to allocate a worker, it encountered an error, causing the consumption loop to break and, consequently, halting the `explicitAckHandler`. As a result, the processor side could no longer respond to control messages from the runtime side, as evidenced in the log with the message: `"Failed to read control message","more":{"errRootCause":"EOF"}}`.

This PR modifies this behavior so that the consumption loop does not break upon receiving the `ErrAllWorkersAreTerminated` error.


Jira - https://jira.iguazeng.com/browse/NUC-139