### PR TITLE
[Dashboard] Display kaniko pod warning events in the build logs

### DIFF
--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -734,7 +734,7 @@ func (k *Kaniko) getPodEvents(ctx context.Context, namespace, podName string) *v
 		k.logger.WarnWithCtx(ctx,
 			"Failed to list events for Kaniko pod",
 			"podName", podName,
-			"err", err)
+			"err", err.Error())
 		return nil
 	}
 	return events

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -647,7 +647,7 @@ func (k *Kaniko) resolveFailFast(ctx context.Context, buildLogger logger.Logger,
 					if errorMessage != lastError {
 						buildLogger.WarnWithCtx(ctx, fmt.Sprintf("%s event for Kaniko pod", failure.Reason),
 							"podName", jobPod.Name,
-							"message", failure.Message)
+							"reason", failure.Message)
 						lastError = errorMessage
 					}
 				}

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -507,7 +507,12 @@ func (k *Kaniko) compileJobName(ctx context.Context, image string) string {
 	return jobName
 }
 
-func (k *Kaniko) waitForJobCompletion(ctx context.Context, namespace string, jobName string, buildTimeoutSeconds int64, readinessTimoutSeconds int, buildLogger logger.Logger) error {
+func (k *Kaniko) waitForJobCompletion(ctx context.Context,
+	namespace string,
+	jobName string,
+	buildTimeoutSeconds int64,
+	readinessTimoutSeconds int,
+	buildLogger logger.Logger) error {
 	k.logger.DebugWithCtx(ctx,
 		"Waiting for job completion",
 		"buildTimeoutSeconds", buildTimeoutSeconds,
@@ -600,7 +605,11 @@ func (k *Kaniko) waitForJobCompletion(ctx context.Context, namespace string, job
 	return fmt.Errorf("Job has timed out. Job logs:\n%s", jobLogs)
 }
 
-func (k *Kaniko) resolveFailFast(ctx context.Context, buildLogger logger.Logger, namespace, jobName string, readinessTimout time.Duration) error {
+func (k *Kaniko) resolveFailFast(ctx context.Context,
+	buildLogger logger.Logger,
+	namespace,
+	jobName string,
+	readinessTimout time.Duration) error {
 
 	// fail fast timeout is max(readinessTimeout, 5 minutes)
 	if readinessTimout < 5*time.Minute {
@@ -645,9 +654,11 @@ func (k *Kaniko) resolveFailFast(ctx context.Context, buildLogger logger.Logger,
 
 					// if an error has changed, print it to the logs
 					if errorMessage != lastError {
-						buildLogger.WarnWithCtx(ctx, fmt.Sprintf("%s event for Kaniko pod", failure.Reason),
-							"podName", jobPod.Name,
-							"reason", failure.Message)
+						buildLogger.WarnWithCtx(ctx,
+							"Kaniko pod received a warning event",
+							"eventReason", failure.Reason,
+							"eventMessage", failure.Message,
+							"podName", jobPod.Name)
 						lastError = errorMessage
 					}
 				}

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -618,8 +618,12 @@ func (k *Kaniko) resolveFailFast(ctx context.Context, buildLogger logger.Logger,
 				"jobName", jobName,
 				"failFastTimeoutDuration", readinessTimout.String())
 
-			return fmt.Errorf("Job was not completed in time, job name: %s. Error: %s ", jobName,
-				lastError)
+			if lastError != "" {
+				return fmt.Errorf("Job was not completed in time, job name: %s. Error: %s ", jobName,
+					lastError)
+			} else {
+				return fmt.Errorf("Job was not completed in time, job name: %s", jobName)
+			}
 		default:
 			jobPod, err := k.getJobPod(ctx, jobName, namespace, true)
 			if err != nil {

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 
 	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
 	"k8s.io/api/core/v1"
 )
 
@@ -52,6 +53,8 @@ type BuildOptions struct {
 	FunctionServiceAccount  string
 	BuilderServiceAccount   string
 	SecurityContext         *v1.PodSecurityContext
+
+	BuildLogger logger.Logger
 }
 
 type ContainerBuilderConfiguration struct {

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1119,6 +1119,7 @@ func (b *Builder) buildProcessorImage(ctx context.Context) (string, error) {
 			ReadinessTimeoutSeconds: b.platform.GetConfig().GetFunctionReadinessTimeoutOrDefault(
 				b.options.FunctionConfig.Spec.ReadinessTimeoutSeconds),
 			SecurityContext: b.options.FunctionConfig.Spec.SecurityContext,
+			BuildLogger:     b.logger,
 		})
 
 	return taggedImageName, err


### PR DESCRIPTION
This PR addresses the issue where the Kaniko pod remains in a Pending status (e.g., when it is not schedulable). Previously, no information was provided to assist users in troubleshooting this issue. With this PR, the Kubernetes events for the Kaniko pod are now checked, allowing real-time warnings to be displayed in the build logs.

Build log example: 
![image](https://github.com/user-attachments/assets/7afb4bd3-32bb-4a6c-bd5d-137fee647bc6)



jira - iguazio.atlassian.net/browse/NUC-232