### PR TITLE
[Project] Filter invalid labels if creating project from leader request

### DIFF
--- a/pkg/common/k8s.go
+++ b/pkg/common/k8s.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/mitchellh/go-homedir"
@@ -167,11 +166,12 @@ func getKubeconfigFromHomeDir() string {
 	return ""
 }
 
-func ValidateNodeSelector(nodeSelector map[string]string) error {
-	if nodeSelector == nil {
+// ValidateLabels validates the given labels according to k8s label constraints
+func ValidateLabels(labels map[string]string) error {
+	if labels == nil {
 		return nil
 	}
-	for labelKey, labelValue := range nodeSelector {
+	for labelKey, labelValue := range labels {
 		if errs := validation.IsValidLabelValue(labelValue); len(errs) > 0 {
 			errs = append([]string{fmt.Sprintf("Invalid value: %s", labelValue)}, errs...)
 			return nuclio.NewErrBadRequest(strings.Join(errs, ", "))
@@ -188,18 +188,19 @@ func ValidateNodeSelector(nodeSelector map[string]string) error {
 	return nil
 }
 
+// FilterInvalidLabels filters out invalid kubernetes labels from a map of labels
 func FilterInvalidLabels(labels map[string]string) map[string]string {
 
 	// From k8s docs:
 	//   a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.',
 	//   and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345',
 	//   regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
-	regex := regexp.MustCompile(`^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$`)
 	filteredLabels := map[string]string{}
 	for key, value := range labels {
-		if regex.MatchString(key) {
-			filteredLabels[key] = value
+		if len(validation.IsQualifiedName(key)) != 0 || len(validation.IsValidLabelValue(value)) != 0 {
+			continue
 		}
+		filteredLabels[key] = value
 	}
 	return filteredLabels
 }

--- a/pkg/common/k8s.go
+++ b/pkg/common/k8s.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/mitchellh/go-homedir"
@@ -185,4 +186,20 @@ func ValidateNodeSelector(nodeSelector map[string]string) error {
 		}
 	}
 	return nil
+}
+
+func FilterInvalidLabels(labels map[string]string) map[string]string {
+
+	// From k8s docs:
+	//   a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.',
+	//   and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345',
+	//   regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
+	regex := regexp.MustCompile(`^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$`)
+	filteredLabels := map[string]string{}
+	for key, value := range labels {
+		if regex.MatchString(key) {
+			filteredLabels[key] = value
+		}
+	}
+	return filteredLabels
 }

--- a/pkg/common/k8s_test.go
+++ b/pkg/common/k8s_test.go
@@ -1,0 +1,61 @@
+//go:build test_unit
+
+/*
+Copyright 2023 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type k8sTestSuite struct {
+	suite.Suite
+}
+
+func (suite *k8sTestSuite) TestFilterInvalidLabels() {
+	invalidLabels := map[string]string{
+		"my@weird/label":   "value",
+		"my.wierd/label":   "value@",
+		"%weird+/label":    "v8$alue",
+		"email.like@label": "value",
+	}
+
+	labels := map[string]string{
+		"valid":          "label",
+		"another-valid":  "label-value",
+		"also_123_valid": "label_456_value",
+	}
+
+	// add invalid labels to labels
+	for key, value := range invalidLabels {
+		labels[key] = value
+	}
+
+	filteredLabels := FilterInvalidLabels(labels)
+
+	suite.Require().Equal(len(filteredLabels), len(labels)-len(invalidLabels))
+	for key := range invalidLabels {
+		_, ok := filteredLabels[key]
+		suite.Require().False(ok, "invalid label %s should not be in filtered labels", key)
+	}
+}
+
+func TestK8sTestSuite(t *testing.T) {
+	suite.Run(t, new(k8sTestSuite))
+}

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -798,6 +798,12 @@ func (ap *Platform) EnrichCreateProjectConfig(createProjectOptions *platform.Cre
 		createProjectOptions.ProjectConfig.Spec.Owner = createProjectOptions.AuthSession.GetUsername()
 	}
 
+	if ap.Config.ProjectsLeader != nil && createProjectOptions.RequestOrigin == ap.Config.ProjectsLeader.Kind {
+
+		// ignore project's invalid labels instead of failing validation
+		createProjectOptions.ProjectConfig.Meta.Labels = common.FilterInvalidLabels(createProjectOptions.ProjectConfig.Meta.Labels)
+	}
+
 	return nil
 }
 

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -180,6 +180,21 @@ func (suite *AbstractPlatformTestSuite) TestProjectCreateOptions() {
 			},
 			ExpectValidationFailure: true,
 		},
+		{
+			Name: "InvalidLabels",
+			CreateProjectOptions: &platform.CreateProjectOptions{
+				ProjectConfig: &platform.ProjectConfig{
+					Meta: platform.ProjectMeta{
+						Name: "a-name",
+						Labels: map[string]string{
+							"invalid label ## .. %%": "value",
+							"valid-key":              "invalid value ## .. %%",
+						},
+					},
+				},
+			},
+			ExpectValidationFailure: true,
+		},
 	} {
 		suite.Run(testCase.Name, func() {
 			defer func() {

--- a/pkg/platform/abstract/project/external/leader/iguazio/client.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/client.go
@@ -139,7 +139,7 @@ func (c *Client) Create(ctx context.Context, createProjectOptions *platform.Crea
 
 	// send the request
 	c.logger.DebugWithCtx(ctx,
-		"Creating project",
+		"Creating project request to leader",
 		"body", string(body))
 	responseBody, response, err := common.SendHTTPRequestWithContext(ctx,
 		c.httpClient,

--- a/pkg/platform/abstract/project/external/leader/iguazio/synchronizer_test.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/synchronizer_test.go
@@ -191,33 +191,6 @@ func (suite *SynchronizerTestSuite) TestLeaderProjectsThatExistInternally() {
 		&testBeginningTime)
 }
 
-func (suite *SynchronizerTestSuite) TestFilterInvalidLabels() {
-	invalidLabels := map[string]string{
-		"my@weird/label": "value",
-		"my.wierd/label": "value@",
-		"%weird+/label":  "v8$alue",
-	}
-
-	labels := map[string]string{
-		"valid":          "label",
-		"another-valid":  "label-value",
-		"also_123_valid": "label_456_value",
-	}
-
-	// add invalid labels to labels
-	for key, value := range invalidLabels {
-		labels[key] = value
-	}
-
-	filteredLabels := suite.synchronizer.filterInvalidLabels(labels)
-
-	suite.Require().Equal(len(filteredLabels), len(labels)-len(invalidLabels))
-	for key := range invalidLabels {
-		_, ok := filteredLabels[key]
-		suite.Require().False(ok, "invalid label %s should not be in filtered labels", key)
-	}
-}
-
 func (suite *SynchronizerTestSuite) testSynchronizeProjectsFromLeader(namespace string,
 	leaderProjects []platform.Project,
 	internalProjects []platform.Project,

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -2089,13 +2089,15 @@ func (suite *ProjectTestSuite) TestCreate() {
 }
 
 func (suite *ProjectTestSuite) TestCreateFromLeaderIgnoreInvalidLabels() {
-	invalidLabelKey := "invalid.label@-key"
+	invalidLabelKey1 := "invalid.label@-key"
+	invalidLabelKey2 := "the-key-is-invalid"
 	projectConfig := platform.ProjectConfig{
 		Meta: platform.ProjectMeta{
 			Name:      "test-project",
 			Namespace: suite.Namespace,
 			Labels: map[string]string{
-				invalidLabelKey: "label-value",
+				invalidLabelKey1: "label-value",
+				invalidLabelKey2: "inva!id_v8$alue",
 			},
 		},
 		Spec: platform.ProjectSpec{
@@ -2131,7 +2133,8 @@ func (suite *ProjectTestSuite) TestCreateFromLeaderIgnoreInvalidLabels() {
 
 	// verify created project does not contain the invalid label
 	createdProject := projects[0]
-	suite.Require().NotContains(createdProject.GetConfig().Meta.Labels, invalidLabelKey)
+	suite.Require().NotContains(createdProject.GetConfig().Meta.Labels, invalidLabelKey1)
+	suite.Require().NotContains(createdProject.GetConfig().Meta.Labels, invalidLabelKey2)
 }
 
 func (suite *ProjectTestSuite) TestUpdate() {


### PR DESCRIPTION
When a new project is created in the leader, it sends a POST request to Nuclio to create the project, instead of relying on Nuclio's synchronization mechanism.
Since currently the leaders allow for project labels that are invalid in k8s, we want to just ignore those labels when we receive a create project request from the leader.

**Note:** these labels are already filtered in the synchronization mechanism (see #2794).

In addition, some more improvements regarding this flow:
- Move label filtering to the common k8s module.
- Validate project labels to get a better traceback and failing early, instead of failing on the actual CRD creation.
- Differentiate the `Creating projects` logs a bit for a better debugging experience. 