### PR TITLE
[Scrubber] API Gateway Scrubber

### DIFF
--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -333,7 +333,7 @@ func (p *Processor) restoreFunctionConfig(config *functionconfig.Config) (*funct
 		return nil, errors.Wrap(err, "Failed to restore function config")
 	}
 
-	return restoredFunctionConfig, nil
+	return functionconfig.GetFunctionConfigFromInterface(restoredFunctionConfig), nil
 }
 
 func (p *Processor) getSecretsMap(scrubber *functionconfig.Scrubber) (map[string]string, error) {

--- a/pkg/common/scrubber.go
+++ b/pkg/common/scrubber.go
@@ -41,13 +41,20 @@ const (
 )
 
 type Scrubber interface {
+	// Scrub scrubs sensitive data from an object
 	Scrub(objectToScrub interface{}, existingSecretMap map[string]string, sensitiveFields []*regexp.Regexp) (interface{}, map[string]string, error)
+
+	// Restore restores sensitive data in an object from a secrets map
 	Restore(scrubbedFunctionConfig interface{}, secretsMap map[string]string) (interface{}, error)
+
+	// ValidateReference validates references in a scrubbed object
 	ValidateReference(objectToScrub interface{},
 		existingSecretMap map[string]string,
 		fieldPath,
 		secretKey,
 		stringValue string) error
+
+	// ConvertMapToConfig converts map back to an object entity
 	ConvertMapToConfig(mapConfig interface{}) (interface{}, error)
 }
 

--- a/pkg/common/scrubber.go
+++ b/pkg/common/scrubber.go
@@ -41,6 +41,8 @@ const (
 )
 
 type Scrubber interface {
+	Scrub(objectToScrub interface{}, existingSecretMap map[string]string, sensitiveFields []*regexp.Regexp) (interface{}, map[string]string, error)
+	Restore(scrubbedFunctionConfig interface{}, secretsMap map[string]string) (interface{}, error)
 	ValidateReference(objectToScrub interface{},
 		existingSecretMap map[string]string,
 		fieldPath,

--- a/pkg/common/scrubber.go
+++ b/pkg/common/scrubber.go
@@ -1,0 +1,341 @@
+/*
+Copyright 2023 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/gosecretive"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	ReferencePrefix                  = "$ref:"
+	ReferenceToEnvVarPrefix          = "NUCLIO_B64_"
+	NuclioFlexVolumeSecretNamePrefix = "nuclio-flexvolume"
+	SecretTypeFunctionConfig         = "nuclio.io/functionconfig"
+	SecretTypeV3ioFuse               = "v3io/fuse"
+	SecretContentKey                 = "content"
+	FunctionSecretMountPath          = "/etc/nuclio/secrets"
+)
+
+type Scrubber interface {
+	ValidateReference(objectToScrub interface{},
+		existingSecretMap map[string]string,
+		fieldPath,
+		secretKey,
+		stringValue string) error
+	ConvertMapToConfig(mapConfig interface{}) (interface{}, error)
+}
+
+type AbstractScrubber struct {
+	SensitiveFields []*regexp.Regexp
+	KubeClientSet   kubernetes.Interface
+	ReferencePrefix string
+	Scrubber        Scrubber
+}
+
+// NewAbstractScrubber returns a new AbstractScrubber
+// If the scrubber is only used for restoring, the arguments can be nil
+func NewAbstractScrubber(sensitiveFields []*regexp.Regexp, kubeClientSet kubernetes.Interface) *AbstractScrubber {
+	return &AbstractScrubber{
+		SensitiveFields: sensitiveFields,
+		KubeClientSet:   kubeClientSet,
+		ReferencePrefix: ReferencePrefix,
+	}
+}
+
+// Scrub scrubs sensitive data from a function config
+func (s *AbstractScrubber) Scrub(objectToScrub interface{},
+	existingSecretMap map[string]string,
+	sensitiveFields []*regexp.Regexp) (interface{}, map[string]string, error) {
+
+	var scrubErr error
+
+	// hack to support avoid losing unexported fields while scrubbing.
+	// scrub the function config to map[string]interface{} and revert it back to a function config later
+	functionConfigAsMap := StructureToMap(objectToScrub)
+	if len(functionConfigAsMap) == 0 {
+		return nil, nil, errors.New("Failed to convert function config to map")
+	}
+
+	// scrub the function config
+	scrubbedFunctionConfigAsMap, secretsMap := gosecretive.Scrub(functionConfigAsMap, func(fieldPath string, valueToScrub interface{}) *string {
+
+		for _, fieldPathRegexToScrub := range sensitiveFields {
+
+			// if the field path matches the field path to scrub, scrub it
+			if fieldPathRegexToScrub.MatchString(fieldPath) {
+
+				secretKey := s.generateSecretKey(fieldPath)
+
+				// if the value to scrub is a string, make sure that we need to scrub it
+				if kind := reflect.ValueOf(valueToScrub).Kind(); kind == reflect.String {
+					stringValue := reflect.ValueOf(valueToScrub).String()
+
+					// if it's an empty string, don't scrub it
+					if stringValue == "" {
+						return nil
+					}
+
+					// if it's already a reference, validate that the value exists
+					if strings.HasPrefix(stringValue, ReferencePrefix) {
+						scrubErr = s.ValidateReference(objectToScrub, existingSecretMap, fieldPath, secretKey, stringValue)
+						return nil
+					}
+				}
+
+				// scrub the value, and leave a $ref placeholder
+				return &secretKey
+			}
+		}
+
+		// do not scrub
+		return nil
+	})
+
+	// merge the new secrets map with the existing one
+	// In case of a conflict, the new secrets map will override the existing value
+	if existingSecretMap != nil {
+		secretsMap = labels.Merge(existingSecretMap, secretsMap)
+	}
+
+	scrubbedFunctionConfig, err := s.ConvertMapToConfig(scrubbedFunctionConfigAsMap)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "Failed to convert scrubbed function config map to function config")
+	}
+
+	return scrubbedFunctionConfig, secretsMap, scrubErr
+}
+
+// Restore restores sensitive data in a function config from a secrets map
+func (s *AbstractScrubber) Restore(scrubbedFunctionConfig interface{}, secretsMap map[string]string) (interface{}, error) {
+
+	// hack to avoid changing complex objects in the function config.
+	// convert the function config to map[string]interface{} and revert it back to a function config later
+	scrubbedFunctionConfigAsMap := StructureToMap(scrubbedFunctionConfig)
+	if len(scrubbedFunctionConfigAsMap) == 0 {
+		return nil, errors.New("Failed to convert function config to map")
+	}
+
+	restoredFunctionConfigMap := gosecretive.Restore(scrubbedFunctionConfigAsMap, secretsMap)
+
+	restoredFunctionConfig, err := s.ConvertMapToConfig(restoredFunctionConfigMap)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to convert restored function config map to function config")
+	}
+
+	return restoredFunctionConfig, nil
+}
+
+// HasScrubbedConfig checks if a function config has scrubbed data, using the Scrub function
+func (s *AbstractScrubber) HasScrubbedConfig(object interface{}, sensitiveFields []*regexp.Regexp) (bool, error) {
+	var hasScrubbed bool
+
+	// hack to support avoid losing unexported fields while scrubbing.
+	// scrub the function config to map[string]interface{} and revert it back to a function config later
+	functionConfigAsMap := StructureToMap(object)
+	if len(functionConfigAsMap) == 0 {
+		return false, errors.New("Failed to convert function config to map")
+	}
+
+	// scrub the function config
+	_, _ = gosecretive.Scrub(functionConfigAsMap, func(fieldPath string, valueToScrub interface{}) *string {
+
+		for _, fieldPathRegexToScrub := range sensitiveFields {
+
+			// if the field path matches the field path to scrub, scrub it
+			if fieldPathRegexToScrub.MatchString(fieldPath) {
+
+				// if the value to is a string, check if it's a reference
+				if kind := reflect.ValueOf(valueToScrub).Kind(); kind == reflect.String {
+					stringValue := reflect.ValueOf(valueToScrub).String()
+
+					if strings.HasPrefix(stringValue, ReferencePrefix) {
+						hasScrubbed = true
+					}
+				}
+
+				// we never actually scrub the value
+				return nil
+			}
+		}
+
+		return nil
+	})
+
+	return hasScrubbed, nil
+}
+
+// EncodeSecretsMap encodes the keys of a secrets map
+func (s *AbstractScrubber) EncodeSecretsMap(secretsMap map[string]string) (map[string]string, error) {
+	encodedSecretsMap := map[string]string{}
+
+	// encode secret map keys
+	for secretKey, secretValue := range secretsMap {
+		encodedSecretsMap[s.EncodeSecretKey(secretKey)] = secretValue
+	}
+
+	if len(encodedSecretsMap) > 0 {
+
+		// encode the entire map into a single string
+		secretsMapContent, err := json.Marshal(encodedSecretsMap)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to marshal secrets map")
+		}
+		encodedSecretsMap[SecretContentKey] = base64.StdEncoding.EncodeToString(secretsMapContent)
+	} else {
+
+		// if the map is empty, set the content to an empty string anyway,
+		// so that the secret will be created and mounted
+		encodedSecretsMap[SecretContentKey] = ""
+	}
+
+	return encodedSecretsMap, nil
+}
+
+// DecodeSecretsMapContent decodes the secrets map content
+func (s *AbstractScrubber) DecodeSecretsMapContent(secretsMapContent string) (map[string]string, error) {
+
+	// decode secret
+	secretContentStr, err := base64.StdEncoding.DecodeString(secretsMapContent)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to decode function secret")
+	}
+	if len(secretContentStr) == 0 {
+
+		// secret is empty, return empty map
+		return map[string]string{}, nil
+	}
+
+	// unmarshal secret into map
+	encodedSecretMap := map[string]string{}
+	if err := json.Unmarshal(secretContentStr, &encodedSecretMap); err != nil {
+		return nil, errors.Wrap(err, "Failed to unmarshal function secret")
+	}
+
+	// decode secret keys and values
+	// convert values to byte array for decoding purposes
+	secretMap, err := s.DecodeSecretData(MapStringStringToMapStringBytesArray(encodedSecretMap))
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to decode function secret data")
+	}
+
+	return secretMap, nil
+}
+
+// DecodeSecretData decodes the keys of a secrets map
+func (s *AbstractScrubber) DecodeSecretData(secretData map[string][]byte) (map[string]string, error) {
+	decodedSecretsMap := map[string]string{}
+	for secretKey, secretValue := range secretData {
+		if secretKey == SecretContentKey {
+
+			// when the secret is created, the entire map is encoded into a single string under the "content" key
+			// which we don't care about when decoding
+			continue
+		}
+		decodedSecretKey, err := s.DecodeSecretKey(secretKey)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to decode secret key")
+		}
+		decodedSecretsMap[decodedSecretKey] = string(secretValue)
+	}
+	return decodedSecretsMap, nil
+}
+
+// GenerateFunctionSecretName generates a secret name for a function, in the form of:
+// `nuclio-secret-<project-name>-<function-name>-<unique-id>`
+func (s *AbstractScrubber) GenerateFunctionSecretName(functionName string) string {
+	secretName := fmt.Sprintf("%s-%s", "nuclio", functionName)
+	if len(secretName) > KubernetesDomainLevelMaxLength-8 {
+		secretName = secretName[:KubernetesDomainLevelMaxLength-8]
+	}
+
+	// remove trailing non-alphanumeric characters
+	secretName = strings.TrimRight(secretName, "-_")
+
+	// add a unique id to the end of the name
+	secretName = fmt.Sprintf("%s-%s", secretName, GenerateRandomString(8, SmallLettersAndNumbers))
+
+	return secretName
+}
+
+// GenerateFlexVolumeSecretName generates a secret name for a flex volume, in the form of:
+// `nuclio-flex-volume-<volume-name>-<unique-id>`
+func (s *AbstractScrubber) GenerateFlexVolumeSecretName(functionName, volumeName string) string {
+	secretName := fmt.Sprintf("%s-%s-%s", NuclioFlexVolumeSecretNamePrefix, functionName, volumeName)
+
+	// if the secret name is too long, drop the function and project name
+	if len(secretName) > KubernetesDomainLevelMaxLength {
+		secretName = fmt.Sprintf("%s-%s", NuclioFlexVolumeSecretNamePrefix, volumeName)
+
+	}
+
+	// if the secret name is still too long, trim it and keep space for the unique id
+	if len(secretName) > KubernetesDomainLevelMaxLength-8 {
+		secretName = secretName[:KubernetesDomainLevelMaxLength-8]
+	}
+
+	// remove trailing non-alphanumeric characters
+	secretName = strings.TrimRight(secretName, "-_")
+
+	// add a unique id to the end of the name
+	secretName = fmt.Sprintf("%s-%s", secretName, GenerateRandomString(8, SmallLettersAndNumbers))
+
+	return secretName
+}
+
+// EncodeSecretKey encodes a secret key
+func (s *AbstractScrubber) EncodeSecretKey(fieldPath string) string {
+	encodedFieldPath := base64.StdEncoding.EncodeToString([]byte(fieldPath))
+	encodedFieldPath = strings.ReplaceAll(encodedFieldPath, "=", "_")
+	return fmt.Sprintf("%s%s", ReferenceToEnvVarPrefix, encodedFieldPath)
+}
+
+// DecodeSecretKey decodes a secret key and returns the original field
+func (s *AbstractScrubber) DecodeSecretKey(secretKey string) (string, error) {
+	encodedFieldPath := strings.TrimPrefix(secretKey, ReferenceToEnvVarPrefix)
+	encodedFieldPath = strings.ReplaceAll(encodedFieldPath, "_", "=")
+	decodedFieldPath, err := base64.StdEncoding.DecodeString(encodedFieldPath)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to decode secret key")
+	}
+	return string(decodedFieldPath), nil
+}
+
+func (s *AbstractScrubber) generateSecretKey(fieldPath string) string {
+	return fmt.Sprintf("%s%s", ReferencePrefix, strings.ToLower(fieldPath))
+}
+
+func (s *AbstractScrubber) ConvertMapToConfig(mapConfig interface{}) (interface{}, error) {
+	return s.Scrubber.ConvertMapToConfig(mapConfig)
+}
+
+func (s *AbstractScrubber) ValidateReference(objectToScrub interface{},
+	existingSecretMap map[string]string,
+	fieldPath,
+	secretKey,
+	stringValue string) error {
+	return s.Scrubber.ValidateReference(objectToScrub, existingSecretMap, fieldPath, secretKey, stringValue)
+}

--- a/pkg/common/scrubber.go
+++ b/pkg/common/scrubber.go
@@ -273,35 +273,10 @@ func (s *AbstractScrubber) DecodeSecretData(secretData map[string][]byte) (map[s
 	return decodedSecretsMap, nil
 }
 
-// GenerateFunctionSecretName generates a secret name for a function, in the form of:
-// `nuclio-secret-<project-name>-<function-name>-<unique-id>`
-func (s *AbstractScrubber) GenerateFunctionSecretName(functionName string) string {
-	secretName := fmt.Sprintf("%s-%s", "nuclio", functionName)
-	if len(secretName) > KubernetesDomainLevelMaxLength-8 {
-		secretName = secretName[:KubernetesDomainLevelMaxLength-8]
-	}
-
-	// remove trailing non-alphanumeric characters
-	secretName = strings.TrimRight(secretName, "-_")
-
-	// add a unique id to the end of the name
-	secretName = fmt.Sprintf("%s-%s", secretName, GenerateRandomString(8, SmallLettersAndNumbers))
-
-	return secretName
-}
-
-// GenerateFlexVolumeSecretName generates a secret name for a flex volume, in the form of:
-// `nuclio-flex-volume-<volume-name>-<unique-id>`
-func (s *AbstractScrubber) GenerateFlexVolumeSecretName(functionName, volumeName string) string {
-	secretName := fmt.Sprintf("%s-%s-%s", NuclioFlexVolumeSecretNamePrefix, functionName, volumeName)
-
-	// if the secret name is too long, drop the function and project name
-	if len(secretName) > KubernetesDomainLevelMaxLength {
-		secretName = fmt.Sprintf("%s-%s", NuclioFlexVolumeSecretNamePrefix, volumeName)
-
-	}
-
-	// if the secret name is still too long, trim it and keep space for the unique id
+// GenerateObjectSecretName e generates a secret name for a function, in the form of:
+// `nuclio-secret-<project-name>-<object-name>-<unique-id>`
+func (s *AbstractScrubber) GenerateObjectSecretName(objectName string) string {
+	secretName := fmt.Sprintf("%s-%s", "nuclio", objectName)
 	if len(secretName) > KubernetesDomainLevelMaxLength-8 {
 		secretName = secretName[:KubernetesDomainLevelMaxLength-8]
 	}

--- a/pkg/functionconfig/scrubber.go
+++ b/pkg/functionconfig/scrubber.go
@@ -18,10 +18,8 @@ package functionconfig
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -29,9 +27,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common"
 
 	"github.com/nuclio/errors"
-	"github.com/nuclio/gosecretive"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -46,100 +42,18 @@ const (
 )
 
 type Scrubber struct {
-	SensitiveFields []*regexp.Regexp
-	KubeClientSet   kubernetes.Interface
+	*common.AbstractScrubber
 }
 
 // NewScrubber returns a new scrubber
 // If the scrubber is only used for restoring, the arguments can be nil
 func NewScrubber(sensitiveFields []*regexp.Regexp, kubeClientSet kubernetes.Interface) *Scrubber {
-	return &Scrubber{
-		SensitiveFields: sensitiveFields,
-		KubeClientSet:   kubeClientSet,
+	abstractScrubber := common.NewAbstractScrubber(sensitiveFields, kubeClientSet)
+	scrubber := &Scrubber{
+		AbstractScrubber: abstractScrubber,
 	}
-}
-
-// Scrub scrubs sensitive data from a function config
-func (s *Scrubber) Scrub(functionConfig *Config,
-	existingSecretMap map[string]string,
-	sensitiveFields []*regexp.Regexp) (*Config, map[string]string, error) {
-
-	var scrubErr error
-
-	// hack to support avoid losing unexported fields while scrubbing.
-	// scrub the function config to map[string]interface{} and revert it back to a function config later
-	functionConfigAsMap := common.StructureToMap(functionConfig)
-	if len(functionConfigAsMap) == 0 {
-		return nil, nil, errors.New("Failed to convert function config to map")
-	}
-
-	// scrub the function config
-	scrubbedFunctionConfigAsMap, secretsMap := gosecretive.Scrub(functionConfigAsMap, func(fieldPath string, valueToScrub interface{}) *string {
-
-		for _, fieldPathRegexToScrub := range sensitiveFields {
-
-			// if the field path matches the field path to scrub, scrub it
-			if fieldPathRegexToScrub.MatchString(fieldPath) {
-
-				secretKey := s.generateSecretKey(fieldPath)
-
-				// if the value to scrub is a string, make sure that we need to scrub it
-				if kind := reflect.ValueOf(valueToScrub).Kind(); kind == reflect.String {
-					stringValue := reflect.ValueOf(valueToScrub).String()
-
-					// if it's an empty string, don't scrub it
-					if stringValue == "" {
-						return nil
-					}
-
-					// if it's already a reference, validate that the value exists
-					if strings.HasPrefix(stringValue, ReferencePrefix) {
-						scrubErr = s.validateReference(functionConfig, existingSecretMap, fieldPath, secretKey, stringValue)
-						return nil
-					}
-				}
-
-				// scrub the value, and leave a $ref placeholder
-				return &secretKey
-			}
-		}
-
-		// do not scrub
-		return nil
-	})
-
-	// merge the new secrets map with the existing one
-	// In case of a conflict, the new secrets map will override the existing value
-	if existingSecretMap != nil {
-		secretsMap = labels.Merge(existingSecretMap, secretsMap)
-	}
-
-	scrubbedFunctionConfig, err := s.convertMapToConfig(scrubbedFunctionConfigAsMap)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "Failed to convert scrubbed function config map to function config")
-	}
-
-	return scrubbedFunctionConfig, secretsMap, scrubErr
-}
-
-// Restore restores sensitive data in a function config from a secrets map
-func (s *Scrubber) Restore(scrubbedFunctionConfig *Config, secretsMap map[string]string) (*Config, error) {
-
-	// hack to avoid changing complex objects in the function config.
-	// convert the function config to map[string]interface{} and revert it back to a function config later
-	scrubbedFunctionConfigAsMap := common.StructureToMap(scrubbedFunctionConfig)
-	if len(scrubbedFunctionConfigAsMap) == 0 {
-		return nil, errors.New("Failed to convert function config to map")
-	}
-
-	restoredFunctionConfigMap := gosecretive.Restore(scrubbedFunctionConfigAsMap, secretsMap)
-
-	restoredFunctionConfig, err := s.convertMapToConfig(restoredFunctionConfigMap)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to convert restored function config map to function config")
-	}
-
-	return restoredFunctionConfig, nil
+	abstractScrubber.Scrubber = scrubber
+	return scrubber
 }
 
 // RestoreFunctionConfig restores a function config from a secret, in case we're running in a kube platform
@@ -164,7 +78,7 @@ func (s *Scrubber) RestoreFunctionConfig(ctx context.Context,
 			if err != nil {
 				return nil, errors.Wrap(err, "Failed to restore function config")
 			}
-			return restoredFunctionConfig, nil
+			return restoredFunctionConfig.(*Config), nil
 		}
 	}
 
@@ -172,191 +86,12 @@ func (s *Scrubber) RestoreFunctionConfig(ctx context.Context,
 	return functionConfig, nil
 }
 
-// EncodeSecretsMap encodes the keys of a secrets map
-func (s *Scrubber) EncodeSecretsMap(secretsMap map[string]string) (map[string]string, error) {
-	encodedSecretsMap := map[string]string{}
-
-	// encode secret map keys
-	for secretKey, secretValue := range secretsMap {
-		encodedSecretsMap[s.encodeSecretKey(secretKey)] = secretValue
-	}
-
-	if len(encodedSecretsMap) > 0 {
-
-		// encode the entire map into a single string
-		secretsMapContent, err := json.Marshal(encodedSecretsMap)
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to marshal secrets map")
-		}
-		encodedSecretsMap[SecretContentKey] = base64.StdEncoding.EncodeToString(secretsMapContent)
-	} else {
-
-		// if the map is empty, set the content to an empty string anyway,
-		// so that the secret will be created and mounted
-		encodedSecretsMap[SecretContentKey] = ""
-	}
-
-	return encodedSecretsMap, nil
-}
-
-// DecodeSecretsMapContent decodes the secrets map content
-func (s *Scrubber) DecodeSecretsMapContent(secretsMapContent string) (map[string]string, error) {
-
-	// decode secret
-	secretContentStr, err := base64.StdEncoding.DecodeString(secretsMapContent)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to decode function secret")
-	}
-	if len(secretContentStr) == 0 {
-
-		// secret is empty, return empty map
-		return map[string]string{}, nil
-	}
-
-	// unmarshal secret into map
-	encodedSecretMap := map[string]string{}
-	if err := json.Unmarshal(secretContentStr, &encodedSecretMap); err != nil {
-		return nil, errors.Wrap(err, "Failed to unmarshal function secret")
-	}
-
-	// decode secret keys and values
-	// convert values to byte array for decoding purposes
-	secretMap, err := s.DecodeSecretData(common.MapStringStringToMapStringBytesArray(encodedSecretMap))
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to decode function secret data")
-	}
-
-	return secretMap, nil
-}
-
-// DecodeSecretData decodes the keys of a secrets map
-func (s *Scrubber) DecodeSecretData(secretData map[string][]byte) (map[string]string, error) {
-	decodedSecretsMap := map[string]string{}
-	for secretKey, secretValue := range secretData {
-		if secretKey == SecretContentKey {
-
-			// when the secret is created, the entire map is encoded into a single string under the "content" key
-			// which we don't care about when decoding
-			continue
-		}
-		decodedSecretKey, err := s.decodeSecretKey(secretKey)
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to decode secret key")
-		}
-		decodedSecretsMap[decodedSecretKey] = string(secretValue)
-	}
-	return decodedSecretsMap, nil
-}
-
-// GenerateFunctionSecretName generates a secret name for a function, in the form of:
-// `nuclio-secret-<project-name>-<function-name>-<unique-id>`
-func (s *Scrubber) GenerateFunctionSecretName(functionName string) string {
-	secretName := fmt.Sprintf("%s-%s", "nuclio", functionName)
-	if len(secretName) > common.KubernetesDomainLevelMaxLength-8 {
-		secretName = secretName[:common.KubernetesDomainLevelMaxLength-8]
-	}
-
-	// remove trailing non-alphanumeric characters
-	secretName = strings.TrimRight(secretName, "-_")
-
-	// add a unique id to the end of the name
-	secretName = fmt.Sprintf("%s-%s", secretName, common.GenerateRandomString(8, common.SmallLettersAndNumbers))
-
-	return secretName
-}
-
-// GenerateFlexVolumeSecretName generates a secret name for a flex volume, in the form of:
-// `nuclio-flex-volume-<volume-name>-<unique-id>`
-func (s *Scrubber) GenerateFlexVolumeSecretName(functionName, volumeName string) string {
-	secretName := fmt.Sprintf("%s-%s-%s", NuclioFlexVolumeSecretNamePrefix, functionName, volumeName)
-
-	// if the secret name is too long, drop the function and project name
-	if len(secretName) > common.KubernetesDomainLevelMaxLength {
-		secretName = fmt.Sprintf("%s-%s", NuclioFlexVolumeSecretNamePrefix, volumeName)
-
-	}
-
-	// if the secret name is still too long, trim it and keep space for the unique id
-	if len(secretName) > common.KubernetesDomainLevelMaxLength-8 {
-		secretName = secretName[:common.KubernetesDomainLevelMaxLength-8]
-	}
-
-	// remove trailing non-alphanumeric characters
-	secretName = strings.TrimRight(secretName, "-_")
-
-	// add a unique id to the end of the name
-	secretName = fmt.Sprintf("%s-%s", secretName, common.GenerateRandomString(8, common.SmallLettersAndNumbers))
-
-	return secretName
-}
-
-// HasScrubbedConfig checks if a function config has scrubbed data, using the Scrub function
-func (s *Scrubber) HasScrubbedConfig(functionConfig *Config, sensitiveFields []*regexp.Regexp) (bool, error) {
-	var hasScrubbed bool
-
-	// hack to support avoid losing unexported fields while scrubbing.
-	// scrub the function config to map[string]interface{} and revert it back to a function config later
-	functionConfigAsMap := common.StructureToMap(functionConfig)
-	if len(functionConfigAsMap) == 0 {
-		return false, errors.New("Failed to convert function config to map")
-	}
-
-	// scrub the function config
-	_, _ = gosecretive.Scrub(functionConfigAsMap, func(fieldPath string, valueToScrub interface{}) *string {
-
-		for _, fieldPathRegexToScrub := range sensitiveFields {
-
-			// if the field path matches the field path to scrub, scrub it
-			if fieldPathRegexToScrub.MatchString(fieldPath) {
-
-				// if the value to is a string, check if it's a reference
-				if kind := reflect.ValueOf(valueToScrub).Kind(); kind == reflect.String {
-					stringValue := reflect.ValueOf(valueToScrub).String()
-
-					if strings.HasPrefix(stringValue, ReferencePrefix) {
-						hasScrubbed = true
-					}
-				}
-
-				// we never actually scrub the value
-				return nil
-			}
-		}
-
-		return nil
-	})
-
-	return hasScrubbed, nil
-}
-
-// encodeSecretKey encodes a secret key
-func (s *Scrubber) encodeSecretKey(fieldPath string) string {
-	encodedFieldPath := base64.StdEncoding.EncodeToString([]byte(fieldPath))
-	encodedFieldPath = strings.ReplaceAll(encodedFieldPath, "=", "_")
-	return fmt.Sprintf("%s%s", ReferenceToEnvVarPrefix, encodedFieldPath)
-}
-
-// decodeSecretKey decodes a secret key and returns the original field
-func (s *Scrubber) decodeSecretKey(secretKey string) (string, error) {
-	encodedFieldPath := strings.TrimPrefix(secretKey, ReferenceToEnvVarPrefix)
-	encodedFieldPath = strings.ReplaceAll(encodedFieldPath, "_", "=")
-	decodedFieldPath, err := base64.StdEncoding.DecodeString(encodedFieldPath)
-	if err != nil {
-		return "", errors.Wrap(err, "Failed to decode secret key")
-	}
-	return string(decodedFieldPath), nil
-}
-
-func (s *Scrubber) generateSecretKey(fieldPath string) string {
-	return fmt.Sprintf("%s%s", ReferencePrefix, strings.ToLower(fieldPath))
-}
-
-func (s *Scrubber) validateReference(functionConfig *Config,
+func (s *Scrubber) ValidateReference(objectToScrub interface{},
 	existingSecretMap map[string]string,
 	fieldPath,
 	secretKey,
 	stringValue string) error {
-
+	functionConfig := objectToScrub.(*Config)
 	// for flex volume access keys, we need to check if the volume secret exists
 	if strings.Contains(stringValue, "flexvolume") {
 
@@ -397,7 +132,7 @@ func (s *Scrubber) validateReference(functionConfig *Config,
 	return errors.New(fmt.Sprintf("Config data in path %s is already masked, but secret does not exist.", fieldPath))
 }
 
-func (s *Scrubber) convertMapToConfig(mapConfig interface{}) (*Config, error) {
+func (s *Scrubber) ConvertMapToConfig(mapConfig interface{}) (interface{}, error) {
 
 	// marshal and unmarshal the map object back to function config
 	functionConfig := &Config{}

--- a/pkg/functionconfig/scrubber.go
+++ b/pkg/functionconfig/scrubber.go
@@ -152,7 +152,7 @@ func (s *Scrubber) ConvertMapToConfig(mapConfig interface{}) (interface{}, error
 func (s *Scrubber) GenerateFlexVolumeSecretName(functionName, volumeName string) string {
 	secretName := fmt.Sprintf("%s-%s-%s", NuclioFlexVolumeSecretNamePrefix, functionName, volumeName)
 
-	// if the secret name is too long, drop the function and project name
+	// if the secret name is too long, drop the function name
 	if len(secretName) > common.KubernetesDomainLevelMaxLength {
 		secretName = fmt.Sprintf("%s-%s", NuclioFlexVolumeSecretNamePrefix, volumeName)
 

--- a/pkg/functionconfig/scrubber_test.go
+++ b/pkg/functionconfig/scrubber_test.go
@@ -404,7 +404,7 @@ func (suite *ScrubberTestSuite) TestGenerateFunctionSecretName() {
 		suite.Run(testCase.name, func() {
 			var secretName string
 			if testCase.volumeName == "" {
-				secretName = suite.scrubber.GenerateFunctionSecretName(testCase.functionName)
+				secretName = suite.scrubber.GenerateObjectSecretName(testCase.functionName)
 			} else {
 				secretName = suite.scrubber.GenerateFlexVolumeSecretName(testCase.functionName, testCase.volumeName)
 			}

--- a/pkg/functionconfig/scrubber_test.go
+++ b/pkg/functionconfig/scrubber_test.go
@@ -434,8 +434,8 @@ func (suite *ScrubberTestSuite) TestRestoreConfigWithResources() {
 	secretMap := map[string]string{}
 
 	// restore the config
-	scrubbedInterface, err := suite.scrubber.Restore(config, secretMap)
-	restoredFunctionConfig := GetFunctionConfigFromInterface(scrubbedInterface)
+	restoredConfigInterface, err := suite.scrubber.Restore(config, secretMap)
+	restoredFunctionConfig := GetFunctionConfigFromInterface(restoredConfigInterface)
 	suite.Require().NoError(err)
 
 	// check that the restored config has the same resources

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -578,6 +578,13 @@ type Config struct {
 	Spec Spec `json:"spec,omitempty"`
 }
 
+func GetFunctionConfigFromInterface(functionConfigInterface interface{}) *Config {
+	if functionConfig, ok := functionConfigInterface.(*Config); ok {
+		return functionConfig
+	}
+	return nil
+}
+
 // NewConfig creates a new configuration structure
 func NewConfig() *Config {
 	return &Config{

--- a/pkg/platform/apigateway_test.go
+++ b/pkg/platform/apigateway_test.go
@@ -20,12 +20,14 @@ package platform
 
 import (
 	"context"
-	"github.com/nuclio/logger"
+	"testing"
+
 	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
+
+	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
-	"testing"
 )
 
 type ScrubberTestSuite struct {

--- a/pkg/platform/apigateway_test.go
+++ b/pkg/platform/apigateway_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package platform
 
 import (

--- a/pkg/platform/apigateway_test.go
+++ b/pkg/platform/apigateway_test.go
@@ -1,3 +1,5 @@
+//go:build test_unit
+
 /*
 Copyright 2024 The Nuclio Authors.
 

--- a/pkg/platform/apigateway_test.go
+++ b/pkg/platform/apigateway_test.go
@@ -1,0 +1,60 @@
+package platform
+
+import (
+	"context"
+	"github.com/nuclio/logger"
+	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
+	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"testing"
+)
+
+type ScrubberTestSuite struct {
+	suite.Suite
+	logger       logger.Logger
+	ctx          context.Context
+	k8sClientSet *k8sfake.Clientset
+	scrubber     *APIGatewayScrubber
+}
+
+func (suite *ScrubberTestSuite) SetupTest() {
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
+	suite.ctx = context.Background()
+	suite.k8sClientSet = k8sfake.NewSimpleClientset()
+	suite.scrubber = NewAPIGatewayScrubber(GetAPIGatewaySensitiveField(), suite.k8sClientSet)
+}
+
+func (suite *ScrubberTestSuite) TestScrubBasics() {
+	apiGatewayConfig := &APIGatewayConfig{Meta: APIGatewayMeta{}, Spec: APIGatewaySpec{
+		Host:               "host.com",
+		Name:               "test-scrubber",
+		AuthenticationMode: ingress.AuthenticationModeBasicAuth,
+		Authentication: &APIGatewayAuthenticationSpec{BasicAuth: &BasicAuth{
+			Username: "test",
+			Password: "my-password",
+		}},
+	}}
+
+	// scrub the function config
+	scrubbedInterface, secretMap, err := suite.scrubber.Scrub(apiGatewayConfig, nil, GetAPIGatewaySensitiveField())
+	scrubbedApiGatewayConfig := GetAPIGatewayConfigFromInterface(scrubbedInterface)
+	suite.Require().NotEqual(apiGatewayConfig.Spec.Authentication.BasicAuth.Password, scrubbedApiGatewayConfig.Spec.Authentication.BasicAuth.Password)
+	suite.Require().NoError(err)
+
+	suite.logger.DebugWith("Scrubbed function config", "functionConfig", scrubbedApiGatewayConfig, "secretMap", secretMap)
+
+	suite.Require().NotEmpty(secretMap)
+
+	restoredInterface, err := suite.scrubber.Restore(scrubbedApiGatewayConfig, secretMap)
+	restoredApiGatewayConfig := GetAPIGatewayConfigFromInterface(restoredInterface)
+	suite.Require().NoError(err)
+	suite.Require().Equal(apiGatewayConfig.Spec.Authentication.BasicAuth.Password, restoredApiGatewayConfig.Spec.Authentication.BasicAuth.Password)
+
+	suite.logger.DebugWith("Restored function config", "functionConfig", restoredApiGatewayConfig)
+	suite.Require().Equal(apiGatewayConfig, restoredApiGatewayConfig)
+}
+
+func TestScrubberTestSuite(t *testing.T) {
+	suite.Run(t, new(ScrubberTestSuite))
+}

--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -218,7 +218,7 @@ func (d *Deployer) ScrubFunctionConfig(ctx context.Context,
 		return nil, errors.Wrap(err, "Failed to create or update function secret")
 	}
 
-	return scrubbedFunctionConfig, nil
+	return functionconfig.GetFunctionConfigFromInterface(scrubbedFunctionConfig), nil
 }
 
 func (d *Deployer) createOrUpdateFunctionSecret(ctx context.Context,

--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -229,7 +229,7 @@ func (d *Deployer) createOrUpdateFunctionSecret(ctx context.Context,
 	projectName string) error {
 
 	if secretName == "" {
-		secretName = d.scrubber.GenerateFunctionSecretName(name)
+		secretName = d.scrubber.GenerateObjectSecretName(name)
 	}
 
 	secretConfig := &v1.Secret{

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -481,6 +481,13 @@ type APIGatewayConfig struct {
 	Status APIGatewayStatus `json:"status,omitempty"`
 }
 
+func GetAPIGatewayConfigFromInterface(functionConfigInterface interface{}) *APIGatewayConfig {
+	if apiGatewayConfig, ok := functionConfigInterface.(*APIGatewayConfig); ok {
+		return apiGatewayConfig
+	}
+	return nil
+}
+
 // APIGatewayState is state of api gateway
 type APIGatewayState string
 


### PR DESCRIPTION
This PR is the first iteration of implementing a masking functionality for API gateways. 

Within this PR scrubber was defined as an interface in `common` pkg. All the abstract functionality was moved to AbstractScrubber entity. Two structs inherit `AbstractScrubber` - `functionconfig.Scrubber` and `APIGatewayScrubber`. 
Also, `ReferencePrefix` is a configurable field now.

1st part of https://iguazio.atlassian.net/browse/NUC-114 - https://iguazio.atlassian.net/browse/NUC-169