### PR TITLE
[Test] Fix TestGenerateKanikoProcessorDockerfile

### DIFF
--- a/pkg/processor/build/test/build_test.go
+++ b/pkg/processor/build/test/build_test.go
@@ -835,7 +835,6 @@ preCopyKind2 preCopyValue2
 COPY --from=gcr.io/iguazio/uhttpc:0.0.3-amd64 /home/nuclio/bin/uhttpc /usr/local/bin/uhttpc
 COPY --from=onbuild-1 onbuildLocal1 onbuildImage1
 COPY --from=onbuild-1 onbuildLocal2 onbuildImage2
-COPY --from=gcr.io/iguazio/uhttpc:0.0.2-amd64 /home/nuclio/bin/uhttpc /usr/local/bin/uhttpc
 COPY imageLocal1 imageImage1
 COPY imageLocal2 imageImage2
 # Readiness probe


### PR DESCRIPTION
After merging 1.13.x commit for bumping uhttpc to development, both strings remained, so deleting the old one