### PR TITLE
[Processor] Optimise result creation

### DIFF
--- a/pkg/processor/runtime/rpc/connection/abstract.go
+++ b/pkg/processor/runtime/rpc/connection/abstract.go
@@ -446,8 +446,12 @@ func (be *AbstractEventConnection) RunHandler() {
 				// otherwise it may get stuck here and block select
 				case be.resultChan <- batchedResultsWithError:
 				default:
-					// if no receiver is waiting for the result, we should not send it
+					// Explicitly clear batchedResultsWithError to release memory and indicate it's no longer needed.
+					// Although the variable isn't used afterward, we assign nil here intentionally to help the
+					// garbage collector reclaim memory early, especially if it held a large data structure.
 					batchedResultsWithError = nil
+					_ = batchedResultsWithError // suppress 'ineffassign' linter warning about unused assignment
+
 				}
 				continue
 			}

--- a/pkg/processor/runtime/rpc/connection/abstract.go
+++ b/pkg/processor/runtime/rpc/connection/abstract.go
@@ -424,34 +424,37 @@ func (be *AbstractEventConnection) RunHandler() {
 
 		default:
 
-			unmarshalledResults := result.NewBatchedResults()
 			var data []byte
-			data, unmarshalledResults.Err = outReader.ReadBytes('\n')
+			var err error
+			data, err = outReader.ReadBytes('\n')
 
-			if unmarshalledResults.Err != nil {
+			if err != nil {
 				// if matches one of the errors and status is not ready, no need to log it, expected during restart/stop
 				// if status is ready, we should always log the error
 				if be.GetStatus() == status.Ready || !common.StringSliceContainsStringSuffix([]string{
 					"EOF",
 					"connection reset by peer",
 					"use of closed network connection",
-				}, unmarshalledResults.Err.Error()) {
+				}, errors.RootCause(err).Error()) {
 					be.Logger.WarnWith(string(common.FailedReadFromEventConnection),
-						"err", errors.RootCause(unmarshalledResults.Err).Error())
+						"err", errors.RootCause(err).Error())
 				}
 
+				batchedResultsWithError := result.NewBatchedResultsWithError(err)
 				select {
 				// if no receiver is waiting for the result, we should not send it
 				// otherwise it may get stuck here and block select
-				case be.resultChan <- unmarshalledResults:
+				case be.resultChan <- batchedResultsWithError:
 				default:
+					// if no receiver is waiting for the result, we should not send it
+					batchedResultsWithError = nil
 				}
-
 				continue
 			}
 
 			switch data[0] {
 			case 'r':
+				unmarshalledResults := result.NewBatchedResults()
 				unmarshalledResults.UnmarshalResponseData(be.Logger, data[1:])
 
 				// write back to result channel

--- a/pkg/processor/runtime/rpc/result/result.go
+++ b/pkg/processor/runtime/rpc/result/result.go
@@ -52,6 +52,10 @@ func NewBatchedResults() *BatchedResults {
 	return &BatchedResults{Results: make([]*Result, 0)}
 }
 
+func NewBatchedResultsWithError(err error) *BatchedResults {
+	return &BatchedResults{Err: err}
+}
+
 func (br *BatchedResults) UnmarshalResponseData(logger logger.Logger, data []byte) {
 	var results []*Result
 


### PR DESCRIPTION
During wrapper (=connection allocator) restart before changes:

![image](https://github.com/user-attachments/assets/5346d1d1-b340-44ff-86f1-421acb02aaa7)
which was quite a work for garbage collector. 

And after changes:
![image](https://github.com/user-attachments/assets/78510fb3-3a7f-4ae4-9d1e-c67169119196)
