### PR TITLE
[Docs] Add `markdown` library to requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+markdown
 recommonmark
 python_docs_theme
 sphinx_book_theme


### PR DESCRIPTION
Missing for making #3185 work