### PR TITLE
[UI] Bump iguazio.dashboard-controls to `1.0.4`

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^3.0.2",
     "i18next-localstorage-backend": "^3.1.3",
     "i18next-xhr-backend": "^3.2.2",
-    "iguazio.dashboard-controls": "^1.0.3",
+    "iguazio.dashboard-controls": "^1.0.4",
     "jquery": "*",
     "jquery-ui": "1.13.2",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
- **UI**: Bump iguazio.dashboard-controls to `1.0.4`
   Related To: https://github.com/iguazio/dashboard-controls/pull/1553
   Jira: https://iguazio.atlassian.net/browse/IG-22787