### PR TITLE
[Processor] Move stop trigger after termination signaling [1.13.x]

### DIFF
--- a/pkg/common/status/status.go
+++ b/pkg/common/status/status.go
@@ -37,6 +37,7 @@ const (
 	Ready
 	Error
 	Stopped
+	Stopping
 )
 
 func (s Status) String() string {


### PR DESCRIPTION
Jira - part of https://iguazio.atlassian.net/browse/NUC-298

We need to stop triggers after sending SIGTERM. Otherwise, we risk closing the server before responding to the last event, which may still be processing when the termination signal is received.

Additionally, we need to set the status to non-ready as soon as possible. To achieve this, I introduced a new Stopping status, which is set right before sending SIGTERM to the runtime. This provides an extra layer of protection by notifying Kubernetes earlier that the pod is no longer ready to process requests.