### PR TITLE
[CI] Fix building nuctl

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -315,7 +315,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.bump_helm_charts_only != 'true'
     name: Release Binary ${{ matrix.arch }}
     runs-on: ubuntu-latest
-    needs: [ prepare-inputs ]
+    needs: [ prepare-inputs , release ]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -315,7 +315,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.bump_helm_charts_only != 'true'
     name: Release Binary ${{ matrix.arch }}
     runs-on: ubuntu-latest
-    needs: [ prepare-inputs , release ]
+    needs: [ prepare-inputs ]
     strategy:
       fail-fast: false
       matrix:
@@ -358,6 +358,7 @@ jobs:
       - name: Upload binaries
         uses: AButler/upload-release-assets@v3.0
         with:
+          release-tag: ${{ needs.prepare-inputs.outputs.version }}
           files: '/home/runner/go/bin/nuctl-*'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Since we previously ran the release CI with on: release, and now we run it on workflow_dispatch, it doesn't have a tag inside the execution anymore. So, the tag needs to be passed explicitly.