### PR TITLE
[Kaniko] Fix non-zero slice initialization

### DIFF
--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -133,7 +133,7 @@ func (k *Kaniko) BuildAndPushContainerImage(ctx context.Context,
 }
 
 func (k *Kaniko) GetOnbuildStages(onbuildArtifacts []runtime.Artifact) ([]string, error) {
-	onbuildStages := make([]string, len(onbuildArtifacts))
+	onbuildStages := make([]string, 0, len(onbuildArtifacts))
 	stage := 0
 
 	for _, artifact := range onbuildArtifacts {


### PR DESCRIPTION
I was running github actions to run linter [makezero](https://github.com/ashanbrown/makezero) for top github golang repos.

see issues https://github.com/alingse/go-linter-runner/issues/1

and the github actions output https://github.com/alingse/go-linter-runner/actions/runs/9242646334/job/25425727611 

```
====================================================================================================
append to slice `onbuildStages` with non-zero initialized length at https://github.com/nuclio/nuclio/blob/development/pkg/containerimagebuilderpusher/kaniko.go#L155:19
====================================================================================================
```