### PR TITLE
[Controller] Set function status to `unhealthy` instead of `error` during fast-fail check

### DIFF
--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -216,8 +216,23 @@ The `status` section contains the requirements and attributes and has the follow
 | internalInvocationUrls | []string | A list of internal urls to invoke the function                                                    |
 | externalInvocationUrls | []string | A list of external urls to invoke the function, including ingresses and external-ip:function-port |
 
-<a id="status-example"></a>
+### Function state
 
+Here is a list of all possible function states:
+
+| **State**                       | **Description**                                                                                                                                    |
+|:--------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|
+| ready                           | Function is deployed successfully and ready to process events.                                                                                     |
+| imported                        | Function is imported from file and hasn't been deployed yet.                                                                                       |
+| error                           | Error occurred during function deployment and cannot be rectified without redeployment.                                                            |
+| unhealthy                       | Error occurred during function deployment, which can be resolved over time. For example, issues such as insufficient resources or a missing image. |
+| scaledToZero                    | Function is scaled to zero, so the number of function replicas is zero.                                                                            |
+| building                        | Function image is being built.                                                                                                                     |
+| waitingForResourceConfiguration | Function waits for resources to be ready. For instance, in case of k8s function waits for deployment/pods and etc.                                 |
+| waitingForScaleResourceFromZero | Function is scaling up from zero replicas.                                                                                                         |
+| waitingForScaleResourceToZero   | Function is scaling down to zero replicas.                                                                                                         |
+
+<a id="status-example"></a>
 ### Example
 
 ```yaml

--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -223,14 +223,14 @@ Here is a list of all possible function states:
 | **State**                       | **Description**                                                                                                                                    |
 |:--------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|
 | ready                           | Function is deployed successfully and ready to process events.                                                                                     |
-| imported                        | Function is imported from file and hasn't been deployed yet.                                                                                       |
-| error                           | Error occurred during function deployment and cannot be rectified without redeployment.                                                            |
-| unhealthy                       | Error occurred during function deployment, which can be resolved over time. For example, issues such as insufficient resources or a missing image. |
+| imported                        | Function has been imported but hasn't been deployed yet.                                                                                           |
 | scaledToZero                    | Function is scaled to zero, so the number of function replicas is zero.                                                                            |
 | building                        | Function image is being built.                                                                                                                     |
 | waitingForResourceConfiguration | Function waits for resources to be ready. For instance, in case of k8s function waits for deployment/pods and etc.                                 |
 | waitingForScaleResourceFromZero | Function is scaling up from zero replicas.                                                                                                         |
 | waitingForScaleResourceToZero   | Function is scaling down to zero replicas.                                                                                                         |
+| error                           | An error occurred during function deployment that cannot be rectified without redeployment.                                                        |
+| unhealthy                       | An error occurred during function deployment, which can be resolved over time. For example, issues with insufficient resources or a missing image. |
 
 <a id="status-example"></a>
 ### Example

--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -216,21 +216,21 @@ The `status` section contains the requirements and attributes and has the follow
 | internalInvocationUrls | []string | A list of internal urls to invoke the function                                                    |
 | externalInvocationUrls | []string | A list of external urls to invoke the function, including ingresses and external-ip:function-port |
 
-### Function state
+### Function state (`state`)
 
-Here is a list of all possible function states:
+The `state` field describes the current function status, and can be one of the following:
 
-| **State**                       | **Description**                                                                                                                                    |
-|:--------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|
-| ready                           | Function is deployed successfully and ready to process events.                                                                                     |
-| imported                        | Function is imported but not yet deployed.                                                                                                         |
-| scaledToZero                    | Function is scaled to zero, so the number of function replicas is zero.                                                                            |
-| building                        | Function image is being built.                                                                                                                     |
-| waitingForResourceConfiguration | Function waits for resources to be ready. For instance, in case of k8s function waits for deployment/pods and etc.                                 |
-| waitingForScaleResourceFromZero | Function is scaling up from zero replicas.                                                                                                         |
-| waitingForScaleResourceToZero   | Function is scaling down to zero replicas.                                                                                                         |
-| error                           | An error occurred during function deployment that cannot be rectified without redeployment.                                                        |
-| unhealthy                       | An error occurred during function deployment, which can be resolved over time. For example, issues with insufficient resources or a missing image. |
+| **State**                       | **Description**                                                                                                                                                                      |
+|:--------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ready                           | Function is deployed successfully and ready to process events.                                                                                                                       |
+| imported                        | Function is imported but not yet deployed.                                                                                                                                           |
+| scaledToZero                    | Function is scaled to zero, so the number of function replicas is zero.                                                                                                              |
+| building                        | Function image is being built.                                                                                                                                                       |
+| waitingForResourceConfiguration | Function waits for resources to be ready. For instance, in case of k8s function waits for deployment/pods and etc.                                                                   |
+| waitingForScaleResourceFromZero | Function is scaling up from zero replicas.                                                                                                                                           |
+| waitingForScaleResourceToZero   | Function is scaling down to zero replicas.                                                                                                                                           |
+| error                           | An error occurred during function deployment that cannot be rectified without redeployment.                                                                                          |
+| unhealthy                       | An error occurred during function deployment, which might be resolved over time, and might require redeployment. For example, issues with insufficient resources or a missing image. |
 
 <a id="status-example"></a>
 ### Example

--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -223,7 +223,7 @@ Here is a list of all possible function states:
 | **State**                       | **Description**                                                                                                                                    |
 |:--------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|
 | ready                           | Function is deployed successfully and ready to process events.                                                                                     |
-| imported                        | Function has been imported but hasn't been deployed yet.                                                                                           |
+| imported                        | Function is imported but not yet deployed.                                                                                                         |
 | scaledToZero                    | Function is scaled to zero, so the number of function replicas is zero.                                                                            |
 | building                        | Function image is being built.                                                                                                                     |
 | waitingForResourceConfiguration | Function waits for resources to be ready. For instance, in case of k8s function waits for deployment/pods and etc.                                 |

--- a/docs/reference/function-configuration/function-configuration-reference.md
+++ b/docs/reference/function-configuration/function-configuration-reference.md
@@ -10,6 +10,7 @@ This document provides a reference of the Nuclio function configuration.
   - [Function Specification (`spec`)](#specification)
     - [Example](#spec-example)
   - [Function Status (`status`)](#status)
+    - [Function State (`state`)](#function-state-state)
     - [Example](#status-example)
   - [See also](#see-also)
 

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -839,7 +839,7 @@ func (suite *lazyTestSuite) TestFastFailOnAutoScalerEvents() {
 			suite.Require().NoError(err)
 
 			// call resolveFailFast
-			err = suite.client.resolveFailFast(suite.ctx, &podsList, time.Now())
+			_, err = suite.client.resolveFailFast(suite.ctx, &podsList, time.Now())
 			if testCase.expectedError {
 				suite.Require().Error(err)
 			} else {

--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -205,13 +205,13 @@ func (suite *FunctionMonitoringTestSuite) TestNoRecoveryAfterDeployError() {
 			// wait for monitoring
 			time.Sleep(postDeploymentSleepInterval)
 
-			// ensure function is still in error unhealthy (due to deploy error of wrong handler name)
+			// ensure function is still in unhealthy state (due to deploy error of wrong handler name)
 			suite.GetFunctionAndExpectState(getFunctionOptions, functionconfig.FunctionStateUnhealthy)
 
 			// let function monitoring run for a while
 			time.Sleep(postDeploymentSleepInterval)
 
-			// function should be remained in unhealthy state
+			// function should remain in unhealthy state
 			suite.GetFunctionAndExpectState(getFunctionOptions, functionconfig.FunctionStateUnhealthy)
 			return true
 		})

--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -205,14 +205,14 @@ func (suite *FunctionMonitoringTestSuite) TestNoRecoveryAfterDeployError() {
 			// wait for monitoring
 			time.Sleep(postDeploymentSleepInterval)
 
-			// ensure function is still in error state (due to deploy error of missing configmap)
-			suite.GetFunctionAndExpectState(getFunctionOptions, functionconfig.FunctionStateError)
+			// ensure function is still in error unhealthy (due to deploy error of wrong handler name)
+			suite.GetFunctionAndExpectState(getFunctionOptions, functionconfig.FunctionStateUnhealthy)
 
 			// let function monitoring run for a while
 			time.Sleep(postDeploymentSleepInterval)
 
-			// function should be remained in error state
-			suite.GetFunctionAndExpectState(getFunctionOptions, functionconfig.FunctionStateError)
+			// function should be remained in unhealthy state
+			suite.GetFunctionAndExpectState(getFunctionOptions, functionconfig.FunctionStateUnhealthy)
 			return true
 		})
 	suite.Require().Error(err)

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -261,13 +261,6 @@ func (p *Platform) CreateFunction(ctx context.Context, createFunctionOptions *pl
 			briefErrorsMessage = p.clearCallStack(briefErrorsMessage)
 		}
 
-		// low severity to not over log in the warning
-		createFunctionOptions.Logger.DebugWithCtx(ctx, "Function creation failed, brief error message extracted",
-			"briefErrorsMessage", briefErrorsMessage)
-
-		createFunctionOptions.Logger.WarnWithCtx(ctx, "Function creation failed, updating function status",
-			"errorStack", errorStack.String())
-
 		functionStatus := &functionconfig.Status{
 			State:   functionconfig.FunctionStateError,
 			Message: briefErrorsMessage,
@@ -292,10 +285,10 @@ func (p *Platform) CreateFunction(ctx context.Context, createFunctionOptions *pl
 
 		if functionStatus.State == functionconfig.FunctionStateUnhealthy {
 			createFunctionOptions.Logger.WarnWithCtx(ctx, "Function deployment failed, setting state to unhealthy. The issue might be transient or require manual redeployment",
-				"err", creationError)
+				"briefErrorsMessage", briefErrorsMessage)
 		} else {
 			createFunctionOptions.Logger.WarnWithCtx(ctx, "Function creation failed, setting state to error",
-				"err", creationError)
+				"err", errorStack.String())
 		}
 
 		// create or update the function. The possible creation needs to happen here, since on cases of

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -290,6 +290,14 @@ func (p *Platform) CreateFunction(ctx context.Context, createFunctionOptions *pl
 			}
 		}
 
+		if functionStatus.State == functionconfig.FunctionStateUnhealthy {
+			createFunctionOptions.Logger.WarnWithCtx(ctx, "Function deployment failed, setting state to unhealthy. The issue might be transient or require manual redeployment",
+				"err", creationError)
+		} else {
+			createFunctionOptions.Logger.WarnWithCtx(ctx, "Function creation failed, setting state to error",
+				"err", creationError)
+		}
+
 		// create or update the function. The possible creation needs to happen here, since on cases of
 		// early build failures we might get here before the function CR was created. After this point
 		// it is guaranteed to be created and updated with the reported error state

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -261,6 +261,10 @@ func (p *Platform) CreateFunction(ctx context.Context, createFunctionOptions *pl
 			briefErrorsMessage = p.clearCallStack(briefErrorsMessage)
 		}
 
+		// low severity to not over log in the warning
+		createFunctionOptions.Logger.DebugWithCtx(ctx, "Function creation failed, brief error message extracted",
+			"briefErrorsMessage", briefErrorsMessage)
+
 		functionStatus := &functionconfig.Status{
 			State:   functionconfig.FunctionStateError,
 			Message: briefErrorsMessage,
@@ -285,7 +289,7 @@ func (p *Platform) CreateFunction(ctx context.Context, createFunctionOptions *pl
 
 		if functionStatus.State == functionconfig.FunctionStateUnhealthy {
 			createFunctionOptions.Logger.WarnWithCtx(ctx, "Function deployment failed, setting state to unhealthy. The issue might be transient or require manual redeployment",
-				"briefErrorsMessage", briefErrorsMessage)
+				"err", errorStack.String())
 		} else {
 			createFunctionOptions.Logger.WarnWithCtx(ctx, "Function creation failed, setting state to error",
 				"err", errorStack.String())


### PR DESCRIPTION
This PR addresses pretty old bug where we set function to error state within the fast-fail controller's mechanism because of either CrashLoop or scheduling issues. So, we could end up with working and healthy function stacked in error state forever, because our approach to Nuclio states assumes that `error` state is a permanent state which can not be changed per time. While `unhealthy` state is a state that we monitor with FunctionMonitor component, so it is changeable. In light of this, we decided to set function to `unhealthy` state in case of any of above described errors occurred. 

Also, `resolveFailFast` function returns not only error, but also a status to which controller should set the function in case of error. For now, we only set function to `unhealthy` state here, but we plan to add more checks, so this change provides a flexibly for future changes. 

Jira - https://jira.iguazeng.com/browse/NUC-26

[**SOLVED** - Have decided to change a `warn` log message to show the difference between `error` and `unhealthy` states]
_Question: it is crucial to say that if function is unhealthy, we will anyway (with current logic) set the `status.Logs`  so that user can understand what the problem is. Taking into account the fact that `unhealthy` status is monitored by `FunctionMonitor` we should consider what will happen with the function if it is fixed and is set to `ready` state. Maybe it worth cleaning up `status.logs` on that case?_


Example:

1. When `unhealthy` 

![image](https://github.com/nuclio/nuclio/assets/35141662/32e68946-93a0-445e-9c62-263757c4e1cb)

2. After finding image (function is ready, but logs are still there)

![image](https://github.com/nuclio/nuclio/assets/35141662/8b2b7f54-dec5-4340-9ac6-5906f64b3b3d)
