### PR TITLE
[Test] Fix runtime archive tests

### DIFF
--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -69,7 +69,10 @@ func (suite *TestSuite) SetupSuite() {
 
 	suite.archiveInfos = []archiveInfo{
 		{".zip", archiver.Zip{}.Archive},
-		{".tar.gz", archiver.Tar{}.Archive},
+		{".tar.gz", archiver.CompressedArchive{
+			Compression: archiver.Gz{},
+			Archival:    archiver.Tar{},
+		}.Archive},
 	}
 }
 


### PR DESCRIPTION
When creating a compressed archive, we need to specify the compressions format, otherwise it returns an undefined file that is not recognized as an archive.