### PR TITLE
[Nuctl] Add more detailed fail description for patch manifest

### DIFF
--- a/pkg/nuctl/command/common/patchmanifest.go
+++ b/pkg/nuctl/command/common/patchmanifest.go
@@ -84,7 +84,7 @@ func (m *PatchManifest) AddFailure(name string, err error, retryable bool) {
 	defer m.lock.Unlock()
 
 	m.Failed[name] = failDescription{
-		Err:       err.Error(),
+		Err:       errors.GetErrorStackString(err, 10),
 		Retryable: retryable,
 	}
 }

--- a/pkg/nuctl/command/common/patchmanifest.go
+++ b/pkg/nuctl/command/common/patchmanifest.go
@@ -84,7 +84,7 @@ func (m *PatchManifest) AddFailure(name string, err error, retryable bool) {
 	defer m.lock.Unlock()
 
 	m.Failed[name] = failDescription{
-		Err:       errors.GetErrorStackString(err, 10),
+		Err:       errors.Cause(err).Error(),
 		Retryable: retryable,
 	}
 }

--- a/pkg/nuctl/command/common/patchmanifest_test.go
+++ b/pkg/nuctl/command/common/patchmanifest_test.go
@@ -100,7 +100,7 @@ func (suite *PatchManifestTestSuite) TestPatchManifestSaveToFile() {
 	manifest.AddSuccess("success1")
 	manifest.AddSuccess("success2")
 
-	manifest.AddFailure("failed1", errors.New("error1"), false)
+	manifest.AddFailure("failed1", errors.Wrap(errors.New("error1"), "Failed to patch function"), false)
 	manifest.AddFailure("failed2", errors.New("error2"), true)
 
 	tempFile, err := os.CreateTemp(suite.tempDir, "test_save_file")


### PR DESCRIPTION
Here is an example of the error we got:

```
cmex020008l4lvyj0igny3-extract  
error   "Failed to patch function"
retryable   false
```

That's not meaningful enough, because it's a wrapped error, not the error cause, so we need to print the error cause.