### PR TITLE
[Processor] Implement non-blocking pool allocator

### DIFF
--- a/pkg/processor/eventprocessor/abstract.go
+++ b/pkg/processor/eventprocessor/abstract.go
@@ -45,7 +45,6 @@ func (a *abstractPoolAllocator) SignalDraining() error {
 	errGroup, _ := errgroup.WithContext(context.Background(), a.logger)
 
 	for _, objectInstance := range a.GetObjects() {
-		objectInstance := objectInstance
 
 		errGroup.Go(fmt.Sprintf("Drain object %d", objectInstance.GetIndex()), func() error {
 			// if object is not already drained, signal it to drain events
@@ -66,7 +65,6 @@ func (a *abstractPoolAllocator) SignalContinue() error {
 	errGroup, _ := errgroup.WithContext(context.Background(), a.logger)
 
 	for _, objectInstance := range a.GetObjects() {
-		objectInstance := objectInstance
 
 		errGroup.Go(fmt.Sprintf("Send continue signal to object %d", objectInstance.GetIndex()), func() error {
 			if err := objectInstance.Continue(); err != nil {
@@ -87,7 +85,6 @@ func (a *abstractPoolAllocator) SignalTermination() error {
 	errGroup, _ := errgroup.WithContext(context.Background(), a.logger)
 	a.isTerminated.Store(true)
 	for _, objectInstance := range a.GetObjects() {
-		objectInstance := objectInstance
 
 		errGroup.Go(fmt.Sprintf("Terminate object %d", objectInstance.GetIndex()), func() error {
 

--- a/pkg/processor/eventprocessor/abstract.go
+++ b/pkg/processor/eventprocessor/abstract.go
@@ -1,0 +1,105 @@
+package eventprocessor
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/nuclio/nuclio/pkg/errgroup"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+)
+
+type abstractPoolAllocator struct {
+	logger       logger.Logger
+	objects      []EventProcessor
+	isTerminated atomic.Bool
+}
+
+func newAbstractPoolAllocator(loggerInstance logger.Logger) *abstractPoolAllocator {
+	return &abstractPoolAllocator{
+		logger:       loggerInstance,
+		isTerminated: atomic.Bool{},
+	}
+}
+
+func (a *abstractPoolAllocator) SignalDraining() error {
+	errGroup, _ := errgroup.WithContext(context.Background(), a.logger)
+
+	for _, objectInstance := range a.GetObjects() {
+		objectInstance := objectInstance
+
+		errGroup.Go(fmt.Sprintf("Drain object %d", objectInstance.GetIndex()), func() error {
+			// if object is not already drained, signal it to drain events
+			if err := objectInstance.Drain(); err != nil {
+				return errors.Wrapf(err, "Failed to signal object %d to drain events", objectInstance.GetIndex())
+			}
+			return nil
+		})
+	}
+
+	if err := errGroup.Wait(); err != nil {
+		return errors.Wrap(err, "At least one object failed to drain")
+	}
+
+	return nil
+}
+func (a *abstractPoolAllocator) SignalContinue() error {
+	errGroup, _ := errgroup.WithContext(context.Background(), a.logger)
+
+	for _, objectInstance := range a.GetObjects() {
+		objectInstance := objectInstance
+
+		errGroup.Go(fmt.Sprintf("Send continue signal to object %d", objectInstance.GetIndex()), func() error {
+			if err := objectInstance.Continue(); err != nil {
+				return errors.Wrapf(err, "Failed to signal object %d to continue event processing", objectInstance.GetIndex())
+			}
+			return nil
+		})
+	}
+
+	if err := errGroup.Wait(); err != nil {
+		return errors.Wrap(err, "At least one object failed to continue")
+	}
+
+	return nil
+}
+
+func (a *abstractPoolAllocator) SignalTermination() error {
+	errGroup, _ := errgroup.WithContext(context.Background(), a.logger)
+	a.isTerminated.Store(true)
+	for _, objectInstance := range a.GetObjects() {
+		objectInstance := objectInstance
+
+		errGroup.Go(fmt.Sprintf("Terminate object %d", objectInstance.GetIndex()), func() error {
+
+			if err := objectInstance.Terminate(); err != nil {
+				return errors.Wrapf(err, "Failed to signal object %d to terminate", objectInstance.GetIndex())
+			}
+			return nil
+		})
+	}
+
+	if err := errGroup.Wait(); err != nil {
+		return errors.Wrap(err, "At least one object failed to terminate")
+	}
+
+	return nil
+}
+
+func (a *abstractPoolAllocator) IsTerminated() bool {
+	return a.isTerminated.Load()
+}
+func (a *abstractPoolAllocator) GetObjects() []EventProcessor {
+	return a.objects
+}
+
+func (a *abstractPoolAllocator) GetNumObjectsAvailable() int {
+	return len(a.objects)
+}
+
+func (a *abstractPoolAllocator) GetStatistics() *statistics.AllocatorStatistics {
+	return nil
+}

--- a/pkg/processor/eventprocessor/abstract.go
+++ b/pkg/processor/eventprocessor/abstract.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package eventprocessor
 
 import (

--- a/pkg/processor/eventprocessor/abstract.go
+++ b/pkg/processor/eventprocessor/abstract.go
@@ -61,6 +61,7 @@ func (a *abstractPoolAllocator) SignalDraining() error {
 
 	return nil
 }
+
 func (a *abstractPoolAllocator) SignalContinue() error {
 	errGroup, _ := errgroup.WithContext(context.Background(), a.logger)
 
@@ -105,6 +106,7 @@ func (a *abstractPoolAllocator) SignalTermination() error {
 func (a *abstractPoolAllocator) IsTerminated() bool {
 	return a.isTerminated.Load()
 }
+
 func (a *abstractPoolAllocator) GetObjects() []EventProcessor {
 	return a.objects
 }

--- a/pkg/processor/eventprocessor/pool.go
+++ b/pkg/processor/eventprocessor/pool.go
@@ -18,12 +18,10 @@ package eventprocessor
 
 import (
 	"context"
-	"fmt"
 	"sync/atomic"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
-	"github.com/nuclio/nuclio/pkg/errgroup"
 	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/errors"
@@ -31,19 +29,16 @@ import (
 )
 
 type syncPoolAllocator struct {
-	logger      logger.Logger
+	*abstractPoolAllocator
 	objectsChan chan EventProcessor
-	objects     []EventProcessor
 	statistics  safeAllocatorStatistics
-
-	isTerminated atomic.Bool
 }
 
 func NewSyncPoolAllocator(parentLogger logger.Logger, objects []EventProcessor) (Allocator, error) {
+	abstractPoolAllocatorInstance := newAbstractPoolAllocator(parentLogger.GetChild("sync_pool_allocator"))
 	newFixedPool := &syncPoolAllocator{
-		logger:       parentLogger.GetChild("sync_pool_allocator"),
-		statistics:   safeAllocatorStatistics{},
-		isTerminated: atomic.Bool{},
+		abstractPoolAllocator: abstractPoolAllocatorInstance,
+		statistics:            safeAllocatorStatistics{},
 	}
 
 	if err := newFixedPool.SetObjects(objects); err != nil {
@@ -123,14 +118,6 @@ func (sa *syncPoolAllocator) Release(object EventProcessor) {
 	sa.objectsChan <- object
 }
 
-func (sa *syncPoolAllocator) GetObjects() []EventProcessor {
-	return sa.objects
-}
-
-func (sa *syncPoolAllocator) GetNumObjectsAvailable() int {
-	return len(sa.objectsChan)
-}
-
 func (sa *syncPoolAllocator) SetObjects(objects []EventProcessor) error {
 	// Stop() cleans up sa.objects, so if `objects` and `sa.objects` are the same reference,
 	// the new objects will be cleaned up as well.
@@ -175,71 +162,75 @@ func (sa *syncPoolAllocator) GetStatistics() *statistics.AllocatorStatistics {
 	return allocatorStatistics
 }
 
-func (sa *syncPoolAllocator) SignalDraining() error {
-	errGroup, _ := errgroup.WithContext(context.Background(), sa.logger)
+type nonBlockingPoolAllocator struct {
+	*abstractPoolAllocator
 
-	for _, objectInstance := range sa.GetObjects() {
-		objectInstance := objectInstance
+	// index used for round-robin allocation
+	index atomic.Uint64
+}
 
-		errGroup.Go(fmt.Sprintf("Drain object %d", objectInstance.GetIndex()), func() error {
-			// if object is not already drained, signal it to drain events
-			if err := objectInstance.Drain(); err != nil {
-				return errors.Wrapf(err, "Failed to signal object %d to drain events", objectInstance.GetIndex())
-			}
-			return nil
-		})
+func NewNonBlockingPoolAllocator(parentLogger logger.Logger, processors []EventProcessor) (Allocator, error) {
+	nonBlockingPoolAllocatorInstance := &nonBlockingPoolAllocator{
+		abstractPoolAllocator: newAbstractPoolAllocator(parentLogger.GetChild("nonblock_pool_allocator")),
+		index:                 atomic.Uint64{},
+	}
+	if err := nonBlockingPoolAllocatorInstance.SetObjects(processors); err != nil {
+		return nil, errors.Wrap(err, "Failed to set non blocking pool allocator")
 	}
 
-	if err := errGroup.Wait(); err != nil {
-		return errors.Wrap(err, "At least one object failed to drain")
+	return nonBlockingPoolAllocatorInstance, nil
+}
+
+// Allocate allocates an EventProcessor in a non-blocking manner
+func (nba *nonBlockingPoolAllocator) Allocate(timeout time.Duration) (EventProcessor, error) {
+	// Atomically increment and get the index
+	// If idx exceeds math.MaxUint64, it will wrap back to 0, and the subsequent modulo will still yield nba valid slot
+	// For optimal performance, this uses a combined atomic add-and-load operation.
+	// As a result, the first allocated object will have index 1 instead of 0, which is only
+	idx := nba.index.Add(1)
+
+	// Select the next EventProcessor in nba round-robin manner, wrapping around if needed.
+	// This ensures even distribution of allocations across all processors.
+	selected := nba.objects[idx%uint64(len(nba.objects))]
+
+	return selected, nil
+}
+
+// Release is a no-op for non-blocking allocators
+func (nba *nonBlockingPoolAllocator) Release(object EventProcessor) {
+}
+
+func (nba *nonBlockingPoolAllocator) Stop() error {
+	// Stop the old objects that are being cleaned up
+	if err := nba.SignalTermination(); err != nil {
+		nba.logger.DebugWith("Failed to stop objects in allocator",
+			"error", err.Error())
 	}
 
+	// clean up objects
+	clear(nba.objects)
 	return nil
 }
 
-func (sa *syncPoolAllocator) SignalContinue() error {
-	errGroup, _ := errgroup.WithContext(context.Background(), sa.logger)
+func (nba *nonBlockingPoolAllocator) SetObjects(objects []EventProcessor) error {
+	// Stop() cleans up sa.objects, so if `objects` and `sa.objects` are the same reference,
+	// the new objects will be cleaned up as well.
+	// To avoid this, we create nba copy of the `objects` slice
+	objects = append([]EventProcessor(nil), objects...)
 
-	for _, objectInstance := range sa.GetObjects() {
-		objectInstance := objectInstance
-
-		errGroup.Go(fmt.Sprintf("Send continue signal to object %d", objectInstance.GetIndex()), func() error {
-			if err := objectInstance.Continue(); err != nil {
-				return errors.Wrapf(err, "Failed to signal object %d to continue event processing", objectInstance.GetIndex())
-			}
-			return nil
-		})
+	if err := nba.Stop(); err != nil {
+		nba.logger.WarnWith("Failed to stop objects in allocator",
+			"error", err.Error())
 	}
 
-	if err := errGroup.Wait(); err != nil {
-		return errors.Wrap(err, "At least one object failed to continue")
-	}
+	// Stop() marks the allocator as terminated and closes the channel,
+	// so we can safely set new objects
+	nba.isTerminated.Store(false)
 
+	// Set new objects
+	nba.objects = objects
+
+	// Log the update of allocator objects
+	nba.logger.DebugWith("Allocator objects updated", "size", len(objects))
 	return nil
-}
-
-func (sa *syncPoolAllocator) SignalTermination() error {
-	errGroup, _ := errgroup.WithContext(context.Background(), sa.logger)
-	sa.isTerminated.Store(true)
-	for _, objectInstance := range sa.GetObjects() {
-		objectInstance := objectInstance
-
-		errGroup.Go(fmt.Sprintf("Terminate object %d", objectInstance.GetIndex()), func() error {
-
-			if err := objectInstance.Terminate(); err != nil {
-				return errors.Wrapf(err, "Failed to signal object %d to terminate", objectInstance.GetIndex())
-			}
-			return nil
-		})
-	}
-
-	if err := errGroup.Wait(); err != nil {
-		return errors.Wrap(err, "At least one object failed to terminate")
-	}
-
-	return nil
-}
-
-func (sa *syncPoolAllocator) IsTerminated() bool {
-	return sa.isTerminated.Load()
 }

--- a/pkg/processor/eventprocessor/pool.go
+++ b/pkg/processor/eventprocessor/pool.go
@@ -35,7 +35,7 @@ type syncPoolAllocator struct {
 }
 
 func NewSyncPoolAllocator(parentLogger logger.Logger, objects []EventProcessor) (Allocator, error) {
-	abstractPoolAllocatorInstance := newAbstractPoolAllocator(parentLogger.GetChild("sync_pool_allocator"))
+	abstractPoolAllocatorInstance := newAbstractPoolAllocator(parentLogger.GetChild("sync-pool-allocator"))
 	newFixedPool := &syncPoolAllocator{
 		abstractPoolAllocator: abstractPoolAllocatorInstance,
 		statistics:            safeAllocatorStatistics{},
@@ -171,7 +171,7 @@ type nonBlockingPoolAllocator struct {
 
 func NewNonBlockingPoolAllocator(parentLogger logger.Logger, processors []EventProcessor) (Allocator, error) {
 	nonBlockingPoolAllocatorInstance := &nonBlockingPoolAllocator{
-		abstractPoolAllocator: newAbstractPoolAllocator(parentLogger.GetChild("nonblock_pool_allocator")),
+		abstractPoolAllocator: newAbstractPoolAllocator(parentLogger.GetChild("nonblock-pool-allocator")),
 		index:                 atomic.Uint64{},
 	}
 	if err := nonBlockingPoolAllocatorInstance.SetObjects(processors); err != nil {
@@ -186,7 +186,8 @@ func (nba *nonBlockingPoolAllocator) Allocate(timeout time.Duration) (EventProce
 	// Atomically increment and get the index
 	// If idx exceeds math.MaxUint64, it will wrap back to 0, and the subsequent modulo will still yield nba valid slot
 	// For optimal performance, this uses a combined atomic add-and-load operation.
-	// As a result, the first allocated object will have index 1 instead of 0, which is only
+	// As a result, the first allocated object will have index 1 instead of 0, which is only the case if len(object) >=2
+	// If len(object) == 1, the first object will be allocated with index 0
 	idx := nba.index.Add(1)
 
 	// Select the next EventProcessor in nba round-robin manner, wrapping around if needed.
@@ -213,7 +214,7 @@ func (nba *nonBlockingPoolAllocator) Stop() error {
 }
 
 func (nba *nonBlockingPoolAllocator) SetObjects(objects []EventProcessor) error {
-	// Stop() cleans up sa.objects, so if `objects` and `sa.objects` are the same reference,
+	// Stop() cleans up nba.objects, so if `objects` and `nba.objects` are the same reference,
 	// the new objects will be cleaned up as well.
 	// To avoid this, we create nba copy of the `objects` slice
 	objects = append([]EventProcessor(nil), objects...)

--- a/pkg/processor/trigger/http/factory.go
+++ b/pkg/processor/trigger/http/factory.go
@@ -52,7 +52,8 @@ func (f *factory) Create(parentLogger logger.Logger,
 		func() (eventprocessor.Allocator, error) {
 			switch triggerConfiguration.Mode {
 			case functionconfig.AsyncTriggerWorkMode:
-				return worker.WorkerFactorySingleton.CreateAsyncSingletonPoolWorkerAllocator(triggerLogger,
+				return worker.WorkerFactorySingleton.CreateNonBlockingWorkerAllocator(triggerLogger,
+					configuration.NumWorkers,
 					runtimeConfiguration)
 			default:
 				return worker.WorkerFactorySingleton.CreateFixedPoolWorkerAllocator(triggerLogger,

--- a/pkg/processor/trigger/rabbitmq/factory.go
+++ b/pkg/processor/trigger/rabbitmq/factory.go
@@ -50,7 +50,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	workerAllocator, err := f.GetWorkerAllocator(triggerConfiguration.WorkerAllocatorName,
 		namedWorkerAllocators,
 		func() (eventprocessor.Allocator, error) {
-			return worker.WorkerFactorySingleton.CreateAsyncSingletonPoolWorkerAllocator(triggerLogger,
+			return worker.WorkerFactorySingleton.CreateNonBlockingWorkerAllocator(triggerLogger, 1,
 				runtimeConfiguration)
 		})
 

--- a/pkg/processor/worker/allocator_test.go
+++ b/pkg/processor/worker/allocator_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package worker
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -59,15 +60,45 @@ func (suite *AllocatorTestSuite) TestSingletonAllocator() {
 	suite.Require().NotPanics(func() { sa.Release(worker1) })
 }
 
-func (suite *AllocatorTestSuite) TestFixedPoolAllocator() {
-	worker1 := &Worker{index: 0, runtime: &MockRuntime{}, logger: suite.logger}
-	worker2 := &Worker{index: 1, runtime: &MockRuntime{}, logger: suite.logger}
-	workers := []*Worker{worker1, worker2}
+func (suite *AllocatorTestSuite) TestNonPoolAllocator() {
+	eventProcessors := suite.createEventProcessors(2)
 
-	eventProcessors := make([]eventprocessor.EventProcessor, 2)
-	for i, worker := range workers {
-		eventProcessors[i] = worker
-	}
+	worker1 := eventProcessors[1]
+	worker2 := eventProcessors[0]
+
+	fpa, err := eventprocessor.NewNonBlockingPoolAllocator(suite.logger, eventProcessors)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(fpa)
+
+	// allocate and not release
+	firstAllocatedWorker, err := fpa.Allocate(time.Second)
+	suite.Require().NoError(err)
+	suite.Require().Equal(worker1, firstAllocatedWorker)
+
+	// ensure round robin allocation
+	nextAllocatedWorker, err := fpa.Allocate(time.Second)
+	suite.Require().NoError(err)
+	suite.Require().Equal(worker2, nextAllocatedWorker)
+
+	// allocate 1st again (check round robin + allocation of already allocated worker)
+	nextAllocatedWorker, err = fpa.Allocate(time.Second)
+	suite.Require().NoError(err)
+	suite.Require().Equal(firstAllocatedWorker, nextAllocatedWorker)
+
+	// release the first worker
+	fpa.Release(worker1)
+
+	// ensure that fpa allocates the seocnd worker anyway
+	nextAllocatedWorker, err = fpa.Allocate(time.Second)
+	suite.Require().NoError(err)
+	suite.Require().Equal(worker2, nextAllocatedWorker)
+
+	fpa.Release(worker2)
+}
+
+func (suite *AllocatorTestSuite) TestFixedBlockingPoolAllocator() {
+	eventProcessors := suite.createEventProcessors(2)
+	worker2 := eventProcessors[1]
 
 	fpa, err := eventprocessor.NewSyncPoolAllocator(suite.logger, eventProcessors)
 	suite.Require().NoError(err)
@@ -76,12 +107,12 @@ func (suite *AllocatorTestSuite) TestFixedPoolAllocator() {
 	// allocate once - should allocate
 	firstAllocatedWorker, err := fpa.Allocate(time.Hour)
 	suite.Require().NoError(err)
-	suite.Require().Contains(workers, firstAllocatedWorker)
+	suite.Require().Contains(eventProcessors, firstAllocatedWorker)
 
 	// allocate again - should allocate other worker
 	secondAllocatedWorker, err := fpa.Allocate(time.Hour)
 	suite.Require().NoError(err)
-	suite.Require().Contains(workers, secondAllocatedWorker)
+	suite.Require().Contains(eventProcessors, secondAllocatedWorker)
 	suite.NotEqual(firstAllocatedWorker, secondAllocatedWorker)
 
 	// allocate yet again - should time out
@@ -115,7 +146,7 @@ func (suite *AllocatorTestSuite) TestFixedPoolAllocator() {
 	// check allocation
 	workerInstance, err := fpa.Allocate(time.Hour)
 	suite.Require().NoError(err)
-	suite.Require().Contains(workers, workerInstance)
+	suite.Require().Contains(eventProcessors, workerInstance)
 
 	// check that statistics wasn't reset
 	err = common.RetryUntilSuccessful(3*time.Second,
@@ -129,15 +160,63 @@ func (suite *AllocatorTestSuite) TestFixedPoolAllocator() {
 	suite.Require().NoError(err)
 }
 
+func (suite *AllocatorTestSuite) createEventProcessors(numEventProcessors int) []eventprocessor.EventProcessor {
+	workers := suite.createWorkers(numEventProcessors)
+	eventProcessors := make([]eventprocessor.EventProcessor, numEventProcessors)
+	for i, worker := range workers {
+		eventProcessors[i] = worker
+	}
+	return eventProcessors
+}
+
+func (suite *AllocatorTestSuite) createWorkers(numWorkers int) []*Worker {
+	workers := make([]*Worker, numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		workers[i] = suite.createWorker(i)
+	}
+	return workers
+}
+
+func (suite *AllocatorTestSuite) createWorker(index int) *Worker {
+	worker := &Worker{
+		index:   index,
+		runtime: &MockRuntime{},
+		logger:  suite.logger,
+	}
+
+	return worker
+}
+
 func TestAllocatorTestSuite(t *testing.T) {
 	suite.Run(t, new(AllocatorTestSuite))
 }
 
-func BenchmarkParallelAllocation100(b *testing.B) {
-	benchmarkParallelAllocation(b, 100)
+func BenchmarkParallelAllocation(b *testing.B) {
+	workerCounts := []int{10, 100, 1000}
+	allocatorTypes := []struct {
+		name        string
+		constructor func(logger logger.Logger, eps []eventprocessor.EventProcessor) (eventprocessor.Allocator, error)
+	}{
+		{
+			name:        "Sync",
+			constructor: eventprocessor.NewSyncPoolAllocator,
+		},
+		{
+			name:        "NonBlocking",
+			constructor: eventprocessor.NewNonBlockingPoolAllocator,
+		},
+	}
+
+	for _, count := range workerCounts {
+		for _, allocator := range allocatorTypes {
+			b.Run(fmt.Sprintf("%s_%dWorkers", allocator.name, count), func(b *testing.B) {
+				benchmarkParallelAllocation(b, count, allocator.constructor)
+			})
+		}
+	}
 }
 
-func benchmarkParallelAllocation(b *testing.B, numberOfWorkers int) {
+func benchmarkParallelAllocation(b *testing.B, numberOfWorkers int, allocatorConstructor func(logger.Logger, []eventprocessor.EventProcessor) (eventprocessor.Allocator, error)) {
 	// Initialize logger
 	logger, _ := nucliozap.NewNuclioZapTest("benchmark")
 
@@ -154,7 +233,7 @@ func benchmarkParallelAllocation(b *testing.B, numberOfWorkers int) {
 	}
 
 	// Create a new SyncPoolAllocator
-	fpa, _ := eventprocessor.NewSyncPoolAllocator(logger, eventProcessors)
+	fpa, _ := allocatorConstructor(logger, eventProcessors)
 
 	// Reset the timer to exclude setup time
 	b.ResetTimer()

--- a/pkg/processor/worker/allocator_test.go
+++ b/pkg/processor/worker/allocator_test.go
@@ -100,38 +100,38 @@ func (suite *AllocatorTestSuite) TestFixedBlockingPoolAllocator() {
 	eventProcessors := suite.createEventProcessors(2)
 	worker2 := eventProcessors[1]
 
-	fpa, err := eventprocessor.NewSyncPoolAllocator(suite.logger, eventProcessors)
+	allocator, err := eventprocessor.NewSyncPoolAllocator(suite.logger, eventProcessors)
 	suite.Require().NoError(err)
-	suite.Require().NotNil(fpa)
+	suite.Require().NotNil(allocator)
 
 	// allocate once - should allocate
-	firstAllocatedWorker, err := fpa.Allocate(time.Hour)
+	firstAllocatedWorker, err := allocator.Allocate(time.Hour)
 	suite.Require().NoError(err)
 	suite.Require().Contains(eventProcessors, firstAllocatedWorker)
 
 	// allocate again - should allocate other worker
-	secondAllocatedWorker, err := fpa.Allocate(time.Hour)
+	secondAllocatedWorker, err := allocator.Allocate(time.Hour)
 	suite.Require().NoError(err)
 	suite.Require().Contains(eventProcessors, secondAllocatedWorker)
 	suite.NotEqual(firstAllocatedWorker, secondAllocatedWorker)
 
 	// allocate yet again - should time out
-	failedAllocationWorker, err := fpa.Allocate(50 * time.Millisecond)
+	failedAllocationWorker, err := allocator.Allocate(50 * time.Millisecond)
 	suite.Require().Error(err)
 	suite.Require().Nil(failedAllocationWorker)
 
 	// release the second worker
-	suite.Require().NotPanics(func() { fpa.Release(worker2) })
+	suite.Require().NotPanics(func() { allocator.Release(worker2) })
 
 	// allocate again - should allocate second worker
-	thirdAllocatedWorker, err := fpa.Allocate(time.Hour)
+	thirdAllocatedWorker, err := allocator.Allocate(time.Hour)
 	suite.Require().NoError(err)
 	suite.Require().Equal(worker2, thirdAllocatedWorker)
 
 	err = common.RetryUntilSuccessful(3*time.Second,
 		1*time.Second,
 		func() bool {
-			statistics := fpa.GetStatistics()
+			statistics := allocator.GetStatistics()
 			return statistics.AllocationCount == uint64(4) &&
 				statistics.AllocationSuccessImmediateTotal == uint64(3) &&
 				statistics.AllocationTimeoutTotal == uint64(1)
@@ -140,11 +140,11 @@ func (suite *AllocatorTestSuite) TestFixedBlockingPoolAllocator() {
 	suite.Require().NoError(err)
 
 	// reset objects in allocator (both should become available)
-	err = fpa.SetObjects(eventProcessors)
+	err = allocator.SetObjects(eventProcessors)
 	suite.Require().NoError(err)
 
 	// check allocation
-	workerInstance, err := fpa.Allocate(time.Hour)
+	workerInstance, err := allocator.Allocate(time.Hour)
 	suite.Require().NoError(err)
 	suite.Require().Contains(eventProcessors, workerInstance)
 
@@ -152,7 +152,7 @@ func (suite *AllocatorTestSuite) TestFixedBlockingPoolAllocator() {
 	err = common.RetryUntilSuccessful(3*time.Second,
 		1*time.Second,
 		func() bool {
-			statistics := fpa.GetStatistics()
+			statistics := allocator.GetStatistics()
 			return statistics.AllocationCount == uint64(5) &&
 				statistics.AllocationSuccessImmediateTotal == uint64(4) &&
 				statistics.AllocationTimeoutTotal == uint64(1)
@@ -232,8 +232,8 @@ func benchmarkParallelAllocation(b *testing.B, numberOfWorkers int, allocatorCon
 		eventProcessors[i] = worker
 	}
 
-	// Create a new SyncPoolAllocator
-	fpa, _ := allocatorConstructor(logger, eventProcessors)
+	// Create an allocator
+	allocator, _ := allocatorConstructor(logger, eventProcessors)
 
 	// Reset the timer to exclude setup time
 	b.ResetTimer()
@@ -242,11 +242,11 @@ func benchmarkParallelAllocation(b *testing.B, numberOfWorkers int, allocatorCon
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			// Allocate a worker
-			processor, err := fpa.Allocate(time.Hour)
+			processor, err := allocator.Allocate(time.Hour)
 			if err != nil {
 				b.Error(err)
 			}
-			fpa.Release(processor)
+			allocator.Release(processor)
 		}
 	})
 }

--- a/pkg/processor/worker/allocator_test.go
+++ b/pkg/processor/worker/allocator_test.go
@@ -43,21 +43,21 @@ func (suite *AllocatorTestSuite) SetupSuite() {
 func (suite *AllocatorTestSuite) TestSingletonAllocator() {
 	worker1 := &Worker{}
 
-	sa := eventprocessor.NewAsyncSingletonAllocator(suite.logger, worker1)
-	suite.Require().NotNil(sa)
+	allocator := eventprocessor.NewAsyncSingletonAllocator(suite.logger, worker1)
+	suite.Require().NotNil(allocator)
 
 	// allocate once, time should be ignored
-	allocatedWorker, err := sa.Allocate(time.Hour)
+	allocatedWorker, err := allocator.Allocate(time.Hour)
 	suite.Require().NoError(err)
 	suite.Require().Equal(worker1, allocatedWorker)
 
 	// allocate again, release doesn't need to happen
-	allocatedWorker, err = sa.Allocate(time.Hour)
+	allocatedWorker, err = allocator.Allocate(time.Hour)
 	suite.Require().NoError(err)
 	suite.Require().Equal(worker1, allocatedWorker)
 
 	// release shouldn't do anything
-	suite.Require().NotPanics(func() { sa.Release(worker1) })
+	suite.Require().NotPanics(func() { allocator.Release(worker1) })
 }
 
 func (suite *AllocatorTestSuite) TestNonPoolAllocator() {
@@ -66,34 +66,34 @@ func (suite *AllocatorTestSuite) TestNonPoolAllocator() {
 	worker1 := eventProcessors[1]
 	worker2 := eventProcessors[0]
 
-	fpa, err := eventprocessor.NewNonBlockingPoolAllocator(suite.logger, eventProcessors)
+	allocator, err := eventprocessor.NewNonBlockingPoolAllocator(suite.logger, eventProcessors)
 	suite.Require().NoError(err)
-	suite.Require().NotNil(fpa)
+	suite.Require().NotNil(allocator)
 
 	// allocate and not release
-	firstAllocatedWorker, err := fpa.Allocate(time.Second)
+	firstAllocatedWorker, err := allocator.Allocate(time.Second)
 	suite.Require().NoError(err)
 	suite.Require().Equal(worker1, firstAllocatedWorker)
 
 	// ensure round robin allocation
-	nextAllocatedWorker, err := fpa.Allocate(time.Second)
+	nextAllocatedWorker, err := allocator.Allocate(time.Second)
 	suite.Require().NoError(err)
 	suite.Require().Equal(worker2, nextAllocatedWorker)
 
 	// allocate 1st again (check round robin + allocation of already allocated worker)
-	nextAllocatedWorker, err = fpa.Allocate(time.Second)
+	nextAllocatedWorker, err = allocator.Allocate(time.Second)
 	suite.Require().NoError(err)
 	suite.Require().Equal(firstAllocatedWorker, nextAllocatedWorker)
 
 	// release the first worker
-	fpa.Release(worker1)
+	allocator.Release(worker1)
 
-	// ensure that fpa allocates the seocnd worker anyway
-	nextAllocatedWorker, err = fpa.Allocate(time.Second)
+	// ensure that allocator allocates the seocnd worker anyway
+	nextAllocatedWorker, err = allocator.Allocate(time.Second)
 	suite.Require().NoError(err)
 	suite.Require().Equal(worker2, nextAllocatedWorker)
 
-	fpa.Release(worker2)
+	allocator.Release(worker2)
 }
 
 func (suite *AllocatorTestSuite) TestFixedBlockingPoolAllocator() {

--- a/pkg/processor/worker/factory.go
+++ b/pkg/processor/worker/factory.go
@@ -55,19 +55,23 @@ func (waf *Factory) CreateFixedPoolWorkerAllocator(logger logger.Logger,
 	return workerAllocator, nil
 }
 
-func (waf *Factory) CreateAsyncSingletonPoolWorkerAllocator(logger logger.Logger,
+func (waf *Factory) CreateNonBlockingWorkerAllocator(logger logger.Logger,
+	numWorkers int,
 	runtimeConfiguration *runtime.Configuration) (eventprocessor.Allocator, error) {
 
 	// create the workers
-	workerInstance, err := waf.createWorker(logger, 0, runtimeConfiguration)
+	workers, err := waf.createWorkers(logger, numWorkers, runtimeConfiguration)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create HTTP trigger")
 	}
-
-	// create an allocator
-	workerAllocator := eventprocessor.NewAsyncSingletonAllocator(logger, workerInstance)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create worker allocator")
+	var workerAllocator eventprocessor.Allocator
+	switch numWorkers {
+	case 1:
+		workerAllocator = eventprocessor.NewAsyncSingletonAllocator(logger, workers[0])
+	default:
+		if workerAllocator, err = eventprocessor.NewNonBlockingPoolAllocator(logger, workers); err != nil {
+			return nil, errors.Wrap(err, "Failed to create worker allocator")
+		}
 	}
 
 	return workerAllocator, nil


### PR DESCRIPTION
Jira - https://iguazio.atlassian.net/browse/NUC-410

The base branch is [feature/nuc-201-phase2](https://github.com/nuclio/nuclio/tree/feature/nuc-201-phase2), so we will merge to develop only when everything is ready.

Implements a new non-blocking pool allocator that allocates objects using a round-robin strategy. The round-robin mechanism is driven by an atomic index, which is incremented with each allocation. Additionally, the shared pool logic has been refactored into an abstract base class, `abstractPoolAllocator`.

The `BenchmarkParallelAllocation` test has also been made generic for different allocator implementations. This allows us to pass in a constructor and benchmark any allocator, which is valuable since the allocator component is a critical part of overall performance.

