### PR TITLE
[HTTP] Change readiness probe during termination to increase stability [1.13.x]

### DIFF
--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -375,6 +375,54 @@ func (suite *FunctionMonitoringTestSuite) TestPausedFunctionShouldRemainInReadyS
 	})
 }
 
+func (suite *FunctionMonitoringTestSuite) TestTerminatingFunctionAvailability() {
+	functionName := "terminating-function"
+	createFunctionOptions := suite.CompileCreateFunctionOptions(functionName)
+
+	*createFunctionOptions.FunctionConfig.Spec.Replicas = 2
+	waitForFunctionStart := make(chan *platform.CreateFunctionResult)
+	ctx, cancel := context.WithCancel(suite.Ctx)
+	go func() {
+		deployResult := <-waitForFunctionStart
+		// bombing function with requests to check that events are processed with no errors during deployment replacement
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				suite.InvokeFunction("GET", deployResult.Port, "", nil, true)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	suite.DeployFunction(createFunctionOptions, func(deployResults *platform.CreateFunctionResult) bool {
+		waitForFunctionStart <- deployResults
+		one := 1
+		deployResults.UpdatedFunctionConfig.Spec.Replicas = &one
+		deployResults.UpdatedFunctionConfig.Spec.Image = deployResults.Image
+
+		err := suite.Platform.UpdateFunction(context.Background(),
+			&platform.UpdateFunctionOptions{
+				FunctionMeta: &deployResults.UpdatedFunctionConfig.Meta,
+				FunctionSpec: &deployResults.UpdatedFunctionConfig.Spec,
+			})
+		suite.Require().NoError(err, "Failed to update function")
+
+		// wait for function deployment replicas gets to zero
+		suite.WaitForFunctionDeployment(functionName,
+			1*time.Minute,
+			func(functionDeployment *appsv1.Deployment) bool {
+				suite.Logger.InfoWith("Waiting for deployment replicas to be one",
+					"replicas", functionDeployment.Status.Replicas)
+				return functionDeployment.Status.Replicas == 1
+			})
+		cancel()
+		return true
+	})
+}
+
 func TestFunctionMonitoringTestSuite(t *testing.T) {
 	if testing.Short() {
 		return

--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -378,8 +378,9 @@ func (suite *FunctionMonitoringTestSuite) TestPausedFunctionShouldRemainInReadyS
 func (suite *FunctionMonitoringTestSuite) TestTerminatingFunctionAvailability() {
 	functionName := "terminating-function"
 	createFunctionOptions := suite.CompileCreateFunctionOptions(functionName)
+	two := 2
+	createFunctionOptions.FunctionConfig.Spec.Replicas = &two
 
-	*createFunctionOptions.FunctionConfig.Spec.Replicas = 2
 	waitForFunctionStart := make(chan *platform.CreateFunctionResult)
 	ctx, cancel := context.WithCancel(suite.Ctx)
 	go func() {

--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -405,6 +405,7 @@ func (suite *FunctionMonitoringTestSuite) TestTerminatingFunctionAvailability() 
 		functionPort <- deployResult.Port
 		one := 1
 		deployResult.UpdatedFunctionConfig.Spec.Replicas = &one
+		deployResult.UpdatedFunctionConfig.Spec.MaxReplicas = &one
 		deployResult.UpdatedFunctionConfig.Spec.Image = deployResult.Image
 
 		err := suite.Platform.UpdateFunction(context.Background(),

--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -381,39 +381,42 @@ func (suite *FunctionMonitoringTestSuite) TestTerminatingFunctionAvailability() 
 	two := 2
 	createFunctionOptions.FunctionConfig.Spec.Replicas = &two
 
-	waitForFunctionStart := make(chan *platform.CreateFunctionResult)
+	functionPort := make(chan int)
+	defer close(functionPort)
+
 	ctx, cancel := context.WithCancel(suite.Ctx)
 	go func() {
-		deployResult := <-waitForFunctionStart
-		// bombing function with requests to check that events are processed with no errors during deployment replacement
+		port := <-functionPort
+		// bombing function with requests to check that events are processed with no errors during scale down
 		ticker := time.NewTicker(50 * time.Millisecond)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
-				suite.InvokeFunction("GET", deployResult.Port, "", nil, true)
+				suite.InvokeFunction("GET", port, "", nil, true)
 			case <-ctx.Done():
 				return
 			}
 		}
 	}()
 
-	suite.DeployFunction(createFunctionOptions, func(deployResults *platform.CreateFunctionResult) bool {
-		waitForFunctionStart <- deployResults
+	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+		suite.Require().NotNil(deployResult)
+		functionPort <- deployResult.Port
 		one := 1
-		deployResults.UpdatedFunctionConfig.Spec.Replicas = &one
-		deployResults.UpdatedFunctionConfig.Spec.Image = deployResults.Image
+		deployResult.UpdatedFunctionConfig.Spec.Replicas = &one
+		deployResult.UpdatedFunctionConfig.Spec.Image = deployResult.Image
 
 		err := suite.Platform.UpdateFunction(context.Background(),
 			&platform.UpdateFunctionOptions{
-				FunctionMeta: &deployResults.UpdatedFunctionConfig.Meta,
-				FunctionSpec: &deployResults.UpdatedFunctionConfig.Spec,
+				FunctionMeta: &deployResult.UpdatedFunctionConfig.Meta,
+				FunctionSpec: &deployResult.UpdatedFunctionConfig.Spec,
 			})
 		suite.Require().NoError(err, "Failed to update function")
 
-		// wait for function deployment replicas gets to zero
+		// wait for function deployment replicas gets to one
 		suite.WaitForFunctionDeployment(functionName,
-			1*time.Minute,
+			5*time.Minute,
 			func(functionDeployment *appsv1.Deployment) bool {
 				suite.Logger.InfoWith("Waiting for deployment replicas to be one",
 					"replicas", functionDeployment.Status.Replicas)

--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -401,6 +401,7 @@ func (suite *FunctionMonitoringTestSuite) TestTerminatingFunctionAvailability() 
 	}()
 
 	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+		defer cancel()
 		suite.Require().NotNil(deployResult)
 		functionPort <- deployResult.Port
 		one := 1
@@ -423,7 +424,6 @@ func (suite *FunctionMonitoringTestSuite) TestTerminatingFunctionAvailability() 
 					"replicas", functionDeployment.Status.Replicas)
 				return functionDeployment.Status.Replicas == 1
 			})
-		cancel()
 		return true
 	})
 }

--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -400,6 +400,11 @@ func (suite *FunctionMonitoringTestSuite) TestTerminatingFunctionAvailability() 
 		}
 	}()
 
+	getFunctionOptions := &platform.GetFunctionsOptions{
+		Name:      createFunctionOptions.FunctionConfig.Meta.Name,
+		Namespace: createFunctionOptions.FunctionConfig.Meta.Namespace,
+	}
+
 	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
 		defer cancel()
 		suite.Require().NotNil(deployResult)
@@ -409,7 +414,8 @@ func (suite *FunctionMonitoringTestSuite) TestTerminatingFunctionAvailability() 
 		deployResult.UpdatedFunctionConfig.Spec.MaxReplicas = &one
 		deployResult.UpdatedFunctionConfig.Spec.MinReplicas = &one
 
-		deployResult.UpdatedFunctionConfig.Spec.Image = deployResult.Image
+		function := suite.GetFunction(getFunctionOptions)
+		deployResult.UpdatedFunctionConfig.Spec.Image = function.GetStatus().ContainerImage
 
 		err := suite.Platform.UpdateFunction(context.Background(),
 			&platform.UpdateFunctionOptions{
@@ -420,7 +426,7 @@ func (suite *FunctionMonitoringTestSuite) TestTerminatingFunctionAvailability() 
 
 		// wait for function deployment replicas gets to one
 		suite.WaitForFunctionDeployment(functionName,
-			5*time.Minute,
+			1*time.Minute,
 			func(functionDeployment *appsv1.Deployment) bool {
 				suite.Logger.InfoWith("Waiting for deployment replicas to be one",
 					"replicas", functionDeployment.Status.Replicas)

--- a/pkg/platform/kube/monitoring/test/function_test.go
+++ b/pkg/platform/kube/monitoring/test/function_test.go
@@ -407,6 +407,8 @@ func (suite *FunctionMonitoringTestSuite) TestTerminatingFunctionAvailability() 
 		one := 1
 		deployResult.UpdatedFunctionConfig.Spec.Replicas = &one
 		deployResult.UpdatedFunctionConfig.Spec.MaxReplicas = &one
+		deployResult.UpdatedFunctionConfig.Spec.MinReplicas = &one
+
 		deployResult.UpdatedFunctionConfig.Spec.Image = deployResult.Image
 
 		err := suite.Platform.UpdateFunction(context.Background(),

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -342,8 +342,6 @@ func (h *http) handlePreflightRequest(ctx *fasthttp.RequestCtx) {
 }
 
 func (h *http) preHandleRequestValidation(ctx *fasthttp.RequestCtx) bool {
-
-	// Ensure the server is running
 	// Here, we want to allow not only the 'ready' status but also the 'stopping' status,
 	// as it indicates that the HTTP service is about to stop. This allows it to process
 	// requests during this time while also informing the readiness probe that the service
@@ -387,6 +385,7 @@ func (h *http) preHandleRequestValidation(ctx *fasthttp.RequestCtx) bool {
 }
 
 func (h *http) preHandleStatusValidation(ctx *fasthttp.RequestCtx, expectedStatuses ...status.Status) bool {
+	// Ensure the server is running
 	if triggerStatus := h.status.GetStatus(); !triggerStatus.OneOf(expectedStatuses...) {
 		h.Logger.DebugWith("Pre-handle validation failed because trigger is not ready",
 			"triggerName", h.Name,

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -343,24 +343,16 @@ func (h *http) handlePreflightRequest(ctx *fasthttp.RequestCtx) {
 
 func (h *http) preHandleRequestValidation(ctx *fasthttp.RequestCtx) bool {
 
-	// ensure server is running
-	if triggerStatus := h.status.GetStatus(); triggerStatus != status.Ready {
-		h.Logger.DebugWith("Pre-handle validation failed because trigger is not ready",
-			"triggerName", h.Name,
-			"triggerKind", h.Kind,
-			"triggerStatus", triggerStatus)
-		ctx.Response.SetStatusCode(nethttp.StatusServiceUnavailable)
-		msg := map[string]interface{}{
-			"error":  "Server not ready",
-			"status": h.status.String(),
-		}
-
-		if err := json.NewEncoder(ctx).Encode(msg); err != nil {
-			h.Logger.WarnWith("Can't encode error message", "error", err)
-		}
+	// Ensure the server is running
+	// Here, we want to allow not only the 'ready' status but also the 'stopping' status,
+	// as it indicates that the HTTP service is about to stop. This allows it to process
+	// requests during this time while also informing the readiness probe that the service
+	// is no longer ready, preventing Kubernetes from sending further traffic to the pod.
+	if ok := h.preHandleStatusValidation(ctx,
+		status.Ready,
+		status.Stopping); !ok {
 		return false
 	}
-
 	// if cors is enabled, ensure request is valid
 	if h.configuration.corsEnabled() {
 
@@ -394,6 +386,27 @@ func (h *http) preHandleRequestValidation(ctx *fasthttp.RequestCtx) bool {
 	return true
 }
 
+func (h *http) preHandleStatusValidation(ctx *fasthttp.RequestCtx, expectedStatuses ...status.Status) bool {
+	// ensure server is running
+	if triggerStatus := h.status.GetStatus(); !triggerStatus.OneOf(expectedStatuses...) {
+		h.Logger.DebugWith("Pre-handle validation failed because trigger is not ready",
+			"triggerName", h.Name,
+			"triggerKind", h.Kind,
+			"triggerStatus", triggerStatus)
+		ctx.Response.SetStatusCode(nethttp.StatusServiceUnavailable)
+		msg := map[string]interface{}{
+			"error":  "Server not ready",
+			"status": h.status.String(),
+		}
+
+		if err := json.NewEncoder(ctx).Encode(msg); err != nil {
+			h.Logger.WarnWith("Can't encode error message", "error", err)
+		}
+		return false
+	}
+	return true
+}
+
 func (h *http) handleRequest(ctx *fasthttp.RequestCtx) {
 	var functionLogger logger.Logger
 	var bufferLogger *nucliozap.BufferLogger
@@ -401,6 +414,14 @@ func (h *http) handleRequest(ctx *fasthttp.RequestCtx) {
 	// internal endpoint to allow clients the information whether the http server is taking requests in
 	// this is an internal endpoint, we do not want to update statistics here
 	if bytes.HasPrefix(ctx.URI().Path(), h.internalHealthPath) {
+		// here we want to allow only ready status
+		// because as soon as status has become non-ready,
+		// we want k8s to stop sending traffic to this pod
+		if ok := h.preHandleStatusValidation(
+			ctx,
+			status.Ready); !ok {
+			return
+		}
 		ctx.Response.SetStatusCode(nethttp.StatusOK)
 		return
 	}

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -387,7 +387,6 @@ func (h *http) preHandleRequestValidation(ctx *fasthttp.RequestCtx) bool {
 }
 
 func (h *http) preHandleStatusValidation(ctx *fasthttp.RequestCtx, expectedStatuses ...status.Status) bool {
-	// ensure server is running
 	if triggerStatus := h.status.GetStatus(); !triggerStatus.OneOf(expectedStatuses...) {
 		h.Logger.DebugWith("Pre-handle validation failed because trigger is not ready",
 			"triggerName", h.Name,

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -383,7 +383,11 @@ func (at *AbstractTrigger) SignalWorkersToContinue() error {
 }
 
 func (at *AbstractTrigger) SignalWorkersToTerminate() error {
+	// DO NOT REMOVE
+	// this sleep is needed to give k8s some time to stop sending traffic to the service
+	// before we shut worker down
 	time.Sleep(1 * time.Second)
+
 	if err := at.WorkerAllocator.SignalTermination(); err != nil {
 		return errors.Wrap(err, "Failed to signal all workers to terminate")
 	}

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -383,6 +383,7 @@ func (at *AbstractTrigger) SignalWorkersToContinue() error {
 }
 
 func (at *AbstractTrigger) SignalWorkersToTerminate() error {
+	time.Sleep(1 * time.Second)
 	if err := at.WorkerAllocator.SignalTermination(); err != nil {
 		return errors.Wrap(err, "Failed to signal all workers to terminate")
 	}


### PR DESCRIPTION
This pr adds some logic to readiness probe check and pre-event-handling validation as follows:

1. readiness probe will be marked as ready only if trigger is in ready state. 
2. for other requests, we will process request if trigger in `ready` or in `stopping` state. Because `stopping` state is just a temporarily state of trigger which exists only to take k8s some time to stop sending requests to this pod when it's being terminated.