### PR TITLE
[Security] Change directory access back to 755

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -84,6 +84,7 @@ func EnsureDirExists(ctx context.Context, loggerInstance logger.Logger, dir stri
 			"Creating directory as it does not exist",
 			"directory", dir)
 
+		// we need 755 permission to allow running nuclio function with non-root SecurityContext
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return err
 		}

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -84,7 +84,7 @@ func EnsureDirExists(ctx context.Context, loggerInstance logger.Logger, dir stri
 			"Creating directory as it does not exist",
 			"directory", dir)
 
-		if err := os.MkdirAll(dir, 0700); err != nil {
+		if err := os.MkdirAll(dir, 0755); err != nil {
 			return err
 		}
 	}

--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -180,6 +180,7 @@ func (d *Docker) gatherArtifactsForSingleStageDockerfile(ctx context.Context,
 	artifactsDir := path.Join(buildOptions.ContextDir, artifactDirNameInStaging)
 
 	// create an artifacts directory to which we'll copy all of our stuff
+	// we need 755 permission to allow running nuclio function with non-root SecurityContext
 	if err := os.MkdirAll(artifactsDir, 0755); err != nil {
 		return errors.Wrap(err, "Failed to create artifacts directory")
 	}

--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -180,7 +180,7 @@ func (d *Docker) gatherArtifactsForSingleStageDockerfile(ctx context.Context,
 	artifactsDir := path.Join(buildOptions.ContextDir, artifactDirNameInStaging)
 
 	// create an artifacts directory to which we'll copy all of our stuff
-	if err := os.MkdirAll(artifactsDir, 0700); err != nil {
+	if err := os.MkdirAll(artifactsDir, 0755); err != nil {
 		return errors.Wrap(err, "Failed to create artifacts directory")
 	}
 

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -229,6 +229,7 @@ func (k *Kaniko) createContainerBuildBundle(ctx context.Context,
 	}
 
 	buildDir := "/tmp/kaniko-builds"
+	// we need 755 permission to allow running nuclio function with non-root SecurityContext
 	if err := os.MkdirAll(buildDir, 0755); err != nil {
 		return "", "", errors.Wrapf(err, "Failed to ensure directory")
 	}

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -962,6 +962,8 @@ func (b *Builder) prepareStagingDir() error {
 
 	// make sure the handler staging dir exists
 	handlerDirIncludingSubPath := path.Join(handlerDirInStaging, handlerSubPath)
+
+	// we need 755 permission to allow running nuclio function with non-root SecurityContext
 	if err := os.MkdirAll(handlerDirIncludingSubPath, 0755); err != nil {
 		return errors.Wrapf(err, "Failed to create handler path in staging @ %s", handlerDirIncludingSubPath)
 	}

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -33,6 +33,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/build"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
 	"github.com/nuclio/nuclio/test/httpsrv"
+	"k8s.io/api/core/v1"
 
 	"github.com/mholt/archiver/v4"
 	"github.com/nuclio/errors"
@@ -323,6 +324,16 @@ func (suite *TestSuite) compressAndDeployFunctionFromURL(archiveExtension string
 	compressor func(context.Context, io.Writer, []archiver.File) error) {
 
 	createFunctionOptions := suite.getDeployOptionsDir("reverser")
+	runAsUserID := int64(1000)
+	runAsGroupID := int64(2000)
+	fsGroup := int64(3000)
+
+	// setting security context to check that function can be run in non-root mode
+	createFunctionOptions.FunctionConfig.Spec.SecurityContext = &v1.PodSecurityContext{
+		RunAsUser:  &runAsUserID,
+		RunAsGroup: &runAsGroupID,
+		FSGroup:    &fsGroup,
+	}
 
 	archivePath := suite.createFunctionArchive(createFunctionOptions.FunctionConfig.Spec.Build.Path,
 		archiveExtension,

--- a/pkg/processor/build/runtime/test/suite/suite.go
+++ b/pkg/processor/build/runtime/test/suite/suite.go
@@ -33,10 +33,10 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/build"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/http/test/suite"
 	"github.com/nuclio/nuclio/test/httpsrv"
-	"k8s.io/api/core/v1"
 
 	"github.com/mholt/archiver/v4"
 	"github.com/nuclio/errors"
+	"k8s.io/api/core/v1"
 )
 
 type FunctionInfo struct {

--- a/pkg/processor/build/util/unarchive.go
+++ b/pkg/processor/build/util/unarchive.go
@@ -81,6 +81,7 @@ func (d *Unarchiver) extractFile(file archiver.File, targetPath string) error {
 
 	if file.IsDir() {
 		// create the directory if it doesn't exist and continue to the next file
+		// we need 755 permission to allow running nuclio function with non-root SecurityContext
 		if err := os.MkdirAll(filePath, 0755); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Failed to create directory %s", filePath))
 		}
@@ -88,6 +89,7 @@ func (d *Unarchiver) extractFile(file archiver.File, targetPath string) error {
 	}
 
 	// create the file's parent directory if it doesn't exist
+	// we need 755 permission to allow running nuclio function with non-root SecurityContext
 	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Failed to create directory %s", filepath.Dir(filePath)))
 	}

--- a/pkg/processor/build/util/unarchive.go
+++ b/pkg/processor/build/util/unarchive.go
@@ -81,14 +81,14 @@ func (d *Unarchiver) extractFile(file archiver.File, targetPath string) error {
 
 	if file.IsDir() {
 		// create the directory if it doesn't exist and continue to the next file
-		if err := os.MkdirAll(filePath, 0700); err != nil {
+		if err := os.MkdirAll(filePath, 0755); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Failed to create directory %s", filePath))
 		}
 		return nil
 	}
 
 	// create the file's parent directory if it doesn't exist
-	if err := os.MkdirAll(filepath.Dir(filePath), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Failed to create directory %s", filepath.Dir(filePath)))
 	}
 


### PR DESCRIPTION
Kaniko job can't be executed as non-root user and it also doesn't allow to change a file owner to another user. But we still want to be able to execute nuclio functions with `SecurityContext` set to non-root. For these, we need to revert the changes done in https://github.com/nuclio/nuclio/pull/3349/files.