### PR TITLE
[Golang] Fix go runtime on low-latency setup

### DIFF
--- a/pkg/processor/runtime/golang/runtime.go
+++ b/pkg/processor/runtime/golang/runtime.go
@@ -114,6 +114,7 @@ func (g *golang) Restart() error {
 
 func (g *golang) Stop() error {
 	g.SetStatus(status.Stopped)
+	g.Logger.Info("Stopping golang runtime")
 
 	select {
 	case cancelEventHandling := <-g.cancelEventHandlingChan:
@@ -184,15 +185,10 @@ func (g *golang) callEntrypoint(event nuclio.Event, functionLogger logger.Logger
 
 		// calculate how long it took to invoke the function
 		callDuration := time.Since(startTime)
+		responseChan <- processingResult
 
-		select {
-		// if the reader is waiting, then it means that runtime wasn't stopped and waits for a response
-		case responseChan <- processingResult:
-			// add duration to sum
-			g.Statistics.DurationMilliSecondsSum += uint64(callDuration.Nanoseconds() / 1000000)
-			g.Statistics.DurationMilliSecondsCount++
-		default:
-		}
+		g.Statistics.DurationMilliSecondsSum += uint64(callDuration.Nanoseconds() / 1000000)
+		g.Statistics.DurationMilliSecondsCount++
 	}()
 
 	select {

--- a/pkg/processor/runtime/golang/runtime.go
+++ b/pkg/processor/runtime/golang/runtime.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"runtime/debug"
+	"sync"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common/status"
@@ -37,6 +38,8 @@ type golang struct {
 
 	// TODO: support multiple cancels when implementing async
 	cancelEventHandlingChan chan context.CancelFunc
+	// TODO: remove when implement full safe statistics for async processing
+	statisticsMutex sync.RWMutex
 }
 
 // NewRuntime returns a new golang runtime
@@ -63,6 +66,7 @@ func NewRuntime(parentLogger logger.Logger,
 		AbstractRuntime: abstractRuntime,
 		configuration:   configuration,
 		entrypoint:      handler.getEntrypoint(),
+		statisticsMutex: sync.RWMutex{},
 	}
 
 	// try to initialize the context, if applicable
@@ -187,8 +191,7 @@ func (g *golang) callEntrypoint(event nuclio.Event, functionLogger logger.Logger
 		callDuration := time.Since(startTime)
 		responseChan <- processingResult
 
-		g.Statistics.DurationMilliSecondsSum += uint64(callDuration.Nanoseconds() / 1000000)
-		g.Statistics.DurationMilliSecondsCount++
+		g.AddStatistics(callDuration)
 	}()
 
 	select {
@@ -203,6 +206,14 @@ func (g *golang) callEntrypoint(event nuclio.Event, functionLogger logger.Logger
 	case <-ctx.Done():
 		return nil, errors.New("Event processing was cancelled")
 	}
+}
+
+func (g *golang) AddStatistics(callDuration time.Duration) {
+	g.statisticsMutex.Lock()
+	defer g.statisticsMutex.Unlock()
+
+	g.Statistics.DurationMilliSecondsSum += uint64(callDuration.Nanoseconds() / 1000000)
+	g.Statistics.DurationMilliSecondsCount++
 }
 
 type processingResponse struct {

--- a/pkg/processor/runtime/golang/runtime_test.go
+++ b/pkg/processor/runtime/golang/runtime_test.go
@@ -101,12 +101,24 @@ func (suite *runtimeTestSuite) TestRestartRuntime() {
 }
 
 func (suite *runtimeTestSuite) TestProcessEvent() {
-	golangRuntime, err := NewRuntime(suite.logger, suite.runtimeConfiguration, suite.handler)
+
+	abstractHandler := abstractHandler{
+		logger: suite.logger,
+		entrypoint: func(*nuclio.Context, nuclio.Event) (interface{}, error) {
+			return "success", nil
+		},
+	}
+	golangRuntime, err := NewRuntime(suite.logger, suite.runtimeConfiguration, &pluginHandlerLoader{
+		abstractHandler,
+	})
 	suite.Require().NoError(err)
 
-	res, err := golangRuntime.ProcessEvent(nil, suite.logger)
-	suite.Require().NoError(err)
-	suite.Require().Equal(res, "success")
+	for i := 0; i < 10000; i++ {
+		suite.logger.DebugWith("start", "iter", i)
+		res, err := golangRuntime.ProcessEvent(nil, suite.logger)
+		suite.Require().NoError(err)
+		suite.Require().Equal("success", res)
+	}
 }
 
 func (suite *runtimeTestSuite) TestPanicHandler() {

--- a/pkg/processor/runtime/golang/runtime_test.go
+++ b/pkg/processor/runtime/golang/runtime_test.go
@@ -114,7 +114,6 @@ func (suite *runtimeTestSuite) TestProcessEvent() {
 	suite.Require().NoError(err)
 
 	for i := 0; i < 10000; i++ {
-		suite.logger.DebugWith("start", "iter", i)
 		res, err := golangRuntime.ProcessEvent(nil, suite.logger)
 		suite.Require().NoError(err)
 		suite.Require().Equal("success", res)

--- a/pkg/processor/runtime/golang/runtime_test.go
+++ b/pkg/processor/runtime/golang/runtime_test.go
@@ -113,6 +113,7 @@ func (suite *runtimeTestSuite) TestProcessEvent() {
 	})
 	suite.Require().NoError(err)
 
+	// many iterations to ensure stability
 	for i := 0; i < 10000; i++ {
 		res, err := golangRuntime.ProcessEvent(nil, suite.logger)
 		suite.Require().NoError(err)


### PR DESCRIPTION
There was an issue with the low-latency test in the Go runtime.

The problem was that we sometimes attempted to write to the channel when the reader wasn’t ready yet. In this case, a blocking write is acceptable because if the runtime is terminated, the channel will be closed, causing the writing goroutine to panic and handle the panic accordingly (which is covered in the Go tests).

Additionally, I added a test that reproduces the issue. It only occurred after 10,000 iterations, so I set the test to run for 10,000 iterations. While that may seem like a lot, it doesn’t take much time and serves as a reliable test to ensure the stability of the Go runtime.

UPD: test fails because of race condition in metrics, working on it