### PR TITLE
[Dashboard] Fix streaming memory spike

### DIFF
--- a/pkg/restful/middleware/middleware.go
+++ b/pkg/restful/middleware/middleware.go
@@ -17,9 +17,7 @@ limitations under the License.
 package middleware
 
 import (
-	"bytes"
 	"context"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -84,20 +82,11 @@ func AlignRequestIDKeyToZapLogger(next http.Handler) http.Handler {
 func RequestResponseLogger(logger logger.Logger) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, request *http.Request) {
-			responseBodyBuffer := bytes.Buffer{}
-
 			// create a response wrapper so we can access stuff
 			responseWrapper := middleware.NewWrapResponseWriter(w, request.ProtoMajor)
-			responseWrapper.Tee(&responseBodyBuffer)
 
 			// take start time
 			requestStartTime := time.Now()
-
-			// get request body
-			requestBody, _ := io.ReadAll(request.Body)
-
-			// restore body for further processing
-			request.Body = io.NopCloser(bytes.NewBuffer(requestBody))
 
 			requestHeaders := request.Header.Clone() // for logging purposes
 			for _, headerToRedact := range []string{
@@ -115,7 +104,6 @@ func RequestResponseLogger(logger logger.Logger) func(next http.Handler) http.Ha
 					"Handled request",
 					"requestMethod", request.Method,
 					"requestPath", request.URL,
-					"requestBodyLen", len(requestBody),
 					"responseStatus", responseWrapper.Status(),
 					"responseTime", time.Since(requestStartTime).String())
 			}()


### PR DESCRIPTION
This PR modifies the RequestResponseLogger middleware to eliminate response body buffering using responseWrapper.Tee(), which was previously used for logging body len which is not functionally required. The change significantly reduces memory usage and avoids performance degradation under load.


Before 
Memory usage increase from ~30Mb to ~60-90Mb when streaming high load from ES.  
![image](https://github.com/user-attachments/assets/aca9e212-b8a3-4df0-b91c-c28bab463218)

After:
Memory increase from 34 to 37Mb under the same high load. 
![image](https://github.com/user-attachments/assets/65904c20-c05e-465b-9dd4-07fac9bcb520)
