### PR TITLE
[Platform] Add ElasticSearchConfig to platform config

### DIFF
--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -130,6 +130,13 @@ spec:
           value: {{ .Values.dashboard.kaniko.image.pullPolicy }}
         - name: NUCLIO_KANIKO_JOB_DELETION_TIMEOUT
           value: {{ .Values.dashboard.kaniko.jobDeletionTimeout | quote }}
+        {{- if and .Values.dashboard.elasticSearch.secretName .Values.dashboard.elasticSearch.secretKey }}
+        - name: NUCLIO_ELASTIC_SEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.dashboard.elasticSearch.secretName }}
+              key: {{ .Values.dashboard.elasticSearch.secretKey }}
+         {{- end }}
         {{- if .Values.dashboard.kaniko.insecurePushRegistry }}
         - name: NUCLIO_KANIKO_INSECURE_PUSH_REGISTRY
           value: "true"

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -130,12 +130,12 @@ spec:
           value: {{ .Values.dashboard.kaniko.image.pullPolicy }}
         - name: NUCLIO_KANIKO_JOB_DELETION_TIMEOUT
           value: {{ .Values.dashboard.kaniko.jobDeletionTimeout | quote }}
-        {{- if and .Values.dashboard.elasticSearch.secretName .Values.dashboard.elasticSearch.secretKey }}
+        {{- if and .Values.dashboard.elasticSearchPassword.secretName .Values.dashboard.elasticSearchPassword.secretKey }}
         - name: NUCLIO_ELASTIC_SEARCH_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.dashboard.elasticSearch.secretName }}
-              key: {{ .Values.dashboard.elasticSearch.secretKey }}
+              name: {{ .Values.dashboard.elasticSearchPassword.secretName }}
+              key: {{ .Values.dashboard.elasticSearchPassword.secretKey }}
          {{- end }}
         {{- if .Values.dashboard.kaniko.insecurePushRegistry }}
         - name: NUCLIO_KANIKO_INSECURE_PUSH_REGISTRY

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -286,6 +286,10 @@ dashboard:
       periodSeconds: 15
       failureThreshold: 4
 
+  elasticSearch:
+    secretName: ""
+    secretKey: ""
+
   # Use to volumize pip ca cert
   # Note: secret name must contain "pip-ca-certificates.crt" key
   pipCACertSecretName: ""

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -286,7 +286,7 @@ dashboard:
       periodSeconds: 15
       failureThreshold: 4
 
-  elasticSearch:
+  elasticSearchPassword:
     secretName: ""
     secretKey: ""
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -492,7 +492,7 @@ func (c *Config) enrichElasticSearchConfig() {
 	}
 
 	// override with environment variable if set
-	if envPassword := os.Getenv("ELASTIC_SEARCH_PASSWORD"); envPassword != "" {
+	if envPassword := os.Getenv("NUCLIO_ELASTIC_SEARCH_PASSWORD"); envPassword != "" {
 		c.Kube.ElasticSearchConfig.Password = envPassword
 	}
 }

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -184,6 +184,7 @@ func (c *Config) EnrichPlatformConfig() error {
 
 	common.EnrichProbe(&c.Kube.DefaultReadinessProbe, defaultPlatformConfiguration.Kube.DefaultReadinessProbe)
 	common.EnrichProbe(&c.Kube.DefaultLivenessProbe, defaultPlatformConfiguration.Kube.DefaultLivenessProbe)
+	c.enrichElasticSearchConfig()
 
 	return nil
 }
@@ -352,6 +353,14 @@ func (c *Config) EnrichSupplementaryContainerResources(ctx context.Context,
 		false)
 }
 
+func (c *Config) EnableSensitiveFieldMasking() {
+	c.SensitiveFields.MaskSensitiveFields = true
+}
+
+func (c *Config) DisableSensitiveFieldMasking() {
+	c.SensitiveFields.MaskSensitiveFields = false
+}
+
 // enrichContainerResources enriches an object's requests and limits with the default
 // resources defined in the platform config, only if they are not already configured
 func (c *Config) enrichContainerResources(ctx context.Context,
@@ -477,12 +486,15 @@ func (c *Config) enrichOpaConfig() {
 	}
 }
 
-func (c *Config) EnableSensitiveFieldMasking() {
-	c.SensitiveFields.MaskSensitiveFields = true
-}
+func (c *Config) enrichElasticSearchConfig() {
+	if c.Kube.ElasticSearchConfig == nil {
+		return
+	}
 
-func (c *Config) DisableSensitiveFieldMasking() {
-	c.SensitiveFields.MaskSensitiveFields = false
+	// override with environment variable if set
+	if envPassword := os.Getenv("ELASTIC_SEARCH_PASSWORD"); envPassword != "" {
+		c.Kube.ElasticSearchConfig.Password = envPassword
+	}
 }
 
 func GetDefaultPlatformConfiguration() *Config {

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/common"
@@ -602,6 +603,63 @@ func (suite *PlatformConfigTestSuite) TestEnrichContainerResources() {
 	suite.Require().Equal(expectedResources["requestsMemory"], resources.Requests["memory"])
 	suite.Require().Equal(expectedResources["limitsCPU"], resources.Limits["cpu"])
 	suite.Require().Equal(expectedResources["limitsMemory"], resources.Limits["memory"])
+}
+
+func (suite *PlatformConfigTestSuite) TestEnrichElasticSearchConfig() {
+	testCases := []struct {
+		name              string
+		configurationYAML string
+		envPassword       string
+		expectedPassword  string
+	}{
+		{
+			name: "overriddenByEnv",
+			configurationYAML: `
+kube:
+  elasticSearchConfig:
+    password: "preset-password"
+`,
+			envPassword:      "env-password",
+			expectedPassword: "env-password",
+		},
+		{
+			name: "fromEnv",
+			configurationYAML: `
+kube:
+  elasticSearchConfig:
+    password: ""
+`,
+			envPassword:      "env-password",
+			expectedPassword: "env-password",
+		},
+		{
+			name: "fromConfig",
+			configurationYAML: `
+kube:
+  elasticSearchConfig:
+    password: "config-password"
+`,
+			envPassword:      "",
+			expectedPassword: "config-password",
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			if tc.envPassword != "" {
+				os.Setenv("ELASTIC_SEARCH_PASSWORD", tc.envPassword)
+				defer os.Unsetenv("ELASTIC_SEARCH_PASSWORD")
+			}
+
+			var readConfiguration Config
+
+			err := suite.reader.Read(bytes.NewBufferString(tc.configurationYAML), "yaml", &readConfiguration)
+			suite.Require().NoError(err)
+
+			readConfiguration.enrichElasticSearchConfig()
+			suite.Equal(tc.expectedPassword, readConfiguration.Kube.ElasticSearchConfig.Password)
+		})
+	}
 }
 
 func (suite *PlatformConfigTestSuite) TestEnrichContainerResourcesWithoutDefaults() {

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -647,8 +647,8 @@ kube:
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			if tc.envPassword != "" {
-				os.Setenv("ELASTIC_SEARCH_PASSWORD", tc.envPassword)
-				defer os.Unsetenv("ELASTIC_SEARCH_PASSWORD")
+				os.Setenv("NUCLIO_ELASTIC_SEARCH_PASSWORD", tc.envPassword)
+				defer os.Unsetenv("NUCLIO_ELASTIC_SEARCH_PASSWORD")
 			}
 
 			var readConfiguration Config

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -198,6 +198,7 @@ type PlatformKubeConfig struct {
 	PreemptibleNodes                 *PreemptibleNodes       `json:"preemptibleNodes,omitempty"`
 	DefaultReadinessProbe            *corev1.Probe           `json:"readinessProbe,omitempty"`
 	DefaultLivenessProbe             *corev1.Probe           `json:"livenessProbe,omitempty"`
+	ElasticSearchConfig              *ElasticSearchConfig    `json:"elasticSearchConfig,omitempty"`
 }
 
 // PreemptibleNodes Holds data needed when user decided to run his function pods on a preemptible node (aka Spot node)
@@ -276,6 +277,15 @@ type IngressConfig struct {
 	IguazioSignInURL           string   `json:"iguazioSignInURL,omitempty"`
 	AllowedAuthenticationModes []string `json:"allowedAuthenticationModes,omitempty"`
 	Oauth2ProxyURL             string   `json:"oauth2ProxyURL,omitempty"`
+}
+
+type ElasticSearchConfig struct {
+	URL                  string `json:"url,omitempty"`
+	SSLVerificationMode  string `json:"sslVerificationMode,omitempty"`
+	Username             string `json:"username,omitempty"`
+	Password             string `json:"password,omitempty"`
+	Index                string `json:"index,omitempty"`
+	CustomQueryParameter string `json:"customQueryParameter,omitempty"`
 }
 
 type CronTriggerCreationMode string


### PR DESCRIPTION
First ticket of ES integration for proxying logs. 

Jira - https://iguazio.atlassian.net/browse/NUC-427

Adds ES configuration options to a platform config and allows reading sensitive data(password) from envvar (which can be set to be taken from secret in k8s).