### PR TITLE
[Processor] Do not limit metadata timeout by default aligning with default client behaviour

### DIFF
--- a/pkg/processor/trigger/kafka/kafka_test.go
+++ b/pkg/processor/trigger/kafka/kafka_test.go
@@ -484,9 +484,6 @@ func (suite *TestSuite) TestTimeoutFieldsConfiguration() {
 				configuration.adminTimeout)
 			suite.Require().Equal(
 				testCase.expectedTimeout,
-				configuration.metadataTimeout)
-			suite.Require().Equal(
-				testCase.expectedTimeout,
 				configuration.netDialTimeout)
 
 			// metadataRetryBackoff and adminRetryBackoff are set to 2 seconds by default
@@ -495,11 +492,19 @@ func (suite *TestSuite) TestTimeoutFieldsConfiguration() {
 					configuration.metadataRetryBackoff)
 				suite.Require().Equal(2*time.Second,
 					configuration.adminRetryBackoff)
+
+				// isn't limited by default
+				suite.Require().Equal(
+					time.Duration(0),
+					configuration.metadataTimeout)
 			} else {
 				suite.Require().Equal(testCase.expectedTimeout,
 					configuration.metadataRetryBackoff)
 				suite.Require().Equal(testCase.expectedTimeout,
 					configuration.adminRetryBackoff)
+				suite.Require().Equal(
+					testCase.expectedTimeout,
+					configuration.metadataTimeout)
 			}
 
 		})

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -510,7 +510,10 @@ func (k *kafka) newKafkaConfig() (*sarama.Config, error) {
 
 	config.Net.DialTimeout = k.configuration.netDialTimeout
 
-	config.Metadata.Timeout = k.configuration.metadataTimeout
+	if k.configuration.metadataTimeout != 0 {
+		config.Metadata.Timeout = k.configuration.metadataTimeout
+	}
+
 	config.Metadata.Retry.Backoff = k.configuration.metadataRetryBackoff
 	config.Metadata.Retry.Max = k.configuration.MetadataRetryMax
 

--- a/pkg/processor/trigger/kafka/types.go
+++ b/pkg/processor/trigger/kafka/types.go
@@ -351,7 +351,7 @@ func NewConfiguration(id string,
 			Name:    "wait for a successful metadata response",
 			Value:   newConfiguration.MetadataTimeout,
 			Field:   &newConfiguration.metadataTimeout,
-			Default: 15 * time.Second,
+			Default: 0, // do not limit by default
 		},
 		{
 			Name:    "wait between metadata retries",


### PR DESCRIPTION
While it makes sense to have default value for `AdmitTimeout` set explicitly to 15s (default is 3s). Setting timeout for metadata explicitly isn't needed as by default this value isn't limited.

Jira - https://iguazio.atlassian.net/browse/NUC-444  