### PR TITLE
[Dashboard] Don't print pod warning events if empty [1.13.x]

### DIFF
--- a/pkg/platform/kube/client/deployer.go
+++ b/pkg/platform/kube/client/deployer.go
@@ -283,6 +283,10 @@ func (d *Deployer) getFunctionPodWarningEvents(ctx context.Context, namespace st
 		}
 	}
 
+	if len(podWarningEvents) == 0 {
+		return "", nil
+	}
+
 	return fmt.Sprintf("%s\n", strings.Join(podWarningEvents, "\n")), nil
 }
 


### PR DESCRIPTION
`"Warning events"` are logged if `podWarningEvents != ""`, however even if we didn't have pod events, we still returns a string with newline characters.