### PR TITLE
[Local] Use docker copy instead of docker exec when saving function to a storage

### DIFF
--- a/pkg/dockerclient/dockerclient.go
+++ b/pkg/dockerclient/dockerclient.go
@@ -31,6 +31,9 @@ type Client interface {
 	// this through an intermediate container which is deleted afterwards
 	CopyObjectsFromImage(imageName string, objectsToCopy map[string]string, allowCopyErrors bool) error
 
+	// CopyObjectsToContainer copies objects (files, directories) from a local storage to a container
+	CopyObjectsToContainer(containerName string, objectsToCopy map[string]string) error
+
 	// PushImage pushes a local image to a remote docker repository
 	PushImage(imageName string, registryURL string) error
 

--- a/pkg/dockerclient/dockerclient.go
+++ b/pkg/dockerclient/dockerclient.go
@@ -32,7 +32,7 @@ type Client interface {
 	CopyObjectsFromImage(imageName string, objectsToCopy map[string]string, allowCopyErrors bool) error
 
 	// CopyObjectsToContainer copies objects (files, directories) from a local storage to a container
-	// objectToCopy is a map where keys are local storage path and values and container paths
+	// objectToCopy is a map where keys are local storage path and values are container paths
 	CopyObjectsToContainer(containerName string, objectsToCopy map[string]string) error
 
 	// PushImage pushes a local image to a remote docker repository

--- a/pkg/dockerclient/dockerclient.go
+++ b/pkg/dockerclient/dockerclient.go
@@ -32,6 +32,7 @@ type Client interface {
 	CopyObjectsFromImage(imageName string, objectsToCopy map[string]string, allowCopyErrors bool) error
 
 	// CopyObjectsToContainer copies objects (files, directories) from a local storage to a container
+	// objectToCopy is a map where keys are local storage path and values and container paths
 	CopyObjectsToContainer(containerName string, objectsToCopy map[string]string) error
 
 	// PushImage pushes a local image to a remote docker repository

--- a/pkg/dockerclient/mock.go
+++ b/pkg/dockerclient/mock.go
@@ -48,6 +48,7 @@ func (mdc *MockDockerClient) CopyObjectsFromImage(imageName string, objectsToCop
 }
 
 // CopyObjectsToContainer copies objects (files, directories) from a local storage to a container
+// objectToCopy is a map where keys are local storage path and values are container paths
 func (mdc *MockDockerClient) CopyObjectsToContainer(containerName string, objectsToCopy map[string]string) error {
 	return nil
 }

--- a/pkg/dockerclient/mock.go
+++ b/pkg/dockerclient/mock.go
@@ -47,6 +47,11 @@ func (mdc *MockDockerClient) CopyObjectsFromImage(imageName string, objectsToCop
 	return nil
 }
 
+// CopyObjectsToContainer copies objects (files, directories) from a local storage to a container
+func (mdc *MockDockerClient) CopyObjectsToContainer(containerName string, objectsToCopy map[string]string) error {
+	return nil
+}
+
 // PushImage pushes a local image to a remote docker repository
 func (mdc *MockDockerClient) PushImage(imageName string, registryURL string) error {
 	return nil

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -158,10 +158,10 @@ func (c *ShellClient) CopyObjectsToContainer(containerName string, objectsToCopy
 	// copy objects
 	for objectLocalPath, objectContainerPath := range objectsToCopy {
 
-		// check if target directory exists, create it if it doesn't
+		// create target directory if it doesn't exist
 		fileDir := path.Dir(objectContainerPath)
 		if _, err := c.runCommand(nil, "docker exec %s mkdir -p %s", containerName, fileDir); err != nil {
-			return errors.Wrapf(err, "Error when creating directory for new file in container")
+			return errors.Wrapf(err, "Failed creating directory in container")
 		}
 
 		// copy an object from local storage to the given container
@@ -170,7 +170,7 @@ func (c *ShellClient) CopyObjectsToContainer(containerName string, objectsToCopy
 			objectLocalPath,
 			containerName,
 			objectContainerPath); err != nil {
-			return errors.Wrapf(err, "Can't copy %s:%s -> %s", containerName, objectContainerPath, objectLocalPath)
+			return errors.Wrapf(err, "Failed copying object %s to container %s:%s", objectLocalPath, containerName, objectContainerPath)
 		}
 	}
 

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -152,6 +152,29 @@ func (c *ShellClient) CopyObjectsFromImage(imageName string,
 	return nil
 }
 
+// CopyObjectsToContainer copies objects (files, directories) from a local storage to a container
+func (c *ShellClient) CopyObjectsToContainer(containerName string, objectsToCopy map[string]string) error {
+
+	// copy objects
+	for objectLocalPath, objectContainerPath := range objectsToCopy {
+
+		fileDir := path.Dir(objectContainerPath)
+		if _, err := c.runCommand(nil, "docker exec %s mkdir -p %s", containerName, fileDir); err != nil {
+			return errors.Wrapf(err, "Error when creating directory for new file in container")
+		}
+
+		if _, err := c.runCommand(nil,
+			"docker cp %s %s:%s ",
+			objectLocalPath,
+			containerName,
+			objectContainerPath); err != nil {
+			return errors.Wrapf(err, "Can't copy %s:%s -> %s", containerName, objectContainerPath, objectLocalPath)
+		}
+	}
+
+	return nil
+}
+
 // PushImage pushes a local image to a remote docker repository
 func (c *ShellClient) PushImage(imageName string, registryURL string) error {
 	taggedImage := common.CompileImageName(registryURL, imageName)

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -158,11 +158,13 @@ func (c *ShellClient) CopyObjectsToContainer(containerName string, objectsToCopy
 	// copy objects
 	for objectLocalPath, objectContainerPath := range objectsToCopy {
 
+		// check if target directory exists, create it if it doesn't
 		fileDir := path.Dir(objectContainerPath)
 		if _, err := c.runCommand(nil, "docker exec %s mkdir -p %s", containerName, fileDir); err != nil {
 			return errors.Wrapf(err, "Error when creating directory for new file in container")
 		}
 
+		// copy an object from local storage to the given container
 		if _, err := c.runCommand(nil,
 			"docker cp %s %s:%s ",
 			objectLocalPath,

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -153,6 +153,7 @@ func (c *ShellClient) CopyObjectsFromImage(imageName string,
 }
 
 // CopyObjectsToContainer copies objects (files, directories) from a local storage to a container
+// objectToCopy is a map where keys are local storage path and values are container paths
 func (c *ShellClient) CopyObjectsToContainer(containerName string, objectsToCopy map[string]string) error {
 
 	// copy objects

--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -371,7 +371,7 @@ func (s *Store) getResources(resourceDir string,
 func (s *Store) writeFileContents(filePath string, contents []byte) error {
 	s.logger.DebugWith("Writing file contents", "path", filePath, "contents", string(contents))
 
-	tempFile, err := os.CreateTemp(".", "contents-temp-file")
+	tempFile, err := os.CreateTemp(".", "nuclio-contents-temp-file-*")
 	if err != nil {
 		fmt.Println("Error creating temporary file:", err)
 		return err
@@ -381,9 +381,7 @@ func (s *Store) writeFileContents(filePath string, contents []byte) error {
 	defer os.Remove(tempFile.Name())
 
 	// Write content to the temporary file
-	encodedContent := base64.StdEncoding.EncodeToString(contents)
-	_, err = tempFile.WriteString(encodedContent)
-	if err != nil {
+	if _, err = tempFile.WriteString(base64.StdEncoding.EncodeToString(contents)); err != nil {
 		fmt.Println("Error writing to temporary file:", err)
 		return err
 	}

--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -396,7 +396,10 @@ func (s *Store) writeFileContents(filePath string, contents []byte) error {
 	}
 
 	// copy temporary file content to container
-	return s.dockerClient.CopyObjectsToContainer(containerName, map[string]string{tempFile.Name(): filePath})
+	return s.dockerClient.CopyObjectsToContainer(containerName,
+		map[string]string{
+			tempFile.Name(): filePath,
+		})
 
 }
 

--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -377,7 +377,7 @@ func (s *Store) writeFileContents(filePath string, contents []byte) error {
 	}
 
 	// remove the temporary file at the end
-	defer os.Remove(tempFile.Name())
+	defer os.Remove(tempFile.Name()) // nolint: errcheck
 
 	// encode contents to base64 and add a newline at the end
 	// newline at the end is needed to be able to parse files one be one
@@ -386,13 +386,13 @@ func (s *Store) writeFileContents(filePath string, contents []byte) error {
 
 	// write content to the temporary file
 	if _, err = tempFile.WriteString(encodedContents); err != nil {
-		tempFile.Close()
-		return errors.Wrap(err, "Error writing to temporary file")
+		tempFile.Close() // nolint: errcheck
+		return errors.Wrap(err, "Failed writing to temporary file")
 	}
 
-	// not using defer to ensure than we have closed the file before copying it
+	// not using defer to ensure that we have closed the file before copying it
 	if err = tempFile.Close(); err != nil {
-		return errors.Wrap(err, "Error closing temporary file")
+		return errors.Wrap(err, "Failed closing temporary file")
 	}
 
 	// copy temporary file content to container

--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -381,7 +381,8 @@ func (s *Store) writeFileContents(filePath string, contents []byte) error {
 	defer os.Remove(tempFile.Name())
 
 	// Write content to the temporary file
-	_, err = tempFile.Write(contents)
+	encodedContent := base64.StdEncoding.EncodeToString(contents)
+	_, err = tempFile.WriteString(encodedContent)
 	if err != nil {
 		fmt.Println("Error writing to temporary file:", err)
 		return err

--- a/pkg/platform/local/platform_test.go
+++ b/pkg/platform/local/platform_test.go
@@ -172,27 +172,22 @@ func (suite *localPlatformTestSuite) TestVeryBigFunction() {
 	// a small hack to set up required environment
 	_, _ = suite.platform.localStore.GetFunctions(&functionconfig.Meta{})
 
-	for _, testCase := range []struct {
-		name          string
-		stringToWrite string
-	}{
-		{
-			name:          "Try to write a very big file to local storage",
-			stringToWrite: strings.Repeat("t", 200000),
+	config := &functionconfig.ConfigWithStatus{
+		Config: functionconfig.Config{
+			Spec: functionconfig.Spec{
+				Build: functionconfig.Build{
+					FunctionSourceCode: strings.Repeat("t", 200000),
+				},
+			},
 		},
-	} {
-		suite.Run(testCase.name, func() {
-
-			config := &functionconfig.ConfigWithStatus{Config: functionconfig.Config{Spec: functionconfig.Spec{Build: functionconfig.Build{FunctionSourceCode: testCase.stringToWrite}}}}
-
-			err := suite.platform.localStore.CreateOrUpdateFunction(config)
-			suite.Require().NoError(err)
-
-			// check that function can be parsed successfully
-			_, err = suite.platform.localStore.GetFunctions(&functionconfig.Meta{Namespace: "nuclio"})
-			suite.Require().NoError(err)
-		})
 	}
+
+	err := suite.platform.localStore.CreateOrUpdateFunction(config)
+	suite.Require().NoError(err)
+
+	// check that function can be parsed successfully
+	_, err = suite.platform.localStore.GetFunctions(&functionconfig.Meta{Namespace: "nuclio"})
+	suite.Require().NoError(err)
 }
 
 func TestKubePlatformTestSuite(t *testing.T) {

--- a/pkg/platform/local/platform_test.go
+++ b/pkg/platform/local/platform_test.go
@@ -20,6 +20,7 @@ package local
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
@@ -162,6 +163,29 @@ func (suite *localPlatformTestSuite) TestResolveFunctionSpecRequestMemory() {
 				},
 			})
 			suite.Require().Equal(testCase.expectedMemory, cpus)
+		})
+	}
+}
+
+func (suite *localPlatformTestSuite) TestVeryBigFunction() {
+
+	_, _ = suite.platform.localStore.GetFunctions(&functionconfig.Meta{})
+
+	for _, testCase := range []struct {
+		name          string
+		stringToWrite string
+	}{
+		{
+			name:          "Try to write a very big file to local storage",
+			stringToWrite: strings.Repeat("t", 200000),
+		},
+	} {
+		suite.Run(testCase.name, func() {
+
+			config := &functionconfig.ConfigWithStatus{Config: functionconfig.Config{Spec: functionconfig.Spec{Build: functionconfig.Build{FunctionSourceCode: testCase.stringToWrite}}}}
+
+			err := suite.platform.localStore.CreateOrUpdateFunction(config)
+			suite.Require().NoError(err)
 		})
 	}
 }

--- a/pkg/platform/local/platform_test.go
+++ b/pkg/platform/local/platform_test.go
@@ -20,7 +20,6 @@ package local
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
@@ -163,38 +162,6 @@ func (suite *localPlatformTestSuite) TestResolveFunctionSpecRequestMemory() {
 				},
 			})
 			suite.Require().Equal(testCase.expectedMemory, cpus)
-		})
-	}
-}
-
-func (suite *localPlatformTestSuite) TestVeryBigFunction() {
-
-	_, err := suite.platform.dockerClient.RunContainer("gcr.io/iguazio/alpine:3.17", &dockerclient.RunOptions{
-		Remove:           true,
-		Command:          `/bin/sh -c "/bin/sleep 6h"`,
-		Stdout:           nil,
-		ImageMayNotExist: true,
-		ContainerName:    "nuclio-local-storage-reader",
-	})
-	suite.Require().NoError(err)
-
-	defer suite.platform.dockerClient.StopContainer("nuclio-local-storage-reader")
-
-	for _, testCase := range []struct {
-		name          string
-		stringToWrite string
-	}{
-		{
-			name:          "Try to write a very big file to local storage",
-			stringToWrite: strings.Repeat("t", 200000),
-		},
-	} {
-		suite.Run(testCase.name, func() {
-
-			config := &functionconfig.ConfigWithStatus{Config: functionconfig.Config{Spec: functionconfig.Spec{Build: functionconfig.Build{FunctionSourceCode: testCase.stringToWrite}}}}
-
-			err := suite.platform.localStore.CreateOrUpdateFunction(config)
-			suite.Require().NoError(err)
 		})
 	}
 }

--- a/pkg/platform/local/platform_test.go
+++ b/pkg/platform/local/platform_test.go
@@ -20,6 +20,7 @@ package local
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
@@ -162,6 +163,26 @@ func (suite *localPlatformTestSuite) TestResolveFunctionSpecRequestMemory() {
 				},
 			})
 			suite.Require().Equal(testCase.expectedMemory, cpus)
+		})
+	}
+}
+
+func (suite *localPlatformTestSuite) TestVeryBigFunction() {
+	for _, testCase := range []struct {
+		name          string
+		stringToWrite string
+	}{
+		{
+			name:          "Try to write a very big file to local storage",
+			stringToWrite: strings.Repeat("t", 200000),
+		},
+	} {
+		suite.Run(testCase.name, func() {
+
+			config := &functionconfig.ConfigWithStatus{Config: functionconfig.Config{Spec: functionconfig.Spec{Build: functionconfig.Build{FunctionSourceCode: testCase.stringToWrite}}}}
+
+			err := suite.platform.localStore.CreateOrUpdateFunction(config)
+			suite.Require().NoError(err)
 		})
 	}
 }

--- a/pkg/platform/local/platform_test.go
+++ b/pkg/platform/local/platform_test.go
@@ -169,7 +169,7 @@ func (suite *localPlatformTestSuite) TestResolveFunctionSpecRequestMemory() {
 
 func (suite *localPlatformTestSuite) TestVeryBigFunction() {
 
-	// a small hack to set up required environment
+	// a small hack to set up local storage reader
 	_, _ = suite.platform.localStore.GetFunctions(&functionconfig.Meta{})
 
 	config := &functionconfig.ConfigWithStatus{

--- a/pkg/platform/local/platform_test.go
+++ b/pkg/platform/local/platform_test.go
@@ -168,6 +168,18 @@ func (suite *localPlatformTestSuite) TestResolveFunctionSpecRequestMemory() {
 }
 
 func (suite *localPlatformTestSuite) TestVeryBigFunction() {
+
+	_, err := suite.platform.dockerClient.RunContainer("gcr.io/iguazio/alpine:3.17", &dockerclient.RunOptions{
+		Remove:           true,
+		Command:          `/bin/sh -c "/bin/sleep 6h"`,
+		Stdout:           nil,
+		ImageMayNotExist: true,
+		ContainerName:    "nuclio-local-storage-reader",
+	})
+	suite.Require().NoError(err)
+
+	defer suite.platform.dockerClient.StopContainer("nuclio-local-storage-reader")
+
 	for _, testCase := range []struct {
 		name          string
 		stringToWrite string

--- a/pkg/platform/local/platform_test.go
+++ b/pkg/platform/local/platform_test.go
@@ -169,6 +169,7 @@ func (suite *localPlatformTestSuite) TestResolveFunctionSpecRequestMemory() {
 
 func (suite *localPlatformTestSuite) TestVeryBigFunction() {
 
+	// a small hack to set up required environment
 	_, _ = suite.platform.localStore.GetFunctions(&functionconfig.Meta{})
 
 	for _, testCase := range []struct {
@@ -185,6 +186,10 @@ func (suite *localPlatformTestSuite) TestVeryBigFunction() {
 			config := &functionconfig.ConfigWithStatus{Config: functionconfig.Config{Spec: functionconfig.Spec{Build: functionconfig.Build{FunctionSourceCode: testCase.stringToWrite}}}}
 
 			err := suite.platform.localStore.CreateOrUpdateFunction(config)
+			suite.Require().NoError(err)
+
+			// check that function can be parsed successfully
+			_, err = suite.platform.localStore.GetFunctions(&functionconfig.Meta{Namespace: "nuclio"})
 			suite.Require().NoError(err)
 		})
 	}

--- a/pkg/platform/local/test/platform_test.go
+++ b/pkg/platform/local/test/platform_test.go
@@ -312,22 +312,6 @@ func (suite *TestSuite) TestDeployFunctionDisabledDefaultHttpTrigger() {
 		})
 }
 
-func (suite *TestSuite) TestDeployFunctionWithVeryLongSourceCode() {
-	createFunctionOptions := suite.getDeployOptions("very-long-func")
-	createFunctionOptions.FunctionConfig.Meta.Namespace = suite.namespace
-	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = strings.Repeat("t", 200000)
-	localPlatform := suite.Platform.(*local.Platform)
-	suite.DeployFunction(createFunctionOptions,
-
-		// sanity
-		func(deployResult *platform.CreateFunctionResult) bool {
-			suite.Require().NotNil(deployResult)
-			containerId := suite.getFunctionContainerId(localPlatform, &createFunctionOptions.FunctionConfig)
-			suite.Require().NotEqual("", containerId)
-			return true
-		})
-}
-
 func (suite *TestSuite) TestDeployFunctionDisablePublishingPorts() {
 	createFunctionOptions := suite.getDeployOptions("no-publish-ports")
 	createFunctionOptions.FunctionConfig.Meta.Namespace = suite.namespace

--- a/pkg/platform/local/test/platform_test.go
+++ b/pkg/platform/local/test/platform_test.go
@@ -312,6 +312,22 @@ func (suite *TestSuite) TestDeployFunctionDisabledDefaultHttpTrigger() {
 		})
 }
 
+func (suite *TestSuite) TestDeployFunctionWithVeryLongSourceCode() {
+	createFunctionOptions := suite.getDeployOptions("very-long-func")
+	createFunctionOptions.FunctionConfig.Meta.Namespace = suite.namespace
+	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = strings.Repeat("t", 200000)
+	localPlatform := suite.Platform.(*local.Platform)
+	suite.DeployFunction(createFunctionOptions,
+
+		// sanity
+		func(deployResult *platform.CreateFunctionResult) bool {
+			suite.Require().NotNil(deployResult)
+			containerId := suite.getFunctionContainerId(localPlatform, &createFunctionOptions.FunctionConfig)
+			suite.Require().NotEqual("", containerId)
+			return true
+		})
+}
+
 func (suite *TestSuite) TestDeployFunctionDisablePublishingPorts() {
 	createFunctionOptions := suite.getDeployOptions("no-publish-ports")
 	createFunctionOptions.FunctionConfig.Meta.Namespace = suite.namespace


### PR DESCRIPTION
This PR addresses #3261 issue, where user faced a `docker exec` error, because argument was too long (> 131072, see restrictions [here](https://man7.org/linux/man-pages/man2/execve.2.html) for argument `MAX_ARG_STRLEN`)

To address this issue, I've updated the approach for writing files. Instead of using docker exec to write directly to the container, we now create a temporary file locally, copy it to the storage container, and then delete the temporary file.

Test fails on the old version:
![image](https://github.com/nuclio/nuclio/assets/35141662/3e7f48b4-0a8c-451a-8929-2a9f5cc8d53a)
