### PR TITLE
[Dependencies] Upgrade fasthttp to v1.59.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/v3io/v3io-go v0.3.12
 	github.com/v3io/v3io-go-http v0.0.1
 	github.com/v3io/version-go v0.0.2
-	github.com/valyala/fasthttp v1.58.0
+	github.com/valyala/fasthttp v1.59.0
 	github.com/vmihailenco/msgpack/v4 v4.3.12
 	github.com/xdg-go/scram v1.1.2
 	golang.org/x/image v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -469,6 +469,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.58.0 h1:GGB2dWxSbEprU9j0iMJHgdKYJVDyjrOwF9RE59PbRuE=
 github.com/valyala/fasthttp v1.58.0/go.mod h1:SYXvHHaFp7QZHGKSHmoMipInhrI5StHrhDTYVEjK/Kw=
+github.com/valyala/fasthttp v1.59.0 h1:Qu0qYHfXvPk1mSLNqcFtEk6DpxgA26hy6bmydotDpRI=
+github.com/valyala/fasthttp v1.59.0/go.mod h1:GTxNb9Bc6r2a9D0TWNSPwDz78UxnTGBViY3xZNEqyYU=
 github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvCazn8G65U=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=


### PR DESCRIPTION
It seems current periodic failure comes from fasthttp lib, thus bumping the package with hopes that it will solve the issue.

```
Caught panic: runtime error: slice bounds out of range [:-1]

goroutine 1110 [running]:
runtime/debug.Stack()
    /opt/hostedtoolcache/go/1.23.0/x64/src/runtime/debug/stack.go:26 +0x5e
github.com/nuclio/nuclio/pkg/processor/trigger.(*AbstractTrigger).HandleSubmitPanic(0xc0007a0820, {0x0, 0x0}, 0xc001525950)
    /home/runner/work/nuclio/nuclio/pkg/processor/trigger/trigger.go:281 +0x58
panic({0x2225b00?, 0xc0012d4888?})
    /opt/hostedtoolcache/go/1.23.0/x64/src/runtime/panic.go:785 +0x132

github.com/valyala/fasthttp.releaseArg(...)
    /home/runner/go/pkg/mod/github.com/valyala/fasthttp@v1.58.0/args.go:469
github.com/valyala/fasthttp.(*Args).ParseBytes(0xc0013a6ee8, {0x0?, 0x217c4e0?, 0xc0008d7860?})
    /home/runner/go/pkg/mod/github.com/valyala/fasthttp@v1.58.0/args.go:102 +0x397
github.com/valyala/fasthttp.(*URI).parseQueryArgs(...)
    /home/runner/go/pkg/mod/github.com/valyala/fasthttp@v1.58.0/uri.go:886
github.com/valyala/fasthttp.(*URI).QueryArgs(...)
    /home/runner/go/pkg/mod/github.com/valyala/fasthttp@v1.58.0/uri.go:878
github.com/valyala/fasthttp.(*RequestCtx).QueryArgs(0xc0013a6c08)
    /home/runner/go/pkg/mod/github.com/valyala/fasthttp@v1.58.0/server.go:1004 +0x58

github.com/nuclio/nuclio/pkg/processor/trigger/http.(*Event).GetFields(0xc001622be0)
    /home/runner/work/nuclio/nuclio/pkg/processor/trigger/http/event.go:97 +0x2e
github.com/nuclio/nuclio/pkg/processor/runtime/rpc/encoder.eventAsMap({0x282b660, 0xc001622be0})
    /home/runner/work/nuclio/nuclio/pkg/processor/runtime/rpc/encoder/encode.go:36 +0x271
github.com/nuclio/nuclio/pkg/processor/runtime/rpc/encoder.(*EventMsgPackEncoder).Encode.func1({0x282b660, 0xc001622be0})
    /home/runner/work/nuclio/nuclio/pkg/processor/runtime/rpc/encoder/encode_msgpack.go:48 +0x25
github.com/nuclio/nuclio/pkg/processor/runtime/rpc/encoder.(*EventMsgPackEncoder).Encode(0xc000771bd0, {0x2322600?, 0xc001622be0?})
    /home/runner/work/nuclio/nuclio/pkg/processor/runtime/rpc/encoder/encode_msgpack.go:61 +0x208
```
