### PR TITLE
[Dashboard] Allow passing empty API gateway host

### DIFF
--- a/pkg/common/consts.go
+++ b/pkg/common/consts.go
@@ -59,3 +59,5 @@ const (
 const RestoreConfigFromSecretEnvVar = "NUCLIO_RESTORE_FUNCTION_CONFIG_FROM_SECRET"
 
 const FunctionConfigFileName = "function.yaml"
+
+const DefaultIngressHostTemplate = "@nuclio.fromDefault"

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -342,7 +342,7 @@ func (suite *lazyTestSuite) TestNoChanges() {
 	defaultHTTPTrigger.Attributes = map[string]interface{}{
 		"ingresses": map[string]interface{}{
 			"0": map[string]interface{}{
-				"hostTemplate": "@nuclio.fromDefault",
+				"hostTemplate": common.DefaultIngressHostTemplate,
 				"paths":        []string{"/"},
 			},
 		},

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -2041,7 +2041,8 @@ func (p *Platform) renderIngressHost(ctx context.Context, ingressHostTemplate st
 	if ingressHostTemplate == common.DefaultIngressHostTemplate {
 		ingressHostTemplate = p.Config.Kube.DefaultHTTPIngressHostTemplate
 	} else {
-		p.Logger.DebugWithCtx(ctx, "Received custom ingress host template to enrich host with",
+		p.Logger.DebugWithCtx(ctx,
+			"Received custom ingress host template to enrich host with",
 			"ingressHostTemplate", ingressHostTemplate)
 	}
 

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -1950,15 +1950,6 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayEnrichmentAndValidat
 			validationError: "One or more upstreams must be provided in spec",
 		},
 		{
-			name: "ValidateHostExistence",
-			apiGatewayConfig: func() *platform.APIGatewayConfig {
-				apiGatewayConfig := suite.compileAPIGatewayConfig()
-				apiGatewayConfig.Spec.Host = ""
-				return &apiGatewayConfig
-			}(),
-			validationError: "Host must be provided in spec",
-		},
-		{
 			name: "ValidateUpstreamKind",
 			apiGatewayConfig: func() *platform.APIGatewayConfig {
 				apiGatewayConfig := suite.compileAPIGatewayConfig()

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -1047,14 +1047,14 @@ func (suite *FunctionKubePlatformTestSuite) TestRenderFunctionIngress() {
 				Attributes: map[string]interface{}{
 					"ingresses": map[string]interface{}{
 						"0": map[string]interface{}{
-							"hostTemplate": "@nuclio.fromDefault",
+							"hostTemplate": common.DefaultIngressHostTemplate,
 						},
 					},
 				},
 			},
 			want: map[string]interface{}{
 				"0": map[string]interface{}{
-					"hostTemplate": "@nuclio.fromDefault",
+					"hostTemplate": common.DefaultIngressHostTemplate,
 					"host":         "some-name.some-namespace.test.com",
 					"pathType":     networkingv1.PathTypeImplementationSpecific,
 				},
@@ -1068,7 +1068,7 @@ func (suite *FunctionKubePlatformTestSuite) TestRenderFunctionIngress() {
 				Attributes: map[string]interface{}{
 					"ingresses": map[string]interface{}{
 						"0": map[string]interface{}{
-							"hostTemplate": "@nuclio.fromDefault",
+							"hostTemplate": common.DefaultIngressHostTemplate,
 						},
 						"1": map[string]interface{}{
 							"host": "leave-it-as.is.com",
@@ -1078,7 +1078,7 @@ func (suite *FunctionKubePlatformTestSuite) TestRenderFunctionIngress() {
 			},
 			want: map[string]interface{}{
 				"0": map[string]interface{}{
-					"hostTemplate": "@nuclio.fromDefault",
+					"hostTemplate": common.DefaultIngressHostTemplate,
 					"host":         "some-name.some-namespace.test.com",
 					"pathType":     networkingv1.PathTypeImplementationSpecific,
 				},
@@ -1096,7 +1096,7 @@ func (suite *FunctionKubePlatformTestSuite) TestRenderFunctionIngress() {
 				Attributes: map[string]interface{}{
 					"ingresses": map[string]interface{}{
 						"0": map[string]interface{}{
-							"hostTemplate": "@nuclio.fromDefault",
+							"hostTemplate": common.DefaultIngressHostTemplate,
 							"host":         "",
 						},
 					},
@@ -1104,7 +1104,7 @@ func (suite *FunctionKubePlatformTestSuite) TestRenderFunctionIngress() {
 			},
 			want: map[string]interface{}{
 				"0": map[string]interface{}{
-					"hostTemplate": "@nuclio.fromDefault",
+					"hostTemplate": common.DefaultIngressHostTemplate,
 					"host":         "some-name.some-namespace.test.com",
 					"pathType":     networkingv1.PathTypeImplementationSpecific,
 				},
@@ -1118,7 +1118,7 @@ func (suite *FunctionKubePlatformTestSuite) TestRenderFunctionIngress() {
 				Attributes: map[string]interface{}{
 					"ingresses": map[string]interface{}{
 						"0": map[string]interface{}{
-							"hostTemplate": "@nuclio.fromDefault",
+							"hostTemplate": common.DefaultIngressHostTemplate,
 							"host":         "dont-override-me.com",
 						},
 					},
@@ -1126,7 +1126,7 @@ func (suite *FunctionKubePlatformTestSuite) TestRenderFunctionIngress() {
 			},
 			want: map[string]interface{}{
 				"0": map[string]interface{}{
-					"hostTemplate": "@nuclio.fromDefault",
+					"hostTemplate": common.DefaultIngressHostTemplate,
 					"host":         "dont-override-me.com",
 					"pathType":     networkingv1.PathTypeImplementationSpecific,
 				},
@@ -1803,6 +1803,13 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayEnrichmentAndValidat
 		On("List", suite.ctx, metav1.ListOptions{}).
 		Return(&v1beta1.NuclioAPIGatewayList{}, nil)
 
+	// set the template for api gateway host generation
+	suite.platform.GetConfig().Kube.DefaultHTTPIngressHostTemplate = "{{ .ResourceName }}.{{ .Namespace }}.app.dev.com"
+	defer func() {
+		// unset the template for api gateway host generation
+		suite.platform.GetConfig().Kube.DefaultHTTPIngressHostTemplate = ""
+	}()
+
 	for _, testCase := range []struct {
 		name             string
 		setUpFunction    func() error
@@ -1836,6 +1843,19 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayEnrichmentAndValidat
 				apiGatewayConfig := suite.compileAPIGatewayConfig()
 				apiGatewayConfig.Spec.Name = "meta-name"
 				apiGatewayConfig.Meta.Name = "meta-name"
+				return &apiGatewayConfig
+			}(),
+		},
+		{
+			name: "HostEnriched",
+			apiGatewayConfig: func() *platform.APIGatewayConfig {
+				apiGatewayConfig := suite.compileAPIGatewayConfig()
+				apiGatewayConfig.Spec.Host = ""
+				return &apiGatewayConfig
+			}(),
+			expectedEnrichedAPIGateway: func() *platform.APIGatewayConfig {
+				apiGatewayConfig := suite.compileAPIGatewayConfig()
+				apiGatewayConfig.Spec.Host = "default-name.default-namespace.app.dev.com"
 				return &apiGatewayConfig
 			}(),
 		},


### PR DESCRIPTION
Currently, we don't allow passing an empty host for the API gateway. Typically, it's generated on the UI side, which hasn't been a significant issue until now. However, with the implementation of API Gateways on the MLRun side, where MLRun will create API gateways via the Nuclio API, we want to enable MLRun to not set the host explicitly and leave this task to Nuclio.

https://iguazio.atlassian.net/browse/NUC-116