### PR TITLE
[Kaniko] Enrich and Validate service account

### DIFF
--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -20,8 +20,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"github.com/nuclio/nuclio/pkg/platform/kube/utils"
-
 	"io"
 	"os"
 	"path"
@@ -31,6 +29,7 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/platform/kube/utils"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 
 	"github.com/nuclio/errors"

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -20,6 +20,8 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"github.com/nuclio/nuclio/pkg/platform/kube/utils"
+
 	"io"
 	"os"
 	"path"
@@ -95,8 +97,10 @@ func (k *Kaniko) BuildAndPushContainerImage(ctx context.Context,
 	defer os.Remove(assetPath) // nolint: errcheck
 
 	// Generate job spec
-	jobSpec := k.compileJobSpec(ctx, namespace, buildOptions, bundleFilename)
-
+	jobSpec, err := k.compileJobSpec(ctx, namespace, buildOptions, bundleFilename)
+	if err != nil {
+		return errors.Wrap(err, "Failed to compile kaniko job spec")
+	}
 	// create job
 	k.logger.DebugWithCtx(ctx,
 		"Creating job",
@@ -251,7 +255,7 @@ func (k *Kaniko) createContainerBuildBundle(ctx context.Context,
 func (k *Kaniko) compileJobSpec(ctx context.Context,
 	namespace string,
 	buildOptions *BuildOptions,
-	bundleFilename string) *batchv1.Job {
+	bundleFilename string) (*batchv1.Job, error) {
 
 	completions := int32(1)
 	backoffLimit := int32(0)
@@ -298,7 +302,10 @@ func (k *Kaniko) compileJobSpec(ctx context.Context,
 	assetsURL := fmt.Sprintf("http://%s:8070/kaniko/%s", os.Getenv("NUCLIO_DASHBOARD_DEPLOYMENT_NAME"), bundleFilename)
 	getAssetCommand := fmt.Sprintf("while true; do wget -T 5 -c %s -P %s && break; done", assetsURL, tmpFolderVolumeMount.MountPath)
 
-	serviceAccount := k.resolveServiceAccount(buildOptions)
+	serviceAccount, err := k.enrichAndValidateServiceAccount(ctx, buildOptions, namespace)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to enrich and validate service account")
+	}
 
 	kanikoJobSpec := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -376,7 +383,7 @@ func (k *Kaniko) compileJobSpec(ctx context.Context,
 	}
 
 	k.configureSecretVolumeMount(buildOptions, kanikoJobSpec)
-	return kanikoJobSpec
+	return kanikoJobSpec, nil
 }
 
 func (k *Kaniko) configureSecretVolumeMount(buildOptions *BuildOptions, kanikoJobSpec *batchv1.Job) {
@@ -815,8 +822,25 @@ func (k *Kaniko) resolveAWSRegionFromECR(registryURL string) string {
 	return strings.Split(registryURL, ".")[3]
 }
 
-func (k *Kaniko) resolveServiceAccount(buildOptions *BuildOptions) string {
+func (k *Kaniko) enrichAndValidateServiceAccount(ctx context.Context, buildOptions *BuildOptions, namespace string) (string, error) {
+	// try to enrich service account from builder configuration
+	enrichedServiceAccount := k.enrichServiceAccountFromBuilderConfiguration(buildOptions)
 
+	// enrich (from project/platform) and validate service account
+	return utils.EnrichAndValidateServiceAccount(ctx,
+		k.kubeClientSet,
+		buildOptions.DefaultPlatformServiceAccount,
+		buildOptions.ProjectSecretTemplate,
+		buildOptions.ProjectSecretDefaultServiceAccountKey,
+		buildOptions.ProjectSecretAllowedServiceAccountsKey,
+		enrichedServiceAccount,
+		buildOptions.ProjectName,
+		namespace,
+		true,
+	)
+}
+
+func (k *Kaniko) enrichServiceAccountFromBuilderConfiguration(buildOptions *BuildOptions) string {
 	// if a builder service account is provided in build options, use it.
 	if buildOptions.BuilderServiceAccount != "" {
 		return buildOptions.BuilderServiceAccount
@@ -825,6 +849,5 @@ func (k *Kaniko) resolveServiceAccount(buildOptions *BuildOptions) string {
 	if k.builderConfiguration.DefaultServiceAccount != "" {
 		return k.builderConfiguration.DefaultServiceAccount
 	}
-	// otherwise, use function service account.
 	return buildOptions.FunctionServiceAccount
 }

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -30,30 +30,35 @@ import (
 
 // BuildOptions are options for building a container image
 type BuildOptions struct {
-	Image                   string
-	ContextDir              string
-	TempDir                 string
-	DockerfileInfo          *runtime.ProcessorDockerfileInfo
-	NoCache                 bool
-	Pull                    bool
-	NoBaseImagePull         bool
-	BuildFlags              map[string]bool
-	BuildArgs               map[string]string
-	RegistryURL             string
-	RepoName                string
-	SecretName              string
-	OutputImageFile         string
-	BuildTimeoutSeconds     int64
-	Affinity                *v1.Affinity
-	NodeSelector            map[string]string
-	NodeName                string
-	PriorityClassName       string
-	Tolerations             []v1.Toleration
-	ReadinessTimeoutSeconds int
-	FunctionServiceAccount  string
-	BuilderServiceAccount   string
-	SecurityContext         *v1.PodSecurityContext
-	Resources               v1.ResourceRequirements
+	Image                                  string
+	ContextDir                             string
+	TempDir                                string
+	DockerfileInfo                         *runtime.ProcessorDockerfileInfo
+	NoCache                                bool
+	Pull                                   bool
+	NoBaseImagePull                        bool
+	BuildFlags                             map[string]bool
+	BuildArgs                              map[string]string
+	RegistryURL                            string
+	RepoName                               string
+	SecretName                             string
+	OutputImageFile                        string
+	BuildTimeoutSeconds                    int64
+	Affinity                               *v1.Affinity
+	NodeSelector                           map[string]string
+	NodeName                               string
+	PriorityClassName                      string
+	Tolerations                            []v1.Toleration
+	ReadinessTimeoutSeconds                int
+	FunctionServiceAccount                 string
+	BuilderServiceAccount                  string
+	SecurityContext                        *v1.PodSecurityContext
+	Resources                              v1.ResourceRequirements
+	ProjectName                            string
+	ProjectSecretTemplate                  string
+	ProjectSecretAllowedServiceAccountsKey string
+	ProjectSecretDefaultServiceAccountKey  string
+	DefaultPlatformServiceAccount          string
 
 	BuildLogger logger.Logger
 }

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1056,6 +1056,10 @@ func (b *Builder) cleanupTempDir() error {
 }
 
 func (b *Builder) buildProcessorImage(ctx context.Context) (string, error) {
+	projectName, err := b.options.FunctionConfig.GetProjectName()
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to get project name for the function")
+	}
 	buildArgs := b.getBuildArgs()
 	buildFlags := b.getBuildFlags()
 
@@ -1066,7 +1070,6 @@ func (b *Builder) buildProcessorImage(ctx context.Context) (string, error) {
 	// to its fully qualified image name (different for each runtime)
 	// - An empty onbuildImageRegistry will result in onbuild images looked for in quay.io
 	baseImageRegistry := b.options.FunctionConfig.Spec.Build.BaseImageRegistry
-	var err error
 
 	if baseImageRegistry == "" {
 		baseImageRegistry, err = b.platform.GetBaseImageRegistry(b.options.FunctionConfig.Spec.Build.Registry,
@@ -1133,9 +1136,14 @@ func (b *Builder) buildProcessorImage(ctx context.Context) (string, error) {
 			BuilderServiceAccount:  b.options.FunctionConfig.Spec.Build.BuilderServiceAccount,
 			ReadinessTimeoutSeconds: b.platform.GetConfig().GetFunctionReadinessTimeoutOrDefault(
 				b.options.FunctionConfig.Spec.ReadinessTimeoutSeconds),
-			SecurityContext: b.options.FunctionConfig.Spec.SecurityContext,
-			BuildLogger:     b.logger,
-			Resources:       b.resolveResources(),
+			SecurityContext:                        b.options.FunctionConfig.Spec.SecurityContext,
+			BuildLogger:                            b.logger,
+			Resources:                              b.resolveResources(),
+			ProjectName:                            projectName,
+			ProjectSecretTemplate:                  b.platform.GetConfig().Kube.ProjectSecretTemplate,
+			ProjectSecretAllowedServiceAccountsKey: b.platform.GetConfig().Kube.ProjectSecretAllowedServiceAccountsKey,
+			ProjectSecretDefaultServiceAccountKey:  b.platform.GetConfig().Kube.ProjectSecretDefaultServiceAccountKey,
+			DefaultPlatformServiceAccount:          b.platform.GetConfig().Kube.DefaultFunctionServiceAccount,
 		})
 
 	return taggedImageName, err


### PR DESCRIPTION
Enrich and Validate SA for kaniko builder. In addition to the logic that applies for usual functions' SA flow, try to enrich from builder-specific configuration first. Other than that, the flow is the same as described in #3711 

Jira - https://iguazio.atlassian.net/browse/NUC-518