### PR TITLE
[Processor] Move signaling to Python runtime

### DIFF
--- a/pkg/processor/runtime/python/runtime.go
+++ b/pkg/processor/runtime/python/runtime.go
@@ -23,8 +23,10 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc"
 	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/encoder"
@@ -126,6 +128,54 @@ func (py *python) WaitForStart() bool {
 
 func (py *python) SupportsControlCommunication() bool {
 	return true
+}
+
+// Drain signals to the runtime to drain its accumulated events and waits for it to finish
+func (py *python) Drain() error {
+
+	// do not send a signal if the runtime isn't ready,
+	// because the signal handler may not be initialized yet.
+	// if the process receives a signal before the handler is set up,
+	// the default behaviour will cause the Linux process to terminate.
+	if py.GetStatus() != status.Ready {
+		return nil
+	}
+
+	// we use SIGUSR2 to signal the wrapper process to drain events
+	if err := py.Signal(syscall.SIGUSR2); err != nil {
+		return errors.Wrap(err, "Failed to signal wrapper process to drain")
+	}
+
+	// wait for process to finish event handling or timeout
+	// TODO: replace the following function with one that waits for a control communication message or timeout
+	py.AbstractRuntime.WaitForProcessTermination(py.configuration.WorkerTerminationTimeout)
+
+	return nil
+}
+
+// Terminate signals to the runtime process that processor is about to stop working
+func (py *python) Terminate() error {
+
+	// we use SIGUSR1 to signal the wrapper process to terminate
+	if err := py.Signal(syscall.SIGUSR1); err != nil {
+		return errors.Wrap(err, "Failed to signal wrapper process to terminate")
+	}
+
+	// wait for process to finish event handling or timeout
+	// TODO: replace the following function with one that waits for a control communication message or timeout
+	py.WaitForProcessTermination(py.configuration.WorkerTerminationTimeout)
+
+	return nil
+}
+
+// Continue signals the runtime to continue event processing
+func (py *python) Continue() error {
+	// we use SIGCONT to signal the wrapper process to continue event processing
+	if err := py.Signal(syscall.SIGCONT); err != nil {
+		return errors.Wrap(err, "Failed to signal wrapper process to continue")
+	}
+
+	return nil
 }
 
 func (py *python) getHandler() string {

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -147,7 +147,7 @@ func (r *AbstractRuntime) Stop() error {
 		}
 	}
 
-	r.waitForProcessTermination(10 * time.Second)
+	r.WaitForProcessTermination(10 * time.Second)
 
 	r.wrapperProcess = nil
 	r.Logger.Warn("Successfully stopped wrapper process")
@@ -189,70 +189,7 @@ func (r *AbstractRuntime) SupportsControlCommunication() bool {
 	return false
 }
 
-// Drain signals to the runtime to drain its accumulated events and waits for it to finish
-func (r *AbstractRuntime) Drain() error {
-
-	// do not send a signal if the runtime isn't ready,
-	// because the signal handler may not be initialized yet.
-	// if the process receives a signal before the handler is set up,
-	// the default behaviour will cause the Linux process to terminate.
-	if r.GetStatus() != status.Ready {
-		return nil
-	}
-
-	// we use SIGUSR2 to signal the wrapper process to drain events
-	if err := r.signal(syscall.SIGUSR2); err != nil {
-		return errors.Wrap(err, "Failed to signal wrapper process to drain")
-	}
-
-	// wait for process to finish event handling or timeout
-	// TODO: replace the following function with one that waits for a control communication message or timeout
-	r.waitForProcessTermination(r.configuration.WorkerTerminationTimeout)
-
-	return nil
-}
-
-// Continue signals the runtime to continue event processing
-func (r *AbstractRuntime) Continue() error {
-	// we use SIGCONT to signal the wrapper process to continue event processing
-	if err := r.signal(syscall.SIGCONT); err != nil {
-		return errors.Wrap(err, "Failed to signal wrapper process to continue")
-	}
-
-	return nil
-}
-
-// Terminate signals to the runtime process that processor is about to stop working
-func (r *AbstractRuntime) Terminate() error {
-
-	// we use SIGUSR1 to signal the wrapper process to terminate
-	if err := r.signal(syscall.SIGUSR1); err != nil {
-		return errors.Wrap(err, "Failed to signal wrapper process to terminate")
-	}
-
-	// wait for process to finish event handling or timeout
-	// TODO: replace the following function with one that waits for a control communication message or timeout
-	r.waitForProcessTermination(r.configuration.WorkerTerminationTimeout)
-
-	return nil
-}
-
-func (r *AbstractRuntime) processItemAndWaitForResult(item interface{}, functionLogger logger.Logger) (*result.BatchedResults, error) {
-
-	if currentStatus := r.GetStatus(); currentStatus != status.Ready {
-		return nil, errors.Errorf("Processor not ready (current status: %s)", currentStatus)
-	}
-
-	connection, err := r.connectionManager.Allocate()
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to allocate connection")
-	}
-	processingResult, err := connection.ProcessEvent(item, functionLogger)
-
-	return processingResult, err
-}
-
-func (r *AbstractRuntime) signal(signal syscall.Signal) error {
+func (r *AbstractRuntime) Signal(signal syscall.Signal) error {
 
 	if r.wrapperProcess != nil {
 		r.Logger.DebugWith("Signaling wrapper process",
@@ -269,6 +206,44 @@ func (r *AbstractRuntime) signal(signal syscall.Signal) error {
 	}
 
 	return nil
+}
+
+// WaitForProcessTermination will best effort wait few seconds to stop channel, if timeout - assume closed
+func (r *AbstractRuntime) WaitForProcessTermination(timeout time.Duration) {
+	r.Logger.DebugWith("Waiting for process termination",
+		"wid", r.Context.WorkerID,
+		"process", r.wrapperProcess,
+		"timeout", timeout.String())
+
+	for {
+		select {
+		case <-r.stopChan:
+			r.Logger.DebugWith("Process terminated",
+				"wid", r.Context.WorkerID,
+				"process", r.wrapperProcess)
+			return
+		case <-time.After(timeout):
+			r.Logger.DebugWith("Timeout waiting for process termination, assuming closed",
+				"wid", r.Context.WorkerID,
+				"process", r.wrapperProcess)
+			return
+		}
+	}
+}
+
+func (r *AbstractRuntime) processItemAndWaitForResult(item interface{}, functionLogger logger.Logger) (*result.BatchedResults, error) {
+
+	if currentStatus := r.GetStatus(); currentStatus != status.Ready {
+		return nil, errors.Errorf("Processor not ready (current status: %s)", currentStatus)
+	}
+
+	connection, err := r.connectionManager.Allocate()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to allocate connection")
+	}
+	processingResult, err := connection.ProcessEvent(item, functionLogger)
+
+	return processingResult, err
 }
 
 func (r *AbstractRuntime) startWrapper() error {
@@ -353,27 +328,4 @@ func (r *AbstractRuntime) watchWrapperProcess() {
 	}
 
 	panic(fmt.Sprintf("Wrapper process for worker %d exited unexpectedly with: %s", r.Context.WorkerID, panicMessage))
-}
-
-// waitForProcessTermination will best effort wait few seconds to stop channel, if timeout - assume closed
-func (r *AbstractRuntime) waitForProcessTermination(timeout time.Duration) {
-	r.Logger.DebugWith("Waiting for process termination",
-		"wid", r.Context.WorkerID,
-		"process", r.wrapperProcess,
-		"timeout", timeout.String())
-
-	for {
-		select {
-		case <-r.stopChan:
-			r.Logger.DebugWith("Process terminated",
-				"wid", r.Context.WorkerID,
-				"process", r.wrapperProcess)
-			return
-		case <-time.After(timeout):
-			r.Logger.DebugWith("Timeout waiting for process termination, assuming closed",
-				"wid", r.Context.WorkerID,
-				"process", r.wrapperProcess)
-			return
-		}
-	}
 }

--- a/pkg/processor/runtime/runtime.go
+++ b/pkg/processor/runtime/runtime.go
@@ -184,6 +184,24 @@ func (ar *AbstractRuntime) GetControlMessageBroker() controlcommunication.Contro
 	return ar.configuration.ControlMessageBroker
 }
 
+// Stop stops the runtime
+func (ar *AbstractRuntime) Stop() error {
+	ar.SetStatus(status.Stopped)
+	return nil
+}
+
+func (ar *AbstractRuntime) Drain() error {
+	return nil
+}
+
+func (ar *AbstractRuntime) Terminate() error {
+	return nil
+}
+
+func (ar *AbstractRuntime) Continue() error {
+	return nil
+}
+
 func (ar *AbstractRuntime) createAndStartDataBindings(parentLogger logger.Logger,
 	configuration *Configuration) (map[string]databinding.DataBinding, error) {
 
@@ -253,22 +271,4 @@ func (ar *AbstractRuntime) createContext(parentLogger logger.Logger,
 	}
 
 	return newContext, nil
-}
-
-// Stop stops the runtime
-func (ar *AbstractRuntime) Stop() error {
-	ar.SetStatus(status.Stopped)
-	return nil
-}
-
-func (ar *AbstractRuntime) Drain() error {
-	return nil
-}
-
-func (ar *AbstractRuntime) Terminate() error {
-	return nil
-}
-
-func (ar *AbstractRuntime) Continue() error {
-	return nil
 }


### PR DESCRIPTION
The processor uses system signals to tell the RPC runtime wrapper process something is about to happen:
- SIGUSR1: The process is about to be terminated (e.g. by k8s), following a SIGTERM caught by the processor
- SIGUSR2: For Kafka trigger - A rebalance is about to happen
- SIGCONT: For Kafka trigger - runtime can continue handling events.

The issue is that only the Python runtime handler implemented logic to catch these signals and run the relevant procedure.
All other RPC runtimes (e.g. Java, Node) don't catch these signals.
The bug is that the signaling is implemented in the Abstract RPC Runtime, and not only for Python runtime, which caused other runtimes to panic when receiving these signals.

This PR fixes it by moving the logic to the python runtime.

Ticket: TBD