### PR TITLE
Impl [UI] Do not show default http trigger banner if feature is disabled

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -49,7 +49,7 @@
     "i18next-chained-backend": "^3.0.2",
     "i18next-localstorage-backend": "^3.1.3",
     "i18next-xhr-backend": "^3.2.2",
-    "iguazio.dashboard-controls": "^0.39.20",
+    "iguazio.dashboard-controls": "^0.40.2",
     "jquery": "*",
     "jquery-ui": "1.13.2",
     "js-base64": "^2.5.2",

--- a/pkg/dashboard/ui/src/app/app.run.js
+++ b/pkg/dashboard/ui/src/app/app.run.js
@@ -45,6 +45,7 @@ limitations under the License.
                             allowedAuthenticationModes: lodash.get(response, 'allowedAuthenticationModes', []),
                             defaultFunctionConfig: lodash.get(response, 'defaultFunctionConfig', {}),
                             defaultFunctionPodResources: lodash.get(response, 'defaultFunctionPodResources', {}),
+                            disableDefaultHttpTrigger: lodash.get(response, 'disableDefaultHttpTrigger', false),
                             externalIPAddress: lodash.get(response, 'externalIPAddresses[0]', ''),
                             imageNamePrefixTemplate: lodash.get(response, 'imageNamePrefixTemplate', ''),
                             ingressHostTemplate: lodash.get(response, 'defaultHTTPIngressHostTemplate', ''),


### PR DESCRIPTION
- **Nuclio UI**: Do not show default http trigger banner if feature is disabled
   Depends On: https://github.com/iguazio/dashboard-controls/pull/1522
   Jira: https://jira.iguazeng.com/browse/NUC-55