### PR TITLE
[Nuctl][Dashboard] Fix importing function that was in error or building state before export

### DIFF
--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1617,6 +1617,21 @@ func (suite *functionExportImportTestSuite) TestImportFunction() {
 	suite.assertFunctionImported(functionName, true)
 }
 
+func (suite *functionExportImportTestSuite) TestImportFunctionWhichNeverRun() {
+	functionConfigPath := path.Join(suite.GetImportsDir(), "never_run_before_export_function.yaml")
+
+	// this name is defined within never_run_before_export_function.yaml
+	functionName := "never-run-func"
+
+	defer suite.ExecuteNuctl([]string{"delete", "fu", functionName}, nil) // nolint: errcheck
+
+	// import the project
+	err := suite.ExecuteNuctl([]string{"import", "fu", functionConfigPath, "--verbose"}, nil) // nolint: errcheck
+	suite.Require().NoError(err)
+
+	suite.assertFunctionImported(functionName, true)
+}
+
 func (suite *functionExportImportTestSuite) TestAutofixWhenImportFunction() {
 	functionConfigPath := path.Join(suite.GetImportsDir(), "autofixable_function.yaml")
 

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1611,7 +1611,7 @@ func (suite *functionExportImportTestSuite) TestImportFunction() {
 	defer suite.ExecuteNuctl([]string{"delete", "fu", functionName}, nil) // nolint: errcheck
 
 	// import the project
-	err := suite.ExecuteNuctl([]string{"import", "fu", functionConfigPath, "--verbose"}, nil) // nolint: errcheck
+	err := suite.ExecuteNuctl([]string{"import", "fu", functionConfigPath, "--verbose"}, nil)
 	suite.Require().NoError(err)
 
 	suite.assertFunctionImported(functionName, true)
@@ -1626,7 +1626,7 @@ func (suite *functionExportImportTestSuite) TestImportFunctionWhichNeverRun() {
 	defer suite.ExecuteNuctl([]string{"delete", "fu", functionName}, nil) // nolint: errcheck
 
 	// import the project
-	err := suite.ExecuteNuctl([]string{"import", "fu", functionConfigPath, "--verbose"}, nil) // nolint: errcheck
+	err := suite.ExecuteNuctl([]string{"import", "fu", functionConfigPath, "--verbose"}, nil)
 	suite.Require().NoError(err)
 
 	suite.assertFunctionImported(functionName, true)

--- a/test/_imports/never_run_before_export_function.yaml
+++ b/test/_imports/never_run_before_export_function.yaml
@@ -8,7 +8,7 @@ spec:
   alias: latest
   build:
     codeEntryType: image
-    image: ""
+    image: ""  #this function always leads to an `error` state due to image isn't defined
     noBaseImagesPull: true
   disableDefaultHTTPTrigger: false
   platform: {}

--- a/test/_imports/never_run_before_export_function.yaml
+++ b/test/_imports/never_run_before_export_function.yaml
@@ -1,0 +1,36 @@
+metadata:
+  annotations:
+    nuclio.io/previous-state: error
+    skip-build: "true"
+    skip-deploy: "true"
+  name: never-run-func
+spec:
+  alias: latest
+  build:
+    codeEntryType: image
+    image: ""
+    noBaseImagesPull: true
+  disableDefaultHTTPTrigger: false
+  platform: {}
+  preemptionMode: prevent
+  priorityClassName: igz-workload-medium
+  resources:
+    limits:
+      cpu: "2"
+      memory: 20Gi
+    requests:
+      cpu: 25m
+      memory: 1Mi
+  runtime: python:3.9
+  securityContext:
+    runAsGroup: 65534
+    runAsUser: 50
+  serviceType: ClusterIP
+  triggers:
+    http:
+      class: ""
+      kind: http
+      maxWorkers: 1
+      name: http
+      numWorkers: 1
+      workerAvailabilityTimeoutMilliseconds: 10000

--- a/test/_imports/never_run_before_export_function.yaml
+++ b/test/_imports/never_run_before_export_function.yaml
@@ -1,3 +1,16 @@
+# Copyright 2024 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 metadata:
   annotations:
     nuclio.io/previous-state: error


### PR DESCRIPTION
The main change in this PR is that, instead of first checking functionBuildRequired and then looking for the skip-build annotation, we will now first check for the presence of the annotation. If it exists, we will then check functionBuildRequired. This change resolves a bug that occurred when importing a function that had never been in a healthy state before export.

Also, adds a test which fails without changes.

Jira - https://iguazio.atlassian.net/browse/NUC-268