### PR TITLE
[Docs] Fix nuctl docs link

### DIFF
--- a/docs/reference/nuctl/index.rst
+++ b/docs/reference/nuctl/index.rst
@@ -11,4 +11,4 @@ Nuctl
    :maxdepth: 1
   
    nuctl
-   cli-docs/index
+   cli/index


### PR DESCRIPTION
We renamed the folder from `cli-docs` to `cli`. This is the place where we forgot to do this and as a result there is no proper link to generated documentation in our website.