### PR TITLE
[Nuctl] Print nuctl parse report without logging

### DIFF
--- a/pkg/nuctl/command/parse.go
+++ b/pkg/nuctl/command/parse.go
@@ -19,6 +19,7 @@ package command
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/nuclio/nuclio/pkg/nuctl/command/common"
@@ -93,7 +94,7 @@ func (pc *parseCommandeer) ParseReport(ctx context.Context, logger logger.Logger
 						"error", err.Error())
 				}
 			}
-			logger.Info(output)
+			fmt.Println(output)
 			return nil
 		}
 	}


### PR DESCRIPTION
Simply print the generated report instead of logging it.
[No ticket]