### PR TITLE
[Dependencies] Change go version to 1.23.8 [1.13.x]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,8 @@ endif
 
 NUCLIO_PYTHON_BASE_IMAGE_NAME ?= gcr.io/iguazio/python
 
-NUCLIO_BASE_IMAGE_TAG ?= 1.23
-NUCLIO_BASE_ALPINE_IMAGE_TAG ?= 1.23-alpine
+NUCLIO_BASE_IMAGE_TAG ?= 1.23.8
+NUCLIO_BASE_ALPINE_IMAGE_TAG ?= 1.23.8-alpine
 
 #
 #  Must be first target

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nuclio/nuclio
 
-go 1.23.0
+go 1.23.8
 
 require (
 	cloud.google.com/go/pubsub v1.33.0

--- a/test/_functions/golang/with-modules/go.mod
+++ b/test/_functions/golang/with-modules/go.mod
@@ -1,6 +1,6 @@
 module my-awesome-test-function
 
-go 1.23
+go 1.23.8
 
 require (
 	github.com/aidarkhanov/nanoid v1.0.8

--- a/test/_functions/golang/with-modules/go.sum
+++ b/test/_functions/golang/with-modules/go.sum
@@ -1,11 +1,7 @@
 github.com/aidarkhanov/nanoid v1.0.8 h1:yxyJkgsEDFXP7+97vc6JevMcjyb03Zw+/9fqhlVXBXA=
 github.com/aidarkhanov/nanoid v1.0.8/go.mod h1:vadfZHT+m4uDhttg0yY4wW3GKtl2T6i4d2Age+45pYk=
-github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
-github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
-github.com/klauspost/compress v1.17.0 h1:Rnbp4K9EjcDuVuHtd0dgA4qNuv9yKDYKK1ulpJwgrqM=
-github.com/klauspost/compress v1.17.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/nuclio/logger v0.0.1 h1:e+vT/Ug65RC+u0QX2J+lq3P57ZBwJ1ZA6Q2LCEcViwE=
@@ -14,8 +10,7 @@ github.com/nuclio/nuclio-sdk-go v0.5.1 h1:+FVeE9siHf4AQdkvRjO5yQ+Tugio9DHBtrZ9JG
 github.com/nuclio/nuclio-sdk-go v0.5.1/go.mod h1:nJfISTlsf+blZKhIfmHDDrZupMjyRNnBl6tNM9qweAg=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
-github.com/valyala/fasthttp v1.51.0 h1:8b30A5JlZ6C7AS81RsWjYMQmrZG6feChmgAolCl1SqA=
-github.com/valyala/fasthttp v1.51.0/go.mod h1:oI2XroL+lI7vdXyYoQk03bXBThfFl2cVdIA3Xl7cH8g=
 github.com/valyala/fasthttp v1.58.0 h1:GGB2dWxSbEprU9j0iMJHgdKYJVDyjrOwF9RE59PbRuE=
 github.com/valyala/fasthttp v1.58.0/go.mod h1:SYXvHHaFp7QZHGKSHmoMipInhrI5StHrhDTYVEjK/Kw=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=


### PR DESCRIPTION
Change go version to 1.23.8, also setting images to have a patch version. 

During security check we noticed misalignment that was caused by 1.23.0 in go.mod and 1.23.7 version of the go image itself. In order to have clarity of which version we use, it was decided to always have a patch version specified.