### PR TITLE
[Kafka] Replace Kafka images in integration test suite

### DIFF
--- a/pkg/processor/trigger/kafka/test/kafka_test.go
+++ b/pkg/processor/trigger/kafka/test/kafka_test.go
@@ -621,7 +621,7 @@ func (suite *testSuite) TestDrainHook() {
 
 // GetContainerRunInfo returns information about the broker container
 func (suite *testSuite) GetContainerRunInfo() (string, *dockerclient.RunOptions) {
-	return "wurstmeister/kafka", &dockerclient.RunOptions{
+	return "gcr.io/iguazio/kafka", &dockerclient.RunOptions{
 		ContainerName: suite.brokerContainerName,
 		Network:       suite.BrokerContainerNetworkName,
 		Remove:        true,
@@ -647,7 +647,7 @@ func (suite *testSuite) GetContainerRunInfo() (string, *dockerclient.RunOptions)
 }
 
 func (suite *testSuite) getKafkaZooKeeperContainerRunInfo() (string, *dockerclient.RunOptions) {
-	return "wurstmeister/zookeeper", &dockerclient.RunOptions{
+	return "gcr.io/iguazio/zookeeper", &dockerclient.RunOptions{
 		ContainerName: suite.zooKeeperContainerName,
 		Network:       suite.BrokerContainerNetworkName,
 		Remove:        true,


### PR DESCRIPTION
The `wurstmeister` project is no longer maintained, and its images have been deleted from docker hub (see [this issue](https://github.com/wurstmeister/kafka-docker/issues/744).

Replacing the absent images with the same images on iguazio gcr.