### PR TITLE
[V3io] Do not filter ExplicitAck by streamPath for v3io trigger

### DIFF
--- a/pkg/processor/trigger/v3iostream/trigger.go
+++ b/pkg/processor/trigger/v3iostream/trigger.go
@@ -449,10 +449,9 @@ func (vs *v3iostream) explicitAckHandler(
 		// transform offset data into a StreamRecord - MarkRecord uses record.ShardID & record.SequenceNumber
 		// to determine which shard/sequence number to mark.
 		shardID := int(explicitAckAttributes.Partition)
-		streamPath := explicitAckAttributes.Topic
 
-		// skip the message if it is not for this shardId and streamPath
-		if !(claimShardId == shardID && claimStreamPath == streamPath) {
+		// skip the message if it is not for this shardId
+		if claimShardId != shardID {
 			continue
 		}
 


### PR DESCRIPTION
Jira - https://iguazio.atlassian.net/browse/NUC-256

In contrast to Kafka, where we support processing from multiple topics within a single trigger, in V3io, we only support processing from a single stream path. 
Furthermore, the v3io-go library does not require the streamPath when committing a record, as it is already configured on the `claim`. 
Therefore, we can remove this check in the V3io trigger.