### PR TITLE
[Dashboard] Add new api to get replicas and proxy logs from ES

### DIFF
--- a/.github/styles/Nuclio/ignore.txt
+++ b/.github/styles/Nuclio/ignore.txt
@@ -72,3 +72,4 @@ yaml
 Gurubase
 ACLs
 ACL
+substring

--- a/docs/reference/api/README.md
+++ b/docs/reference/api/README.md
@@ -294,12 +294,18 @@ you `DELETE /api/function_invocations`, the HTTP method in the event as received
 * URL: `GET /api/functions/<function name>/replicas`
 * Headers:
     * `x-nuclio-function-namespace`: Namespace (required)
+* Params:
+    * includeOffline (optional, bool): If set to true, the API will return both active and offline replicas. Offline replicas are fetched from Elasticsearch. Defaults to false, maintaining backward compatibility with previous versions.
+
+    *timeFilter (optional, json-encoded string): Use this to filter offline replicas by time. This must be a URI-encoded JSON string.
+          Example: `timeFilter={"since":"2025-05-01T00:00:00Z","until":"2025-05-16T23:59:59Z","sort":"asc"}`
 
 #### Response
 
 * Status code: 200
 * Body:
 
+Default Behavior (no includeOffline):
 ```json
 {
   "names": [
@@ -308,6 +314,29 @@ you `DELETE /api/function_invocations`, the HTTP method in the event as received
 }
 ```
 
+Extended Response (includeOffline=true):
+
+```json
+{
+  "replicas": {
+    "names": [
+      "nuclio-hello-5884964d9b-2wqth"
+      ]
+  },
+  "offlineReplicas": {
+    "names": [
+    "nuclio-hello-5884964d9b-vs7pn",
+    "nuclio-hello-5c47d58d89-279qc",
+    "nuclio-hello-6c9799c89c-tz857",
+    "nuclio-hello-7ddc68b7f7-dnwbm",
+    "nuclio-hello-7ff67c876c-c22f7",
+    "nuclio-hello-85488958f5-kjzkh",
+    "nuclio-hello-c8846649c-bx99b"
+    ]
+  }
+}
+
+```
 ### Get function replica logs stream
 
 #### Request
@@ -328,6 +357,43 @@ you `DELETE /api/function_invocations`, the HTTP method in the event as received
 
 ```text
 ...Function replica logs...
+```
+
+### Proxy logs from a source
+
+#### Request
+
+* URL: `GET /api/functions/<function name>/logs/proxy-logs`
+    * Headers:
+    * `x-nuclio-function-namespace`: Namespace (required)
+    * Params:
+    | Parameter      | Type       | Description                                                                 |
+    |----------------|------------|-----------------------------------------------------------------------------|
+    | `timeFilter`   | object     | Time range to filter logs (optional). See `TimeFilter` structure below.     |
+    | `substring`    | string     | Filter logs containing a specific substring (optional).                     |
+    | `regexp`       | string     | Filter logs matching a regular expression (optional).                       |
+    | `replicaNames` | string[]   | Filter logs by specific replica names (optional).                           |
+    | `logLevels`    | string[]   | Filter logs by log levels (e.g. `debug`, `info`, `error`) (optional).       |
+    | `size`         | integer    | Max number of log entries to return (optional).                             |
+    | `searchAfter`  | string[]   | For paginated log fetching (optional).                                      |
+    | `source`       | string     | Source to retrieve logs from (e.g. `es`) (optional).                        |
+
+timeFilter example:
+```
+{
+  "since": "2025-05-01T00:00:00Z",   // ISO 8601 format, optional
+  "until": "2025-05-16T23:59:59Z",   // ISO 8601 format, optional
+  "sort": "desc"                     // "asc" or "desc", optional
+}
+```
+
+#### Response
+
+    * Status code: 200
+    * Body:
+
+```text
+...Stream logs...
 ```
 
 ## Project

--- a/docs/reference/api/README.md
+++ b/docs/reference/api/README.md
@@ -295,7 +295,7 @@ you `DELETE /api/function_invocations`, the HTTP method in the event as received
 * Headers:
     * `x-nuclio-function-namespace`: Namespace (required)
 * Params:
-    * includeOffline (optional, bool): If set to true, the API will return both active and offline replicas. Offline replicas are fetched from Elasticsearch. Defaults to false, maintaining backward compatibility with previous versions.
+    * includeOffline (optional, bool): If set to true, the API will return both active and offline replicas. Offline replicas are fetched from Elasticsearch if it is configured. Defaults to false, maintaining backward compatibility with previous versions.
 
     *timeFilter (optional, json-encoded string): Use this to filter offline replicas by time. This must be a URI-encoded JSON string.
           Example: `timeFilter={"since":"2025-05-01T00:00:00Z","until":"2025-05-16T23:59:59Z","sort":"asc"}`
@@ -326,12 +326,7 @@ Extended Response (includeOffline=true):
   "offlineReplicas": {
     "names": [
     "nuclio-hello-5884964d9b-vs7pn",
-    "nuclio-hello-5c47d58d89-279qc",
-    "nuclio-hello-6c9799c89c-tz857",
-    "nuclio-hello-7ddc68b7f7-dnwbm",
-    "nuclio-hello-7ff67c876c-c22f7",
-    "nuclio-hello-85488958f5-kjzkh",
-    "nuclio-hello-c8846649c-bx99b"
+    "nuclio-hello-5c47d58d89-279qc"
     ]
   }
 }
@@ -363,7 +358,7 @@ Extended Response (includeOffline=true):
 
 #### Request
 
-* URL: `GET /api/functions/<function name>/logs/proxy-logs`
+* URL: `GET /api/functions/<function name>/proxy-logs`
     * Headers:
     * `x-nuclio-function-namespace`: Namespace (required)
     * Params:
@@ -376,7 +371,7 @@ Extended Response (includeOffline=true):
     | `logLevels`    | string[]   | Filter logs by log levels (e.g. `debug`, `info`, `error`) (optional).       |
     | `size`         | integer    | Max number of log entries to return (optional).                             |
     | `searchAfter`  | string[]   | For paginated log fetching (optional).                                      |
-    | `source`       | string     | Source to retrieve logs from (e.g. `es`) (optional).                        |
+    | `source`       | string     | Source to retrieve logs from (e.g. `elasticsearch`) (optional).                        |
 
 timeFilter example:
 ```

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -685,3 +685,7 @@ func GetFunctionName(function interface{}) string {
 
 	return shortName
 }
+
+func Pointer[T any](v T) *T {
+	return &v
+}

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -432,6 +432,8 @@ func (fr *functionResource) proxyFunctionLogs(request *http.Request) (*restful.C
 			"Content-Type":  "text/plain",
 			"Cache-Control": "no-cache, private",
 		},
+		ForceFlush:    true,
+		FlushInternal: time.Second,
 	}, nil
 }
 

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -411,8 +411,7 @@ func (fr *functionResource) proxyFunctionLogs(request *http.Request) (*restful.C
 	}
 
 	// ensure access
-	_, err := fr.getFunction(request, functionName)
-	if err != nil {
+	if _, err := fr.getFunction(request, functionName); err != nil {
 		return nil, errors.Wrap(err, "Failed to get function")
 	}
 
@@ -497,14 +496,19 @@ func (fr *functionResource) getFunctionReplicas(request *http.Request) (
 		RaiseForbidden:      true,
 	}
 
-	responseAttributes := map[string]restful.Attributes{}
-
 	activeReplicaNames, err := fr.getPlatform().GetFunctionActiveReplicaNames(ctx, function, permissionOptions)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get function replicas")
 	}
-	responseAttributes["replicas"] = map[string]interface{}{
+
+	response := &restful.CustomRouteFuncResponse{
+		Resources:  map[string]restful.Attributes{},
+		Single:     false,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		StatusCode: http.StatusOK,
+	}
+	response.Resources["replicas"] = map[string]interface{}{
 		"names": activeReplicaNames,
 	}
 	if includeOffline {
@@ -518,17 +522,15 @@ func (fr *functionResource) getFunctionReplicas(request *http.Request) (
 
 		// filter out online replicas
 		offlineReplicas := fr.getOfflineReplicas(allReplicaNames, activeReplicaNames)
-		responseAttributes["offlineReplicas"] = map[string]interface{}{
-			"names": offlineReplicas,
+		if len(offlineReplicas) > 0 {
+			response.Resources["offlineReplicas"] = map[string]interface{}{
+				"names": offlineReplicas,
+			}
+			response.Single = false
 		}
 	}
 
-	return &restful.CustomRouteFuncResponse{
-		Resources:  responseAttributes,
-		Single:     false,
-		Headers:    map[string]string{"Content-Type": "application/json"},
-		StatusCode: http.StatusOK,
-	}, nil
+	return response, nil
 }
 
 func (fr *functionResource) deleteFunction(request *http.Request) (*restful.CustomRouteFuncResponse, error) {
@@ -845,10 +847,10 @@ func (fr *functionResource) populateProxyFunctionLogsOptions(request *http.Reque
 	})
 	proxyFunctionLogsOptions.Substring = fr.GetURLParamStringOrDefault(request, "substring", "")
 	proxyFunctionLogsOptions.Regexp = fr.GetURLParamStringOrDefault(request, "regexp", "")
-	proxyFunctionLogsOptions.ReplicaNames = fr.GetURLParamStringValues("replicaNames", request)
-	proxyFunctionLogsOptions.LogLevels = fr.GetURLParamStringValues("logLevels", request)
+	proxyFunctionLogsOptions.ReplicaNames = fr.GetURLParamStringSliceValues("replicaNames", request)
+	proxyFunctionLogsOptions.LogLevels = fr.GetURLParamStringSliceValues("logLevels", request)
 	proxyFunctionLogsOptions.Size = fr.GetURLParamInt64OrDefault(request, "size", 100)
-	proxyFunctionLogsOptions.SearchAfter = fr.GetURLParamStringValues("searchAfter", request)
+	proxyFunctionLogsOptions.SearchAfter = fr.GetURLParamStringSliceValues("searchAfter", request)
 	proxyFunctionLogsOptions.Source = platform.ProxyLogsSource(fr.GetURLParamStringOrDefault(
 		request,
 		"source",

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -231,6 +231,11 @@ func (fr *functionResource) GetCustomRoutes() ([]restful.CustomRoute, error) {
 			StreamRouteFunc: fr.getFunctionLogs,
 			Stream:          true,
 		},
+		{
+			Pattern:         "/{id}/proxy-logs",
+			Method:          http.MethodGet,
+			StreamRouteFunc: fr.proxyFunctionLogs,
+		},
 	}, nil
 }
 
@@ -380,7 +385,7 @@ func (fr *functionResource) getFunctionLogs(request *http.Request) (*restful.Cus
 	}
 
 	// get function instance logs stream
-	stream, err := fr.getPlatform().GetFunctionReplicaLogsStream(request.Context(), getFunctionReplicaLogsStreamOptions)
+	stream, err := fr.getPlatform().ProxyFunctionLogs(request.Context(), getFunctionReplicaLogsStreamOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to stream function logs")
 	}
@@ -397,10 +402,43 @@ func (fr *functionResource) getFunctionLogs(request *http.Request) (*restful.Cus
 	}, nil
 }
 
+func (fr *functionResource) proxyFunctionLogs(request *http.Request) (*restful.CustomRouteFuncStreamResponse, error) {
+	// ensure function name
+	functionName := fr.GetRouterURLParam(request, "id")
+	if functionName == "" {
+		return nil, errors.New("Function name must not be empty")
+	}
+
+	// ensure access
+	_, err := fr.getFunction(request, functionName)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get function")
+	}
+
+	// populate get options
+	getFunctionLogsOptions, err := fr.populateProxyFunctionLogsOptions(request, functionName)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to populate get function logs options")
+	}
+
+	stream, err := fr.getPlatform().ProxyFunctionLogs(request.Context(), getFunctionLogsOptions)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to stream function logs")
+	}
+	return &restful.CustomRouteFuncStreamResponse{
+		ReadCloser: stream,
+		StatusCode: http.StatusOK,
+		Headers: map[string]string{
+			"Content-Type":  "text/plain",
+			"Cache-Control": "no-cache, private",
+		},
+	}, nil
+}
+
 func (fr *functionResource) validateLogStreamOptions(ctx context.Context,
 	function platform.Function,
 	getFunctionReplicaLogsStreamOptions *platform.GetFunctionReplicaLogsStreamOptions) error {
-	replicaNames, err := fr.getPlatform().GetFunctionReplicaNames(ctx, function, getFunctionReplicaLogsStreamOptions.PermissionOptions)
+	replicaNames, err := fr.getPlatform().GetFunctionActiveReplicaNames(ctx, function, getFunctionReplicaLogsStreamOptions.PermissionOptions)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get function replica names")
 	}
@@ -450,22 +488,42 @@ func (fr *functionResource) getFunctionReplicas(request *http.Request) (
 		return nil, errors.Wrap(err, "Failed to get function")
 	}
 
+	includeOffline := fr.GetURLParamBoolOrDefault(request, "includeOffline", false)
+
 	permissionOptions := opa.PermissionOptions{
 		MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fr.getCtxSession(ctx)),
 		OverrideHeaderValue: request.Header.Get(opa.OverrideHeader),
 		RaiseForbidden:      true,
 	}
 
-	replicaNames, err := fr.getPlatform().GetFunctionReplicaNames(ctx, function, permissionOptions)
+	responseAttributes := map[string]restful.Attributes{}
+
+	activeReplicaNames, err := fr.getPlatform().GetFunctionActiveReplicaNames(ctx, function, permissionOptions)
+
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get function replicas")
 	}
+	responseAttributes["replicas"] = map[string]interface{}{
+		"names": activeReplicaNames,
+	}
+	if includeOffline {
+		timeFilter := fr.getURLParamTimeFilterOrDefault("timeFilter", request, nil)
+
+		// get all replicas
+		allReplicaNames, err := fr.getPlatform().GetFunctionAllReplicaNames(ctx, function, permissionOptions, timeFilter)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to get function replicas")
+		}
+
+		// filter out online replicas
+		offlineReplicas := fr.getOfflineReplicas(allReplicaNames, activeReplicaNames)
+		responseAttributes["offlineReplicas"] = map[string]interface{}{
+			"names": offlineReplicas,
+		}
+	}
+
 	return &restful.CustomRouteFuncResponse{
-		Resources: map[string]restful.Attributes{
-			"replicas": map[string]interface{}{
-				"names": replicaNames,
-			},
-		},
+		Resources:  responseAttributes,
 		Single:     true,
 		Headers:    map[string]string{"Content-Type": "application/json"},
 		StatusCode: http.StatusOK,
@@ -777,7 +835,58 @@ func (fr *functionResource) populateGetFunctionReplicaLogsStreamOptions(request 
 	}
 
 	return getFunctionReplicaLogsStreamOptions, nil
+}
 
+func (fr *functionResource) populateProxyFunctionLogsOptions(request *http.Request, functionName string) (*platform.ProxyFunctionLogsOptions, error) {
+	proxyFunctionLogsOptions := platform.NewProxyFunctionLogsOptions(functionName)
+	proxyFunctionLogsOptions.TimeFilter = fr.getURLParamTimeFilterOrDefault("timeFilter", request, &platform.TimeFilter{
+		Sort: "desc",
+	})
+	proxyFunctionLogsOptions.Substring = fr.GetURLParamStringOrDefault(request, "substring", "")
+	proxyFunctionLogsOptions.Regexp = fr.GetURLParamStringOrDefault(request, "regexp", "")
+	proxyFunctionLogsOptions.ReplicaNames = fr.GetURLParamStringValues("replicaNames", request)
+	proxyFunctionLogsOptions.LogLevels = fr.GetURLParamStringValues("logLevels", request)
+	proxyFunctionLogsOptions.Size = fr.GetURLParamInt64OrDefault(request, "size", 100)
+	proxyFunctionLogsOptions.SearchAfter = fr.GetURLParamStringValues("searchAfter", request)
+	proxyFunctionLogsOptions.Source = platform.ProxyLogsSource(fr.GetURLParamStringOrDefault(
+		request,
+		"source",
+		string(platform.ProxyLogsSourceES),
+	))
+
+	return proxyFunctionLogsOptions, nil
+}
+
+func (fr *functionResource) getURLParamTimeFilterOrDefault(param string,
+	request *http.Request,
+	defaultTimeFilter *platform.TimeFilter) *platform.TimeFilter {
+	var value string
+	if value = request.URL.Query().Get(param); value == "" {
+		return defaultTimeFilter
+	}
+
+	timeFilter := &platform.TimeFilter{}
+	if err := json.Unmarshal([]byte(value), timeFilter); err != nil {
+		return defaultTimeFilter
+	}
+
+	return timeFilter
+}
+
+func (fr *functionResource) getOfflineReplicas(allReplicas []string, activeReplicas []string) []string {
+	activeSet := make(map[string]struct{}, len(activeReplicas))
+	for _, replica := range activeReplicas {
+		activeSet[replica] = struct{}{}
+	}
+
+	var inactiveReplicas []string
+	for _, replica := range allReplicas {
+		if _, isActive := activeSet[replica]; !isActive {
+			inactiveReplicas = append(inactiveReplicas, replica)
+		}
+	}
+
+	return inactiveReplicas
 }
 
 func (fr *functionResource) getCreationStateUpdatedTimeout(request *http.Request) time.Duration {

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -506,7 +506,7 @@ func (fr *functionResource) getFunctionReplicas(request *http.Request) (
 
 	response := &restful.CustomRouteFuncResponse{
 		Resources:  map[string]restful.Attributes{},
-		Single:     false,
+		Single:     true,
 		Headers:    map[string]string{"Content-Type": "application/json"},
 		StatusCode: http.StatusOK,
 	}

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -235,6 +235,7 @@ func (fr *functionResource) GetCustomRoutes() ([]restful.CustomRoute, error) {
 			Pattern:         "/{id}/proxy-logs",
 			Method:          http.MethodGet,
 			StreamRouteFunc: fr.proxyFunctionLogs,
+			Stream:          true,
 		},
 	}, nil
 }
@@ -524,7 +525,7 @@ func (fr *functionResource) getFunctionReplicas(request *http.Request) (
 
 	return &restful.CustomRouteFuncResponse{
 		Resources:  responseAttributes,
-		Single:     true,
+		Single:     false,
 		Headers:    map[string]string{"Content-Type": "application/json"},
 		StatusCode: http.StatusOK,
 	}, nil

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -854,7 +854,7 @@ func (fr *functionResource) populateProxyFunctionLogsOptions(request *http.Reque
 	proxyFunctionLogsOptions.Source = platform.ProxyLogsSource(fr.GetURLParamStringOrDefault(
 		request,
 		"source",
-		string(platform.ProxyLogsSourceES),
+		string(fr.getPlatform().GetDefaultProxyLogsSource()),
 	))
 
 	return proxyFunctionLogsOptions, nil

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -464,7 +464,7 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context,
 
 				if err := lc.waitFunctionIngressReadiness(ctx, function); err != nil {
 					lc.logger.WarnWithCtx(ctx,
-						"	Function ingress is not ready yet, continuing",
+						"Function ingress is not ready yet, continuing",
 						"err", err.Error(),
 						"namespace", function.Namespace,
 						"name", function.Name)

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -464,7 +464,7 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context,
 
 				if err := lc.waitFunctionIngressReadiness(ctx, function); err != nil {
 					lc.logger.WarnWithCtx(ctx,
-						"Function ingress is not ready yet, continuing",
+						"	Function ingress is not ready yet, continuing",
 						"err", err.Error(),
 						"namespace", function.Namespace,
 						"name", function.Name)

--- a/pkg/platform/kube/logProxy/elastic.go
+++ b/pkg/platform/kube/logProxy/elastic.go
@@ -103,7 +103,7 @@ func (e *ElasticLogProxy) GetFunctionReplicas(ctx context.Context, options *GetF
 
 	agg, ok := resp.Aggregations["distinct_pod_names"]
 	if !ok {
-		return nil, errors.New("Failed to get 'distinct_pod_names' in response from ES")
+		return nil, errors.New("Failed to get 'distinct_pod_names' in response from ElasticSearch")
 	}
 
 	// Convert to typed aggregation:
@@ -270,14 +270,14 @@ func (e *ElasticLogProxy) addTimeSort(request *search.Request, sort string) erro
 			&types.SortOptions{
 				SortOptions: map[string]types.FieldSort{
 					"@timestamp": {
-						Order: &sortorder.Asc,
+						Order: &sortOrder,
 					},
 				},
 			},
 			&types.SortOptions{
 				SortOptions: map[string]types.FieldSort{
 					"_id": {
-						Order: &sortorder.Asc,
+						Order: &sortOrder,
 					},
 				},
 			},

--- a/pkg/platform/kube/logProxy/elastic.go
+++ b/pkg/platform/kube/logProxy/elastic.go
@@ -19,13 +19,19 @@ package logProxy
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net/http"
+	"time"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
 	"github.com/elastic/go-elasticsearch/v9"
+	"github.com/elastic/go-elasticsearch/v9/typedapi/core/search"
+	"github.com/elastic/go-elasticsearch/v9/typedapi/types"
+	"github.com/elastic/go-elasticsearch/v9/typedapi/types/enums/sortorder"
 	"github.com/nuclio/errors"
 )
 
@@ -60,10 +66,222 @@ func NewElasticLogProxy(config *platformconfig.ElasticSearchConfig) (*ElasticLog
 	return esClient, err
 }
 
-func (e *ElasticLogProxy) ProxyFunctionLogs(ctx context.Context, options *platform.ProxyFunctionLogsOptions) (io.ReadCloser, error) {
-	return nil, nil
+func (e *ElasticLogProxy) GetFunctionReplicas(ctx context.Context, options *GetFunctionReplicaOptions) ([]string, error) {
+	if e.client == nil {
+		return nil, errors.New("Elasticsearch client is not configured")
+	}
+
+	searchRequest := e.getFunctionBaseSearchRequest(options.FunctionName)
+
+	// Set to 0 to avoid fetching actual log documents (hits).
+	// We're only interested in aggregation results (e.g., distinct pod names),
+	// so setting this to 0 reduces response size, improves query performance,
+	// and saves bandwidth and memory.
+	searchRequest.Size = common.Pointer(0)
+
+	if err := e.addTimeFilter(searchRequest, options.TimeFilter); err != nil {
+		return nil, errors.Wrap(err, "Failed to apply time filter")
+	}
+
+	// aggregate by pod names
+	searchRequest.Aggregations = map[string]types.Aggregations{
+		"distinct_pod_names": {
+			Terms: &types.TermsAggregation{
+				Field: common.Pointer("kubernetes.pod.name"),
+				Size:  common.Pointer(100000),
+			},
+		},
+	}
+
+	resp, err := e.client.Search().
+		Index(e.index).
+		Request(searchRequest).
+		Do(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to execute search")
+	}
+
+	agg, ok := resp.Aggregations["distinct_pod_names"]
+	if !ok {
+		return nil, errors.New("Failed to get 'distinct_pod_names' in response from ES")
+	}
+
+	// Convert to typed aggregation:
+	termsAgg, ok := agg.(*types.StringTermsAggregate)
+	if !ok {
+		return nil, errors.New("Failed to convert aggregations to StringTermsAggregate")
+	}
+
+	replicas := make([]string, 0)
+
+	switch buckets := termsAgg.Buckets.(type) {
+	case []types.StringTermsBucket:
+		for _, bucket := range buckets {
+			replicas = append(replicas, bucket.Key.(string))
+		}
+	case map[string]types.StringTermsBucket:
+		for _, bucket := range buckets {
+			replicas = append(replicas, bucket.Key.(string))
+		}
+	default:
+		return nil, errors.New("Failed to determine bucket format")
+	}
+
+	return replicas, nil
+
 }
 
-func (e *ElasticLogProxy) GetFunctionReplicas(ctx context.Context, options *GetFunctionReplicaOptions) ([]string, error) {
-	return nil, nil
+func (e *ElasticLogProxy) ProxyFunctionLogs(ctx context.Context, options *platform.ProxyFunctionLogsOptions) (io.ReadCloser, error) {
+	if e.client == nil {
+		return nil, errors.New("Elasticsearch client is not configured")
+	}
+	searchRequest := e.getFunctionBaseSearchRequest(options.GetFunctionName())
+
+	// Substring match
+	if options.Substring != "" {
+		searchRequest.Query.Bool.Must = append(searchRequest.Query.Bool.Must, types.Query{
+			MatchPhrase: map[string]types.MatchPhraseQuery{
+				"message": {Query: options.Substring},
+			},
+		})
+	}
+
+	// Regex match
+	if options.Regexp != "" {
+		searchRequest.Query.Bool.Must = append(searchRequest.Query.Bool.Must, types.Query{
+			Regexp: map[string]types.RegexpQuery{
+				"message": {Value: options.Regexp},
+			},
+		})
+	}
+
+	e.addTermsFilter(searchRequest, "kubernetes.pod.name", options.ReplicaNames)
+	e.addTermsFilter(searchRequest, "level", options.LogLevels)
+
+	if options.Size != 0 {
+		searchRequest.Size = common.Pointer(int(options.Size))
+	}
+
+	if err := e.addTimeFilter(searchRequest, options.TimeFilter); err != nil {
+		return nil, errors.Wrap(err, "Failed to add time filter")
+	}
+
+	if len(options.SearchAfter) > 0 {
+		for _, searchString := range options.SearchAfter {
+			searchRequest.SearchAfter = append(searchRequest.SearchAfter, searchString)
+		}
+	}
+
+	resp, err := e.client.Search().
+		Index(e.index).
+		Request(searchRequest).
+		Perform(ctx)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to execute search request")
+	}
+	return resp.Body, nil
+}
+
+func (e *ElasticLogProxy) getFunctionBaseSearchRequest(functionName string) *search.Request {
+	searchRequest := search.NewRequest()
+
+	// filters by function name custom query parameter
+	query := types.Query{
+		Bool: &types.BoolQuery{
+			Must: []types.Query{
+				{
+					Wildcard: map[string]types.WildcardQuery{
+						"kubernetes.pod.name": {
+							Value: common.Pointer(fmt.Sprintf("nuclio-%s-*", functionName)),
+						},
+					},
+				},
+				{
+					QueryString: &types.QueryStringQuery{
+						Query: e.customQueryParam,
+					},
+				},
+			},
+		},
+	}
+
+	searchRequest.Query = &query
+	return searchRequest
+}
+
+func (e *ElasticLogProxy) addTermsFilter(searchRequest *search.Request, field string, values []string) {
+	if len(values) == 0 {
+		return
+	}
+
+	fieldValues := make([]types.FieldValue, len(values))
+	for i, val := range values {
+		fieldValues[i] = types.FieldValue(val)
+	}
+
+	query := types.Query{
+		Terms: &types.TermsQuery{
+			TermsQuery: map[string]types.TermsQueryField{
+				field: types.TermsQueryField(fieldValues),
+			},
+		},
+	}
+
+	searchRequest.Query.Bool.Filter = append(searchRequest.Query.Bool.Filter, query)
+}
+
+func (e *ElasticLogProxy) addTimeFilter(request *search.Request, timeFilter *platform.TimeFilter) error {
+	if timeFilter == nil {
+		return nil
+	}
+	if err := e.addTimeSort(request, timeFilter.Sort); err != nil {
+		return errors.Wrap(err, "Failed to unmarshal sort order")
+	}
+	if timeFilter.Since != nil || timeFilter.Until != nil {
+		rangeQuery := types.DateRangeQuery{}
+		// Date fields are stored in Elasticsearch in a standard format based on ISO 8601
+		// When you use range filters (like gte or lte), the values should be in this format:
+		// "2023-11-21T14:00:00Z"
+		if timeFilter.Since != nil {
+			rangeQuery.Gte = common.Pointer(timeFilter.Since.Format(time.RFC3339Nano))
+		}
+
+		if timeFilter.Until != nil {
+			rangeQuery.Lte = common.Pointer(timeFilter.Until.Format(time.RFC3339Nano))
+		}
+
+		request.Query.Bool.Filter = append(request.Query.Bool.Filter, types.Query{
+			Range: map[string]types.RangeQuery{
+				"@timestamp": rangeQuery,
+			},
+		})
+	}
+	return nil
+}
+
+func (e *ElasticLogProxy) addTimeSort(request *search.Request, sort string) error {
+	if sort != "" {
+		var sortOrder sortorder.SortOrder
+		if err := sortOrder.UnmarshalText([]byte(sort)); err != nil {
+			return errors.Wrap(err, "Failed to unmarshal sort order")
+		}
+		request.Sort = []types.SortCombinations{
+			&types.SortOptions{
+				SortOptions: map[string]types.FieldSort{
+					"@timestamp": {
+						Order: &sortorder.Asc,
+					},
+				},
+			},
+			&types.SortOptions{
+				SortOptions: map[string]types.FieldSort{
+					"_id": {
+						Order: &sortorder.Asc,
+					},
+				},
+			},
+		}
+	}
+	return nil
 }

--- a/pkg/platform/kube/logProxy/elastic.go
+++ b/pkg/platform/kube/logProxy/elastic.go
@@ -35,6 +35,8 @@ import (
 	"github.com/nuclio/errors"
 )
 
+const distinctPodNamesFilter = "distinct_pod_names"
+
 type ElasticLogProxy struct {
 	client *elasticsearch.TypedClient
 
@@ -85,7 +87,7 @@ func (e *ElasticLogProxy) GetFunctionReplicas(ctx context.Context, options *GetF
 
 	// aggregate by pod names
 	searchRequest.Aggregations = map[string]types.Aggregations{
-		"distinct_pod_names": {
+		distinctPodNamesFilter: {
 			Terms: &types.TermsAggregation{
 				Field: common.Pointer("kubernetes.pod.name"),
 				Size:  common.Pointer(100000),
@@ -101,7 +103,7 @@ func (e *ElasticLogProxy) GetFunctionReplicas(ctx context.Context, options *GetF
 		return nil, errors.Wrap(err, "Failed to execute search")
 	}
 
-	agg, ok := resp.Aggregations["distinct_pod_names"]
+	agg, ok := resp.Aggregations[distinctPodNamesFilter]
 	if !ok {
 		return nil, errors.New("Failed to get 'distinct_pod_names' in response from ElasticSearch")
 	}

--- a/pkg/platform/kube/logProxy/elastic_test.go
+++ b/pkg/platform/kube/logProxy/elastic_test.go
@@ -1,3 +1,5 @@
+//go:build test_unit
+
 /*
 Copyright 2025 The Nuclio Authors.
 

--- a/pkg/platform/kube/logProxy/elastic_test.go
+++ b/pkg/platform/kube/logProxy/elastic_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package logProxy
+
+/*
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ElasticTestSuite struct {
+	suite.Suite
+	proxier *ElasticLogProxy
+	ctx     context.Context
+}
+
+func (suite *ElasticTestSuite) SetupSuite() {
+	var err error
+	suite.proxier, err = NewElasticLogProxy(&platformconfig.ElasticSearchConfig{
+		URL:                  "",
+		Username:             "",
+		Password:             "",
+		Index:                "filebeat-vmdev93-default-tenant-*",
+		CustomQueryParameter: "system-id=\"vmdev93\"",
+		SSLVerificationMode:  "none",
+	})
+	suite.Require().NoError(err, "Failed to create proxier")
+	suite.ctx = context.Background()
+}
+
+func (suite *ElasticTestSuite) TestGetFunctionReplicas() {
+	replicas, err := suite.proxier.GetFunctionReplicas(suite.ctx, &GetFunctionReplicaOptions{FunctionName: "hello"})
+	suite.Require().NoError(err)
+	//suite.Require().Len(replicas, 1)
+	var logs io.ReadCloser
+	//yday := time.Date(2025, 5, 13, 0, 0, 0, 0, time.UTC)
+	options := platform.NewProxyFunctionLogsOptions("hello")
+	options.Size = 100
+	options.ReplicaNames = replicas
+	options.LogLevels = []string{"debug"}
+	logs, err = suite.proxier.ProxyFunctionLogs(suite.ctx, options)
+
+	body, err := io.ReadAll(logs)
+	suite.Require().NotEqual(0, len(body))
+
+}
+
+func TestElasticTestSuite(t *testing.T) {
+	suite.Run(t, new(ElasticTestSuite))
+}
+
+*/

--- a/pkg/platform/kube/logProxy/elastic_test.go
+++ b/pkg/platform/kube/logProxy/elastic_test.go
@@ -31,35 +31,33 @@ import (
 
 type ElasticTestSuite struct {
 	suite.Suite
-	proxier *ElasticLogProxy
+	proxy *ElasticLogProxy
 	ctx     context.Context
 }
-
+// fill in the configuration for ElasticSearch
 func (suite *ElasticTestSuite) SetupSuite() {
 	var err error
-	suite.proxier, err = NewElasticLogProxy(&platformconfig.ElasticSearchConfig{
+	suite.proxy, err = NewElasticLogProxy(&platformconfig.ElasticSearchConfig{
 		URL:                  "",
 		Username:             "",
 		Password:             "",
-		Index:                "filebeat-vmdev93-default-tenant-*",
-		CustomQueryParameter: "system-id=\"vmdev93\"",
+		Index:                "filebeat-<system-id>-<namespace>-*",
+		CustomQueryParameter: "system-id=\"system-id\"",
 		SSLVerificationMode:  "none",
 	})
-	suite.Require().NoError(err, "Failed to create proxier")
+	suite.Require().NoError(err, "Failed to create proxy")
 	suite.ctx = context.Background()
 }
 
 func (suite *ElasticTestSuite) TestGetFunctionReplicas() {
-	replicas, err := suite.proxier.GetFunctionReplicas(suite.ctx, &GetFunctionReplicaOptions{FunctionName: "hello"})
+	replicas, err := suite.proxy.GetFunctionReplicas(suite.ctx, &GetFunctionReplicaOptions{FunctionName: "hello"})
 	suite.Require().NoError(err)
-	//suite.Require().Len(replicas, 1)
 	var logs io.ReadCloser
-	//yday := time.Date(2025, 5, 13, 0, 0, 0, 0, time.UTC)
 	options := platform.NewProxyFunctionLogsOptions("hello")
 	options.Size = 100
 	options.ReplicaNames = replicas
 	options.LogLevels = []string{"debug"}
-	logs, err = suite.proxier.ProxyFunctionLogs(suite.ctx, options)
+	logs, err = suite.proxy.ProxyFunctionLogs(suite.ctx, options)
 
 	body, err := io.ReadAll(logs)
 	suite.Require().NotEqual(0, len(body))

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -639,21 +639,37 @@ func (p *Platform) RedeployFunction(ctx context.Context, redeployFunctionOptions
 	return nil
 }
 
-func (p *Platform) GetFunctionReplicaLogsStream(ctx context.Context,
-	options *platform.GetFunctionReplicaLogsStreamOptions) (io.ReadCloser, error) {
-	return p.consumer.KubeClientSet.
-		CoreV1().
-		Pods(options.Namespace).
-		GetLogs(options.Name, &v1.PodLogOptions{
-			Container:    options.ContainerName,
-			SinceSeconds: options.SinceSeconds,
-			TailLines:    options.TailLines,
-			Follow:       options.Follow,
-		}).
-		Stream(ctx)
+func (p *Platform) ProxyFunctionLogs(ctx context.Context,
+	options interface{}) (io.ReadCloser, error) {
+	switch typedOptions := options.(type) {
+	case *platform.GetFunctionReplicaLogsStreamOptions:
+		return p.consumer.KubeClientSet.
+			CoreV1().
+			Pods(typedOptions.Namespace).
+			GetLogs(typedOptions.Name, &v1.PodLogOptions{
+				Container:    typedOptions.ContainerName,
+				SinceSeconds: typedOptions.SinceSeconds,
+				TailLines:    typedOptions.TailLines,
+				Follow:       typedOptions.Follow,
+			}).
+			Stream(ctx)
+	case *platform.ProxyFunctionLogsOptions:
+		switch typedOptions.Source {
+		case platform.ProxyLogsSourceES:
+			return p.elasticSearchClient.ProxyFunctionLogs(ctx, typedOptions)
+		case platform.ProxyLogsSourceK8s:
+			// TODO: add k8s proxy logs
+			// for now just return an error and recommend using another API
+			return nil, errors.New("K8s proxy logs not implemented, please use /logs/{replicaName} api")
+		default:
+			return nil, errors.New("Unknown logs source")
+		}
+	default:
+		return nil, errors.New("Unsupported options type")
+	}
 }
 
-func (p *Platform) GetFunctionReplicaNames(ctx context.Context,
+func (p *Platform) GetFunctionActiveReplicaNames(ctx context.Context,
 	function platform.Function, permissionOptions opa.PermissionOptions) ([]string, error) {
 
 	functions, err := p.Platform.FilterFunctionsByPermissions(ctx, &permissionOptions, []platform.Function{function})
@@ -679,6 +695,24 @@ func (p *Platform) GetFunctionReplicaNames(ctx context.Context,
 		names = append(names, pod.GetName())
 	}
 	return names, nil
+}
+
+func (p *Platform) GetFunctionAllReplicaNames(ctx context.Context, function platform.Function, permissionOptions opa.PermissionOptions, timeFilter *platform.TimeFilter) ([]string, error) {
+
+	functions, err := p.Platform.FilterFunctionsByPermissions(ctx, &permissionOptions, []platform.Function{function})
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to filter functions by permissions")
+	}
+
+	if len(functions) == 0 {
+		// Function was filtered out by permissions, return not found error
+		return nil, nuclio.NewErrNotFound(fmt.Sprintf("Function not found - %s", function.GetConfig().Meta.Name))
+	}
+
+	return p.elasticSearchClient.GetFunctionReplicas(ctx, &logProxy.GetFunctionReplicaOptions{
+		TimeFilter:   timeFilter,
+		FunctionName: function.GetConfig().Meta.Name,
+	})
 }
 
 func (p *Platform) GetFunctionReplicaContainers(ctx context.Context, functionConfig *functionconfig.Config, replicaName string) ([]string, error) {

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -68,6 +68,7 @@ type Platform struct {
 	projectsCache       *cache.Expiring
 	apiGatewayScrubber  *platform.APIGatewayScrubber
 	elasticSearchClient *logProxy.ElasticLogProxy
+	defaultProxySource  platform.ProxyLogsSource
 }
 
 const Mib = 1048576
@@ -144,12 +145,16 @@ func NewPlatform(ctx context.Context,
 		return nil, errors.Wrap(err, "Failed to create an updater")
 	}
 
+	newPlatform.defaultProxySource = platform.ProxyLogsSourceK8s
+
 	if platformConfiguration.Kube.ElasticSearchConfig != nil {
 		// create elastic search client
 		newPlatform.elasticSearchClient, err = logProxy.NewElasticLogProxy(platformConfiguration.Kube.ElasticSearchConfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to create elasticsearch client")
 		}
+
+		newPlatform.defaultProxySource = platform.ProxyLogsSourceES
 	}
 	// set kubeClientSet for Function Scrubber
 	newPlatform.FunctionScrubber = functionconfig.NewScrubber(parentLogger,
@@ -639,6 +644,10 @@ func (p *Platform) RedeployFunction(ctx context.Context, redeployFunctionOptions
 	return nil
 }
 
+func (p *Platform) GetDefaultProxyLogsSource() platform.ProxyLogsSource {
+	return p.defaultProxySource
+}
+
 func (p *Platform) ProxyFunctionLogs(ctx context.Context,
 	options interface{}) (io.ReadCloser, error) {
 	switch typedOptions := options.(type) {
@@ -709,10 +718,15 @@ func (p *Platform) GetFunctionAllReplicaNames(ctx context.Context, function plat
 		return nil, nuclio.NewErrNotFound(fmt.Sprintf("Function not found - %s", function.GetConfig().Meta.Name))
 	}
 
-	return p.elasticSearchClient.GetFunctionReplicas(ctx, &logProxy.GetFunctionReplicaOptions{
-		TimeFilter:   timeFilter,
-		FunctionName: function.GetConfig().Meta.Name,
-	})
+	switch p.defaultProxySource {
+	case platform.ProxyLogsSourceES:
+		return p.elasticSearchClient.GetFunctionReplicas(ctx, &logProxy.GetFunctionReplicaOptions{
+			TimeFilter:   timeFilter,
+			FunctionName: function.GetConfig().Meta.Name,
+		})
+	default:
+		return nil, nil
+	}
 }
 
 func (p *Platform) GetFunctionReplicaContainers(ctx context.Context, functionConfig *functionconfig.Config, replicaName string) ([]string, error) {

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -493,33 +493,40 @@ func (p *Platform) RedeployFunction(ctx context.Context, redeployFunctionOptions
 	return nil
 }
 
-func (p *Platform) GetFunctionReplicaLogsStream(ctx context.Context,
-	options *platform.GetFunctionReplicaLogsStreamOptions) (io.ReadCloser, error) {
+func (p *Platform) ProxyFunctionLogs(ctx context.Context, options interface{}) (io.ReadCloser, error) {
+	switch typedOptions := options.(type) {
+	case *platform.GetFunctionReplicaLogsStreamOptions:
+		sinceDuration := ""
+		if typedOptions.SinceSeconds != nil {
+			sinceDuration = (time.Second * time.Duration(*typedOptions.SinceSeconds)).String()
+		}
 
-	sinceDuration := ""
-	if options.SinceSeconds != nil {
-		sinceDuration = (time.Second * time.Duration(*options.SinceSeconds)).String()
+		tail := ""
+		if typedOptions.TailLines != nil {
+			tail = strconv.FormatInt(*typedOptions.TailLines, 10)
+		}
+
+		return p.dockerClient.GetContainerLogStream(ctx,
+			typedOptions.Name,
+			&dockerclient.ContainerLogsOptions{
+				Follow: typedOptions.Follow,
+				Since:  sinceDuration,
+				Tail:   tail,
+			})
+	default:
+		return nil, errors.New("Unsupported options type")
 	}
-
-	tail := ""
-	if options.TailLines != nil {
-		tail = strconv.FormatInt(*options.TailLines, 10)
-	}
-
-	return p.dockerClient.GetContainerLogStream(ctx,
-		options.Name,
-		&dockerclient.ContainerLogsOptions{
-			Follow: options.Follow,
-			Since:  sinceDuration,
-			Tail:   tail,
-		})
 }
 
-func (p *Platform) GetFunctionReplicaNames(ctx context.Context,
+func (p *Platform) GetFunctionActiveReplicaNames(ctx context.Context,
 	function platform.Function, permissionOptions opa.PermissionOptions) ([]string, error) {
 	return []string{
 		p.GetFunctionContainerName(function.GetConfig()),
 	}, nil
+}
+
+func (p *Platform) GetFunctionAllReplicaNames(ctx context.Context, function platform.Function, permissionOptions opa.PermissionOptions, filter *platform.TimeFilter) ([]string, error) {
+	return nil, nil
 }
 
 func (p *Platform) GetFunctionReplicaContainers(ctx context.Context, functionConfig *functionconfig.Config, replicaName string) ([]string, error) {

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -518,6 +518,10 @@ func (p *Platform) ProxyFunctionLogs(ctx context.Context, options interface{}) (
 	}
 }
 
+func (p *Platform) GetDefaultProxyLogsSource() platform.ProxyLogsSource {
+	return platform.ProxyLogsSourceLocal
+}
+
 func (p *Platform) GetFunctionActiveReplicaNames(ctx context.Context,
 	function platform.Function, permissionOptions opa.PermissionOptions) ([]string, error) {
 	return []string{

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -143,14 +143,20 @@ func (mp *Platform) FilterFunctionsByPermissions(ctx context.Context,
 	return args.Get(0).([]platform.Function), args.Error(1)
 }
 
-// GetFunctionReplicaLogsStream return the function instance (Kubernetes - Pod / Docker - Container) logs stream
-func (mp *Platform) GetFunctionReplicaLogsStream(ctx context.Context, options *platform.GetFunctionReplicaLogsStreamOptions) (io.ReadCloser, error) {
+// ProxyFunctionLogs return the function instance (Kubernetes - Pod / Docker - Container) logs stream
+func (mp *Platform) ProxyFunctionLogs(ctx context.Context, options interface{}) (io.ReadCloser, error) {
 	args := mp.Called(ctx, options)
 	return args.Get(0).(io.ReadCloser), args.Error(1)
 }
 
-// GetFunctionReplicaNames returns function replica names (Pod / Container names)
-func (mp *Platform) GetFunctionReplicaNames(ctx context.Context, function platform.Function, permissionOptions opa.PermissionOptions) ([]string, error) {
+// GetFunctionActiveReplicaNames returns function active replica names (Pod / Container names)
+func (mp *Platform) GetFunctionActiveReplicaNames(ctx context.Context, function platform.Function, permissionOptions opa.PermissionOptions) ([]string, error) {
+	args := mp.Called(ctx, function, permissionOptions)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+// GetFunctionAllReplicaNames returns function all replica names (active + old) (Pod / Container names)
+func (mp *Platform) GetFunctionAllReplicaNames(ctx context.Context, function platform.Function, permissionOptions opa.PermissionOptions, filter *platform.TimeFilter) ([]string, error) {
 	args := mp.Called(ctx, function, permissionOptions)
 	return args.Get(0).([]string), args.Error(1)
 }

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -149,6 +149,12 @@ func (mp *Platform) ProxyFunctionLogs(ctx context.Context, options interface{}) 
 	return args.Get(0).(io.ReadCloser), args.Error(1)
 }
 
+// GetDefaultProxyLogsSource returns the default proxy source for a platform
+func (mp *Platform) GetDefaultProxyLogsSource() platform.ProxyLogsSource {
+	args := mp.Called()
+	return args.Get(0).(platform.ProxyLogsSource)
+}
+
 // GetFunctionActiveReplicaNames returns function's active replica names (Pod / Container names)
 func (mp *Platform) GetFunctionActiveReplicaNames(ctx context.Context, function platform.Function, permissionOptions opa.PermissionOptions) ([]string, error) {
 	args := mp.Called(ctx, function, permissionOptions)

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -149,7 +149,7 @@ func (mp *Platform) ProxyFunctionLogs(ctx context.Context, options interface{}) 
 	return args.Get(0).(io.ReadCloser), args.Error(1)
 }
 
-// GetFunctionActiveReplicaNames returns function active replica names (Pod / Container names)
+// GetFunctionActiveReplicaNames returns function's active replica names (Pod / Container names)
 func (mp *Platform) GetFunctionActiveReplicaNames(ctx context.Context, function platform.Function, permissionOptions opa.PermissionOptions) ([]string, error) {
 	args := mp.Called(ctx, function, permissionOptions)
 	return args.Get(0).([]string), args.Error(1)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -86,10 +86,10 @@ type Platform interface {
 	// ProxyFunctionLogs return the function logs stream
 	ProxyFunctionLogs(context.Context, interface{}) (io.ReadCloser, error)
 
-	// GetFunctionActiveReplicaNames returns function active replica names (Pod / Container names)
+	// GetFunctionActiveReplicaNames returns function's active replica names (Pod / Container names)
 	GetFunctionActiveReplicaNames(context.Context, Function, opa.PermissionOptions) ([]string, error)
 
-	// GetFunctionAllReplicaNames returns function all replica names (active + old Pods)
+	// GetFunctionAllReplicaNames returns all function replica names (active + old pods / containers)
 	GetFunctionAllReplicaNames(context.Context, Function, opa.PermissionOptions, *TimeFilter) ([]string, error)
 
 	// GetFunctionReplicaContainers returns function replica containers (Pod / Container names)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -83,11 +83,14 @@ type Platform interface {
 	// GetDefaultInvokeIPAddresses will return a list of ip addresses to be used by the platform to invoke a function
 	GetDefaultInvokeIPAddresses() ([]string, error)
 
-	// GetFunctionReplicaLogsStream return the function instance (Kubernetes - Pod / Docker - Container) logs stream
-	GetFunctionReplicaLogsStream(context.Context, *GetFunctionReplicaLogsStreamOptions) (io.ReadCloser, error)
+	// ProxyFunctionLogs return the function logs stream
+	ProxyFunctionLogs(context.Context, interface{}) (io.ReadCloser, error)
 
-	// GetFunctionReplicaNames returns function replica names (Pod / Container names)
-	GetFunctionReplicaNames(context.Context, Function, opa.PermissionOptions) ([]string, error)
+	// GetFunctionActiveReplicaNames returns function active replica names (Pod / Container names)
+	GetFunctionActiveReplicaNames(context.Context, Function, opa.PermissionOptions) ([]string, error)
+
+	// GetFunctionAllReplicaNames returns function all replica names (active + old Pods)
+	GetFunctionAllReplicaNames(context.Context, Function, opa.PermissionOptions, *TimeFilter) ([]string, error)
 
 	// GetFunctionReplicaContainers returns function replica containers (Pod / Container names)
 	GetFunctionReplicaContainers(context.Context, *functionconfig.Config, string) ([]string, error)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -86,6 +86,9 @@ type Platform interface {
 	// ProxyFunctionLogs return the function logs stream
 	ProxyFunctionLogs(context.Context, interface{}) (io.ReadCloser, error)
 
+	// GetDefaultProxyLogsSource returns the default proxy source for a platform
+	GetDefaultProxyLogsSource() ProxyLogsSource
+
 	// GetFunctionActiveReplicaNames returns function's active replica names (Pod / Container names)
 	GetFunctionActiveReplicaNames(context.Context, Function, opa.PermissionOptions) ([]string, error)
 

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -135,8 +135,9 @@ type GetFunctionsOptions struct {
 type ProxyLogsSource string
 
 const (
-	ProxyLogsSourceES  ProxyLogsSource = "elasticsearch"
-	ProxyLogsSourceK8s ProxyLogsSource = "kubernetes"
+	ProxyLogsSourceES    ProxyLogsSource = "elasticsearch"
+	ProxyLogsSourceK8s   ProxyLogsSource = "kubernetes"
+	ProxyLogsSourceLocal ProxyLogsSource = "local"
 )
 
 type ProxyFunctionLogsOptions struct {

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -152,6 +152,17 @@ type ProxyFunctionLogsOptions struct {
 	SearchAfter []string `json:"searchAfter,omitempty"`
 
 	Source ProxyLogsSource `json:"source,omitempty"`
+
+	// populated internally
+	functionName string
+}
+
+func (p *ProxyFunctionLogsOptions) GetFunctionName() string {
+	return p.functionName
+}
+
+func NewProxyFunctionLogsOptions(functionName string) *ProxyFunctionLogsOptions {
+	return &ProxyFunctionLogsOptions{functionName: functionName}
 }
 
 type TimeFilter struct {

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -272,7 +272,7 @@ func (ar *AbstractResource) GetURLParamValues(paramKey string, request *http.Req
 	return values
 }
 
-func (ar *AbstractResource) GetURLParamStringValues(paramKey string, request *http.Request) []string {
+func (ar *AbstractResource) GetURLParamStringSliceValues(paramKey string, request *http.Request) []string {
 	paramValues, ok := request.URL.Query()[paramKey]
 	if !ok || len(paramValues) == 0 {
 		return nil

--- a/pkg/restful/resource.go
+++ b/pkg/restful/resource.go
@@ -272,6 +272,23 @@ func (ar *AbstractResource) GetURLParamValues(paramKey string, request *http.Req
 	return values
 }
 
+func (ar *AbstractResource) GetURLParamStringValues(paramKey string, request *http.Request) []string {
+	paramValues, ok := request.URL.Query()[paramKey]
+	if !ok || len(paramValues) == 0 {
+		return nil
+	}
+
+	var values []string
+	for _, value := range paramValues {
+		parsed := ar.parseURLParamValue(value)
+		if strVal, ok := parsed.(string); ok {
+			values = append(values, strVal)
+		}
+	}
+
+	return values
+}
+
 func (ar *AbstractResource) GetURLParamValue(paramKey string, request *http.Request) interface{} {
 	paramValues, ok := request.URL.Query()[paramKey]
 	if !ok || len(paramValues) == 0 {


### PR DESCRIPTION
Jira - https://iguazio.atlassian.net/browse/NUC-430, https://iguazio.atlassian.net/browse/NUC-431

Within this PR:

* **New api `/function-name/proxy-logs` is added:**

Supported params:

```
type ProxyFunctionLogsOptions struct {
	// filtering options
	TimeFilter   *TimeFilter `json:"timeFilter,omitempty"`
	Substring    string      `json:"substring,omitempty"`
	Regexp       string      `json:"regexp,omitempty"`
	ReplicaNames []string    `json:"replicaNames,omitempty"`
	LogLevels    []string    `json:"logLevels,omitempty"`

	// limit options
	Size        int64    `json:"size,omitempty"`
	SearchAfter []string `json:"searchAfter,omitempty"`

	Source ProxyLogsSource `json:"source,omitempty"`
}
```
```
type TimeFilter struct {
	Since *time.Time `json:"since,omitempty"`
	Until *time.Time `json:"until,omitempty"`

	Sort string `json:"sort,omitempty"` // desc or asc
}
```

<details>
  <summary>Click to see response example </summary>

```
{"took":24,"timed_out":false,"_shards":{"total":29,"successful":29,"skipped":0,"failed":0},"hits":{"total":{"value":7,"relation":"eq"},"max_score":null,"hits":[{"_index":".ds-filebeat-vmdev93-default-tenant-2025.04.25-2025.04.24-000001","_type":"_doc","_id":"PckubZYB9U8jGNigFSNF","_score":null,"_source":{"@timestamp":"2025-04-25T13:40:54.059Z","nuclio":{"project_name":"default"},"more":{"signal":"terminated"},"name":"hello","host":{"name":"log-forwarder-nm9hd"},"agent":{"name":"log-forwarder-nm9hd","type":"filebeat","version":"8.17.4","ephemeral_id":"dcb973fa-e378-47c8-a36f-3499dfc6ecb6","id":"55802e3f-55cd-4504-ab05-f7c93acd856e"},"ecs":{"version":"8.0.0"},"kubernetes":{"container":{"name":"nuclio"},"namespace":"default-tenant","node":{"name":"k8s-node3"},"pod":{"name":"nuclio-hello-85488958f5-kjzkh"}},"message":"Got system signal","tenant":"default-tenant","system-id":"vmdev93","level":"warn"},"sort":[1745588454059,"PckubZYB9U8jGNigFSNF"]},{"_index":".ds-filebeat-vmdev93-default-tenant-2025.04.25-2025.04.24-000001","_type":"_doc","_id":"78kwbZYB9U8jGNiggiO6","_score":null,"_source":{"@timestamp":"2025-04-25T13:43:31.219Z","kubernetes":{"container":{"name":"nuclio"},"namespace":"default-tenant","node":{"name":"k8s-node3"},"pod":{"name":"nuclio-hello-6c9799c89c-tz857"}},"nuclio":{"project_name":"default"},"name":"hello","host":{"name":"log-forwarder-nm9hd"},"system-id":"vmdev93","agent":{"version":"8.17.4","ephemeral_id":"dcb973fa-e378-47c8-a36f-3499dfc6ecb6","id":"55802e3f-55cd-4504-ab05-f7c93acd856e","name":"log-forwarder-nm9hd","type":"filebeat"},"ecs":{"version":"8.0.0"},"level":"warn","message":"Got system signal","more":{"signal":"terminated"},"tenant":"default-tenant"},"sort":[1745588611219,"78kwbZYB9U8jGNiggiO6"]},{"_index":".ds-filebeat-vmdev93-default-tenant-2025.04.25-2025.04.24-000001","_type":"_doc","_id":"tsk0bZYB9U8jGNigeiRr","_score":null,"_source":{"@timestamp":"2025-04-25T13:47:39.380Z","kubernetes":{"namespace":"default-tenant","node":{"name":"k8s-node3"},"pod":{"name":"nuclio-hello-7ddc68b7f7-dnwbm"},"container":{"name":"nuclio"}},"level":"warn","message":"Got system signal","more":{"signal":"terminated"},"system-id":"vmdev93","nuclio":{"project_name":"default"},"name":"hello","tenant":"default-tenant","ecs":{"version":"8.0.0"},"host":{"name":"log-forwarder-nm9hd"},"agent":{"version":"8.17.4","ephemeral_id":"dcb973fa-e378-47c8-a36f-3499dfc6ecb6","id":"55802e3f-55cd-4504-ab05-f7c93acd856e","name":"log-forwarder-nm9hd","type":"filebeat"}},"sort":[1745588859380,"tsk0bZYB9U8jGNigeiRr"]},{"_index":".ds-filebeat-vmdev93-default-tenant-2025.04.25-2025.04.24-000001","_type":"_doc","_id":"esk2bZYB9U8jGNigvSUb","_score":null,"_source":{"@timestamp":"2025-04-25T13:50:06.966Z","kubernetes":{"container":{"name":"nuclio"},"namespace":"default-tenant","node":{"name":"k8s-node3"},"pod":{"name":"nuclio-hello-7ff67c876c-c22f7"}},"level":"warn","name":"hello","tenant":"default-tenant","system-id":"vmdev93","nuclio":{"project_name":"default"},"message":"Got system signal","more":{"signal":"terminated"},"agent":{"name":"log-forwarder-nm9hd","type":"filebeat","version":"8.17.4","ephemeral_id":"dcb973fa-e378-47c8-a36f-3499dfc6ecb6","id":"55802e3f-55cd-4504-ab05-f7c93acd856e"},"ecs":{"version":"8.0.0"},"host":{"name":"log-forwarder-nm9hd"}},"sort":[1745589006966,"esk2bZYB9U8jGNigvSUb"]},{"_index":".ds-filebeat-vmdev93-default-tenant-2025.05.14-2025.05.14-000001","_type":"_doc","_id":"v9c5zpYB9U8jGNig5xs_","_score":null,"_source":{"@timestamp":"2025-05-14T09:56:59.001Z","more":{"signal":"terminated"},"tenant":"default-tenant","system-id":"vmdev93","ecs":{"version":"8.0.0"},"host":{"name":"log-forwarder-nr9mp"},"agent":{"type":"filebeat","version":"8.17.4","ephemeral_id":"5d8d0b75-321a-44e1-92b6-037f9544f4a2","id":"6f2fcadd-361f-4f2c-8e7d-f918c2efde8e","name":"log-forwarder-nr9mp"},"kubernetes":{"container":{"name":"nuclio"},"namespace":"default-tenant","node":{"name":"k8s-node2"},"pod":{"name":"nuclio-hello-5c47d58d89-279qc"}},"message":"Got system signal","name":"hello","nuclio":{"project_name":"default"},"level":"warn"},"sort":[1747216619001,"v9c5zpYB9U8jGNig5xs_"]},{"_index":".ds-filebeat-vmdev93-default-tenant-2025.05.15-2025.05.14-000001","_type":"_doc","_id":"9tc51JYB9U8jGNig4fru","_score":null,"_source":{"@timestamp":"2025-05-15T13:54:39.358Z","kubernetes":{"container":{"name":"nuclio"},"namespace":"default-tenant","node":{"name":"k8s-node2"},"pod":{"name":"nuclio-hello-c8846649c-bx99b"}},"message":"Got system signal","nuclio":{"project_name":"default"},"level":"warn","more":{"signal":"terminated"},"name":"hello","tenant":"default-tenant","system-id":"vmdev93","ecs":{"version":"8.0.0"},"host":{"name":"log-forwarder-nr9mp"},"agent":{"id":"6f2fcadd-361f-4f2c-8e7d-f918c2efde8e","name":"log-forwarder-nr9mp","type":"filebeat","version":"8.17.4","ephemeral_id":"5d8d0b75-321a-44e1-92b6-037f9544f4a2"}},"sort":[1747317279358,"9tc51JYB9U8jGNig4fru"]},{"_index":".ds-filebeat-vmdev93-default-tenant-2025.05.15-2025.05.14-000001","_type":"_doc","_id":"mNdX1JYB9U8jGNigk_yT","_score":null,"_source":{"@timestamp":"2025-05-15T14:27:00.472Z","host":{"name":"log-forwarder-nr9mp"},"kubernetes":{"node":{"name":"k8s-node2"},"pod":{"name":"nuclio-hello-5884964d9b-vs7pn"},"container":{"name":"nuclio"},"namespace":"default-tenant"},"nuclio":{"project_name":"default"},"name":"hello","tenant":"default-tenant","system-id":"vmdev93","level":"warn","message":"Got system signal","more":{"signal":"terminated"},"agent":{"name":"log-forwarder-nr9mp","type":"filebeat","version":"8.17.4","ephemeral_id":"5d8d0b75-321a-44e1-92b6-037f9544f4a2","id":"6f2fcadd-361f-4f2c-8e7d-f918c2efde8e"},"ecs":{"version":"8.0.0"}},"sort":[1747319220472,"mNdX1JYB9U8jGNigk_yT"]}]}}
```
</details>


*  **Also, `/function-name/replicas` api was extended and now has 2 new parameters:**
```
includeOffline bool // if set to true, will return offline replicas from ES, false by default
timeFilter *TimeFilter
```
```
type TimeFilter struct {
	Since *time.Time `json:"since,omitempty"`
	Until *time.Time `json:"until,omitempty"`

	Sort string `json:"sort,omitempty"` // desc or asc
}

```
if `includeOffline` isn't set, api will behave as before to keep BC. If new param is set, response will be:

```{"offlineReplicas":{"names":["nuclio-hello-5884964d9b-vs7pn","nuclio-hello-5c47d58d89-279qc","nuclio-hello-6c9799c89c-tz857","nuclio-hello-7ddc68b7f7-dnwbm","nuclio-hello-7ff67c876c-c22f7","nuclio-hello-85488958f5-kjzkh","nuclio-hello-c8846649c-bx99b"]},"replicas":{"names":["nuclio-hello-5884964d9b-2wqth"]}}```