### PR TITLE
[Security] Fix regexes and file path escaping

### DIFF
--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -292,8 +292,8 @@ func (s *Server) resolveDockerCredentialsRegistryURL(credentials dockercreds.Cre
 	// if the user specified the docker hub, we can't use this as-is. add the user name to the URL
 	// to generate a valid URL
 	if common.MatchStringPatterns([]string{
-		`\.docker\.com`,
-		`\.docker\.io`,
+		`^.*\.docker\.com.*$`,
+		`^.*\.docker\.io.*$`,
 	}, registryURL) {
 		registryURL = common.StripSuffixes(registryURL, []string{
 

--- a/pkg/functionconfig/scrubber_test.go
+++ b/pkg/functionconfig/scrubber_test.go
@@ -51,6 +51,11 @@ func (suite *ScrubberTestSuite) SetupTest() {
 
 func (suite *ScrubberTestSuite) TestScrubBasics() {
 	functionConfig := &Config{
+		Meta: Meta{
+			Annotations: map[string]string{
+				"nuclio.io/kafka-ca-cert": "some-ca-cert",
+			},
+		},
 		Spec: Spec{
 			Build: Build{
 				CodeEntryAttributes: map[string]interface{}{
@@ -127,6 +132,8 @@ func (suite *ScrubberTestSuite) TestScrubBasics() {
 		scrubbedFunctionConfig.Spec.Triggers["non-secret-trigger"].Attributes["not-a-password"])
 	suite.Require().NotEqual(functionConfig.Spec.Volumes[0].Volume.VolumeSource.FlexVolume.Options["accesskey"],
 		scrubbedFunctionConfig.Spec.Volumes[0].Volume.VolumeSource.FlexVolume.Options["accesskey"])
+	suite.Require().NotEqual(functionConfig.Meta.Annotations["nuclio.io/kafka-ca-cert"],
+		scrubbedFunctionConfig.Meta.Annotations["nuclio.io/kafka-ca-cert"])
 
 	restoredFunctionConfig, err := suite.scrubber.Restore(scrubbedFunctionConfig, secretMap)
 	suite.Require().NoError(err)
@@ -383,6 +390,9 @@ func (suite *ScrubberTestSuite) getSensitiveFieldsPathsRegex() []*regexp.Regexp 
 		"^/Spec/Triggers/.+/Password$",
 		// Nested path in any map element
 		"^/Spec/Triggers/.+/Attributes/password$",
+
+		// Annotations
+		"^/metadata/annotations/nuclio\\.io/kafka-ca-cert$",
 	} {
 		regexpList = append(regexpList, regexp.MustCompile("(?i)"+sensitiveFieldPath))
 	}

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -332,12 +332,12 @@ func (sfc *SensitiveFieldsConfig) GetDefaultSensitiveFields() []string {
 		"^/spec/triggers/.+/attributes/sasl/password$",
 		"^/spec/triggers/.+/attributes/sasl/oauth/clientsecret$",
 		// - kafka annotations
-		"^/metadata/annotations/nuclio.io/kafka-ca-cert$",
-		"^/metadata/annotations/nuclio.io/kafka-access-key$",
-		"^/metadata/annotations/nuclio.io/kafka-access-cert$",
-		"^/metadata/annotations/nuclio.io/kafka-sasl-password$",
-		"^/metadata/annotations/nuclio.io/kafka-sasl-oauth-client-secret$",
-		"^/metadata/annotations/nuclio.io/kafka-sasl-oauth-token-url$",
+		"^/metadata/annotations/nuclio\\.io/kafka-ca-cert$",
+		"^/metadata/annotations/nuclio\\.io/kafka-access-key$",
+		"^/metadata/annotations/nuclio\\.io/kafka-access-cert$",
+		"^/metadata/annotations/nuclio\\.io/kafka-sasl-password$",
+		"^/metadata/annotations/nuclio\\.io/kafka-sasl-oauth-client-secret$",
+		"^/metadata/annotations/nuclio\\.io/kafka-sasl-oauth-token-url$",
 	}
 }
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -71,7 +71,7 @@ const (
 	// TODO: Remove in 1.16.0
 	GithubEntryType = "github"
 
-	GithubURLRegexPattern = "^.*://.*github.com(?:/repos)?/(?P<org>[^/]+)/(?P<repo>[^/]+)/?$"
+	GithubURLRegexPattern = "^.*://.*github\\.com(?:/repos)?/(?P<org>[^/]+)/(?P<repo>[^/]+)/?$"
 )
 
 // githubURLRegex complies the GitHub URL regex once instead of every function build, to improve performance
@@ -1594,7 +1594,7 @@ func (b *Builder) getSourceCodeFromFilePath() (string, error) {
 
 	// if user supplied a file containing printable only characters (i.e. not a zip, jar, etc) - copy the contents
 	// to functionSourceCode so that the dashboard may display it
-	functionContents, err := os.ReadFile(b.options.FunctionConfig.Spec.Build.Path)
+	functionContents, err := os.ReadFile(filepath.Clean(b.options.FunctionConfig.Spec.Build.Path))
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to read file contents to source code")
 	}
@@ -1800,7 +1800,7 @@ func (b *Builder) getFunctionTempFile(tempDir string,
 	codeEntryType string) (*os.File, error) {
 	var err error
 
-	functionPathBase := path.Base(functionPath)
+	functionPathBase := path.Base(filepath.Clean(functionPath))
 
 	// if the codeEntryType of the function is s3 - set its itemKey as the function path
 	// (so the file extension will be parsed correctly)

--- a/pkg/processor/build/util/unarchive.go
+++ b/pkg/processor/build/util/unarchive.go
@@ -44,6 +44,9 @@ func NewUnarchiver(parentLogger logger.Logger) (*Unarchiver, error) {
 
 // Extract extracts the source archive to the target path
 func (d *Unarchiver) Extract(ctx context.Context, sourcePath string, targetPath string) error {
+	// sanitize input
+	sourcePath = filepath.Clean(sourcePath)
+
 	file, err := os.Open(sourcePath)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Failed to open archive file: %s", sourcePath))
@@ -146,6 +149,8 @@ func (d *Unarchiver) filterFile(file archiver.File, targetPath string) (bool, er
 
 // IsArchive checks if the file is an archive
 func IsArchive(source string) bool {
+	// sanitize input
+	source = filepath.Clean(source)
 
 	// Jars are special case
 	if IsJar(source) {


### PR DESCRIPTION
This PR resolves several security vulnerabilities:

* **Regex escaping:**

- https://github.com/nuclio/nuclio/security/code-scanning/547
- https://github.com/nuclio/nuclio/security/code-scanning/546
- https://github.com/nuclio/nuclio/security/code-scanning/545
- https://github.com/nuclio/nuclio/security/code-scanning/544
- https://github.com/nuclio/nuclio/security/code-scanning/543
- https://github.com/nuclio/nuclio/security/code-scanning/542
- https://github.com/nuclio/nuclio/security/code-scanning/541
- https://github.com/nuclio/nuclio/security/code-scanning/540
- https://github.com/nuclio/nuclio/security/code-scanning/539

* **Filepath clean:** 

- https://github.com/nuclio/nuclio/security/code-scanning/536
- https://github.com/nuclio/nuclio/security/code-scanning/535
- https://github.com/nuclio/nuclio/security/code-scanning/534
- https://github.com/nuclio/nuclio/security/code-scanning/532