### PR TITLE
[Processor] Add keepalive configuration for kafka connection

### DIFF
--- a/.github/styles/Nuclio/ignore.txt
+++ b/.github/styles/Nuclio/ignore.txt
@@ -73,3 +73,5 @@ Gurubase
 ACLs
 ACL
 substring
+kafka
+Kafka

--- a/docs/reference/triggers/kafka.md
+++ b/docs/reference/triggers/kafka.md
@@ -426,6 +426,14 @@ You can configure each attribute either in the `triggers.<trigger>.attributes.<a
   **Default Value:** `"15s"` (15 seconds)<!-- 15 * time.Second -->
   <!-- sarama `Net.DialTimeout ` -->
 
+- <a id="NetKeepAliveInterval"></a>**`netKeepAliveInterval`** (**`kafka-net-keep-alive-interval`**) - Keep alive interval for kafka connections.
+  <br/>
+  **Type:** `string` - a string containing one or more duration strings of the format `"[0-9]+[ns|us|ms|s|m|h]"`; for example, `"300ms"` (300 milliseconds) or `"2h45m"` (2 hours and 45 minutes). See the [`ParseDuration`](https://golang.org/pkg/time/#ParseDuration) Go function.
+  <br/>
+  **Default Value:** `"90s"` (90 seconds)<!-- 90 * time.Second -->
+  <!-- sarama `Net.DialTimeout ` -->
+
+
 <a id="rebalancing-config-choice"></a>
 ### Choosing the right configuration for rebalancing
 

--- a/pkg/processor/trigger/kafka/kafka_test.go
+++ b/pkg/processor/trigger/kafka/kafka_test.go
@@ -458,6 +458,7 @@ func (suite *TestSuite) TestTimeoutFieldsConfiguration() {
 				"netDialTimeout":       testCase.timeoutConfig,
 				"metadataRetryBackoff": testCase.timeoutConfig,
 				"adminRetryBackoff":    testCase.timeoutConfig,
+				"netKeepAliveInterval": testCase.timeoutConfig,
 			},
 		}
 
@@ -469,6 +470,7 @@ func (suite *TestSuite) TestTimeoutFieldsConfiguration() {
 				annotations["nuclio.io/kafka-admin-timeout"] = testCase.timeoutAnnotation
 				annotations["nuclio.io/kafka-metadata-retry-backoff"] = testCase.timeoutAnnotation
 				annotations["nuclio.io/kafka-admin-retry-backoff"] = testCase.timeoutAnnotation
+				annotations["nuclio.io/kafka-net-keep-alive-interval"] = testCase.timeoutAnnotation
 			}
 			configuration, err := NewConfiguration(testCase.name,
 				triggerInstance,
@@ -497,6 +499,9 @@ func (suite *TestSuite) TestTimeoutFieldsConfiguration() {
 				suite.Require().Equal(
 					time.Duration(0),
 					configuration.metadataTimeout)
+
+				suite.Require().Equal(90*time.Second,
+					configuration.netKeepAliveInterval)
 			} else {
 				suite.Require().Equal(testCase.expectedTimeout,
 					configuration.metadataRetryBackoff)
@@ -505,6 +510,9 @@ func (suite *TestSuite) TestTimeoutFieldsConfiguration() {
 				suite.Require().Equal(
 					testCase.expectedTimeout,
 					configuration.metadataTimeout)
+				suite.Require().Equal(
+					testCase.expectedTimeout,
+					configuration.netKeepAliveInterval)
 			}
 
 		})

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -509,6 +509,7 @@ func (k *kafka) newKafkaConfig() (*sarama.Config, error) {
 	config.Admin.Retry.Max = k.configuration.AdminRetryMax
 
 	config.Net.DialTimeout = k.configuration.netDialTimeout
+	config.Net.KeepAlive = k.configuration.netKeepAliveInterval
 
 	if k.configuration.metadataTimeout != 0 {
 		config.Metadata.Timeout = k.configuration.metadataTimeout

--- a/pkg/processor/trigger/kafka/types.go
+++ b/pkg/processor/trigger/kafka/types.go
@@ -82,6 +82,7 @@ type Configuration struct {
 	MetadataRetryBackoff          string
 	MetadataRetryMax              int
 	NetDialTimeout                string
+	NetKeepAliveInterval          string
 	WorkerAllocationMode          partitionworker.AllocationMode
 	RebalanceRetryMax             int
 	FetchMin                      int
@@ -113,6 +114,7 @@ type Configuration struct {
 	metadataTimeout                       time.Duration
 	metadataRetryBackoff                  time.Duration
 	netDialTimeout                        time.Duration
+	netKeepAliveInterval                  time.Duration
 	ackWindowSize                         int
 }
 
@@ -205,6 +207,9 @@ func NewConfiguration(id string,
 
 		// max retry for admin
 		{Key: "nuclio.io/kafka-admin-retry-max", ValueInt: &newConfiguration.AdminRetryMax},
+
+		// net keep alive interval
+		{Key: "nuclio.io/kafka-net-keep-alive-interval", ValueString: &newConfiguration.NetKeepAliveInterval},
 	})
 
 	if err != nil {
@@ -364,6 +369,13 @@ func NewConfiguration(id string,
 			Value:   newConfiguration.NetDialTimeout,
 			Field:   &newConfiguration.netDialTimeout,
 			Default: 15 * time.Second,
+		},
+		// often required for confluent cloud as connections' lifetime is short there
+		{
+			Name:    "default keep alive time",
+			Value:   newConfiguration.NetKeepAliveInterval,
+			Field:   &newConfiguration.netKeepAliveInterval,
+			Default: 90 * time.Second,
 		},
 	} {
 		if err = newConfiguration.ParseDurationOrDefault(&durationConfigField); err != nil {


### PR DESCRIPTION
Add keepalive configuration for kafka connection, default is 90s. 
Jira - https://iguazio.atlassian.net/browse/NUC-445