### PR TITLE
[Processor] Remove spammy logs from async wrapper

### DIFF
--- a/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
@@ -147,9 +147,8 @@ class AsyncWrapper(AbstractWrapper):
         self._context.logger = connection_logger
 
         # signal start
-        self._logger.debug("Signalling connection processing start")
         await self._write_packet_to_processor(sock, 's')
-        self._logger.debug(f"Event processing started for socket")
+
         try:
             while True:
                 # resolve event message length


### PR DESCRIPTION
Too many logs from too many async tasks at the same time may lead to the problem where socket buffer is full. This problem should be handled from logger side (nuclio-sdk-py) as well. In previous implementation we never saw this problem because the general load on logging in sockets was incomparable with the current one. 