### PR TITLE
[Kafka] Return empty path in for kafka's event GetPath()

### DIFF
--- a/pkg/processor/trigger/kafka/event.go
+++ b/pkg/processor/trigger/kafka/event.go
@@ -41,7 +41,7 @@ func (e *Event) GetShardID() int {
 }
 
 func (e *Event) GetPath() string {
-	return e.kafkaMessage.Topic
+	return "/"
 }
 
 func (e *Event) GetTimestamp() time.Time {


### PR DESCRIPTION
⚠️ Breaking Changes ⚠️

This PR changes how the `GetPath` method works for Kafka events. It used to return a Kafka topic because we didn't have a `GetTopic` method until recent releases. Now that we have the `GetTopic` method, there is no need to return the topic in both methods, especially since the `path` entity doesn't make much sense for a Kafka event.


:heavy_exclamation_mark: Please be aware that any code using the `GetPath` method to get the Kafka topic needs to be changed to use the `GetTopic` method instead.

Jira - https://iguazio.atlassian.net/browse/NUC-178