### PR TITLE
[Dashboard] Change logic of `allow` preemption mode

### DIFF
--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1583,20 +1583,6 @@ func (p *Platform) enrichFunctionPreemptionSpec(ctx context.Context,
 
 	case functionconfig.RunOnPreemptibleNodesAllow:
 
-		// purges any `affinity` / `anti-affinity` preemption related configuration
-		// remove anti-affinity
-		functionConfig.
-			PruneAffinityNodeSelectorRequirement(
-				preemptibleNodes.CompileAffinityByLabelSelector(v1.NodeSelectorOpNotIn), "matchAll")
-
-		// remove affinity
-		functionConfig.
-			PruneAffinityNodeSelectorRequirement(
-				preemptibleNodes.CompileAffinityByLabelSelector(v1.NodeSelectorOpIn), "oneOf")
-
-		// remove preemptible nodes constrain
-		functionConfig.PruneNodeSelector(preemptibleNodes.NodeSelector)
-
 		// enrich with tolerations
 		functionConfig.EnrichWithTolerations(preemptibleNodes.Tolerations)
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1458,7 +1458,6 @@ func (p *Platform) enrichFunctionsWithAPIGateways(ctx context.Context, functions
 // configuration is given, do nothing.
 //
 //		`Allow` 	- Adds Tolerations / GPU Tolerations if taints were given. otherwise, assume pods can be scheduled on preemptible nodes.
-//	               > Purges any `affinity` / `anti-affinity` preemption related configuration
 //		`Constrain` - Uses node-affinity to make sure pods are assigned using OR on the given node label selectors.
 //	               > Uses `Allow` configuration as well.
 //	               > Purges any `anti-affinity` preemption related configuration

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -1658,6 +1658,137 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithPreemptionSpec
 
 }
 
+func (suite *FunctionKubePlatformTestSuite) TestEnrichPreemptionMode() {
+	defaultPreemptibleNodes := &platformconfig.PreemptibleNodes{
+		NodeSelector: map[string]string{"node-label-key": "node-label-value"},
+		Tolerations: []v1.Toleration{
+			{
+				Key:   "toleration-key",
+				Value: "toleration-value",
+			},
+		},
+	}
+	defaultCustomAffinity := &v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "node-label-key",
+								Operator: v1.NodeSelectorOpNotIn,
+								Values:   []string{"node-label-value"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	defaultCustomAntiAffinity := &v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "node-label-key",
+								Operator: v1.NodeSelectorOpNotIn,
+								Values:   []string{"node-label-value"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	defaultCustomNodeSelector := map[string]string{
+		"node-label-key": "node-label-value",
+		"custom-ns":      "custom-ns-value",
+	}
+	for _, testCase := range []struct {
+		name               string
+		preemptionMode     functionconfig.RunOnPreemptibleNodeMode
+		preemptibleNodes   *platformconfig.PreemptibleNodes
+		customNodeSelector map[string]string
+		customAffinity     *v1.Affinity
+	}{
+		{
+			name:               "allow-affinity",
+			preemptionMode:     functionconfig.RunOnPreemptibleNodesAllow,
+			preemptibleNodes:   defaultPreemptibleNodes,
+			customNodeSelector: defaultCustomNodeSelector,
+			customAffinity:     defaultCustomAffinity,
+		},
+		{
+			name:               "allow-anti-affinity",
+			preemptionMode:     functionconfig.RunOnPreemptibleNodesAllow,
+			preemptibleNodes:   defaultPreemptibleNodes,
+			customNodeSelector: defaultCustomNodeSelector,
+			customAffinity:     defaultCustomAntiAffinity,
+		},
+		{
+			name:               "constrain",
+			preemptionMode:     functionconfig.RunOnPreemptibleNodesConstrain,
+			preemptibleNodes:   defaultPreemptibleNodes,
+			customNodeSelector: defaultCustomNodeSelector,
+		},
+		{
+			name:               "prevent-no-affinity",
+			preemptionMode:     functionconfig.RunOnPreemptibleNodesPrevent,
+			preemptibleNodes:   defaultPreemptibleNodes,
+			customNodeSelector: defaultCustomNodeSelector,
+		},
+		{
+			name:               "prevent-with-affinity",
+			preemptionMode:     functionconfig.RunOnPreemptibleNodesPrevent,
+			preemptibleNodes:   defaultPreemptibleNodes,
+			customNodeSelector: defaultCustomNodeSelector,
+			customAffinity:     defaultCustomAntiAffinity,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.platform.Config.Kube.PreemptibleNodes = testCase.preemptibleNodes
+			functionName := "some-func"
+
+			functionConfig := functionconfig.NewConfig()
+			functionConfig.Meta.Name = functionName
+			functionConfig.Spec.PreemptionMode = testCase.preemptionMode
+			functionConfig.Spec.NodeSelector = testCase.customNodeSelector
+			functionConfig.Spec.Affinity = testCase.customAffinity.DeepCopy()
+
+			for i := 0; i < 2; i++ {
+				// make sure that nothing was added twice
+				suite.platform.enrichFunctionPreemptionSpec(suite.ctx, testCase.preemptibleNodes, functionConfig)
+
+				switch testCase.preemptionMode {
+				case functionconfig.RunOnPreemptibleNodesAllow:
+					suite.Require().Equal(testCase.preemptibleNodes.Tolerations, functionConfig.Spec.Tolerations)
+					suite.Require().Equal(testCase.customNodeSelector, functionConfig.Spec.NodeSelector)
+					suite.Require().Equal(testCase.customAffinity, functionConfig.Spec.Affinity)
+				case functionconfig.RunOnPreemptibleNodesConstrain:
+					suite.Require().Equal(testCase.preemptibleNodes.Tolerations, functionConfig.Spec.Tolerations)
+					suite.Require().Equal(
+						functionConfig.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
+						testCase.preemptibleNodes.CompileAffinityByLabelSelectorScheduleOnOneOfMatchingNodes())
+					suite.Require().Equal(testCase.customNodeSelector, functionConfig.Spec.NodeSelector)
+				case functionconfig.RunOnPreemptibleNodesPrevent:
+					suite.Require().Empty(functionConfig.Spec.Tolerations)
+					suite.Require().Equal(testCase.customNodeSelector, functionConfig.Spec.NodeSelector)
+					// affinity is pruned (prevention is done using taints)
+					if testCase.customAffinity == nil {
+						suite.Require().Empty(functionConfig.Spec.Affinity)
+					} else {
+						suite.Require().Empty(cmp.Diff(
+							functionConfig.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
+							testCase.preemptibleNodes.CompileAntiAffinityByLabelSelectorNoScheduleOnMatchingNodes()))
+					}
+				}
+			}
+		})
+	}
+}
+
 func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithUserNameLabel() {
 
 	functionName := "some-func"

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -1600,7 +1600,9 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithPreemptionSpec
 	functionConfig.Spec.PreemptionMode = functionconfig.RunOnPreemptibleNodesAllow
 	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig)
 	suite.Require().Empty(functionConfig.Spec.Tolerations) // no toleration were given on config, that's intentional
-	suite.Require().Nil(functionConfig.Spec.Affinity)
+	suite.Require().Empty(cmp.Diff(
+		functionConfig.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
+		preemptibleNodes.CompileAntiAffinityByLabelSelectorNoScheduleOnMatchingNodes()))
 
 	// preserve custom affinity
 	functionConfig.Spec.PreemptionMode = functionconfig.RunOnPreemptibleNodesPrevent
@@ -1621,8 +1623,9 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithPreemptionSpec
 	suite.platform.enrichFunctionPreemptionSpec(suite.ctx, preemptibleNodes, functionConfig)
 	suite.Require().NotNil(functionConfig.Spec.Affinity.PodAffinity)
 	suite.Require().NotNil(functionConfig.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
+	index := len(functionConfig.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms) - 1
 	suite.Require().Equal("dummy",
-		functionConfig.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchFields[0].Key)
+		functionConfig.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[index].MatchFields[0].Key)
 
 	// reset specs, constrain -> prevent (for tolerations + node selector)
 	preemptibleNodes = &platformconfig.PreemptibleNodes{


### PR DESCRIPTION
Jira - https://iguazio.atlassian.net/browse/NUC-362

We don't want to remove affinity or node selectors from function config in `allow` preemption mode. 