### PR TITLE
[Docs] Add note about API Gateways on kubernetes

### DIFF
--- a/docs/reference/api-gateway/index.rst
+++ b/docs/reference/api-gateway/index.rst
@@ -5,6 +5,8 @@ API Gateway is a service that allows you to expose your functions as a web servi
 Essentially, it is a proxy that forwards requests to your functions and returns the response.
 It can be used to invoke your functions, and can provide authentication, canary deployments and other features.
 
+.. note:: The API Gateway feature is available only for kubernetes-based deployments
+
 See how to create and invoke your functions with the Nuclio API Gateway in different ways:
 
 .. toctree::


### PR DESCRIPTION
It wasn't clear in the Docs that the API Gateway feature is only supported in K8s deployments, and not in Docker.

The Note looks like this:
<img width="954" alt="image" src="https://github.com/user-attachments/assets/061ac67a-465d-41c7-ae84-f77fa7a180d9">
