### PR TITLE
[Controller] Change threshold back to 10

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2388,7 +2388,7 @@ func (lc *lazyClient) populateDeploymentContainer(ctx context.Context,
 		InitialDelaySeconds: 5,
 		TimeoutSeconds:      1,
 		PeriodSeconds:       1,
-		FailureThreshold:    3,
+		FailureThreshold:    10,
 	}
 
 	container.LivenessProbe = &v1.Probe{


### PR DESCRIPTION
Reverts change from https://github.com/nuclio/nuclio/pull/3511

Jira - https://iguazio.atlassian.net/browse/NUC-390

It was intended to improve termination flow. However, it didn't - just introduced some instability in case of high load. 