### PR TITLE
[Dashboard] Return nuclio.ErrAccepted instead of nil when we don't redeploy function because it is not imported 

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -529,7 +529,7 @@ func (fr *functionResource) redeployFunction(request *http.Request,
 
 	if importedOnly && function.GetStatus().State != functionconfig.FunctionStateImported {
 		fr.Logger.DebugWithCtx(ctx, "Function is not imported, skipping redeploy", "functionName", id, "functionState", function.GetStatus().State)
-		return nil
+		return nuclio.ErrAccepted
 	}
 
 	fr.Logger.DebugWith("Redeploying function",

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -529,7 +529,7 @@ func (fr *functionResource) redeployFunction(request *http.Request,
 
 	if importedOnly && function.GetStatus().State != functionconfig.FunctionStateImported {
 		fr.Logger.DebugWithCtx(ctx, "Function is not imported, skipping redeploy", "functionName", id, "functionState", function.GetStatus().State)
-		return nuclio.ErrAccepted
+		return nuclio.ErrNoContent
 	}
 
 	fr.Logger.DebugWith("Redeploying function",

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -529,7 +529,7 @@ func (fr *functionResource) redeployFunction(request *http.Request,
 
 	if importedOnly && function.GetStatus().State != functionconfig.FunctionStateImported {
 		fr.Logger.DebugWithCtx(ctx, "Function is not imported, skipping redeploy", "functionName", id, "functionState", function.GetStatus().State)
-		return nuclio.ErrNoContent
+		return nuclio.ErrAccepted
 	}
 
 	fr.Logger.DebugWith("Redeploying function",

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1153,7 +1153,7 @@ func (suite *functionTestSuite) TestPatchFunction() {
 			name:               "readyFunction",
 			functionName:       "ready-func",
 			functionState:      functionconfig.FunctionStateReady,
-			expectedStatusCode: http.StatusNoContent,
+			expectedStatusCode: http.StatusAccepted,
 			importedOnly:       "true",
 			desiredState:       "ready",
 			minReplicas:        1,


### PR DESCRIPTION
Nuctl expects dashboard to return Accepted status, otherwise it fails function redeploy. It makes sense to return `Accepted` if function is ready on condition that user want to redeploy only `imported` functions.  