### PR TITLE
[Dashboard] Validate service account is allowed

### DIFF
--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -489,7 +489,7 @@ platform: {}
 #      nodeLabelKey: nodeLabelValue
 #    defaultServiceType: ClusterIP
 #    defaultHTTPIngressHostTemplate: ""
-#    projectSecretTemplate: "
+#    projectSecretTemplate: ""
 #    projectSecretAllowedServiceAccountsKey: ""
 #    projectSecretDefaultServiceAccountKey: ""
 #    defaultHTTPIngressAnnotations:

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -489,6 +489,9 @@ platform: {}
 #      nodeLabelKey: nodeLabelValue
 #    defaultServiceType: ClusterIP
 #    defaultHTTPIngressHostTemplate: ""
+#    projectSecretTemplate: "
+#    projectSecretAllowedServiceAccountsKey: ""
+#    projectSecretDefaultServiceAccountKey: ""
 #    defaultHTTPIngressAnnotations:
 #      ingressAnnotationKey: ingressAnnotationValue
 #    defaultHTTPIngressClassName: ""

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1954,8 +1954,18 @@ func (p *Platform) validateServiceType(functionConfig *functionconfig.Config) er
 
 func (p *Platform) validateServiceAccount(ctx context.Context, functionConfig *functionconfig.Config) error {
 	// if function does not have service account specified, skip validation
-	// it will be enriched later by the controller
 	if functionConfig.Spec.ServiceAccount == "" {
+		return nil
+	}
+
+	// if project secret template is not specified, skip validation
+	if p.Config.Kube.ProjectSecretTemplate == "" {
+		return nil
+	}
+
+	// if project secret allowed service accounts key is not configured, skip validation
+	if p.Config.Kube.ProjectSecretAllowedServiceAccountsKey == "" {
+		p.Logger.DebugWithCtx(ctx, "Skipping service account secret validation as no `projectSecretAllowedServiceAccountsKey` is configured")
 		return nil
 	}
 
@@ -1995,14 +2005,14 @@ func (p *Platform) isServiceAccountAllowed(ctx context.Context, functionConfig *
 	allowedSAs := strings.Split(string(allowedRaw), ",")
 
 	// trim spaces and check membership
-	requestedSA := strings.TrimSpace(functionConfig.Spec.ServiceAccount)
+	requestedSA := strings.ToLower(strings.TrimSpace(functionConfig.Spec.ServiceAccount))
 	for _, sa := range allowedSAs {
-		if strings.TrimSpace(sa) == requestedSA {
-			return nil // valid SA
+		if strings.ToLower(strings.TrimSpace(sa)) == requestedSA {
+			return nil
 		}
 	}
 
-	return errors.Errorf("ServiceAccount %q is not in the list of allowed service accounts for project %q",
+	return errors.Errorf("Service account %q is not allowed for project %q",
 		requestedSA, projectName)
 }
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1990,12 +1990,6 @@ func (p *Platform) isServiceAccountAllowed(ctx context.Context, functionConfig *
 		return nil
 	}
 
-	// get the key name to use for allowed service accounts
-	if p.Config.Kube.ProjectSecretAllowedServiceAccountsKey == "" {
-		p.Logger.DebugWithCtx(ctx, "Skipping service account secret validation as no `projectSecretAllowedServiceAccountsKey` is configured")
-		return nil
-	}
-
 	allowedRaw, ok := secret.Data[p.Config.Kube.ProjectSecretAllowedServiceAccountsKey]
 	if !ok {
 		// no restriction , so allow any SA
@@ -2367,9 +2361,6 @@ func (p *Platform) renderIngressHost(ctx context.Context, ingressHostTemplate st
 }
 
 func (p *Platform) renderProjectSecretName(templateData map[string]interface{}) (string, error) {
-	if p.Config.Kube.ProjectSecretTemplate == "" {
-		return "", nil
-	}
 	renderedIngressHost, err := common.RenderTemplate(p.Config.Kube.ProjectSecretTemplate, templateData)
 	if err != nil {
 		return "", err

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1414,6 +1414,10 @@ func (p *Platform) ValidateFunctionConfig(ctx context.Context, functionConfig *f
 		return errors.Wrap(err, "Service type validation failed")
 	}
 
+	if err := p.validateServiceAccount(ctx, functionConfig); err != nil {
+		return errors.Wrap(err, "Service account validation failed")
+	}
+
 	if err := p.validateInitContainersSpec(functionConfig); err != nil {
 		return errors.Wrap(err, "Init containers validation failed")
 	}
@@ -1948,6 +1952,88 @@ func (p *Platform) validateServiceType(functionConfig *functionconfig.Config) er
 	}
 }
 
+func (p *Platform) validateServiceAccount(ctx context.Context, functionConfig *functionconfig.Config) error {
+	// if function does not have service account specified, skip validation
+	// it will be enriched later by the controller
+	if functionConfig.Spec.ServiceAccount == "" {
+		return nil
+	}
+
+	// check if the service account is allowed
+	return p.isServiceAccountAllowed(ctx, functionConfig)
+}
+
+func (p *Platform) isServiceAccountAllowed(ctx context.Context, functionConfig *functionconfig.Config) error {
+	projectName, ok := functionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName]
+	if !ok {
+		return errors.New("Function does not have a project label, cannot validate service account")
+	}
+
+	// fetch the secret from Kubernetes
+	secret, err := p.getProjectSecret(ctx, projectName, functionConfig.Meta.Namespace)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to get project secret. Project: %s", projectName)
+	}
+
+	if secret == nil {
+		// if the secret does not exist, skip validation
+		return nil
+	}
+
+	// get the key name to use for allowed service accounts
+	if p.Config.Kube.ProjectSecretAllowedServiceAccountsKey == "" {
+		p.Logger.DebugWithCtx(ctx, "Skipping service account secret validation as no `projectSecretAllowedServiceAccountsKey` is configured")
+		return nil
+	}
+
+	allowedRaw, ok := secret.Data[p.Config.Kube.ProjectSecretAllowedServiceAccountsKey]
+	if !ok {
+		// no restriction , so allow any SA
+		return nil
+	}
+
+	allowedSAs := strings.Split(string(allowedRaw), ",")
+
+	// trim spaces and check membership
+	requestedSA := strings.TrimSpace(functionConfig.Spec.ServiceAccount)
+	for _, sa := range allowedSAs {
+		if strings.TrimSpace(sa) == requestedSA {
+			return nil // valid SA
+		}
+	}
+
+	return errors.Errorf("ServiceAccount %q is not in the list of allowed service accounts for project %q",
+		requestedSA, projectName)
+}
+
+func (p *Platform) getProjectSecret(ctx context.Context, projectName, namespace string) (*v1.Secret, error) {
+	// if project secret template is not specified, return empty data
+	if p.Config.Kube.ProjectSecretTemplate == "" {
+		return nil, nil
+	}
+
+	// render the project secret name using the template
+	templateData := map[string]interface{}{
+		"ProjectName": projectName,
+		"Namespace":   namespace,
+	}
+	secretName, err := p.renderProjectSecretName(templateData)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to render project secret name")
+	}
+
+	// fetch the secret from Kubernetes
+	projectSecret, err := p.consumer.KubeClientSet.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		// if not found, skip validation
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, errors.Wrapf(err, "Failed to get secret %s", secretName)
+	}
+	return projectSecret, nil
+}
+
 func (p *Platform) validateCronTriggers(functionConfig *functionconfig.Config) error {
 	if functionConfig.Spec.DisableDefaultHTTPTrigger != nil && *functionConfig.Spec.DisableDefaultHTTPTrigger &&
 		len(functionconfig.GetTriggersByKind(functionConfig.Spec.Triggers, "cron")) > 0 &&
@@ -2268,6 +2354,17 @@ func (p *Platform) renderIngressHost(ctx context.Context, ingressHostTemplate st
 	}
 
 	return p.alignIngressHostSubdomainLevel(renderedIngressHost, hostTemplateRandomCharsLength), nil
+}
+
+func (p *Platform) renderProjectSecretName(templateData map[string]interface{}) (string, error) {
+	if p.Config.Kube.ProjectSecretTemplate == "" {
+		return "", nil
+	}
+	renderedIngressHost, err := common.RenderTemplate(p.Config.Kube.ProjectSecretTemplate, templateData)
+	if err != nil {
+		return "", err
+	}
+	return renderedIngressHost, nil
 }
 
 // will take a host, split to "."

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/auth"
@@ -1111,6 +1112,145 @@ func (suite *FunctionKubePlatformTestSuite) TestGetFunctionsPermissions() {
 				suite.Require().Equal(1, len(functions))
 				suite.Require().Equal(functionName, functions[0].GetConfig().Meta.Name)
 			}
+		})
+	}
+}
+
+func (suite *FunctionKubePlatformTestSuite) TestValidateServiceAccount() {
+
+	projectName := "test-project"
+	secretName := fmt.Sprintf("nuclio-project-secrets-%s", projectName)
+	allowedKey := "allowed-sa-key"
+	allowedSAs := []string{"sa1", "sa2"}
+
+	oldAllowedKey := suite.platform.Config.Kube.ProjectSecretAllowedServiceAccountsKey
+	suite.platform.Config.Kube.ProjectSecretAllowedServiceAccountsKey = allowedKey
+
+	oldProjectSecretTemplate := suite.platform.Config.Kube.ProjectSecretTemplate
+	suite.platform.Config.Kube.ProjectSecretTemplate = "nuclio-project-secrets-{{ .ProjectName }}"
+	// revert the change
+	defer func() {
+		suite.platform.Config.Kube.ProjectSecretAllowedServiceAccountsKey = oldAllowedKey
+		suite.platform.Config.Kube.ProjectSecretTemplate = oldProjectSecretTemplate
+	}()
+
+	createSecret := func(data map[string][]byte) *v1.Secret {
+		return &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: suite.Namespace,
+			},
+			Data: data,
+		}
+	}
+
+	for _, testcase := range []struct {
+		name          string
+		secret        *v1.Secret
+		configKey     string
+		requestedSA   string
+		expectedError string
+	}{
+		{
+			name:        "AllowedServiceAccount",
+			secret:      createSecret(map[string][]byte{allowedKey: []byte(strings.Join(allowedSAs, ","))}),
+			configKey:   allowedKey,
+			requestedSA: "sa1",
+		},
+		{
+			name:          "DisallowedServiceAccount",
+			secret:        createSecret(map[string][]byte{allowedKey: []byte(strings.Join(allowedSAs, ","))}),
+			configKey:     allowedKey,
+			requestedSA:   "sa3",
+			expectedError: "ServiceAccount \"sa3\" is not in the list of allowed service accounts",
+		},
+		{
+			name:        "NoRestrictionKeyMissing",
+			secret:      createSecret(map[string][]byte{"other-key": []byte("irrelevant")}),
+			configKey:   allowedKey,
+			requestedSA: "sa3",
+		},
+		{
+			name:        "SecretNotFound",
+			secret:      nil,
+			configKey:   allowedKey,
+			requestedSA: "sa1",
+		},
+		{
+			name:        "AllowedServiceAccountsKeyNotConfigured",
+			secret:      createSecret(map[string][]byte{allowedKey: []byte(strings.Join(allowedSAs, ","))}),
+			configKey:   "",
+			requestedSA: "sa1",
+		},
+	} {
+		suite.Run(testcase.name, func() {
+			functionConfig := &functionconfig.Config{
+				Meta: functionconfig.Meta{
+					Namespace: suite.Namespace,
+					Labels: map[string]string{
+						common.NuclioResourceLabelKeyProjectName: projectName,
+					},
+				},
+				Spec: functionconfig.Spec{
+					ServiceAccount: testcase.requestedSA,
+				},
+			}
+
+			if testcase.secret != nil {
+				_, err := suite.kubeClientSet.CoreV1().Secrets(suite.Namespace).Create(suite.ctx, testcase.secret, metav1.CreateOptions{})
+				suite.Require().NoError(err)
+
+				defer suite.kubeClientSet.CoreV1().Secrets(suite.Namespace).Delete(suite.ctx, testcase.secret.Name, metav1.DeleteOptions{}) //nolint:errcheck
+			}
+
+			err := suite.platform.validateServiceAccount(suite.ctx, functionConfig)
+			if testcase.expectedError != "" {
+				suite.Require().Error(err, testcase.expectedError)
+			} else {
+				suite.Require().NoError(err)
+			}
+		})
+	}
+}
+
+func (suite *FunctionKubePlatformTestSuite) TestRenderProjectSecretName() {
+	templateData := map[string]interface{}{
+		"ProjectName": "myproj",
+		"Namespace":   "ns1",
+	}
+	testCases := []struct {
+		name               string
+		template           string
+		expectedSecretName string
+	}{
+		{
+			name:               "WithProjectAndNamespace",
+			template:           "nuclio-project-secrets-{{ .ProjectName }}-{{ .Namespace }}",
+			expectedSecretName: "nuclio-project-secrets-myproj-ns1",
+		},
+		{
+			name:               "WithProjectOnly",
+			template:           "nuclio-project-secrets-{{ .ProjectName }}",
+			expectedSecretName: "nuclio-project-secrets-myproj",
+		},
+		{
+			name:               "Empty",
+			expectedSecretName: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		suite.Run(testCase.name, func() {
+			oldProjectSecretTemplate := suite.platform.Config.Kube.ProjectSecretTemplate
+			suite.platform.Config.Kube.ProjectSecretTemplate = testCase.template
+			// revert the change
+			defer func() {
+				suite.platform.Config.Kube.ProjectSecretTemplate = oldProjectSecretTemplate
+			}()
+
+			secretName, err := suite.platform.renderProjectSecretName(templateData)
+			suite.Require().NoError(err)
+			suite.Require().Equal(testCase.expectedSecretName, secretName)
 		})
 	}
 }

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -184,21 +184,24 @@ type PlatformKubeConfig struct {
 	KubeConfigPath string `json:"kubeConfigPath,omitempty"`
 
 	// TODO: Move IngressConfig here
-	DefaultServiceType               corev1.ServiceType      `json:"defaultServiceType,omitempty"`
-	DefaultFunctionNodeSelector      map[string]string       `json:"defaultFunctionNodeSelector,omitempty"`
-	DefaultHTTPIngressHostTemplate   string                  `json:"defaultHTTPIngressHostTemplate,omitempty"`
-	DefaultHTTPIngressAnnotations    map[string]string       `json:"defaultHTTPIngressAnnotations,omitempty"`
-	DefaultHTTPIngressClassName      string                  `json:"defaultHTTPIngressClassName,omitempty"`
-	DefaultFunctionPriorityClassName string                  `json:"defaultFunctionPriorityClassName,omitempty"`
-	DefaultFunctionServiceAccount    string                  `json:"defaultFunctionServiceAccount,omitempty"`
-	ValidFunctionPriorityClassNames  []string                `json:"validFunctionPriorityClassNames,omitempty"`
-	DefaultFunctionPodResources      PodResourceRequirements `json:"defaultFunctionPodResources,omitempty"`
-	DefaultSidecarResources          PodResourceRequirements `json:"defaultSidecarResources,omitempty"`
-	DefaultFunctionTolerations       []corev1.Toleration     `json:"defaultFunctionTolerations,omitempty"`
-	PreemptibleNodes                 *PreemptibleNodes       `json:"preemptibleNodes,omitempty"`
-	DefaultReadinessProbe            *corev1.Probe           `json:"readinessProbe,omitempty"`
-	DefaultLivenessProbe             *corev1.Probe           `json:"livenessProbe,omitempty"`
-	ElasticSearchConfig              *ElasticSearchConfig    `json:"elasticSearchConfig,omitempty"`
+	DefaultServiceType                     corev1.ServiceType      `json:"defaultServiceType,omitempty"`
+	DefaultFunctionNodeSelector            map[string]string       `json:"defaultFunctionNodeSelector,omitempty"`
+	DefaultHTTPIngressHostTemplate         string                  `json:"defaultHTTPIngressHostTemplate,omitempty"`
+	DefaultHTTPIngressAnnotations          map[string]string       `json:"defaultHTTPIngressAnnotations,omitempty"`
+	DefaultHTTPIngressClassName            string                  `json:"defaultHTTPIngressClassName,omitempty"`
+	DefaultFunctionPriorityClassName       string                  `json:"defaultFunctionPriorityClassName,omitempty"`
+	DefaultFunctionServiceAccount          string                  `json:"defaultFunctionServiceAccount,omitempty"`
+	ValidFunctionPriorityClassNames        []string                `json:"validFunctionPriorityClassNames,omitempty"`
+	DefaultFunctionPodResources            PodResourceRequirements `json:"defaultFunctionPodResources,omitempty"`
+	DefaultSidecarResources                PodResourceRequirements `json:"defaultSidecarResources,omitempty"`
+	DefaultFunctionTolerations             []corev1.Toleration     `json:"defaultFunctionTolerations,omitempty"`
+	PreemptibleNodes                       *PreemptibleNodes       `json:"preemptibleNodes,omitempty"`
+	DefaultReadinessProbe                  *corev1.Probe           `json:"readinessProbe,omitempty"`
+	DefaultLivenessProbe                   *corev1.Probe           `json:"livenessProbe,omitempty"`
+	ElasticSearchConfig                    *ElasticSearchConfig    `json:"elasticSearchConfig,omitempty"`
+	ProjectSecretTemplate                  string                  `json:"projectSecretTemplate,omitempty"`
+	ProjectSecretAllowedServiceAccountsKey string                  `json:"projectSecretAllowedServiceAccountsKey,omitempty"`
+	ProjectSecretDefaultServiceAccountKey  string                  `json:"projectSecretDefaultServiceAccountKey,omitempty"`
 }
 
 // PreemptibleNodes Holds data needed when user decided to run his function pods on a preemptible node (aka Spot node)


### PR DESCRIPTION
* Add configuration `projectSecretTemplate` to platform config that determines how to locate project secrets.
* Add configuration of key names of allowed and default SA - `projectSecretAllowedServiceAccountsKey`/`projectSecretDefaultServiceAccountKey`
* Add validation that SA in function spec is allowed 

Jira :
* https://iguazio.atlassian.net/browse/NUC-516 (helm charts + function config part)
* validation part https://iguazio.atlassian.net/browse/NUC-520

