### PR TITLE
[Processor] Fix ExplicitAck on 2 and more triggers of the same type

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1799,7 +1799,7 @@ func (ap *Platform) enrichTriggers(ctx context.Context, functionConfig *function
 
 		if triggerInstance.WorkerAllocatorName == "" {
 			triggerInstance.WorkerAllocatorName = triggerName
-			ap.Logger.InfoWithCtx(ctx, "WorkerAllocatorName enriched",
+			ap.Logger.DebugWithCtx(ctx, "Enriched WorkerAllocatorName",
 				"triggerName", triggerName,
 				"triggerKind", triggerInstance.Kind,
 				"WorkerAllocatorName", triggerInstance.WorkerAllocatorName,

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1797,6 +1797,15 @@ func (ap *Platform) enrichTriggers(ctx context.Context, functionConfig *function
 			}
 		}
 
+		if triggerInstance.WorkerAllocatorName == "" {
+			triggerInstance.WorkerAllocatorName = triggerName
+			ap.Logger.InfoWithCtx(ctx, "WorkerAllocatorName enriched",
+				"triggerName", triggerName,
+				"triggerKind", triggerInstance.Kind,
+				"WorkerAllocatorName", triggerInstance.WorkerAllocatorName,
+			)
+		}
+
 		functionConfig.Spec.Triggers[triggerName] = triggerInstance
 	}
 

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -1072,9 +1072,10 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 			},
 			expectedEnrichedTriggers: map[string]functionconfig.Trigger{
 				"some-trigger": {
-					Kind:       "http",
-					NumWorkers: 1,
-					Name:       "some-trigger",
+					Kind:                "http",
+					NumWorkers:          1,
+					Name:                "some-trigger",
+					WorkerAllocatorName: "some-trigger",
 				},
 			},
 		},
@@ -1084,6 +1085,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 			triggers: nil,
 			expectedEnrichedTriggers: func() map[string]functionconfig.Trigger {
 				defaultHTTPTrigger := functionconfig.GetDefaultHTTPTrigger()
+				defaultHTTPTrigger.WorkerAllocatorName = defaultHTTPTrigger.Name
 				return map[string]functionconfig.Trigger{
 					defaultHTTPTrigger.Name: defaultHTTPTrigger,
 				}
@@ -1155,15 +1157,17 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 			},
 			expectedEnrichedTriggers: map[string]functionconfig.Trigger{
 				"http-trigger": {
-					Kind:       "http",
-					NumWorkers: 1,
-					Name:       "http-trigger",
+					Kind:                "http",
+					NumWorkers:          1,
+					Name:                "http-trigger",
+					WorkerAllocatorName: "http-trigger",
 				},
 				"kafka-trigger": {
 					Kind:                     "kafka-cluster",
 					Name:                     "kafka-trigger",
 					ExplicitAckMode:          functionconfig.ExplicitAckModeDisable,
 					WorkerTerminationTimeout: functionconfig.DefaultWorkerTerminationTimeout,
+					WorkerAllocatorName:      "kafka-trigger",
 				},
 			},
 			shouldFailValidation: false,

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -639,6 +639,7 @@ func (suite *FunctionKubePlatformTestSuite) TestFunctionTriggersEnrichmentAndVal
 			triggers: nil,
 			expectedEnrichedTriggers: func() map[string]functionconfig.Trigger {
 				defaultHTTPTrigger := functionconfig.GetDefaultHTTPTrigger()
+				defaultHTTPTrigger.WorkerAllocatorName = defaultHTTPTrigger.Name
 				defaultHTTPTrigger.Attributes = map[string]interface{}{
 					"serviceType": suite.platformKubeConfig.DefaultServiceType,
 				}

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -232,7 +232,12 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 			return errors.Wrap(err, "Failed to subscribe to explicit ack control messages")
 		}
 
-		go k.explicitAckHandler(session, explicitAckControlMessageChan, claim.Partition(), claim.Topic())
+		go k.explicitAckHandler(
+			session,
+			explicitAckControlMessageChan,
+			claim.Partition(),
+			claim.Topic(),
+		)
 	}
 
 	k.Logger.DebugWith("Starting claim consumption",
@@ -633,7 +638,11 @@ func (k *kafka) resolveSCRAMClientGeneratorFunc(mechanism sarama.SASLMechanism) 
 
 // explicitAckHandler reads offset data messages from the trigger's control channel, and marks the
 // offset accordingly
-func (k *kafka) explicitAckHandler(session sarama.ConsumerGroupSession, controlMessageChan chan *controlcommunication.ControlMessage, partitionNumber int32, topic string) {
+func (k *kafka) explicitAckHandler(
+	session sarama.ConsumerGroupSession,
+	controlMessageChan chan *controlcommunication.ControlMessage,
+	partitionNumber int32,
+	topic string) {
 
 	k.Logger.InfoWith("Listening for explicit ack control messages")
 

--- a/pkg/processor/trigger/v3iostream/trigger.go
+++ b/pkg/processor/trigger/v3iostream/trigger.go
@@ -192,7 +192,12 @@ func (vs *v3iostream) ConsumeClaim(session streamconsumergroup.Session, claim st
 			return errors.Wrap(err, "Failed to subscribe to explicit ack control messages")
 		}
 
-		go vs.explicitAckHandler(explicitAckControlMessageChan, commitRecordFuncHandler, claim.GetShardID(), claim.GetStreamPath())
+		go vs.explicitAckHandler(
+			explicitAckControlMessageChan,
+			commitRecordFuncHandler,
+			claim.GetShardID(),
+			claim.GetStreamPath(),
+		)
 	}
 
 	// the exit condition is that (a) the Messages() channel was closed and (b) we got a signal telling us
@@ -420,7 +425,11 @@ func (vs *v3iostream) resolveCommitRecordFuncHandler(session streamconsumergroup
 	return commitRecordDefaultFuncHandler
 }
 
-func (vs *v3iostream) explicitAckHandler(controlMessageChan chan *controlcommunication.ControlMessage, commitRecordFuncHandler func(*v3io.StreamRecord), claimShardId int, claimStreamPath string) {
+func (vs *v3iostream) explicitAckHandler(
+	controlMessageChan chan *controlcommunication.ControlMessage,
+	commitRecordFuncHandler func(*v3io.StreamRecord),
+	claimShardId int,
+	claimStreamPath string) {
 
 	vs.Logger.DebugWith("Listening for explicit ack control messages")
 

--- a/pkg/processor/trigger/v3iostream/trigger.go
+++ b/pkg/processor/trigger/v3iostream/trigger.go
@@ -192,7 +192,7 @@ func (vs *v3iostream) ConsumeClaim(session streamconsumergroup.Session, claim st
 			return errors.Wrap(err, "Failed to subscribe to explicit ack control messages")
 		}
 
-		go vs.explicitAckHandler(explicitAckControlMessageChan, commitRecordFuncHandler)
+		go vs.explicitAckHandler(explicitAckControlMessageChan, commitRecordFuncHandler, claim.GetShardID(), claim.GetStreamPath())
 	}
 
 	// the exit condition is that (a) the Messages() channel was closed and (b) we got a signal telling us
@@ -420,8 +420,7 @@ func (vs *v3iostream) resolveCommitRecordFuncHandler(session streamconsumergroup
 	return commitRecordDefaultFuncHandler
 }
 
-func (vs *v3iostream) explicitAckHandler(controlMessageChan chan *controlcommunication.ControlMessage,
-	commitRecordFuncHandler func(*v3io.StreamRecord)) {
+func (vs *v3iostream) explicitAckHandler(controlMessageChan chan *controlcommunication.ControlMessage, commitRecordFuncHandler func(*v3io.StreamRecord), claimShardId int, claimStreamPath string) {
 
 	vs.Logger.DebugWith("Listening for explicit ack control messages")
 
@@ -441,6 +440,12 @@ func (vs *v3iostream) explicitAckHandler(controlMessageChan chan *controlcommuni
 		// transform offset data into a StreamRecord - MarkRecord uses record.ShardID & record.SequenceNumber
 		// to determine which shard/sequence number to mark.
 		shardID := int(explicitAckAttributes.Partition)
+		streamPath := explicitAckAttributes.Topic
+
+		// skip the message if it is not for this shardId and streamPath
+		if !(claimShardId == shardID && claimStreamPath == streamPath) {
+			continue
+		}
 
 		record := &v3io.StreamRecord{
 			ShardID:        &shardID,


### PR DESCRIPTION
Jira - https://iguazio.atlassian.net/browse/NUC-233

This PR addresses three issues:

1. **Sharing workerAllocation between triggers of the same kind by default**. Previously, if a trigger's `WorkerAllocatorName` configuration was not defined, the same worker allocator (represented by an empty string) was used. This behavior has been changed. Now, by default, `WorkerAllocatorName` will be enriched with the `TriggerName` if it isn't explicitly defined. 
_Workaround for previous versions_: Define a unique `WorkerAllocatorName` for each trigger of the same kind.

2. **ExplicitAck on v3io.** Control messages were not filtered by shard and stream path, leading to incorrect event committing.
_Workaround for previous versions_: doesn't exist

3. **ExplicitAck on Kafka.**  Control messages were not filtered by topic, which led to incorrect event committing. This issue occurred only when more than one Kafka stream was used, and `WorkerAllocatorName` wasn't defined.
_Workaround for previous versions_: Define a unique `WorkerAllocatorName` for each trigger of the same kind.