### PR TITLE
Revert "[Processor] Fix ExplicitAck on 2 and more triggers of the same type [1.13.x]"

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1762,15 +1762,6 @@ func (ap *Platform) enrichTriggers(ctx context.Context, functionConfig *function
 			}
 		}
 
-		if triggerInstance.WorkerAllocatorName == "" {
-			triggerInstance.WorkerAllocatorName = triggerName
-			ap.Logger.DebugWithCtx(ctx, "Enriched WorkerAllocatorName",
-				"triggerName", triggerName,
-				"triggerKind", triggerInstance.Kind,
-				"WorkerAllocatorName", triggerInstance.WorkerAllocatorName,
-			)
-		}
-
 		functionConfig.Spec.Triggers[triggerName] = triggerInstance
 	}
 

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -955,10 +955,9 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 			},
 			expectedEnrichedTriggers: map[string]functionconfig.Trigger{
 				"some-trigger": {
-					Kind:                "http",
-					NumWorkers:          1,
-					Name:                "some-trigger",
-					WorkerAllocatorName: "some-trigger",
+					Kind:       "http",
+					NumWorkers: 1,
+					Name:       "some-trigger",
 				},
 			},
 		},
@@ -968,7 +967,6 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 			triggers: nil,
 			expectedEnrichedTriggers: func() map[string]functionconfig.Trigger {
 				defaultHTTPTrigger := functionconfig.GetDefaultHTTPTrigger()
-				defaultHTTPTrigger.WorkerAllocatorName = defaultHTTPTrigger.Name
 				return map[string]functionconfig.Trigger{
 					defaultHTTPTrigger.Name: defaultHTTPTrigger,
 				}
@@ -1040,17 +1038,15 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 			},
 			expectedEnrichedTriggers: map[string]functionconfig.Trigger{
 				"http-trigger": {
-					Kind:                "http",
-					NumWorkers:          1,
-					Name:                "http-trigger",
-					WorkerAllocatorName: "http-trigger",
+					Kind:       "http",
+					NumWorkers: 1,
+					Name:       "http-trigger",
 				},
 				"kafka-trigger": {
 					Kind:                     "kafka-cluster",
 					Name:                     "kafka-trigger",
 					ExplicitAckMode:          functionconfig.ExplicitAckModeDisable,
 					WorkerTerminationTimeout: functionconfig.DefaultWorkerTerminationTimeout,
-					WorkerAllocatorName:      "kafka-trigger",
 				},
 			},
 			shouldFailValidation: false,

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -639,7 +639,6 @@ func (suite *FunctionKubePlatformTestSuite) TestFunctionTriggersEnrichmentAndVal
 			triggers: nil,
 			expectedEnrichedTriggers: func() map[string]functionconfig.Trigger {
 				defaultHTTPTrigger := functionconfig.GetDefaultHTTPTrigger()
-				defaultHTTPTrigger.WorkerAllocatorName = defaultHTTPTrigger.Name
 				defaultHTTPTrigger.Attributes = map[string]interface{}{
 					"serviceType": suite.platformKubeConfig.DefaultServiceType,
 				}

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -232,12 +232,7 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 			return errors.Wrap(err, "Failed to subscribe to explicit ack control messages")
 		}
 
-		go k.explicitAckHandler(
-			session,
-			explicitAckControlMessageChan,
-			claim.Partition(),
-			claim.Topic(),
-		)
+		go k.explicitAckHandler(session, explicitAckControlMessageChan, claim.Partition())
 	}
 
 	k.Logger.DebugWith("Starting claim consumption",
@@ -638,11 +633,9 @@ func (k *kafka) resolveSCRAMClientGeneratorFunc(mechanism sarama.SASLMechanism) 
 
 // explicitAckHandler reads offset data messages from the trigger's control channel, and marks the
 // offset accordingly
-func (k *kafka) explicitAckHandler(
-	session sarama.ConsumerGroupSession,
+func (k *kafka) explicitAckHandler(session sarama.ConsumerGroupSession,
 	controlMessageChan chan *controlcommunication.ControlMessage,
-	partitionNumber int32,
-	topic string) {
+	partitionNumber int32) {
 
 	k.Logger.InfoWith("Listening for explicit ack control messages")
 
@@ -657,8 +650,8 @@ func (k *kafka) explicitAckHandler(
 			continue
 		}
 
-		// skip the message if it is not for this topic and partition
-		if !(explicitAckAttributes.Partition == partitionNumber && explicitAckAttributes.Topic == topic) {
+		// skip the message if it is not for this partition
+		if explicitAckAttributes.Partition != partitionNumber {
 			continue
 		}
 

--- a/pkg/processor/trigger/v3iostream/trigger.go
+++ b/pkg/processor/trigger/v3iostream/trigger.go
@@ -192,12 +192,7 @@ func (vs *v3iostream) ConsumeClaim(session streamconsumergroup.Session, claim st
 			return errors.Wrap(err, "Failed to subscribe to explicit ack control messages")
 		}
 
-		go vs.explicitAckHandler(
-			explicitAckControlMessageChan,
-			commitRecordFuncHandler,
-			claim.GetShardID(),
-			claim.GetStreamPath(),
-		)
+		go vs.explicitAckHandler(explicitAckControlMessageChan, commitRecordFuncHandler)
 	}
 
 	// the exit condition is that (a) the Messages() channel was closed and (b) we got a signal telling us
@@ -425,11 +420,8 @@ func (vs *v3iostream) resolveCommitRecordFuncHandler(session streamconsumergroup
 	return commitRecordDefaultFuncHandler
 }
 
-func (vs *v3iostream) explicitAckHandler(
-	controlMessageChan chan *controlcommunication.ControlMessage,
-	commitRecordFuncHandler func(*v3io.StreamRecord),
-	claimShardId int,
-	claimStreamPath string) {
+func (vs *v3iostream) explicitAckHandler(controlMessageChan chan *controlcommunication.ControlMessage,
+	commitRecordFuncHandler func(*v3io.StreamRecord)) {
 
 	vs.Logger.DebugWith("Listening for explicit ack control messages")
 
@@ -449,12 +441,6 @@ func (vs *v3iostream) explicitAckHandler(
 		// transform offset data into a StreamRecord - MarkRecord uses record.ShardID & record.SequenceNumber
 		// to determine which shard/sequence number to mark.
 		shardID := int(explicitAckAttributes.Partition)
-		streamPath := explicitAckAttributes.Topic
-
-		// skip the message if it is not for this shardId and streamPath
-		if !(claimShardId == shardID && claimStreamPath == streamPath) {
-			continue
-		}
 
 		record := &v3io.StreamRecord{
 			ShardID:        &shardID,


### PR DESCRIPTION
Reverts nuclio/nuclio#3340 , as it breaks backwards compatibility.

https://iguazio.atlassian.net/browse/NUC-256
https://iguazio.atlassian.net/browse/NUC-257