### PR TITLE
[Async processing] Add mode to http trigger configuration

### DIFF
--- a/pkg/processor/trigger/http/types.go
+++ b/pkg/processor/trigger/http/types.go
@@ -43,7 +43,18 @@ type Configuration struct {
 
 	// Used to disable port publishing for the HTTP trigger on docker platform
 	DisablePortPublishing bool
+
+	Mode TriggerMode `json:"mode,omitempty"`
 }
+
+type TriggerMode string
+
+const (
+	TriggerModeAsync TriggerMode = "async"
+	TriggerModeSync  TriggerMode = "sync"
+
+	DefaultTriggerMode = TriggerModeSync
+)
 
 func NewConfiguration(id string,
 	triggerConfiguration *functionconfig.Trigger,
@@ -68,6 +79,10 @@ func NewConfiguration(id string,
 
 	if newConfiguration.ReadBufferSize == 0 {
 		newConfiguration.ReadBufferSize = DefaultReadBufferSize
+	}
+
+	if newConfiguration.Mode == "" {
+		newConfiguration.Mode = DefaultTriggerMode
 	}
 
 	if newConfiguration.MaxRequestBodySize == 0 {

--- a/pkg/processor/trigger/http/types.go
+++ b/pkg/processor/trigger/http/types.go
@@ -32,17 +32,17 @@ const InternalHealthPath = "/__internal/health"
 
 type Configuration struct {
 	trigger.Configuration
-	ReadBufferSize int
+	ReadBufferSize int `json:"readBufferSize,omitempty"`
 
 	// NOTE: Modifying the max request body size affect with gradually memory consumption increasing
 	// as the entire request being read into the memory
 	// https://github.com/valyala/fasthttp/issues/667#issuecomment-540965683
-	MaxRequestBodySize int
-	ReduceMemoryUsage  bool
-	CORS               *cors.CORS
+	MaxRequestBodySize int        `json:"maxRequestBodySize,omitempty"`
+	ReduceMemoryUsage  bool       `json:"reduceMemoryUsage,omitempty"`
+	CORS               *cors.CORS `json:"cors,omitempty"`
 
 	// Used to disable port publishing for the HTTP trigger on docker platform
-	DisablePortPublishing bool
+	DisablePortPublishing bool `json:"disablePortPublishing,omitempty"`
 
 	Mode TriggerMode `json:"mode,omitempty"`
 }


### PR DESCRIPTION
Part of new async event processing feature which defines two modes for http trigger.


Jira - https://iguazio.atlassian.net/browse/NUC-244