### PR TITLE
[v3iostream] Remove `GetPath` implementation from v3iostream event [1.12.x]

### DIFF
--- a/pkg/processor/trigger/v3iostream/event.go
+++ b/pkg/processor/trigger/v3iostream/event.go
@@ -52,7 +52,3 @@ func (e *Event) GetTimestamp() time.Time {
 func (e *Event) GetTopic() string {
 	return e.StreamPath
 }
-
-func (e *Event) GetPath() string {
-	return e.StreamPath
-}


### PR DESCRIPTION
Backport of #3220