### PR TITLE
[Platform] Fix default http trigger enrichment

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -333,7 +333,7 @@ func (ap *Platform) enrichDefaultHTTPTrigger(functionConfig *functionconfig.Conf
 	if len(functionconfig.GetTriggersByKind(functionConfig.Spec.Triggers, "http")) > 0 {
 		return
 	}
-	if ap.Config.DisableDefaultHTTPTrigger {
+	if functionConfig.Spec.DisableDefaultHTTPTrigger != nil && *functionConfig.Spec.DisableDefaultHTTPTrigger == true {
 		ap.Logger.Debug("Skipping default http trigger creation")
 		return
 	}

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -273,6 +273,14 @@ func (ap *Platform) EnrichFunctionConfig(ctx context.Context, functionConfig *fu
 		functionConfig.Spec.Runtime = "python:3.9"
 	}
 
+	if functionConfig.Spec.DisableDefaultHTTPTrigger == nil {
+		ap.Logger.DebugWithCtx(ctx,
+			"Enriching disable default http trigger flag",
+			"functionName", functionConfig.Meta.Name,
+			"disableDefaultHttpTrigger", ap.Config.DisableDefaultHTTPTrigger)
+		functionConfig.Spec.DisableDefaultHTTPTrigger = &ap.Config.DisableDefaultHTTPTrigger
+	}
+
 	// enrich triggers
 	if err := ap.enrichTriggers(ctx, functionConfig); err != nil {
 		return errors.Wrap(err, "Failed enriching triggers")
@@ -285,14 +293,6 @@ func (ap *Platform) EnrichFunctionConfig(ctx context.Context, functionConfig *fu
 
 	if err := ap.enrichVolumes(functionConfig); err != nil {
 		return errors.Wrap(err, "Failed enriching volumes")
-	}
-
-	if functionConfig.Spec.DisableDefaultHTTPTrigger == nil {
-		ap.Logger.DebugWithCtx(ctx,
-			"Enriching disable default http trigger flag",
-			"functionName", functionConfig.Meta.Name,
-			"disableDefaultHttpTrigger", ap.Config.DisableDefaultHTTPTrigger)
-		functionConfig.Spec.DisableDefaultHTTPTrigger = &ap.Config.DisableDefaultHTTPTrigger
 	}
 
 	ap.enrichEnvVars(functionConfig)
@@ -333,7 +333,7 @@ func (ap *Platform) enrichDefaultHTTPTrigger(functionConfig *functionconfig.Conf
 	if len(functionconfig.GetTriggersByKind(functionConfig.Spec.Triggers, "http")) > 0 {
 		return
 	}
-	if functionConfig.Spec.DisableDefaultHTTPTrigger != nil && *functionConfig.Spec.DisableDefaultHTTPTrigger == true {
+	if functionConfig.Spec.DisableDefaultHTTPTrigger != nil && *functionConfig.Spec.DisableDefaultHTTPTrigger {
 		ap.Logger.Debug("Skipping default http trigger creation")
 		return
 	}

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -306,12 +306,6 @@ func (suite *AbstractPlatformTestSuite) TestValidationFailOnMalformedIngressesSt
 }
 
 func (suite *AbstractPlatformTestSuite) TestEnrichDefaultHttpTrigger() {
-	functionConfig := functionconfig.NewConfig()
-	functionConfig.Meta.Name = "f1"
-	functionConfig.Meta.Namespace = "default"
-	functionConfig.Meta.Labels = map[string]string{
-		common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
-	}
 	trueValue := true
 	falseValue := false
 
@@ -352,6 +346,12 @@ func (suite *AbstractPlatformTestSuite) TestEnrichDefaultHttpTrigger() {
 			&platform.AbstractProject{},
 		}, nil).Once()
 
+		functionConfig := functionconfig.NewConfig()
+		functionConfig.Meta.Name = "f1"
+		functionConfig.Meta.Namespace = "default"
+		functionConfig.Meta.Labels = map[string]string{
+			common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
+		}
 		suite.Platform.Config.DisableDefaultHTTPTrigger = testCase.PlatformDisableDefaultHttpTrigger
 		functionConfig.Spec.DisableDefaultHTTPTrigger = testCase.FunctionDisableDefaultHttpTrigger
 
@@ -361,8 +361,9 @@ func (suite *AbstractPlatformTestSuite) TestEnrichDefaultHttpTrigger() {
 
 		suite.Require().Equal(testCase.ExpectedValue, *functionConfig.Spec.DisableDefaultHTTPTrigger)
 
+		// check that value
 		if testCase.ExpectedValue {
-			suite.Require().Contains(functionConfig.Spec.Triggers, functionconfig.GetDefaultHTTPTrigger().Name)
+			suite.Require().NotContains(functionConfig.Spec.Triggers, functionconfig.GetDefaultHTTPTrigger().Name)
 		} else {
 			suite.Require().Contains(functionConfig.Spec.Triggers, functionconfig.GetDefaultHTTPTrigger().Name)
 		}

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -361,7 +361,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichDefaultHttpTrigger() {
 
 		suite.Require().Equal(testCase.ExpectedValue, *functionConfig.Spec.DisableDefaultHTTPTrigger)
 
-		// check that value
+		// check that http trigger exists/doesn't exist after enrichment
 		if testCase.ExpectedValue {
 			suite.Require().NotContains(functionConfig.Spec.Triggers, functionconfig.GetDefaultHTTPTrigger().Name)
 		} else {

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -360,6 +360,12 @@ func (suite *AbstractPlatformTestSuite) TestEnrichDefaultHttpTrigger() {
 		suite.Require().NoError(err)
 
 		suite.Require().Equal(testCase.ExpectedValue, *functionConfig.Spec.DisableDefaultHTTPTrigger)
+
+		if testCase.ExpectedValue {
+			suite.Require().Contains(functionConfig.Spec.Triggers, functionconfig.GetDefaultHTTPTrigger().Name)
+		} else {
+			suite.Require().Contains(functionConfig.Spec.Triggers, functionconfig.GetDefaultHTTPTrigger().Name)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR fixes the enrichment of `disableDefaultHTTPTrigger` configuration. The original PR which implemented this functionality had some parts left only for platform configuration enrichment and as a result there are some code parts left misaligned with function configuration. 