### PR TITLE
[ContainerImageBuilderPusher] Bump awscli and kaniko versions

### DIFF
--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -90,7 +90,7 @@ func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) 
 	}
 	if containerBuilderConfiguration.AWSCLIImage == "" {
 		containerBuilderConfiguration.AWSCLIImage = common.GetEnvOrDefaultString("NUCLIO_AWS_CLI_CONTAINER_IMAGE",
-			"amazon/aws-cli:2.7.10")
+			"amazon/aws-cli:2.17.16")
 	}
 	if containerBuilderConfiguration.RegistryProviderSecretName == "" {
 		containerBuilderConfiguration.RegistryProviderSecretName = common.GetEnvOrDefaultString("NUCLIO_KANIKO_REGISTRY_PROVIDER_AUTH_SECRET_NAME",
@@ -98,7 +98,7 @@ func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) 
 	}
 	if containerBuilderConfiguration.KanikoImage == "" {
 		containerBuilderConfiguration.KanikoImage = common.GetEnvOrDefaultString("NUCLIO_KANIKO_CONTAINER_IMAGE",
-			"gcr.io/kaniko-project/executor:v1.9.0")
+			"gcr.io/kaniko-project/executor:v1.23.2")
 	}
 	if containerBuilderConfiguration.KanikoImagePullPolicy == "" {
 		containerBuilderConfiguration.KanikoImagePullPolicy = common.GetEnvOrDefaultString(


### PR DESCRIPTION
- Older versions do not support pod-identity-association auth