### PR TITLE
[Dependencies] Bump nuclio-sdk-py to 0.5.13

### DIFF
--- a/pkg/processor/runtime/python/py/requirements/common.txt
+++ b/pkg/processor/runtime/python/py/requirements/common.txt
@@ -1,3 +1,3 @@
 mock==2.0.0
-nuclio-sdk==0.5.12
+nuclio-sdk==0.5.13
 pip==23.3.1

--- a/pkg/processor/runtime/python/py/requirements/common.txt
+++ b/pkg/processor/runtime/python/py/requirements/common.txt
@@ -1,3 +1,3 @@
 mock==2.0.0
-nuclio-sdk==0.5.10
+nuclio-sdk==0.5.11
 pip==23.3.1

--- a/pkg/processor/runtime/python/py/requirements/common.txt
+++ b/pkg/processor/runtime/python/py/requirements/common.txt
@@ -1,3 +1,3 @@
 mock==2.0.0
-nuclio-sdk==0.5.11
+nuclio-sdk==0.5.12
 pip==23.3.1


### PR DESCRIPTION
Bumps nuclio-sdk-py to the latest version: https://github.com/nuclio/nuclio-sdk-py/releases/tag/v0.5.13