### PR TITLE
[Security] Fix access rights for wrapper

### DIFF
--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -229,7 +229,7 @@ func (k *Kaniko) createContainerBuildBundle(ctx context.Context,
 	}
 
 	buildDir := "/tmp/kaniko-builds"
-	if err := os.MkdirAll(buildDir, 0700); err != nil {
+	if err := os.MkdirAll(buildDir, 0755); err != nil {
 		return "", "", errors.Wrapf(err, "Failed to ensure directory")
 	}
 

--- a/pkg/platform/kube/test/function/function_test.go
+++ b/pkg/platform/kube/test/function/function_test.go
@@ -470,6 +470,7 @@ func (suite *DeployFunctionTestSuite) TestSecurityContext() {
 			runAsGroupID,
 			fsGroup),
 			strings.TrimSpace(results.Output))
+		suite.InvokeFunction("GET", deployResult.Port, "", nil)
 		return true
 	})
 }

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -962,7 +962,7 @@ func (b *Builder) prepareStagingDir() error {
 
 	// make sure the handler staging dir exists
 	handlerDirIncludingSubPath := path.Join(handlerDirInStaging, handlerSubPath)
-	if err := os.MkdirAll(handlerDirIncludingSubPath, 0700); err != nil {
+	if err := os.MkdirAll(handlerDirIncludingSubPath, 0755); err != nil {
 		return errors.Wrapf(err, "Failed to create handler path in staging @ %s", handlerDirIncludingSubPath)
 	}
 


### PR DESCRIPTION
Reverts part of the changes made in [this PR](https://github.com/nuclio/nuclio/pull/3351), which caused a bug when running a Nuclio function with a defined `SecurityContext` (i.e., when the user is not root). The issue is that the Kaniko builder must be run as root, so we can not propagate the SecurityContext to the KanikoBuilder. As a result, all files are created as root within the container. When running a container as a non-root user, access to these files is denied due to their 700 permissions.

Jira - https://iguazio.atlassian.net/browse/NUC-263