### PR TITLE
[Processor] Do not allow ExplicitAck for runtimes in which it is not supported 

### DIFF
--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -166,6 +166,17 @@ const (
 	DefaultWorkerTerminationTimeout string = "10s"
 )
 
+var runtimesSupportingExplicitAck = []string{"python"}
+
+func RuntimeSupportExplicitAck(runtime string) bool {
+	for _, supportedRuntime := range runtimesSupportingExplicitAck {
+		if strings.HasPrefix(runtime, supportedRuntime) {
+			return true
+		}
+	}
+	return false
+}
+
 func ExplicitAckModeInSlice(ackMode ExplicitAckMode, ackModes []ExplicitAckMode) bool {
 	for _, mode := range ackModes {
 		if ackMode == mode {

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1823,6 +1823,16 @@ func (ap *Platform) enrichExplicitAckParams(ctx context.Context, functionConfig 
 			triggerInstance.ExplicitAckMode = functionconfig.ExplicitAckModeDisable
 		}
 
+		if triggerInstance.ExplicitAckMode != functionconfig.ExplicitAckModeDisable &&
+			!functionconfig.RuntimeSupportExplicitAck(functionConfig.Spec.Runtime) {
+			ap.Logger.WarnWith("Explicit Ack is not supported for the configured runtime. "+
+				"Setting explicitAck mode to `disable`",
+				"functionName", functionConfig.Meta.Name,
+				"runtime", functionConfig.Spec.Runtime,
+				"trigger", triggerName)
+			triggerInstance.ExplicitAckMode = functionconfig.ExplicitAckModeDisable
+		}
+
 		if triggerInstance.WorkerTerminationTimeout == "" {
 			triggerInstance.WorkerTerminationTimeout = functionconfig.DefaultWorkerTerminationTimeout
 		}

--- a/pkg/processor/trigger/kafka/kafka_test.go
+++ b/pkg/processor/trigger/kafka/kafka_test.go
@@ -102,43 +102,71 @@ func (suite *TestSuite) TestExplicitAckModeWithWorkerAllocationModes() {
 		name                 string
 		explicitAckMode      functionconfig.ExplicitAckMode
 		workerAllocationMode partitionworker.AllocationMode
+		runtime              string
 		expectedFailure      bool
 	}{
 		{
-			name:                 "Disable-Static",
+			name:                 "Python-Disable-Static",
 			explicitAckMode:      functionconfig.ExplicitAckModeDisable,
 			workerAllocationMode: partitionworker.AllocationModeStatic,
+			runtime:              "python",
 			expectedFailure:      false,
 		},
 		{
-			name:                 "Disable-Pool",
+			name:                 "Python-Disable-Pool",
 			explicitAckMode:      functionconfig.ExplicitAckModeDisable,
 			workerAllocationMode: partitionworker.AllocationModePool,
+			runtime:              "python",
 			expectedFailure:      false,
 		},
 		{
-			name:                 "Enable-Static",
+			name:                 "Python-Enable-Static",
 			explicitAckMode:      functionconfig.ExplicitAckModeEnable,
 			workerAllocationMode: partitionworker.AllocationModeStatic,
+			runtime:              "python",
 			expectedFailure:      false,
 		},
 		{
-			name:                 "Enable-Pool",
+			name:                 "Python-Enable-Pool",
 			explicitAckMode:      functionconfig.ExplicitAckModeEnable,
 			workerAllocationMode: partitionworker.AllocationModePool,
+			runtime:              "python3.9",
 			expectedFailure:      true,
 		},
 		{
-			name:                 "ExplicitOnly-Static",
+			name:                 "Python-ExplicitOnly-Static",
 			explicitAckMode:      functionconfig.ExplicitAckModeExplicitOnly,
 			workerAllocationMode: partitionworker.AllocationModeStatic,
+			runtime:              "python3.10",
 			expectedFailure:      false,
 		},
 		{
-			name:                 "ExplicitOnly-Pool",
+			name:                 "Python-ExplicitOnly-Pool",
+			explicitAckMode:      functionconfig.ExplicitAckModeExplicitOnly,
+			workerAllocationMode: partitionworker.AllocationModePool,
+			runtime:              "python",
+			expectedFailure:      true,
+		},
+		{
+			name:                 "Golang-Enable-Pool",
 			explicitAckMode:      functionconfig.ExplicitAckModeEnable,
 			workerAllocationMode: partitionworker.AllocationModePool,
-			expectedFailure:      true,
+			runtime:              "golang",
+			expectedFailure:      false,
+		},
+		{
+			name:                 "Golang-ExplicitOnly-Pool",
+			explicitAckMode:      functionconfig.ExplicitAckModeEnable,
+			workerAllocationMode: partitionworker.AllocationModePool,
+			runtime:              "golang",
+			expectedFailure:      false,
+		},
+		{
+			name:                 "Golang-ExplicitOnly-Static",
+			explicitAckMode:      functionconfig.ExplicitAckModeExplicitOnly,
+			workerAllocationMode: partitionworker.AllocationModeStatic,
+			runtime:              "golang",
+			expectedFailure:      false,
 		},
 	} {
 		suite.Run(testCase.name, func() {
@@ -164,6 +192,9 @@ func (suite *TestSuite) TestExplicitAckModeWithWorkerAllocationModes() {
 								Annotations: map[string]string{
 									"nuclio.io/kafka-explicit-ack-mode": string(testCase.explicitAckMode),
 								},
+							},
+							Spec: functionconfig.Spec{
+								Runtime: testCase.runtime,
 							},
 						},
 					},

--- a/pkg/processor/trigger/kafka/types.go
+++ b/pkg/processor/trigger/kafka/types.go
@@ -184,7 +184,9 @@ func NewConfiguration(id string,
 		return nil, errors.Wrap(err, "Failed to populate configuration from secrets")
 	}
 
-	if err := newConfiguration.PopulateExplicitAckMode(explicitAckModeValue,
+	if err := newConfiguration.PopulateExplicitAckMode(
+		logger,
+		explicitAckModeValue,
 		triggerConfiguration.ExplicitAckMode); err != nil {
 		return nil, errors.Wrap(err, "Failed to populate explicit ack mode")
 	}

--- a/pkg/processor/trigger/v3iostream/types.go
+++ b/pkg/processor/trigger/v3iostream/types.go
@@ -85,7 +85,9 @@ func NewConfiguration(id string, triggerConfiguration *functionconfig.Trigger,
 		return nil, errors.Wrap(err, "Failed to populate configuration from annotations")
 	}
 
-	if err := newConfiguration.PopulateExplicitAckMode(explicitAckModeValue,
+	if err := newConfiguration.PopulateExplicitAckMode(
+		logger,
+		explicitAckModeValue,
 		triggerConfiguration.ExplicitAckMode); err != nil {
 		return nil, errors.Wrap(err, "Failed to populate explicit ack mode")
 	}

--- a/pkg/processor/trigger/v3iostream/v3iostream_test.go
+++ b/pkg/processor/trigger/v3iostream/v3iostream_test.go
@@ -54,43 +54,71 @@ func (suite *TestSuite) TestExplicitAckModeWithWorkerAllocationModes() {
 		name                 string
 		explicitAckMode      functionconfig.ExplicitAckMode
 		workerAllocationMode partitionworker.AllocationMode
+		runtime              string
 		expectedFailure      bool
 	}{
 		{
-			name:                 "Disable-Static",
+			name:                 "Python-Disable-Static",
 			explicitAckMode:      functionconfig.ExplicitAckModeDisable,
 			workerAllocationMode: partitionworker.AllocationModeStatic,
+			runtime:              "python",
 			expectedFailure:      false,
 		},
 		{
-			name:                 "Disable-Pool",
+			name:                 "Python-Disable-Pool",
 			explicitAckMode:      functionconfig.ExplicitAckModeDisable,
 			workerAllocationMode: partitionworker.AllocationModePool,
+			runtime:              "python",
 			expectedFailure:      false,
 		},
 		{
-			name:                 "Enable-Static",
+			name:                 "Python-Enable-Static",
 			explicitAckMode:      functionconfig.ExplicitAckModeEnable,
 			workerAllocationMode: partitionworker.AllocationModeStatic,
+			runtime:              "python",
 			expectedFailure:      false,
 		},
 		{
-			name:                 "Enable-Pool",
+			name:                 "Python-Enable-Pool",
 			explicitAckMode:      functionconfig.ExplicitAckModeEnable,
 			workerAllocationMode: partitionworker.AllocationModePool,
+			runtime:              "python3.9",
 			expectedFailure:      true,
 		},
 		{
-			name:                 "ExplicitOnly-Static",
+			name:                 "Python-ExplicitOnly-Static",
 			explicitAckMode:      functionconfig.ExplicitAckModeExplicitOnly,
 			workerAllocationMode: partitionworker.AllocationModeStatic,
+			runtime:              "python3.10",
 			expectedFailure:      false,
 		},
 		{
-			name:                 "ExplicitOnly-Pool",
+			name:                 "Python-ExplicitOnly-Pool",
+			explicitAckMode:      functionconfig.ExplicitAckModeExplicitOnly,
+			workerAllocationMode: partitionworker.AllocationModePool,
+			runtime:              "python",
+			expectedFailure:      true,
+		},
+		{
+			name:                 "Golang-Enable-Pool",
 			explicitAckMode:      functionconfig.ExplicitAckModeEnable,
 			workerAllocationMode: partitionworker.AllocationModePool,
-			expectedFailure:      true,
+			runtime:              "golang",
+			expectedFailure:      false,
+		},
+		{
+			name:                 "Golang-ExplicitOnly-Pool",
+			explicitAckMode:      functionconfig.ExplicitAckModeExplicitOnly,
+			workerAllocationMode: partitionworker.AllocationModePool,
+			runtime:              "golang",
+			expectedFailure:      false,
+		},
+		{
+			name:                 "Golang-ExplicitOnly-Static",
+			explicitAckMode:      functionconfig.ExplicitAckModeExplicitOnly,
+			workerAllocationMode: partitionworker.AllocationModeStatic,
+			runtime:              "golang",
+			expectedFailure:      false,
 		},
 	} {
 		suite.Run(testCase.name, func() {
@@ -112,6 +140,9 @@ func (suite *TestSuite) TestExplicitAckModeWithWorkerAllocationModes() {
 								Annotations: map[string]string{
 									"nuclio.io/v3iostream-explicit-ack-mode": string(testCase.explicitAckMode),
 								},
+							},
+							Spec: functionconfig.Spec{
+								Runtime: testCase.runtime,
 							},
 						},
 					},


### PR DESCRIPTION
backport #3445 