### PR TITLE
[CI] Update ubuntu on periodic

### DIFF
--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -24,9 +24,7 @@ env:
 jobs:
   periodic:
     name: Periodic Regression
-    # TODO: update this to ubuntu-latest when the runner issue is fixed:
-    # https://github.com/actions/runner-images/discussions/7188
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,7 +124,7 @@ jobs:
 
     - name: Install QEMU
       if: matrix.arch != 'amd64'
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: ${{ matrix.arch }}
 


### PR DESCRIPTION
Message from Github:
> The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail.

The [discussion](https://github.com/actions/runner-images/discussions/7188) mentioned doesn't seem to be resolved, but we cannot continue using ubuntu-20.04 . 
We can hope that ubuntu-latest doesn't have this issue, and if it does we should consider the workaround mentioned in [this comment](https://github.com/actions/runner-images/discussions/7188#discussioncomment-6750749).

Additionally, bump the `setup-qemu-action` to v3 as v2 has some [issues](https://github.com/nuclio/nuclio/actions/runs/13290516068/job/37146398841).