### PR TITLE
[Docs] Introducing Nuclio Guru on Gurubase.io

### DIFF
--- a/.github/styles/Nuclio/ignore.txt
+++ b/.github/styles/Nuclio/ignore.txt
@@ -68,3 +68,4 @@ volumize
 Webadmin
 westeurope
 yaml
+Gurubase

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Slack](https://img.shields.io/badge/slack-chat-blueviolet.svg?label=Slack&logo=slack)](https://nuclio-io.slack.com)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/nuclio)](https://artifacthub.io/packages/search?repo=nuclio)
 [![Iguazio Careers](https://img.shields.io/badge/careers-We're%20Hiring!-informational?style=square-flat-square)](https://www.iguazio.com/careers)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Nuclio%20Guru-006BFF)](https://gurubase.io/g/nuclio)
 
 <p align="center"><img src="/docs/assets/images/logo.png" width="180" alt="nuclio"/></p>
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Nuclio Guru](https://gurubase.io/g/nuclio) to Gurubase. Nuclio Guru uses the data from this repo and data from the [docs](https://docs.nuclio.io/en/stable/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Nuclio Guru", which highlights that Nuclio now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Nuclio Guru in Gurubase, just let me know that's totally fine.
