### PR TITLE
[Processor] Limit the number of file descriptors in use to 80 percent

### DIFF
--- a/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
@@ -69,7 +69,8 @@ class AsyncWrapper(AbstractWrapper):
         self._port = int(split_address[1])
 
         # 80 percent of Max file descriptors allowed by the OS
-        self._max_connections = max_connections if max_connections else int(os.sysconf("SC_OPEN_MAX") * 0.8)
+        system_max_connections = int(os.sysconf("SC_OPEN_MAX") * 0.8)
+        self._max_connections = min(max_connections, system_max_connections) if max_connections else system_max_connections
         self.selector = selectors.DefaultSelector()
         self.connections = {}  # Track active sockets
         self.tasks = {}  # Track active asyncio tasks

--- a/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
@@ -68,8 +68,8 @@ class AsyncWrapper(AbstractWrapper):
         self._host = split_address[0]
         self._port = int(split_address[1])
 
-        # Max file descriptors allowed by the OS
-        self._max_connections = max_connections if max_connections else os.sysconf("SC_OPEN_MAX")
+        # 80 percent of Max file descriptors allowed by the OS
+        self._max_connections = max_connections if max_connections else int(os.sysconf("SC_OPEN_MAX") * 0.8)
         self.selector = selectors.DefaultSelector()
         self.connections = {}  # Track active sockets
         self.tasks = {}  # Track active asyncio tasks


### PR DESCRIPTION
Limiting the number of file descriptors in use to 80 percent of the maximum allowed by the OS helps maintain system stability and ensures resource availability for other critical operations. This practice prevents exhausting all file descriptors, reducing the risk of system failures and performance degradation.