### PR TITLE
[CI] Consolidate version resolution logic to a single conditional step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,6 +123,7 @@ jobs:
           
       - name: Set version to unstable
         if: github.event_name != 'workflow_dispatch'
+        id: resolve
         run: |
           echo "prev_version=" >> $GITHUB_OUTPUT
           echo "helm_version=" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,30 +105,26 @@ jobs:
           TARGET_VERSION: ${{ inputs.target_version }}
           HELM_TARGET_VERSION: ${{ inputs.helm_chart_target_version }}
 
-      - name: Resolve inputs for release
-        id: resolve
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          CURRENT_VERSION_INPUT=$(make get-current-version)
-          TARGET_VERSION_INPUT=$(make get-target-version)
-          HELM_VERSION_INPUT=$(make get-helm-target-version)
-          
-          echo "CURRENT_VERSION_INPUT=${CURRENT_VERSION_INPUT}"
-          echo "TARGET_VERSION_INPUT=${TARGET_VERSION_INPUT}"
-          echo "HELM_VERSION_INPUT=${HELM_VERSION_INPUT}"
-
-          echo "prev_version=${CURRENT_VERSION_INPUT}" >> $GITHUB_OUTPUT
-          echo "version=${TARGET_VERSION_INPUT}" >> $GITHUB_OUTPUT
-          echo "helm_version=${HELM_VERSION_INPUT}" >> $GITHUB_OUTPUT
-          
-      - name: Set version to unstable
-        if: github.event_name != 'workflow_dispatch'
+      - name: Resolve version inputs
         id: resolve
         run: |
-          echo "prev_version=" >> $GITHUB_OUTPUT
-          echo "helm_version=" >> $GITHUB_OUTPUT
-          echo "version=unstable" >> $GITHUB_OUTPUT
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            CURRENT_VERSION_INPUT=$(make get-current-version)
+            TARGET_VERSION_INPUT=$(make get-target-version)
+            HELM_VERSION_INPUT=$(make get-helm-target-version)
 
+            echo "CURRENT_VERSION_INPUT=${CURRENT_VERSION_INPUT}"
+            echo "TARGET_VERSION_INPUT=${TARGET_VERSION_INPUT}"
+            echo "HELM_VERSION_INPUT=${HELM_VERSION_INPUT}"
+
+            echo "prev_version=${CURRENT_VERSION_INPUT}" >> $GITHUB_OUTPUT
+            echo "version=${TARGET_VERSION_INPUT}" >> $GITHUB_OUTPUT
+            echo "helm_version=${HELM_VERSION_INPUT}" >> $GITHUB_OUTPUT
+          else
+            echo "prev_version=" >> $GITHUB_OUTPUT
+            echo "version=unstable" >> $GITHUB_OUTPUT
+            echo "helm_version=" >> $GITHUB_OUTPUT
+          fi
 
   release:
     name: Generate Changelog & Create Release


### PR DESCRIPTION
This PR simplifies and fixes the version resolution logic in the release workflow by consolidating both paths (workflow_dispatch and others) into a single step with internal conditional logic. This:

* Prevents duplicate step id: resolve, which causes validation failures

* Resolves the issue where version=unstable was not being set correctly