### PR TITLE
[Builder] Fix Github archive url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -890,8 +890,9 @@ generate-nuctl-docs:
 # PATCH REMOTE SYSTEM
 #
 
-PATCH_HOST_IP ?= $(shell cat hack/scripts/patch-remote/patch_env.yml | awk '/HOST_IP/ {print $$2}')
-PATCH_USERNAME ?= $(shell cat hack/scripts/patch-remote/patch_env.yml | awk '/SSH_USER/ {print $$2}')
+PATCH_ENV_FILE_PATH = hack/scripts/patch-remote/patch_env.yml
+PATCH_HOST_IP ?= $(shell [ -f $(PATCH_ENV_FILE_PATH) ] && awk '/HOST_IP/ {print $$2}' $(PATCH_ENV_FILE_PATH))
+PATCH_USERNAME ?= $(shell [ -f $(PATCH_ENV_FILE_PATH) ] && awk '/SSH_USER/ {print $$2}' $(PATCH_ENV_FILE_PATH))
 
 hack/scripts/patch-remote/.ssh/key_$(PATCH_HOST_IP)_$(PATCH_USERNAME):
 	mkdir -p hack/scripts/patch-remote/.ssh

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -685,7 +685,7 @@ func (b *Builder) resolveFunctionPath(ctx context.Context, functionPath string) 
 
 	// if the function path is a URL, type is Github or S3 - first download the file
 	// for backwards compatibility, don't check for entry type url specifically
-	if functionPath, err = b.resolveFunctionPathFromURL(functionPath, codeEntryType); err != nil {
+	if functionPath, err = b.resolveFunctionPathFromURL(ctx, functionPath, codeEntryType); err != nil {
 		return "", "", errors.Wrap(err, "Failed to download function from the given URL")
 	}
 
@@ -1609,11 +1609,13 @@ func (b *Builder) renderDependantImageURL(imageURL string, dependantImagesRegist
 	return renderedImageURL, nil
 }
 
-func (b *Builder) resolveFunctionPathFromURL(functionPath string, codeEntryType string) (string, error) {
+func (b *Builder) resolveFunctionPathFromURL(ctx context.Context, functionPath string, codeEntryType string) (string, error) {
 	var err error
 
 	if common.IsURL(functionPath) || codeEntryType == S3EntryType {
 		if codeEntryType == GithubEntryType {
+			b.logger.WarnCtx(ctx, "'Github' code entry type is deprecated and will be removed in Nuclio 1.16.x, "+
+				"please use 'Git' entry type instead")
 			functionPath, err = b.getFunctionPathFromGithubURL(functionPath)
 			if err != nil {
 				return "", errors.Wrapf(err, "Failed to infer function path of github entry type")

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -67,7 +67,6 @@ const (
 	ImageEntryType      = "image"
 	SourceCodeEntryType = "sourceCode"
 
-	// Deprecated: use GitEntryType
 	// TODO: Remove in 1.16.0
 	GithubEntryType = "github"
 )

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -66,9 +66,10 @@ const (
 	S3EntryType         = "s3"
 	ImageEntryType      = "image"
 	SourceCodeEntryType = "sourceCode"
-
 	// TODO: Remove in 1.16.0
 	GithubEntryType = "github"
+
+	GithubURLRegexPattern = "^.*://.*github.com(?:/repos)?/(?P<org>[^/]+)/(?P<repo>[^/]+)/?$"
 )
 
 // holds parameters for things that are required before a runtime can be initialized
@@ -126,6 +127,9 @@ type Builder struct {
 	versionInfo *version.Info
 
 	gitClient gitcommon.Client
+
+	// TODO: Remove in 1.16.x once we remove the deprecated `github` entry type
+	githubRegex *regexp.Regexp
 }
 
 // NewBuilder returns a new builder
@@ -137,6 +141,9 @@ func NewBuilder(parentLogger logger.Logger, platform platform.Platform, s3Client
 		platform:    platform,
 		s3Client:    s3Client,
 		versionInfo: version.Get(),
+
+		// TODO: Remove in 1.16.x once we remove the deprecated `github` entry type
+		githubRegex: regexp.MustCompile(GithubURLRegexPattern),
 	}
 
 	newBuilder.initializeSupportedRuntimes()
@@ -747,50 +754,48 @@ func (b *Builder) validateAndParseS3Attributes(attributes map[string]interface{}
 func (b *Builder) getFunctionPathFromGithubURL(functionPath string) (string, error) {
 	if branch, ok := b.options.FunctionConfig.Spec.Build.CodeEntryAttributes["branch"]; ok {
 		var err error
-		functionPath, err = b.generateGithubZipballURL(functionPath, branch.(string))
-		if err != nil {
+		if functionPath, err = b.generateGithubZipballURL(functionPath, branch.(string)); err != nil {
 			return "", errors.Wrap(err, "Failed to generate github zipball URL")
 		}
 	} else {
-		return "", errors.New("If code entry type is github, branch must be provided")
+		return "", errors.New("If code entry type is GitHub, branch must be provided")
 	}
 	return functionPath, nil
 }
 
+// generateGithubZipballURL generates the URL for downloading the branch's zip archive from GitHub
 func (b *Builder) generateGithubZipballURL(functionPath, branch string) (string, error) {
 	// split the URL to get the ORG and REPO using regex
-	org, repo, err := b.resolveGithubUrlComponents(functionPath)
+	org, repo, err := b.extractOrgAndRepoFromGithubURL(functionPath)
 	if err != nil {
-		return "", errors.Wrap(err, "Failed to resolve github URL components")
+		return "", errors.Wrap(err, "Failed to resolve GitHub URL components")
 	}
 
-	// create the URL for downloading the zipball Github api
+	// create the URL for downloading the zipball GitHub api
 	return fmt.Sprintf("https://api.github.com/repos/%s/%s/zipball/%s", org, repo, branch), nil
 }
 
-func (b *Builder) resolveGithubUrlComponents(url string) (string, string, error) {
-	githubURLPattern := "^.*://.*github.com(?:/repos)?/(?P<org>[^/]+)/(?P<repo>[^/]+)/?$"
-	exp := regexp.MustCompile(githubURLPattern)
-	match := exp.FindStringSubmatch(url)
-
+// extractOrgAndRepoFromGithubURL extracts the org and repo from a GitHub URL
+func (b *Builder) extractOrgAndRepoFromGithubURL(url string) (string, string, error) {
+	match := b.githubRegex.FindStringSubmatch(url)
 	if match == nil {
-		return "", "", errors.New("Failed to match github URL")
+		return "", "", errors.New("Failed to match GitHub URL")
 	}
 
 	result := map[string]string{}
-	for i, name := range exp.SubexpNames() {
+	for i, name := range b.githubRegex.SubexpNames() {
 		if i != 0 && name != "" {
 			result[name] = match[i]
 		}
 	}
 
-	_, orgOk := result["org"]
-	_, repoOk := result["repo"]
+	org, orgOk := result["org"]
+	repo, repoOk := result["repo"]
 	if !orgOk || !repoOk {
-		return "", "", errors.New("Failed to extract org and repo from github URL")
+		return "", "", errors.New("Failed to extract org and repo from GitHub URL")
 	}
 
-	return result["org"], result["repo"], nil
+	return org, repo, nil
 }
 
 func (b *Builder) extractFunctionArchive(ctx context.Context, functionPath string) (string, error) {
@@ -1614,7 +1619,7 @@ func (b *Builder) resolveFunctionPathFromURL(ctx context.Context, functionPath s
 
 	if common.IsURL(functionPath) || codeEntryType == S3EntryType {
 		if codeEntryType == GithubEntryType {
-			b.logger.WarnCtx(ctx, "'Github' code entry type is deprecated and will be removed in Nuclio 1.16.x, "+
+			b.logger.WarnCtx(ctx, "'GitHub' code entry type is deprecated and will be removed in Nuclio 1.16.x, "+
 				"please use 'Git' entry type instead")
 			functionPath, err = b.getFunctionPathFromGithubURL(functionPath)
 			if err != nil {

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -880,7 +880,7 @@ func (suite *testSuite) TestResolveRepoName() {
 	}
 }
 
-func (suite *testSuite) TestResolveGithubUrlComponents() {
+func (suite *testSuite) TestExtractOrgAndRepoFromGithubURL() {
 	for _, testCase := range []struct {
 		name          string
 		url           string
@@ -939,7 +939,7 @@ func (suite *testSuite) TestResolveGithubUrlComponents() {
 		},
 	} {
 		suite.Run(testCase.name, func() {
-			org, repo, err := suite.builder.resolveGithubUrlComponents(testCase.url)
+			org, repo, err := suite.builder.extractOrgAndRepoFromGithubURL(testCase.url)
 			if testCase.expectedError {
 				suite.Require().Error(err)
 			} else {


### PR DESCRIPTION
When using `Github` code entry type with a fine-grained token, downloading the file from the URL `"https://github.com/<ORG>/<REPO>/archive/<BRANCH>.zip"` doesn't work, as the fined grained token only works with the Github API.
In this PR we replace the URL with the archive API url: `"https://api.github.com/repos/<ORG>/<REPO>/zipball/<BRANCH>"`, which works both with Github's fine-grained tokens and classic tokens.

Additionally, since the `Git` code entry type is uses the go-git client and is a lot more resilient and robust, we deprecate the `Github` code entry type and will encourage users to use `Git` instead.