### PR TITLE
[Helm] Align OPA container args to latest version

### DIFF
--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -232,6 +232,7 @@ spec:
         args:
           - "run"
           - "--server"
+          - "--addr=0.0.0.0:8181"
           - "--config-file=/config/config.yaml"
           - "--log-level={{ .Values.dashboard.opa.logLevel }}"
           - "--log-format={{ .Values.dashboard.opa.logFormat }}"

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -237,6 +237,7 @@ spec:
           - "--log-level={{ .Values.dashboard.opa.logLevel }}"
           - "--log-format={{ .Values.dashboard.opa.logFormat }}"
           - "--ignore=.*"
+          - "--disable-telemetry"
         volumeMounts:
           - readOnly: true
             mountPath: /config

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -218,7 +218,7 @@ spec:
         imagePullPolicy: {{ .Values.dashboard.opa.image.pullPolicy }}
         ports:
           - name: http
-            containerPort: 8181
+            containerPort: {{ .Values.dashboard.opa.port }}
         {{- if .Values.dashboard.opa.livenessProbe }}
         livenessProbe:
           {{ toYaml .Values.dashboard.opa.livenessProbe | nindent 12 }}
@@ -232,7 +232,7 @@ spec:
         args:
           - "run"
           - "--server"
-          - "--addr=0.0.0.0:8181"
+          - "--addr=0.0.0.0:{{ .Values.dashboard.opa.port }}"
           - "--config-file=/config/config.yaml"
           - "--log-level={{ .Values.dashboard.opa.logLevel }}"
           - "--log-format={{ .Values.dashboard.opa.logFormat }}"

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -261,6 +261,9 @@ dashboard:
       pullSecrets: []
     resources: {}
     securityContext: {}
+
+    port: 8181
+
     # capabilities:
     #   drop:
     #   - ALL


### PR DESCRIPTION
Latest OPA clients (version 1.5.1) require the listening address to be passed explicitly.
This is backwards compatible with older versions.

https://iguazio.atlassian.net/browse/IG-23798
https://iguazio.atlassian.net/browse/IG-23799