### PR TITLE
[Processor] Align ExplicitAck log for v3io and kafka

### DIFF
--- a/pkg/processor/trigger/v3iostream/trigger.go
+++ b/pkg/processor/trigger/v3iostream/trigger.go
@@ -435,8 +435,6 @@ func (vs *v3iostream) explicitAckHandler(
 
 	for streamAckControlMessage := range controlMessageChan {
 
-		vs.Logger.DebugWith("Received explicit ack control message", "controlMessage", streamAckControlMessage)
-
 		// retrieve attributes from control message
 		explicitAckAttributes := &controlcommunication.ControlMessageAttributesExplicitAck{}
 
@@ -458,6 +456,15 @@ func (vs *v3iostream) explicitAckHandler(
 		record := &v3io.StreamRecord{
 			ShardID:        &shardID,
 			SequenceNumber: uint64(explicitAckAttributes.Offset),
+		}
+
+		// this log is mostly for development purposes, to see that we are actually marking the offset
+		// to enable it use the "nuclio.io/v3io-log-level" annotation
+		if vs.configuration.LogLevel > 5 {
+			vs.Logger.InfoWith("Marking offset on explicit ack request",
+				"streamPath", claimStreamPath,
+				"shardId", shardID,
+				"offset", record.SequenceNumber)
 		}
 
 		// commit record

--- a/pkg/processor/trigger/v3iostream/trigger.go
+++ b/pkg/processor/trigger/v3iostream/trigger.go
@@ -459,7 +459,7 @@ func (vs *v3iostream) explicitAckHandler(
 		}
 
 		// this log is mostly for development purposes, to see that we are actually marking the offset
-		// to enable it use the "nuclio.io/v3io-log-level" annotation
+		// to enable it use the "nuclio.io/v3iostream-log-level" annotation
 		if vs.configuration.LogLevel > 5 {
 			vs.Logger.InfoWith("Marking offset on explicit ack request",
 				"streamPath", claimStreamPath,

--- a/pkg/processor/trigger/v3iostream/types.go
+++ b/pkg/processor/trigger/v3iostream/types.go
@@ -51,8 +51,8 @@ type Configuration struct {
 	SequenceNumberShardWaitInterval string
 	RecordBatchSizeChan             int
 	AckWindowSize                   uint64
-
-	seekTo v3io.SeekShardInputType
+	LogLevel                        int
+	seekTo                          v3io.SeekShardInputType
 
 	// backwards compatibility
 	PollingIntervalMs int
@@ -76,6 +76,8 @@ func NewConfiguration(id string, triggerConfiguration *functionconfig.Trigger,
 	if err := newConfiguration.PopulateConfigurationFromAnnotations([]trigger.AnnotationConfigField{
 		{Key: "custom.nuclio.io/v3iostream-window-size", ValueUInt64: &newConfiguration.AckWindowSize},
 		{Key: "nuclio.io/v3iostream-worker-allocation-mode", ValueString: &workerAllocationModeValue},
+
+		{Key: "nuclio.io/v3io-log-level", ValueInt: &newConfiguration.LogLevel},
 
 		// allow changing explicit ack mode via annotation
 		{Key: "nuclio.io/v3iostream-explicit-ack-mode", ValueString: &explicitAckModeValue},

--- a/pkg/processor/trigger/v3iostream/types.go
+++ b/pkg/processor/trigger/v3iostream/types.go
@@ -77,7 +77,7 @@ func NewConfiguration(id string, triggerConfiguration *functionconfig.Trigger,
 		{Key: "custom.nuclio.io/v3iostream-window-size", ValueUInt64: &newConfiguration.AckWindowSize},
 		{Key: "nuclio.io/v3iostream-worker-allocation-mode", ValueString: &workerAllocationModeValue},
 
-		{Key: "nuclio.io/v3io-log-level", ValueInt: &newConfiguration.LogLevel},
+		{Key: "nuclio.io/v3iostream-log-level", ValueInt: &newConfiguration.LogLevel},
 
 		// allow changing explicit ack mode via annotation
 		{Key: "nuclio.io/v3iostream-explicit-ack-mode", ValueString: &explicitAckModeValue},


### PR DESCRIPTION
Part of https://iguazio.atlassian.net/browse/NUC-267

This log is important for debugging purposes mainly and is already hidden for default execution in kafka. This PR aligns the logging logic of v3io with kafka. 