### PR TITLE
[Processor] Check status when allocating from non-blocking pool

### DIFF
--- a/pkg/processor/eventprocessor/mock.go
+++ b/pkg/processor/eventprocessor/mock.go
@@ -17,15 +17,17 @@ limitations under the License.
 package eventprocessor
 
 import (
-	"github.com/nuclio/logger"
-	"github.com/nuclio/nuclio-sdk-go"
+	"time"
+
 	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/cloudevent"
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/statistics"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/stretchr/testify/mock"
-	"time"
 )
 
 type MockEventProcessor struct {
@@ -43,7 +45,7 @@ func (m *MockEventProcessor) ProcessEventBatch(batch []nuclio.Event, functionLog
 }
 
 func (m *MockEventProcessor) Terminate() error {
-	return m.Called().Error(0)
+	return nil
 }
 
 func (m *MockEventProcessor) Drain() error {
@@ -55,7 +57,7 @@ func (m *MockEventProcessor) Continue() error {
 }
 
 func (m *MockEventProcessor) GetIndex() int {
-	return m.Called().Int(0)
+	return 0
 }
 
 func (m *MockEventProcessor) GetRuntime() runtime.Runtime {

--- a/pkg/processor/eventprocessor/pool.go
+++ b/pkg/processor/eventprocessor/pool.go
@@ -207,11 +207,12 @@ func (nba *nonBlockingPoolAllocator) Allocate(timeout time.Duration) (EventProce
 			return eventProcessor, nil
 		}
 
-		// If timeout is set and exceeded, stop trying further
 		nba.logger.DebugWith("Object is not ready, cannot allocate",
 			"status", currentStatus,
+			"objectIndex", eventProcessor.GetIndex(),
 			"attempt", attempt+1)
 
+		// If timeout is set and exceeded, stop trying further
 		if timeout > 0 && time.Since(startTime) >= timeout {
 			break
 		}

--- a/pkg/processor/eventprocessor/pool.go
+++ b/pkg/processor/eventprocessor/pool.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/errors"
@@ -183,8 +184,43 @@ func NewNonBlockingPoolAllocator(parentLogger logger.Logger, processors []EventP
 	return nonBlockingPoolAllocatorInstance, nil
 }
 
-// Allocate allocates an EventProcessor in a non-blocking manner
+// Allocate attempts to retrieve a ready EventProcessor instance from the pool in a non-blocking manner.
+// If a ready instance is found, it is immediately returned.
+// Otherwise, it retries allocation across available instances up to len(objects) times, respecting an optional timeout constraint.
 func (nba *nonBlockingPoolAllocator) Allocate(timeout time.Duration) (EventProcessor, error) {
+	var startTime time.Time
+	// If a timeout is specified, record the start time
+	if timeout > 0 {
+		startTime = time.Now()
+	}
+
+	// Perform up to len(objects) allocation attempts
+	for attempt := 0; attempt < len(nba.objects); attempt++ {
+		eventProcessor := nba.allocate()
+		currentStatus := eventProcessor.GetStatus()
+
+		// If the allocated object is ready, return it immediately
+		if currentStatus == status.Ready {
+			nba.logger.DebugWith("Object is ready, allocated",
+				"id", eventProcessor.GetIndex())
+
+			return eventProcessor, nil
+		}
+
+		// If timeout is set and exceeded, stop trying further
+		nba.logger.DebugWith("Object is not ready, cannot allocate",
+			"status", currentStatus,
+			"attempt", attempt+1)
+
+		if timeout > 0 && time.Since(startTime) >= timeout {
+			break
+		}
+	}
+
+	return nil, ErrNoAvailableObjects
+}
+
+func (nba *nonBlockingPoolAllocator) allocate() EventProcessor {
 	// Atomically increment and get the index
 	// If idx exceeds math.MaxUint64, it will wrap back to 0, and the subsequent modulo will still yield nba valid slot
 	// For optimal performance, this uses a combined atomic add-and-load operation.
@@ -194,9 +230,7 @@ func (nba *nonBlockingPoolAllocator) Allocate(timeout time.Duration) (EventProce
 
 	// Select the next EventProcessor in nba round-robin manner, wrapping around if needed.
 	// This ensures even distribution of allocations across all processors.
-	selected := nba.objects[idx%uint64(len(nba.objects))]
-
-	return selected, nil
+	return nba.objects[idx%uint64(len(nba.objects))]
 }
 
 // Release is a no-op for non-blocking allocators

--- a/pkg/processor/worker/allocator_test.go
+++ b/pkg/processor/worker/allocator_test.go
@@ -20,12 +20,13 @@ package worker
 
 import (
 	"fmt"
-	"github.com/nuclio/nuclio/pkg/processor/statistics"
 	"testing"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/logger"
 	"github.com/nuclio/zap"
@@ -50,12 +51,12 @@ func (suite *AllocatorTestSuite) TestSingletonAllocator() {
 	// allocate once, time should be ignored
 	allocatedEventProcessor1, err := allocator.Allocate(time.Hour)
 	suite.Require().NoError(err)
-	suite.Require().Equal(eventProcessor1, allocatedEventProcessor1)
+	suite.Require().Same(eventProcessor1, allocatedEventProcessor1)
 
 	// allocate again, release doesn't need to happen
 	allocatedEventProcessor1, err = allocator.Allocate(time.Hour)
 	suite.Require().NoError(err)
-	suite.Require().Equal(eventProcessor1, allocatedEventProcessor1)
+	suite.Require().Same(eventProcessor1, allocatedEventProcessor1)
 
 	// release shouldn't do anything
 	suite.Require().NotPanics(func() { allocator.Release(eventProcessor1) })
@@ -67,6 +68,14 @@ func (suite *AllocatorTestSuite) TestNonBlockingPoolAllocator() {
 	eventProcessor1 := eventProcessors[1]
 	eventProcessor2 := eventProcessors[0]
 
+	// Cast to mock versions for method mocking
+	mockEventProcessor1 := eventProcessors[1].(*eventprocessor.MockEventProcessor)
+	mockEventProcessor2 := eventProcessors[0].(*eventprocessor.MockEventProcessor)
+
+	// Mock GetStatus to return Ready for both event processors initially
+	mockEventProcessor1.On("GetStatus").Return(status.Ready).Times(4)
+	mockEventProcessor2.On("GetStatus").Return(status.Ready).Twice()
+
 	allocator, err := eventprocessor.NewNonBlockingPoolAllocator(suite.logger, eventProcessors)
 	suite.Require().NoError(err)
 	suite.Require().NotNil(allocator)
@@ -74,17 +83,17 @@ func (suite *AllocatorTestSuite) TestNonBlockingPoolAllocator() {
 	// allocate and not release
 	firstAllocatedEventProcessor1, err := allocator.Allocate(time.Second)
 	suite.Require().NoError(err)
-	suite.Require().Equal(eventProcessor1, firstAllocatedEventProcessor1)
+	suite.Require().Same(eventProcessor1, firstAllocatedEventProcessor1)
 
 	// ensure round robin allocation
 	nextAllocatedEventProcessor1, err := allocator.Allocate(time.Second)
 	suite.Require().NoError(err)
-	suite.Require().Equal(eventProcessor2, nextAllocatedEventProcessor1)
+	suite.Require().Same(eventProcessor2, nextAllocatedEventProcessor1)
 
 	// allocate 1st again (check round robin + allocation of already allocated event processor)
 	nextAllocatedEventProcessor1, err = allocator.Allocate(time.Second)
 	suite.Require().NoError(err)
-	suite.Require().Equal(firstAllocatedEventProcessor1, nextAllocatedEventProcessor1)
+	suite.Require().Same(firstAllocatedEventProcessor1, nextAllocatedEventProcessor1)
 
 	// release the first event processor
 	allocator.Release(eventProcessor1)
@@ -92,9 +101,37 @@ func (suite *AllocatorTestSuite) TestNonBlockingPoolAllocator() {
 	// ensure that allocator allocates the second event processor anyway
 	nextAllocatedEventProcessor1, err = allocator.Allocate(time.Second)
 	suite.Require().NoError(err)
-	suite.Require().Equal(eventProcessor2, nextAllocatedEventProcessor1)
+	suite.Require().Same(eventProcessor2, nextAllocatedEventProcessor1)
 
 	allocator.Release(eventProcessor2)
+
+	mockEventProcessor2.On("GetStatus").Return(status.Stopped).Twice()
+
+	// should allocate eventProcessor1 (only one that's ready)
+	// it's turn for the 1st one that's ready anyway
+	allocatedEventProcessor, err := allocator.Allocate(time.Second)
+	suite.Require().NoError(err)
+	suite.Require().Same(eventProcessor1, allocatedEventProcessor)
+
+	// it's turn for the 2nd event processor, however it's not ready
+	// so it should allocate the 1st one again
+	allocatedEventProcessor, err = allocator.Allocate(time.Second)
+	suite.Require().NoError(err)
+	suite.Require().Same(eventProcessor1, allocatedEventProcessor)
+
+	// simulate eventProcessor1 becoming not ready too
+	mockEventProcessor1.On("GetStatus").Return(status.Stopped).Once()
+
+	// both processors are not ready, should fail
+	allocatedEventProcessor, err = allocator.Allocate(100 * time.Millisecond)
+	suite.Require().ErrorIs(err, eventprocessor.ErrNoAvailableObjects)
+	suite.Require().Nil(allocatedEventProcessor)
+
+	allocator.Release(eventProcessor1)
+	allocator.Release(eventProcessor2)
+
+	mockEventProcessor1.AssertExpectations(suite.T())
+	mockEventProcessor2.AssertExpectations(suite.T())
 }
 
 func (suite *AllocatorTestSuite) TestNonBlockingPoolAllocatorStatistics() {
@@ -144,6 +181,7 @@ func (suite *AllocatorTestSuite) TestNonBlockingPoolAllocatorStatistics() {
 func (suite *AllocatorTestSuite) TestFixedBlockingPoolAllocator() {
 	eventProcessors := createEventProcessors(2)
 	eventProcessor2 := eventProcessors[1]
+	eventProcessor1 := eventProcessors[0]
 
 	allocator, err := eventprocessor.NewBlockingPoolAllocator(suite.logger, eventProcessors)
 	suite.Require().NoError(err)
@@ -152,13 +190,14 @@ func (suite *AllocatorTestSuite) TestFixedBlockingPoolAllocator() {
 	// allocate once - should allocate
 	firstAllocatedEventProcessor, err := allocator.Allocate(time.Hour)
 	suite.Require().NoError(err)
+	suite.Require().Same(firstAllocatedEventProcessor, eventProcessor1)
 	suite.Require().Contains(eventProcessors, firstAllocatedEventProcessor)
 
 	// allocate again - should allocate other event processor
 	secondAllocatedEventProcessor, err := allocator.Allocate(time.Hour)
 	suite.Require().NoError(err)
 	suite.Require().Contains(eventProcessors, secondAllocatedEventProcessor)
-	suite.NotEqual(firstAllocatedEventProcessor, secondAllocatedEventProcessor)
+	suite.NotSame(firstAllocatedEventProcessor, secondAllocatedEventProcessor)
 
 	// allocate yet again - should time out
 	failedAllocationEventProcessor, err := allocator.Allocate(50 * time.Millisecond)
@@ -171,7 +210,7 @@ func (suite *AllocatorTestSuite) TestFixedBlockingPoolAllocator() {
 	// allocate again - should allocate second event processor
 	thirdAllocatedEventProcessor, err := allocator.Allocate(time.Hour)
 	suite.Require().NoError(err)
-	suite.Require().Equal(eventProcessor2, thirdAllocatedEventProcessor)
+	suite.Require().Same(eventProcessor2, thirdAllocatedEventProcessor)
 
 	err = common.RetryUntilSuccessful(3*time.Second,
 		1*time.Second,


### PR DESCRIPTION
Improves the allocation method in the non-blocking pool so that it checks the state of the allocated object. If the object is not ready, it will retry N times, where N is the number of objects in the allocator.

Also, replaced `Equal` with `Same` in allocator test. 
When mocks like MockEventProcessor are compared, identical internal state can cause them to be seen as equal even if they are distinct instances.
What needs to be verified in the tests is whether two different instances are returned, not just objects with matching fields.
With Same, a comparison based on memory address is performed, ensuring that true object identity is validated.
For this reason, Same (or NotSame) is preferred over Equal (or NotEqual) when verifying allocation behavior with mocks.

Jira - https://iguazio.atlassian.net/browse/NUC-413