### PR TITLE
[Nuctl] Fix autofixing of v3io trigger configuration

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -482,10 +482,10 @@ func (ap *Platform) AutoFixConfiguration(ctx context.Context, err error, functio
 	if errors.RootCause(err).Error() == "V3IO Stream trigger does not support autoscaling" {
 		if *functionConfig.Spec.MinReplicas == 0 {
 			ap.Logger.WarnWithCtx(ctx, "V3IO Stream doesn't support scaling from zero - "+
-				"Auth fixing by setting minReplicas to 1",
+				"Auto fixing by setting minReplicas to 1",
 				"function", functionConfig.Meta.Name)
 			oneValue := 1
-			functionConfig.Spec.MaxReplicas = &oneValue
+			functionConfig.Spec.MinReplicas = &oneValue
 		}
 
 		ap.Logger.WarnWithCtx(ctx, "V3IO Stream trigger does not support autoscaling - "+

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -480,6 +480,14 @@ func (ap *Platform) ValidateFunctionConfig(ctx context.Context, functionConfig *
 
 func (ap *Platform) AutoFixConfiguration(ctx context.Context, err error, functionConfig *functionconfig.Config) bool {
 	if errors.RootCause(err).Error() == "V3IO Stream trigger does not support autoscaling" {
+		if *functionConfig.Spec.MinReplicas == 0 {
+			ap.Logger.WarnWithCtx(ctx, "V3IO Stream doesn't support scaling from zero - "+
+				"Auth fixing by setting minReplicas to 1",
+				"function", functionConfig.Meta.Name)
+			oneValue := 1
+			functionConfig.Spec.MaxReplicas = &oneValue
+		}
+
 		ap.Logger.WarnWithCtx(ctx, "V3IO Stream trigger does not support autoscaling - "+
 			"Auto fixing by setting maxReplicas to minReplicas for function",
 			"function", functionConfig.Meta.Name,


### PR DESCRIPTION
Jira - https://iguazio.atlassian.net/browse/NUC-189

This PR addresses the bug which happened during upgrade. 
The function that failed importing had the following in its spec:
* V3io Stream trigger
* MinReplicas = 0
* MaxReplicas = 4

In Nuclio, we autofix functions with v3io stream triggers and `MinReplicas != MaxReplicas` to `MinReplicas == MaxReplicas`, so what happened is that the resulting spec was `MinReplicas = MaxReplicas = 0` - which is not allowed. So, the new logic is to check `minReplicas` value and if it's equal to `0` , set it to `1`.