### PR TITLE
[Builder] Add tempDir validations (#3552)

### DIFF
--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -926,10 +926,20 @@ func (b *Builder) createTempDir() error {
 
 	// either use injected temporary dir or generate a new one
 	if b.options.FunctionConfig.Spec.Build.TempDir != "" {
-		b.tempDir = b.options.FunctionConfig.Spec.Build.TempDir
+
+		// Validate the user-provided temporary directory to ensure it does not contain directory traversal sequences
+		if strings.Contains(b.options.FunctionConfig.Spec.Build.TempDir, "..") {
+			return errors.New("Invalid temporary directory path: contains '..'")
+		}
+
+		// if the user-provided temp directory is not under /tmp, create it under /tmp
+		if !strings.HasPrefix(b.options.FunctionConfig.Spec.Build.TempDir, "/tmp") {
+			b.tempDir = filepath.Join("/tmp", b.options.FunctionConfig.Spec.Build.TempDir)
+		} else {
+			b.tempDir = b.options.FunctionConfig.Spec.Build.TempDir
+		}
 
 		err = os.MkdirAll(b.tempDir, 0744)
-
 	} else {
 		b.tempDir, err = os.MkdirTemp("", "nuclio-build-")
 	}

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -1012,6 +1012,72 @@ func (suite *testSuite) TestResolveResources() {
 	}
 }
 
+func (suite *testSuite) TestCreateTempDir() {
+	tests := []struct {
+		name        string
+		tempDir     string
+		expectError bool
+		expectedDir string
+	}{
+		{
+			name:        "Valid temp dir under /tmp",
+			tempDir:     "/tmp/test-dir",
+			expectError: false,
+			expectedDir: "/tmp/test-dir",
+		},
+		{
+			name:        "Invalid traversal path",
+			tempDir:     "/tmp/../etc/passwd",
+			expectError: true,
+		},
+		{
+			name:        "Injection attempt with multiple traversal sequences",
+			tempDir:     "../..//..//etc",
+			expectError: true,
+		},
+		{
+			name:        "Temp dir outside /tmp",
+			tempDir:     "custom-dir",
+			expectError: false,
+			expectedDir: "/tmp/custom-dir",
+		},
+		{
+			name:        "No temp dir provided",
+			tempDir:     "",
+			expectError: false,
+		},
+	}
+
+	for _, testCase := range tests {
+		suite.Run(testCase.name, func() {
+			tempDir := suite.builder.options.FunctionConfig.Spec.Build.TempDir
+			suite.builder.options.FunctionConfig.Spec.Build.TempDir = testCase.tempDir
+
+			// revert changes
+			defer func() {
+				suite.builder.options.FunctionConfig.Spec.Build.TempDir = tempDir
+			}()
+
+			err := suite.builder.createTempDir()
+			defer os.RemoveAll(suite.builder.tempDir) // nolint: errcheck
+
+			if testCase.expectError {
+				suite.Require().Error(err, "Expected an error for tempDir: %s", testCase.tempDir)
+			} else {
+				suite.Require().NoError(err, "Did not expect an error for tempDir: %s", testCase.tempDir)
+
+				if testCase.tempDir != "" {
+					suite.Require().Equal(testCase.expectedDir, suite.builder.tempDir)
+				} else {
+					// Verify temp dir is created in the system's temporary directory
+					suite.Require().Contains(suite.builder.tempDir, os.TempDir())
+				}
+
+			}
+		})
+	}
+}
+
 func (suite *testSuite) testResolveFunctionPathRemoteCodeFile(fileExtension string) {
 
 	// mock http response


### PR DESCRIPTION
Don't allow tempdir not under `/tmp`.

Jira - part of https://iguazio.atlassian.net/browse/NUC-388