### PR TITLE
[Dashboard] Add defaultProxyLogsSource to frontend spec and remove logsScreenEnabled

### DIFF
--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -210,8 +210,6 @@ spec:
           value: {{ template "nuclio.externalIPAddresses" . }}
         - name: NUCLIO_DASHBOARD_IMAGE_NAME_PREFIX_TEMPLATE
           value: {{ .Values.dashboard.imageNamePrefixTemplate | quote }}
-        - name: NUCLIO_DASHBOARD_LOGS_SCREEN_ENABLED
-          value: {{ .Values.dashboard.logsScreenEnabled | quote }}
       {{- if .Values.dashboard.opa.enabled }}
       - name: {{ template "nuclio.name" . }}-{{ .Values.dashboard.opa.name }}
         securityContext:

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -294,8 +294,6 @@ dashboard:
   # Note: secret name must contain "pip-ca-certificates.crt" key
   pipCACertSecretName: ""
 
-  logsScreenEnabled: false
-
 autoscaler:
   enabled: false
   replicas: 1

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -84,7 +84,6 @@ func (fsr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restfu
 	validFunctionPriorityClassNames := fsr.resolveValidFunctionPriorityClassNames()
 	defaultFunctionPodResources := fsr.resolveDefaultFunctionPodResources()
 	autoScaleMetrics := fsr.resolveAutoScaleMetrics(inactivityWindowPresets)
-	logsScreenEnabled := fsr.isLogsScreenEnabled()
 
 	frontendSpec := map[string]restful.Attributes{
 		"frontendSpec": { // frontendSpec is the ID of this singleton resource
@@ -100,7 +99,7 @@ func (fsr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restfu
 			"defaultFunctionPodResources":     defaultFunctionPodResources,
 			"autoScaleMetrics":                autoScaleMetrics,
 			"disableDefaultHttpTrigger":       fsr.getPlatform().GetDisableDefaultHttpTrigger(),
-			"logsScreenEnabled":               logsScreenEnabled,
+			"defaultProxyLogsSource":          fsr.getPlatform().GetDefaultProxyLogsSource(),
 		},
 	}
 
@@ -283,12 +282,6 @@ func (fsr *frontendSpecResource) getDefaultHTTPIngressHostTemplate() string {
 
 	return common.GetEnvOrDefaultString(
 		"NUCLIO_DASHBOARD_HTTP_INGRESS_HOST_TEMPLATE", "")
-}
-
-func (fsr *frontendSpecResource) isLogsScreenEnabled() bool {
-	// This is a workaround until a BE log solution is implemented
-	return common.GetEnvOrDefaultBool(
-		"NUCLIO_DASHBOARD_LOGS_SCREEN_ENABLED", false)
 }
 
 // register the resource

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -3636,6 +3636,11 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
 		Return(false).
 		Once()
 
+	suite.mockPlatform.
+		On("GetDefaultProxyLogsSource").
+		Return(platform.ProxyLogsSourceK8s).
+		Once()
+
 	expectedStatusCode := http.StatusOK
 	expectedResponseBody := `{
     "defaultFunctionConfig": {
@@ -3765,7 +3770,7 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
 			"2m"
 		]
 	},
-	"logsScreenEnabled": false
+	"defaultProxyLogsSource": "kubernetes"
 }`
 
 	suite.sendRequest("GET",


### PR DESCRIPTION
* Add `defaultProxyLogsSource` to frontend spec
*  remove `logsScreenEnabled` from frontend spec (was never used and not needed anymore )
Jira - https://iguazio.atlassian.net/browse/NUC-454