### PR TITLE
Revert "[UI] remove python 3.12 from nuclio runtimes list"

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^3.0.2",
     "i18next-localstorage-backend": "^3.1.3",
     "i18next-xhr-backend": "^3.2.2",
-    "iguazio.dashboard-controls": "1.2.11",
+    "iguazio.dashboard-controls": "1.2.12",
     "jquery": ">=3.7.1",
     "jquery-ui": "1.13.2",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
Related to [IG-23960](https://iguazio.atlassian.net/browse/IG-23960)

[IG-23960]: https://iguazio.atlassian.net/browse/IG-23960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ