### PR TITLE
[V3IOStream] Generate access key from env var [1.13.x]

### DIFF
--- a/docs/reference/triggers/v3iostream.md
+++ b/docs/reference/triggers/v3iostream.md
@@ -142,7 +142,7 @@ As of Nuclio v1.1.33 / v1.3.20, you can configure the following configuration pa
 - **Read Batch Size**: Read batch size - the number of messages to read in each read request that's submitted to the platform.
 - **Polling Interval (ms)**: The time, in milliseconds, to wait between reading messages from the platform stream.
 - **Username**: DEPRECATED (ignored)
-- **Password**: A platform access key for accessing the data.
+- **Password**: A platform access key for accessing the data. If set as `$generate`, Nuclio will look for the `V3IO_ACCESS_KEY` environment variable and use its value as the access key.
 - **Worker allocator name**: DEPRECATED (ignored)
 
 > **Note:** In future versions of Nuclio, it's planned that the dashboard will better reflect the role of the configuration parameters and add more parameters (such as session timeout and heartbeat interval, which are currently always set to the default values of 10s and 3s, respectively, unless you edit the function-configuration file).


### PR DESCRIPTION
To help avoid setting explicit access keys in the v3io stream trigger configuration, we now support setting the access key as `$generate`.
In such a case, Nuclio will look for the from the `V3IO_ACCESS_KEY` env var, and take the access key from there if it exists.
The env var can be set from a secret, thus keeping all of the data secure.

Related to a [change in MLRun](https://github.com/mlrun/mlrun/pull/6307).

https://iguazio.atlassian.net/browse/ML-7779