### PR TITLE
[Dashboard] Allow deleting a function along with its api gateways

### DIFF
--- a/pkg/common/headers/headers.go
+++ b/pkg/common/headers/headers.go
@@ -27,6 +27,7 @@ const (
 	FunctionNamespace                   = "X-Nuclio-Function-Namespace"
 	WaitFunctionAction                  = "X-Nuclio-Wait-Function-Action"
 	DeleteFunctionIgnoreStateValidation = "X-Nuclio-Delete-Function-Ignore-State-Validation"
+	DeleteFunctionWithGateways          = "X-Nuclio-Delete-Function-With-API-Gateways"
 	CreationStateUpdatedTimeout         = "X-Nuclio-Creation-State-Updated-Timeout"
 	FunctionEnrichApiGateways           = "X-Nuclio-Function-Enrich-Apigateways"
 	ImportedFunctionOnly                = "X-Nuclio-Imported-Function-Only"

--- a/pkg/common/headers/headers.go
+++ b/pkg/common/headers/headers.go
@@ -27,7 +27,7 @@ const (
 	FunctionNamespace                   = "X-Nuclio-Function-Namespace"
 	WaitFunctionAction                  = "X-Nuclio-Wait-Function-Action"
 	DeleteFunctionIgnoreStateValidation = "X-Nuclio-Delete-Function-Ignore-State-Validation"
-	DeleteFunctionWithGateways          = "X-Nuclio-Delete-Function-With-API-Gateways"
+	DeleteFunctionWithAPIGateways       = "X-Nuclio-Delete-Function-With-API-Gateways"
 	CreationStateUpdatedTimeout         = "X-Nuclio-Creation-State-Updated-Timeout"
 	FunctionEnrichApiGateways           = "X-Nuclio-Function-Enrich-Apigateways"
 	ImportedFunctionOnly                = "X-Nuclio-Imported-Function-Only"

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -498,7 +498,7 @@ func (fr *functionResource) deleteFunction(request *http.Request) (*restful.Cust
 		IgnoreFunctionStateValidation: fr.headerValueIsTrue(request,
 			headers.DeleteFunctionIgnoreStateValidation),
 		DeleteApiGateways: fr.headerValueIsTrue(request,
-			headers.DeleteFunctionWithGateways),
+			headers.DeleteFunctionWithAPIGateways),
 	}
 
 	deleteFunctionOptions.FunctionConfig.Meta = *functionInfo.Meta

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -497,6 +497,8 @@ func (fr *functionResource) deleteFunction(request *http.Request) (*restful.Cust
 		},
 		IgnoreFunctionStateValidation: fr.headerValueIsTrue(request,
 			headers.DeleteFunctionIgnoreStateValidation),
+		DeleteApiGateways: fr.headerValueIsTrue(request,
+			headers.DeleteFunctionWithGateways),
 	}
 
 	deleteFunctionOptions.FunctionConfig.Meta = *functionInfo.Meta

--- a/pkg/nuctl/command/delete.go
+++ b/pkg/nuctl/command/delete.go
@@ -105,7 +105,7 @@ func newDeleteFunctionCommandeer(ctx context.Context, deleteCommandeer *deleteCo
 			return deleteCommandeer.rootCommandeer.platform.DeleteFunction(ctx, deleteFunctionOptions)
 		},
 	}
-	cmd.Flags().BoolVar(&commandeer.withAPIGateways, "with-api-gateways", false, `Whether function should be removed with its api gateways (default: false)`)
+	cmd.Flags().BoolVar(&commandeer.withAPIGateways, "with-api-gateways", false, "Whether function should be removed with its api gateways (default: false)")
 	commandeer.cmd = cmd
 
 	return commandeer

--- a/pkg/nuctl/command/delete.go
+++ b/pkg/nuctl/command/delete.go
@@ -65,7 +65,8 @@ func newDeleteCommandeer(ctx context.Context, rootCommandeer *RootCommandeer) *d
 
 type deleteFunctionCommandeer struct {
 	*deleteCommandeer
-	functionConfig functionconfig.Config
+	functionConfig  functionconfig.Config
+	withAPIGateways bool
 }
 
 func newDeleteFunctionCommandeer(ctx context.Context, deleteCommandeer *deleteCommandeer) *deleteFunctionCommandeer {
@@ -94,7 +95,8 @@ func newDeleteFunctionCommandeer(ctx context.Context, deleteCommandeer *deleteCo
 			commandeer.functionConfig.Meta.Namespace = deleteCommandeer.rootCommandeer.namespace
 
 			deleteFunctionOptions := &platform.DeleteFunctionOptions{
-				FunctionConfig: commandeer.functionConfig,
+				FunctionConfig:    commandeer.functionConfig,
+				DeleteApiGateways: commandeer.withAPIGateways,
 			}
 			if deleteCommandeer.forceDelete {
 				deleteFunctionOptions.IgnoreFunctionStateValidation = true
@@ -103,7 +105,7 @@ func newDeleteFunctionCommandeer(ctx context.Context, deleteCommandeer *deleteCo
 			return deleteCommandeer.rootCommandeer.platform.DeleteFunction(ctx, deleteFunctionOptions)
 		},
 	}
-
+	cmd.Flags().BoolVar(&commandeer.withAPIGateways, "with-api-gateways", false, `Whether function should be removed with its api gateways (default: false)`)
 	commandeer.cmd = cmd
 
 	return commandeer

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -575,7 +575,8 @@ func (p *Platform) DeleteFunction(ctx context.Context, deleteFunctionOptions *pl
 			// check if there is any canary function in which this function is used
 			// if there is one, we not allow deleting such functions
 			if len(apiGatewayInstance.Spec.Upstreams) == 2 {
-				return errors.New("Failed to delete function - it is used in canary api gateway")
+				return errors.New(fmt.Sprintf("Failed to delete function - it is used in canary api gateway - %s",
+					apiGatewayInstance.Name))
 			}
 		}
 		for _, apiGatewayInstance := range apiGateways {

--- a/pkg/platform/kube/test/platform_test.go
+++ b/pkg/platform/kube/test/platform_test.go
@@ -1759,7 +1759,7 @@ func (suite *DeleteFunctionTestSuite) TestDeleteFunctionWhichHasApiGateway() {
 				FunctionConfig: createFunctionOptions.FunctionConfig,
 			})
 			// expect deletion error
-			suite.Assert().Equal(platform.ErrFunctionIsUsedByAPIGateways, errors.RootCause(err))
+			suite.Require().Equal(platform.ErrFunctionIsUsedByAPIGateways, errors.RootCause(err))
 
 			// try to delete the function while it uses this api gateway with DeleteApiGateways flag
 			err = suite.Platform.DeleteFunction(suite.Ctx, &platform.DeleteFunctionOptions{

--- a/pkg/platform/kube/test/suite.go
+++ b/pkg/platform/kube/test/suite.go
@@ -562,10 +562,9 @@ func (suite *KubeTestSuite) DeployAPIGateway(createAPIGatewayOptions *platform.C
 	// delete the api gateway when done
 	defer func() {
 		suite.Logger.Debug("Deleting deployed api gateway")
-		err := suite.Platform.DeleteAPIGateway(suite.Ctx, &platform.DeleteAPIGatewayOptions{
+		_ = suite.Platform.DeleteAPIGateway(suite.Ctx, &platform.DeleteAPIGatewayOptions{
 			Meta: createAPIGatewayOptions.APIGatewayConfig.Meta,
 		})
-		suite.Require().NoError(err)
 		suite.verifyAPIGatewayIngress(createAPIGatewayOptions, false)
 
 	}()

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -86,6 +86,9 @@ type DeleteFunctionOptions struct {
 
 	// whether to ignore the validation where functions being provisioned cannot be deleted
 	IgnoreFunctionStateValidation bool
+
+	// whether api gateways should be deleted if ones exist
+	DeleteApiGateways bool
 }
 
 type RedeployFunctionOptions struct {


### PR DESCRIPTION
Jira - https://iguazio.atlassian.net/browse/ML-6561

This PR provides the ability to define via handler whether API gateways associated with a function should be deleted when deleting the function. The default behavior remains the same, meaning the API gateway will not be deleted, and the user will need to delete it manually.