### PR TITLE
[Build] Continue after mkdir when extracting directory

### DIFF
--- a/pkg/processor/build/util/unarchive.go
+++ b/pkg/processor/build/util/unarchive.go
@@ -79,7 +79,15 @@ func (d *Unarchiver) Extract(ctx context.Context, sourcePath string, targetPath 
 func (d *Unarchiver) extractFile(file archiver.File, targetPath string) error {
 	filePath := filepath.Join(targetPath, file.NameInArchive)
 
-	// create the directory if it doesn't exist
+	if file.IsDir() {
+		// create the directory if it doesn't exist and continue to the next file
+		if err := os.MkdirAll(filePath, 0755); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Failed to create directory %s", filePath))
+		}
+		return nil
+	}
+
+	// create the file's parent directory if it doesn't exist
 	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Failed to create directory %s", filepath.Dir(filePath)))
 	}


### PR DESCRIPTION
When extracting an archive, we iterate over the files in archive using the `archiver` package.
`archiver.File` can also be a directory. If so, we only want to create the directory in the target path and continue extracting the rest of the files.