### PR TITLE
[API Gateways] Add option to list API gateways associated with a specific function

### DIFF
--- a/pkg/dashboard/resource/apigateway.go
+++ b/pkg/dashboard/resource/apigateway.go
@@ -62,11 +62,13 @@ func (agr *apiGatewayResource) GetAll(request *http.Request) (map[string]restful
 
 	exportFunction := agr.GetURLParamBoolOrDefault(request, restful.ParamExport, false)
 	projectName := request.Header.Get(headers.ProjectName)
+	functionName := request.Header.Get(headers.FunctionName)
 
 	// filter by project name (when it's specified)
 	getAPIGatewaysOptions := platform.GetAPIGatewaysOptions{
-		AuthSession: agr.getCtxSession(ctx),
-		Namespace:   namespace,
+		AuthSession:  agr.getCtxSession(ctx),
+		FunctionName: functionName,
+		Namespace:    namespace,
 	}
 	if projectName != "" {
 		getAPIGatewaysOptions.Labels = fmt.Sprintf("%s=%s",

--- a/pkg/nuctl/command/get.go
+++ b/pkg/nuctl/command/get.go
@@ -275,6 +275,7 @@ func newGetAPIGatewayCommandeer(ctx context.Context, getCommandeer *getCommandee
 	}
 
 	cmd.PersistentFlags().StringVarP(&commandeer.output, "output", "o", common.OutputFormatText, "Output format - \"text\", \"wide\", \"yaml\", or \"json\"")
+	cmd.PersistentFlags().StringVar(&commandeer.getAPIGatewaysOptions.FunctionName, "function-name", "", "Function name to filter api gateways")
 
 	commandeer.cmd = cmd
 

--- a/pkg/nuctl/test/apigagteway_test.go
+++ b/pkg/nuctl/test/apigagteway_test.go
@@ -108,18 +108,22 @@ func (suite *apiGatewayCreateGetAndDeleteTestSuite) TestList() {
 		apiGatewayName := "get-test-apigateway" + uniqueSuffix
 		functionName := fmt.Sprintf("function-%d", apiGatewayIdx)
 		namedArgs := map[string]string{
-			"host":              fmt.Sprintf("some-host-%d", apiGatewayIdx),
-			"description":       fmt.Sprintf("some-description-%d", apiGatewayIdx),
-			"path":              fmt.Sprintf("some-path-%d", apiGatewayIdx),
-			"function":          fmt.Sprintf("function-%d", apiGatewayIdx),
-			"canary-function":   fmt.Sprintf("canary-function-%d", apiGatewayIdx),
-			"canary-percentage": "25",
+			"host":                fmt.Sprintf("some-host-%d", apiGatewayIdx),
+			"description":         fmt.Sprintf("some-description-%d", apiGatewayIdx),
+			"path":                fmt.Sprintf("some-path-%d", apiGatewayIdx),
+			"authentication-mode": "basicAuth",
+			"basic-auth-username": "basic-username",
+			"basic-auth-password": "basic-password",
+			"function":            fmt.Sprintf("function-%d", apiGatewayIdx),
+			"canary-function":     fmt.Sprintf("canary-function-%d", apiGatewayIdx),
+			"canary-percentage":   "25",
 		}
 
 		err := suite.ExecuteNuctl([]string{
 			"create",
 			"apigateway",
 			apiGatewayName,
+			"--mask-sensitive-fields",
 		}, namedArgs)
 
 		suite.Require().NoError(err)

--- a/pkg/nuctl/test/apigagteway_test.go
+++ b/pkg/nuctl/test/apigagteway_test.go
@@ -100,7 +100,7 @@ func (suite *apiGatewayCreateGetAndDeleteTestSuite) TestCreateGetAndDelete() {
 
 func (suite *apiGatewayCreateGetAndDeleteTestSuite) TestList() {
 	numOfAPIGateways := 3
-	var apiGatewaysName []string
+	var apiGatewayNames []string
 
 	for apiGatewayIdx := 0; apiGatewayIdx < numOfAPIGateways; apiGatewayIdx++ {
 		uniqueSuffix := fmt.Sprintf("-%s-%d", xid.New().String(), apiGatewayIdx)
@@ -108,13 +108,13 @@ func (suite *apiGatewayCreateGetAndDeleteTestSuite) TestList() {
 		apiGatewayName := "get-test-apigateway" + uniqueSuffix
 		functionName := fmt.Sprintf("function-%d", apiGatewayIdx)
 		namedArgs := map[string]string{
-			"host":                fmt.Sprintf("some-host-%d", apiGatewayIdx),
+			"host":                fmt.Sprintf("host-%s", uniqueSuffix),
 			"description":         fmt.Sprintf("some-description-%d", apiGatewayIdx),
 			"path":                fmt.Sprintf("some-path-%d", apiGatewayIdx),
 			"authentication-mode": "basicAuth",
 			"basic-auth-username": "basic-username",
 			"basic-auth-password": "basic-password",
-			"function":            fmt.Sprintf("function-%d", apiGatewayIdx),
+			"function":            functionName,
 			"canary-function":     fmt.Sprintf("canary-function-%d", apiGatewayIdx),
 			"canary-percentage":   "25",
 		}
@@ -139,7 +139,7 @@ func (suite *apiGatewayCreateGetAndDeleteTestSuite) TestList() {
 		suite.Require().NoError(err)
 		suite.Require().Contains(suite.outputBuffer.String(), apiGatewayName)
 
-		for _, gateway := range apiGatewaysName {
+		for _, gateway := range apiGatewayNames {
 			suite.Require().NotContains(suite.outputBuffer.String(), gateway)
 		}
 
@@ -149,12 +149,12 @@ func (suite *apiGatewayCreateGetAndDeleteTestSuite) TestList() {
 			suite.Require().NoError(err)
 		}()
 
-		apiGatewaysName = append(apiGatewaysName, apiGatewayName)
+		apiGatewayNames = append(apiGatewayNames, apiGatewayName)
 
 		// list all api gateways
 		err = suite.ExecuteNuctl([]string{"get", "apigateway"}, nil)
 		suite.Require().NoError(err)
-		for _, gateway := range apiGatewaysName {
+		for _, gateway := range apiGatewayNames {
 			suite.Require().Contains(suite.outputBuffer.String(), gateway)
 		}
 	}

--- a/pkg/nuctl/test/apigagteway_test.go
+++ b/pkg/nuctl/test/apigagteway_test.go
@@ -98,6 +98,64 @@ func (suite *apiGatewayCreateGetAndDeleteTestSuite) TestCreateGetAndDelete() {
 	}
 }
 
+func (suite *apiGatewayCreateGetAndDeleteTestSuite) TestList() {
+	numOfAPIGateways := 3
+	var apiGatewaysName []string
+
+	for apiGatewayIdx := 0; apiGatewayIdx < numOfAPIGateways; apiGatewayIdx++ {
+		uniqueSuffix := fmt.Sprintf("-%s-%d", xid.New().String(), apiGatewayIdx)
+
+		apiGatewayName := "get-test-apigateway" + uniqueSuffix
+		functionName := fmt.Sprintf("function-%d", apiGatewayIdx)
+		namedArgs := map[string]string{
+			"host":              fmt.Sprintf("some-host-%d", apiGatewayIdx),
+			"description":       fmt.Sprintf("some-description-%d", apiGatewayIdx),
+			"path":              fmt.Sprintf("some-path-%d", apiGatewayIdx),
+			"function":          fmt.Sprintf("function-%d", apiGatewayIdx),
+			"canary-function":   fmt.Sprintf("canary-function-%d", apiGatewayIdx),
+			"canary-percentage": "25",
+		}
+
+		err := suite.ExecuteNuctl([]string{
+			"create",
+			"apigateway",
+			apiGatewayName,
+		}, namedArgs)
+
+		suite.Require().NoError(err)
+
+		err = suite.ExecuteNuctl([]string{"get", "apigateway", apiGatewayName, "-o", nuctlcommon.OutputFormatYAML},
+			nil)
+		suite.Require().NoError(err)
+
+		// list api gateways by function name - make sure that only one api gateway returned,
+		// because we create one api gateway on each function
+		err = suite.ExecuteNuctl([]string{"get", "apigateway", "--function-name", functionName},
+			nil)
+		suite.Require().NoError(err)
+		suite.Require().Contains(suite.outputBuffer.String(), apiGatewayName)
+
+		for _, gateway := range apiGatewaysName {
+			suite.Require().NotContains(suite.outputBuffer.String(), gateway)
+		}
+
+		// delete api gateway
+		defer func() {
+			err = suite.ExecuteNuctl([]string{"delete", "apigateway", apiGatewayName}, nil) // nolint: errcheck
+			suite.Require().NoError(err)
+		}()
+
+		apiGatewaysName = append(apiGatewaysName, apiGatewayName)
+
+		// list all api gateways
+		err = suite.ExecuteNuctl([]string{"get", "apigateway"}, nil)
+		suite.Require().NoError(err)
+		for _, gateway := range apiGatewaysName {
+			suite.Require().Contains(suite.outputBuffer.String(), gateway)
+		}
+	}
+}
+
 func (suite *apiGatewayCreateGetAndDeleteTestSuite) TestCreateFailsOnReservedResourceName() {
 	apiGatewayName := "dashboard"
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -564,7 +564,11 @@ func (p *Platform) DeleteFunction(ctx context.Context, deleteFunctionOptions *pl
 		}
 	} else {
 
-		apiGateways, err := p.getApiGateways(ctx, &platform.GetAPIGatewaysOptions{FunctionName: deleteFunctionOptions.FunctionConfig.Meta.Name, Namespace: deleteFunctionOptions.FunctionConfig.Meta.Namespace})
+		apiGateways, err := p.getApiGateways(ctx,
+			&platform.GetAPIGatewaysOptions{
+				FunctionName: deleteFunctionOptions.FunctionConfig.Meta.Name,
+				Namespace:    deleteFunctionOptions.FunctionConfig.Meta.Namespace,
+			})
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Failed to get API gateways for function %s",
 				deleteFunctionOptions.FunctionConfig.Meta.Name))
@@ -1418,20 +1422,20 @@ func (p *Platform) getApiGateways(ctx context.Context, getAPIGatewaysOptions *pl
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to list API gateways")
 	}
-	if getAPIGatewaysOptions.FunctionName != "" {
-		var functionsApiGateways []nuclioio.NuclioAPIGateway
-		for _, apiGateway := range apiGateways.Items {
-			for _, upstream := range apiGateway.Spec.Upstreams {
+	if getAPIGatewaysOptions.FunctionName == "" {
+		return apiGateways.Items, nil
+	}
+	var functionsApiGateways []nuclioio.NuclioAPIGateway
+	for _, apiGateway := range apiGateways.Items {
+		for _, upstream := range apiGateway.Spec.Upstreams {
 
-				if upstream.NuclioFunction.Name == getAPIGatewaysOptions.FunctionName {
-					functionsApiGateways = append(functionsApiGateways, apiGateway)
-					break
-				}
+			if upstream.NuclioFunction.Name == getAPIGatewaysOptions.FunctionName {
+				functionsApiGateways = append(functionsApiGateways, apiGateway)
+				break
 			}
 		}
-		return functionsApiGateways, nil
 	}
-	return apiGateways.Items, nil
+	return functionsApiGateways, nil
 }
 
 func (p *Platform) enrichFunctionsWithAPIGateways(ctx context.Context, functions []platform.Function, namespace string) error {

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -564,7 +564,7 @@ func (p *Platform) DeleteFunction(ctx context.Context, deleteFunctionOptions *pl
 		}
 	} else {
 
-		apiGateways, err := p.getApiGatewaysForFunction(ctx, deleteFunctionOptions.FunctionConfig.Meta.Namespace, deleteFunctionOptions.FunctionConfig.Meta.Name)
+		apiGateways, err := p.getApiGateways(ctx, &platform.GetAPIGatewaysOptions{FunctionName: deleteFunctionOptions.FunctionConfig.Meta.Name, Namespace: deleteFunctionOptions.FunctionConfig.Meta.Namespace})
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Failed to get API gateways for function %s",
 				deleteFunctionOptions.FunctionConfig.Meta.Name))
@@ -962,6 +962,7 @@ func (p *Platform) DeleteAPIGateway(ctx context.Context, deleteAPIGatewayOptions
 func (p *Platform) GetAPIGateways(ctx context.Context, getAPIGatewaysOptions *platform.GetAPIGatewaysOptions) ([]platform.APIGateway, error) {
 	var platformAPIGateways []platform.APIGateway
 	var apiGateways []nuclioio.NuclioAPIGateway
+	var err error
 
 	// if identifier specified, we need to get a single NuclioAPIGateway
 	if getAPIGatewaysOptions.Name != "" {
@@ -983,15 +984,10 @@ func (p *Platform) GetAPIGateways(ctx context.Context, getAPIGatewaysOptions *pl
 		apiGateways = append(apiGateways, *apiGateway)
 
 	} else {
-
-		apiGatewayInstanceList, err := p.consumer.NuclioClientSet.NuclioV1beta1().
-			NuclioAPIGateways(getAPIGatewaysOptions.Namespace).
-			List(ctx, metav1.ListOptions{LabelSelector: getAPIGatewaysOptions.Labels})
+		apiGateways, err = p.getApiGateways(ctx, getAPIGatewaysOptions)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to list API gateways")
 		}
-
-		apiGateways = apiGatewayInstanceList.Items
 	}
 
 	// convert []nuclioio.NuclioAPIGateway -> NuclioAPIGateway
@@ -1414,27 +1410,28 @@ func (p *Platform) generateFunctionToAPIGatewaysMapping(ctx context.Context, nam
 	return functionToAPIGateways, nil
 }
 
-func (p *Platform) getApiGatewaysForFunction(ctx context.Context,
-	namespace string,
-	functionName string) ([]nuclioio.NuclioAPIGateway, error) {
-	var functionsApiGateways []nuclioio.NuclioAPIGateway
+func (p *Platform) getApiGateways(ctx context.Context, getAPIGatewaysOptions *platform.GetAPIGatewaysOptions) ([]nuclioio.NuclioAPIGateway, error) {
 
 	apiGateways, err := p.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioAPIGateways(namespace).
+		NuclioAPIGateways(getAPIGatewaysOptions.Namespace).
 		List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to list API gateways")
 	}
-	for _, apiGateway := range apiGateways.Items {
-		for _, upstream := range apiGateway.Spec.Upstreams {
+	if getAPIGatewaysOptions.FunctionName != "" {
+		var functionsApiGateways []nuclioio.NuclioAPIGateway
+		for _, apiGateway := range apiGateways.Items {
+			for _, upstream := range apiGateway.Spec.Upstreams {
 
-			if upstream.NuclioFunction.Name == functionName {
-				functionsApiGateways = append(functionsApiGateways, apiGateway)
-				break
+				if upstream.NuclioFunction.Name == getAPIGatewaysOptions.FunctionName {
+					functionsApiGateways = append(functionsApiGateways, apiGateway)
+					break
+				}
 			}
 		}
+		return functionsApiGateways, nil
 	}
-	return functionsApiGateways, nil
+	return apiGateways.Items, nil
 }
 
 func (p *Platform) enrichFunctionsWithAPIGateways(ctx context.Context, functions []platform.Function, namespace string) error {

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -527,10 +527,11 @@ type DeleteAPIGatewayOptions struct {
 }
 
 type GetAPIGatewaysOptions struct {
-	Name        string
-	Namespace   string
-	Labels      string
-	AuthSession auth.Session
+	Name         string
+	Namespace    string
+	Labels       string
+	FunctionName string
+	AuthSession  auth.Session
 }
 
 // to appease k8s


### PR DESCRIPTION
This change allows to get list of api gateways attached to specific function. 

* In nuctl, the function name can be specified by `--function-name <function-name>`. 
* When sending a request to the Dashboard to get API gateways attached to a specific function, the function name should be included in the request header as "X-Nuclio-Function-Name".

Jira: https://iguazio.atlassian.net/issues/NUC-205