### PR TITLE
Revert "[Processor] Add a control message to inform the processor that draining is done"

### DIFF
--- a/pkg/processor/controlcommunication/types.go
+++ b/pkg/processor/controlcommunication/types.go
@@ -27,7 +27,6 @@ type ControlMessageKind string
 
 const (
 	StreamMessageAckKind ControlMessageKind = "streamMessageAck"
-	DrainDoneMessageKind ControlMessageKind = "drainDone"
 )
 
 // TODO: move to nuclio-sdk-go

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -39,9 +39,6 @@ class Constants:
     termination_signal = signal.SIGUSR1
     drain_signal = signal.SIGUSR2
     continue_signal = signal.SIGCONT
-    drain_done_message = {
-        'kind': 'drainDone',
-    }
 
 
 class WrapperFatalException(Exception):
@@ -184,7 +181,6 @@ class Wrapper(object):
                     result = self._call_drain_handler()
                     if asyncio.iscoroutine(result):
                         await result
-                    await self._inform_processor_drain_done()
 
                 if self._is_termination_needed:
                     result = self._call_termination_handler()
@@ -235,26 +231,18 @@ class Wrapper(object):
                 raise
 
     def _register_to_signal(self):
-
         on_termination_signal = functools.partial(self._on_termination_signal, Constants.termination_signal.name)
+        on_drain_signal = functools.partial(self._on_drain_signal, Constants.drain_signal.name)
         on_continue_signal = functools.partial(self._on_continue_signal, Constants.continue_signal.name)
 
         asyncio.get_running_loop().add_signal_handler(Constants.termination_signal, on_termination_signal)
+        asyncio.get_running_loop().add_signal_handler(Constants.drain_signal, on_drain_signal)
         asyncio.get_running_loop().add_signal_handler(Constants.continue_signal, on_continue_signal)
 
-        # _on_drain_signal is async function, so we have to register it differently
-        asyncio.get_running_loop().add_signal_handler(
-            Constants.drain_signal,
-            lambda: asyncio.create_task(
-                self._on_drain_signal(Constants.drain_signal.name)
-            ),
-        )
-
-    async def _on_drain_signal(self, signal_name):
+    def _on_drain_signal(self, signal_name):
         # do not perform draining if discarding events
         if self._discard_events:
             self._logger.debug('Draining signal is received, but it will be ignored as the worker is already drained')
-            await self._inform_processor_drain_done()
             return
 
         self._logger.debug_with('Received signal', signal=signal_name)
@@ -302,13 +290,8 @@ class Wrapper(object):
         # to indicate that the termination handler has finished, and the processor can exit early
         return self._platform._on_signal(callback_type="termination")
 
-    async def _inform_processor_drain_done(self):
-        await self._send_data_on_control_socket(Constants.drain_done_message)
-
     async def _send_data_on_control_socket(self, data):
-        self._logger.debug_with('Sending data on control socket',
-                                data_length=len(data),
-                                message_kind=data.get('kind'))
+        self._logger.debug_with('Sending data on control socket', data_length=len(data))
 
         # send message to processor
         encoded_offset_data = self._json_encoder.encode(data)

--- a/pkg/processor/trigger/kafka/test/kafka_test.go
+++ b/pkg/processor/trigger/kafka/test/kafka_test.go
@@ -43,8 +43,7 @@ import (
 type testSuite struct {
 	*triggertest.AbstractBrokerSuite
 
-	httpClient   *http.Client
-	dockerClient *dockerclient.ShellClient
+	httpClient *http.Client
 
 	// kafka clients
 	broker   *sarama.Broker
@@ -90,9 +89,6 @@ func (suite *testSuite) SetupSuite() {
 	suite.AbstractBrokerSuite.SkipStartBrokerContainer = true
 	suite.AbstractBrokerSuite.BrokerContainerNetworkName = "nuclio-kafka-test"
 	suite.AbstractBrokerSuite.SetupSuite()
-
-	suite.dockerClient, err = dockerclient.NewShellClient(suite.Logger, nil)
-	suite.Require().NoError(err, "Failed to create docker client")
 
 	// start zoo keeper container
 	suite.zooKeeperContainerID = suite.RunContainer(suite.getKafkaZooKeeperContainerRunInfo())
@@ -433,11 +429,6 @@ func (suite *testSuite) TestDrainHook() {
 			return true
 		})
 
-		// get logs from 1st function container and check that draining was done within the timeout
-		logs, err := suite.dockerClient.GetContainerLogs(deployResult.ContainerID)
-		suite.Require().NoError(err)
-		suite.Require().NotContains(logs, "Timeout waiting for drain to be done, assuming process is drained")
-		suite.Require().Contains(logs, "Received drain done control message")
 		return true
 	})
 

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -364,6 +364,9 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 		}
 
 		go func() {
+			// this needs to occur once. the reason is that this specific function (ConsumeClaim)
+			// runs in parallel for each partition, and we want to make sure that we only
+			// drain the workers once.
 			if err := k.SignalWorkersToDrain(); err != nil {
 				k.Logger.DebugWith("Failed to signal worker draining",
 					"err", err.Error(),


### PR DESCRIPTION
Reverts nuclio/nuclio#3153.

We have seen that this new functionality causes issues and is unstable regarding the different handling of the 2 control message kinds:
- stream ack message is received once by each partition, who always listens for these messages.
- drain done messages are sent from each partition to every worker, meaning that for N partition and M workers - we will have NxM messages. This requires a much more complex logic to handle, which is risky at this point of the development.

Reverting back to only waiting on timeout until we have a better solution to that.

Resolves https://jira.iguazeng.com/browse/NUC-141 