### PR TITLE
[MQTT] Add properties to the mqtt event

### DIFF
--- a/docs/reference/triggers/mqtt.md
+++ b/docs/reference/triggers/mqtt.md
@@ -22,3 +22,12 @@ triggers:
         - topic: weather/humidity
           qos: 0
 ```
+
+### Event
+
+The mqtt trigger emits an event object with the following attributes:
+-  `URL`: The URL of the MQTT broker
+- `topic`: The topic of the message
+- `path`: The topic of the message (alias for `topic`)
+- `body`: The message payload
+- `id`: The message id

--- a/pkg/processor/trigger/kinesis/event.go
+++ b/pkg/processor/trigger/kinesis/event.go
@@ -20,7 +20,7 @@ import (
 	"github.com/nuclio/nuclio-sdk-go"
 )
 
-// allows accessing an amqp.Delivery
+// Event allows access to the event body
 type Event struct {
 	nuclio.AbstractEvent
 	body []byte

--- a/pkg/processor/trigger/mqtt/event.go
+++ b/pkg/processor/trigger/mqtt/event.go
@@ -17,15 +17,17 @@ limitations under the License.
 package mqtt
 
 import (
+	"strconv"
+
 	mqttclient "github.com/eclipse/paho.mqtt.golang"
 	"github.com/nuclio/nuclio-sdk-go"
-	"strconv"
 )
 
 // Event allows access to the MQTT message
 type Event struct {
 	nuclio.AbstractEvent
 	message mqttclient.Message
+	url     string
 }
 
 func (e *Event) GetBody() []byte {
@@ -34,6 +36,11 @@ func (e *Event) GetBody() []byte {
 
 // GetURL returns the topic of the event
 func (e *Event) GetURL() string {
+	return e.url
+}
+
+// GetPath returns the topic of the event
+func (e *Event) GetPath() string {
 	return e.message.Topic()
 }
 

--- a/pkg/processor/trigger/mqtt/event.go
+++ b/pkg/processor/trigger/mqtt/event.go
@@ -19,9 +19,10 @@ package mqtt
 import (
 	mqttclient "github.com/eclipse/paho.mqtt.golang"
 	"github.com/nuclio/nuclio-sdk-go"
+	"strconv"
 )
 
-// allows accessing an amqp.Delivery
+// Event allows access to the MQTT message
 type Event struct {
 	nuclio.AbstractEvent
 	message mqttclient.Message
@@ -34,4 +35,14 @@ func (e *Event) GetBody() []byte {
 // GetURL returns the topic of the event
 func (e *Event) GetURL() string {
 	return e.message.Topic()
+}
+
+// GetTopic returns the topic of the event
+func (e *Event) GetTopic() string {
+	return e.message.Topic()
+}
+
+// GetID returns the message ID
+func (e *Event) GetID() nuclio.ID {
+	return nuclio.ID(strconv.Itoa(int(e.message.MessageID())))
 }

--- a/pkg/processor/trigger/mqtt/trigger.go
+++ b/pkg/processor/trigger/mqtt/trigger.go
@@ -167,7 +167,13 @@ func (t *AbstractTrigger) handleMessage(client mqttclient.Client, message mqttcl
 		return
 	}
 
-	t.SubmitEventToWorker(nil, workerInstance, &Event{message: message}) // nolint: errcheck
+	//nolint: errcheck
+	t.SubmitEventToWorker(nil,
+		workerInstance,
+		&Event{
+			message: message,
+			url:     t.configuration.URL,
+		})
 
 	workerAllocator.Release(workerInstance)
 }

--- a/pkg/processor/trigger/nats/event.go
+++ b/pkg/processor/trigger/nats/event.go
@@ -21,7 +21,7 @@ import (
 	"github.com/nuclio/nuclio-sdk-go"
 )
 
-// Event allows accessing an amqp.Delivery
+// Event allows access to the NATS message
 type Event struct {
 	nuclio.AbstractEvent
 	natsMessage *natsio.Msg

--- a/pkg/processor/trigger/partitioned/eventhub/event.go
+++ b/pkg/processor/trigger/partitioned/eventhub/event.go
@@ -20,7 +20,7 @@ import (
 	"github.com/nuclio/nuclio-sdk-go"
 )
 
-// allows accessing an amqp.Delivery
+// Event allows access to the EventHub message
 type Event struct {
 	nuclio.AbstractEvent
 	body []byte


### PR DESCRIPTION
The MQTT topic was previously populated in the URL field of the event, and was confused with the recently added (empty) `topic` property.

In this PR I added some fields to the MQTT event, as suggested in #3170 :
-  `URL`: The URL of the MQTT broker
- `topic`: The topic of the message
- `path`: The topic of the message (alias for `topic`)
- `body`: The message payload
- `id`: The message id

Resolves #3170 