### PR TITLE
[v3iostream] Remove `GetPath` implementation from v3iostream event

### DIFF
--- a/pkg/processor/trigger/v3iostream/event.go
+++ b/pkg/processor/trigger/v3iostream/event.go
@@ -52,7 +52,3 @@ func (e *Event) GetTimestamp() time.Time {
 func (e *Event) GetTopic() string {
 	return e.StreamPath
 }
-
-func (e *Event) GetPath() string {
-	return e.StreamPath
-}


### PR DESCRIPTION
Revert a small part of #3125 , since the event path is not supposed to be the stream path (which is basically the topic), but an internal path in the function.
This causes some issues for functions that handle different paths.

Resolves https://iguazio.atlassian.net/browse/NUC-177