### PR TITLE
[Controller] Don't override default container annotation if exists [1.13.x]

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1781,9 +1781,10 @@ func (lc *lazyClient) getPodAnnotations(function *nuclioio.NuclioFunction) (map[
 		annotations[annotationKey] = annotationValue
 	}
 
-	// if a sidecar is defined, configure the processor container as default
-	if len(function.Spec.Sidecars) > 0 {
-		annotations["kubectl.kubernetes.io/default-container"] = client.FunctionContainerName
+	// set default container annotation if not exists, for logging purposes
+	defaultContainerAnnotation := "kubectl.kubernetes.io/default-container"
+	if _, ok := annotations[defaultContainerAnnotation]; !ok {
+		annotations[defaultContainerAnnotation] = client.FunctionContainerName
 	}
 
 	return annotations, nil


### PR DESCRIPTION
If user wants to set one of the sidecar containers as the default container, don't override the annotation with the nuclio container.

Related to https://iguazio.atlassian.net/browse/ML-7345