### PR TITLE
[Nuctl] Fix redeploy errors and logs [1.13.x]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -614,16 +614,12 @@ $(eval DOCKER_IMAGES_CACHE += $(filter-out $(DOCKER_IMAGES_CACHE),$(NUCLIO_DOCKE
 #
 
 .PHONY: fmt
-fmt:
+fmt: ensure-golangci-linter
 	gofmt -s -w .
-	golangci-lint run --fix
+	$(GOPATH)/bin/golangci-lint run --fix
 
 .PHONY: lint
-lint: modules ensure-test-files-annotated
-	@echo Installing linters...
-	@test -e $(GOPATH)/bin/golangci-lint || \
-	  	(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.54.2)
-
+lint: modules ensure-test-files-annotated ensure-golangci-linter
 	@echo Linting...
 	$(GOPATH)/bin/golangci-lint run -v
 	@echo Done.
@@ -639,6 +635,12 @@ ensure-test-files-annotated:
 	fi
 	@echo "All go test files have //go:build test_X annotation"
 	@exit $(.SHELLSTATUS)
+
+.PHONY: ensure-golangci-linter
+ensure-golangci-linter:
+	@echo Ensuring linters...
+	@test -e $(GOPATH)/bin/golangci-lint || \
+		(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.54.2)
 
 #
 # Testing

--- a/Makefile
+++ b/Makefile
@@ -614,12 +614,16 @@ $(eval DOCKER_IMAGES_CACHE += $(filter-out $(DOCKER_IMAGES_CACHE),$(NUCLIO_DOCKE
 #
 
 .PHONY: fmt
-fmt: ensure-golangci-linter
+fmt:
 	gofmt -s -w .
-	$(GOPATH)/bin/golangci-lint run --fix
+	golangci-lint run --fix
 
 .PHONY: lint
-lint: modules ensure-test-files-annotated ensure-golangci-linter
+lint: modules ensure-test-files-annotated
+	@echo Installing linters...
+	@test -e $(GOPATH)/bin/golangci-lint || \
+	  	(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.54.2)
+
 	@echo Linting...
 	$(GOPATH)/bin/golangci-lint run -v
 	@echo Done.
@@ -635,12 +639,6 @@ ensure-test-files-annotated:
 	fi
 	@echo "All go test files have //go:build test_X annotation"
 	@exit $(.SHELLSTATUS)
-
-.PHONY: ensure-golangci-linter
-ensure-golangci-linter:
-	@echo Ensuring linters...
-	@test -e $(GOPATH)/bin/golangci-lint || \
-		(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.54.2)
 
 #
 # Testing

--- a/pkg/nuctl/client/api.go
+++ b/pkg/nuctl/client/api.go
@@ -238,26 +238,19 @@ func (c *NuclioAPIClient) sendRequest(ctx context.Context,
 		return nil, nil, errors.Wrap(err, "Failed to send request")
 	}
 
-	// extract the response message
-	encodedResponseBody, err := io.ReadAll(response.Body)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "Failed to read response body")
-	}
-
-	defer response.Body.Close() // nolint: errcheck
-
-	decodedResponseBody := map[string]interface{}{}
-	if err := json.Unmarshal(encodedResponseBody, &decodedResponseBody); err != nil {
-		return nil, nil, errors.Wrap(err, "Failed to decode response body")
-	}
-
 	if response.StatusCode != expectedStatusCode {
 		reason := ""
 		message := fmt.Sprintf("Expected status code %d, got %d", expectedStatusCode, response.StatusCode)
-		if errString, ok := decodedResponseBody["error"].(string); ok {
-			reason = errString
-			message = fmt.Sprintf("%s: %s", message, errString)
+
+		// try to extract the error message from the response, ignore it if it fails
+		decodedResponseBody, err := c.decodeResponseBody(response)
+		if err == nil {
+			if errString, ok := decodedResponseBody["error"].(string); ok {
+				reason = errString
+				message = fmt.Sprintf("%s: %s", message, errString)
+			}
 		}
+
 		c.logger.WarnWithCtx(ctx,
 			"Received unexpected status code",
 			"statusCode", response.StatusCode,
@@ -269,7 +262,28 @@ func (c *NuclioAPIClient) sendRequest(ctx context.Context,
 		return response, nil, nil
 	}
 
+	// extract the response message
+	decodedResponseBody, err := c.decodeResponseBody(response)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "Failed to decode response body")
+	}
+
 	return response, decodedResponseBody, nil
+}
+
+func (c *NuclioAPIClient) decodeResponseBody(response *http.Response) (map[string]interface{}, error) {
+	encodedResponseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to read response body")
+	}
+
+	defer response.Body.Close() // nolint: errcheck
+
+	decodedResponseBody := map[string]interface{}{}
+	if err := json.Unmarshal(encodedResponseBody, &decodedResponseBody); err != nil {
+		return nil, errors.Wrap(err, "Failed to decode response body")
+	}
+	return decodedResponseBody, nil
 }
 
 // createAuthorizationHeaders creates authorization headers for the nuclio API

--- a/pkg/nuctl/client/api.go
+++ b/pkg/nuctl/client/api.go
@@ -193,7 +193,7 @@ func (c *NuclioAPIClient) PatchFunction(ctx context.Context,
 		false); err != nil {
 		switch typedError := err.(type) {
 		case *nuclio.ErrorWithStatusCode:
-			return nuclio.GetWrapByStatusCode(typedError.StatusCode())(errors.Wrap(err, "Failed to send patch API request"))
+			return errors.Wrap(typedError.GetError(), "Failed to send patch API request")
 		default:
 			return errors.Wrap(typedError, "Failed to send patch API request")
 		}
@@ -239,6 +239,7 @@ func (c *NuclioAPIClient) sendRequest(ctx context.Context,
 	}
 
 	if response.StatusCode != expectedStatusCode {
+		c.logger.WarnWithCtx(ctx, "Received unexpected status code", "statusCode", response.StatusCode)
 		return nil, nil, nuclio.GetByStatusCode(response.StatusCode)(fmt.Sprintf("Expected status code %d, got %d", expectedStatusCode, response.StatusCode))
 	}
 

--- a/pkg/nuctl/client/api.go
+++ b/pkg/nuctl/client/api.go
@@ -193,7 +193,7 @@ func (c *NuclioAPIClient) PatchFunction(ctx context.Context,
 		false); err != nil {
 		switch typedError := err.(type) {
 		case *nuclio.ErrorWithStatusCode:
-			return errors.Wrap(typedError.GetError(), "Failed to send patch API request")
+			return nuclio.GetWrapByStatusCode(typedError.StatusCode())(typedError.GetError())
 		default:
 			return errors.Wrap(typedError, "Failed to send patch API request")
 		}

--- a/pkg/nuctl/command/common/patchmanifest.go
+++ b/pkg/nuctl/command/common/patchmanifest.go
@@ -84,7 +84,7 @@ func (m *PatchManifest) AddFailure(name string, err error, retryable bool) {
 	defer m.lock.Unlock()
 
 	m.Failed[name] = failDescription{
-		Err:       errors.GetErrorStackString(err, 5),
+		Err:       errors.RootCause(err).Error(),
 		Retryable: retryable,
 	}
 }

--- a/pkg/nuctl/command/common/patchmanifest.go
+++ b/pkg/nuctl/command/common/patchmanifest.go
@@ -84,7 +84,7 @@ func (m *PatchManifest) AddFailure(name string, err error, retryable bool) {
 	defer m.lock.Unlock()
 
 	m.Failed[name] = failDescription{
-		Err:       errors.Cause(err).Error(),
+		Err:       errors.GetErrorStackString(err, 5),
 		Retryable: retryable,
 	}
 }
@@ -162,7 +162,7 @@ func (m *PatchManifest) SprintfError() string {
 
 	for name, reason := range m.Failed {
 		errorString += fmt.Sprintf(
-			"Failed to redeploy function `%s`.Reason: `%s`. Retryable: %t.",
+			"Failed to redeploy function `%s`.\n\tReason: `%s`.\n\tRetryable: %t.\n",
 			name,
 			reason.Err,
 			reason.Retryable)

--- a/pkg/nuctl/command/redeploy.go
+++ b/pkg/nuctl/command/redeploy.go
@@ -235,7 +235,7 @@ func (d *redeployCommandeer) redeployFunctions(ctx context.Context, functionName
 func (d *redeployCommandeer) patchFunction(ctx context.Context, functionName string, desiredState string) error {
 
 	d.rootCommandeer.loggerInstance.InfoWithCtx(ctx,
-		"Patching function",
+		"Redeploying function",
 		"function", functionName,
 		"desiredState", desiredState)
 

--- a/pkg/nuctl/command/redeploy.go
+++ b/pkg/nuctl/command/redeploy.go
@@ -204,7 +204,6 @@ func (d *redeployCommandeer) redeployFunctions(ctx context.Context, functionName
 		function := function
 		patchErrGroup.Go("redeploy function", func() error {
 			if err := d.patchFunction(ctx, function, d.desiredState); err != nil {
-				d.rootCommandeer.loggerInstance.WarnWithCtx(ctx, "TOMER - Failed to redeploy function", "function", function, "err", err.Error())
 				d.outputManifest.AddFailure(function, err, d.isRedeploymentRetryable(err))
 				return errors.Wrap(err, "Failed to redeploy function")
 			}

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1911,13 +1911,13 @@ func (suite *functionRedeployTestSuite) TestRedeploy() {
 			name:        "failed-retryable",
 			expectError: true,
 			statusCode:  http.StatusInternalServerError,
-			report:      `{"failed":{"redeploy-test-function":{"error":"Failed to patch function","retryable":true}}}`,
+			report:      `{"failed":{"redeploy-test-function":{"error":"Expected status code 202, got 500","retryable":true}}}`,
 		},
 		{
 			name:        "failed-not-retryable",
 			expectError: true,
 			statusCode:  http.StatusPreconditionFailed,
-			report:      `{"failed":{"redeploy-test-function":{"error":"Failed to patch function","retryable":false}}}`,
+			report:      `{"failed":{"redeploy-test-function":{"error":"Expected status code 202, got 412","retryable":false}}}`,
 		},
 	} {
 		suite.Run(testcase.name, func() {


### PR DESCRIPTION
Following a client failure to redeploy functions, it was impossible to understand what was the actual failure from the traceback and logs:
```
24.09.04 05:06:55.975 (W)                     nuctl Failed to patch functions {"err": "Failed to patch function", "errVerbose": "\nError - Failed to patch function\n    /nuclio/pkg/nuctl/command/redeploy.go:208\n\nCall stack:\nFailed to patch function\n    /nuclio/pkg/nuctl/command/redeploy.go:208\nFailed to patch function"}

...

Failed to redeploy function `pr-administration-notifications`.Reason: `Failed to patch function`. Retryable: false
...
```

In this case, the investigation led to the failure reason being a 412 response from the API, although it wasn't shown in the logs at all.

To improve the error handling experience, in this PR we:
1. Remove the "Failed to patch function" errors duplication by changing it according to what actually failed.
2. Remove multiple wrapping of the error from the api call, as we already create an error with `"Expected status code %d, got %d"`.
3. Get the response message from the API also on error.
4. Add the failure's **Root Cause** to the patch manifest on failure, instead of the Cause.

Now the errors log as follows:
```

24.09.05 12:41:18.318 (W)          nuctl.api-client Received unexpected status code {"statusCode": 412, "reason": "Can not patch function because registry is internal"}
24.09.05 12:41:18.319 (E)                     nuctl Failed to patch function {"function": "with-ns", "err": "Expected status code 202, got 412: Can not patch function because registry is internal", "retryable": true}

...

Failed to redeploy function `with-ns`.
        Reason: `Expected status code 202, got 412: Can not patch function because registry is internal`.
        Retryable: true.
```