### PR TITLE
[Misc] Fix the error `json: unsupported value: encountered a cycle via`

### DIFF
--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -210,8 +210,6 @@ func (p *Processor) Start() error {
 	// handles system signals (for now only SIGTERM)
 	go p.handleSignals()
 
-	p.logger.DebugWith("Starting triggers", "triggers", p.triggers)
-
 	// iterate over all triggers and start them
 	for _, triggerInstance := range p.triggers {
 		if err := triggerInstance.Start(nil); err != nil {
@@ -219,6 +217,10 @@ func (p *Processor) Start() error {
 				"kind", triggerInstance.GetKind(),
 				"err", err.Error())
 			return errors.Wrap(err, "Failed to start trigger")
+		} else {
+			p.logger.DebugWith("Trigger successfully started",
+				"kind", triggerInstance.GetKind(),
+				"name", triggerInstance.GetName())
 		}
 	}
 

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -210,6 +210,8 @@ func (p *Processor) Start() error {
 	// handles system signals (for now only SIGTERM)
 	go p.handleSignals()
 
+	p.logger.Debug("Starting triggers")
+
 	// iterate over all triggers and start them
 	for _, triggerInstance := range p.triggers {
 		if err := triggerInstance.Start(nil); err != nil {


### PR DESCRIPTION
jira - https://iguazio.atlassian.net/browse/NUC-163

This PR fixes a bug where we see `json: unsupported value: encountered a cycle via` in the log. The culprit is this line: `p.logger.DebugWith("Starting triggers", "triggers", p.triggers)`. Here, `p.triggers` is of type `[]Trigger`, where Trigger is an interface. Each trigger in the list is a child of an `AbstractTrigger`. Each `AbstractTrigger` maintains a pointer to the original child trigger.So here is a loop. Hence, this log line itself is the reason we encounter this error. The logger was unable to encode the object into JSON.