### PR TITLE
[Makefile] Ensure golangci linter on both `fmt` and `lint` rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -614,16 +614,12 @@ $(eval DOCKER_IMAGES_CACHE += $(filter-out $(DOCKER_IMAGES_CACHE),$(NUCLIO_DOCKE
 #
 
 .PHONY: fmt
-fmt:
+fmt: ensure-golangci-linter
 	gofmt -s -w .
-	golangci-lint run --fix
+	$(GOPATH)/bin/golangci-lint run --fix
 
 .PHONY: lint
-lint: modules ensure-test-files-annotated
-	@echo Installing linters...
-	@test -e $(GOPATH)/bin/golangci-lint || \
-	  	(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.54.2)
-
+lint: modules ensure-test-files-annotated ensure-golangci-linter
 	@echo Linting...
 	$(GOPATH)/bin/golangci-lint run -v
 	@echo Done.
@@ -648,6 +644,12 @@ ensure-test-files-annotated:
 	fi
 	@echo "All go test files have //go:build test_X annotation"
 	@exit $(.SHELLSTATUS)
+
+.PHONY: ensure-golangci-linter
+ensure-golangci-linter:
+	@echo Ensuring linters...
+	@test -e $(GOPATH)/bin/golangci-lint || \
+		(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.54.2)
 
 #
 # Testing


### PR DESCRIPTION
Use the same `golangci-lint` from the GOPATH for both rules, and ensure it exists first.