### PR TITLE
[Docs] Add docs for elastic search configuration

### DIFF
--- a/docs/reference/api/README.md
+++ b/docs/reference/api/README.md
@@ -371,7 +371,8 @@ Extended Response (includeOffline=true):
     | `logLevels`    | string[]   | Filter logs by log levels (e.g. `debug`, `info`, `error`) (optional).       |
     | `size`         | integer    | Max number of log entries to return (optional).                             |
     | `searchAfter`  | string[]   | For paginated log fetching (optional).                                      |
-    | `source`       | string     | Source to retrieve logs from (e.g. `elasticsearch`) (optional).                        |
+    | `source`       | string     | Source to retrieve logs from (e.g. `elasticsearch`) (optional).             |
+    | `from`         | int        | From parameter for pagination. Should be used in pair with `size`           |
 
 timeFilter example:
 ```

--- a/docs/tasks/configuring-a-platform.md
+++ b/docs/tasks/configuring-a-platform.md
@@ -283,7 +283,7 @@ To add a password, you need to create a secret with a password for the ElasticSe
 ```
 kubectl create secret generic nuclio-es-secret --from-literal=password='password'
 ```
-and set these params in helm values:
+and set these parameters in helm values:
 ```yaml
   elasticSearchPassword:
     secretName: ""

--- a/docs/tasks/configuring-a-platform.md
+++ b/docs/tasks/configuring-a-platform.md
@@ -279,11 +279,18 @@ kube:
     index: {elastic-search-index} # index regexp
 ```
 
-To add a password, you need to create a secret with a password for the ElasticSearch or OpenSearch instance and mount it to nuclio-dashboard:
+To add a password, you need to create a secret with a password for the ElasticSearch or OpenSearch instance:
 ```
 kubectl create secret generic nuclio-es-secret --from-literal=password='password'
 ```
+and set this params in helm values:
+```yaml
+  elasticSearchPassword:
+    secretName: ""
+    secretKey: ""
+```
 
+OR mount it to nuclio-dashboard deployment manually:
 ```sh
 kubectl patch deployment nuclio-dashboard \
   -n <ns> \

--- a/docs/tasks/configuring-a-platform.md
+++ b/docs/tasks/configuring-a-platform.md
@@ -283,7 +283,7 @@ To add a password, you need to create a secret with a password for the ElasticSe
 ```
 kubectl create secret generic nuclio-es-secret --from-literal=password='password'
 ```
-and set this params in helm values:
+and set these params in helm values:
 ```yaml
   elasticSearchPassword:
     secretName: ""

--- a/docs/tasks/configuring-a-platform.md
+++ b/docs/tasks/configuring-a-platform.md
@@ -262,3 +262,46 @@ Example:
     failureThreshold: 3
 ```
 
+
+<a id="elastic-search"></a>
+### Proxy logs from ElasticSearch or OpenSearch
+
+To proxy logs from ElasticSearch or OpenSearch, you can use the `elasticsearch` configuration section. This allows you to specify the connection details and how logs should be retrieved.
+
+Example:
+```yaml
+kube:
+  elasticSearchConfig:
+    url: {url}
+    sslVerificationMode: none # either "none" or "full"
+    username: {username}
+    customQueryParameter: {any_custom_query_parameter} # optional
+    index: {elastic-search-index} # index regexp
+```
+
+To add a password, you need to create a secret with a password for the ElasticSearch or OpenSearch instance and mount it to nuclio-dashboard:
+```
+kubectl create secret generic nuclio-es-secret --from-literal=password='password'
+```
+
+```sh
+kubectl patch deployment nuclio-dashboard \
+  -n <ns> \
+  --type='json' \
+  -p='[
+    {
+      "op": "add",
+      "path": "/spec/template/spec/containers/0/env/-",
+      "value": {
+        "name": "NUCLIO_ELASTIC_SEARCH_PASSWORD",
+        "valueFrom": {
+          "secretKeyRef": {
+            "name": "nuclio-es-secret",
+            "key": "password"
+          }
+        }
+      }
+    }
+  ]'
+```
+


### PR DESCRIPTION
Adds documentation about how to configure elasticsearch or opensearch to proxy logs. 