### PR TITLE
[Processor] Add metric EventsStreamingFinishedSuccessfully

### DIFF
--- a/pkg/processor/eventprocessor/mock.go
+++ b/pkg/processor/eventprocessor/mock.go
@@ -85,6 +85,10 @@ func (m *MockEventProcessor) GetStatistics() *statistics.EventProcessingStatisti
 	return m.Called().Get(0).(*statistics.EventProcessingStatistics)
 }
 
+func (m *MockEventProcessor) StreamProcessedSuccessfully() {
+	m.Called()
+}
+
 func (m *MockEventProcessor) GetAllocationStatistics() *statistics.AllocatorStatistics {
 	return m.Called().Get(0).(*statistics.AllocatorStatistics)
 }

--- a/pkg/processor/eventprocessor/types.go
+++ b/pkg/processor/eventprocessor/types.go
@@ -106,7 +106,7 @@ type EventProcessor interface {
 	// GetStatistics returns event processing statistics, such as counts and latencies
 	GetStatistics() *statistics.EventProcessingStatistics
 
-	// StreamProcessedSuccessfully signals that the stream has been processed successfully
+	// StreamProcessedSuccessfully says to event processor that the stream has been processed successfully
 	StreamProcessedSuccessfully()
 
 	// GetAllocationStatistics returns allocation statistics, such as allocation time and number of allocations

--- a/pkg/processor/eventprocessor/types.go
+++ b/pkg/processor/eventprocessor/types.go
@@ -106,6 +106,9 @@ type EventProcessor interface {
 	// GetStatistics returns event processing statistics, such as counts and latencies
 	GetStatistics() *statistics.EventProcessingStatistics
 
+	// StreamProcessedSuccessfully signals that the stream has been processed successfully
+	StreamProcessedSuccessfully()
+
 	// GetAllocationStatistics returns allocation statistics, such as allocation time and number of allocations
 	GetAllocationStatistics() *statistics.AllocatorStatistics
 

--- a/pkg/processor/runtime/rpc/connection/abstract.go
+++ b/pkg/processor/runtime/rpc/connection/abstract.go
@@ -510,6 +510,9 @@ func (be *AbstractEventConnection) GetStatistics() *statistics.EventProcessingSt
 	return nil
 }
 
+func (be *AbstractEventConnection) StreamProcessedSuccessfully() {
+}
+
 // GetAllocationStatistics returns the statistics of the allocator if there is any in the runtime
 // AbstractEventConnection runtime doesn't have any allocator in it, so return nil
 func (be *AbstractEventConnection) GetAllocationStatistics() *statistics.AllocatorStatistics {

--- a/pkg/processor/statistics/types.go
+++ b/pkg/processor/statistics/types.go
@@ -17,10 +17,11 @@ limitations under the License.
 package statistics
 
 type EventProcessingStatistics struct {
-	EventsHandledSuccess               uint64
-	EventsHandledError                 uint64
-	EventsStreamingStartedSuccessfully uint64
-	EventsStreamingStartedError        uint64
+	EventsHandledSuccess                uint64
+	EventsHandledError                  uint64
+	EventsStreamingStartedSuccessfully  uint64
+	EventsStreamingStartedError         uint64
+	EventsStreamingFinishedSuccessfully uint64
 }
 
 // AllocatorStatistics is not a safe statistics object and should be used only to copy safe object to it and return to outside

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -596,6 +596,13 @@ func (h *http) handleRequest(ctx *fasthttp.RequestCtx) {
 			}
 		}
 	}
+
+	if response.IsStream() {
+		// signal to worker that the stream has been processed successfully
+		// worker will increment the statistics
+		workerInstance.StreamProcessedSuccessfully()
+	}
+
 	if !workerReleased {
 		// try to release the worker instance asap
 		// if code won't get here (because of the error, then the defer will take care of it)

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -91,6 +91,7 @@ func (w *Worker) GetStatistics() *statistics.EventProcessingStatistics {
 
 func (w *Worker) StreamProcessedSuccessfully() {
 	w.statistics.EventsStreamingFinishedSuccessfully += 1
+	w.statistics.EventsHandledSuccess += 1
 }
 
 func (w *Worker) GetAllocationStatistics() *statistics.AllocatorStatistics {
@@ -213,6 +214,7 @@ func (w *Worker) calculateProcessingMetrics(response nuclio.ProcessingResult, er
 			atomic.AddUint64(&w.statistics.EventsStreamingStartedSuccessfully, 1)
 		} else {
 			atomic.AddUint64(&w.statistics.EventsStreamingStartedError, 1)
+			atomic.AddUint64(&w.statistics.EventsHandledError, 1)
 		}
 		return
 	}

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -89,6 +89,10 @@ func (w *Worker) GetStatistics() *statistics.EventProcessingStatistics {
 	return &w.statistics
 }
 
+func (w *Worker) StreamProcessedSuccessfully() {
+	w.statistics.EventsStreamingFinishedSuccessfully += 1
+}
+
 func (w *Worker) GetAllocationStatistics() *statistics.AllocatorStatistics {
 	return w.runtime.GetAllocationStatistics()
 }


### PR DESCRIPTION
Adds new metric `EventsStreamingFinishedSuccessfully` to signal about successful processing of stream. If something happens during processing, worker entity isn't aware of this, so it will be possible to find out by checking that `EventsStreamingStartedSuccessfully==EventsStreamingFinishedSuccessfully`.

Jira - https://iguazio.atlassian.net/browse/NUC-467