### PR TITLE
[Makefile] Ensure golangci-lint version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -690,11 +690,22 @@ ensure-test-files-annotated:
 	@echo "All go test files have //go:build test_X annotation"
 	@exit $(.SHELLSTATUS)
 
+GOLANGCI_LINT_VERSION := v1.64.6
+GOLANGCI_LINT_BIN := $(GOPATH)/bin/golangci-lint
+GOLANGCI_LINT_INSTALL_COMMAND := GOBIN=$(GOPATH)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
 .PHONY: ensure-golangci-linter
 ensure-golangci-linter:
-	@echo Ensuring linters...
-	@test -e $(GOPATH)/bin/golangci-lint || \
-		(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.63.4)
+	@if ! command -v $(GOLANGCI_LINT_BIN) >/dev/null 2>&1; then \
+		echo "golangci-lint not found. Installing..."; \
+		$(GOLANGCI_LINT_INSTALL_COMMAND); \
+	else \
+		installed_version=$$($(GOLANGCI_LINT_BIN) version | awk '/version/ {print $$4}'); \
+		if [ "$$installed_version" != "$(GOLANGCI_LINT_VERSION)" ]; then \
+			echo "golangci-lint version mismatch ($$installed_version != $(GOLANGCI_LINT_VERSION)). Reinstalling..."; \
+			$(GOLANGCI_LINT_INSTALL_COMMAND); \
+		fi \
+	fi
 
 #
 # Testing


### PR DESCRIPTION
`golangci-lint` versions are dependent on go versions, so if you have older versions already installed locally, linting will fail.

In this PR:
- Replace the `golangci-lint` binary installation from curl to go install, which ensures we get the binary that aligns to the correct go version.
- Ensure the `golangci-lint` version of existing binaries, by reinstalling if the version is not the expected version.