### PR TITLE
[Ingress] Override ssl redirect annotation only if it is not set

### DIFF
--- a/pkg/platform/kube/ingress/ingress.go
+++ b/pkg/platform/kube/ingress/ingress.go
@@ -333,10 +333,12 @@ func (m *Manager) compileAnnotations(ctx context.Context, spec Spec) (map[string
 			enableSSLRedirect = *spec.EnableSSLRedirect
 		}
 
+		// if SSL redirect is enabled, set the annotation to true, otherwise set it to false unless it's already set
+		SSLRedirectAnnotation := "nginx.ingress.kubernetes.io/ssl-redirect"
 		if enableSSLRedirect {
-			ingressAnnotations["nginx.ingress.kubernetes.io/ssl-redirect"] = "true"
-		} else {
-			ingressAnnotations["nginx.ingress.kubernetes.io/ssl-redirect"] = "false"
+			ingressAnnotations[SSLRedirectAnnotation] = "true"
+		} else if _, ok := ingressAnnotations[SSLRedirectAnnotation]; !ok {
+			ingressAnnotations[SSLRedirectAnnotation] = "false"
 		}
 	}
 


### PR DESCRIPTION
The `ssl-redirect` nginx annotation is determined only by the value in the platform config, and if it is set on an ingress explicitly (e.g. on an API Gateway), it will always be overridden by the value from the platform config.

Instead:
- If the platform config enables SSL Redirect: set to True
- If not, only set to false if not already explicitly set

Related to https://iguazio.atlassian.net/browse/ML-7108