### PR TITLE
[Platformconfig] Enrich cron trigger creation mode according to platform kind

### DIFF
--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -107,10 +107,14 @@ func NewPlatformConfig(configurationPath string) (*Config, error) {
 		config.Logger.System = platformConfigurationReader.GetDefaultConfiguration().Logger.System
 	}
 
-	// default cron trigger creation mode to processor
-	// TODO: move under `config.Kube`
+	// resolve cron trigger creation mode according to platform
 	if config.CronTriggerCreationMode == "" {
-		config.CronTriggerCreationMode = ProcessorCronTriggerCreationMode
+		switch config.Kind {
+		case common.KubePlatformName:
+			config.CronTriggerCreationMode = KubeCronTriggerCreationMode
+		default:
+			config.CronTriggerCreationMode = ProcessorCronTriggerCreationMode
+		}
 	}
 
 	if config.Kube.DefaultServiceType == "" {

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -696,6 +696,6 @@ func (suite *PlatformConfigTestSuite) TestEnrichContainerResourcesPartialDefault
 	suite.Require().Empty(resources.Limits["memory"])
 }
 
-func TestRegistryTestSuite(t *testing.T) {
+func TestPlatformConfigTestSuite(t *testing.T) {
 	suite.Run(t, new(PlatformConfigTestSuite))
 }


### PR DESCRIPTION
No reason to default to "Processor" mode if we are in a kubernetes environment.

Related to a discussion in https://iguazio.atlassian.net/browse/CEML-325