### PR TITLE
[CI] Bump upload/download artifact actions

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -133,7 +133,7 @@ jobs:
             await script({ github, context, prNumber, labelsToAdd, labelsToRemove })
 
       - name: Upload benchmarking results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmarking
           path: ./.benchmarking

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -202,7 +202,7 @@ jobs:
         run: make save-docker-images
 
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nuclio-docker-images
           path: nuclio-docker-images-*.tar.gz
@@ -246,7 +246,7 @@ jobs:
           minikube kubectl -- config view --flatten > kubeconfig_flatten
 
       - name: Fetch nuclio docker images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nuclio-docker-images
 
@@ -324,7 +324,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Fetch nuclio docker images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nuclio-docker-images
 
@@ -377,7 +377,7 @@ jobs:
           minikube kubectl -- config view --flatten > kubeconfig_flatten
 
       - name: Fetch nuclio docker images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nuclio-docker-images
 


### PR DESCRIPTION
Following security fixes and deprecations. 
Must bump both together as v4 is not backwards compatible.

- https://github.com/actions/upload-artifact
- https://github.com/actions/download-artifact

closes #3339