### PR TITLE
[Test] Add java runtime with kafka trigger test

### DIFF
--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -605,9 +605,14 @@ func (suite *TestSuite) deployFunctionPopulateMissingFields(createFunctionOption
 			functionConfig = deployResult.UpdatedFunctionConfig
 		}
 
-		suite.Platform.DeleteFunction(suite.ctx, &platform.DeleteFunctionOptions{ // nolint: errcheck
+		err := suite.Platform.DeleteFunction(suite.ctx, &platform.DeleteFunctionOptions{ // nolint: errcheck
 			FunctionConfig: functionConfig,
 		})
+		if err != nil {
+			suite.Logger.WarnWith("Failed to delete function",
+				"functionName", createFunctionOptions.FunctionConfig.Meta.Name,
+				"error", err)
+		}
 	}()
 
 	return suite.deployFunction(createFunctionOptions, onAfterContainerRun)

--- a/pkg/processor/trigger/kafka/test/kafka_confluent_test.go
+++ b/pkg/processor/trigger/kafka/test/kafka_confluent_test.go
@@ -135,7 +135,8 @@ func (suite *testConfluentSuite) TestReceiveRecords() {
 			},
 		},
 		nil,
-		suite.publishMessageToTopic)
+		suite.publishMessageToTopic,
+		nil)
 }
 
 func (suite *testConfluentSuite) publishMessageToTopic(topic string, body string) error {

--- a/pkg/processor/trigger/kinesis/test/kinesis_test.go
+++ b/pkg/processor/trigger/kinesis/test/kinesis_test.go
@@ -92,7 +92,8 @@ func (suite *testSuite) TestReceiveRecords() {
 		createFunctionOptions,
 		map[string]triggertest.TopicMessages{suite.streamName: {NumMessages: suite.shardCount}},
 		nil,
-		suite.publishMessageToTopic)
+		suite.publishMessageToTopic,
+		nil)
 }
 
 // GetContainerRunInfo returns information about the broker container

--- a/pkg/processor/trigger/mqtt/basic/test/mqtt_test.go
+++ b/pkg/processor/trigger/mqtt/basic/test/mqtt_test.go
@@ -129,7 +129,8 @@ func (suite *testSuite) TestMultipleTopics() {
 			"a2/b2/c3/c4": {NumMessages: 3},
 		},
 		nil,
-		suite.publishMessageToTopic)
+		suite.publishMessageToTopic,
+		nil)
 }
 
 func (suite *testSuite) getCreateFunctionOptionsWithMQTTTrigger(triggerConfig functionconfig.Trigger) *platform.CreateFunctionOptions {

--- a/pkg/processor/trigger/nats/test/nats_test.go
+++ b/pkg/processor/trigger/nats/test/nats_test.go
@@ -70,7 +70,8 @@ func (suite *testSuite) TestPostEvent() {
 			suite.topicName: {NumMessages: 20},
 		},
 		nil,
-		suite.publishMessageToTopic)
+		suite.publishMessageToTopic,
+		nil)
 }
 
 func (suite *testSuite) getDeployOptions() *platform.CreateFunctionOptions {

--- a/pkg/processor/trigger/partitioned/eventhub/test/eventhub_test.go
+++ b/pkg/processor/trigger/partitioned/eventhub/test/eventhub_test.go
@@ -84,7 +84,8 @@ func (suite *testSuite) TestReceiveRecords() {
 		createFunctionOptions,
 		map[string]triggertest.TopicMessages{"": {NumMessages: 3}},
 		nil,
-		suite.publishMessageToTopic)
+		suite.publishMessageToTopic,
+		nil)
 }
 
 func (suite *testSuite) publishMessageToTopic(topic string, body string) error {

--- a/pkg/processor/trigger/pubsub/test/pubsub_test.go
+++ b/pkg/processor/trigger/pubsub/test/pubsub_test.go
@@ -135,7 +135,8 @@ func (suite *testSuite) TestReceiveRecords() {
 			},
 		},
 		nil,
-		suite.publishMessageToTopic)
+		suite.publishMessageToTopic,
+		nil)
 }
 
 // GetContainerRunInfo returns information about the broker container

--- a/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
+++ b/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
@@ -133,7 +133,7 @@ func (suite *testSuite) TestReconnect() {
 
 			// publish
 			return suite.publishMessageToTopic(topic, body)
-		})
+		}, nil)
 }
 
 func (suite *testSuite) TestPreexistingResources() {
@@ -163,7 +163,8 @@ func (suite *testSuite) TestPreexistingResources() {
 			"t3": {NumMessages: 3},
 		},
 		nil,
-		suite.publishMessageToTopic)
+		suite.publishMessageToTopic,
+		nil)
 }
 
 func (suite *testSuite) TestResourcesCreatedByFunction() {
@@ -192,7 +193,8 @@ func (suite *testSuite) TestResourcesCreatedByFunction() {
 			"t4": {NumMessages: 3},
 			"t5": {NumMessages: 3},
 		},
-		suite.publishMessageToTopic)
+		suite.publishMessageToTopic,
+		nil)
 }
 
 func (suite *testSuite) getCreateFunctionOptionsWithRmqTrigger(triggerConfig functionconfig.Trigger) *platform.CreateFunctionOptions {

--- a/pkg/processor/trigger/test/broker.go
+++ b/pkg/processor/trigger/test/broker.go
@@ -82,6 +82,13 @@ func NewAbstractBrokerSuite(brokerSuite BrokerSuite) *AbstractBrokerSuite {
 		"event-recorder",
 		"golang",
 		"event_recorder.go")
+
+	newAbstractBrokerSuite.FunctionPaths["java"] = path.Join(newAbstractBrokerSuite.GetTestFunctionsDir(),
+		"common",
+		"event-recorder",
+		"java",
+		"Handler.java")
+
 	return newAbstractBrokerSuite
 }
 

--- a/pkg/processor/trigger/test/eventrecorder.go
+++ b/pkg/processor/trigger/test/eventrecorder.go
@@ -41,15 +41,24 @@ type Event struct {
 type MessagePublisher func(string, string) error
 
 type TopicMessages struct {
-	NumMessages int
+	NumMessages         int
+	CustomMessagePrefix string
 }
 
-func InvokeEventRecorder(suite *processorsuite.TestSuite,
+type PostPublishChecks struct {
+	EnsureAckFunction                func(consumerGroup string, topic string, expectedNumberOfCommittedOffsets int) bool
+	ExpectedNumberOfCommittedOffsets int
+	ConsumerGroup                    string
+}
+
+func InvokeEventRecorder(
+	suite *processorsuite.TestSuite,
 	host string,
 	createFunctionOptions *platform.CreateFunctionOptions,
-	numExpectedMessagesPerTopic map[string]TopicMessages,
+	expectedMessagesPerTopic map[string]TopicMessages,
 	numNonExpectedMessagesPerTopic map[string]TopicMessages,
-	messagePublisher MessagePublisher) {
+	messagePublisher MessagePublisher,
+	postPublishChecks *PostPublishChecks) {
 
 	// deploy functions
 	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
@@ -57,13 +66,18 @@ func InvokeEventRecorder(suite *processorsuite.TestSuite,
 		var sentBodies []string
 
 		suite.Logger.DebugWith("Producing",
-			"numExpectedMessagesPerTopic", numExpectedMessagesPerTopic,
+			"expectedMessagesPerTopic", expectedMessagesPerTopic,
 			"numNonExpectedMessagesPerTopic", numNonExpectedMessagesPerTopic)
 
 		// send messages we expect to see arrive @ the function, each to their own topic
-		for topic, topicMessages := range numExpectedMessagesPerTopic {
+		for topic, topicMessages := range expectedMessagesPerTopic {
 			for messageIdx := 0; messageIdx < topicMessages.NumMessages; messageIdx++ {
-				messageBody := fmt.Sprintf("%s-%d", topic, messageIdx)
+				var messageBody string
+				if topicMessages.CustomMessagePrefix != "" {
+					messageBody = fmt.Sprintf("%s-%s-%d", topicMessages.CustomMessagePrefix, topic, messageIdx)
+				} else {
+					messageBody = fmt.Sprintf("%s-%d", topic, messageIdx)
+				}
 
 				// send the message
 				err := messagePublisher(topic, messageBody)
@@ -114,6 +128,18 @@ func InvokeEventRecorder(suite *processorsuite.TestSuite,
 		// compare bodies
 		suite.Require().Equal(sentBodies, receivedBodies)
 
+		if postPublishChecks != nil {
+			if postPublishChecks.EnsureAckFunction != nil {
+				err = common.RetryUntilSuccessful(
+					60*time.Second,
+					2*time.Second,
+					func() bool {
+						return postPublishChecks.EnsureAckFunction(postPublishChecks.ConsumerGroup, "", postPublishChecks.ExpectedNumberOfCommittedOffsets)
+					},
+				)
+				suite.Require().NoError(err)
+			}
+		}
 		return true
 	})
 }

--- a/pkg/processor/trigger/v3iostream/test/v3iostream_test.go
+++ b/pkg/processor/trigger/v3iostream/test/v3iostream_test.go
@@ -295,7 +295,8 @@ func (suite *testSuite) TestReceiveRecords() {
 			},
 		},
 		nil,
-		suite.writeMessageToStream)
+		suite.writeMessageToStream,
+		nil)
 }
 
 // before running this test - create a function on your system with numOfReplicas and a v3iostream trigger,

--- a/test/_functions/common/event-recorder/java/Handler.java
+++ b/test/_functions/common/event-recorder/java/Handler.java
@@ -1,0 +1,124 @@
+/*
+Copyright 2023 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import io.nuclio.Context;
+import io.nuclio.Event;
+import io.nuclio.EventHandler;
+import io.nuclio.Response;
+
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Handler implements EventHandler {
+
+    private static final String EVENTS_LOG_FILE_PATH = "/tmp/events.json";
+
+    @Override
+    public Response handleEvent(Context context, Event event) {
+        try {
+            String triggerKind = ensureString(event.getTriggerInfo().getKindName());
+            if (!"http".equals(triggerKind) || invokedByCron(event)) {
+                String body = ensureString(event.getBody());
+                context.getLogger().debug("Received event with body: " + body);
+
+                // Serialize record
+                Map<String, Object> record = new HashMap<>();
+                record.put("body", body);
+                record.put("headers", ensureHeaders(event.getHeaders()));
+                record.put("timestamp", Instant.now().toString());
+
+                String serializedRecord = new JSONObject(record).toString();
+
+                // Append record to log file
+                appendToLogFile(serializedRecord);
+                return new Response();
+            }
+
+            // Read log file and return events
+            String encodedEventLog = getEventsLog();
+            context.getLogger().debug("Returning events: " + encodedEventLog);
+            return new Response().setBody(encodedEventLog).setStatusCode(200);
+        } catch (Exception e) {
+            context.getLogger().error("Error handling event", e);
+            return new Response().setBody(e.toString()).setStatusCode(500);
+        }
+    }
+
+    private boolean invokedByCron(Event event) {
+        String header = getHeader(event, "x-nuclio-invoke-trigger");
+        return "cron".equals(header);
+    }
+
+    private String ensureString(Object value) {
+        if (value instanceof String) {
+            return (String) value;
+        } else if (value instanceof byte[]) {
+            return new String((byte[]) value);
+        } else {
+            throw new IllegalArgumentException("Unexpected type: " + value.getClass());
+        }
+    }
+
+    private Map<String, String> ensureHeaders(Map<String, Object> headers) {
+        Map<String, String> ensuredHeaders = new HashMap<>();
+        headers.forEach((key, value) -> ensuredHeaders.put(ensureString(key), ensureString(value)));
+        return ensuredHeaders;
+    }
+
+    private String getHeader(Event event, String key) {
+        Map<String, Object> headers = event.getHeaders();
+        if (headers != null && headers.containsKey(key)) {
+            return ensureString(headers.get(key));
+        }
+        return "";
+    }
+
+    private void appendToLogFile(String record) throws IOException {
+        File logFile = new File(EVENTS_LOG_FILE_PATH);
+
+        // Read existing content, if any
+        String existingData = logFile.exists() ? Files.readString(logFile.toPath()).trim() : "[]";
+
+        // Parse existing data and append the new record
+        String updatedData;
+        if (existingData.equals("[]")) {
+            updatedData = "[" + record + "]";
+        } else {
+            updatedData = existingData.substring(0, existingData.length() - 1) + "," + record + "]";
+        }
+
+        // Write the updated data back to the file
+        try (FileWriter fileWriter = new FileWriter(logFile, false)) {
+            fileWriter.write(updatedData);
+        }
+    }
+
+    private String getEventsLog() throws IOException {
+        File logFile = new File(EVENTS_LOG_FILE_PATH);
+        if (!logFile.exists()) {
+            return "[]";
+        }
+
+        String data = Files.readString(logFile.toPath()).trim();
+        return data.isEmpty() ? "[]" : data;
+    }
+}


### PR DESCRIPTION
This PR adds another test for kafka trigger - this time for java runtime.

Also, within this PR I added function `getNumberOfCommittedOffsets` which allows to get number of committed offsets from broker itself, because we need to make sure that messages are committed before stopping a function.