### PR TITLE
[Processor] Stop triggers before termination

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,10 +43,6 @@ run:
     - test_iguazio
     - test_broken
 
-  skip-dirs:
-    - docs
-    - vendor
-
 linters-settings:
   revive:
     rules:
@@ -57,7 +53,8 @@ linters-settings:
 
   gocritic:
     disabled-checks:
-      - commentFormatting # we dont want to enforce space before the comment text
+      # we don't want to enforce space before the comment text
+      - commentFormatting
 
   gci:
     sections:
@@ -75,6 +72,10 @@ issues:
   exclude:
     - "comment on"
     - "error should be the last"
+
+  exclude-dirs:
+    - docs
+    - vendor
 
   exclude-rules:
 

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -657,6 +657,16 @@ func (p *Processor) terminateAllTriggers(signal os.Signal) {
 		// drains all workers in trigger (for each trigger in parallel)
 		go func(triggerInstance trigger.Trigger, wg *sync.WaitGroup) {
 			defer wg.Done()
+
+			// stop trigger
+			if _, err := triggerInstance.Stop(false); err != nil {
+				p.logger.WarnWith("Failed to stop trigger",
+					"triggerKind", triggerInstance.GetKind(),
+					"triggerName", triggerInstance.GetName(),
+					"err", err.Error())
+			}
+
+			// invoke termination callbacks for all workers
 			if err := triggerInstance.SignalWorkersToTerminate(); err != nil {
 				p.logger.WarnWith("Failed to signal worker termination",
 					"triggerKind", triggerInstance.GetKind(),

--- a/pkg/platform/kube/test/function/function_test.go
+++ b/pkg/platform/kube/test/function/function_test.go
@@ -470,7 +470,7 @@ func (suite *DeployFunctionTestSuite) TestSecurityContext() {
 			runAsGroupID,
 			fsGroup),
 			strings.TrimSpace(results.Output))
-		suite.InvokeFunction("GET", deployResult.Port, "", nil)
+		suite.InvokeFunction("GET", deployResult.Port, "", nil, true)
 		return true
 	})
 }
@@ -1881,7 +1881,7 @@ def init_context(context):
 			for {
 				select {
 				case <-ticker.C:
-					suite.InvokeFunction("GET", deployResult.Port, "", nil)
+					suite.InvokeFunction("GET", deployResult.Port, "", nil, false)
 				case <-ctx.Done():
 					return
 				}
@@ -1894,12 +1894,13 @@ def init_context(context):
 		err = suite.KubeClientSet.CoreV1().Pods(firstPod.Namespace).Delete(suite.Ctx, firstPod.Name, metav1.DeleteOptions{})
 		suite.Require().NoError(err)
 
+		cancel()
+
 		err = suite.WaitMessageInPodLog(firstPod.Namespace, firstPod.Name, "Stopping HTTP trigger", &v1.PodLogOptions{}, 20*time.Second)
-		suite.Require().NotNil(err)
+		suite.Require().NoError(err)
 
 		err = suite.WaitMessageInPodLog(firstPod.Namespace, firstPod.Name, "All triggers are terminated", &v1.PodLogOptions{}, 30*time.Second)
 		suite.Require().NoError(err, "triggers were not terminated")
-		cancel()
 		return true
 	})
 }

--- a/pkg/platform/kube/test/function/function_test.go
+++ b/pkg/platform/kube/test/function/function_test.go
@@ -1849,6 +1849,7 @@ func (suite *DeployFunctionTestSuite) TestProcessorShutdown() {
 	// change source code
 	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = base64.StdEncoding.EncodeToString([]byte(`
 terminated = False
+
 def handler(context, event):
     if terminated:
         context.logger.info("Got event after termination")
@@ -1893,12 +1894,12 @@ def init_context(context):
 		err = suite.KubeClientSet.CoreV1().Pods(firstPod.Namespace).Delete(suite.Ctx, firstPod.Name, metav1.DeleteOptions{})
 		suite.Require().NoError(err)
 
+		err = suite.WaitMessageInPodLog(firstPod.Namespace, firstPod.Name, "Stopping HTTP trigger", &v1.PodLogOptions{}, 20*time.Second)
+		suite.Require().NotNil(err)
+
 		err = suite.WaitMessageInPodLog(firstPod.Namespace, firstPod.Name, "All triggers are terminated", &v1.PodLogOptions{}, 30*time.Second)
 		suite.Require().NoError(err, "triggers were not terminated")
 		cancel()
-
-		err = suite.WaitMessageInPodLog(firstPod.Namespace, firstPod.Name, "Got event after termination", &v1.PodLogOptions{}, 20*time.Second)
-		suite.Require().NotNil(err)
 		return true
 	})
 }

--- a/pkg/platform/kube/test/suite/suite.go
+++ b/pkg/platform/kube/test/suite/suite.go
@@ -235,13 +235,17 @@ def handler(context, event):
 }
 
 // InvokeFunction invokes function via HTTP trigger
-func (suite *KubeTestSuite) InvokeFunction(method string, port int, path string, requestBody []byte) {
+func (suite *KubeTestSuite) InvokeFunction(method string, port int, path string, requestBody []byte, failOnError bool) {
 	url := fmt.Sprintf("http://%s:%d%s", suite.GetNuclioExternalIP(), port, path)
 	request, err := http.NewRequest(method, url, bytes.NewBuffer(requestBody))
 	suite.Require().NoError(err)
 
 	_, err = suite.httpClient.Do(request)
-	suite.Require().NoError(err)
+	if failOnError {
+		suite.Require().NoError(err)
+	} else if err != nil {
+		suite.Logger.WarnWith("Failed to invoke function", "err", err)
+	}
 }
 
 func (suite *KubeTestSuite) GetNuclioExternalIP() string {

--- a/pkg/processor/trigger/http/http_test.go
+++ b/pkg/processor/trigger/http/http_test.go
@@ -54,6 +54,7 @@ func (suite *TestSuite) SetupSuite() {
 			Logger: suite.logger,
 		},
 		configuration: &Configuration{},
+		status:        status.NewSafeStatus(status.Ready),
 	}
 	suite.fastDummyHTTPServer = fasthttputil.NewInmemoryListener()
 	suite.serveDummyHTTPServer(suite.trigger.onRequestFromFastHTTP())

--- a/pkg/processor/trigger/http/http_test.go
+++ b/pkg/processor/trigger/http/http_test.go
@@ -140,7 +140,7 @@ func (suite *TestSuite) TestCORS() {
 		suite.trigger.Statistics.EventsHandledFailureTotal = 0
 
 		// ensure trigger is ready
-		suite.trigger.status = status.Ready
+		suite.trigger.status.SetStatus(status.Ready)
 
 		// create request, use OPTIONS to trigger preflight flow
 		request, err := nethttp.NewRequest(fasthttp.MethodOptions, "http://foo.bar/", nil)
@@ -193,7 +193,7 @@ func (suite *TestSuite) TestInternalHealthiness() {
 			suite.logger.DebugWith("Testing internal healthiness endpoint", "testCase", testCase)
 
 			// ensure trigger is ready
-			suite.trigger.status = status.Ready
+			suite.trigger.status.SetStatus(status.Ready)
 
 			request, err := nethttp.NewRequest(nethttp.MethodGet,
 				"http://foo.bar"+string(suite.trigger.internalHealthPath),

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -142,7 +142,7 @@ func (h *http) Start(checkpoint functionconfig.Checkpoint) error {
 }
 
 func (h *http) Stop(force bool) (functionconfig.Checkpoint, error) {
-	h.Logger.Debug("Shutting down")
+	h.Logger.Debug("Shutting down server")
 
 	h.status = status.Stopped
 

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -552,11 +552,12 @@ func (h *http) handleRequest(ctx *fasthttp.RequestCtx) {
 
 		// no available workers
 		case worker.ErrNoAvailableWorkers, worker.ErrAllWorkersAreTerminated:
+			h.Logger.WarnWith("No workers available", "err", submitError.Error())
 			ctx.Response.SetStatusCode(nethttp.StatusServiceUnavailable)
 
 			// something else - most likely a bug
 		default:
-			h.Logger.WarnWith("Failed to submit event", "err", submitError)
+			h.Logger.WarnWith("Failed to submit event", "err", submitError.Error())
 			ctx.Response.SetStatusCode(nethttp.StatusInternalServerError)
 		}
 

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -51,7 +51,7 @@ type http struct {
 	configuration      *Configuration
 	events             []Event
 	bufferLoggerPool   *nucliozap.BufferLoggerPool
-	status             status.Status
+	status             *status.SafeStatus
 	activeContexts     []*fasthttp.RequestCtx
 	timeouts           []uint64 // flag of worker is in timeout
 	answering          []uint64 // flag the worker is answering
@@ -95,7 +95,7 @@ func newTrigger(logger logger.Logger,
 		AbstractTrigger:    abstractTrigger,
 		configuration:      configuration,
 		bufferLoggerPool:   bufferLoggerPool,
-		status:             status.Initializing,
+		status:             status.NewSafeStatus(status.Initializing),
 		activeContexts:     make([]*fasthttp.RequestCtx, numWorkers),
 		timeouts:           make([]uint64, numWorkers),
 		answering:          make([]uint64, numWorkers),
@@ -137,14 +137,14 @@ func (h *http) Start(checkpoint functionconfig.Checkpoint) error {
 	// start listening
 	go h.server.ListenAndServe(h.configuration.URL) // nolint: errcheck
 
-	h.status = status.Ready
+	h.status.SetStatus(status.Ready)
 	return nil
 }
 
 func (h *http) Stop(force bool) (functionconfig.Checkpoint, error) {
-	h.Logger.Debug("Shutting down server")
+	h.Logger.Debug("Stopping HTTP trigger")
 
-	h.status = status.Stopped
+	h.status.SetStatus(status.Stopped)
 
 	if h.server != nil {
 		err := h.server.Shutdown()
@@ -377,7 +377,7 @@ func (h *http) handlePreflightRequest(ctx *fasthttp.RequestCtx) {
 func (h *http) preHandleRequestValidation(ctx *fasthttp.RequestCtx) bool {
 
 	// ensure server is running
-	if h.status != status.Ready {
+	if h.status.GetStatus() != status.Ready {
 		ctx.Response.SetStatusCode(nethttp.StatusServiceUnavailable)
 		msg := map[string]interface{}{
 			"error":  "Server not ready",
@@ -552,12 +552,14 @@ func (h *http) handleRequest(ctx *fasthttp.RequestCtx) {
 
 		// no available workers
 		case worker.ErrNoAvailableWorkers, worker.ErrAllWorkersAreTerminated:
-			h.Logger.WarnWith("No workers available", "err", submitError.Error())
+			h.Logger.WarnWith("No workers available",
+				"err", submitError.Error())
 			ctx.Response.SetStatusCode(nethttp.StatusServiceUnavailable)
 
 			// something else - most likely a bug
 		default:
-			h.Logger.WarnWith("Failed to submit event", "err", submitError.Error())
+			h.Logger.WarnWith("Failed to submit event",
+				"err", submitError.Error())
 			ctx.Response.SetStatusCode(nethttp.StatusInternalServerError)
 		}
 


### PR DESCRIPTION
When getting a SIGTERM from k8s, stop all triggers so they won't handle new incoming events.

In HTTP trigger, use `SafeStatus` to avoid concurrent RW on the trigger's status.

https://iguazio.atlassian.net/browse/NUC-298