### PR TITLE
[Cron] Add target name header

### DIFF
--- a/hack/scripts/patch-remote/patch_remote.py
+++ b/hack/scripts/patch-remote/patch_remote.py
@@ -99,7 +99,7 @@ class NuclioPatcher:
             self._log_pod_names()
 
         self._logger.info(
-            "Successfully patched branch successfully to remote (Note this may not survive system restarts)"
+            "Successfully patched local branch to remote (Note this may not survive system restarts)"
         )
 
     def _validate_config(self):

--- a/pkg/common/headers/headers.go
+++ b/pkg/common/headers/headers.go
@@ -45,6 +45,7 @@ const (
 	InvokeURL           = "X-Nuclio-Invoke-Url"
 	InvokeTimeout       = "X-Nuclio-Invoke-Timeout"
 	InvokeVia           = "X-Nuclio-Invoke-Via"
+	InvokeTrigger       = "X-Nuclio-Invoke-Trigger"
 	SkipTLSVerification = "X-Nuclio-Skip-Tls-Verification"
 	Path                = "X-Nuclio-Path"
 	LogLevel            = "X-Nuclio-Log-Level"

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/common/headers"
 	"github.com/nuclio/nuclio/pkg/errgroup"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform/abstract"
@@ -2060,8 +2061,14 @@ func (lc *lazyClient) generateCronTriggerCronJobSpec(ctx context.Context,
 		headersAsCurlArg = fmt.Sprintf("%s --header \"%s: %s\"", headersAsCurlArg, headerKey, headerValue)
 	}
 
-	// add default header
-	headersAsCurlArg = fmt.Sprintf("%s --header \"%s: %s\"", headersAsCurlArg, "x-nuclio-invoke-trigger", "cron")
+	// add default headers
+	headersAsCurlArg = fmt.Sprintf("%s --header \"%s: %s\" --header \"%s: %s\"",
+		headersAsCurlArg,
+		headers.InvokeTrigger,
+		"cron",
+		headers.TargetName,
+		function.Name,
+	)
 
 	functionAddress, err := lc.getCronTriggerInvocationURL(resources, function.Namespace)
 	if err != nil {


### PR DESCRIPTION
The cron job invokes the function's service using an http request.
When a function is scaled to zero, the DLX is listening for function invocations, but it is looking for the `X-Nuclio-Target` header to know which service to invoke.
This header was missing from the Cron job's http request, and thus scaling from zero wasn't possible using a Cron trigger.

https://iguazio.atlassian.net/browse/NUC-313