### PR TITLE
[Dependencies] Bump Docker client version in dashboard image

### DIFF
--- a/cmd/dashboard/docker/Dockerfile
+++ b/cmd/dashboard/docker/Dockerfile
@@ -58,7 +58,7 @@ FROM $NUCLIO_DOCKER_ALPINE_IMAGE as downloaddocker
 
 # docker client
 ARG DOCKER_CLI_ARCH=x86_64
-ARG DOCKER_CLI_VERSION="23.0.1"
+ARG DOCKER_CLI_VERSION="28.0.4"
 ENV DOCKER_CLI_DOWNLOAD_URL="https://download.docker.com/linux/static/stable/$DOCKER_CLI_ARCH/docker-$DOCKER_CLI_VERSION.tgz"
 
 RUN apk --update --no-cache add curl \

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -20,7 +20,7 @@ FROM $ALPINE_IMAGE as builder
 
 # docker
 ARG DOCKER_CLI_ARCH=x86_64
-ARG DOCKER_CLI_VERSION="23.0.1"
+ARG DOCKER_CLI_VERSION="28.0.4"
 ENV DOCKER_CLI_DOWNLOAD_URL="https://download.docker.com/linux/static/stable/$DOCKER_CLI_ARCH/docker-$DOCKER_CLI_VERSION.tgz"
 
 # kubectl


### PR DESCRIPTION
The previous docker client was using Go 1.19.5, which had some security vulnerabilities.
Bumping to docker 28.0.4 that is built using Go 1.23.7, which contains fixes for these vulnerabilities.

https://iguazio.atlassian.net/browse/IG-23639
https://iguazio.atlassian.net/browse/IG-23640
https://iguazio.atlassian.net/browse/NUC-342