### PR TITLE
[Builder] Create temp dir based on os.TempDir()

### DIFF
--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -931,9 +931,9 @@ func (b *Builder) createTempDir() error {
 			return errors.New("Invalid temporary directory path: contains '..'")
 		}
 
-		// if the user-provided temp directory is not under /tmp, create it under /tmp
-		if !strings.HasPrefix(b.options.FunctionConfig.Spec.Build.TempDir, "/tmp") {
-			b.tempDir = filepath.Join("/tmp", b.options.FunctionConfig.Spec.Build.TempDir)
+		// if the user-provided temp directory is not under `/tmp` or `/var/folders/` (depends on OS), create it under it
+		if !strings.HasPrefix(b.options.FunctionConfig.Spec.Build.TempDir, os.TempDir()) {
+			b.tempDir = filepath.Join(os.TempDir(), b.options.FunctionConfig.Spec.Build.TempDir)
 		} else {
 			b.tempDir = b.options.FunctionConfig.Spec.Build.TempDir
 		}

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -1018,6 +1018,7 @@ func (suite *testSuite) TestResolveResources() {
 }
 
 func (suite *testSuite) TestCreateTempDir() {
+	systemTempDir := os.TempDir()
 	tests := []struct {
 		name        string
 		tempDir     string
@@ -1028,7 +1029,7 @@ func (suite *testSuite) TestCreateTempDir() {
 			name:        "Valid temp dir under /tmp",
 			tempDir:     "/tmp/test-dir",
 			expectError: false,
-			expectedDir: "/tmp/test-dir",
+			expectedDir: filepath.Join(systemTempDir, "tmp/test-dir"),
 		},
 		{
 			name:        "Invalid traversal path",
@@ -1044,7 +1045,7 @@ func (suite *testSuite) TestCreateTempDir() {
 			name:        "Temp dir outside /tmp",
 			tempDir:     "custom-dir",
 			expectError: false,
-			expectedDir: "/tmp/custom-dir",
+			expectedDir: filepath.Join(systemTempDir, "custom-dir"),
 		},
 		{
 			name:        "No temp dir provided",


### PR DESCRIPTION
Previously, the path `/tmp` was hardcoded, which is not ideal for macOS deployments, as the temporary directory on macOS is typically located under `/var/folders`. This change improves flexibility by accommodating platform-specific temporary directories.