### PR TITLE
[Helm] Fix mounting empty name secret

### DIFF
--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.20.2
+version: 0.20.1
 appVersion: 1.14.1
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.20.1
+version: 0.20.2
 appVersion: 1.14.1
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -251,7 +251,7 @@ spec:
         hostPath:
           path: /var/run/docker.sock
       {{- end }}
-      {{- if (include "nuclio.registry.credentialsSecretName" .) }}
+      {{- if ne (include "nuclio.registry.credentialsSecretName" .) "" }}
       - name: registry-credentials
         secret:
           secretName: {{ template "nuclio.registry.credentialsSecretName" . }}

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -80,7 +80,7 @@ spec:
         - mountPath: /var/run/docker.sock
           name: docker-sock
         {{- end }}
-        {{- if (include "nuclio.registry.credentialsSecretName" .) }}
+        {{- if ne (include "nuclio.registry.credentialsSecretName" .) "" }}
         - name: registry-credentials
           mountPath: "/etc/nuclio/dashboard/registry-credentials"
           readOnly: true


### PR DESCRIPTION
Observed when mlrun ce installation without secret name was failed due to missing secret name

```
Deployment.apps "nuclio-dashboard" is invalid: [spec.template.spec.volumes[0].secret.secretName: Required value
```

as its deployment was generated with

```
      - name: registry-credentials
        secret:
          secretName: ""
          optional: true
```

this is allegedly because Helm's `if` condition works with empty strings  - treats them as truthy 
