### PR TITLE
[Nuctl] Add test for redeploy command and make it exit with error if failed

### DIFF
--- a/pkg/nuctl/command/common/patchmanifest.go
+++ b/pkg/nuctl/command/common/patchmanifest.go
@@ -19,6 +19,7 @@ package common
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"sync"
 
@@ -148,6 +149,25 @@ func (m *PatchManifest) SaveToFile(ctx context.Context, loggerInstance logger.Lo
 		loggerInstance.WarnWithCtx(ctx,
 			"Some functions failed to patch. To retry redeploying them, rerun the command with the \"--from-report\" flag")
 	}
+}
+
+func (m *PatchManifest) SprintfError() string {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if len(m.Failed) == 0 {
+		return ""
+	}
+	errorString := "Failed to redeploy some functions. "
+
+	for name, reason := range m.Failed {
+		errorString += fmt.Sprintf(
+			"Failed to redeploy function `%s`.Reason: `%s`. Retryable: %t.",
+			name,
+			reason.Err,
+			reason.Retryable)
+	}
+	return errorString
 }
 
 func readManifestFromFile(path string) (*patchManifest, error) {

--- a/pkg/nuctl/command/redeploy.go
+++ b/pkg/nuctl/command/redeploy.go
@@ -224,6 +224,10 @@ func (d *redeployCommandeer) redeployFunctions(ctx context.Context, functionName
 		d.outputManifest.SaveToFile(ctx, d.rootCommandeer.loggerInstance, d.reportFilePath)
 	}
 
+	if errorString := d.outputManifest.SprintfError(); errorString != "" {
+		return errors.New(errorString)
+	}
+
 	return nil
 }
 

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1927,7 +1927,7 @@ func (suite *functionRedeployTestSuite) TestRedeploy() {
 
 			err = suite.ExecuteNuctl([]string{"beta", "redeploy", functionName, "--save-report"}, namedArgs)
 			if testcase.expectError {
-				//suite.Require().Error(err)
+				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
 			}

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1922,7 +1922,8 @@ func (suite *functionRedeployTestSuite) TestRedeploy() {
 			httpmock.Activate()
 			defer httpmock.DeactivateAndReset()
 
-			httpmock.RegisterResponder("PATCH", fmt.Sprintf("%s/functions/%s", apiUrl, functionName),
+			httpmock.RegisterResponder("PATCH",
+				fmt.Sprintf("%s/functions/%s", apiUrl, functionName),
 				httpmock.NewStringResponder(testcase.statusCode, ""))
 
 			err = suite.ExecuteNuctl([]string{"beta", "redeploy", functionName, "--save-report"}, namedArgs)
@@ -1934,7 +1935,6 @@ func (suite *functionRedeployTestSuite) TestRedeploy() {
 
 			reportBytes, err := os.ReadFile(reportPath)
 			suite.Require().NoError(err)
-
 			suite.Require().Equal(testcase.report, string(reportBytes))
 
 		})

--- a/test/_imports/redeploy-test-function.yaml
+++ b/test/_imports/redeploy-test-function.yaml
@@ -1,0 +1,26 @@
+# Copyright 2023 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+metadata:
+  annotations:
+    skip-build: "true"
+    skip-deploy: "true"
+  name: redeploy-test-function
+spec:
+  build:
+    codeEntryType: sourceCode
+    functionSourceCode: ZWNobyAidGVzdDEi
+    noBaseImagesPull: true
+  handler: main.sh
+  runtime: shell


### PR DESCRIPTION
This PR adds a test for `nuctl redeploy`, and also during writing tests, I noticed that we exit with a zero-code even if some redeployments fail. I've changed this so that we analyse the report and, based on it, raise an error or do not raise one.

Jira - https://jira.iguazeng.com/browse/NUC-52