### PR TITLE
[Wrapper] Use get_running_loop() with fallback to avoid DeprecationWarning in Python 3.12

### DIFF
--- a/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
@@ -276,7 +276,11 @@ def run_wrapper():
     # bind worker_id to the logger
     root_logger.bind(worker_id=args.worker_id)
 
-    loop = asyncio.get_event_loop()
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
     try:
 

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -190,7 +190,11 @@ def run_wrapper():
     # bind worker_id to the logger
     root_logger.bind(worker_id=args.worker_id)
 
-    loop = asyncio.get_event_loop()
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
     try:
 


### PR DESCRIPTION
This PR updates the logic for getting the asyncio event loop to be compatible with Python 3.12, which deprecates the use of asyncio.get_event_loop() when no event loop is set.

Previously, calling asyncio.get_event_loop() without a running loop would raise a DeprecationWarning in Python 3.12:
```
DeprecationWarning: There is no current event loop
```