### PR TITLE
[UI] Remove deprecated python 3.7/3.8 from runtimes list [1.13.x]

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^3.0.2",
     "i18next-localstorage-backend": "^3.1.3",
     "i18next-xhr-backend": "^3.2.2",
-    "iguazio.dashboard-controls": "1.0.11-1.13.x",
+    "iguazio.dashboard-controls": "1.0.12-1.13.x",
     "jquery": "*",
     "jquery-ui": "1.13.2",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
- **UI**: Remove deprecated python 3.7/3.8 from runtimes list `1.13.x`
   Jira: https://iguazio.atlassian.net/browse/NUC-371