### PR TITLE
[Security] Add permissions and pin actions to a full length commit

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -14,6 +14,10 @@
 #
 name: Function HTTP Load Benchmark
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/docs-language-linter.yml
+++ b/.github/workflows/docs-language-linter.yml
@@ -13,6 +13,11 @@
 # limitations under the License
 
 name: Docs Language Linter
+
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     paths:
@@ -28,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: errata-ai/vale-action@reviewdog
+      - uses: errata-ai/vale-action@d89dee975228ae261d22c15adcd03578634d429c # 2.1.1
         with:
           reporter: github-pr-check
 

--- a/.github/workflows/long_ci.yaml
+++ b/.github/workflows/long_ci.yaml
@@ -24,6 +24,10 @@ on:
   schedule:
     - cron: '0 */12 * * *'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   START_LABEL: long-ci-started
   SUCCESS_LABEL: long-ci-succeeded
@@ -140,7 +144,7 @@ jobs:
 
       - name: Report Status
         if: github.event_name == 'schedule' && always()
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # 2.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ needs.long_ci.result }}

--- a/.github/workflows/pr-title-checker.yaml
+++ b/.github/workflows/pr-title-checker.yaml
@@ -13,8 +13,11 @@
 # limitations under the License.
 #
 name: "PR Title Checker"
-on:
+permissions:
+  contents: read
+  pull-requests: write
 
+on:
   # when opening PRs from forks
   pull_request_target:
     types:
@@ -28,7 +31,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: thehanimo/pr-title-checker@v1.4.3
+      - uses: thehanimo/pr-title-checker@7fbfe05602bdd86f926d3fb3bccb6f3aed43bc70 # 1.4.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           configuration_path: .github/pr-title-checker-config.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -142,7 +142,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate Changelog with git-cliff
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@4a4a951bc43fafe41cd2348d181853f52356bee7 # 4.4.2
         id: git-cliff
         with:
           config: cliff.toml
@@ -260,19 +260,19 @@ jobs:
 
       - name: Install QEMU
         if: matrix.arch != 'amd64'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # 3.6.0
         with:
           platforms: ${{ matrix.arch }}
 
       - name: Login to registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # 3.4.0
         with:
           registry: ${{ env.REPO }}
           username: ${{ secrets.QUAYIO_DOCKER_USERNAME }}
           password: ${{ secrets.QUAYIO_DOCKER_PASSWORD }}
 
       - name: Login to cache registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # 3.4.0
         with:
           registry: ${{ env.CACHE_REPO }}
           username: ${{ env.CACHE_REPO_NAME }}
@@ -339,7 +339,7 @@ jobs:
 
       - name: Install QEMU
         if: matrix.arch != 'amd64'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # 3.6.0
         with:
           platforms: ${{ matrix.arch }}
 
@@ -356,7 +356,7 @@ jobs:
           DOCKER_DEFAULT_PLATFORM: linux/${{ matrix.arch }}
 
       - name: Upload binaries
-        uses: AButler/upload-release-assets@v3.0
+        uses: AButler/upload-release-assets@3d6774fae0ed91407dc5ae29d576b166536d1777 # v3.0
         with:
           release-tag: ${{ needs.prepare-inputs.outputs.version }}
           files: '/home/runner/go/bin/nuctl-*'

--- a/.github/workflows/security_scan.yaml
+++ b/.github/workflows/security_scan.yaml
@@ -15,6 +15,10 @@
 
 name: Security Scan
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   workflow_dispatch:
     inputs:
@@ -139,7 +143,7 @@ jobs:
           fi
 
       - name: Scan image
-        uses: anchore/scan-action@v6
+        uses: anchore/scan-action@2c901ab7378897c01b8efaa2d0c9bf519cc64b9e # 6.2.0
         id: scan
         with:
           image: ${{ env.image_name }}
@@ -184,7 +188,7 @@ jobs:
           fi
 
       - name: Scan fs
-        uses: anchore/scan-action@v6
+        uses: anchore/scan-action@2c901ab7378897c01b8efaa2d0c9bf519cc64b9e # 6.2.0
         id: scan
         with:
           path: "."


### PR DESCRIPTION
Second part of fixing medium security issues in CI.

Resolves:

* https://github.com/nuclio/nuclio/security/code-scanning/745
* https://github.com/nuclio/nuclio/security/code-scanning/743
* https://github.com/nuclio/nuclio/security/code-scanning/740
* https://github.com/nuclio/nuclio/security/code-scanning/738
* https://github.com/nuclio/nuclio/security/code-scanning/736
* https://github.com/nuclio/nuclio/security/code-scanning/734
* https://github.com/nuclio/nuclio/security/code-scanning/732
* https://github.com/nuclio/nuclio/security/code-scanning/731
* https://github.com/nuclio/nuclio/security/code-scanning/730
* https://github.com/nuclio/nuclio/security/code-scanning/729
* https://github.com/nuclio/nuclio/security/code-scanning/766
* https://github.com/nuclio/nuclio/security/code-scanning/765
* https://github.com/nuclio/nuclio/security/code-scanning/764
* https://github.com/nuclio/nuclio/security/code-scanning/763
* https://github.com/nuclio/nuclio/security/code-scanning/762
* https://github.com/nuclio/nuclio/security/code-scanning/759
* https://github.com/nuclio/nuclio/security/code-scanning/758
* https://github.com/nuclio/nuclio/security/code-scanning/756
* https://github.com/nuclio/nuclio/security/code-scanning/753
* https://github.com/nuclio/nuclio/security/code-scanning/751
* https://github.com/nuclio/nuclio/security/code-scanning/750