### PR TITLE
[Dependencies] Bump nuclio-sdk-py to 0.6.0

### DIFF
--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -35,7 +35,7 @@ const pipCAFileLocation = "/etc/ssl/certs/nuclio/pip-ca-certificates.crt"
 // If the user provides a base image that includes these dependencies, their versions
 // will serve as the version constraints. If the user does not provide an image or is in
 // an air-gapped environment, Nuclio will handle installing these dependencies automatically.
-const nuclioSDKRequirement = "nuclio-sdk>=0.5.16"
+const nuclioSDKRequirement = "nuclio-sdk>=0.6.0"
 const msgPackRequirement = "msgpack"
 
 type python struct {

--- a/pkg/processor/runtime/python/py/requirements/common.txt
+++ b/pkg/processor/runtime/python/py/requirements/common.txt
@@ -1,4 +1,4 @@
 mock==2.0.0
-nuclio-sdk==0.5.16
+nuclio-sdk==0.6.0
 pip==24.3.1
 msgpack==1.1.0


### PR DESCRIPTION
Since nuclio-sdk changes were changed to be worth bumping minor, bumping it here as well