### PR TITLE
[Dashboard] Add name validation for api gateway

### DIFF
--- a/pkg/common/strings.go
+++ b/pkg/common/strings.go
@@ -20,6 +20,7 @@ package common
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -106,4 +107,12 @@ func returnEarlyIfPossible(stringOne, stringTwo string) float32 {
 	}
 
 	return -1
+}
+
+// Define the regex pattern for a k8s resource name
+var k8sResourceRegexp = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+// IsValidK8sResourceName checks if the given name is a valid Kubernetes resource name
+func IsValidK8sResourceName(name string) bool {
+	return k8sResourceRegexp.MatchString(name)
 }

--- a/pkg/common/strings.go
+++ b/pkg/common/strings.go
@@ -20,7 +20,6 @@ package common
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 )
 
@@ -107,12 +106,4 @@ func returnEarlyIfPossible(stringOne, stringTwo string) float32 {
 	}
 
 	return -1
-}
-
-// Define the regex pattern for a k8s resource name
-var k8sResourceRegexp = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
-
-// IsValidK8sResourceName checks if the given name is a valid Kubernetes resource name
-func IsValidK8sResourceName(name string) bool {
-	return k8sResourceRegexp.MatchString(name)
 }

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1734,6 +1734,10 @@ func (p *Platform) validateAPIGatewayMeta(platformAPIGatewayMeta *platform.APIGa
 		return nuclio.NewErrBadRequest("Api gateway name must be provided in metadata")
 	}
 
+	if !common.IsValidK8sResourceName(platformAPIGatewayMeta.Name) {
+		return nuclio.NewErrBadRequest(fmt.Sprintf("Invalid API gateway name: %s. The name should only consist of letters, numbers, and dashes.", platformAPIGatewayMeta.Name))
+	}
+
 	if platformAPIGatewayMeta.Namespace == "" {
 		return nuclio.NewErrBadRequest("Api gateway namespace must be provided in metadata")
 	}

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"net/url"
 	"strings"
 	"sync"
@@ -1734,8 +1735,11 @@ func (p *Platform) validateAPIGatewayMeta(platformAPIGatewayMeta *platform.APIGa
 		return nuclio.NewErrBadRequest("Api gateway name must be provided in metadata")
 	}
 
-	if !common.IsValidK8sResourceName(platformAPIGatewayMeta.Name) {
-		return nuclio.NewErrBadRequest(fmt.Sprintf("Invalid API gateway name: %s. The name should only consist of letters, numbers, and dashes.", platformAPIGatewayMeta.Name))
+	// validate api gateway name is according to k8s convention
+	errorMessages := validation.IsQualifiedName(platformAPIGatewayMeta.Name)
+	if len(errorMessages) != 0 {
+		joinedErrorMessage := strings.Join(errorMessages, ", ")
+		return errors.Errorf("Api gateway name doesn't conform to k8s naming convention. Errors: %s", joinedErrorMessage)
 	}
 
 	if platformAPIGatewayMeta.Namespace == "" {

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"net/url"
 	"strings"
 	"sync"
@@ -54,6 +53,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/cache"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 type Platform struct {

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -912,6 +912,58 @@ func (suite *FunctionKubePlatformTestSuite) TestFunctionTriggersEnrichmentAndVal
 	}
 }
 
+func (suite *FunctionKubePlatformTestSuite) TestValidateAPIGateway() {
+	for _, testCase := range []struct {
+		name           string
+		apiGatewayName string
+		namespace      string
+		expectError    bool
+	}{
+		{
+			name:           "correct-config-1",
+			apiGatewayName: "function-name",
+			namespace:      "ns",
+			expectError:    false,
+		},
+		{
+			name:           "empty-ns",
+			apiGatewayName: "function-name",
+			expectError:    true,
+		},
+		{
+			name:           "empty-name",
+			apiGatewayName: "function-name",
+			expectError:    true,
+		},
+		{
+			name:           "wrong-name-1",
+			apiGatewayName: "--2-821",
+			namespace:      "ns",
+			expectError:    true,
+		},
+		{
+			name:           "wrong-name-1",
+			apiGatewayName: "2-%-%%^1",
+			namespace:      "ns",
+			expectError:    true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+
+			err := suite.platform.validateAPIGatewayMeta(&platform.APIGatewayMeta{
+				Name:      testCase.apiGatewayName,
+				Namespace: testCase.namespace,
+			})
+			if testCase.expectError {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+			}
+
+		})
+	}
+}
+
 func (suite *FunctionKubePlatformTestSuite) TestGetFunctionInstanceAndConfig() {
 	for _, testCase := range []struct {
 		name                    string


### PR DESCRIPTION
We don't have any name validation for api gateway, so this PR addresses this issue and adds a validation. 
I decided to implement it by adding the common method which checks if name follows k8s common naming rules because from the api_gateway name we create an ingress object.

Jira - https://iguazio.atlassian.net/browse/ML-6487