### PR TITLE
[Platform] Add platform configuration to merge platform's default node selectors with project's node selectors

### DIFF
--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1762,19 +1762,33 @@ func (p *Platform) enrichFunctionNodeSelector(ctx context.Context, functionConfi
 	if err != nil {
 		return errors.Wrap(err, "Failed to get function project")
 	}
-	p.Logger.DebugWithCtx(ctx,
-		"Enriching function node selector from project",
-		"functionName", functionConfig.Meta.Name,
-		"nodeSelector", p.Config.Kube.DefaultFunctionNodeSelector)
-	functionConfig.Spec.NodeSelector = labels.Merge(functionProject.GetConfig().Spec.DefaultFunctionNodeSelector, functionConfig.Spec.NodeSelector)
 
-	if p.Config.Kube.MergePlatformAndProjectNodeSelectors {
+	var defaultNodeSelector map[string]string
+
+	if p.Config.Kube.IgnorePlatformIfProjectNodeSelectors {
+		if functionProject.GetConfig().Spec.DefaultFunctionNodeSelector != nil {
+			p.Logger.DebugWithCtx(ctx,
+				"Enriching function node selector from project",
+				"functionName", functionConfig.Meta.Name,
+				"nodeSelector", p.Config.Kube.DefaultFunctionNodeSelector)
+			defaultNodeSelector = functionProject.GetConfig().Spec.DefaultFunctionNodeSelector
+		} else {
+			p.Logger.DebugWithCtx(ctx,
+				"Enriching function node selector from platform config",
+				"functionName", functionConfig.Meta.Name,
+				"nodeSelector", p.Config.Kube.DefaultFunctionNodeSelector)
+			defaultNodeSelector = p.Config.Kube.DefaultFunctionNodeSelector
+		}
+	} else {
 		p.Logger.DebugWithCtx(ctx,
-			"Enriching function node selector from platform config",
+			"Enriching function node selector from platform config and project",
 			"functionName", functionConfig.Meta.Name,
-			"nodeSelector", p.Config.Kube.DefaultFunctionNodeSelector)
-		functionConfig.Spec.NodeSelector = labels.Merge(p.Config.Kube.DefaultFunctionNodeSelector, functionConfig.Spec.NodeSelector)
+			"platformNodeSelector", p.Config.Kube.DefaultFunctionNodeSelector,
+			"projectNodeSelector", functionProject.GetConfig().Spec.DefaultFunctionNodeSelector)
+		defaultNodeSelector = labels.Merge(p.Config.Kube.DefaultFunctionNodeSelector, functionProject.GetConfig().Spec.DefaultFunctionNodeSelector)
 	}
+
+	functionConfig.Spec.NodeSelector = labels.Merge(defaultNodeSelector, functionConfig.Spec.NodeSelector)
 	return nil
 }
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1768,11 +1768,13 @@ func (p *Platform) enrichFunctionNodeSelector(ctx context.Context, functionConfi
 		"nodeSelector", p.Config.Kube.DefaultFunctionNodeSelector)
 	functionConfig.Spec.NodeSelector = labels.Merge(functionProject.GetConfig().Spec.DefaultFunctionNodeSelector, functionConfig.Spec.NodeSelector)
 
-	p.Logger.DebugWithCtx(ctx,
-		"Enriching function node selector from platform config",
-		"functionName", functionConfig.Meta.Name,
-		"nodeSelector", p.Config.Kube.DefaultFunctionNodeSelector)
-	functionConfig.Spec.NodeSelector = labels.Merge(p.Config.Kube.DefaultFunctionNodeSelector, functionConfig.Spec.NodeSelector)
+	if p.Config.Kube.MergePlatformAndProjectNodeSelectors {
+		p.Logger.DebugWithCtx(ctx,
+			"Enriching function node selector from platform config",
+			"functionName", functionConfig.Meta.Name,
+			"nodeSelector", p.Config.Kube.DefaultFunctionNodeSelector)
+		functionConfig.Spec.NodeSelector = labels.Merge(p.Config.Kube.DefaultFunctionNodeSelector, functionConfig.Spec.NodeSelector)
+	}
 	return nil
 }
 

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -340,6 +340,7 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichNodeSelector() {
 		platformNodeSelector         map[string]string
 		projectNodeSelector          map[string]string
 		expectedFunctionNodeSelector map[string]string
+		mergeProjectAndPlatform      bool
 	}{
 		{
 			name:                         "all-selectors-empty",
@@ -349,6 +350,7 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichNodeSelector() {
 			name:                         "get-selector-from-platform",
 			platformNodeSelector:         map[string]string{"test": "test"},
 			expectedFunctionNodeSelector: map[string]string{"test": "test"},
+			mergeProjectAndPlatform:      true,
 		},
 		{
 			name: "get-selector-from-project",
@@ -365,6 +367,7 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichNodeSelector() {
 				"test1": "from-project1",
 				"test2": "from-platform2",
 			},
+			mergeProjectAndPlatform: true,
 		},
 		{
 			name: "get-selector-from-project",
@@ -382,6 +385,23 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichNodeSelector() {
 				"test1": "from-project1",
 				"test2": "from-platform2",
 			},
+			mergeProjectAndPlatform: true,
+		},
+		{
+			name: "get-selector-from-project",
+			platformNodeSelector: map[string]string{
+				"test":  "from-platform",
+				"test2": "from-platform2",
+			},
+			projectNodeSelector: map[string]string{
+				"test":  "from-project",
+				"test1": "from-project1",
+			},
+			functionNodeSelector: map[string]string{"test": "from-function"},
+			expectedFunctionNodeSelector: map[string]string{
+				"test":  "from-function",
+				"test1": "from-project1",
+			},
 		},
 	} {
 		suite.Run(testCase.name, func() {
@@ -396,6 +416,7 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichNodeSelector() {
 					&platform.AbstractProject{ProjectConfig: platform.ProjectConfig{Spec: platform.ProjectSpec{DefaultFunctionNodeSelector: testCase.projectNodeSelector}}},
 				}, nil).
 				Once()
+			suite.platform.Config.Kube.MergePlatformAndProjectNodeSelectors = testCase.mergeProjectAndPlatform
 			functionConfig := *functionconfig.NewConfig()
 			functionConfig.Spec.NodeSelector = testCase.functionNodeSelector
 

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -182,8 +182,9 @@ type PlatformKubeConfig struct {
 	DefaultFunctionTolerations       []corev1.Toleration     `json:"defaultFunctionTolerations,omitempty"`
 	PreemptibleNodes                 *PreemptibleNodes       `json:"preemptibleNodes,omitempty"`
 
-	// If this flag is set, we ignore platform's node selectors on condition that project's node selectors are set
-	// but if project's node selectors aren't set, we use platform's selectors anyway
+	// when enriching function node selector, if this flag is set we ignore platform's node selectors if the project's node selectors are set.
+	// if project's node selectors aren't set, we enrich with the platform's selectors anyway.
+	// if set to false, we will enrich function node selector with the values in both the platform config and the project
 	IgnorePlatformIfProjectNodeSelectors bool `json:"ignorePlatformIfProjectNodeSelectors,omitempty"`
 }
 

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -170,17 +170,18 @@ type PlatformKubeConfig struct {
 	KubeConfigPath string `json:"kubeConfigPath,omitempty"`
 
 	// TODO: Move IngressConfig here
-	DefaultServiceType               corev1.ServiceType      `json:"defaultServiceType,omitempty"`
-	DefaultFunctionNodeSelector      map[string]string       `json:"defaultFunctionNodeSelector,omitempty"`
-	DefaultHTTPIngressHostTemplate   string                  `json:"defaultHTTPIngressHostTemplate,omitempty"`
-	DefaultHTTPIngressAnnotations    map[string]string       `json:"defaultHTTPIngressAnnotations,omitempty"`
-	DefaultFunctionPriorityClassName string                  `json:"defaultFunctionPriorityClassName,omitempty"`
-	DefaultFunctionServiceAccount    string                  `json:"defaultFunctionServiceAccount,omitempty"`
-	ValidFunctionPriorityClassNames  []string                `json:"validFunctionPriorityClassNames,omitempty"`
-	DefaultFunctionPodResources      PodResourceRequirements `json:"defaultFunctionPodResources,omitempty"`
-	DefaultSidecarResources          PodResourceRequirements `json:"defaultSidecarResources,omitempty"`
-	DefaultFunctionTolerations       []corev1.Toleration     `json:"defaultFunctionTolerations,omitempty"`
-	PreemptibleNodes                 *PreemptibleNodes       `json:"preemptibleNodes,omitempty"`
+	DefaultServiceType                   corev1.ServiceType      `json:"defaultServiceType,omitempty"`
+	DefaultFunctionNodeSelector          map[string]string       `json:"defaultFunctionNodeSelector,omitempty"`
+	DefaultHTTPIngressHostTemplate       string                  `json:"defaultHTTPIngressHostTemplate,omitempty"`
+	DefaultHTTPIngressAnnotations        map[string]string       `json:"defaultHTTPIngressAnnotations,omitempty"`
+	DefaultFunctionPriorityClassName     string                  `json:"defaultFunctionPriorityClassName,omitempty"`
+	DefaultFunctionServiceAccount        string                  `json:"defaultFunctionServiceAccount,omitempty"`
+	ValidFunctionPriorityClassNames      []string                `json:"validFunctionPriorityClassNames,omitempty"`
+	DefaultFunctionPodResources          PodResourceRequirements `json:"defaultFunctionPodResources,omitempty"`
+	DefaultSidecarResources              PodResourceRequirements `json:"defaultSidecarResources,omitempty"`
+	DefaultFunctionTolerations           []corev1.Toleration     `json:"defaultFunctionTolerations,omitempty"`
+	PreemptibleNodes                     *PreemptibleNodes       `json:"preemptibleNodes,omitempty"`
+	MergePlatformAndProjectNodeSelectors bool                    `json:"mergePlatformAndProjectNodeSelectors"`
 }
 
 // PreemptibleNodes Holds data needed when user decided to run his function pods on a preemptible node (aka Spot node)

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -170,18 +170,21 @@ type PlatformKubeConfig struct {
 	KubeConfigPath string `json:"kubeConfigPath,omitempty"`
 
 	// TODO: Move IngressConfig here
-	DefaultServiceType                   corev1.ServiceType      `json:"defaultServiceType,omitempty"`
-	DefaultFunctionNodeSelector          map[string]string       `json:"defaultFunctionNodeSelector,omitempty"`
-	DefaultHTTPIngressHostTemplate       string                  `json:"defaultHTTPIngressHostTemplate,omitempty"`
-	DefaultHTTPIngressAnnotations        map[string]string       `json:"defaultHTTPIngressAnnotations,omitempty"`
-	DefaultFunctionPriorityClassName     string                  `json:"defaultFunctionPriorityClassName,omitempty"`
-	DefaultFunctionServiceAccount        string                  `json:"defaultFunctionServiceAccount,omitempty"`
-	ValidFunctionPriorityClassNames      []string                `json:"validFunctionPriorityClassNames,omitempty"`
-	DefaultFunctionPodResources          PodResourceRequirements `json:"defaultFunctionPodResources,omitempty"`
-	DefaultSidecarResources              PodResourceRequirements `json:"defaultSidecarResources,omitempty"`
-	DefaultFunctionTolerations           []corev1.Toleration     `json:"defaultFunctionTolerations,omitempty"`
-	PreemptibleNodes                     *PreemptibleNodes       `json:"preemptibleNodes,omitempty"`
-	IgnorePlatformIfProjectNodeSelectors bool                    `json:"ignorePlatformIfProjectNodeSelectors,omitempty"`
+	DefaultServiceType               corev1.ServiceType      `json:"defaultServiceType,omitempty"`
+	DefaultFunctionNodeSelector      map[string]string       `json:"defaultFunctionNodeSelector,omitempty"`
+	DefaultHTTPIngressHostTemplate   string                  `json:"defaultHTTPIngressHostTemplate,omitempty"`
+	DefaultHTTPIngressAnnotations    map[string]string       `json:"defaultHTTPIngressAnnotations,omitempty"`
+	DefaultFunctionPriorityClassName string                  `json:"defaultFunctionPriorityClassName,omitempty"`
+	DefaultFunctionServiceAccount    string                  `json:"defaultFunctionServiceAccount,omitempty"`
+	ValidFunctionPriorityClassNames  []string                `json:"validFunctionPriorityClassNames,omitempty"`
+	DefaultFunctionPodResources      PodResourceRequirements `json:"defaultFunctionPodResources,omitempty"`
+	DefaultSidecarResources          PodResourceRequirements `json:"defaultSidecarResources,omitempty"`
+	DefaultFunctionTolerations       []corev1.Toleration     `json:"defaultFunctionTolerations,omitempty"`
+	PreemptibleNodes                 *PreemptibleNodes       `json:"preemptibleNodes,omitempty"`
+
+	// If this flag is set, we ignore platform's node selectors on condition that project's node selectors are set
+	// but if project's node selectors aren't set, we use platform's selectors anyway
+	IgnorePlatformIfProjectNodeSelectors bool `json:"ignorePlatformIfProjectNodeSelectors,omitempty"`
 }
 
 // PreemptibleNodes Holds data needed when user decided to run his function pods on a preemptible node (aka Spot node)

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -181,7 +181,7 @@ type PlatformKubeConfig struct {
 	DefaultSidecarResources              PodResourceRequirements `json:"defaultSidecarResources,omitempty"`
 	DefaultFunctionTolerations           []corev1.Toleration     `json:"defaultFunctionTolerations,omitempty"`
 	PreemptibleNodes                     *PreemptibleNodes       `json:"preemptibleNodes,omitempty"`
-	MergePlatformAndProjectNodeSelectors bool                    `json:"mergePlatformAndProjectNodeSelectors"`
+	IgnorePlatformIfProjectNodeSelectors bool                    `json:"ignorePlatformIfProjectNodeSelectors,omitempty"`
 }
 
 // PreemptibleNodes Holds data needed when user decided to run his function pods on a preemptible node (aka Spot node)


### PR DESCRIPTION
The default behavior has been modified to consider the platform's NodeSelectors only if the project's NodeSelectors are not set. This adjustment aims to synchronize MLRun's logic with Nuclio's. Despite altering the default behavior, this pull request aims to provide users with the option to re-enable the merging logic.

Jira - https://iguazio.atlassian.net/browse/NUC-171