### PR TITLE
[Processor] Support yielding in wrapper

### DIFF
--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -35,7 +35,7 @@ const pipCAFileLocation = "/etc/ssl/certs/nuclio/pip-ca-certificates.crt"
 // If the user provides a base image that includes these dependencies, their versions
 // will serve as the version constraints. If the user does not provide an image or is in
 // an air-gapped environment, Nuclio will handle installing these dependencies automatically.
-const nuclioSDKRequirement = "nuclio-sdk>=0.5.15"
+const nuclioSDKRequirement = "nuclio-sdk>=0.5.16"
 const msgPackRequirement = "msgpack"
 
 type python struct {

--- a/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
@@ -209,16 +209,7 @@ class AsyncWrapper(AbstractWrapper):
         # call the entrypoint
         entrypoint_output = await self._entrypoint(self._context, event)
 
-        # measure duration, set to minimum float in case execution was too fast
-        duration = time.time() - start_time or sys.float_info.min
-
-        await self._write_packet_to_processor(sock, 'm' + json.dumps({'duration': duration}))
-
-        # try to json encode the response
-        encoded_response = self._encode_entrypoint_output(entrypoint_output)
-
-        # write response to the socket
-        await self._write_packet_to_processor(sock, 'r' + encoded_response)
+        await self._handle_entrypoint_output(entrypoint_output, start_time, sock)
 
     def _cleanup_connection(self, sock, cancel_task=True):
         """Cleanup resources for a disconnected client."""

--- a/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
@@ -29,6 +29,7 @@ from wrapper_common import (
     EventSocketDisconnected,
     WrapperFatalException,
     EventSocketException,
+    PacketType,
     JSONFormatterOverEventSocket,
     AbstractWrapper,
     create_logger,
@@ -148,7 +149,7 @@ class AsyncWrapper(AbstractWrapper):
         self._context.logger = connection_logger
 
         # signal start
-        await self._write_packet_to_processor(sock, 's')
+        await self._write_packet_to_processor(sock, PacketType.WRAPPER_START)
 
         try:
             while True:

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -24,6 +24,7 @@ from wrapper_common import (
     WrapperFatalException,
     EventSocketDisconnected,
     EventSocketException,
+    PacketType,
     JSONFormatterOverEventSocket,
     AbstractWrapper,
     create_logger,
@@ -150,7 +151,7 @@ class Wrapper(AbstractWrapper):
         self._register_to_signal()
 
         # indicate that we're ready
-        await self._write_packet_to_processor(self._event_sock, 's')
+        await self._write_packet_to_processor(self._event_sock, PacketType.WRAPPER_START)
         await self._send_data_on_control_socket({
             'kind': 'wrapperInitialized',
             'attributes': {'ready': 'true'}

--- a/pkg/processor/runtime/python/py/requirements/common.txt
+++ b/pkg/processor/runtime/python/py/requirements/common.txt
@@ -1,4 +1,4 @@
 mock==2.0.0
-nuclio-sdk==0.5.15
+nuclio-sdk==0.5.16
 pip==24.3.1
 msgpack==1.1.0

--- a/pkg/processor/runtime/python/py/test_server_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_server_wrapper.py
@@ -234,7 +234,9 @@ class TestSubmitEvents(BaseTestSubmitEvents):
             split_data = data.split(delimiter)
             for message in split_data[:-1]:
                 messages.append(message)
-                if message.startswith(b'r'):
+                # If the message starts with 'm', then it is a metric message
+                # which is the last message in the response
+                if message.startswith(b'm'):
                     return b'\n'.join(messages).decode('utf-8')
 
             # Keep the remaining part if the last chunk does not end with the delimiter

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -30,6 +30,7 @@ import nuclio_sdk
 import nuclio_sdk.helpers
 
 import _nuclio_wrapper as wrapper
+from wrapper_common import PacketType
 from test_base import BaseTestSubmitEvents
 
 
@@ -310,17 +311,21 @@ class TestSubmitEvents(BaseTestSubmitEvents):
         prefixes = [prefix for prefix, _ in packets]
 
         # Ensure 'c' exists and comes before any 'b'
-        assert prefixes.index("c") < prefixes.index("b"), "'c' must come before 'b'"
+        assert prefixes.index(PacketType.STREAM_START) < prefixes.index(PacketType.BODY_CHUNK)
+        # Ensure 'b' exists and comes before any 'e'
+        assert prefixes.index(PacketType.BODY_CHUNK) < prefixes.index(PacketType.END_OF_STREAM)
+        # Ensure 'e' exists and comes before any 'm'
+        assert prefixes.index(PacketType.END_OF_STREAM) < prefixes.index(PacketType.METRICS)
 
         payload_by_prefix = {
             prefix: payload for prefix, payload in packets
         }
 
-        self.assertEqual(payload_by_prefix["c"], json.dumps("chunk1"))
-        self.assertEqual(payload_by_prefix["b"], json.dumps("chunk2"))
-        self.assertIn("e", prefixes)
-        self.assertIn("m", prefixes)
-        self.assertNotIn("r", prefixes)
+        self.assertEqual(payload_by_prefix[PacketType.STREAM_START], json.dumps("chunk1"))
+        self.assertEqual(payload_by_prefix[PacketType.BODY_CHUNK], json.dumps("chunk2"))
+        self.assertIn(PacketType.END_OF_STREAM, prefixes)
+        self.assertIn(PacketType.METRICS, prefixes)
+        self.assertNotIn(PacketType.SINGLE_RESPONSE, prefixes)
 
     async def test_encode_single_value_entrypoint_output(self):
         # Simulate regular async function returning a single value
@@ -335,21 +340,25 @@ class TestSubmitEvents(BaseTestSubmitEvents):
             (prefix, payload)
             async for prefix, payload in self._wrapper._generate_processor_packets(entrypoint_output, start_time=0)
         ]
+        self.assertEqual(len(packets), 2)
 
         prefixes = [prefix for prefix, _ in packets]
 
-        self.assertIn("r", prefixes)
-        self.assertIn("m", prefixes)
-        self.assertNotIn("c", prefixes)
-        self.assertNotIn("b", prefixes)
-        self.assertNotIn("e", prefixes)
+        self.assertIn(PacketType.SINGLE_RESPONSE, prefixes)
+        self.assertIn(PacketType.METRICS, prefixes)
+        self.assertNotIn(PacketType.STREAM_START, prefixes)
+        self.assertNotIn(PacketType.BODY_CHUNK, prefixes)
+        self.assertNotIn(PacketType.END_OF_STREAM, prefixes)
+
 
         payload_by_prefix = {
             prefix: payload for prefix, payload in packets
         }
 
-        self.assertEqual(payload_by_prefix["r"], json.dumps({"body": "ok", "status_code": 200}))
-
+        self.assertEqual(
+            payload_by_prefix[PacketType.SINGLE_RESPONSE],
+            json.dumps({"body": "ok", "status_code": 200})
+        )
 
     async def test_encode_batched_entrypoint_output(self):
         single_response = nuclio_sdk.Response(

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -154,12 +154,12 @@ class TestSubmitEvents(BaseTestSubmitEvents):
         t.join()
 
         # processor start
-        # duration
         # function response
-        # malformed log line (wrapper)
+        # duration
         # malformed response
         # duration
         # function response
+        # duration
         expected_messages = 7
 
         self._wait_until_received_messages(
@@ -167,7 +167,7 @@ class TestSubmitEvents(BaseTestSubmitEvents):
             messages=self._unix_stream_server._messages,
         )
 
-        malformed_response = self._unix_stream_server._messages[-3]['body']
+        malformed_response = self._unix_stream_server._messages[-4]['body']
 
         if self._decode_event_strings:
 
@@ -178,7 +178,7 @@ class TestSubmitEvents(BaseTestSubmitEvents):
             self.assertEqual(events[malformed_event_index]['body'], malformed_response['body'])
 
         # ensure messages coming after malformed request are still valid
-        last_function_response = self._unix_stream_server._messages[-1]['body']
+        last_function_response = self._unix_stream_server._messages[-2]['body']
         self.assertEqual(http.client.OK, last_function_response['status_code'])
         self.assertEqual(events[-1]['body'], last_function_response['body'])
 
@@ -290,17 +290,96 @@ class TestSubmitEvents(BaseTestSubmitEvents):
             self.assertEqual(recorded_event_index, recorded_event.id)
             self.assertEqual('e{}'.format(recorded_event_index), self._ensure_str(recorded_event.body))
 
-    def test_encode_batched_entrypoint_output(self):
+
+    async def test_encode_streaming_entrypoint_output(self):
+        # Simulated streaming output (e.g., async generator)
+        async def streaming_handler_output():
+            yield "chunk1"
+            yield "chunk2"
+
+        # Entrypoint output is an async generator
+        entrypoint_output = streaming_handler_output()
+
+        # Collect packets from the async generator
+        packets = [
+            (prefix, payload)
+            async for prefix, payload in self._wrapper._generate_processor_packets(entrypoint_output, start_time=0)
+        ]
+
+        # Extract prefix sequence for ordering check
+        prefixes = [prefix for prefix, _ in packets]
+
+        # Ensure 'c' exists and comes before any 'b'
+        assert prefixes.index("c") < prefixes.index("b"), "'c' must come before 'b'"
+
+        payload_by_prefix = {
+            prefix: payload for prefix, payload in packets
+        }
+
+        self.assertEqual(payload_by_prefix["c"], json.dumps("chunk1"))
+        self.assertEqual(payload_by_prefix["b"], json.dumps("chunk2"))
+        self.assertIn("e", prefixes)
+        self.assertIn("m", prefixes)
+        self.assertNotIn("r", prefixes)
+
+    async def test_encode_single_value_entrypoint_output(self):
+        # Simulate regular async function returning a single value
+        async def single_value_handler_output():
+            return "ok"
+
+        # Call the function and await the result
+        entrypoint_output = await single_value_handler_output()
+
+        # Pass it into the packet generator
+        packets = [
+            (prefix, payload)
+            async for prefix, payload in self._wrapper._generate_processor_packets(entrypoint_output, start_time=0)
+        ]
+
+        prefixes = [prefix for prefix, _ in packets]
+
+        self.assertIn("r", prefixes)
+        self.assertIn("m", prefixes)
+        self.assertNotIn("c", prefixes)
+        self.assertNotIn("b", prefixes)
+        self.assertNotIn("e", prefixes)
+
+        payload_by_prefix = {
+            prefix: payload for prefix, payload in packets
+        }
+
+        self.assertEqual(payload_by_prefix["r"], json.dumps({"body": "ok", "status_code": 200}))
+
+
+    async def test_encode_batched_entrypoint_output(self):
         single_response = nuclio_sdk.Response(
             body=str(123),
             headers={},
             content_type=123,
             status_code=200,
         )
-        encoded_single = json.loads(self._wrapper._encode_entrypoint_output(single_response))
-        encoded_batch = json.loads(self._wrapper._encode_entrypoint_output([single_response, single_response]))
-        assert encoded_batch[0] == encoded_single
-        assert encoded_batch[1] == encoded_single
+
+        # Consume single response packets
+        single_packets = [
+            (prefix, payload) async for prefix, payload in
+            self._wrapper._generate_processor_packets(single_response, start_time=0)
+        ]
+
+        # Consume batch response packets
+        batch_packets = [
+            (prefix, payload) async for prefix, payload in
+            self._wrapper._generate_processor_packets([single_response, single_response], start_time=0)
+        ]
+
+        # Extract the actual payloads for comparison
+        single_payload = next((payload for prefix, payload in single_packets if prefix == "r"), None)
+        batch_payload = next((payload for prefix, payload in batch_packets if prefix == "r"), None)
+
+        decoded_single = json.loads(single_payload)
+        decoded_batch = json.loads(batch_payload)
+
+        assert decoded_batch[0] == decoded_single
+        assert decoded_batch[1] == decoded_single
 
     # to run memory profiling test, uncomment the tests below
     # and from terminal run with

--- a/pkg/processor/runtime/python/py/wrapper_common.py
+++ b/pkg/processor/runtime/python/py/wrapper_common.py
@@ -29,6 +29,13 @@ import traceback
 import json
 
 
+class PacketType:
+    SINGLE_RESPONSE = 'r'
+    STREAM_START = 'c'
+    BODY_CHUNK = 'b'
+    END_OF_STREAM = 'e'
+    METRICS = 'm'
+
 class Constants:
     # in msgpack protoctol, binary messages' length is 4 bytes long
     msgpack_message_length_bytes = 4
@@ -197,11 +204,9 @@ class AbstractWrapper(object):
 
     async def _handle_entrypoint_output(self, entrypoint_output, start_time, sock):
         async for prefix, payload in self._generate_processor_packets(entrypoint_output, start_time):
-            if payload is not None:
-                await self._write_packet_to_processor(sock, prefix + payload)
-            else:
-                await self._write_packet_to_processor(sock, prefix)
-
+            # concatenate prefix and payload if payload is not None
+            packet = prefix if payload is None else prefix + payload
+            await self._write_packet_to_processor(sock, packet)
 
     async def _generate_processor_packets(self, entrypoint_output, start_time):
         """
@@ -235,8 +240,8 @@ class AbstractWrapper(object):
                 nuclio_sdk.Response.from_entrypoint_output(self._json_encoder.encode, _output)
                 for _output in entrypoint_output
             ]
-            yield 'm', json.dumps({'duration': duration})
-            yield 'r', self._json_encoder.encode(responses)
+            yield PacketType.METRICS, json.dumps({'duration': duration})
+            yield PacketType.METRICS, self._json_encoder.encode(responses)
             return
 
         # Case 2: streamed or dynamic async response
@@ -247,19 +252,19 @@ class AbstractWrapper(object):
                 self._json_encoder.encode, entrypoint_output
         ):
             if message_num == 0:
-                prefix = 'r' if handler_output_type == SINGLE_RESPONSE else 'c'
+                prefix = PacketType.METRICS if handler_output_type == SINGLE_RESPONSE else PacketType.STREAM_START
                 response =  self._json_encoder.encode(response)
             else:
-                prefix = 'b'
+                prefix = PacketType.BODY_CHUNK
             yield prefix, response
             message_num += 1
 
         # Only send end-of-stream if multiple chunks were sent
         if message_num > 1:
             duration = time.time() - start_time or sys.float_info.min
-            yield 'e', None
+            yield PacketType.END_OF_STREAM, None
 
-        yield 'm', json.dumps({'duration': duration})
+        yield PacketType.METRICS, json.dumps({'duration': duration})
 
     async def _send_data_on_control_socket(self, data):
         if not self._control_sock:

--- a/pkg/processor/runtime/python/py/wrapper_common.py
+++ b/pkg/processor/runtime/python/py/wrapper_common.py
@@ -222,7 +222,7 @@ class AbstractWrapper(object):
             'c' – Stream start (first chunk in a generator-style response)
             'b' – Body chunk in a stream (after the first)
             'e' – End of stream (no payload)
-            'm' – Metadata including processing duration
+            'm' – Metrics including processing duration
         - payload: The encoded response body (or metadata), or None if not applicable
 
         Parameters:

--- a/pkg/processor/runtime/python/py/wrapper_common.py
+++ b/pkg/processor/runtime/python/py/wrapper_common.py
@@ -35,6 +35,7 @@ class PacketType:
     BODY_CHUNK = 'b'
     END_OF_STREAM = 'e'
     METRICS = 'm'
+    WRAPPER_START = 's'
 
 class Constants:
     # in msgpack protoctol, binary messages' length is 4 bytes long

--- a/pkg/processor/runtime/python/py/wrapper_common.py
+++ b/pkg/processor/runtime/python/py/wrapper_common.py
@@ -18,6 +18,7 @@ import time
 import msgpack
 import nuclio_sdk
 import nuclio_sdk.helpers
+from nuclio_sdk.response import SINGLE_RESPONSE
 import nuclio_sdk.json_encoder
 import sys
 import asyncio
@@ -192,16 +193,7 @@ class AbstractWrapper(object):
         if asyncio.iscoroutine(entrypoint_output):
             entrypoint_output = await entrypoint_output
 
-        # measure duration, set to minimum float in case execution was too fast
-        duration = time.time() - start_time or sys.float_info.min
-
-        await self._write_packet_to_processor(sock, 'm' + json.dumps({'duration': duration}))
-
-        # try to json encode the response
-        encoded_response = self._encode_entrypoint_output(entrypoint_output)
-
-        # write response to the socket
-        await self._write_packet_to_processor(sock, 'r' + encoded_response)
+        await self._handle_entrypoint_output(entrypoint_output, start_time, sock)
 
     def _encode_entrypoint_output(self, entrypoint_output):
 
@@ -214,6 +206,72 @@ class AbstractWrapper(object):
 
         # try to json encode the response
         return self._json_encoder.encode(response)
+
+    async def _handle_entrypoint_output(self, entrypoint_output, start_time, sock):
+        async for prefix, payload in self._generate_processor_packets(entrypoint_output, start_time):
+            if payload is not None:
+                await self._write_packet_to_processor(sock, prefix + payload)
+            else:
+                await self._write_packet_to_processor(sock, prefix)
+
+
+    async def _generate_processor_packets(self, entrypoint_output, start_time):
+        """
+        Generate packets to be sent to the Nuclio processor based on the given function output.
+
+        This function handles both:
+        - Batched synchronous responses (lists of outputs)
+        - Single or streaming async responses (including generators and async generators)
+
+        It yields tuples of the form (prefix, payload), where:
+        - prefix: One of the packet type identifiers:
+            'r' – Regular single response or first response in a stream
+            'c' – Stream start (first chunk in a generator-style response)
+            'b' – Body chunk in a stream (after the first)
+            'e' – End of stream (no payload)
+            'm' – Metadata including processing duration
+        - payload: The encoded response body (or metadata), or None if not applicable
+
+        Parameters:
+            entrypoint_output: The output returned by the function entrypoint.
+            start_time: The timestamp when execution started (for duration calculation).
+
+        Yields:
+            Tuple[str, Optional[str]]: Message type prefix and encoded payload or None.
+        """
+        duration = time.time() - start_time or sys.float_info.min
+
+        # Case 1: batched synchronous response
+        if isinstance(entrypoint_output, list):
+            responses = [
+                nuclio_sdk.Response.from_entrypoint_output(self._json_encoder.encode, _output)
+                for _output in entrypoint_output
+            ]
+            yield 'm', json.dumps({'duration': duration})
+            yield 'r', self._json_encoder.encode(responses)
+            return
+
+        # Case 2: streamed or dynamic async response
+        handler_output_type = nuclio_sdk.Response.get_handler_output_type(entrypoint_output)
+        message_num = 0
+
+        async for response in nuclio_sdk.Response.from_entrypoint_output_async(
+                self._json_encoder.encode, entrypoint_output
+        ):
+            if message_num == 0:
+                prefix = 'r' if handler_output_type == SINGLE_RESPONSE else 'c'
+                response =  self._json_encoder.encode(response)
+            else:
+                prefix = 'b'
+            yield prefix, response
+            message_num += 1
+
+        # Only send end-of-stream if multiple chunks were sent
+        if message_num > 1:
+            duration = time.time() - start_time or sys.float_info.min
+            yield 'e', None
+
+        yield 'm', json.dumps({'duration': duration})
 
     async def _send_data_on_control_socket(self, data):
         if not self._control_sock:

--- a/pkg/processor/runtime/python/py/wrapper_common.py
+++ b/pkg/processor/runtime/python/py/wrapper_common.py
@@ -241,7 +241,7 @@ class AbstractWrapper(object):
                 for _output in entrypoint_output
             ]
             yield PacketType.METRICS, json.dumps({'duration': duration})
-            yield PacketType.METRICS, self._json_encoder.encode(responses)
+            yield PacketType.SINGLE_RESPONSE, self._json_encoder.encode(responses)
             return
 
         # Case 2: streamed or dynamic async response
@@ -252,7 +252,7 @@ class AbstractWrapper(object):
                 self._json_encoder.encode, entrypoint_output
         ):
             if message_num == 0:
-                prefix = PacketType.METRICS if handler_output_type == SINGLE_RESPONSE else PacketType.STREAM_START
+                prefix = PacketType.SINGLE_RESPONSE if handler_output_type == SINGLE_RESPONSE else PacketType.STREAM_START
                 response =  self._json_encoder.encode(response)
             else:
                 prefix = PacketType.BODY_CHUNK

--- a/pkg/processor/runtime/python/py/wrapper_common.py
+++ b/pkg/processor/runtime/python/py/wrapper_common.py
@@ -195,18 +195,6 @@ class AbstractWrapper(object):
 
         await self._handle_entrypoint_output(entrypoint_output, start_time, sock)
 
-    def _encode_entrypoint_output(self, entrypoint_output):
-
-        # processing entrypoint output if response is batched
-        if isinstance(entrypoint_output, list):
-            response = [nuclio_sdk.Response.from_entrypoint_output(self._json_encoder.encode,
-                                                                   _output) for _output in entrypoint_output]
-        else:
-            response = nuclio_sdk.Response.from_entrypoint_output(self._json_encoder.encode, entrypoint_output)
-
-        # try to json encode the response
-        return self._json_encoder.encode(response)
-
     async def _handle_entrypoint_output(self, entrypoint_output, start_time, sock):
         async for prefix, payload in self._generate_processor_packets(entrypoint_output, start_time):
             if payload is not None:


### PR DESCRIPTION
Jira - https://iguazio.atlassian.net/browse/NUC-465

Refactored handling of function outputs to support both batched and streaming responses in a unified async flow.

Introduced `_generate_processor_packets()` to abstract packet generation logic for different response types (single, batched, and streamed).

Replaced manual duration encoding and response writing with _handle_entrypoint_output() that consumes the generated packets and writes them to the processor socket.

Enables proper handling of async generators and streamed responses with correct packet prefixes (`r`, `c`, `b`, `e`,`m`), improving flexibility and consistency.