### PR TITLE
[Dashboard] Make python lib version requirements less strict for custom base image

### DIFF
--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -31,6 +31,10 @@ import (
 )
 
 const pipCAFileLocation = "/etc/ssl/certs/nuclio/pip-ca-certificates.crt"
+
+// If the user provides a base image that includes these dependencies, their versions
+// will serve as the version constraints. If the user does not provide an image or is in
+// an air-gapped environment, Nuclio will handle installing these dependencies automatically.
 const nuclioSDKRequirement = "nuclio-sdk>=0.5.15"
 const msgPackRequirement = "msgpack"
 

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -31,8 +31,8 @@ import (
 )
 
 const pipCAFileLocation = "/etc/ssl/certs/nuclio/pip-ca-certificates.crt"
-const nuclioSDKRequirement = "nuclio-sdk==0.5.15"
-const msgPackRequirement = "msgpack==1.1.0"
+const nuclioSDKRequirement = "nuclio-sdk>=0.5.15"
+const msgPackRequirement = "msgpack"
 
 type python struct {
 	*runtime.AbstractRuntime

--- a/pkg/processor/build/runtime/python/runtime_test.go
+++ b/pkg/processor/build/runtime/python/runtime_test.go
@@ -39,8 +39,8 @@ func (suite *TestSuite) TestDependenciesAlignment() {
 	// Ensure only the expected packages are in the map
 	// If there are any additional packages, the test will fail
 	expectedPackages := map[string]bool{
-		nuclioSDKRequirement: true,
-		msgPackRequirement:   true,
+		extractPackageName(nuclioSDKRequirement): true,
+		extractPackageName(msgPackRequirement):   true,
 	}
 	suite.Require().Equal(expectedPackages, packages)
 }
@@ -57,28 +57,28 @@ func parseRequirementsFile(filePath string, excludeList []string) (map[string]bo
 
 	// Map to store each line
 	packages := make(map[string]bool)
+	excludeMap := make(map[string]struct{}, len(excludeList))
+	for _, ex := range excludeList {
+		excludeMap[strings.ToLower(ex)] = struct{}{}
+	}
 
 	// Loop over each line in the file
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		line := scanner.Text()
+		line := strings.TrimSpace(scanner.Text())
 
-		// Trim any surrounding whitespace from the line
-		line = strings.TrimSpace(line)
-
-		// Check if the line is in the exclude list
-		exclude := false
-		for _, excludePkg := range excludeList {
-			if strings.Contains(line, excludePkg) {
-				exclude = true
-				break
-			}
+		// Skip comments and empty lines
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
 		}
 
-		// If it's not excluded, add it to the map
-		if !exclude {
-			packages[line] = true
+		// Extract just the package name (strip version)
+		pkgName := extractPackageName(line)
+		if _, excluded := excludeMap[strings.ToLower(pkgName)]; excluded {
+			continue
 		}
+
+		packages[pkgName] = true
 	}
 
 	// Check for any scanner errors
@@ -88,6 +88,18 @@ func parseRequirementsFile(filePath string, excludeList []string) (map[string]bo
 
 	return packages, nil
 }
+
+func extractPackageName(line string) string {
+	separators := []string{"==", ">=", "<=", "~=", ">", "<"}
+	for _, sep := range separators {
+		if parts := strings.Split(line, sep); len(parts) > 1 {
+			return strings.ToLower(strings.TrimSpace(parts[0]))
+		}
+	}
+	// If no version constraint, return as-is
+	return strings.ToLower(strings.TrimSpace(line))
+}
+
 func TestRuntime(t *testing.T) {
 	suite.Run(t, new(TestSuite))
 }


### PR DESCRIPTION
Versions in common.txt which are for onbuild images will remain strict, however for base images we will allow any version of msgpack and the version of nuclio-sdk-py which should be compatible with current version. 

Jira - https://iguazio.atlassian.net/browse/NUC-492