### PR TITLE
[Controller] Enrich probes during populate deployment container

### DIFF
--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -221,9 +221,7 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 					"namespace", function.Namespace)
 				return nil
 			}
-
 		}
-
 	}
 
 	// wait for up to the default readiness timeout or whatever was set in the spec

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2487,10 +2487,11 @@ func (lc *lazyClient) populateDeploymentContainer(ctx context.Context,
 		})
 	}
 
-	defaultPlatformConfiguration := platformconfig.GetDefaultPlatformConfiguration()
-
 	// enrichment ensures backward compatibility for functions created with controller versions < v1.14.5, where probes may be nil
+	defaultPlatformConfiguration := platformconfig.GetDefaultPlatformConfiguration()
 	common.EnrichProbe(&function.Spec.ReadinessProbe, defaultPlatformConfiguration.Kube.DefaultReadinessProbe)
+	common.EnrichProbe(&function.Spec.LivenessProbe, defaultPlatformConfiguration.Kube.DefaultLivenessProbe)
+
 	container.ReadinessProbe = &v1.Probe{
 		ProbeHandler: v1.ProbeHandler{
 			HTTPGet: &v1.HTTPGetAction{
@@ -2504,8 +2505,6 @@ func (lc *lazyClient) populateDeploymentContainer(ctx context.Context,
 		FailureThreshold:    function.Spec.ReadinessProbe.FailureThreshold,
 	}
 
-	// enrichment ensures backward compatibility for functions created with controller versions < v1.14.5, where probes may be nil
-	common.EnrichProbe(&function.Spec.LivenessProbe, defaultPlatformConfiguration.Kube.DefaultLivenessProbe)
 	container.LivenessProbe = &v1.Probe{
 		ProbeHandler: v1.ProbeHandler{
 			HTTPGet: &v1.HTTPGetAction{

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2487,6 +2487,10 @@ func (lc *lazyClient) populateDeploymentContainer(ctx context.Context,
 		})
 	}
 
+	defaultPlatformConfiguration := platformconfig.GetDefaultPlatformConfiguration()
+
+	// enrichment ensures backward compatibility for functions created with controller versions < v1.14.5, where probes may be nil
+	common.EnrichProbe(&function.Spec.ReadinessProbe, defaultPlatformConfiguration.Kube.DefaultReadinessProbe)
 	container.ReadinessProbe = &v1.Probe{
 		ProbeHandler: v1.ProbeHandler{
 			HTTPGet: &v1.HTTPGetAction{
@@ -2500,6 +2504,8 @@ func (lc *lazyClient) populateDeploymentContainer(ctx context.Context,
 		FailureThreshold:    function.Spec.ReadinessProbe.FailureThreshold,
 	}
 
+	// enrichment ensures backward compatibility for functions created with controller versions < v1.14.5, where probes may be nil
+	common.EnrichProbe(&function.Spec.LivenessProbe, defaultPlatformConfiguration.Kube.DefaultLivenessProbe)
 	container.LivenessProbe = &v1.Probe{
 		ProbeHandler: v1.ProbeHandler{
 			HTTPGet: &v1.HTTPGetAction{

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -754,24 +754,41 @@ func (suite *lazyTestSuite) TestEnrichDeploymentFromPlatformConfiguration() {
 
 func (suite *lazyTestSuite) TestEnrichProbesInPopulateDeploymentContainer() {
 	// Prepare
-	functionInstance := suite.getFunctionInstanceWithDefaultProbes("test-enrich-probes-function")
-	testFunctionLabels := suite.client.getFunctionLabels(functionInstance)
-	testContainer := &v1.Container{}
+	for _, testCase := range []struct {
+		name              string
+		functionInstance *nuclioio.NuclioFunction
+	}{
+		{
+			name:              "test-enrich-probes-function",
+			functionInstance: suite.getFunctionInstanceWithDefaultProbes("test-enrich-probes-function"),
+		},{
+			// Test backward compatibility for functions created with controller versions < v1.14.5, where probes are nil.
+			// After an upgrade, the new controller will access these fields.
+			name:              "test-empty-probes-function",
+			functionInstance: &nuclioio.NuclioFunction{},
+		},
 
-	// Populate the container with configuration from the function instance
-	suite.client.populateDeploymentContainer(suite.ctx, testFunctionLabels, functionInstance, testContainer)
+	} {
+		suite.Run(testCase.name, func() {
+			testFunctionLabels := suite.client.getFunctionLabels(testCase.functionInstance)
+			testContainer := &v1.Container{}
 
-	// Verify readinessProbe is populated with default values
-	suite.Require().Equal(testContainer.ReadinessProbe.InitialDelaySeconds, platformconfig.DefaultReadinessProbeConfiguration.InitialDelaySeconds)
-	suite.Require().Equal(testContainer.ReadinessProbe.TimeoutSeconds, platformconfig.DefaultReadinessProbeConfiguration.TimeoutSeconds)
-	suite.Require().Equal(testContainer.ReadinessProbe.PeriodSeconds, platformconfig.DefaultReadinessProbeConfiguration.PeriodSeconds)
-	suite.Require().Equal(testContainer.ReadinessProbe.FailureThreshold, platformconfig.DefaultReadinessProbeConfiguration.FailureThreshold)
+			// Populate the container with configuration from the function instance
+			suite.client.populateDeploymentContainer(suite.ctx, testFunctionLabels, testCase.functionInstance, testContainer)
 
-	// Verify LivenessProbe is populated with default values
-	suite.Require().Equal(testContainer.LivenessProbe.InitialDelaySeconds, platformconfig.DefaultLivenessProbeConfiguration.InitialDelaySeconds)
-	suite.Require().Equal(testContainer.LivenessProbe.TimeoutSeconds, platformconfig.DefaultLivenessProbeConfiguration.TimeoutSeconds)
-	suite.Require().Equal(testContainer.LivenessProbe.PeriodSeconds, platformconfig.DefaultLivenessProbeConfiguration.PeriodSeconds)
-	suite.Require().Equal(testContainer.LivenessProbe.FailureThreshold, platformconfig.DefaultLivenessProbeConfiguration.FailureThreshold)
+			// Verify readinessProbe is populated with default values
+			suite.Require().Equal(testContainer.ReadinessProbe.InitialDelaySeconds, platformconfig.DefaultReadinessProbeConfiguration.InitialDelaySeconds)
+			suite.Require().Equal(testContainer.ReadinessProbe.TimeoutSeconds, platformconfig.DefaultReadinessProbeConfiguration.TimeoutSeconds)
+			suite.Require().Equal(testContainer.ReadinessProbe.PeriodSeconds, platformconfig.DefaultReadinessProbeConfiguration.PeriodSeconds)
+			suite.Require().Equal(testContainer.ReadinessProbe.FailureThreshold, platformconfig.DefaultReadinessProbeConfiguration.FailureThreshold)
+
+			// Verify LivenessProbe is populated with default values
+			suite.Require().Equal(testContainer.LivenessProbe.InitialDelaySeconds, platformconfig.DefaultLivenessProbeConfiguration.InitialDelaySeconds)
+			suite.Require().Equal(testContainer.LivenessProbe.TimeoutSeconds, platformconfig.DefaultLivenessProbeConfiguration.TimeoutSeconds)
+			suite.Require().Equal(testContainer.LivenessProbe.PeriodSeconds, platformconfig.DefaultLivenessProbeConfiguration.PeriodSeconds)
+			suite.Require().Equal(testContainer.LivenessProbe.FailureThreshold, platformconfig.DefaultLivenessProbeConfiguration.FailureThreshold)
+		})
+	}
 }
 
 func (suite *lazyTestSuite) TestFastFailOnAutoScalerEvents() {

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -755,19 +755,18 @@ func (suite *lazyTestSuite) TestEnrichDeploymentFromPlatformConfiguration() {
 func (suite *lazyTestSuite) TestEnrichProbesInPopulateDeploymentContainer() {
 	// Prepare
 	for _, testCase := range []struct {
-		name              string
+		name             string
 		functionInstance *nuclioio.NuclioFunction
 	}{
 		{
-			name:              "test-enrich-probes-function",
+			name:             "test-enrich-probes-function",
 			functionInstance: suite.getFunctionInstanceWithDefaultProbes("test-enrich-probes-function"),
-		},{
+		}, {
 			// Test backward compatibility for functions created with controller versions < v1.14.5, where probes are nil.
 			// After an upgrade, the new controller will access these fields.
-			name:              "test-empty-probes-function",
+			name:             "test-empty-probes-function",
 			functionInstance: &nuclioio.NuclioFunction{},
 		},
-
 	} {
 		suite.Run(testCase.name, func() {
 			testFunctionLabels := suite.client.getFunctionLabels(testCase.functionInstance)


### PR DESCRIPTION
### **Motivation**  
Described in the ticket - https://iguazio.atlassian.net/browse/NUC-447

### **Root Cause**  

1. Function created with controller version < [1.14.5](https://github.com/nuclio/nuclio/releases/tag/1.14.5) (i.e. - the function doesn't have `spec.ReadinessProbe`).
2. Upgrading controller's version
3. When the controller reach the `populateDeployment` it tries to reach the `spec.ReadinessProbe`, which is nil

### **Description**  
In this PR, the code changes are basically adding the probes enrichment the same way that were done [here](https://github.com/nuclio/nuclio/pull/3609/files#diff-ff8e7e972e8e2db67ff18af4a7af59aa7f367aa33b98c6ed32ce6298ea3f96fdR185).
This enrichment ensures backward compatibility for functions created with controller versions < v1.14.5.

### **Affected Areas**  
Nuclio-controller

### **Testing**  
- unit test coverage
- Manual test of the fix

### **Changes Made**  
- Added the enrichment logic to the controller's population logic

### **Additional Notes**  
It seems that every controller upgrade triggers an unnecessary CreateOrUpdate call per function.
This doesn't affect running pods, as the final K8s request is ignored when the deployment hasn't changed.
Further investigation is needed.