### PR TITLE
[Kafka] Remove support for TLS version 1.0 and 1.1

### DIFF
--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -510,10 +510,6 @@ func (k *kafka) newKafkaConfig() (*sarama.Config, error) {
 
 		getTLSMinimumVersion := func(version string) uint16 {
 			switch version {
-			case "1.0":
-				return tls.VersionTLS10
-			case "1.1":
-				return tls.VersionTLS11
 			case "1.2":
 				return tls.VersionTLS12
 			case "1.3":


### PR DESCRIPTION
TLS 1.0 and 1.1 are out-of-date protocols and they contain security vulnerabilities that may be exploited by attackers.
Version >= 1.2 should be used instead.

Deprecation: https://datatracker.ietf.org/doc/html/rfc8996 
