### PR TITLE
[Processor] Implement processing of stream

### DIFF
--- a/pkg/processor/eventprocessor/mock.go
+++ b/pkg/processor/eventprocessor/mock.go
@@ -35,9 +35,9 @@ type MockEventProcessor struct {
 	mock.Mock
 }
 
-func (m *MockEventProcessor) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (result.ResultWithNuclioProcessingResult, error) {
+func (m *MockEventProcessor) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (result.ResultWithProcessingResult, error) {
 	args := m.Called(event, functionLogger)
-	return args.Get(0).(result.ResultWithNuclioProcessingResult), args.Error(1)
+	return args.Get(0).(result.ResultWithProcessingResult), args.Error(1)
 }
 
 func (m *MockEventProcessor) ProcessEventBatch(batch []nuclio.Event, functionLogger logger.Logger) (*result.BatchedResults, error) {

--- a/pkg/processor/eventprocessor/mock.go
+++ b/pkg/processor/eventprocessor/mock.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/cloudevent"
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/result"
 	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/logger"
@@ -34,14 +35,18 @@ type MockEventProcessor struct {
 	mock.Mock
 }
 
-func (m *MockEventProcessor) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (nuclio.ProcessingResult, error) {
+func (m *MockEventProcessor) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (result.ResultWithNuclioProcessingResult, error) {
 	args := m.Called(event, functionLogger)
-	return args.Get(0).(nuclio.ProcessingResult), args.Error(1)
+	return args.Get(0).(result.ResultWithNuclioProcessingResult), args.Error(1)
 }
 
-func (m *MockEventProcessor) ProcessEventBatch(batch []nuclio.Event, functionLogger logger.Logger) ([]*runtime.ResponseWithErrors, error) {
+func (m *MockEventProcessor) ProcessEventBatch(batch []nuclio.Event, functionLogger logger.Logger) (*result.BatchedResults, error) {
 	args := m.Called(batch, functionLogger)
-	return args.Get(0).([]*runtime.ResponseWithErrors), args.Error(1)
+	return args.Get(0).(*result.BatchedResults), args.Error(1)
+}
+func (m *MockEventProcessor) ProcessStream(stream *result.StreamStart) error {
+	args := m.Called(stream)
+	return args.Error(0)
 }
 
 func (m *MockEventProcessor) Terminate() error {

--- a/pkg/processor/eventprocessor/types.go
+++ b/pkg/processor/eventprocessor/types.go
@@ -71,7 +71,7 @@ type Allocator interface {
 
 type EventProcessor interface {
 	// ProcessEvent processes a single event
-	ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (result.ResultWithNuclioProcessingResult, error)
+	ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (result.ResultWithProcessingResult, error)
 
 	// ProcessEventBatch processes batch of events
 	ProcessEventBatch(batch []nuclio.Event, functionLogger logger.Logger) (*result.BatchedResults, error)

--- a/pkg/processor/eventprocessor/types.go
+++ b/pkg/processor/eventprocessor/types.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/cloudevent"
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/result"
 	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/errors"
@@ -70,10 +71,13 @@ type Allocator interface {
 
 type EventProcessor interface {
 	// ProcessEvent processes a single event
-	ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (nuclio.ProcessingResult, error)
+	ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (result.ResultWithNuclioProcessingResult, error)
 
 	// ProcessEventBatch processes batch of events
-	ProcessEventBatch(batch []nuclio.Event, functionLogger logger.Logger) ([]*runtime.ResponseWithErrors, error)
+	ProcessEventBatch(batch []nuclio.Event, functionLogger logger.Logger) (*result.BatchedResults, error)
+
+	// ProcessStream processes a stream of events
+	ProcessStream(stream *result.StreamStart) error
 
 	// Terminate terminates event processor
 	Terminate() error

--- a/pkg/processor/runtime/golang/runtime.go
+++ b/pkg/processor/runtime/golang/runtime.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/result"
 	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/errors"
@@ -116,7 +117,7 @@ func (g *golang) IsBusy() bool {
 	return len(g.cancelEventHandlingChan) > 0
 }
 
-func (g *golang) ProcessBatch(batch []nuclio.Event, functionLogger logger.Logger) ([]*runtime.ResponseWithErrors, error) {
+func (g *golang) ProcessBatch(batch []nuclio.Event, functionLogger logger.Logger) (*result.BatchedResults, error) {
 	return nil, nuclio.ErrNotImplemented
 }
 

--- a/pkg/processor/runtime/golang/test/golang_test.go
+++ b/pkg/processor/runtime/golang/test/golang_test.go
@@ -297,6 +297,37 @@ func (suite *TestSuite) TestFileStream() {
 	}
 }
 
+func (suite *TestSuite) TestBasicStream() {
+	createFunctionOptions := suite.GetDeployOptions("streamer",
+		path.Join(suite.GetTestFunctionsDir(), "common", "streamer", "golang"))
+
+	requestMethod := "POST"
+
+	suite.DeployFunctionAndRequests(createFunctionOptions, []*httpsuite.Request{
+		{
+			RequestBody:          "alphabet",
+			RequestMethod:        requestMethod,
+			ExpectedResponseBody: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		},
+		{
+			RequestBody:          "text",
+			RequestMethod:        requestMethod,
+			ExpectedResponseBody: "First sentence of the file.Second sentence of the file.Third sentence of the file.",
+		},
+		{
+			RequestBody:          "numbers",
+			RequestMethod:        requestMethod,
+			ExpectedResponseBody: "012345678910",
+		},
+		{
+			RequestBody:                "testbody",
+			RequestMethod:              requestMethod,
+			ExpectedResponseBody:       "Unsupported stream type: testbody",
+			ExpectedResponseStatusCode: common.Pointer(500),
+		},
+	})
+}
+
 func (suite *TestSuite) TestStress() {
 
 	// Create blastConfiguration using default configurations + changes for golang specification

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -213,7 +213,7 @@ func (r *AbstractRuntime) WaitForProcessTermination(timeout time.Duration) {
 	}
 }
 
-func (r *AbstractRuntime) processEventAndWaitForResult(event nuclio.Event, functionLogger logger.Logger) (result.ResultWithNuclioProcessingResult, error) {
+func (r *AbstractRuntime) processEventAndWaitForResult(event nuclio.Event, functionLogger logger.Logger) (result.ResultWithProcessingResult, error) {
 	connectionInstance, err := r.allocateConnection()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to allocate connection for processing event")
@@ -227,6 +227,7 @@ func (r *AbstractRuntime) processEventAndWaitForResult(event nuclio.Event, funct
 		return processingResult, err
 	}
 
+	// Stream response in the background
 	go func() {
 		// release connection after processing stream
 		defer r.connectionManager.Release(connectionInstance)

--- a/pkg/processor/runtime/rpc/abstract.go
+++ b/pkg/processor/runtime/rpc/abstract.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/connection"
+	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/result"
 	"github.com/nuclio/nuclio/pkg/processor/statistics"
 	"github.com/nuclio/nuclio/pkg/processwaiter"
 
@@ -87,7 +88,7 @@ func (r *AbstractRuntime) IsBusy() bool {
 }
 
 // ProcessBatch processes a batch of events
-func (r *AbstractRuntime) ProcessBatch(batch []nuclio.Event, functionLogger logger.Logger) ([]*runtime.ResponseWithErrors, error) {
+func (r *AbstractRuntime) ProcessBatch(batch []nuclio.Event, functionLogger logger.Logger) (*result.BatchedResults, error) {
 	return r.processBatchAndWaitForResult(batch, functionLogger)
 }
 
@@ -212,31 +213,52 @@ func (r *AbstractRuntime) WaitForProcessTermination(timeout time.Duration) {
 	}
 }
 
-func (r *AbstractRuntime) processEventAndWaitForResult(event nuclio.Event, functionLogger logger.Logger) (interface{}, error) {
+func (r *AbstractRuntime) processEventAndWaitForResult(event nuclio.Event, functionLogger logger.Logger) (result.ResultWithNuclioProcessingResult, error) {
 	connectionInstance, err := r.allocateConnection()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to allocate connection for processing event")
 	}
-	result, err := connectionInstance.ProcessEvent(event, functionLogger)
+	processingResult, err := connectionInstance.ProcessEvent(event, functionLogger)
 
-	// release connection after processing event
-	// in goroutine to avoid blocking the processing
-	go r.connectionManager.Release(connectionInstance)
+	if err != nil || (processingResult != nil && !processingResult.IsStream()) {
+		// release connection after processing event
+		// in goroutine to avoid blocking the processing
+		go r.connectionManager.Release(connectionInstance)
+		return processingResult, err
+	}
 
-	return result, err
+	go func() {
+		// release connection after processing stream
+		defer r.connectionManager.Release(connectionInstance)
+		stream, ok := processingResult.(*result.StreamStart)
+
+		// should never happen
+		if !ok {
+			r.Logger.ErrorWith("Failed to cast result to result.StreamStart",
+				"result", processingResult)
+			return
+		}
+		if streamErr := connectionInstance.ProcessStream(stream); streamErr != nil {
+			r.Logger.ErrorWith("Failed to process stream",
+				"stream", stream,
+				"error", streamErr)
+		}
+	}()
+
+	return processingResult, err
 }
 
-func (r *AbstractRuntime) processBatchAndWaitForResult(batch []nuclio.Event, functionLogger logger.Logger) ([]*runtime.ResponseWithErrors, error) {
+func (r *AbstractRuntime) processBatchAndWaitForResult(batch []nuclio.Event, functionLogger logger.Logger) (*result.BatchedResults, error) {
 	connectionInstance, err := r.allocateConnection()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to allocate connection for processing batch")
 	}
-	result, err := connectionInstance.ProcessEventBatch(batch, functionLogger)
+	processingResult, err := connectionInstance.ProcessEventBatch(batch, functionLogger)
 
 	// release connection after processing event
 	// in goroutine to avoid blocking the processing
 	go r.connectionManager.Release(connectionInstance)
-	return result, err
+	return processingResult, err
 }
 
 func (r *AbstractRuntime) allocateConnection() (eventprocessor.EventProcessor, error) {

--- a/pkg/processor/runtime/rpc/connection/abstract.go
+++ b/pkg/processor/runtime/rpc/connection/abstract.go
@@ -312,7 +312,7 @@ func (b *AbstractConnection) resolveFunctionLogger() logger.Logger {
 
 type AbstractEventConnection struct {
 	*AbstractConnection
-	resultChan chan *result.BatchedResults
+	resultChan chan result.Result
 	startChan  chan struct{}
 
 	connectionManager ConnectionManager
@@ -327,7 +327,7 @@ func NewAbstractEventConnection(parentLogger logger.Logger, connectionManager Co
 	}
 	return &AbstractEventConnection{
 		AbstractConnection: abstractConnection,
-		resultChan:         make(chan *result.BatchedResults),
+		resultChan:         make(chan result.Result),
 		startChan:          make(chan struct{}, 1),
 		connectionManager:  connectionManager,
 	}
@@ -356,41 +356,84 @@ func (be *AbstractEventConnection) WaitForStart(timeout time.Duration) error {
 	return nil
 }
 
-func (be *AbstractEventConnection) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (nuclio.ProcessingResult, error) {
+func (be *AbstractEventConnection) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (result.ResultWithNuclioProcessingResult, error) {
 	processingResult, err := be.processItem(event, functionLogger)
-	if err != nil {
+	if processingResult == nil {
 		return nil, err
 	}
-	// this is a single event processing flow, so we only take the first item from the result
-	return &nuclio.Response{
-		Body:        processingResult.Results[0].DecodedBody,
-		ContentType: processingResult.Results[0].ContentType,
-		Headers:     processingResult.Results[0].Headers,
-		StatusCode:  processingResult.Results[0].StatusCode,
-	}, processingResult.Results[0].Err
+
+	// ensure that processingResult is of type result.ResultWithNuclioProcessingResult
+	switch typedResult := processingResult.(type) {
+	case result.ResultWithNuclioProcessingResult:
+		return typedResult, err
+	case *result.BodyOnly:
+		// if processingResult is of type result.BodyOnly, while this is not really expected and isn't supported from wrapper side yet
+		// there is nothing wrong with it, so just form a SingleResult and return
+		singleResult := result.NewSingleResult(&nuclio.Response{Body: typedResult.Body})
+		singleResult.Err = typedResult.Err
+		return singleResult, err
+	case *result.BatchedResults:
+		// if processingResult is of type result.BatchedResults for some reason, just try the best and get the first result
+		be.Logger.DebugWith("Received batched results in single event processing flow, returning the 1st response only")
+		if len(typedResult.Results) > 0 {
+			// return the first result in the batch
+			return typedResult.Results[0], err
+		} else {
+			return result.NewSingleResult(nil), nil
+		}
+	default:
+		return nil, be.generateWrongResultTypeError(processingResult)
+	}
+
 }
 
-func (be *AbstractEventConnection) ProcessEventBatch(batch []nuclio.Event, functionLogger logger.Logger) ([]*runtime.ResponseWithErrors, error) {
-	processingResults, err := be.processItem(batch, functionLogger)
-	responsesWithErrors := make([]*runtime.ResponseWithErrors, len(processingResults.Results))
+func (be *AbstractEventConnection) ProcessEventBatch(batch []nuclio.Event, functionLogger logger.Logger) (*result.BatchedResults, error) {
+	processingResult, err := be.processItem(batch, functionLogger)
+	switch typedResult := processingResult.(type) {
+	case *result.BatchedResults:
+		return typedResult, err
+	case *result.SingleResult:
+		// if single result return, try wrapping it into batched results
+		return &result.BatchedResults{Results: []*result.SingleResult{typedResult}}, err
+	default:
+		return nil, be.generateWrongResultTypeError(processingResult)
+	}
+}
 
-	for index, processingResult := range processingResults.Results {
-		if processingResult.EventId == "" {
-			functionLogger.WarnWith("Received response with empty event_id, response won't be returned")
-			continue
+func (be *AbstractEventConnection) ProcessStream(stream *result.StreamStart) error {
+	// always close stream when processing is done
+	defer be.postProcessStreaming(stream.ResponseStream)
+
+	// start with writing a first chunk
+	// this is blocking operation, so it will wait until the reader is ready to receive data
+	if err := stream.WriteFirstChunk(); err != nil {
+		return errors.Wrap(err, "Failed to write first chunk to stream")
+	}
+
+	var chunk result.Result
+	var err error
+	// wait for next messages arrival
+	for {
+		if chunk, err = be.waitForNextResponseChunk(); err != nil {
+			// if there was an error, return it
+			return errors.Wrap(err, "Failed to read next chunk from stream")
 		}
-		responsesWithErrors[index] = &runtime.ResponseWithErrors{
-			Response: nuclio.Response{
-				Body:        processingResult.DecodedBody,
-				ContentType: processingResult.ContentType,
-				Headers:     processingResult.Headers,
-				StatusCode:  processingResult.StatusCode,
-			},
-			EventId:      processingResult.EventId,
-			ProcessError: processingResult.Err,
+
+		switch typedChunk := chunk.(type) {
+		case *result.StreamEnd:
+			return nil
+		case *result.BodyOnly:
+			if _, err = stream.SendChunk(typedChunk.Body); err != nil {
+				// if there was an error sending the chunk, mark connection for restart and return error
+				be.SetStatus(status.RestartRequired)
+				return errors.Wrap(err, "Failed to send chunk to stream")
+			}
+			continue
+		default:
+			be.SetStatus(status.RestartRequired)
+			return be.generateWrongResultTypeError(typedChunk)
 		}
 	}
-	return responsesWithErrors, err
 }
 
 // RunHandler runs the event connection handler.
@@ -462,12 +505,14 @@ func (be *AbstractEventConnection) RunHandler() {
 			}
 
 			switch data[0] {
-			case 'r':
-				unmarshalledResults := result.NewBatchedResults()
-				unmarshalledResults.UnmarshalResponseData(be.Logger, data[1:])
-
+			case 'r', 'b', 'e', 'c':
 				// write back to result channel
-				be.resultChan <- unmarshalledResults
+				// 'r' is for a single result (either batched or not)
+				// 'b', 'e' and 'c' are for streaming flow
+				// 'c' starts flow showing that it is a stream
+				// 'b' is every following message after 1st in a stream (it is a base64 encoded body only)
+				// 'e' is the end of the stream, which is always empty
+				be.resultChan <- result.NewResultFromData(data)
 			case 'm':
 				be.handleResponseMetric(data[1:])
 			case 'l':
@@ -592,7 +637,7 @@ func (be *AbstractEventConnection) Unsubscribe(kind controlcommunication.Control
 	return nuclio.ErrNotImplemented
 }
 
-func (be *AbstractEventConnection) processItem(item interface{}, functionLogger logger.Logger) (*result.BatchedResults, error) {
+func (be *AbstractEventConnection) processItem(item interface{}, functionLogger logger.Logger) (result.Result, error) {
 	be.functionLogger = functionLogger
 	if err := be.encoder.Encode(item); err != nil {
 		be.functionLogger = nil
@@ -603,16 +648,23 @@ func (be *AbstractEventConnection) processItem(item interface{}, functionLogger 
 	// if it is set, we wait either for response or the timeout
 	if be.connectionManager.GetConfig().eventTimeout == 0 {
 		processingResults, ok := <-be.resultChan
-		return be.postProcessEventRegularFlow(processingResults, ok)
+		return be.postProcessEventRegularFlow(processingResults, !ok)
 	} else {
 		return be.waitForResponseWithTimeout()
 	}
+}
+
+func (be *AbstractEventConnection) waitForNextResponseChunk() (result.Result, error) {
+	// TODO: add chunk timeout
+	processingResults, ok := <-be.resultChan
+	return be.postProcessResponseCheckForFailure(processingResults, !ok)
 }
 
 func (be *AbstractEventConnection) stop() error {
 	be.SetStatus(status.Stopping)
 	be.AbstractConnection.Stop()
 
+	var err error
 	// close start chan
 	// other two channels (result and cancel chan) are closed in the run handler
 	close(be.startChan)
@@ -620,51 +672,82 @@ func (be *AbstractEventConnection) stop() error {
 	// if the channel is closed while waiting for response in it, this will be handled in processItem() with no issues
 	close(be.resultChan)
 
-	err := be.Conn.Close()
+	if be.Conn != nil {
+		err = be.Conn.Close()
+	}
+
 	be.SetStatus(status.Stopped)
 	return err
 }
 
-func (be *AbstractEventConnection) waitForResponseWithTimeout() (*result.BatchedResults, error) {
+func (be *AbstractEventConnection) waitForResponseWithTimeout() (result.Result, error) {
 	ticker := time.NewTicker(be.connectionManager.GetConfig().eventTimeout)
 	defer ticker.Stop()
 
 	select {
-	case processingResults, isClientDisconnected := <-be.resultChan:
-		return be.postProcessEventRegularFlow(processingResults, isClientDisconnected)
+	case processingResults, ok := <-be.resultChan:
+		return be.postProcessEventRegularFlow(processingResults, !ok)
 	case <-ticker.C:
 		return be.postProcessEventOnTimeout()
 	}
 }
 
-func (be *AbstractEventConnection) postProcessEventRegularFlow(processingResults *result.BatchedResults, isClientDisconnected bool) (*result.BatchedResults, error) {
+func (be *AbstractEventConnection) postProcessEventRegularFlow(processingResults result.Result, isClientDisconnected bool) (result.Result, error) {
 	// We don't use defer to reset be.functionLogger since it decreases performance
-	be.functionLogger = nil
+	if !processingResults.IsStream() || isClientDisconnected {
+		// Instead, we reset it immediately after execution **only if**:
+		// - the result is not part of a stream (i.e., IsStream() is false), **or**
+		// - the client has disconnected.
+		// This ensures we clean up the logger in non-streaming scenarios or when streaming is no longer relevant.
+		be.resetLogger()
+	}
 
-	if !isClientDisconnected {
-		return be.postProcessClientDisconnected()
+	return be.postProcessResponseCheckForFailure(processingResults, isClientDisconnected)
+}
+
+func (be *AbstractEventConnection) postProcessStreaming(stream *nuclio.ResponseStream) {
+	stream.StopStreaming()
+	be.resetLogger()
+}
+
+func (be *AbstractEventConnection) resetLogger() {
+	be.functionLogger = nil
+}
+
+func (be *AbstractEventConnection) postProcessResponseCheckForFailure(processingResults result.Result, isClientDisconnected bool) (result.Result, error) {
+
+	if isClientDisconnected {
+		return nil, be.postProcessClientDisconnected()
 	}
 	// if processingResults.err is not nil, it means that whole batch processing was failed
 	// or that connection was closed (EOF)
-	if processingResults.Err != nil {
+	if processingResults.Error() != nil {
 		// if a client disconnected, we should restart the connection
-		if errors.RootCause(processingResults.Err) == io.EOF {
-			return be.postProcessClientDisconnected()
+		if errors.RootCause(processingResults.Error()) == io.EOF {
+			return nil, be.postProcessClientDisconnected()
 		}
-		return nil, processingResults.Err
+		return nil, processingResults.Error()
 	}
 	return processingResults, nil
 }
 
-func (be *AbstractEventConnection) postProcessClientDisconnected() (*result.BatchedResults, error) {
+func (be *AbstractEventConnection) generateWrongResultTypeError(processingResult interface{}) error {
+	errorMessage := fmt.Sprintf(
+		"Processing result is not of type result.ResultWithNuclioProcessingResult. Actual type: %T",
+		processingResult,
+	)
+	return errors.New(errorMessage)
+}
+
+func (be *AbstractEventConnection) postProcessClientDisconnected() error {
 	msg := "Client disconnected"
 	be.Logger.Error(msg)
 	be.SetStatus(status.RestartRequired)
-	return nil, errors.New(msg)
+	return errors.New(msg)
 }
 
 func (be *AbstractEventConnection) postProcessEventOnTimeout() (*result.BatchedResults, error) {
-	be.functionLogger = nil
+	be.resetLogger()
 	be.Logger.WarnWith("Event processing timed out, connection should be restarted",
 		"localAddress", be.Conn.LocalAddr().String())
 	be.SetStatus(status.RestartRequired)

--- a/pkg/processor/runtime/rpc/connection/abstract.go
+++ b/pkg/processor/runtime/rpc/connection/abstract.go
@@ -362,7 +362,7 @@ func (be *AbstractEventConnection) ProcessEvent(event nuclio.Event, functionLogg
 		return nil, err
 	}
 
-	normalizedResult, normalisationErr := result.NormalizeToResultWithNuclioProcessingResult(processingResult)
+	normalizedResult, normalisationErr := result.NormalizeToResultWithProcessingResult(processingResult)
 	if normalisationErr != nil {
 		return nil, errors.Wrap(normalisationErr, "Failed to normalize result")
 	}

--- a/pkg/processor/runtime/rpc/connection/abstract.go
+++ b/pkg/processor/runtime/rpc/connection/abstract.go
@@ -356,7 +356,7 @@ func (be *AbstractEventConnection) WaitForStart(timeout time.Duration) error {
 	return nil
 }
 
-func (be *AbstractEventConnection) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (result.ResultWithNuclioProcessingResult, error) {
+func (be *AbstractEventConnection) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (result.ResultWithProcessingResult, error) {
 	processingResult, err := be.processItem(event, functionLogger)
 	if processingResult == nil {
 		return nil, err
@@ -488,20 +488,17 @@ func (be *AbstractEventConnection) RunHandler() {
 				continue
 			}
 
-			switch data[0] {
-			case 'r', 'b', 'e', 'c':
-				// write back to result channel
-				// 'r' is for a single result (either batched or not)
-				// 'b', 'e' and 'c' are for streaming flow
-				// 'c' starts flow showing that it is a stream
-				// 'b' is every following message after 1st in a stream (it is a base64 encoded body only)
-				// 'e' is the end of the stream, which is always empty
+			switch result.PacketType(data[0]) {
+			case result.PacketTypeSingleResponse,
+				result.PacketTypeBodyChunk,
+				result.PacketTypeEndOfStream,
+				result.PacketTypeStreamStart:
 				be.resultChan <- result.NewResultFromData(data)
-			case 'm':
+			case result.PacketTypeMetrics:
 				be.handleResponseMetric(data[1:])
-			case 'l':
+			case result.PacketTypeLog:
 				be.handleResponseLog(data[1:])
-			case 's':
+			case result.PacketTypeStart:
 				be.handleStart()
 			}
 		}
@@ -703,7 +700,7 @@ func (be *AbstractEventConnection) postProcessResponseCheckForFailure(processing
 	if isClientDisconnected {
 		return nil, be.postProcessClientDisconnected()
 	}
-	// if processingResults.err is not nil, it means that whole batch processing was failed
+	// if processingResults.err is not nil, it means that whole batch processing has failed
 	// or that connection was closed (EOF)
 	if processingResults.Error() != nil {
 		// if a client disconnected, we should restart the connection

--- a/pkg/processor/runtime/rpc/connection/abstract.go
+++ b/pkg/processor/runtime/rpc/connection/abstract.go
@@ -362,42 +362,26 @@ func (be *AbstractEventConnection) ProcessEvent(event nuclio.Event, functionLogg
 		return nil, err
 	}
 
-	// ensure that processingResult is of type result.ResultWithNuclioProcessingResult
-	switch typedResult := processingResult.(type) {
-	case result.ResultWithNuclioProcessingResult:
-		return typedResult, err
-	case *result.BodyOnly:
-		// if processingResult is of type result.BodyOnly, while this is not really expected and isn't supported from wrapper side yet
-		// there is nothing wrong with it, so just form a SingleResult and return
-		singleResult := result.NewSingleResult(&nuclio.Response{Body: typedResult.Body})
-		singleResult.Err = typedResult.Err
-		return singleResult, err
-	case *result.BatchedResults:
-		// if processingResult is of type result.BatchedResults for some reason, just try the best and get the first result
-		be.Logger.DebugWith("Received batched results in single event processing flow, returning the 1st response only")
-		if len(typedResult.Results) > 0 {
-			// return the first result in the batch
-			return typedResult.Results[0], err
-		} else {
-			return result.NewSingleResult(nil), nil
-		}
-	default:
-		return nil, be.generateWrongResultTypeError(processingResult)
+	normalizedResult, normalisationErr := result.NormalizeToResultWithNuclioProcessingResult(processingResult)
+	if normalisationErr != nil {
+		return nil, errors.Wrap(normalisationErr, "Failed to normalize result")
 	}
 
+	return normalizedResult, err
 }
 
 func (be *AbstractEventConnection) ProcessEventBatch(batch []nuclio.Event, functionLogger logger.Logger) (*result.BatchedResults, error) {
 	processingResult, err := be.processItem(batch, functionLogger)
-	switch typedResult := processingResult.(type) {
-	case *result.BatchedResults:
-		return typedResult, err
-	case *result.SingleResult:
-		// if single result return, try wrapping it into batched results
-		return &result.BatchedResults{Results: []*result.SingleResult{typedResult}}, err
-	default:
-		return nil, be.generateWrongResultTypeError(processingResult)
+	if processingResult == nil {
+		return nil, err
 	}
+
+	normalizedResult, normalisationErr := result.NormalizeToBatchedResults(processingResult)
+	if normalisationErr != nil {
+		return nil, errors.Wrap(normalisationErr, "Failed to normalize result")
+	}
+
+	return normalizedResult, err
 }
 
 func (be *AbstractEventConnection) ProcessStream(stream *result.StreamStart) error {
@@ -431,7 +415,7 @@ func (be *AbstractEventConnection) ProcessStream(stream *result.StreamStart) err
 			continue
 		default:
 			be.SetStatus(status.RestartRequired)
-			return be.generateWrongResultTypeError(typedChunk)
+			return errors.Errorf("Got unsupported message of type %T during stream processing", typedChunk)
 		}
 	}
 }
@@ -488,7 +472,7 @@ func (be *AbstractEventConnection) RunHandler() {
 						"err", errors.RootCause(err).Error())
 				}
 
-				batchedResultsWithError := result.NewBatchedResultsWithError(err)
+				batchedResultsWithError := result.NewSingleResultsWithError(err)
 				select {
 				// if no receiver is waiting for the result, we should not send it
 				// otherwise it may get stuck here and block select
@@ -688,7 +672,7 @@ func (be *AbstractEventConnection) waitForResponseWithTimeout() (result.Result, 
 	case processingResults, ok := <-be.resultChan:
 		return be.postProcessEventRegularFlow(processingResults, !ok)
 	case <-ticker.C:
-		return be.postProcessEventOnTimeout()
+		return nil, be.postProcessEventOnTimeout()
 	}
 }
 
@@ -731,14 +715,6 @@ func (be *AbstractEventConnection) postProcessResponseCheckForFailure(processing
 	return processingResults, nil
 }
 
-func (be *AbstractEventConnection) generateWrongResultTypeError(processingResult interface{}) error {
-	errorMessage := fmt.Sprintf(
-		"Processing result is not of type result.ResultWithNuclioProcessingResult. Actual type: %T",
-		processingResult,
-	)
-	return errors.New(errorMessage)
-}
-
 func (be *AbstractEventConnection) postProcessClientDisconnected() error {
 	msg := "Client disconnected"
 	be.Logger.Error(msg)
@@ -746,12 +722,12 @@ func (be *AbstractEventConnection) postProcessClientDisconnected() error {
 	return errors.New(msg)
 }
 
-func (be *AbstractEventConnection) postProcessEventOnTimeout() (*result.BatchedResults, error) {
+func (be *AbstractEventConnection) postProcessEventOnTimeout() error {
 	be.resetLogger()
 	be.Logger.WarnWith("Event processing timed out, connection should be restarted",
 		"localAddress", be.Conn.LocalAddr().String())
 	be.SetStatus(status.RestartRequired)
-	return nil, nuclio.NewErrRequestTimeout("Execution timed out")
+	return nuclio.NewErrRequestTimeout("Execution timed out")
 }
 
 func (be *AbstractEventConnection) handleResponseMetric(response []byte) {

--- a/pkg/processor/runtime/rpc/connection/connection_test.go
+++ b/pkg/processor/runtime/rpc/connection/connection_test.go
@@ -66,8 +66,12 @@ func (suite *TestConnectionSuite) TestStreamProcessing() {
 	go func() {
 		var err error
 		// send stream messages to the connection's result channel
-		messages := []result.Result{result.NewStreamStart(responseStream), result.NewBodyOnlyFromBase64([]byte(testStreamValueBase64)), result.NewBodyOnlyFromBase64([]byte(testStreamValueBase64)),
-			&result.StreamEnd{}}
+		messages := []result.Result{
+			result.NewStreamStart(responseStream),
+			result.NewBodyOnlyFromBase64([]byte(testStreamValueBase64)),
+			result.NewBodyOnlyFromBase64([]byte(testStreamValueBase64)),
+			&result.StreamEnd{},
+		}
 		for index, message := range messages {
 			if err = suite.sendToChanOrFail(connection.resultChan, message, 5*time.Second); err != nil {
 				sendMessageErrChan <- errors.Wrap(err, fmt.Sprintf("Failed to send message, index: %d", index))

--- a/pkg/processor/runtime/rpc/connection/connection_test.go
+++ b/pkg/processor/runtime/rpc/connection/connection_test.go
@@ -1,0 +1,133 @@
+//go:build test_unit
+
+/*
+Copyright 2025 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package connection
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/encoder"
+	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/result"
+	triggertest "github.com/nuclio/nuclio/pkg/processor/trigger/test"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+	"github.com/nuclio/nuclio-sdk-go"
+	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type TestConnectionSuite struct {
+	suite.Suite
+	logger logger.Logger
+}
+
+func (suite *TestConnectionSuite) SetupTest() {
+	var err error
+	suite.logger, err = nucliozap.NewNuclioZapTest("abstract-connection")
+	suite.Require().NoError(err)
+}
+
+func (suite *TestConnectionSuite) TestStreamProcessing() {
+	mockManager := &MockConnectionManager{}
+	managerConfiguration := suite.getManagerConfiguration()
+
+	mockManager.On("GetConfig").Return(managerConfiguration).Twice()
+	connection := NewAbstractEventConnection(suite.logger, mockManager)
+
+	var buffer bytes.Buffer
+	connection.encoder = encoder.NewEventJSONEncoder(suite.logger, &buffer)
+	defer connection.stop() //nolint: errcheck
+
+	testStreamValue := "test-stream"
+	testStreamValueBase64 := base64.StdEncoding.EncodeToString([]byte(testStreamValue))
+	responseStream := nuclio.NewResponseStream("", nil, 200)
+	sendMessageErrChan := make(chan error, 1)
+	defer close(sendMessageErrChan)
+	go func() {
+		var err error
+		// send stream messages to the connection's result channel
+		messages := []result.Result{result.NewStreamStart(responseStream), result.NewBodyOnlyFromBase64([]byte(testStreamValueBase64)), result.NewBodyOnlyFromBase64([]byte(testStreamValueBase64)),
+			&result.StreamEnd{}}
+		for index, message := range messages {
+			if err = suite.sendToChanOrFail(connection.resultChan, message, 5*time.Second); err != nil {
+				sendMessageErrChan <- errors.Wrap(err, fmt.Sprintf("Failed to send message, index: %d", index))
+				return
+			}
+		}
+		sendMessageErrChan <- nil
+	}()
+	// process the event, which is a stream start
+	processingResult, err := connection.ProcessEvent(&triggertest.TestEvent{}, suite.logger)
+	suite.Require().NoError(err)
+	suite.Require().Equal(processingResult.GetProcessingResult(), responseStream)
+
+	// ensure that logger is still set
+	suite.Require().Equal(suite.logger, connection.functionLogger)
+
+	stream := processingResult.(*result.StreamStart)
+	streamProcessErrChan := make(chan error, 1)
+	defer close(streamProcessErrChan)
+	go func() {
+		// process the stream and writes the results to the io.writer
+		streamProcessErrChan <- connection.ProcessStream(stream)
+	}()
+
+	body := stream.GetBody().(io.ReadCloser)
+	data, err := io.ReadAll(body)
+	suite.Require().NoError(err)
+	suite.Require().Equal(fmt.Sprintf("%s%s", testStreamValue, testStreamValue), string(data))
+
+	streamProcessErr := <-streamProcessErrChan
+	suite.Require().NoError(streamProcessErr)
+
+	sendMessageErr := <-sendMessageErrChan
+	suite.Require().NoError(sendMessageErr)
+
+	// after stream processing is finished, the stream should be closed and functionLogger should be nil
+	suite.Require().Equal(nil, connection.functionLogger)
+}
+
+func (suite *TestConnectionSuite) getManagerConfiguration() ManagerConfigration {
+	return ManagerConfigration{
+		Kind:                        SocketAllocatorManagerKind,
+		SupportControlCommunication: true,
+		WaitForStart:                true,
+		eventTimeout:                10 * time.Second,
+		GetEventEncoderFunc: func(w io.Writer) encoder.EventEncoder {
+			return encoder.NewEventJSONEncoder(nil, w)
+		},
+	}
+}
+
+func (suite *TestConnectionSuite) sendToChanOrFail(resultChan chan result.Result, message result.Result, timeout time.Duration) error {
+	select {
+	case resultChan <- message:
+		return nil
+	case <-time.After(timeout):
+		return errors.New("sending message to a channel timed out")
+	}
+}
+
+func TestConnection(t *testing.T) {
+	suite.Run(t, &TestConnectionSuite{})
+}

--- a/pkg/processor/runtime/rpc/connection/connection_test.go
+++ b/pkg/processor/runtime/rpc/connection/connection_test.go
@@ -77,7 +77,7 @@ func (suite *TestConnectionSuite) TestStreamProcessing() {
 		sendMessageErrChan <- nil
 	}()
 	// process the event, which is a stream start
-	processingResult, err := connection.ProcessEvent(&triggertest.TestEvent{}, suite.logger)
+	processingResult, err := connection.ProcessEvent(triggertest.NewTestEvent("id", nil), suite.logger)
 	suite.Require().NoError(err)
 	suite.Require().Equal(processingResult.GetProcessingResult(), responseStream)
 

--- a/pkg/processor/runtime/rpc/connection/connectionallocator_test.go
+++ b/pkg/processor/runtime/rpc/connection/connectionallocator_test.go
@@ -145,11 +145,11 @@ func (suite *TestConnectionAllocatorSuite) TestReplaceConnection() {
 	go func() {
 		response, err := connection.ProcessEvent(event, suite.logger)
 		suite.Require().NoError(err)
-		suite.Require().Equal("hello", string(response.GetBody().([]byte)))
+		suite.Require().Equal("hello", string(response.GetProcessingResult().GetBody().([]byte)))
 		cancelFunc()
 	}()
 	connection.(*Connection).resultChan <- &result.BatchedResults{
-		Results: []*result.Result{{DecodedBody: []byte("hello")}},
+		Results: []*result.SingleResult{result.NewSingleResult(&nuclio.Response{Body: []byte("hello")})},
 		Err:     nil,
 	}
 	<-ctx.Done()

--- a/pkg/processor/runtime/rpc/connection/connectionallocator_test.go
+++ b/pkg/processor/runtime/rpc/connection/connectionallocator_test.go
@@ -150,7 +150,6 @@ func (suite *TestConnectionAllocatorSuite) TestReplaceConnection() {
 	}()
 	connection.(*Connection).resultChan <- &result.BatchedResults{
 		Results: []*result.SingleResult{result.NewSingleResult(&nuclio.Response{Body: []byte("hello")})},
-		Err:     nil,
 	}
 	<-ctx.Done()
 }

--- a/pkg/processor/runtime/rpc/connection/mock.go
+++ b/pkg/processor/runtime/rpc/connection/mock.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2025 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connection
+
+import (
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/common/status"
+	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockConnectionManager struct {
+	mock.Mock
+}
+
+func (m *MockConnectionManager) Prepare() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockConnectionManager) Start(pid int) error {
+	args := m.Called(pid)
+	return args.Error(0)
+}
+
+func (m *MockConnectionManager) Stop() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockConnectionManager) Allocate(duration time.Duration) (eventprocessor.EventProcessor, error) {
+	args := m.Called(duration)
+	return args.Get(0).(eventprocessor.EventProcessor), args.Error(1)
+}
+
+func (m *MockConnectionManager) Release(ep eventprocessor.EventProcessor) {
+	m.Called(ep)
+}
+
+func (m *MockConnectionManager) GetAddressesForWrapperStart() ([]string, string) {
+	args := m.Called()
+	return args.Get(0).([]string), args.String(1)
+}
+
+func (m *MockConnectionManager) UpdateStatistics(durationSec float64) {
+	m.Called(durationSec)
+}
+
+func (m *MockConnectionManager) GetAllocationStatistics() *statistics.AllocatorStatistics {
+	args := m.Called()
+	return args.Get(0).(*statistics.AllocatorStatistics)
+}
+
+func (m *MockConnectionManager) SetStatus(s status.Status) {
+	m.Called(s)
+}
+
+func (m *MockConnectionManager) GetStatus() status.Status {
+	args := m.Called()
+	return args.Get(0).(status.Status)
+}
+
+func (m *MockConnectionManager) GetConfig() ManagerConfigration {
+	args := m.Called()
+	return args.Get(0).(ManagerConfigration)
+}
+
+func (m *MockConnectionManager) IsAsync() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+func (m *MockConnectionManager) IsBusy() bool {
+	args := m.Called()
+	return args.Bool(0)
+}

--- a/pkg/processor/runtime/rpc/encoder/encode_json_test.go
+++ b/pkg/processor/runtime/rpc/encoder/encode_json_test.go
@@ -22,7 +22,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"testing"
-	"time"
+
+	triggertest "github.com/nuclio/nuclio/pkg/processor/trigger/test"
 
 	"github.com/google/uuid"
 	"github.com/nuclio/nuclio-sdk-go"
@@ -32,136 +33,8 @@ import (
 
 var (
 	testID                  = nuclio.ID(uuid.New().String())
-	testTriggerInfoProvider = &TestTriggerInfoProvider{}
-
-	testHeaders = map[string]interface{}{
-		"h1": "hv1",
-		"h2": 2,
-	}
-	testFields = map[string]interface{}{
-		"f1": "fv1",
-		"f2": 0xF2,
-	}
-	testTime = time.Now().UTC()
+	testTriggerInfoProvider = &triggertest.TestTriggerInfoProvider{}
 )
-
-// nuclio.TriggerInfoProvider interface
-type TestTriggerInfoProvider struct{}
-
-func (ti *TestTriggerInfoProvider) GetClass() string { return "test class" }
-func (ti *TestTriggerInfoProvider) GetKind() string  { return "test kind" }
-func (ti *TestTriggerInfoProvider) GetName() string  { return "test name" }
-
-type TestEvent struct {
-	// We don't embed nuclio.AbstractEvent so we'll have all methods
-}
-
-func (te *TestEvent) GetID() nuclio.ID {
-	return testID
-}
-
-func (te *TestEvent) GetContentType() string {
-	return "text/html"
-}
-
-func (te *TestEvent) GetBody() []byte {
-	return []byte("body of proof")
-}
-
-func (te *TestEvent) GetBodyObject() interface{} {
-	return te.GetBody
-}
-
-func (te *TestEvent) GetHeaders() map[string]interface{} {
-	return testHeaders
-}
-
-func (te *TestEvent) GetFields() map[string]interface{} {
-	return testFields
-}
-
-func (te *TestEvent) GetTimestamp() time.Time {
-	return testTime
-}
-
-func (te *TestEvent) GetPath() string {
-	return "/path/to/test"
-}
-
-func (te *TestEvent) GetURL() string {
-	return "https://github.com/nuclio/nuclio"
-}
-
-func (te *TestEvent) GetMethod() string {
-	return "POST"
-}
-
-func (te *TestEvent) GetShardID() int {
-	return 9
-}
-
-func (te *TestEvent) GetTotalNumShards() int {
-	return 32
-}
-
-func (te *TestEvent) GetType() string {
-	return "test event type"
-}
-
-func (te *TestEvent) GetTypeVersion() string {
-	return "test event type version"
-}
-
-func (te *TestEvent) GetVersion() string {
-	return "test event version"
-}
-
-// GetLastInBatch returns whether the event is the last event in a trigger specific batch
-func (te *TestEvent) GetLastInBatch() bool {
-	return false
-}
-
-// GetOffset returns the offset of the event
-func (te *TestEvent) GetOffset() int {
-	return 0
-}
-
-func (te *TestEvent) GetTopic() string {
-	return ""
-}
-
-func (te *TestEvent) GetTriggerInfo() nuclio.TriggerInfoProvider {
-	return testTriggerInfoProvider
-}
-
-func (te *TestEvent) GetHeader(key string) interface{} {
-	return testHeaders[key]
-}
-func (te *TestEvent) GetHeaderByteSlice(key string) []byte {
-	return testHeaders[key].([]byte)
-}
-func (te *TestEvent) GetHeaderString(key string) string {
-	return testHeaders[key].(string)
-}
-func (te *TestEvent) GetHeaderInt(key string) (int, error) {
-	return testHeaders[key].(int), nil
-}
-
-func (te *TestEvent) GetField(key string) interface{} {
-	return testFields[key]
-}
-func (te *TestEvent) GetFieldByteSlice(key string) []byte {
-	return testFields[key].([]byte)
-}
-func (te *TestEvent) GetFieldString(key string) string {
-	return testFields[key].(string)
-}
-func (te *TestEvent) GetFieldInt(key string) (int, error) {
-	return testFields[key].(int), nil
-}
-func (te *TestEvent) SetID(id nuclio.ID) {}
-
-func (te *TestEvent) SetTriggerInfoProvider(tip nuclio.TriggerInfoProvider) {}
 
 type EventJSONEncoderSuite struct {
 	suite.Suite
@@ -174,7 +47,7 @@ func (suite *EventJSONEncoderSuite) TestEncode() {
 
 	var buf bytes.Buffer
 	enc := NewEventJSONEncoder(logger, &buf)
-	testEvent := &TestEvent{}
+	testEvent := triggertest.TestEvent{}
 	err = enc.Encode(testEvent)
 	require.NoError(err, "Can't encode event")
 
@@ -189,15 +62,15 @@ func (suite *EventJSONEncoderSuite) TestEncode() {
 
 	headers, ok := out["headers"].(map[string]interface{})
 	require.True(ok, "bad headers type")
-	require.Equal(headers["h1"], testHeaders["h1"], "bad h1 header")
+	require.Equal(headers["h1"], triggertest.TestHeaders["h1"], "bad h1 header")
 	// Go converts all numbers to floats
-	require.Equal(int(headers["h2"].(float64)), testHeaders["h2"], "bad h2 header")
+	require.Equal(int(headers["h2"].(float64)), triggertest.TestHeaders["h2"], "bad h2 header")
 
 	fields, ok := out["fields"].(map[string]interface{})
 	require.True(ok, "bad fields type")
-	require.Equal(fields["f1"], testFields["f1"], "bad f1 field")
+	require.Equal(fields["f1"], triggertest.TestHeaders["f1"], "bad f1 field")
 	// Go converts all numbers to floats
-	require.Equal(int(fields["f2"].(float64)), testFields["f2"], "bad f2 field")
+	require.Equal(int(fields["f2"].(float64)), triggertest.TestHeaders["f2"], "bad f2 field")
 
 	triggerInfo := out["trigger"].(map[string]interface{})
 	require.Equal(testTriggerInfoProvider.GetKind(), triggerInfo["kind"], "bad trigger kind")

--- a/pkg/processor/runtime/rpc/encoder/encode_json_test.go
+++ b/pkg/processor/runtime/rpc/encoder/encode_json_test.go
@@ -47,7 +47,7 @@ func (suite *EventJSONEncoderSuite) TestEncode() {
 
 	var buf bytes.Buffer
 	enc := NewEventJSONEncoder(logger, &buf)
-	testEvent := triggertest.TestEvent{}
+	testEvent := triggertest.NewTestEvent(testID, testTriggerInfoProvider)
 	err = enc.Encode(testEvent)
 	require.NoError(err, "Can't encode event")
 
@@ -68,9 +68,9 @@ func (suite *EventJSONEncoderSuite) TestEncode() {
 
 	fields, ok := out["fields"].(map[string]interface{})
 	require.True(ok, "bad fields type")
-	require.Equal(fields["f1"], triggertest.TestHeaders["f1"], "bad f1 field")
+	require.Equal(fields["f1"], triggertest.TestFields["f1"], "bad f1 field")
 	// Go converts all numbers to floats
-	require.Equal(int(fields["f2"].(float64)), triggertest.TestHeaders["f2"], "bad f2 field")
+	require.Equal(int(fields["f2"].(float64)), triggertest.TestFields["f2"], "bad f2 field")
 
 	triggerInfo := out["trigger"].(map[string]interface{})
 	require.Equal(testTriggerInfoProvider.GetKind(), triggerInfo["kind"], "bad trigger kind")

--- a/pkg/processor/runtime/rpc/result/result.go
+++ b/pkg/processor/runtime/rpc/result/result.go
@@ -20,8 +20,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 
-	"github.com/nuclio/logger"
+	"github.com/nuclio/errors"
+	"github.com/nuclio/nuclio-sdk-go"
 )
 
 type RpcLogRecord struct {
@@ -31,62 +33,231 @@ type RpcLogRecord struct {
 	With     map[string]interface{} `json:"with"`
 }
 
-type Result struct {
+type singleSerialisedResult struct {
 	StatusCode   int                    `json:"status_code"`
 	ContentType  string                 `json:"content_type"`
-	Body         string                 `json:"body"`
-	BodyEncoding string                 `json:"body_encoding"`
 	Headers      map[string]interface{} `json:"headers"`
 	EventId      string                 `json:"event_id"`
-
-	DecodedBody []byte
-	Err         error
+	Body         string                 `json:"body"`
+	BodyEncoding string                 `json:"body_encoding"`
 }
 
-type BatchedResults struct {
-	Results []*Result
+type StreamStart struct {
+	*nuclio.ResponseStream
+	Err error
+	// firstChunk is the first chunk of data that was received
+	// we can't write it to the nuclio.ResponseStream until nobody reads from it, because it's blocking operation
+	// so it should be written to the stream only when we should block the execution
+	firstChunk []byte
+}
+
+func NewStreamStart(responseStream *nuclio.ResponseStream) *StreamStart {
+	return &StreamStart{ResponseStream: responseStream}
+}
+
+func newStreamStartFromSingleResult(singleResult *SingleResult) *StreamStart {
+	responseStream := nuclio.NewResponseStream(singleResult.ContentType, singleResult.Headers, singleResult.StatusCode)
+	return &StreamStart{
+		ResponseStream: responseStream,
+		firstChunk:     singleResult.Body,
+	}
+}
+
+func (ss *StreamStart) WriteFirstChunk() error {
+	_, err := ss.SendChunk(ss.firstChunk)
+	return err
+}
+func (ss *StreamStart) IsStream() bool { return true }
+func (ss *StreamStart) Error() error {
+	return ss.Err
+}
+
+func (ss *StreamStart) GetProcessingResult() nuclio.ProcessingResult {
+	return ss.ResponseStream
+}
+
+type StreamEnd struct{}
+
+func (eos *StreamEnd) IsStream() bool { return false }
+
+func (eos *StreamEnd) Error() error {
+	return nil
+}
+
+type BodyOnly struct {
+	Body []byte
+	Err  error
+}
+
+func (b *BodyOnly) IsStream() bool { return false }
+
+func (b *BodyOnly) Error() error {
+	return b.Err
+}
+
+// NewBodyOnlyFromBase64 creates a BodyOnly result from base64-encoded data.
+func NewBodyOnlyFromBase64(data []byte) Result {
+	decoded, err := base64.StdEncoding.DecodeString(string(data))
+	if err != nil {
+		return &BodyOnly{
+			Err: errors.Errorf("failed to decode base64 body: %s", err.Error()),
+		}
+	}
+	return &BodyOnly{
+		Body: decoded,
+	}
+}
+
+type SingleResult struct {
+	*nuclio.Response
+	EventId string `json:"event_id"`
 	Err     error
 }
 
+func NewSingleResult(response *nuclio.Response) *SingleResult {
+	if response == nil {
+		response = &nuclio.Response{}
+	}
+	return &SingleResult{
+		Response: response,
+	}
+}
+
+func (sr *SingleResult) UnmarshalJSON(data []byte) error {
+	var rawResult singleSerialisedResult
+	if err := json.Unmarshal(data, &rawResult); err != nil {
+		return err
+	}
+
+	// Decode body
+	var decodedBody []byte
+	switch rawResult.BodyEncoding {
+	case "text":
+		decodedBody = []byte(rawResult.Body)
+	case "base64":
+		var err error
+		decodedBody, err = base64.StdEncoding.DecodeString(rawResult.Body)
+		if err != nil {
+			sr.Err = err
+			return err
+		}
+	default:
+		err := fmt.Errorf("unknown body encoding %q", rawResult.BodyEncoding)
+		sr.Err = err
+		return err
+	}
+
+	// Fill the Response
+	if sr.Response == nil {
+		sr.Response = &nuclio.Response{}
+	}
+	sr.Response.StatusCode = rawResult.StatusCode
+	sr.Response.ContentType = rawResult.ContentType
+	sr.Response.Headers = rawResult.Headers
+	sr.Response.Body = decodedBody
+
+	// Fill EventId
+	sr.EventId = rawResult.EventId
+
+	return nil
+}
+
+func (sr *SingleResult) IsStream() bool { return false }
+
+func (sr *SingleResult) Error() error {
+	return sr.Err
+}
+
+func (sr *SingleResult) GetProcessingResult() nuclio.ProcessingResult {
+	return sr.Response
+}
+
+type BatchedResults struct {
+	Results []*SingleResult
+	Err     error
+}
+
+func (br *BatchedResults) IsStream() bool { return false }
+func (br *BatchedResults) Error() error {
+	return br.Err
+}
+
 func NewBatchedResults() *BatchedResults {
-	return &BatchedResults{Results: make([]*Result, 0)}
+	return &BatchedResults{Results: make([]*SingleResult, 0)}
 }
 
 func NewBatchedResultsWithError(err error) *BatchedResults {
 	return &BatchedResults{Err: err}
 }
 
-func (br *BatchedResults) UnmarshalResponseData(logger logger.Logger, data []byte) {
-	var results []*Result
-
-	// define method to process a single result
-	handleSingleUnmarshalledResult := func(unmarshalledResult *Result) {
-		switch unmarshalledResult.BodyEncoding {
-		case "text":
-			unmarshalledResult.DecodedBody = []byte(unmarshalledResult.Body)
-		case "base64":
-			unmarshalledResult.DecodedBody, br.Err = base64.StdEncoding.DecodeString(unmarshalledResult.Body)
-		default:
-			unmarshalledResult.Err = fmt.Errorf("Unknown body encoding - %q", unmarshalledResult.BodyEncoding)
+func NewResultFromData(data []byte) Result {
+	switch data[0] {
+	case 'r':
+		// Try unmarshalling as batched results
+		var results []*SingleResult
+		if err := json.Unmarshal(data[1:], &results); err == nil {
+			return &BatchedResults{Results: results}
 		}
-	}
 
-	if br.Err = json.Unmarshal(data, &results); br.Err != nil {
-		// try to unmarshall data as a single result
-		var singleResult *Result
-		if br.Err = json.Unmarshal(data, &singleResult); br.Err != nil {
-			logger.DebugWith("Failed to unmarshal result",
-				"err", br.Err.Error())
-			return
-		} else {
-			handleSingleUnmarshalledResult(singleResult)
-			br.Results = append(br.Results, singleResult)
-			return
+		// Try unmarshalling as single result
+		var singleResult *SingleResult
+		if err := json.Unmarshal(data[1:], &singleResult); err == nil {
+			return singleResult
 		}
-	}
 
-	br.Results = results
-	for _, unmarshalledResult := range br.Results {
-		handleSingleUnmarshalledResult(unmarshalledResult)
+		// Both failed, return BatchedResults with error
+		return NewBatchedResultsWithError(fmt.Errorf("failed to unmarshal as single or batched result"))
+	case 'e':
+		return &StreamEnd{}
+	case 'b':
+		return NewBodyOnlyFromBase64(data[1:])
+	case 'c':
+		var singleResult *SingleResult
+		if err := json.Unmarshal(data[1:], &singleResult); err != nil {
+			singleResult.Err = errors.Wrap(err, "failed to unmarshal single result from stream start")
+			return singleResult
+		}
+		return newStreamStartFromSingleResult(singleResult)
+	default:
+		return nil
+	}
+}
+
+func NewResultWithNuclioProcessingResult(object interface{}) ResultWithNuclioProcessingResult {
+	if object == nil {
+		return NewSingleResult(nil)
+	}
+	switch typedResponse := object.(type) {
+	case ResultWithNuclioProcessingResult:
+		return typedResponse
+	case *nuclio.ResponseStream:
+		return NewStreamStart(typedResponse)
+	case nuclio.ResponseStream:
+		return NewStreamStart(&typedResponse)
+	case *nuclio.Response:
+		return NewSingleResult(typedResponse)
+	case nuclio.Response:
+		return NewSingleResult(&typedResponse)
+	case io.ReadCloser:
+		// if the response is an io.ReadCloser, create a response stream
+		return NewStreamStart(
+			nuclio.NewCustomResponseStream(
+				"", nil, 0, typedResponse, nil),
+		)
+	case []byte:
+		return NewSingleResult(&nuclio.Response{
+			Body: typedResponse,
+		})
+	case string:
+		return NewSingleResult(&nuclio.Response{
+			Body: []byte(typedResponse),
+		})
+	default:
+		// try to JSON-marshal the value
+		if marshaled, marshalErr := json.Marshal(typedResponse); marshalErr == nil {
+			return NewSingleResult(&nuclio.Response{Body: marshaled})
+		}
+		// fallback to string formatting if JSON marshalling fails
+		return NewSingleResult(&nuclio.Response{Body: []byte(fmt.Sprintf("%v", typedResponse))})
 	}
 }

--- a/pkg/processor/runtime/rpc/result/result.go
+++ b/pkg/processor/runtime/rpc/result/result.go
@@ -62,7 +62,7 @@ type singleSerialisedResult struct {
 type StreamStart struct {
 	*nuclio.ResponseStream
 	// firstChunk is the first chunk of data that was received
-	// we can't write it to the nuclio.ResponseStream until somebody from it, because it's blocking operation
+	// we can't write it to the nuclio.ResponseStream until somebody reads from it, because it's blocking operation
 	// so it should be written to the stream only when we should block the execution
 	firstChunk []byte
 }

--- a/pkg/processor/runtime/rpc/result/result.go
+++ b/pkg/processor/runtime/rpc/result/result.go
@@ -273,3 +273,35 @@ func NewResultWithNuclioProcessingResult(object interface{}) ResultWithNuclioPro
 		return NewSingleResult(&nuclio.Response{Body: []byte(fmt.Sprintf("%v", typedResponse))})
 	}
 }
+
+// NormalizeToResultWithNuclioProcessingResult ensures a result is an implementation of ResultWithNuclioProcessingResult
+func NormalizeToResultWithNuclioProcessingResult(result Result) (ResultWithNuclioProcessingResult, error) {
+	switch typedResult := result.(type) {
+	case nil:
+		return nil, nil
+	case ResultWithNuclioProcessingResult:
+		return typedResult, nil
+	case *BodyOnly:
+		single := NewSingleResult(&nuclio.Response{Body: typedResult.Body})
+		single.Err = typedResult.Err
+		return single, nil
+	case *BatchedResults:
+		if len(typedResult.Results) > 0 {
+			return typedResult.Results[0], nil
+		}
+		return NewSingleResult(nil), nil
+	default:
+		return nil, errors.Errorf("cannot convert result of type %T to ResultWithNuclioProcessingResult", result)
+	}
+}
+
+func NormalizeToBatchedResults(result Result) (*BatchedResults, error) {
+	switch typedResult := result.(type) {
+	case *BatchedResults:
+		return typedResult, nil
+	case *SingleResult:
+		return &BatchedResults{Results: []*SingleResult{typedResult}}, nil
+	default:
+		return nil, errors.Errorf("cannot convert result of type %T to BatchedResults", result)
+	}
+}

--- a/pkg/processor/runtime/rpc/result/result.go
+++ b/pkg/processor/runtime/rpc/result/result.go
@@ -162,6 +162,12 @@ func (sr *SingleResult) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func NewSingleResultsWithError(err error) *SingleResult {
+	singleResult := NewSingleResult(nil)
+	singleResult.Err = err
+	return singleResult
+}
+
 func (sr *SingleResult) IsStream() bool { return false }
 
 func (sr *SingleResult) Error() error {
@@ -193,20 +199,26 @@ func NewBatchedResultsWithError(err error) *BatchedResults {
 func NewResultFromData(data []byte) Result {
 	switch data[0] {
 	case 'r':
-		// Try unmarshalling as batched results
-		var results []*SingleResult
-		if err := json.Unmarshal(data[1:], &results); err == nil {
-			return &BatchedResults{Results: results}
+		// data[0] is a known prefix 'r'
+		// data[1:] is expected to be a valid JSON object or array
+		// so if data[1:] is of len 1, then it is not a valid result
+		if len(data) < 2 {
+			return NewSingleResultsWithError(errors.New("Data is too short to contain a valid result"))
 		}
 
-		// Try unmarshalling as single result
-		var singleResult *SingleResult
-		if err := json.Unmarshal(data[1:], &singleResult); err == nil {
-			return singleResult
+		if data[1] == '{' {
+			var singleResult *SingleResult
+			if err := json.Unmarshal(data[1:], &singleResult); err == nil {
+				return singleResult
+			}
+		} else if data[1] == '[' {
+			var results []*SingleResult
+			if err := json.Unmarshal(data[1:], &results); err == nil {
+				return &BatchedResults{Results: results}
+			}
 		}
-
-		// Both failed, return BatchedResults with error
-		return NewBatchedResultsWithError(fmt.Errorf("failed to unmarshal as single or batched result"))
+		// Both failed, return result with error
+		return NewSingleResultsWithError(fmt.Errorf("failed to unmarshal as single or batched result"))
 	case 'e':
 		return &StreamEnd{}
 	case 'b':

--- a/pkg/processor/runtime/rpc/result/result.go
+++ b/pkg/processor/runtime/rpc/result/result.go
@@ -26,6 +26,20 @@ import (
 	"github.com/nuclio/nuclio-sdk-go"
 )
 
+// PacketType represents a single-byte prefix that indicates the type of message
+// being transmitted over the Nuclio processor connection.
+type PacketType byte
+
+const (
+	PacketTypeSingleResponse PacketType = 'r'
+	PacketTypeStreamStart    PacketType = 'c'
+	PacketTypeBodyChunk      PacketType = 'b'
+	PacketTypeEndOfStream    PacketType = 'e'
+	PacketTypeMetrics        PacketType = 'm'
+	PacketTypeLog            PacketType = 'l'
+	PacketTypeStart          PacketType = 's'
+)
+
 type RpcLogRecord struct {
 	DateTime string                 `json:"datetime"`
 	Level    string                 `json:"level"`
@@ -33,6 +47,8 @@ type RpcLogRecord struct {
 	With     map[string]interface{} `json:"with"`
 }
 
+// singleSerialisedResult is an internal struct used for deserialising a JSON response
+// It matches the wire format and includes encoded body and metadata
 type singleSerialisedResult struct {
 	StatusCode   int                    `json:"status_code"`
 	ContentType  string                 `json:"content_type"`
@@ -42,11 +58,11 @@ type singleSerialisedResult struct {
 	BodyEncoding string                 `json:"body_encoding"`
 }
 
+// StreamStart wraps a Nuclio ResponseStream and holds the first chunk to be sent later (when reader is ready)
 type StreamStart struct {
 	*nuclio.ResponseStream
-	Err error
 	// firstChunk is the first chunk of data that was received
-	// we can't write it to the nuclio.ResponseStream until nobody reads from it, because it's blocking operation
+	// we can't write it to the nuclio.ResponseStream until nobody somebody from it, because it's blocking operation
 	// so it should be written to the stream only when we should block the execution
 	firstChunk []byte
 }
@@ -67,15 +83,18 @@ func (ss *StreamStart) WriteFirstChunk() error {
 	_, err := ss.SendChunk(ss.firstChunk)
 	return err
 }
+
 func (ss *StreamStart) IsStream() bool { return true }
+
 func (ss *StreamStart) Error() error {
-	return ss.Err
+	return nil
 }
 
 func (ss *StreamStart) GetProcessingResult() nuclio.ProcessingResult {
 	return ss.ResponseStream
 }
 
+// StreamEnd represents the logical end of a streaming response
 type StreamEnd struct{}
 
 func (eos *StreamEnd) IsStream() bool { return false }
@@ -84,6 +103,8 @@ func (eos *StreamEnd) Error() error {
 	return nil
 }
 
+// BodyOnly represents a single body chunk (as []byte) without any metadata
+// It may also carry an error if decoding failed
 type BodyOnly struct {
 	Body []byte
 	Err  error
@@ -108,6 +129,9 @@ func NewBodyOnlyFromBase64(data []byte) Result {
 	}
 }
 
+// SingleResult represents a full single response, either real or synthetic
+// Includes a decoded body and optionally, an error
+// may carry eventID when used in a batching flow
 type SingleResult struct {
 	*nuclio.Response
 	EventId string `json:"event_id"`
@@ -178,6 +202,8 @@ func (sr *SingleResult) GetProcessingResult() nuclio.ProcessingResult {
 	return sr.Response
 }
 
+// BatchedResults contains a slice of multiple SingleResult items
+// Used for transmitting batched (non-streaming) responses
 type BatchedResults struct {
 	Results []*SingleResult
 	Err     error
@@ -196,9 +222,11 @@ func NewBatchedResultsWithError(err error) *BatchedResults {
 	return &BatchedResults{Err: err}
 }
 
+// NewResultFromData decodes raw incoming data into a typed `Result` object,
+// based on the leading `PacketType` byte
 func NewResultFromData(data []byte) Result {
-	switch data[0] {
-	case 'r':
+	switch PacketType(data[0]) {
+	case PacketTypeSingleResponse:
 		// data[0] is a known prefix 'r'
 		// data[1:] is expected to be a valid JSON object or array
 		// so if data[1:] is of len 1, then it is not a valid result
@@ -218,12 +246,12 @@ func NewResultFromData(data []byte) Result {
 			}
 		}
 		// Both failed, return result with error
-		return NewSingleResultsWithError(fmt.Errorf("failed to unmarshal as single or batched result"))
-	case 'e':
+		return NewSingleResultsWithError(errors.New("failed to unmarshal as single or batched result"))
+	case PacketTypeEndOfStream:
 		return &StreamEnd{}
-	case 'b':
+	case PacketTypeBodyChunk:
 		return NewBodyOnlyFromBase64(data[1:])
-	case 'c':
+	case PacketTypeStreamStart:
 		var singleResult *SingleResult
 		if err := json.Unmarshal(data[1:], &singleResult); err != nil {
 			singleResult.Err = errors.Wrap(err, "failed to unmarshal single result from stream start")
@@ -235,12 +263,13 @@ func NewResultFromData(data []byte) Result {
 	}
 }
 
-func NewResultWithNuclioProcessingResult(object interface{}) ResultWithNuclioProcessingResult {
+// NewResultWithNuclioProcessingResult wraps a generic input value into a `ResultWithProcessingResult`
+func NewResultWithNuclioProcessingResult(object interface{}) ResultWithProcessingResult {
 	if object == nil {
 		return NewSingleResult(nil)
 	}
 	switch typedResponse := object.(type) {
-	case ResultWithNuclioProcessingResult:
+	case ResultWithProcessingResult:
 		return typedResponse
 	case *nuclio.ResponseStream:
 		return NewStreamStart(typedResponse)
@@ -274,12 +303,13 @@ func NewResultWithNuclioProcessingResult(object interface{}) ResultWithNuclioPro
 	}
 }
 
-// NormalizeToResultWithNuclioProcessingResult ensures a result is an implementation of ResultWithNuclioProcessingResult
-func NormalizeToResultWithNuclioProcessingResult(result Result) (ResultWithNuclioProcessingResult, error) {
+// NormalizeToResultWithNuclioProcessingResult ensures that the given `Result` is compatible
+// with the `ResultWithProcessingResult` interface, converting it if necessary.
+func NormalizeToResultWithNuclioProcessingResult(result Result) (ResultWithProcessingResult, error) {
 	switch typedResult := result.(type) {
 	case nil:
 		return nil, nil
-	case ResultWithNuclioProcessingResult:
+	case ResultWithProcessingResult:
 		return typedResult, nil
 	case *BodyOnly:
 		single := NewSingleResult(&nuclio.Response{Body: typedResult.Body})
@@ -291,10 +321,12 @@ func NormalizeToResultWithNuclioProcessingResult(result Result) (ResultWithNucli
 		}
 		return NewSingleResult(nil), nil
 	default:
-		return nil, errors.Errorf("cannot convert result of type %T to ResultWithNuclioProcessingResult", result)
+		return nil, errors.Errorf("cannot convert result of type %T to ResultWithProcessingResult", result)
 	}
 }
 
+// NormalizeToBatchedResults ensures that a given `Result` is returned as a `*BatchedResults`.
+// If it's a `SingleResult`, it wraps it in a batch. If already a batch, it's returned as-is.
 func NormalizeToBatchedResults(result Result) (*BatchedResults, error) {
 	switch typedResult := result.(type) {
 	case *BatchedResults:

--- a/pkg/processor/runtime/rpc/result/result.go
+++ b/pkg/processor/runtime/rpc/result/result.go
@@ -153,22 +153,10 @@ func (sr *SingleResult) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Decode body
-	var decodedBody []byte
-	switch rawResult.BodyEncoding {
-	case "text":
-		decodedBody = []byte(rawResult.Body)
-	case "base64":
-		var err error
-		decodedBody, err = base64.StdEncoding.DecodeString(rawResult.Body)
-		if err != nil {
-			sr.Err = err
-			return err
-		}
-	default:
-		err := fmt.Errorf("unknown body encoding %q", rawResult.BodyEncoding)
-		sr.Err = err
-		return err
+	decodedBody, err := sr.decodeBody(rawResult)
+
+	if err != nil {
+		return errors.Wrap(err, "Failed to decode body")
 	}
 
 	// Fill the Response
@@ -184,6 +172,26 @@ func (sr *SingleResult) UnmarshalJSON(data []byte) error {
 	sr.EventId = rawResult.EventId
 
 	return nil
+}
+
+func (sr *SingleResult) decodeBody(rawResult singleSerialisedResult) ([]byte, error) {
+	var decodedBody []byte
+	switch rawResult.BodyEncoding {
+	case "text":
+		decodedBody = []byte(rawResult.Body)
+	case "base64":
+		var err error
+		decodedBody, err = base64.StdEncoding.DecodeString(rawResult.Body)
+		if err != nil {
+			sr.Err = err
+			return nil, err
+		}
+	default:
+		err := fmt.Errorf("unknown body encoding %q", rawResult.BodyEncoding)
+		sr.Err = err
+		return nil, err
+	}
+	return decodedBody, nil
 }
 
 func NewSingleResultsWithError(err error) *SingleResult {
@@ -263,8 +271,8 @@ func NewResultFromData(data []byte) Result {
 	}
 }
 
-// NewResultWithNuclioProcessingResult wraps a generic input value into a `ResultWithProcessingResult`
-func NewResultWithNuclioProcessingResult(object interface{}) ResultWithProcessingResult {
+// NewResultWithProcessingResult wraps a generic input value into a `ResultWithProcessingResult`
+func NewResultWithProcessingResult(object interface{}) ResultWithProcessingResult {
 	if object == nil {
 		return NewSingleResult(nil)
 	}
@@ -303,9 +311,9 @@ func NewResultWithNuclioProcessingResult(object interface{}) ResultWithProcessin
 	}
 }
 
-// NormalizeToResultWithNuclioProcessingResult ensures that the given `Result` is compatible
+// NormalizeToResultWithProcessingResult ensures that the given `Result` is compatible
 // with the `ResultWithProcessingResult` interface, converting it if necessary.
-func NormalizeToResultWithNuclioProcessingResult(result Result) (ResultWithProcessingResult, error) {
+func NormalizeToResultWithProcessingResult(result Result) (ResultWithProcessingResult, error) {
 	switch typedResult := result.(type) {
 	case nil:
 		return nil, nil

--- a/pkg/processor/runtime/rpc/result/result.go
+++ b/pkg/processor/runtime/rpc/result/result.go
@@ -62,7 +62,7 @@ type singleSerialisedResult struct {
 type StreamStart struct {
 	*nuclio.ResponseStream
 	// firstChunk is the first chunk of data that was received
-	// we can't write it to the nuclio.ResponseStream until nobody somebody from it, because it's blocking operation
+	// we can't write it to the nuclio.ResponseStream until somebody from it, because it's blocking operation
 	// so it should be written to the stream only when we should block the execution
 	firstChunk []byte
 }
@@ -106,14 +106,14 @@ func (eos *StreamEnd) Error() error {
 // BodyOnly represents a single body chunk (as []byte) without any metadata
 // It may also carry an error if decoding failed
 type BodyOnly struct {
-	Body []byte
-	Err  error
+	Body        []byte
+	decodingErr error
 }
 
 func (b *BodyOnly) IsStream() bool { return false }
 
 func (b *BodyOnly) Error() error {
-	return b.Err
+	return b.decodingErr
 }
 
 // NewBodyOnlyFromBase64 creates a BodyOnly result from base64-encoded data.
@@ -121,7 +121,7 @@ func NewBodyOnlyFromBase64(data []byte) Result {
 	decoded, err := base64.StdEncoding.DecodeString(string(data))
 	if err != nil {
 		return &BodyOnly{
-			Err: errors.Errorf("failed to decode base64 body: %s", err.Error()),
+			decodingErr: errors.Errorf("failed to decode base64 body: %s", err.Error()),
 		}
 	}
 	return &BodyOnly{
@@ -135,7 +135,7 @@ func NewBodyOnlyFromBase64(data []byte) Result {
 type SingleResult struct {
 	*nuclio.Response
 	EventId string `json:"event_id"`
-	Err     error
+	err     error
 }
 
 func NewSingleResult(response *nuclio.Response) *SingleResult {
@@ -183,12 +183,12 @@ func (sr *SingleResult) decodeBody(rawResult singleSerialisedResult) ([]byte, er
 		var err error
 		decodedBody, err = base64.StdEncoding.DecodeString(rawResult.Body)
 		if err != nil {
-			sr.Err = err
+			sr.err = err
 			return nil, err
 		}
 	default:
 		err := fmt.Errorf("unknown body encoding %q", rawResult.BodyEncoding)
-		sr.Err = err
+		sr.err = err
 		return nil, err
 	}
 	return decodedBody, nil
@@ -196,14 +196,14 @@ func (sr *SingleResult) decodeBody(rawResult singleSerialisedResult) ([]byte, er
 
 func NewSingleResultsWithError(err error) *SingleResult {
 	singleResult := NewSingleResult(nil)
-	singleResult.Err = err
+	singleResult.err = err
 	return singleResult
 }
 
 func (sr *SingleResult) IsStream() bool { return false }
 
 func (sr *SingleResult) Error() error {
-	return sr.Err
+	return sr.err
 }
 
 func (sr *SingleResult) GetProcessingResult() nuclio.ProcessingResult {
@@ -214,12 +214,13 @@ func (sr *SingleResult) GetProcessingResult() nuclio.ProcessingResult {
 // Used for transmitting batched (non-streaming) responses
 type BatchedResults struct {
 	Results []*SingleResult
-	Err     error
+	err     error
 }
 
 func (br *BatchedResults) IsStream() bool { return false }
+
 func (br *BatchedResults) Error() error {
-	return br.Err
+	return br.err
 }
 
 func NewBatchedResults() *BatchedResults {
@@ -227,7 +228,7 @@ func NewBatchedResults() *BatchedResults {
 }
 
 func NewBatchedResultsWithError(err error) *BatchedResults {
-	return &BatchedResults{Err: err}
+	return &BatchedResults{err: err}
 }
 
 // NewResultFromData decodes raw incoming data into a typed `Result` object,
@@ -262,7 +263,7 @@ func NewResultFromData(data []byte) Result {
 	case PacketTypeStreamStart:
 		var singleResult *SingleResult
 		if err := json.Unmarshal(data[1:], &singleResult); err != nil {
-			singleResult.Err = errors.Wrap(err, "failed to unmarshal single result from stream start")
+			singleResult.err = errors.Wrap(err, "failed to unmarshal single result from stream start")
 			return singleResult
 		}
 		return newStreamStartFromSingleResult(singleResult)
@@ -321,7 +322,7 @@ func NormalizeToResultWithProcessingResult(result Result) (ResultWithProcessingR
 		return typedResult, nil
 	case *BodyOnly:
 		single := NewSingleResult(&nuclio.Response{Body: typedResult.Body})
-		single.Err = typedResult.Err
+		single.err = typedResult.Error()
 		return single, nil
 	case *BatchedResults:
 		if len(typedResult.Results) > 0 {

--- a/pkg/processor/runtime/rpc/result/result_test.go
+++ b/pkg/processor/runtime/rpc/result/result_test.go
@@ -18,15 +18,22 @@ limitations under the License.
 package result
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/nuclio/logger"
+	"github.com/nuclio/nuclio-sdk-go"
 	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
 )
 
 type ResultSuite struct {
 	suite.Suite
+	logger logger.Logger
+}
+
+func (suite *ResultSuite) SuiteSetup() {
+	suite.logger = suite.createLogger()
 }
 
 func (suite *ResultSuite) createLogger() logger.Logger {
@@ -35,46 +42,116 @@ func (suite *ResultSuite) createLogger() logger.Logger {
 
 	return loggerInstance
 }
+func (suite *ResultSuite) TestNewResultFromDataRawInputs() {
+	streamBodyValue := "stream-body"
+	bodyBase64 := base64.StdEncoding.EncodeToString([]byte(streamBodyValue))
 
-func (suite *ResultSuite) TestUnmarshalResponseData() {
-	for _, testCase := range []struct {
-		name               string
-		data               []byte
-		unmarshalledResult []*Result
+	testCases := []struct {
+		name           string
+		rawData        []byte
+		expectedResult any
+		expectedError  bool
 	}{
 		{
-			name: "single-result",
-			data: []byte("{\"body\": \"123\", \"content_type\": \"123\", \"headers\": {}, \"status_code\": 200, \"body_encoding\": \"text\"}"),
-			unmarshalledResult: []*Result{{
-				StatusCode:   200,
-				ContentType:  "123",
-				Body:         "123",
-				BodyEncoding: "text",
-				DecodedBody:  []uint8{49, 50, 51},
-				Headers:      map[string]interface{}{},
-			}},
+			name:    "single result (text body)",
+			rawData: []byte(`r{"body": "123", "content_type": "123", "headers": {}, "status_code": 200, "body_encoding": "text"}`),
+			expectedResult: &SingleResult{
+				Response: &nuclio.Response{
+					StatusCode:  200,
+					ContentType: "123",
+					Headers:     map[string]interface{}{},
+					Body:        []byte("123"),
+				},
+			},
 		},
 		{
-			name: "batch-result",
-			data: []byte("[{\"body\": \"123\", \"content_type\": \"123\", \"headers\": {}, \"status_code\": 200, \"body_encoding\": \"text\"}]"),
-			unmarshalledResult: []*Result{{
-				StatusCode:   200,
-				ContentType:  "123",
-				Body:         "123",
-				BodyEncoding: "text",
-				DecodedBody:  []uint8{49, 50, 51},
-				Headers:      map[string]interface{}{},
-			}},
+			name:    "batch result (text body)",
+			rawData: []byte(`r[{"body": "123", "content_type": "123", "headers": {}, "status_code": 200, "body_encoding": "text"}]`),
+			expectedResult: &BatchedResults{
+				Results: []*SingleResult{
+					{
+						Response: &nuclio.Response{
+							StatusCode:  200,
+							ContentType: "123",
+							Headers:     map[string]interface{}{},
+							Body:        []byte("123"),
+						},
+					},
+				},
+			},
 		},
-	} {
+		{
+			name:           "body only (base64)",
+			rawData:        []byte("b" + bodyBase64),
+			expectedResult: &BodyOnly{Body: []byte(streamBodyValue)},
+		},
+		{
+			name:           "stream end",
+			rawData:        []byte("e"),
+			expectedResult: &StreamEnd{},
+		},
+		{
+			name:    "stream start (text body)",
+			rawData: []byte(`c{"body": "123", "content_type": "123", "headers": {}, "status_code": 200, "body_encoding": "text"}`),
+			expectedResult: func() any {
+				sr := &SingleResult{
+					Response: &nuclio.Response{
+						StatusCode:  200,
+						ContentType: "123",
+						Headers:     map[string]interface{}{},
+						Body:        []byte("123"),
+					},
+				}
+				return newStreamStartFromSingleResult(sr)
+			}(),
+		},
+	}
+
+	for _, testCase := range testCases {
 		suite.Run(testCase.name, func() {
-			unmarshalledResults := NewBatchedResults()
-			unmarshalledResults.UnmarshalResponseData(suite.createLogger(), testCase.data)
-			suite.Require().Equal(unmarshalledResults.Results, testCase.unmarshalledResult)
+			result := NewResultFromData(testCase.rawData)
+			suite.Require().NotNil(result, "expected result, got nil")
+
+			if testCase.expectedError {
+				suite.Error(result.Error())
+			} else {
+				suite.NoError(result.Error())
+			}
+
+			switch expected := testCase.expectedResult.(type) {
+			case *SingleResult:
+				actual, ok := result.(*SingleResult)
+				suite.True(ok)
+				suite.Equal(expected.StatusCode, actual.StatusCode)
+				suite.Equal(expected.ContentType, actual.ContentType)
+				suite.Equal(expected.Body, actual.Body)
+			case *BatchedResults:
+				actual, ok := result.(*BatchedResults)
+				suite.True(ok)
+				suite.Len(actual.Results, len(expected.Results))
+				for i := range actual.Results {
+					suite.Equal(expected.Results[i].Body, actual.Results[i].Body)
+					suite.Equal(expected.Results[i].StatusCode, actual.Results[i].StatusCode)
+				}
+			case *BodyOnly:
+				actual, ok := result.(*BodyOnly)
+				suite.True(ok)
+				suite.Equal(expected, actual)
+			case *StreamEnd:
+				_, ok := result.(*StreamEnd)
+				suite.True(ok)
+			case *StreamStart:
+				actual, ok := result.(*StreamStart)
+				suite.True(ok)
+				suite.Equal(expected.GetStatusCode(), actual.GetStatusCode())
+				suite.Equal(expected.GetContentType(), actual.GetContentType())
+			default:
+				suite.Fail("unhandled result type")
+			}
 		})
 	}
 }
 
-func TestRuntime(t *testing.T) {
+func TestResultSuite(t *testing.T) {
 	suite.Run(t, new(ResultSuite))
 }

--- a/pkg/processor/runtime/rpc/result/types.go
+++ b/pkg/processor/runtime/rpc/result/types.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2025 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package result
+
+import "github.com/nuclio/nuclio-sdk-go"
+
+type ResultWithNuclioProcessingResult interface {
+	Result
+	GetProcessingResult() nuclio.ProcessingResult
+}
+
+type Result interface {
+	IsStream() bool
+
+	Error() error
+}

--- a/pkg/processor/runtime/rpc/result/types.go
+++ b/pkg/processor/runtime/rpc/result/types.go
@@ -18,7 +18,7 @@ package result
 
 import "github.com/nuclio/nuclio-sdk-go"
 
-type ResultWithNuclioProcessingResult interface {
+type ResultWithProcessingResult interface {
 	Result
 	GetProcessingResult() nuclio.ProcessingResult
 }

--- a/pkg/processor/runtime/runtime.go
+++ b/pkg/processor/runtime/runtime.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
 	"github.com/nuclio/nuclio/pkg/processor/databinding"
+	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/result"
 	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/errors"
@@ -37,7 +38,7 @@ type Runtime interface {
 	ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (interface{}, error)
 
 	// ProcessBatch receives the event batch and processes it at the specific runtime
-	ProcessBatch(batch []nuclio.Event, functionLogger logger.Logger) ([]*ResponseWithErrors, error)
+	ProcessBatch(batch []nuclio.Event, functionLogger logger.Logger) (*result.BatchedResults, error)
 
 	// GetFunctionLogger returns the function logger
 	GetFunctionLogger() logger.Logger

--- a/pkg/processor/runtime/shell/runtime.go
+++ b/pkg/processor/runtime/shell/runtime.go
@@ -31,6 +31,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/result"
 	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/errors"
@@ -173,7 +174,7 @@ func (s *shell) waitForResponseWithTimeout(ctx context.Context, responseChan cha
 	}
 }
 
-func (s *shell) ProcessBatch(batch []nuclio.Event, functionLogger logger.Logger) ([]*runtime.ResponseWithErrors, error) {
+func (s *shell) ProcessBatch(batch []nuclio.Event, functionLogger logger.Logger) (*result.BatchedResults, error) {
 	return nil, nuclio.ErrNotImplemented
 }
 

--- a/pkg/processor/trigger/http/test/suite/http_test.go
+++ b/pkg/processor/trigger/http/test/suite/http_test.go
@@ -167,7 +167,7 @@ def handler(context, event):
 			{
 				RequestMethod:              "GET",
 				ExpectedResponseStatusCode: &statusInternalServerError,
-				ExpectedResponseBody:       "json: cannot unmarshal number into Go struct field Result.content_type of type string",
+				ExpectedResponseBody:       "failed to unmarshal as single or batched result",
 			},
 		})
 }

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -596,6 +596,12 @@ func (h *http) handleRequest(ctx *fasthttp.RequestCtx) {
 			}
 		}
 	}
+	if !workerReleased {
+		// try to release the worker instance asap
+		// if code won't get here (because of the error, then the defer will take care of it)
+		h.WorkerAllocator.Release(workerInstance)
+		workerReleased = true
+	}
 
 	// set content type if set
 	if response.GetContentType() != "" {

--- a/pkg/processor/trigger/test/event.go
+++ b/pkg/processor/trigger/test/event.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2025 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package triggertest
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nuclio/nuclio-sdk-go"
+)
+
+var (
+	testID                  = nuclio.ID(uuid.New().String())
+	testTriggerInfoProvider = &TestTriggerInfoProvider{}
+
+	TestHeaders = map[string]interface{}{
+		"h1": "hv1",
+		"h2": 2,
+	}
+	testFields = map[string]interface{}{
+		"f1": "fv1",
+		"f2": 0xF2,
+	}
+)
+
+type TestTriggerInfoProvider struct{}
+
+func (ti *TestTriggerInfoProvider) GetClass() string { return "test class" }
+func (ti *TestTriggerInfoProvider) GetKind() string  { return "test kind" }
+func (ti *TestTriggerInfoProvider) GetName() string  { return "test name" }
+
+type TestEvent struct {
+	// We don't embed nuclio.AbstractEvent so we'll have all methods
+}
+
+func (te *TestEvent) GetID() nuclio.ID {
+	return testID
+}
+
+func (te *TestEvent) GetContentType() string {
+	return "text/html"
+}
+
+func (te *TestEvent) GetBody() []byte {
+	return []byte("body of proof")
+}
+
+func (te *TestEvent) GetBodyObject() interface{} {
+	return te.GetBody
+}
+
+func (te *TestEvent) GetHeaders() map[string]interface{} {
+	return TestHeaders
+}
+
+func (te *TestEvent) GetFields() map[string]interface{} {
+	return testFields
+}
+
+func (te *TestEvent) GetTimestamp() time.Time {
+	return time.Now().UTC()
+}
+
+func (te *TestEvent) GetPath() string {
+	return "/path/to/test"
+}
+
+func (te *TestEvent) GetURL() string {
+	return "https://github.com/nuclio/nuclio"
+}
+
+func (te *TestEvent) GetMethod() string {
+	return "POST"
+}
+
+func (te *TestEvent) GetShardID() int {
+	return 9
+}
+
+func (te *TestEvent) GetTotalNumShards() int {
+	return 32
+}
+
+func (te *TestEvent) GetType() string {
+	return "test event type"
+}
+
+func (te *TestEvent) GetTypeVersion() string {
+	return "test event type version"
+}
+
+func (te *TestEvent) GetVersion() string {
+	return "test event version"
+}
+
+// GetLastInBatch returns whether the event is the last event in a trigger specific batch
+func (te *TestEvent) GetLastInBatch() bool {
+	return false
+}
+
+// GetOffset returns the offset of the event
+func (te *TestEvent) GetOffset() int {
+	return 0
+}
+
+func (te *TestEvent) GetTopic() string {
+	return ""
+}
+
+func (te *TestEvent) GetTriggerInfo() nuclio.TriggerInfoProvider {
+	return testTriggerInfoProvider
+}
+
+func (te *TestEvent) GetHeader(key string) interface{} {
+	return TestHeaders[key]
+}
+func (te *TestEvent) GetHeaderByteSlice(key string) []byte {
+	return TestHeaders[key].([]byte)
+}
+func (te *TestEvent) GetHeaderString(key string) string {
+	return TestHeaders[key].(string)
+}
+func (te *TestEvent) GetHeaderInt(key string) (int, error) {
+	return TestHeaders[key].(int), nil
+}
+
+func (te *TestEvent) GetField(key string) interface{} {
+	return testFields[key]
+}
+func (te *TestEvent) GetFieldByteSlice(key string) []byte {
+	return testFields[key].([]byte)
+}
+func (te *TestEvent) GetFieldString(key string) string {
+	return testFields[key].(string)
+}
+func (te *TestEvent) GetFieldInt(key string) (int, error) {
+	return testFields[key].(int), nil
+}
+func (te *TestEvent) SetID(id nuclio.ID) {}
+
+func (te *TestEvent) SetTriggerInfoProvider(tip nuclio.TriggerInfoProvider) {}

--- a/pkg/processor/trigger/test/event.go
+++ b/pkg/processor/trigger/test/event.go
@@ -46,6 +46,9 @@ type TestEvent struct {
 }
 
 func NewTestEvent(id nuclio.ID, triggerInfoProvide nuclio.TriggerInfoProvider) *TestEvent {
+	if triggerInfoProvide == nil {
+		triggerInfoProvide = &TestTriggerInfoProvider{}
+	}
 	return &TestEvent{
 		testID:                  id,
 		testTriggerInfoProvider: triggerInfoProvide,

--- a/pkg/processor/trigger/test/event.go
+++ b/pkg/processor/trigger/test/event.go
@@ -19,19 +19,15 @@ package triggertest
 import (
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/nuclio/nuclio-sdk-go"
 )
 
 var (
-	testID                  = nuclio.ID(uuid.New().String())
-	testTriggerInfoProvider = &TestTriggerInfoProvider{}
-
 	TestHeaders = map[string]interface{}{
 		"h1": "hv1",
 		"h2": 2,
 	}
-	testFields = map[string]interface{}{
+	TestFields = map[string]interface{}{
 		"f1": "fv1",
 		"f2": 0xF2,
 	}
@@ -44,11 +40,20 @@ func (ti *TestTriggerInfoProvider) GetKind() string  { return "test kind" }
 func (ti *TestTriggerInfoProvider) GetName() string  { return "test name" }
 
 type TestEvent struct {
+	testID                  nuclio.ID
+	testTriggerInfoProvider nuclio.TriggerInfoProvider
 	// We don't embed nuclio.AbstractEvent so we'll have all methods
 }
 
+func NewTestEvent(id nuclio.ID, triggerInfoProvide nuclio.TriggerInfoProvider) *TestEvent {
+	return &TestEvent{
+		testID:                  id,
+		testTriggerInfoProvider: triggerInfoProvide,
+	}
+}
+
 func (te *TestEvent) GetID() nuclio.ID {
-	return testID
+	return te.testID
 }
 
 func (te *TestEvent) GetContentType() string {
@@ -68,7 +73,7 @@ func (te *TestEvent) GetHeaders() map[string]interface{} {
 }
 
 func (te *TestEvent) GetFields() map[string]interface{} {
-	return testFields
+	return TestFields
 }
 
 func (te *TestEvent) GetTimestamp() time.Time {
@@ -122,7 +127,7 @@ func (te *TestEvent) GetTopic() string {
 }
 
 func (te *TestEvent) GetTriggerInfo() nuclio.TriggerInfoProvider {
-	return testTriggerInfoProvider
+	return te.testTriggerInfoProvider
 }
 
 func (te *TestEvent) GetHeader(key string) interface{} {
@@ -139,16 +144,16 @@ func (te *TestEvent) GetHeaderInt(key string) (int, error) {
 }
 
 func (te *TestEvent) GetField(key string) interface{} {
-	return testFields[key]
+	return TestFields[key]
 }
 func (te *TestEvent) GetFieldByteSlice(key string) []byte {
-	return testFields[key].([]byte)
+	return TestFields[key].([]byte)
 }
 func (te *TestEvent) GetFieldString(key string) string {
-	return testFields[key].(string)
+	return TestFields[key].(string)
 }
 func (te *TestEvent) GetFieldInt(key string) (int, error) {
-	return testFields[key].(int), nil
+	return TestFields[key].(int), nil
 }
 func (te *TestEvent) SetID(id nuclio.ID) {}
 

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -293,18 +293,23 @@ func (at *AbstractTrigger) HandleSubmitPanic(workerInstance eventprocessor.Event
 // SubmitEventToWorker submits events to worker and returns response
 func (at *AbstractTrigger) SubmitEventToWorker(functionLogger logger.Logger,
 	workerInstance eventprocessor.EventProcessor,
-	event nuclio.Event) (response nuclio.ProcessingResult, processError error) {
+	event nuclio.Event) (nuclio.ProcessingResult, error) {
 
 	event, err := at.prepareEvent(event, workerInstance)
 	if err != nil {
 		return nil, err
 	}
 
-	response, processError = workerInstance.ProcessEvent(event, functionLogger)
+	response, processError := workerInstance.ProcessEvent(event, functionLogger)
 
 	// increment statistics based on results. if process error is nil, we successfully handled
 	at.UpdateStatistics(processError == nil, 1)
-	return
+	if response == nil {
+		// if the response is nil, return an empty response with the error
+		return &nuclio.Response{}, processError
+	}
+
+	return response.GetProcessingResult(), processError
 }
 
 // UpdateStatistics updates the trigger statistics
@@ -527,7 +532,7 @@ func (at *AbstractTrigger) SubmitBatchAndSendResponses(batch []nuclio.Event, res
 		at.UpdateStatistics(false, uint64(len(responseChans)))
 		return
 	} else {
-		for _, response := range responses {
+		for _, response := range responses.Results {
 			if response.EventId == "" {
 				at.Logger.WarnWith("Received in-batch response without event_id, response won't be returned")
 			}
@@ -537,7 +542,7 @@ func (at *AbstractTrigger) SubmitBatchAndSendResponses(batch []nuclio.Event, res
 			} else {
 				go channel.Write(at.Logger, response)
 				delete(responseChans, response.EventId)
-				if response.ProcessError != nil {
+				if response.Error() != nil {
 					at.UpdateStatistics(false, 1)
 				} else {
 					at.UpdateStatistics(true, 1)

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -63,7 +63,7 @@ func NewWorker(parentLogger logger.Logger,
 }
 
 // ProcessEvent sends the event to the associated runtime
-func (w *Worker) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (result.ResultWithNuclioProcessingResult, error) {
+func (w *Worker) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (result.ResultWithProcessingResult, error) {
 	// process the event at the runtime
 	response, err := w.runtime.ProcessEvent(event, functionLogger)
 

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -17,9 +17,6 @@ limitations under the License.
 package worker
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -30,6 +27,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
 	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/result"
 	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/logger"
@@ -65,51 +63,25 @@ func NewWorker(parentLogger logger.Logger,
 }
 
 // ProcessEvent sends the event to the associated runtime
-func (w *Worker) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (nuclio.ProcessingResult, error) {
+func (w *Worker) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) (result.ResultWithNuclioProcessingResult, error) {
 	// process the event at the runtime
 	response, err := w.runtime.ProcessEvent(event, functionLogger)
 
-	w.calculateProcessingMetrics(response, err)
+	// form a result object from the response
+	resultWithNuclioProcessingResult := result.NewResultWithNuclioProcessingResult(response)
 
-	if response == nil {
-		// if the response is nil, return an empty response with the error
-		// it might be that go runtime handler returned nil, so we want to make sure that we return a valid response
-		return &nuclio.Response{}, err
-	}
+	// calculate processing metrics
+	w.calculateProcessingMetrics(resultWithNuclioProcessingResult.GetProcessingResult(), err)
 
-	// always translate the response to a nuclio.ProcessingResult
-	switch typedResponse := response.(type) {
-	case *nuclio.Response:
-		return typedResponse, err
-	case nuclio.Response:
-		return &typedResponse, err
-	case *nuclio.ResponseStream:
-		return typedResponse, err
-	case nuclio.ResponseStream:
-		return &typedResponse, err
-	case io.ReadCloser:
-		// if the response is an io.ReadCloser, create a response stream
-		return nuclio.NewCustomResponseStream("", nil, 0, typedResponse, nil), err
-	case []byte:
-		return &nuclio.Response{
-			Body: typedResponse,
-		}, err
-	case string:
-		return &nuclio.Response{
-			Body: []byte(typedResponse),
-		}, err
-	default:
-		// try to JSON-marshal the value
-		if marshaled, marshalErr := json.Marshal(typedResponse); marshalErr == nil {
-			return &nuclio.Response{Body: marshaled}, err
-		}
-		// fallback to string formatting if JSON marshalling fails
-		return &nuclio.Response{Body: []byte(fmt.Sprintf("%v", typedResponse))}, err
-	}
+	return resultWithNuclioProcessingResult, err
 }
 
-func (w *Worker) ProcessEventBatch(batch []nuclio.Event, functionLogger logger.Logger) ([]*runtime.ResponseWithErrors, error) {
+func (w *Worker) ProcessEventBatch(batch []nuclio.Event, functionLogger logger.Logger) (*result.BatchedResults, error) {
 	return w.runtime.ProcessBatch(batch, w.logger)
+}
+
+func (w *Worker) ProcessStream(stream *result.StreamStart) error {
+	return nuclio.ErrNotImplemented
 }
 
 // GetStatistics returns a pointer to the statistics object. This must not be modified by the reader
@@ -220,23 +192,19 @@ func (w *Worker) IsBusy() bool {
 	return w.runtime.IsBusy()
 }
 
-func (w *Worker) calculateProcessingMetrics(response interface{}, err error) {
+func (w *Worker) calculateProcessingMetrics(response nuclio.ProcessingResult, err error) {
 	// check if there was a processing error. if so, log it
 	if err != nil {
 		atomic.AddUint64(&w.statistics.EventsHandledError, 1)
 		return
 	}
 	success := true
-	stream := false
 
-	if typedResponse, ok := response.(nuclio.ProcessingResult); ok {
-		if typedResponse.GetStatusCode() > 0 {
-			success = typedResponse.GetStatusCode() < http.StatusBadRequest
-		}
-		stream = typedResponse.IsStream()
+	if response.GetStatusCode() > 0 {
+		success = response.GetStatusCode() < http.StatusBadRequest
 	}
 
-	if stream {
+	if response.IsStream() {
 		if success {
 			atomic.AddUint64(&w.statistics.EventsStreamingStartedSuccessfully, 1)
 		} else {

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -68,12 +68,12 @@ func (w *Worker) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) 
 	response, err := w.runtime.ProcessEvent(event, functionLogger)
 
 	// form a result object from the response
-	resultWithNuclioProcessingResult := result.NewResultWithNuclioProcessingResult(response)
+	resultWithProcessingResult := result.NewResultWithNuclioProcessingResult(response)
 
 	// calculate processing metrics
-	w.calculateProcessingMetrics(resultWithNuclioProcessingResult.GetProcessingResult(), err)
+	w.calculateProcessingMetrics(resultWithProcessingResult.GetProcessingResult(), err)
 
-	return resultWithNuclioProcessingResult, err
+	return resultWithProcessingResult, err
 }
 
 func (w *Worker) ProcessEventBatch(batch []nuclio.Event, functionLogger logger.Logger) (*result.BatchedResults, error) {

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -68,7 +68,7 @@ func (w *Worker) ProcessEvent(event nuclio.Event, functionLogger logger.Logger) 
 	response, err := w.runtime.ProcessEvent(event, functionLogger)
 
 	// form a result object from the response
-	resultWithProcessingResult := result.NewResultWithNuclioProcessingResult(response)
+	resultWithProcessingResult := result.NewResultWithProcessingResult(response)
 
 	// calculate processing metrics
 	w.calculateProcessingMetrics(resultWithProcessingResult.GetProcessingResult(), err)

--- a/pkg/processor/worker/worker_test.go
+++ b/pkg/processor/worker/worker_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common/status"
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/runtime/rpc/result"
 	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/logger"
@@ -45,9 +46,9 @@ func (mr *MockRuntime) ProcessEvent(event nuclio.Event, functionLogger logger.Lo
 func (mr *MockRuntime) GetFunctionLogger() logger.Logger {
 	return nil
 }
-func (mr *MockRuntime) ProcessBatch(batch []nuclio.Event, functionLogger logger.Logger) ([]*runtime.ResponseWithErrors, error) {
+func (mr *MockRuntime) ProcessBatch(batch []nuclio.Event, functionLogger logger.Logger) (*result.BatchedResults, error) {
 	args := mr.Called(batch, functionLogger)
-	return args.Get(0).([]*runtime.ResponseWithErrors), args.Error(1)
+	return args.Get(0).(*result.BatchedResults), args.Error(1)
 }
 
 func (mr *MockRuntime) GetStatistics() runtime.Statistics {

--- a/test/_functions/common/streamer/golang/stream.go
+++ b/test/_functions/common/streamer/golang/stream.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nuclio/nuclio-sdk-go"
+)
+
+func Streamer(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
+	streamType := strings.ToLower(string(event.GetBody()))
+	context.Logger.DebugWith("Got request", "path", event.GetPath(), "streamType", streamType)
+
+	responseStream := nuclio.NewResponseStream(
+		"text/plain",
+		map[string]interface{}{
+			"Content-Type": "text/plain",
+		},
+		200,
+	)
+
+	startStreamErr := make(chan error)
+
+	go func() {
+		defer responseStream.StopStreaming()
+
+		switch streamType {
+		case "alphabet":
+			startStreamErr <- nil
+			for ch := 'A'; ch <= 'Z'; ch++ {
+				chunk := fmt.Sprintf("%c", ch)
+				if _, err := responseStream.SendChunk([]byte(chunk)); err != nil {
+					context.Logger.WarnWith("Failed to send chunk", "error", err)
+					return
+				}
+			}
+		case "numbers":
+			startStreamErr <- nil
+			for i := 0; i <= 10; i++ {
+				chunk := fmt.Sprintf("%d", i)
+				if _, err := responseStream.SendChunk([]byte(chunk)); err != nil {
+					context.Logger.WarnWith("Failed to send chunk", "error", err)
+					return
+				}
+			}
+		case "text":
+			startStreamErr <- nil
+			lines := []string{
+				"First sentence of the file.",
+				"Second sentence of the file.",
+				"Third sentence of the file.",
+			}
+			for _, line := range lines {
+				if _, err := responseStream.SendChunk([]byte(line)); err != nil {
+					context.Logger.WarnWith("Failed to send chunk", "error", err)
+					return
+				}
+			}
+		default:
+			startStreamErr <- fmt.Errorf("Unsupported stream type: %s", streamType)
+		}
+	}()
+	err := <-startStreamErr
+	return responseStream, err
+}


### PR DESCRIPTION
Within this pr:

* added support of new types of messages from a wrapper. Namely:
  - 'c' for stream start
  - 'b' for streaming body
  - 'e' for end of stream
* resultChan will now contain object of result.Result interface which may wrap nuclio.ProcessingResult under the hood. Those which have `nuclio.ProcessingResult`also implement `ResultWithNuclioProcessingResult`. The idea is that from worker we always get `ResultWithNuclioProcessingResult` and from trigger we always get  `nuclio.ProcessingResult`. While all the logic that is before that uses `result.Result`.
* also, moved TestEvent from test to a separate folder and not `test_*` file, so it can be reused across the code, where we don't really care about what is inside an event

Jira - https://iguazio.atlassian.net/browse/NUC-466