### PR TITLE
[Test] Do not log full request body if longer than 256

### DIFF
--- a/pkg/processor/trigger/http/test/suite/suite.go
+++ b/pkg/processor/trigger/http/test/suite/suite.go
@@ -145,7 +145,13 @@ func (suite *TestSuite) DeployFunctionAndRequests(createFunctionOptions *platfor
 		for _, request := range requests {
 			request.Enrich(deployResult)
 			suite.Logger.DebugWith("Sending request",
-				"requestBody", request.RequestBody,
+				"requestBody", func() string {
+					if len(request.RequestBody) > 256 {
+						// Truncate to 256 characters and append "..."
+						return request.RequestBody[:256] + "..."
+					}
+					return request.RequestBody
+				}(),
 				"expectedResponseStatusCode", request.ExpectedResponseStatusCode)
 			if !suite.SendRequestVerifyResponse(request) {
 


### PR DESCRIPTION
python-runtime-tests fail sometimes in periodic CI and it's impossible to understand the reason because log is too big.