### PR TITLE
[Nuctl] Fix autofixing of v3io trigger configuration [1.12.x]

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -485,6 +485,14 @@ func (ap *Platform) ValidateFunctionConfig(ctx context.Context, functionConfig *
 
 func (ap *Platform) AutoFixConfiguration(ctx context.Context, err error, functionConfig *functionconfig.Config) bool {
 	if errors.RootCause(err).Error() == "V3IO Stream trigger does not support autoscaling" {
+		if *functionConfig.Spec.MinReplicas == 0 {
+			ap.Logger.WarnWithCtx(ctx, "V3IO Stream doesn't support scaling from zero - "+
+				"Auto fixing by setting minReplicas to 1",
+				"function", functionConfig.Meta.Name)
+			oneValue := 1
+			functionConfig.Spec.MinReplicas = &oneValue
+		}
+
 		ap.Logger.WarnWithCtx(ctx, "V3IO Stream trigger does not support autoscaling - "+
 			"Auto fixing by setting maxReplicas to minReplicas for function",
 			"function", functionConfig.Meta.Name,


### PR DESCRIPTION
Backport of #3240 