### PR TITLE
[Releaser] Remove extra chart directories

### DIFF
--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -22,7 +22,7 @@ home: https://nuclio.io
 sources:
   - https://github.com/nuclio/nuclio
 maintainers:
-  - name: Liran Ben Gida
-    email: liranb@iguazio.com
   - name: Tomer Shor
-    email: tomers@iguazio.com
+    email: tomer_shor@mckinsey.com
+  - name: Kate Molchanova
+    email: ekaterina_molchanova@mckinsey.com

--- a/hack/scripts/releaser/releaser_test.go
+++ b/hack/scripts/releaser/releaser_test.go
@@ -121,15 +121,14 @@ func (suite *ReleaserTestSuite) TestBumpHelmChartVersion() {
 		Return(cmdrunner.RunResult{}, nil).
 		Once()
 
-	// replace image tag versions X times (e.g.: gke, helm aks)
+	// replace image tag versions
 	suite.cmdRunner.On("Run",
 		mock.Anything,
 		mock.MatchedBy(func(cmd string) bool {
 			return strings.HasPrefix(cmd, "git grep -lF")
 		}),
 		mock.Anything).
-		Return(cmdrunner.RunResult{}, nil).
-		Times(len(suite.releaser.resolveSupportedChartDirs()))
+		Return(cmdrunner.RunResult{}, nil)
 
 	// replace app version
 	suite.cmdRunner.On("Run",
@@ -149,6 +148,18 @@ func (suite *ReleaserTestSuite) TestBumpHelmChartVersion() {
 		}),
 		mock.Anything).
 		Return(cmdrunner.RunResult{}, nil).
+		Once()
+
+	// status
+	suite.cmdRunner.On("Run",
+		mock.Anything,
+		mock.MatchedBy(func(cmd string) bool {
+			return strings.HasPrefix(cmd, `git status`)
+		}),
+		mock.Anything).
+		Return(cmdrunner.RunResult{
+			Output: "M helm/Chart.yaml\nM helm/values.yaml",
+		}, nil).
 		Once()
 
 	// commit


### PR DESCRIPTION
The cloud-specific chart directories were already removed in v1.7.3 (https://github.com/nuclio/nuclio/pull/2407), so performing actions on those directories just causes noise in the releaser script.