### PR TITLE
[Docs] Remove usage of `sphinx_markdown_tables` library [1.12.x]

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,6 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "python_docs_theme",
-    "sphinx_markdown_tables",
     "sphinx_copybutton",
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 recommonmark
 python_docs_theme
 sphinx_book_theme
-sphinx-markdown-tables
 sphinx-copybutton


### PR DESCRIPTION
Backport of #3182