### PR TITLE
[Processor] Change default handshake value to true

### DIFF
--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -558,7 +558,7 @@ func (k *kafka) newKafkaConfig() (*sarama.Config, error) {
 		config.Net.SASL.Password = k.configuration.SASL.Password
 		config.Net.SASL.Mechanism = sarama.SASLMechanism(k.configuration.SASL.Mechanism)
 
-		// Set SASL handshake if explicitly specified in configuration, so we can use sarama's 
+		// Set SASL handshake if explicitly specified in configuration, so we can use sarama's
 		// default handshake (which is true)
 		if k.configuration.SASL.Handshake != nil {
 			config.Net.SASL.Handshake = *k.configuration.SASL.Handshake

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -558,8 +558,8 @@ func (k *kafka) newKafkaConfig() (*sarama.Config, error) {
 		config.Net.SASL.Password = k.configuration.SASL.Password
 		config.Net.SASL.Mechanism = sarama.SASLMechanism(k.configuration.SASL.Mechanism)
 
-		// Set SASL handshake if specified in configuration, defaulting to true if unset
-		// Because sarama's default handshake is true
+		// Set SASL handshake if explicitly specified in configuration, so we can use sarama's 
+		// default handshake (which is true)
 		if k.configuration.SASL.Handshake != nil {
 			config.Net.SASL.Handshake = *k.configuration.SASL.Handshake
 		}

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -557,7 +557,13 @@ func (k *kafka) newKafkaConfig() (*sarama.Config, error) {
 		config.Net.SASL.User = k.configuration.SASL.User
 		config.Net.SASL.Password = k.configuration.SASL.Password
 		config.Net.SASL.Mechanism = sarama.SASLMechanism(k.configuration.SASL.Mechanism)
-		config.Net.SASL.Handshake = k.configuration.SASL.Handshake
+
+		// Set SASL handshake if specified in configuration, defaulting to true if unset
+		// Because sarama's default handshake is true
+		if k.configuration.SASL.Handshake != nil {
+			config.Net.SASL.Handshake = *k.configuration.SASL.Handshake
+		}
+
 		config.Net.SASL.SCRAMClientGeneratorFunc = k.resolveSCRAMClientGeneratorFunc(config.Net.SASL.Mechanism)
 
 		// per mechanism configuration

--- a/pkg/processor/trigger/kafka/types.go
+++ b/pkg/processor/trigger/kafka/types.go
@@ -45,7 +45,7 @@ type Configuration struct {
 	BalanceStrategy string
 	SASL            struct {
 		Enable    bool
-		Handshake bool
+		Handshake *bool
 		User      string
 		Password  string
 		Mechanism string
@@ -155,7 +155,7 @@ func NewConfiguration(id string,
 		{Key: "nuclio.io/kafka-sasl-user", ValueString: &newConfiguration.SASL.User},
 		{Key: "nuclio.io/kafka-sasl-password", ValueString: &newConfiguration.SASL.Password},
 		{Key: "nuclio.io/kafka-sasl-mechanism", ValueString: &newConfiguration.SASL.Mechanism},
-		{Key: "nuclio.io/kafka-sasl-handshake", ValueBool: &newConfiguration.SASL.Handshake},
+		{Key: "nuclio.io/kafka-sasl-handshake", ValueBool: newConfiguration.SASL.Handshake},
 
 		// sasl.oauth
 		{Key: "nuclio.io/kafka-sasl-oauth-client-id", ValueString: &newConfiguration.SASL.OAuth.ClientID},


### PR DESCRIPTION
This change addresses the misleading default behavior by ensuring that Sarama’s `Net.SASL.Handshake` setting now defaults to true, aligning with Sarama's internal default and avoiding unexpected outcomes.

Previously, if the `SASL.Handshake` value wasn’t provided in trigger configuration, it was defaulting to false, leading to potential connection issues and unexpected behavior, especially in environments where true is required. Now, if `SASL.Handshake` isn’t specified, the `Net.SASL.Handshake` setting defaults to true.