### PR TITLE
[Sidecars] Populate function service with sidecar container ports

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -62,6 +62,9 @@ const (
 	FunctionContainerHTTPPort            = 8080
 	FunctionContainerWebAdminHTTPPort    = 8081
 	FunctionContainerHealthCheckHTTPPort = 8082
+	FunctionContainerMetricPort          = 8090
+	FunctionContainerHTTPPortName        = "http"
+	FunctionContainerMetricPortName      = "metrics"
 	DefaultTargetCPU                     = 75
 )
 

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platform/abstract"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	"github.com/nuclio/nuclio/pkg/platform/kube/client"
 	"github.com/nuclio/nuclio/pkg/platform/kube/functionres"
@@ -408,7 +409,7 @@ func (fo *functionOperator) getFunctionHTTPPort(functionResources functionres.Re
 
 	if service != nil && len(service.Spec.Ports) != 0 {
 		for _, port := range service.Spec.Ports {
-			if port.Name == functionres.ContainerHTTPPortName {
+			if port.Name == abstract.FunctionContainerHTTPPortName {
 				httpPort = int(port.NodePort)
 				break
 			}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1880,6 +1880,23 @@ func (lc *lazyClient) populateServiceSpec(ctx context.Context,
 			"ports", spec.Ports)
 	}
 
+	if function.Spec.Sidecars != nil {
+		// Questions:
+		//  1. Do we always want to expose the sidecar ports? what are the disadvantages?
+		//  2. Do we want to expose only the first port of each sidecar?
+
+		if len(spec.Ports) == 0 {
+			spec.Ports = []v1.ServicePort{}
+		}
+		for _, sidecar := range function.Spec.Sidecars {
+			spec.Ports = append(spec.Ports, v1.ServicePort{
+				Name:       sidecar.Name,
+				Port:       sidecar.Ports[0].ContainerPort,
+				TargetPort: intstr.FromInt(int(sidecar.Ports[0].ContainerPort)),
+			})
+		}
+	}
+
 	// check if platform requires additional ports
 	platformServicePorts := lc.getServicePortsFromPlatform(lc.platformConfigurationProvider.GetPlatformConfiguration())
 

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -653,20 +653,20 @@ func (suite *lazyTestSuite) TestPlatformServicePorts() {
 		},
 	})
 	suite.Require().Len(servicePorts, 1)
-	suite.Require().Equal(servicePorts[0].Name, containerMetricPortName)
-	suite.Require().Equal(servicePorts[0].Port, int32(containerMetricPort))
+	suite.Require().Equal(servicePorts[0].Name, abstract.FunctionContainerMetricPortName)
+	suite.Require().Equal(servicePorts[0].Port, int32(abstract.FunctionContainerMetricPort))
 
 	// ensure metric port
 	toServicePorts := suite.client.ensureServicePortsExist([]v1.ServicePort{
 		{
-			Name:     ContainerHTTPPortName,
+			Name:     abstract.FunctionContainerHTTPPortName,
 			Port:     int32(abstract.FunctionContainerHTTPPort),
 			NodePort: 12345,
 		},
 	}, []v1.ServicePort{
 		{
-			Name: containerMetricPortName,
-			Port: int32(containerMetricPort),
+			Name: abstract.FunctionContainerMetricPortName,
+			Port: int32(abstract.FunctionContainerMetricPort),
 		},
 	})
 
@@ -675,14 +675,14 @@ func (suite *lazyTestSuite) TestPlatformServicePorts() {
 
 	toServicePorts = suite.client.ensureServicePortsExist([]v1.ServicePort{
 		{
-			Name:     ContainerHTTPPortName,
+			Name:     abstract.FunctionContainerHTTPPortName,
 			Port:     int32(abstract.FunctionContainerHTTPPort),
 			NodePort: 12345,
 		},
 	}, []v1.ServicePort{
 		{
-			Name: containerMetricPortName,
-			Port: int32(containerMetricPort),
+			Name: abstract.FunctionContainerMetricPortName,
+			Port: int32(abstract.FunctionContainerMetricPort),
 		},
 	})
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1983,9 +1983,7 @@ func (p *Platform) validateContainerSpec(container *v1.Container) error {
 }
 
 func (p *Platform) validateContainerPorts(container *v1.Container) error {
-	if container.Ports == nil || len(container.Ports) == 0 {
-		return nuclio.NewErrBadRequest(fmt.Sprintf("Ports must be provided for container %s", container.Name))
-	} else {
+	if container.Ports != nil {
 		portNames := make(map[string]bool)
 		portNumbers := make(map[int32]bool)
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -46,6 +46,7 @@ import (
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/nuclio/zap"
+	"github.com/samber/lo"
 	"k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1950,6 +1951,10 @@ func (p *Platform) validateSidecarSpec(functionConfig *functionconfig.Config) er
 		if err := p.validateContainerSpec(sidecar); err != nil {
 			return nuclio.WrapErrBadRequest(err)
 		}
+
+		if err := p.validateContainerPorts(sidecar); err != nil {
+			return nuclio.WrapErrBadRequest(err)
+		}
 	}
 
 	return nil
@@ -1973,6 +1978,61 @@ func (p *Platform) validateContainerSpec(container *v1.Container) error {
 	if container.Image == "" {
 		return nuclio.NewErrBadRequest(fmt.Sprintf("Container image must be provided for container %s", container.Name))
 	}
+
+	return nil
+}
+
+func (p *Platform) validateContainerPorts(container *v1.Container) error {
+	if container.Ports == nil || len(container.Ports) == 0 {
+		return nuclio.NewErrBadRequest(fmt.Sprintf("Ports must be provided for container %s", container.Name))
+	} else {
+		portNames := make(map[string]bool)
+		portNumbers := make(map[int32]bool)
+
+		for _, port := range container.Ports {
+			// validate container port exists
+			if port.ContainerPort == 0 {
+				return nuclio.NewErrBadRequest(fmt.Sprintf("Container port must be provided for container %s", container.Name))
+			}
+
+			// validate container port is not reserved
+			if lo.Contains[int]([]int{
+				abstract.FunctionContainerHTTPPort,
+				abstract.FunctionContainerWebAdminHTTPPort,
+				abstract.FunctionContainerHealthCheckHTTPPort,
+				abstract.FunctionContainerMetricPort,
+			}, int(port.ContainerPort)) {
+				return nuclio.NewErrBadRequest(fmt.Sprintf("Container port %d is reserved for Nuclio internal use", port.ContainerPort))
+			}
+
+			// validate port name exists
+			if port.Name == "" {
+				return nuclio.NewErrBadRequest(fmt.Sprintf("Port name must be provided for container %s", container.Name))
+			}
+
+			// validate port name is not reserved
+			if lo.Contains[string]([]string{
+				abstract.FunctionContainerHTTPPortName,
+				abstract.FunctionContainerMetricPortName,
+			}, port.Name) {
+				return nuclio.NewErrBadRequest(fmt.Sprintf("Port name %s is reserved for Nuclio internal use", port.Name))
+			}
+
+			// validate port name is unique
+			if _, exists := portNames[port.Name]; exists {
+				return nuclio.NewErrBadRequest(fmt.Sprintf("Port name %s is duplicated in container %s", port.Name, container.Name))
+			}
+
+			// validate port number is unique
+			if _, exists := portNumbers[port.ContainerPort]; exists {
+				return nuclio.NewErrBadRequest(fmt.Sprintf("Port number %d is duplicated in container %s", port.ContainerPort, container.Name))
+			}
+
+			portNames[port.Name] = true
+			portNumbers[port.ContainerPort] = true
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -414,16 +414,6 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateSidecarContainers() {
 			shouldFailValidation: true,
 		},
 		{
-			name: "invalidNoPorts",
-			sidecars: []*v1.Container{
-				{
-					Name:  sidcarContainerName,
-					Image: "nginx",
-				},
-			},
-			shouldFailValidation: true,
-		},
-		{
 			name: "invalidNoContainerPort",
 			sidecars: []*v1.Container{
 				{

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -1530,7 +1530,8 @@ def handler(context, event):
 
 	// create a busybox sidecar
 	createFunctionOptions.FunctionConfig.Spec.Sidecars = []*v1.Container{
-		{Name: sidecarContainerName,
+		{
+			Name:    sidecarContainerName,
 			Image:   "busybox",
 			Command: commands,
 		},


### PR DESCRIPTION
To allow accessing the sidecar containers directly, we first need to expose them to the internal cluster by adding the sidecar ports to the function service.

Since the function service already populates some other reserved internal ports, added validation to the sidecars' ports so they won't override anything.

https://iguazio.atlassian.net/browse/NUC-185