### PR TITLE
[Docs] Add note on tech-preview runtimes and triggers

### DIFF
--- a/docs/reference/runtimes/dotnetcore/dotnetcore-reference.md
+++ b/docs/reference/runtimes/dotnetcore/dotnetcore-reference.md
@@ -2,6 +2,8 @@
 
 This document describes the specific .NET Core build and deploy configurations.
 
+> **NOTE:**  .Net Core runtime is in tech-preview.
+
 #### In this document
 
 - [Function and handler](#function-and-handler)

--- a/docs/reference/runtimes/java/java-reference.md
+++ b/docs/reference/runtimes/java/java-reference.md
@@ -2,6 +2,8 @@
 
 This document describes specific Java build and deploy configurations.
 
+> **NOTE:**  Java runtime is in tech-preview.
+
 #### In this document
 
 - [Function and handler](#function-and-handler)

--- a/docs/reference/runtimes/nodejs/nodejs-reference.md
+++ b/docs/reference/runtimes/nodejs/nodejs-reference.md
@@ -2,6 +2,8 @@
 
 This document describes the specific NodeJS build and deploy configurations.
 
+> **NOTE:**  NodeJS runtime is in tech-preview.
+
 #### In this document
 
 - [Function and handler](#function-and-handler)

--- a/docs/reference/runtimes/shell/shell-reference.md
+++ b/docs/reference/runtimes/shell/shell-reference.md
@@ -2,6 +2,8 @@
 
 This guide uses practical examples to guide you through the process of writing serverless shell functions.
 
+> **NOTE:**  Shell runtime is in tech-preview.
+
 #### In this document
 
 - [Overview](#overview)

--- a/docs/reference/triggers/eventhub.md
+++ b/docs/reference/triggers/eventhub.md
@@ -1,5 +1,7 @@
 # Azure Event Hub trigger
 
+> **NOTE:**  Azure Event Hub trigger is in tech-preview.
+
 Reads events from [Microsoft Azure Event Hubs](https://azure.microsoft.com/services/event-hubs/).
 
 ## Attributes

--- a/docs/reference/triggers/kinesis.md
+++ b/docs/reference/triggers/kinesis.md
@@ -1,5 +1,7 @@
 # Kinesis trigger
 
+> **NOTE:**  Kinesis trigger is in tech-preview.
+
 Reads records from [Amazon Kinesis](https://aws.amazon.com/kinesis/) streams.
 
 ## In this document

--- a/docs/reference/triggers/mqtt.md
+++ b/docs/reference/triggers/mqtt.md
@@ -1,5 +1,7 @@
 # MQTT trigger
 
+> **NOTE:**  MQTT trigger is in tech-preview.
+
 Reads messages from [MQTT](https://mqtt.org/) topics.
 
 ## Attributes

--- a/docs/reference/triggers/nats.md
+++ b/docs/reference/triggers/nats.md
@@ -1,5 +1,7 @@
 # NATS trigger
 
+> **NOTE:**  NATS trigger is in tech-preview.
+
 Reads messages from [NATS](https://nats.io/) topics. Function replicas are subscribed to a worker group (queue), and messages are load-balanced across replicas. To join a specific worker group, specify a queue-name attribute in the trigger configuration.
 
 The queue name may be a Go template, which may include any of the following fields:

--- a/docs/reference/triggers/rabbitmq.md
+++ b/docs/reference/triggers/rabbitmq.md
@@ -1,5 +1,7 @@
 # RabbitMQ trigger
 
+> **NOTE:**  RabbitMQ trigger is in tech-preview.
+
 Reads messages from [RabbitMQ](https://www.rabbitmq.com/) queues.
 
 ## Attributes


### PR DESCRIPTION
The "Tech Preview" notation marks features that are included in the release but have not undergone comprehensive quality assurance testing, and therefore should not be used in production.

Added a note on each tech-preview trigger and runtime.

https://iguazio.atlassian.net/browse/NUC-334