### PR TITLE
[Kafka] Add timeout parameters to support confluent cloud

### DIFF
--- a/.github/styles/Nuclio/ignore.txt
+++ b/.github/styles/Nuclio/ignore.txt
@@ -70,3 +70,5 @@ Webadmin
 westeurope
 yaml
 Gurubase
+ACLs
+ACL

--- a/docs/reference/triggers/kafka.md
+++ b/docs/reference/triggers/kafka.md
@@ -377,6 +377,27 @@ You can configure each attribute either in the `triggers.<trigger>.attributes.<a
   <br/>
   **Default Value:** `"5s"` (5 seconds)<!-- 5 * time.Second -->
 
+- <a id="AdminTimeout"></a>**`adminTimeout`** (**`kafka-admin-timeout`**) - The maximum duration the administrative Kafka client will wait for ClusterAdmin operations, including topics, brokers, configurations and ACLs.
+  <br/>
+  **Type:** `string` - a string containing one or more duration strings of the format `"[0-9]+[ns|us|ms|s|m|h]"`; for example, `"300ms"` (300 milliseconds) or `"2h45m"` (2 hours and 45 minutes). See the [`ParseDuration`](https://golang.org/pkg/time/#ParseDuration) Go function.
+  <br/>
+  **Default Value:** `"15s"` (15 seconds)<!-- 15 * time.Second -->
+  <!-- sarama `Admin.Timeout` -->
+
+- <a id="MetadataTimeout"></a>**`metadataTimeout`** (**`kafka-metadata-timeout`**) - How long to wait for a successful metadata response.
+  <br/>
+  **Type:** `string` - a string containing one or more duration strings of the format `"[0-9]+[ns|us|ms|s|m|h]"`; for example, `"300ms"` (300 milliseconds) or `"2h45m"` (2 hours and 45 minutes). See the [`ParseDuration`](https://golang.org/pkg/time/#ParseDuration) Go function.
+  <br/>
+  **Default Value:** `"15s"` (15 seconds)<!-- 15 * time.Second -->
+  <!-- sarama `Metadata.Timeout` -->
+
+- <a id="NetDialTimeout"></a>**`netDialTimeout`** (**`kafka-net-dial-timeout`**) - How long to wait for the initial connection.
+  <br/>
+  **Type:** `string` - a string containing one or more duration strings of the format `"[0-9]+[ns|us|ms|s|m|h]"`; for example, `"300ms"` (300 milliseconds) or `"2h45m"` (2 hours and 45 minutes). See the [`ParseDuration`](https://golang.org/pkg/time/#ParseDuration) Go function.
+  <br/>
+  **Default Value:** `"15s"` (15 seconds)<!-- 15 * time.Second -->
+  <!-- sarama `Net.DialTimeout ` -->
+
 <a id="rebalancing-config-choice"></a>
 ### Choosing the right configuration for rebalancing
 

--- a/docs/reference/triggers/kafka.md
+++ b/docs/reference/triggers/kafka.md
@@ -377,7 +377,7 @@ You can configure each attribute either in the `triggers.<trigger>.attributes.<a
   <br/>
   **Default Value:** `"5s"` (5 seconds)<!-- 5 * time.Second -->
 
-- <a id="AdminTimeout"></a>**`adminTimeout`** (**`kafka-admin-timeout`**) - The maximum duration the administrative Kafka client will wait for ClusterAdmin operations, including topics, brokers, configurations and ACLs.
+- <a id="AdminTimeout"></a>**`adminTimeout`** (**`kafka-admin-timeout`**) - The maximum duration the administrative Kafka client will wait for ClusterAdmin operations, including topics, brokers, configurations and access control lists (ACL).
   <br/>
   **Type:** `string` - a string containing one or more duration strings of the format `"[0-9]+[ns|us|ms|s|m|h]"`; for example, `"300ms"` (300 milliseconds) or `"2h45m"` (2 hours and 45 minutes). See the [`ParseDuration`](https://golang.org/pkg/time/#ParseDuration) Go function.
   <br/>

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -504,6 +504,10 @@ func (k *kafka) newKafkaConfig() (*sarama.Config, error) {
 	config.Consumer.MaxProcessingTime = k.configuration.maxProcessingTime
 	config.ChannelBufferSize = k.configuration.ChannelBufferSize
 
+	config.Admin.Timeout = k.configuration.adminTimeout
+	config.Net.DialTimeout = k.configuration.netDialTimeout
+	config.Metadata.Timeout = k.configuration.metadataTimeout
+
 	// configure TLS if applicable
 	config.Net.TLS.Enable = k.configuration.CACert != "" || k.configuration.TLS.Enable
 	if config.Net.TLS.Enable {

--- a/pkg/processor/trigger/kafka/types.go
+++ b/pkg/processor/trigger/kafka/types.go
@@ -75,6 +75,9 @@ type Configuration struct {
 	RetryBackoff                  string
 	MaxWaitTime                   string
 	MaxWaitHandlerDuringRebalance string
+	AdminTimeout                  string
+	MetadataTimeout               string
+	NetDialTimeout                string
 	WorkerAllocationMode          partitionworker.AllocationMode
 	RebalanceRetryMax             int
 	FetchMin                      int
@@ -101,6 +104,9 @@ type Configuration struct {
 	maxWaitTime                           time.Duration
 	maxWaitHandlerDuringRebalance         time.Duration
 	waitExplicitAckDuringRebalanceTimeout time.Duration
+	adminTimeout                          time.Duration
+	metadataTimeout                       time.Duration
+	netDialTimeout                        time.Duration
 	ackWindowSize                         int
 }
 
@@ -119,6 +125,11 @@ func NewConfiguration(id string,
 
 	workerAllocationModeValue := ""
 	explicitAckModeValue := ""
+
+	// parse attributes
+	if err := mapstructure.Decode(newConfiguration.Configuration.Attributes, &newConfiguration); err != nil {
+		return nil, errors.Wrap(err, "Failed to decode attributes")
+	}
 
 	err = newConfiguration.PopulateConfigurationFromAnnotations([]trigger.AnnotationConfigField{
 		{Key: "nuclio.io/kafka-session-timeout", ValueString: &newConfiguration.SessionTimeout},
@@ -174,6 +185,12 @@ func NewConfiguration(id string,
 
 		// allow changing explicit ack mode via annotation
 		{Key: "nuclio.io/wait-explicit-ack-during-rebalance-timeout", ValueString: &triggerConfiguration.WaitExplicitAckDuringRebalanceTimeout},
+
+		// timeouts for initial connection
+		// often need to be adjusted for confluent cloud
+		{Key: "nuclio.io/kafka-net-dial-timeout", ValueString: &newConfiguration.NetDialTimeout},
+		{Key: "nuclio.io/kafka-metadata-timeout", ValueString: &newConfiguration.MetadataTimeout},
+		{Key: "nuclio.io/kafka-admin-timeout", ValueString: &newConfiguration.AdminTimeout},
 	})
 
 	if err != nil {
@@ -224,11 +241,6 @@ func NewConfiguration(id string,
 	// set default
 	if triggerConfiguration.NumWorkers == 0 {
 		triggerConfiguration.NumWorkers = 32
-	}
-
-	// parse attributes
-	if err := mapstructure.Decode(newConfiguration.Configuration.Attributes, &newConfiguration); err != nil {
-		return nil, errors.Wrap(err, "Failed to decode attributes")
 	}
 
 	if len(newConfiguration.Topics) == 0 {
@@ -308,6 +320,24 @@ func NewConfiguration(id string,
 			Value:   newConfiguration.WaitExplicitAckDuringRebalanceTimeout,
 			Field:   &newConfiguration.waitExplicitAckDuringRebalanceTimeout,
 			Default: 100 * time.Millisecond,
+		},
+		{
+			Name:    "wait for operations like topics, brokers, configs, and ACLs",
+			Value:   newConfiguration.AdminTimeout,
+			Field:   &newConfiguration.adminTimeout,
+			Default: 15 * time.Second,
+		},
+		{
+			Name:    "wait for a successful metadata response",
+			Value:   newConfiguration.MetadataTimeout,
+			Field:   &newConfiguration.metadataTimeout,
+			Default: 15 * time.Second,
+		},
+		{
+			Name:    "wait for the initial connection",
+			Value:   newConfiguration.NetDialTimeout,
+			Field:   &newConfiguration.netDialTimeout,
+			Default: 15 * time.Second,
 		},
 	} {
 		if err = newConfiguration.ParseDurationOrDefault(&durationConfigField); err != nil {


### PR DESCRIPTION
Jira - https://iguazio.atlassian.net/browse/NUC-419

Adds support of new 3 kafka-specific params: 
* adminTimeout
* metadataTimeout
* netDialTimeout

Also, during writing test I found a bug with where we didn't enrich values from annotations. The root case is too late decoding of attributes, so moved attributes unmarshalling up in the flow. 