### PR TITLE
[Function] Query permissions for function replica API

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -647,3 +647,15 @@ func SanitizeResponseData(data []byte, headers http.Header) []byte {
 	sanitizedData := policy.Sanitize(string(data))
 	return []byte(sanitizedData)
 }
+
+// GetFunctionName returns the actual name of a function variable
+func GetFunctionName(function interface{}) string {
+	fullName := runtime.FuncForPC(reflect.ValueOf(function).Pointer()).Name()
+	parts := strings.Split(fullName, ".")
+	shortName := parts[len(parts)-1]
+
+	// Methods passed by reference have a suffix of "-fm"
+	shortName = strings.TrimSuffix(shortName, "-fm")
+
+	return shortName
+}

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -431,8 +431,7 @@ func (fr *functionResource) validateLogStreamOptions(ctx context.Context,
 
 func (fr *functionResource) getFunctionReplicas(request *http.Request) (
 	*restful.CustomRouteFuncResponse, error) {
-
-	fr.Logger.InfoWithCtx(request.Context(), "TOMER - Getting function replicas")
+	ctx := request.Context()
 
 	// ensure namespace
 	namespace := fr.getNamespaceFromRequest(request)
@@ -452,12 +451,12 @@ func (fr *functionResource) getFunctionReplicas(request *http.Request) (
 	}
 
 	permissionOptions := opa.PermissionOptions{
-		MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fr.getCtxSession(request.Context())),
+		MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fr.getCtxSession(ctx)),
 		OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		RaiseForbidden:      true,
 	}
 
-	replicaNames, err := fr.getPlatform().GetFunctionReplicaNames(request.Context(), function, permissionOptions)
+	replicaNames, err := fr.getPlatform().GetFunctionReplicaNames(ctx, function, permissionOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get function replicas")
 	}

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -432,6 +432,8 @@ func (fr *functionResource) validateLogStreamOptions(ctx context.Context,
 func (fr *functionResource) getFunctionReplicas(request *http.Request) (
 	*restful.CustomRouteFuncResponse, error) {
 
+	fr.Logger.InfoWithCtx(request.Context(), "TOMER - Getting function replicas")
+
 	// ensure namespace
 	namespace := fr.getNamespaceFromRequest(request)
 	if namespace == "" {

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -644,19 +644,11 @@ func (p *Platform) GetFunctionReplicaLogsStream(ctx context.Context,
 func (p *Platform) GetFunctionReplicaNames(ctx context.Context,
 	function platform.Function, permissionOptions opa.PermissionOptions) ([]string, error) {
 
-	p.Logger.DebugWithCtx(ctx, "TOMER - Getting function replica names",
-		"functionName", function.GetConfig().Meta.Name,
-		"functionNamespace", function.GetConfig().Meta.Namespace,
-		"memberIds", permissionOptions.MemberIds,
-		"overrideHeaderValue", permissionOptions.OverrideHeaderValue)
-
 	functions, err := p.Platform.FilterFunctionsByPermissions(ctx, &permissionOptions, []platform.Function{function})
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to filter functions by permissions")
 	}
 	if len(functions) == 0 {
-		p.Logger.DebugWithCtx(ctx, "TOMER - Function was filtered out by permissions, return not found error",
-			"functionName", function.GetConfig().Meta.Name)
 		// Function was filtered out by permissions, return not found error
 		return nil, nuclio.NewErrNotFound(fmt.Sprintf("Function not found - %s", function.GetConfig().Meta.Name))
 	}

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -644,11 +644,19 @@ func (p *Platform) GetFunctionReplicaLogsStream(ctx context.Context,
 func (p *Platform) GetFunctionReplicaNames(ctx context.Context,
 	function platform.Function, permissionOptions opa.PermissionOptions) ([]string, error) {
 
+	p.Logger.DebugWithCtx(ctx, "TOMER - Getting function replica names",
+		"functionName", function.GetConfig().Meta.Name,
+		"functionNamespace", function.GetConfig().Meta.Namespace,
+		"memberIds", permissionOptions.MemberIds,
+		"overrideHeaderValue", permissionOptions.OverrideHeaderValue)
+
 	functions, err := p.Platform.FilterFunctionsByPermissions(ctx, &permissionOptions, []platform.Function{function})
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to filter functions by permissions")
 	}
 	if len(functions) == 0 {
+		p.Logger.DebugWithCtx(ctx, "TOMER - Function was filtered out by permissions, return not found error",
+			"functionName", function.GetConfig().Meta.Name)
 		// Function was filtered out by permissions, return not found error
 		return nil, nuclio.NewErrNotFound(fmt.Sprintf("Function not found - %s", function.GetConfig().Meta.Name))
 	}

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -516,9 +516,9 @@ func (p *Platform) GetFunctionReplicaLogsStream(ctx context.Context,
 }
 
 func (p *Platform) GetFunctionReplicaNames(ctx context.Context,
-	functionConfig *functionconfig.Config) ([]string, error) {
+	function platform.Function, permissionOptions opa.PermissionOptions) ([]string, error) {
 	return []string{
-		p.GetFunctionContainerName(functionConfig),
+		p.GetFunctionContainerName(function.GetConfig()),
 	}, nil
 }
 

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -150,8 +150,8 @@ func (mp *Platform) GetFunctionReplicaLogsStream(ctx context.Context, options *p
 }
 
 // GetFunctionReplicaNames returns function replica names (Pod / Container names)
-func (mp *Platform) GetFunctionReplicaNames(ctx context.Context, functionConfig *functionconfig.Config) ([]string, error) {
-	args := mp.Called(ctx, functionConfig)
+func (mp *Platform) GetFunctionReplicaNames(ctx context.Context, function platform.Function, permissionOptions opa.PermissionOptions) ([]string, error) {
+	args := mp.Called(ctx, function, permissionOptions)
 	return args.Get(0).([]string), args.Error(1)
 }
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -87,7 +87,7 @@ type Platform interface {
 	GetFunctionReplicaLogsStream(context.Context, *GetFunctionReplicaLogsStreamOptions) (io.ReadCloser, error)
 
 	// GetFunctionReplicaNames returns function replica names (Pod / Container names)
-	GetFunctionReplicaNames(context.Context, *functionconfig.Config) ([]string, error)
+	GetFunctionReplicaNames(context.Context, Function, opa.PermissionOptions) ([]string, error)
 
 	// GetFunctionReplicaContainers returns function replica containers (Pod / Container names)
 	GetFunctionReplicaContainers(context.Context, *functionconfig.Config, string) ([]string, error)

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -534,7 +534,7 @@ type GetAPIGatewaysOptions struct {
 	AuthSession  auth.Session
 }
 
-// to appease k8s
+// DeepCopyInto to appease k8s
 func (s *APIGatewaySpec) DeepCopyInto(out *APIGatewaySpec) {
 
 	// TODO: proper deep copy
@@ -561,4 +561,7 @@ type GetFunctionReplicaLogsStreamOptions struct {
 	// A specific container name to stream logs from (if not specified, the "nuclio" container in the pod is used)
 	// Relevant only for pods with multiple containers
 	ContainerName string
+
+	// Permission options for the log stream
+	PermissionOptions opa.PermissionOptions
 }

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -19,7 +19,6 @@ package restful
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -581,6 +580,7 @@ func (ar *AbstractResource) callCustomStreamRouteFunc(responseWriter http.Respon
 func (ar *AbstractResource) callCustomRouteFunc(responseWriter http.ResponseWriter,
 	request *http.Request,
 	routeFunc CustomRouteFunc) {
+	routeFuncName := common.GetFunctionName(routeFunc)
 
 	// see if the resource only supports a single record
 	response, err := routeFunc(request)
@@ -588,8 +588,9 @@ func (ar *AbstractResource) callCustomRouteFunc(responseWriter http.ResponseWrit
 	if err != nil {
 		ar.Logger.WarnWith("Custom routed handler failed",
 			"err", err.Error(),
-			"routeFunc", fmt.Sprintf("%T", routeFunc),
-			"request", request)
+			"routeFunc", routeFuncName,
+			"requestURL", request.URL.String(),
+			"requestMethod", request.Method)
 	}
 
 	// if response object was not created, fill a placeholder
@@ -600,8 +601,9 @@ func (ar *AbstractResource) callCustomRouteFunc(responseWriter http.ResponseWrit
 			Headers:    map[string]string{"Content-Type": "application/json"},
 		}
 		ar.Logger.WarnWith("Response object not filled by handler, using placeholder",
-			"routeFunc", fmt.Sprintf("%T", routeFunc),
-			"request", request,
+			"routeFunc", routeFuncName,
+			"requestURL", request.URL.String(),
+			"requestMethod", request.Method,
 			"response", response)
 	}
 
@@ -629,9 +631,10 @@ func (ar *AbstractResource) callCustomRouteFunc(responseWriter http.ResponseWrit
 
 				// should never happen
 				ar.Logger.ErrorWith("Response writer failed writing empty resources",
-					"err", err,
-					"routeFunc", routeFunc,
-					"request", request)
+					"err", err.Error(),
+					"routeFunc", routeFuncName,
+					"requestURL", request.URL.String(),
+					"requestMethod", request.Method)
 			}
 
 		}

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -587,7 +587,7 @@ func (ar *AbstractResource) callCustomRouteFunc(responseWriter http.ResponseWrit
 
 	if err != nil {
 		ar.Logger.WarnWith("Custom routed handler failed",
-			"err", err,
+			"err", err.Error(),
 			"routeFunc", fmt.Sprintf("%T", routeFunc),
 			"request", request)
 	}


### PR DESCRIPTION
The following 2 endpoints were missing filtering by permissions, and were open to all:
- `GET /api/functions/<function name>/replicas`
- `GET /api/functions/<function name>/logs/<replica-name>`

Added filtering based on permissions for the `/replicas` endpoint, which is called in the `/logs/<replica-name>` logic too.

Also fixed custom route error logs to avoid failing on non json-able variables.

https://iguazio.atlassian.net/browse/NUC-273