### PR TITLE
[Makefile] Add command to check unit test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -630,6 +630,10 @@ lint: modules ensure-test-files-annotated ensure-golangci-linter
 	$(GOPATH)/bin/golangci-lint run -v
 	@echo Done.
 
+.PHONY: test-coverage
+test-coverage:
+	go test -tags=test_unit -coverprofile=coverage.out ./pkg/... || go tool cover -html=coverage.out
+
 .PHONY: lint-docs
 lint-docs:
 	vale docs


### PR DESCRIPTION
Shows test coverage and opens handy UI which shows what is covered and what isn't:

![image](https://github.com/user-attachments/assets/9680adbd-18f5-4fea-beb5-ad874c5d0bf7)
