### PR TITLE
[Processor] Propagate allocation metrics

### DIFF
--- a/pkg/processor/eventprocessor/pool.go
+++ b/pkg/processor/eventprocessor/pool.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/errgroup"
+	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -133,8 +134,8 @@ func (sa *syncPoolAllocator) SetObjects(objects []EventProcessor) error {
 // GetStatistics returns object allocator statistics
 // return unsafe copy of the statistics to avoid any unnecessary blocking of the actual statistics object
 // used in gatherers which are thread-safe
-func (sa *syncPoolAllocator) GetStatistics() *AllocatorStatistics {
-	statistics := &AllocatorStatistics{
+func (sa *syncPoolAllocator) GetStatistics() *metrics.AllocatorStatistics {
+	allocatorStatistics := &metrics.AllocatorStatistics{
 		AllocationCount:                       sa.statistics.AllocationCount.Load(),
 		AllocationSuccessImmediateTotal:       sa.statistics.AllocationSuccessImmediateTotal.Load(),
 		AllocationSuccessAfterWaitTotal:       sa.statistics.AllocationSuccessAfterWaitTotal.Load(),
@@ -142,7 +143,7 @@ func (sa *syncPoolAllocator) GetStatistics() *AllocatorStatistics {
 		AllocationWaitDurationMilliSecondsSum: sa.statistics.AllocationWaitDurationMilliSecondsSum.Load(),
 		AllocationObjectsAvailablePercentage:  sa.statistics.AllocationObjectsAvailablePercentage.Load(),
 	}
-	return statistics
+	return allocatorStatistics
 }
 
 func (sa *syncPoolAllocator) SignalDraining() error {

--- a/pkg/processor/eventprocessor/pool.go
+++ b/pkg/processor/eventprocessor/pool.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/errgroup"
-	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -163,8 +163,8 @@ func (sa *syncPoolAllocator) SetObjects(objects []EventProcessor) error {
 // GetStatistics returns object allocator statistics
 // return unsafe copy of the statistics to avoid any unnecessary blocking of the actual statistics object
 // used in gatherers which are thread-safe
-func (sa *syncPoolAllocator) GetStatistics() *metrics.AllocatorStatistics {
-	allocatorStatistics := &metrics.AllocatorStatistics{
+func (sa *syncPoolAllocator) GetStatistics() *statistics.AllocatorStatistics {
+	allocatorStatistics := &statistics.AllocatorStatistics{
 		AllocationCount:                       sa.statistics.AllocationCount.Load(),
 		AllocationSuccessImmediateTotal:       sa.statistics.AllocationSuccessImmediateTotal.Load(),
 		AllocationSuccessAfterWaitTotal:       sa.statistics.AllocationSuccessAfterWaitTotal.Load(),

--- a/pkg/processor/eventprocessor/singleton.go
+++ b/pkg/processor/eventprocessor/singleton.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
+
 	"github.com/nuclio/logger"
 )
 
@@ -64,8 +66,8 @@ func (s *asyncSingletonAllocator) GetNumObjectsAvailable() int {
 }
 
 // GetStatistics returns allocator statistics
-func (s *asyncSingletonAllocator) GetStatistics() *AllocatorStatistics {
-	return nil
+func (s *asyncSingletonAllocator) GetStatistics() *metrics.AllocatorStatistics {
+	return s.object.GetAllocationStatistics()
 }
 
 func (s *asyncSingletonAllocator) SignalDraining() error {

--- a/pkg/processor/eventprocessor/singleton.go
+++ b/pkg/processor/eventprocessor/singleton.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/logger"
 )
@@ -66,7 +66,7 @@ func (s *asyncSingletonAllocator) GetNumObjectsAvailable() int {
 }
 
 // GetStatistics returns allocator statistics
-func (s *asyncSingletonAllocator) GetStatistics() *metrics.AllocatorStatistics {
+func (s *asyncSingletonAllocator) GetStatistics() *statistics.AllocatorStatistics {
 	return s.object.GetAllocationStatistics()
 }
 

--- a/pkg/processor/eventprocessor/statistics.go
+++ b/pkg/processor/eventprocessor/statistics.go
@@ -18,34 +18,6 @@ package eventprocessor
 
 import "sync/atomic"
 
-type Statistics struct {
-	EventsHandledSuccess uint64
-	EventsHandledError   uint64
-}
-
-// AllocatorStatistics is not a safe statistics object and should be used only to copy safe object to it and return to outside
-// so it can later be taken by metric gatherers
-type AllocatorStatistics struct {
-	AllocationCount                       uint64
-	AllocationSuccessImmediateTotal       uint64
-	AllocationSuccessAfterWaitTotal       uint64
-	AllocationTimeoutTotal                uint64
-	AllocationWaitDurationMilliSecondsSum uint64
-	AllocationObjectsAvailablePercentage  uint64
-}
-
-func (s *AllocatorStatistics) DiffFrom(prev *AllocatorStatistics) AllocatorStatistics {
-
-	return AllocatorStatistics{
-		AllocationCount:                       s.AllocationCount - prev.AllocationCount,
-		AllocationSuccessImmediateTotal:       s.AllocationSuccessImmediateTotal - prev.AllocationSuccessImmediateTotal,
-		AllocationSuccessAfterWaitTotal:       s.AllocationSuccessAfterWaitTotal - prev.AllocationSuccessAfterWaitTotal,
-		AllocationTimeoutTotal:                s.AllocationTimeoutTotal - prev.AllocationTimeoutTotal,
-		AllocationWaitDurationMilliSecondsSum: s.AllocationWaitDurationMilliSecondsSum - prev.AllocationWaitDurationMilliSecondsSum,
-		AllocationObjectsAvailablePercentage:  s.AllocationObjectsAvailablePercentage - prev.AllocationObjectsAvailablePercentage,
-	}
-}
-
 // safeAllocatorStatistics is a safe statistics object, for outside usages use AllocatorStatistics
 type safeAllocatorStatistics struct {
 	AllocationCount                       atomic.Uint64

--- a/pkg/processor/eventprocessor/types.go
+++ b/pkg/processor/eventprocessor/types.go
@@ -23,7 +23,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/cloudevent"
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
-	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -50,7 +50,7 @@ type Allocator interface {
 	GetNumObjectsAvailable() int
 
 	// GetStatistics returns allocator statistics
-	GetStatistics() *metrics.AllocatorStatistics
+	GetStatistics() *statistics.AllocatorStatistics
 
 	// SignalDraining signals all event processors to drain events
 	SignalDraining() error
@@ -100,10 +100,10 @@ type EventProcessor interface {
 	Stop() error
 
 	// GetStatistics returns event processing statistics, such as counts and latencies
-	GetStatistics() *metrics.EventProcessingStatistics
+	GetStatistics() *statistics.EventProcessingStatistics
 
 	// GetAllocationStatistics returns allocation statistics, such as allocation time and number of allocations
-	GetAllocationStatistics() *metrics.AllocatorStatistics
+	GetAllocationStatistics() *statistics.AllocatorStatistics
 
 	// GetStructuredCloudEvent retrieves the last processed structured CloudEvent
 	GetStructuredCloudEvent() *cloudevent.Structured

--- a/pkg/processor/eventprocessor/types.go
+++ b/pkg/processor/eventprocessor/types.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/cloudevent"
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -49,7 +50,7 @@ type Allocator interface {
 	GetNumObjectsAvailable() int
 
 	// GetStatistics returns allocator statistics
-	GetStatistics() *AllocatorStatistics
+	GetStatistics() *metrics.AllocatorStatistics
 
 	// SignalDraining signals all event processors to drain events
 	SignalDraining() error
@@ -93,7 +94,10 @@ type EventProcessor interface {
 	Stop() error
 
 	// GetStatistics returns event processing statistics, such as counts and latencies
-	GetStatistics() *Statistics
+	GetStatistics() *metrics.EventProcessingStatistics
+
+	// GetAllocationStatistics returns allocation statistics, such as allocation time and number of allocations
+	GetAllocationStatistics() *metrics.AllocatorStatistics
 
 	// GetStructuredCloudEvent retrieves the last processed structured CloudEvent
 	GetStructuredCloudEvent() *cloudevent.Structured

--- a/pkg/processor/runtime/golang/runtime.go
+++ b/pkg/processor/runtime/golang/runtime.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -106,6 +107,12 @@ func (g *golang) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) 
 
 func (g *golang) ProcessBatch(batch []nuclio.Event, functionLogger logger.Logger) ([]*runtime.ResponseWithErrors, error) {
 	return nil, nuclio.ErrNotImplemented
+}
+
+// GetAllocationStatistics returns the statistics of the allocator if there is any in the runtime
+// go runtime doesn't have any allocator in it, so return nil
+func (g *golang) GetAllocationStatistics() *metrics.AllocatorStatistics {
+	return nil
 }
 
 func (g *golang) Restart() error {

--- a/pkg/processor/runtime/golang/runtime.go
+++ b/pkg/processor/runtime/golang/runtime.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
-	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -122,7 +122,7 @@ func (g *golang) ProcessBatch(batch []nuclio.Event, functionLogger logger.Logger
 
 // GetAllocationStatistics returns the statistics of the allocator if there is any in the runtime
 // go runtime doesn't have any allocator in it, so return nil
-func (g *golang) GetAllocationStatistics() *metrics.AllocatorStatistics {
+func (g *golang) GetAllocationStatistics() *statistics.AllocatorStatistics {
 	return nil
 }
 

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/connection"
+	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
 	"github.com/nuclio/nuclio/pkg/processwaiter"
 
 	"github.com/nuclio/errors"
@@ -84,6 +85,10 @@ func (r *AbstractRuntime) ProcessEvent(event nuclio.Event, functionLogger logger
 // ProcessBatch processes a batch of events
 func (r *AbstractRuntime) ProcessBatch(batch []nuclio.Event, functionLogger logger.Logger) ([]*runtime.ResponseWithErrors, error) {
 	return r.processBatchAndWaitForResult(batch, functionLogger)
+}
+
+func (r *AbstractRuntime) GetAllocationStatistics() *metrics.AllocatorStatistics {
+	return r.connectionManager.GetAllocationStatistics()
 }
 
 // Stop stops the runtime

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -27,7 +27,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/connection"
-	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
 	"github.com/nuclio/nuclio/pkg/processwaiter"
 
 	"github.com/nuclio/errors"
@@ -91,7 +91,7 @@ func (r *AbstractRuntime) ProcessBatch(batch []nuclio.Event, functionLogger logg
 	return r.processBatchAndWaitForResult(batch, functionLogger)
 }
 
-func (r *AbstractRuntime) GetAllocationStatistics() *metrics.AllocatorStatistics {
+func (r *AbstractRuntime) GetAllocationStatistics() *statistics.AllocatorStatistics {
 	return r.connectionManager.GetAllocationStatistics()
 }
 

--- a/pkg/processor/runtime/rpc/connection/abstract.go
+++ b/pkg/processor/runtime/rpc/connection/abstract.go
@@ -36,6 +36,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/controlmessagebroker"
 	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/encoder"
 	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/result"
+	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/nuclio/errors"
@@ -86,6 +87,10 @@ func NewAbstractConnectionManager(parentLogger logger.Logger, runtimeConfigurati
 func (bc *AbstractConnectionManager) UpdateStatistics(durationSec float64) {
 	bc.Configuration.Statistics.DurationMilliSecondsCount++
 	bc.Configuration.Statistics.DurationMilliSecondsSum += uint64(durationSec * 1000)
+}
+
+func (bc *AbstractConnectionManager) GetAllocationStatistics() *metrics.AllocatorStatistics {
+	return bc.allocator.GetStatistics()
 }
 
 func (bc *AbstractConnectionManager) SetStatus(newStatus status.Status) {
@@ -414,7 +419,13 @@ func (be *AbstractEventConnection) RunHandler() {
 }
 
 // GetStatistics returns a pointer to the statistics object. This must not be modified by the reader
-func (be *AbstractEventConnection) GetStatistics() *eventprocessor.Statistics {
+func (be *AbstractEventConnection) GetStatistics() *metrics.EventProcessingStatistics {
+	return nil
+}
+
+// GetAllocationStatistics returns the statistics of the allocator if there is any in the runtime
+// AbstractEventConnection runtime doesn't have any allocator in it, so return nil
+func (be *AbstractEventConnection) GetAllocationStatistics() *metrics.AllocatorStatistics {
 	return nil
 }
 

--- a/pkg/processor/runtime/rpc/connection/abstract.go
+++ b/pkg/processor/runtime/rpc/connection/abstract.go
@@ -37,7 +37,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/controlmessagebroker"
 	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/encoder"
 	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/result"
-	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/nuclio/errors"
@@ -89,7 +89,7 @@ func (bc *AbstractConnectionManager) UpdateStatistics(durationSec float64) {
 	bc.Configuration.Statistics.DurationMilliSecondsSum += uint64(durationSec * 1000)
 }
 
-func (bc *AbstractConnectionManager) GetAllocationStatistics() *metrics.AllocatorStatistics {
+func (bc *AbstractConnectionManager) GetAllocationStatistics() *statistics.AllocatorStatistics {
 	return bc.allocator.GetStatistics()
 }
 
@@ -473,13 +473,13 @@ func (be *AbstractEventConnection) RunHandler() {
 }
 
 // GetStatistics returns a pointer to the statistics object. This must not be modified by the reader
-func (be *AbstractEventConnection) GetStatistics() *metrics.EventProcessingStatistics {
+func (be *AbstractEventConnection) GetStatistics() *statistics.EventProcessingStatistics {
 	return nil
 }
 
 // GetAllocationStatistics returns the statistics of the allocator if there is any in the runtime
 // AbstractEventConnection runtime doesn't have any allocator in it, so return nil
-func (be *AbstractEventConnection) GetAllocationStatistics() *metrics.AllocatorStatistics {
+func (be *AbstractEventConnection) GetAllocationStatistics() *statistics.AllocatorStatistics {
 	return nil
 }
 

--- a/pkg/processor/runtime/rpc/connection/types.go
+++ b/pkg/processor/runtime/rpc/connection/types.go
@@ -26,7 +26,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/encoder"
 	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/result"
-	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/logger"
 )
@@ -56,7 +56,7 @@ type ConnectionManager interface {
 	UpdateStatistics(durationSec float64)
 
 	// GetAllocationStatistics retrieves the current statistics of the ConnectionManager allocator
-	GetAllocationStatistics() *metrics.AllocatorStatistics
+	GetAllocationStatistics() *statistics.AllocatorStatistics
 
 	// SetStatus updates the operational status of the ConnectionManager
 	SetStatus(status.Status)

--- a/pkg/processor/runtime/rpc/connection/types.go
+++ b/pkg/processor/runtime/rpc/connection/types.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/encoder"
 	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/result"
+	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
 
 	"github.com/nuclio/logger"
 )
@@ -50,6 +51,9 @@ type ConnectionManager interface {
 	// UpdateStatistics records performance or usage statistics based on the
 	// duration of an event or process, specified in seconds
 	UpdateStatistics(durationSec float64)
+
+	// GetAllocationStatistics retrieves the current statistics of the ConnectionManager allocator
+	GetAllocationStatistics() *metrics.AllocatorStatistics
 
 	// SetStatus updates the operational status of the ConnectionManager
 	SetStatus(status.Status)

--- a/pkg/processor/runtime/runtime.go
+++ b/pkg/processor/runtime/runtime.go
@@ -23,7 +23,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
 	"github.com/nuclio/nuclio/pkg/processor/databinding"
-	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -47,7 +47,7 @@ type Runtime interface {
 
 	// GetAllocationStatistics returns statistics gathered by the allocator
 	// if there is any in the runtime, otherwise returns nil
-	GetAllocationStatistics() *metrics.AllocatorStatistics
+	GetAllocationStatistics() *statistics.AllocatorStatistics
 
 	// GetConfiguration returns the runtime configuration
 	GetConfiguration() *Configuration

--- a/pkg/processor/runtime/runtime.go
+++ b/pkg/processor/runtime/runtime.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
 	"github.com/nuclio/nuclio/pkg/processor/databinding"
+	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -43,6 +44,10 @@ type Runtime interface {
 
 	// GetStatistics returns statistics gathered by the runtime
 	GetStatistics() *Statistics
+
+	// GetAllocationStatistics returns statistics gathered by the allocator
+	// if there is any in the runtime, otherwise returns nil
+	GetAllocationStatistics() *metrics.AllocatorStatistics
 
 	// GetConfiguration returns the runtime configuration
 	GetConfiguration() *Configuration

--- a/pkg/processor/runtime/shell/runtime.go
+++ b/pkg/processor/runtime/shell/runtime.go
@@ -31,7 +31,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
-	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -179,7 +179,7 @@ func (s *shell) ProcessBatch(batch []nuclio.Event, functionLogger logger.Logger)
 
 // GetAllocationStatistics returns the statistics of the allocator if there is any in the runtime
 // shell runtime doesn't have any allocator in it, so return nil
-func (s *shell) GetAllocationStatistics() *metrics.AllocatorStatistics {
+func (s *shell) GetAllocationStatistics() *statistics.AllocatorStatistics {
 	return nil
 }
 

--- a/pkg/processor/runtime/shell/runtime.go
+++ b/pkg/processor/runtime/shell/runtime.go
@@ -31,6 +31,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -126,6 +127,12 @@ func (s *shell) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (
 
 func (s *shell) ProcessBatch(batch []nuclio.Event, functionLogger logger.Logger) ([]*runtime.ResponseWithErrors, error) {
 	return nil, nuclio.ErrNotImplemented
+}
+
+// GetAllocationStatistics returns the statistics of the allocator if there is any in the runtime
+// shell runtime doesn't have any allocator in it, so return nil
+func (s *shell) GetAllocationStatistics() *metrics.AllocatorStatistics {
+	return nil
 }
 
 func (s *shell) processEvent(context context.Context,

--- a/pkg/processor/statistics/gatherer/gatherer.go
+++ b/pkg/processor/statistics/gatherer/gatherer.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statistics
+package gatherer
 
 // a reflection of an object in the processor (e.g. trigger, runtime, worker) that holds prometheus
 // metrics. when Gather() is called, the resource is queried for its primitive statistics. this way we decouple

--- a/pkg/processor/statistics/gatherer/metricpusher.go
+++ b/pkg/processor/statistics/gatherer/metricpusher.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statistics
+package gatherer
 
 import (
 	"os"

--- a/pkg/processor/statistics/gatherer/trigger.go
+++ b/pkg/processor/statistics/gatherer/trigger.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statistics
+package gatherer
 
 import (
 	"sync/atomic"

--- a/pkg/processor/statistics/gatherer/worker.go
+++ b/pkg/processor/statistics/gatherer/worker.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package statistics
+package gatherer
 
 import (
 	"strconv"

--- a/pkg/processor/statistics/metrics/types.go
+++ b/pkg/processor/statistics/metrics/types.go
@@ -1,0 +1,29 @@
+package metrics
+
+type EventProcessingStatistics struct {
+	EventsHandledSuccess uint64
+	EventsHandledError   uint64
+}
+
+// AllocatorStatistics is not a safe statistics object and should be used only to copy safe object to it and return to outside
+// so it can later be taken by metric gatherers
+type AllocatorStatistics struct {
+	AllocationCount                       uint64
+	AllocationSuccessImmediateTotal       uint64
+	AllocationSuccessAfterWaitTotal       uint64
+	AllocationTimeoutTotal                uint64
+	AllocationWaitDurationMilliSecondsSum uint64
+	AllocationObjectsAvailablePercentage  uint64
+}
+
+func (s *AllocatorStatistics) DiffFrom(prev *AllocatorStatistics) AllocatorStatistics {
+
+	return AllocatorStatistics{
+		AllocationCount:                       s.AllocationCount - prev.AllocationCount,
+		AllocationSuccessImmediateTotal:       s.AllocationSuccessImmediateTotal - prev.AllocationSuccessImmediateTotal,
+		AllocationSuccessAfterWaitTotal:       s.AllocationSuccessAfterWaitTotal - prev.AllocationSuccessAfterWaitTotal,
+		AllocationTimeoutTotal:                s.AllocationTimeoutTotal - prev.AllocationTimeoutTotal,
+		AllocationWaitDurationMilliSecondsSum: s.AllocationWaitDurationMilliSecondsSum - prev.AllocationWaitDurationMilliSecondsSum,
+		AllocationObjectsAvailablePercentage:  s.AllocationObjectsAvailablePercentage - prev.AllocationObjectsAvailablePercentage,
+	}
+}

--- a/pkg/processor/statistics/metrics/types.go
+++ b/pkg/processor/statistics/metrics/types.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package metrics
 
 type EventProcessingStatistics struct {

--- a/pkg/processor/statistics/types.go
+++ b/pkg/processor/statistics/types.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package metrics
+package statistics
 
 type EventProcessingStatistics struct {
 	EventsHandledSuccess uint64

--- a/pkg/processor/trigger/types.go
+++ b/pkg/processor/trigger/types.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
-	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
 	"github.com/nuclio/nuclio/pkg/processor/util/partitionworker"
 
 	"github.com/nuclio/errors"
@@ -183,7 +183,7 @@ func (c *Configuration) ResolveWorkerAllocationMode(modeFromAttributes, modeFrom
 type Statistics struct {
 	EventsHandledSuccessTotal uint64
 	EventsHandledFailureTotal uint64
-	WorkerAllocatorStatistics eventprocessor.AllocatorStatistics
+	WorkerAllocatorStatistics metrics.AllocatorStatistics
 }
 
 func (s *Statistics) DiffFrom(prev *Statistics) Statistics {

--- a/pkg/processor/trigger/types.go
+++ b/pkg/processor/trigger/types.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
-	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
 	"github.com/nuclio/nuclio/pkg/processor/util/partitionworker"
 
 	"github.com/nuclio/errors"
@@ -183,7 +183,7 @@ func (c *Configuration) ResolveWorkerAllocationMode(modeFromAttributes, modeFrom
 type Statistics struct {
 	EventsHandledSuccessTotal uint64
 	EventsHandledFailureTotal uint64
-	WorkerAllocatorStatistics metrics.AllocatorStatistics
+	WorkerAllocatorStatistics statistics.AllocatorStatistics
 }
 
 func (s *Statistics) DiffFrom(prev *Statistics) Statistics {

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -27,7 +27,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
 	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
-	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
@@ -37,7 +37,7 @@ import (
 type Worker struct {
 
 	// accessed atomically, keep as first field for alignment
-	statistics metrics.EventProcessingStatistics
+	statistics statistics.EventProcessingStatistics
 
 	logger               logger.Logger
 	index                int
@@ -94,11 +94,11 @@ func (w *Worker) ProcessEventBatch(batch []nuclio.Event, functionLogger logger.L
 }
 
 // GetStatistics returns a pointer to the statistics object. This must not be modified by the reader
-func (w *Worker) GetStatistics() *metrics.EventProcessingStatistics {
+func (w *Worker) GetStatistics() *statistics.EventProcessingStatistics {
 	return &w.statistics
 }
 
-func (w *Worker) GetAllocationStatistics() *metrics.AllocatorStatistics {
+func (w *Worker) GetAllocationStatistics() *statistics.AllocatorStatistics {
 	return w.runtime.GetAllocationStatistics()
 }
 

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -28,7 +28,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
-	"github.com/nuclio/nuclio/pkg/processor/util/clock"
 
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
 	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
 	"github.com/nuclio/nuclio/pkg/processor/util/clock"
 
 	"github.com/nuclio/logger"
@@ -36,7 +37,7 @@ import (
 type Worker struct {
 
 	// accessed atomically, keep as first field for alignment
-	statistics eventprocessor.Statistics
+	statistics metrics.EventProcessingStatistics
 
 	logger               logger.Logger
 	index                int
@@ -97,8 +98,12 @@ func (w *Worker) ProcessEventBatch(batch []nuclio.Event, functionLogger logger.L
 }
 
 // GetStatistics returns a pointer to the statistics object. This must not be modified by the reader
-func (w *Worker) GetStatistics() *eventprocessor.Statistics {
+func (w *Worker) GetStatistics() *metrics.EventProcessingStatistics {
 	return &w.statistics
+}
+
+func (w *Worker) GetAllocationStatistics() *metrics.AllocatorStatistics {
+	return w.runtime.GetAllocationStatistics()
 }
 
 // GetIndex returns the index of the worker, as specified during creation

--- a/pkg/processor/worker/worker_test.go
+++ b/pkg/processor/worker/worker_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
 
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
@@ -50,6 +51,10 @@ func (mr *MockRuntime) ProcessBatch(batch []nuclio.Event, functionLogger logger.
 }
 
 func (mr *MockRuntime) GetStatistics() *runtime.Statistics {
+	return nil
+}
+
+func (mr *MockRuntime) GetAllocationStatistics() *metrics.AllocatorStatistics {
 	return nil
 }
 

--- a/pkg/processor/worker/worker_test.go
+++ b/pkg/processor/worker/worker_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
-	"github.com/nuclio/nuclio/pkg/processor/statistics/metrics"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
@@ -54,7 +54,7 @@ func (mr *MockRuntime) GetStatistics() *runtime.Statistics {
 	return nil
 }
 
-func (mr *MockRuntime) GetAllocationStatistics() *metrics.AllocatorStatistics {
+func (mr *MockRuntime) GetAllocationStatistics() *statistics.AllocatorStatistics {
 	return nil
 }
 


### PR DESCRIPTION
This PR enables the propagation of allocation metrics based on the allocation type.

General Logic:
Async Singleton Allocator: Since an async singleton allocator doesn’t maintain its own metrics, we retrieve allocation metrics from a single object within it.

Sync Pool Allocator: Metrics are directly available, so we return them as is.

Implications:
For any runtime with synchronous event processing, metrics are retrieved from `workerAllocator.statistics`.

For Python runtime with asynchronous event processing, the flow for retrieving metrics is as follows:
```
workerAllocator.GetStatistics()  
└── workerAllocator(.asyncSingleton).object.GetAllocatorStatistics()  
    └── worker.GetAllocatorStatistics()  
        └── runtime.connectionManager.allocator.GetAllocatorStatistics()  
            └── connectionAllocator(.syncPool).GetAllocatorStatistics()
 ```      