### PR TITLE
[API Gateways] Fix filtering api gateways by project

### DIFF
--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1413,7 +1413,7 @@ func (p *Platform) getApiGateways(ctx context.Context, getAPIGatewaysOptions *pl
 
 	apiGateways, err := p.consumer.NuclioClientSet.NuclioV1beta1().
 		NuclioAPIGateways(getAPIGatewaysOptions.Namespace).
-		List(ctx, metav1.ListOptions{})
+		List(ctx, metav1.ListOptions{LabelSelector: getAPIGatewaysOptions.Labels})
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to list API gateways")
 	}


### PR DESCRIPTION
In this [pr](https://github.com/nuclio/nuclio/pull/3262/files) filtering by project was broken by removing `LabelSelector: getAPIGatewaysOptions.Labels` 

This change wasn't released in any version yet, so no backporting needed.