### PR TITLE
[Docs] Remove md emoji

### DIFF
--- a/docs/reference/function-configuration/batching.md
+++ b/docs/reference/function-configuration/batching.md
@@ -1,6 +1,6 @@
 # Event batching
 
-:bangbang: Feature is supported only for:
+**_NOTE:_** Event batching is supported only for:
 * runtimes:
     * `python`
 * trigger kinds:


### PR DESCRIPTION
Sphinx doesn't render GitHub's markdown emoji, so this file is rendered with the raw `:bangbang:`.