### PR TITLE
[Controller] Enable Readiness and Liveness probes configurations

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2385,10 +2385,10 @@ func (lc *lazyClient) populateDeploymentContainer(ctx context.Context,
 				Path: http.InternalHealthPath,
 			},
 		},
-		InitialDelaySeconds: 5,
-		TimeoutSeconds:      1,
-		PeriodSeconds:       1,
-		FailureThreshold:    10,
+		InitialDelaySeconds: function.Spec.ReadinessProbe.InitialDelaySeconds,
+		TimeoutSeconds:      function.Spec.ReadinessProbe.TimeoutSeconds,
+		PeriodSeconds:       function.Spec.ReadinessProbe.PeriodSeconds,
+		FailureThreshold:    function.Spec.ReadinessProbe.FailureThreshold,
 	}
 
 	container.LivenessProbe = &v1.Probe{
@@ -2398,9 +2398,10 @@ func (lc *lazyClient) populateDeploymentContainer(ctx context.Context,
 				Path: "/live",
 			},
 		},
-		InitialDelaySeconds: 10,
-		TimeoutSeconds:      3,
-		PeriodSeconds:       5,
+		InitialDelaySeconds: function.Spec.LivenessProbe.InitialDelaySeconds,
+		TimeoutSeconds:      function.Spec.LivenessProbe.TimeoutSeconds,
+		PeriodSeconds:       function.Spec.LivenessProbe.PeriodSeconds,
+		FailureThreshold:    function.Spec.LivenessProbe.FailureThreshold,
 	}
 
 	// always pull is the default since each create / update will trigger a rollingupdate including

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -89,7 +89,7 @@ func (suite *lazyTestSuite) SetupTest() {
 }
 
 func (suite *lazyTestSuite) TestNodeConstrains() {
-	functionInstance := suite.getFunctionInstance("func-name")
+	functionInstance := suite.getFunctionInstanceWithDefaultProbes("func-name")
 	functionInstance.Spec.NodeName = "some-node-name"
 	functionInstance.Spec.NodeSelector = map[string]string{
 		"some-key": "some-value",
@@ -754,21 +754,20 @@ func (suite *lazyTestSuite) TestEnrichDeploymentFromPlatformConfiguration() {
 
 func (suite *lazyTestSuite) TestEnrichProbesInPopulateDeploymentContainer() {
 	// Prepare
-	functionInstance := suite.getFunctionInstance("test-enrich-probes-function")
+	functionInstance := suite.getFunctionInstanceWithDefaultProbes("test-enrich-probes-function")
 	testFunctionLabels := suite.client.getFunctionLabels(functionInstance)
 	testContainer := &v1.Container{}
 
-	// Act
+	// Populate the container with configuration from the function instance
 	suite.client.populateDeploymentContainer(suite.ctx, testFunctionLabels, functionInstance, testContainer)
 
-	// Assert
-	// Assert ReadinessProbe
+	// Verify readinessProbe is populated with default values
 	suite.Require().Equal(testContainer.ReadinessProbe.InitialDelaySeconds, platformconfig.DefaultReadinessProbeConfiguration.InitialDelaySeconds)
 	suite.Require().Equal(testContainer.ReadinessProbe.TimeoutSeconds, platformconfig.DefaultReadinessProbeConfiguration.TimeoutSeconds)
 	suite.Require().Equal(testContainer.ReadinessProbe.PeriodSeconds, platformconfig.DefaultReadinessProbeConfiguration.PeriodSeconds)
 	suite.Require().Equal(testContainer.ReadinessProbe.FailureThreshold, platformconfig.DefaultReadinessProbeConfiguration.FailureThreshold)
 
-	// Assert LivenessProbe
+	// Verify LivenessProbe is populated with default values
 	suite.Require().Equal(testContainer.LivenessProbe.InitialDelaySeconds, platformconfig.DefaultLivenessProbeConfiguration.InitialDelaySeconds)
 	suite.Require().Equal(testContainer.LivenessProbe.TimeoutSeconds, platformconfig.DefaultLivenessProbeConfiguration.TimeoutSeconds)
 	suite.Require().Equal(testContainer.LivenessProbe.PeriodSeconds, platformconfig.DefaultLivenessProbeConfiguration.PeriodSeconds)
@@ -969,7 +968,7 @@ func (suite *lazyTestSuite) getIngressRuleByHost(rules []networkingv1.IngressRul
 	return nil
 }
 
-func (suite *lazyTestSuite) getFunctionInstance(funcName string) *nuclioio.NuclioFunction {
+func (suite *lazyTestSuite) getFunctionInstanceWithDefaultProbes(funcName string) *nuclioio.NuclioFunction {
 	functionInstance := &nuclioio.NuclioFunction{}
 	functionInstance.Name = funcName
 	functionInstance.Spec.LivenessProbe = platformconfig.DefaultLivenessProbeConfiguration

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -89,8 +89,7 @@ func (suite *lazyTestSuite) SetupTest() {
 }
 
 func (suite *lazyTestSuite) TestNodeConstrains() {
-	functionInstance := &nuclioio.NuclioFunction{}
-	functionInstance.Name = "func-name"
+	functionInstance := suite.getFunctionInstance("func-name")
 	functionInstance.Spec.NodeName = "some-node-name"
 	functionInstance.Spec.NodeSelector = map[string]string{
 		"some-key": "some-value",
@@ -362,6 +361,8 @@ func (suite *lazyTestSuite) TestNoChanges() {
 					},
 				},
 			},
+			LivenessProbe: platformconfig.DefaultLivenessProbeConfiguration,
+			ReadinessProbe: platformconfig.DefaultReadinessProbeConfiguration,
 		},
 	}
 	functionLabels := suite.client.getFunctionLabels(&function)
@@ -751,6 +752,30 @@ func (suite *lazyTestSuite) TestEnrichDeploymentFromPlatformConfiguration() {
 	suite.Require().True(deployment.Spec.Paused)
 }
 
+func (suite *lazyTestSuite) TestEnrichProbesInPopulateDeploymentContainer() {
+	// Prepare
+	functionInstance := suite.getFunctionInstance("")
+	testCtx := context.Background()
+	testFunctionLabels := suite.client.getFunctionLabels(functionInstance)
+	testContainer := &v1.Container{}
+
+	// Act
+	suite.client.populateDeploymentContainer(testCtx, testFunctionLabels, functionInstance, testContainer)
+
+	// Assert
+	// Assert ReadinessProbe
+	suite.Require().Equal(testContainer.ReadinessProbe.InitialDelaySeconds, platformconfig.DefaultReadinessProbeConfiguration.InitialDelaySeconds)
+	suite.Require().Equal(testContainer.ReadinessProbe.TimeoutSeconds, platformconfig.DefaultReadinessProbeConfiguration.TimeoutSeconds)
+	suite.Require().Equal(testContainer.ReadinessProbe.PeriodSeconds, platformconfig.DefaultReadinessProbeConfiguration.PeriodSeconds)
+	suite.Require().Equal(testContainer.ReadinessProbe.FailureThreshold, platformconfig.DefaultReadinessProbeConfiguration.FailureThreshold)
+
+	// Assert LivenessProbe
+	suite.Require().Equal(testContainer.LivenessProbe.InitialDelaySeconds, platformconfig.DefaultLivenessProbeConfiguration.InitialDelaySeconds)
+	suite.Require().Equal(testContainer.LivenessProbe.TimeoutSeconds, platformconfig.DefaultLivenessProbeConfiguration.TimeoutSeconds)
+	suite.Require().Equal(testContainer.LivenessProbe.PeriodSeconds, platformconfig.DefaultLivenessProbeConfiguration.PeriodSeconds)
+	suite.Require().Equal(testContainer.LivenessProbe.FailureThreshold, platformconfig.DefaultLivenessProbeConfiguration.FailureThreshold)
+}
+
 func (suite *lazyTestSuite) TestFastFailOnAutoScalerEvents() {
 	namespace := "some-namespace"
 	podName := "my-pod"
@@ -943,6 +968,15 @@ func (suite *lazyTestSuite) getIngressRuleByHost(rules []networkingv1.IngressRul
 
 	suite.Failf("Could not find host in rules: %s", host)
 	return nil
+}
+
+func (suite *lazyTestSuite) getFunctionInstance(funcName string) *nuclioio.NuclioFunction {
+	functionInstance := &nuclioio.NuclioFunction{}
+	functionInstance.Name = funcName
+	functionInstance.Spec.LivenessProbe = platformconfig.DefaultLivenessProbeConfiguration
+	functionInstance.Spec.ReadinessProbe = platformconfig.DefaultReadinessProbeConfiguration
+
+	return functionInstance
 }
 
 func TestLazyTestSuite(t *testing.T) {

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -361,7 +361,7 @@ func (suite *lazyTestSuite) TestNoChanges() {
 					},
 				},
 			},
-			LivenessProbe: platformconfig.DefaultLivenessProbeConfiguration,
+			LivenessProbe:  platformconfig.DefaultLivenessProbeConfiguration,
 			ReadinessProbe: platformconfig.DefaultReadinessProbeConfiguration,
 		},
 	}
@@ -754,13 +754,12 @@ func (suite *lazyTestSuite) TestEnrichDeploymentFromPlatformConfiguration() {
 
 func (suite *lazyTestSuite) TestEnrichProbesInPopulateDeploymentContainer() {
 	// Prepare
-	functionInstance := suite.getFunctionInstance("")
-	testCtx := context.Background()
+	functionInstance := suite.getFunctionInstance("test-enrich-probes-function")
 	testFunctionLabels := suite.client.getFunctionLabels(functionInstance)
 	testContainer := &v1.Container{}
 
 	// Act
-	suite.client.populateDeploymentContainer(testCtx, testFunctionLabels, functionInstance, testContainer)
+	suite.client.populateDeploymentContainer(suite.ctx, testFunctionLabels, functionInstance, testContainer)
 
 	// Assert
 	// Assert ReadinessProbe

--- a/pkg/platform/kube/test/function/function_test.go
+++ b/pkg/platform/kube/test/function/function_test.go
@@ -1349,7 +1349,6 @@ func (suite *DeployFunctionTestSuite) TestCreateFunctionWithProbes() {
 		Namespace: createFunctionOptions.FunctionConfig.Meta.Namespace,
 	}
 
-	// Act
 	suite.DeployFunction(createFunctionOptions, func(deployResults *platform.CreateFunctionResult) bool {
 
 		// get the function
@@ -1369,7 +1368,6 @@ func (suite *DeployFunctionTestSuite) TestCreateFunctionWithProbes() {
 			return true
 		})
 
-		// Assert
 		// get the function's deployment and validate it has the probes
 		podsList := suite.GetFunctionPods(functionName)
 		suite.Require().Len(podsList, 1)

--- a/pkg/platform/kube/test/function/function_test.go
+++ b/pkg/platform/kube/test/function/function_test.go
@@ -1333,6 +1333,48 @@ func (suite *DeployFunctionTestSuite) TestDeployImportedFunctionAsScaledToZero()
 	suite.Require().Equal(int(*deployment.Spec.Replicas), 0)
 }
 
+func (suite *DeployFunctionTestSuite) TestCreateFunctionWithProbes() {
+	// This test validates that the liveness and readiness probes are set correctly
+	// when creating a function with custom probes.
+	// The test will create a function with custom liveness.TimeoutSeconds probe.
+	// All the other liveness and readiness probes should be taken from the platform default config.
+
+	// Prepare
+	functionName := "func-hello-world"
+	testNum := int32(14)
+	createFunctionOptions := suite.CompileCreateFunctionOptions(functionName)
+	createFunctionOptions.FunctionConfig.Spec.LivenessProbe = &v1.Probe{TimeoutSeconds: testNum}
+
+	// Act
+	result, deployErr := suite.Platform.CreateFunction(suite.Ctx, createFunctionOptions)
+
+	// Assert
+	suite.NoError(deployErr)
+	suite.Require().Equal(result.FunctionStatus.State, functionconfig.FunctionStateReady)
+
+	// get the function's deployment and validate it has the probes
+	podsList := suite.GetFunctionPods(functionName)
+	suite.Require().Len(podsList, 1)
+	suite.Require().Len(podsList[0].Spec.Containers, 1)
+	container := podsList[0].Spec.Containers[0]
+	suite.Require().NotNil(container)
+	suite.Require().NotNil(container.ReadinessProbe)
+	suite.Require().NotNil(container.LivenessProbe)
+
+	// Assert liveness probe - should take all values from the platform default config except timeout
+	liveProbe := container.LivenessProbe
+	suite.Require().Equal(liveProbe.TimeoutSeconds, testNum)
+	suite.Require().Equal(liveProbe.PeriodSeconds, platformconfig.DefaultLivenessProbeConfiguration.PeriodSeconds)
+	suite.Require().Equal(liveProbe.FailureThreshold, platformconfig.DefaultLivenessProbeConfiguration.FailureThreshold)
+	suite.Require().Equal(liveProbe.InitialDelaySeconds, platformconfig.DefaultLivenessProbeConfiguration.InitialDelaySeconds)
+	// Assert readiness probe - should take all values from the platform default config
+	readinessProbe := container.ReadinessProbe
+	suite.Require().Equal(readinessProbe.InitialDelaySeconds, platformconfig.DefaultReadinessProbeConfiguration.InitialDelaySeconds)
+	suite.Require().Equal(readinessProbe.TimeoutSeconds, platformconfig.DefaultReadinessProbeConfiguration.TimeoutSeconds)
+	suite.Require().Equal(readinessProbe.PeriodSeconds, platformconfig.DefaultReadinessProbeConfiguration.PeriodSeconds)
+	suite.Require().Equal(readinessProbe.FailureThreshold, platformconfig.DefaultReadinessProbeConfiguration.FailureThreshold)
+}
+
 func (suite *DeployFunctionTestSuite) TestCreateFunctionWithCustomScalingMetrics() {
 	one := 1
 	four := 4

--- a/pkg/platform/kube/test/function/function_test.go
+++ b/pkg/platform/kube/test/function/function_test.go
@@ -1341,38 +1341,59 @@ func (suite *DeployFunctionTestSuite) TestCreateFunctionWithProbes() {
 
 	// Prepare
 	functionName := "func-hello-world"
-	testNum := int32(14)
+	livenessProbeTimeoutSeconds := int32(14)
 	createFunctionOptions := suite.CompileCreateFunctionOptions(functionName)
-	createFunctionOptions.FunctionConfig.Spec.LivenessProbe = &v1.Probe{TimeoutSeconds: testNum}
+	createFunctionOptions.FunctionConfig.Spec.LivenessProbe = &v1.Probe{TimeoutSeconds: livenessProbeTimeoutSeconds}
+	getFunctionOptions := &platform.GetFunctionsOptions{
+		Name:      createFunctionOptions.FunctionConfig.Meta.Name,
+		Namespace: createFunctionOptions.FunctionConfig.Meta.Namespace,
+	}
 
 	// Act
-	result, deployErr := suite.Platform.CreateFunction(suite.Ctx, createFunctionOptions)
+	suite.DeployFunction(createFunctionOptions, func(deployResults *platform.CreateFunctionResult) bool {
 
-	// Assert
-	suite.NoError(deployErr)
-	suite.Require().Equal(result.FunctionStatus.State, functionconfig.FunctionStateReady)
+		// get the function
+		function := suite.GetFunction(getFunctionOptions)
 
-	// get the function's deployment and validate it has the probes
-	podsList := suite.GetFunctionPods(functionName)
-	suite.Require().Len(podsList, 1)
-	suite.Require().Len(podsList[0].Spec.Containers, 1)
-	container := podsList[0].Spec.Containers[0]
-	suite.Require().NotNil(container)
-	suite.Require().NotNil(container.ReadinessProbe)
-	suite.Require().NotNil(container.LivenessProbe)
+		// ensure function is ready
+		suite.Require().Equal(functionconfig.FunctionStateReady, function.GetStatus().State)
 
-	// Assert liveness probe - should take all values from the platform default config except timeout
-	liveProbe := container.LivenessProbe
-	suite.Require().Equal(liveProbe.TimeoutSeconds, testNum)
-	suite.Require().Equal(liveProbe.PeriodSeconds, platformconfig.DefaultLivenessProbeConfiguration.PeriodSeconds)
-	suite.Require().Equal(liveProbe.FailureThreshold, platformconfig.DefaultLivenessProbeConfiguration.FailureThreshold)
-	suite.Require().Equal(liveProbe.InitialDelaySeconds, platformconfig.DefaultLivenessProbeConfiguration.InitialDelaySeconds)
-	// Assert readiness probe - should take all values from the platform default config
-	readinessProbe := container.ReadinessProbe
-	suite.Require().Equal(readinessProbe.InitialDelaySeconds, platformconfig.DefaultReadinessProbeConfiguration.InitialDelaySeconds)
-	suite.Require().Equal(readinessProbe.TimeoutSeconds, platformconfig.DefaultReadinessProbeConfiguration.TimeoutSeconds)
-	suite.Require().Equal(readinessProbe.PeriodSeconds, platformconfig.DefaultReadinessProbeConfiguration.PeriodSeconds)
-	suite.Require().Equal(readinessProbe.FailureThreshold, platformconfig.DefaultReadinessProbeConfiguration.FailureThreshold)
+		// ensure function pods are running
+		suite.WaitForFunctionPods(functionName, time.Minute, func(pods []v1.Pod) bool {
+			suite.Logger.DebugWith("Ensure function pods are running", "pods", pods)
+			for _, pod := range pods {
+				if pod.Status.Phase != v1.PodRunning {
+					return false
+				}
+			}
+			return true
+		})
+
+		// Assert
+		// get the function's deployment and validate it has the probes
+		podsList := suite.GetFunctionPods(functionName)
+		suite.Require().Len(podsList, 1)
+		suite.Require().Len(podsList[0].Spec.Containers, 1)
+		container := podsList[0].Spec.Containers[0]
+		suite.Require().NotNil(container)
+		suite.Require().NotNil(container.ReadinessProbe)
+		suite.Require().NotNil(container.LivenessProbe)
+
+		// Assert liveness probe - should take all values from the platform default config except timeout
+		liveProbe := container.LivenessProbe
+		suite.Require().Equal(liveProbe.TimeoutSeconds, livenessProbeTimeoutSeconds)
+		suite.Require().Equal(liveProbe.PeriodSeconds, platformconfig.DefaultLivenessProbeConfiguration.PeriodSeconds)
+		suite.Require().Equal(liveProbe.FailureThreshold, platformconfig.DefaultLivenessProbeConfiguration.FailureThreshold)
+		suite.Require().Equal(liveProbe.InitialDelaySeconds, platformconfig.DefaultLivenessProbeConfiguration.InitialDelaySeconds)
+		// Assert readiness probe - should take all values from the platform default config
+		readinessProbe := container.ReadinessProbe
+		suite.Require().Equal(readinessProbe.InitialDelaySeconds, platformconfig.DefaultReadinessProbeConfiguration.InitialDelaySeconds)
+		suite.Require().Equal(readinessProbe.TimeoutSeconds, platformconfig.DefaultReadinessProbeConfiguration.TimeoutSeconds)
+		suite.Require().Equal(readinessProbe.PeriodSeconds, platformconfig.DefaultReadinessProbeConfiguration.PeriodSeconds)
+		suite.Require().Equal(readinessProbe.FailureThreshold, platformconfig.DefaultReadinessProbeConfiguration.FailureThreshold)
+
+		return true
+	})
 }
 
 func (suite *DeployFunctionTestSuite) TestCreateFunctionWithCustomScalingMetrics() {


### PR DESCRIPTION
### **Motivation**  
Described in the [JIRA](https://iguazio.atlassian.net/browse/NUC-409)

### **Root Cause**
Nuclio functions previously used default values for readiness and liveness probes, with no user-facing way to customize them. This limited flexibility in production environments, where probe tuning is often necessary to accommodate different workloads.

### **Description**  
This PR introduces support for configuring readiness and liveness probes by propagating the probe configurations to the container-level configuration.

### **Affected Areas**  
- [Refactor unit tests](https://github.com/nuclio/nuclio/pull/3629/commits/99f186ac07d6ea97db4b6ad2591fc133742c0796) - Added the defaults `functionInstance.Spec.LivenessProbe` and `functionInstance.Spec.ReadinessProbe` to other unit tests. 
This addition was necessary because some tests invoke [lazyClient.CreateOrUpdate](https://github.com/nuclio/nuclio/blob/fa3161f95044d9703514802d0fe32509dfa91e0f/pkg/platform/kube/functionres/lazy.go#L165) which is affected by this PR. 
These changes maintain the tests' consistency.

### **Testing**  
- `CreateOrUpdate` changes were Covered by unit tests
- The full probes propagation flow is covered with an [Integration test](https://github.com/nuclio/nuclio/pull/3629/commits/d309668737646ccd5aed2ea13b6ec2556124aa26#diff-c624dd2cc2b57bbbf2861daae4140a94323f2d99405f4ed3de1cf6c9fff76480R1336)

### **Changes Made**  
- Modified the `ReadinessProbe` and `LivenessProbe` fields to be taken from the function specification instead of using static values.