### PR TITLE
[Function] Support getting log stream from a specific container

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,7 +191,7 @@ jobs:
           cache: true
           go-version-file: go.mod
 
-      - uses: manusa/actions-setup-minikube@v2.7.2
+      - uses: manusa/actions-setup-minikube@v2.10.0
         with:
           minikube version: "v1.31.2"
           kubernetes version: "v1.27.5"
@@ -318,7 +318,7 @@ jobs:
           cache: true
           go-version-file: go.mod
 
-      - uses: manusa/actions-setup-minikube@v2.7.2
+      - uses: manusa/actions-setup-minikube@v2.10.0
         with:
           minikube version: "v1.31.2"
           kubernetes version: "v1.27.5"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,7 +191,7 @@ jobs:
           cache: true
           go-version-file: go.mod
 
-      - uses: manusa/actions-setup-minikube@v2.10.0
+      - uses: manusa/actions-setup-minikube@v2.9.0
         with:
           minikube version: "v1.31.2"
           kubernetes version: "v1.27.5"
@@ -318,7 +318,7 @@ jobs:
           cache: true
           go-version-file: go.mod
 
-      - uses: manusa/actions-setup-minikube@v2.10.0
+      - uses: manusa/actions-setup-minikube@v2.9.0
         with:
           minikube version: "v1.31.2"
           kubernetes version: "v1.27.5"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,12 +191,6 @@ jobs:
           cache: true
           go-version-file: go.mod
 
-      # Resolves "actions-setup-minikube" issue with apt-get update
-      # See: https://github.com/orgs/community/discussions/120966#discussioncomment-9211925
-      - name: Remove apt artifacts
-        run: |
-          sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-
       - uses: manusa/actions-setup-minikube@v2.9.0
         with:
           minikube version: "v1.31.2"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,6 +191,12 @@ jobs:
           cache: true
           go-version-file: go.mod
 
+      # Resolves "actions-setup-minikube" issue with apt-get update
+      # See: https://github.com/orgs/community/discussions/120966#discussioncomment-9211925
+      - name: Remove apt artifacts
+        run: |
+          sudo rm /etc/apt/sources.list.d/microsoft-prod.list
+
       - uses: manusa/actions-setup-minikube@v2.9.0
         with:
           minikube version: "v1.31.2"

--- a/docs/reference/api/README.md
+++ b/docs/reference/api/README.md
@@ -319,6 +319,7 @@ you `DELETE /api/function_invocations`, the HTTP method in the event as received
     * `follow`: Follow the replica log stream (default: true)
     * `since`: A relative time before the current time from which to show logs (optional, e.g.: `1h`)
     * `tailLines`: Number of lines to show from the end of the logs (optional, e.g.: `100`)
+    * `containerName`: Container name to show logs from  - only relevant in kube platform (optional, e.g.: `sidecar-container`)
 
 #### Response
 

--- a/docs/reference/api/README.md
+++ b/docs/reference/api/README.md
@@ -319,7 +319,7 @@ you `DELETE /api/function_invocations`, the HTTP method in the event as received
     * `follow`: Follow the replica log stream (default: true)
     * `since`: A relative time before the current time from which to show logs (optional, e.g.: `1h`)
     * `tailLines`: Number of lines to show from the end of the logs (optional, e.g.: `100`)
-    * `containerName`: Container name to show logs from  - only relevant in kube platform (optional, e.g.: `sidecar-container`)
+    * `containerName`: Container name to show logs from. If not supplied the function container logs will be retrieved [only relevant in `kube` platform] (optional, e.g.: `sidecar-container`)
 
 #### Response
 

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -33,6 +33,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/opa"
 	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platform/kube/client"
 	"github.com/nuclio/nuclio/pkg/restful"
 
 	"github.com/nuclio/errors"
@@ -374,16 +375,8 @@ func (fr *functionResource) getFunctionLogs(request *http.Request) (*restful.Cus
 		return nil, errors.Wrap(err, "Failed to get function")
 	}
 
-	replicaNames, err := fr.getPlatform().GetFunctionReplicaNames(request.Context(), function.GetConfig())
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get function replica names")
-	}
-
-	// ensure replica belongs to function
-	if !common.StringSliceContainsStringCaseInsensitive(replicaNames, functionReplicaName) {
-		return nil, nuclio.NewErrBadRequest(fmt.Sprintf("%s replica does not belong to function %s",
-			functionReplicaName,
-			function.GetConfig().Meta.Name))
+	if err := fr.validateLogStreamOptions(request.Context(), function, getFunctionReplicaLogsStreamOptions); err != nil {
+		return nil, errors.Wrap(err, "Failed to validate log stream options")
 	}
 
 	// get function instance logs stream
@@ -402,6 +395,38 @@ func (fr *functionResource) getFunctionLogs(request *http.Request) (*restful.Cus
 		ForceFlush:    true,
 		FlushInternal: time.Second,
 	}, nil
+}
+
+func (fr *functionResource) validateLogStreamOptions(ctx context.Context,
+	function platform.Function,
+	getFunctionReplicaLogsStreamOptions *platform.GetFunctionReplicaLogsStreamOptions) error {
+	replicaNames, err := fr.getPlatform().GetFunctionReplicaNames(ctx, function.GetConfig())
+	if err != nil {
+		return errors.Wrap(err, "Failed to get function replica names")
+	}
+
+	// ensure replica belongs to function
+	if !common.StringSliceContainsStringCaseInsensitive(replicaNames, getFunctionReplicaLogsStreamOptions.Name) {
+		return nuclio.NewErrBadRequest(fmt.Sprintf("%s replica does not belong to function %s",
+			getFunctionReplicaLogsStreamOptions.Name,
+			function.GetConfig().Meta.Name))
+	}
+
+	// ensure container name is valid for the replica (if provided)
+	if getFunctionReplicaLogsStreamOptions.ContainerName != client.FunctionContainerName {
+		// get the replica's containers
+		replicaContainers, err := fr.getPlatform().GetFunctionReplicaContainers(ctx, function.GetConfig(), getFunctionReplicaLogsStreamOptions.Name)
+		if err != nil {
+			return errors.Wrap(err, "Failed to get function replica containers")
+		}
+
+		if !common.StringSliceContainsStringCaseInsensitive(replicaContainers, getFunctionReplicaLogsStreamOptions.ContainerName) {
+			return nuclio.NewErrBadRequest(fmt.Sprintf("%s container does not belong to function replica %s",
+				getFunctionReplicaLogsStreamOptions.ContainerName,
+				getFunctionReplicaLogsStreamOptions.Name))
+		}
+	}
+	return nil
 }
 
 func (fr *functionResource) getFunctionReplicas(request *http.Request) (
@@ -710,9 +735,10 @@ func (fr *functionResource) populateGetFunctionReplicaLogsStreamOptions(request 
 	namespace string) (*platform.GetFunctionReplicaLogsStreamOptions, error) {
 
 	getFunctionReplicaLogsStreamOptions := &platform.GetFunctionReplicaLogsStreamOptions{
-		Name:      replicaName,
-		Namespace: namespace,
-		Follow:    fr.GetURLParamBoolOrDefault(request, "follow", true),
+		Name:          replicaName,
+		Namespace:     namespace,
+		Follow:        fr.GetURLParamBoolOrDefault(request, "follow", true),
+		ContainerName: fr.GetURLParamStringOrDefault(request, "containerName", client.FunctionContainerName),
 	}
 
 	// populate since seconds

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -591,7 +591,7 @@ func (p *Platform) GetFunctionReplicaLogsStream(ctx context.Context,
 		CoreV1().
 		Pods(options.Namespace).
 		GetLogs(options.Name, &v1.PodLogOptions{
-			Container:    client.FunctionContainerName,
+			Container:    options.ContainerName,
 			SinceSeconds: options.SinceSeconds,
 			TailLines:    options.TailLines,
 			Follow:       options.Follow,
@@ -616,6 +616,21 @@ func (p *Platform) GetFunctionReplicaNames(ctx context.Context,
 		names = append(names, pod.GetName())
 	}
 	return names, nil
+}
+
+func (p *Platform) GetFunctionReplicaContainers(ctx context.Context, functionConfig *functionconfig.Config, replicaName string) ([]string, error) {
+	pod, err := p.consumer.KubeClientSet.
+		CoreV1().
+		Pods(functionConfig.Meta.Namespace).
+		Get(ctx, replicaName, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get function pod")
+	}
+	var containerNames []string
+	for _, container := range pod.Spec.Containers {
+		containerNames = append(containerNames, container.Name)
+	}
+	return containerNames, nil
 }
 
 // GetName returns the platform name

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -522,6 +522,12 @@ func (p *Platform) GetFunctionReplicaNames(ctx context.Context,
 	}, nil
 }
 
+func (p *Platform) GetFunctionReplicaContainers(ctx context.Context, functionConfig *functionconfig.Config, replicaName string) ([]string, error) {
+	return []string{
+		p.GetFunctionContainerName(functionConfig),
+	}, nil
+}
+
 // GetHealthCheckMode returns the healthcheck mode the platform requires
 func (p *Platform) GetHealthCheckMode() platform.HealthCheckMode {
 

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -145,6 +145,11 @@ func (mp *Platform) GetFunctionReplicaNames(ctx context.Context, functionConfig 
 	return args.Get(0).([]string), args.Error(1)
 }
 
+func (mp *Platform) GetFunctionReplicaContainers(ctx context.Context, functionConfig *functionconfig.Config, replicaName string) ([]string, error) {
+	args := mp.Called(ctx, functionConfig, replicaName)
+	return args.Get(0).([]string), args.Error(1)
+}
+
 //
 // Project
 //

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -89,6 +89,9 @@ type Platform interface {
 	// GetFunctionReplicaNames returns function replica names (Pod / Container names)
 	GetFunctionReplicaNames(context.Context, *functionconfig.Config) ([]string, error)
 
+	// GetFunctionReplicaContainers returns function replica containers (Pod / Container names)
+	GetFunctionReplicaContainers(context.Context, *functionconfig.Config, string) ([]string, error)
+
 	//
 	// Project
 	//

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -553,6 +553,10 @@ type GetFunctionReplicaLogsStreamOptions struct {
 
 	// Number of lines to show from the end of the logs
 	TailLines *int64
+
+	// A specific container name to stream logs from (if not specified, the "nuclio" container in the pod is used)
+	// Relevant only for pods with multiple containers
+	ContainerName string
 }
 
 type FunctionSecret struct {


### PR DESCRIPTION
With the addition of sidecars, a function pod can have multiple containers.
We want to provide an API to stream logs from a specific given container.

This PR extends the log streaming API by adding support for the `containerName` query param.

Example usage:
```
GET /api/functions/<function name>/logs/<replica-name>`?containerName=sidecar
```