### PR TITLE
[Controller] Remove the configuration-snippet annotation from ingress

### DIFF
--- a/pkg/common/consts.go
+++ b/pkg/common/consts.go
@@ -64,5 +64,3 @@ const FunctionConfigFileName = "function.yaml"
 const DefaultIngressHostTemplate = "@nuclio.fromDefault"
 
 const FunctionTagLatest = "latest"
-
-const NginxConfigurationSnippetAnnotationKey = "nginx.ingress.kubernetes.io/configuration-snippet"

--- a/pkg/platform/kube/apigatewayres/lazy.go
+++ b/pkg/platform/kube/apigatewayres/lazy.go
@@ -354,23 +354,6 @@ func (lc *lazyClient) resolveBaseAndCanaryUpstreamsFromSpec(upstreams []platform
 func (lc *lazyClient) enrichPrimaryIngressResources(primaryIngressResources *ingress.Resources,
 	primaryUpstream *platform.APIGatewayUpstreamSpec,
 	canaryUpstream *platform.APIGatewayUpstreamSpec) {
-
-	// set nuclio target header on ingress
-	targetHeaderValue := primaryUpstream.NuclioFunction.Name
-	if canaryUpstream != nil {
-		targetHeaderValue = fmt.Sprintf(`%s,%s`,
-			primaryUpstream.NuclioFunction.Name,
-			canaryUpstream.NuclioFunction.Name)
-	}
-	encodedPrimaryTargetHeader := fmt.Sprintf(`proxy_set_header X-Nuclio-Target "%s";`, targetHeaderValue)
-	annotations := primaryIngressResources.Ingress.Annotations
-
-	if _, headerExists := annotations[common.NginxConfigurationSnippetAnnotationKey]; headerExists {
-		annotations[common.NginxConfigurationSnippetAnnotationKey] += fmt.Sprintf("\n%s", encodedPrimaryTargetHeader)
-	} else {
-		annotations[common.NginxConfigurationSnippetAnnotationKey] = encodedPrimaryTargetHeader
-	}
-
 	// set nuclio labels for ingress
 	primaryIngressResources.Ingress.Labels[common.NuclioResourceLabelKeyFunctionName] = primaryUpstream.NuclioFunction.Name
 	if canaryUpstream != nil {

--- a/pkg/platform/kube/apigatewayres/lazy_test.go
+++ b/pkg/platform/kube/apigatewayres/lazy_test.go
@@ -67,27 +67,6 @@ func (suite *lazyTestSuite) SetupTest() {
 	suite.Require().NoError(err)
 }
 
-func (suite *lazyTestSuite) TestEnsurePrimaryIngressHasXNuclioTargetHeader() {
-	primaryFunctionConfig := functionconfig.NewConfig()
-	primaryFunctionConfig.Meta.Name = "primary-function-name"
-	canaryFunctionConfig := functionconfig.NewConfig()
-	canaryFunctionConfig.Meta.Name = "canary-function-name"
-	suite.mockCmdRunner.
-		On("Run", mock.Anything, mock.IsType(""), mock.Anything).
-		Return("echo ehsom | htpasswd -n -i moshe", nil)
-
-	resources, err := suite.client.CreateOrUpdate(context.Background(), suite.getTestAPIGateway(primaryFunctionConfig, canaryFunctionConfig))
-	suite.Require().NoError(err)
-	suite.Require().NotNil(resources.IngressResourcesMap())
-
-	primaryIngressResources, _ := suite.getIngressesFromResources(resources)
-
-	// expect primary function ingress to have `X-Nuclio-Target`
-	// so that if it has STZ option, it would wake up upon a request
-	suite.Require().Equal(`proxy_set_header X-Nuclio-Target "primary-function-name,canary-function-name";`,
-		primaryIngressResources.Ingress.Annotations[common.NginxConfigurationSnippetAnnotationKey])
-}
-
 func (suite *lazyTestSuite) TestEnsurePrimaryIngressHasFunctionLabels() {
 	for _, testCase := range []struct {
 		name                 string

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2300,10 +2300,6 @@ func (lc *lazyClient) populateIngressConfig(ctx context.Context,
 		break
 	}
 
-	// set nuclio target header on ingress
-	meta.Annotations[common.NginxConfigurationSnippetAnnotationKey] = fmt.Sprintf(
-		`proxy_set_header X-Nuclio-Target "%s";`, function.Name)
-
 	// Check if function is a scale to zero candidate
 	//			is not disabled
 	//			is not in imported state

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -179,14 +179,13 @@ func (suite *lazyTestSuite) TestEnrichIngressWithDefaultAnnotations() {
 			functionLabels := suite.client.getFunctionLabels(&function)
 			functionLabels[common.NuclioResourceLabelKeyFunctionName] = function.Name
 
-			// "create the ingress
+			// create the ingress
 			ingressInstance, err := suite.client.createOrUpdateIngress(suite.ctx, functionLabels, &function)
 			suite.Require().NoError(err)
 			suite.Require().NotNil(ingressInstance)
 			suite.Require().NotEmpty(ingressInstance.Annotations)
 
 			// make sure user function annotations exists
-			delete(ingressInstance.Annotations, common.NginxConfigurationSnippetAnnotationKey)
 			suite.Require().Equal(testCase.expectedFunctionIngressAnnotations,
 				ingressInstance.Annotations)
 		})

--- a/pkg/platform/kube/resourcescaler/resourcescaler_test.go
+++ b/pkg/platform/kube/resourcescaler/resourcescaler_test.go
@@ -68,18 +68,6 @@ func (suite *ResourceScalerTestSuite) TestGetResolveTargetsFromIngressCallback()
 			expectedResult: []string{"test-target1", "test-target2"},
 		},
 		{
-			name: "Annotation with targets",
-			ingress: &networkingv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						common.NginxConfigurationSnippetAnnotationKey: `proxy_set_header X-Nuclio-Target "test6,test7";`,
-					},
-				},
-			},
-			expectError: true,
-			errorMsg:    "Failed to resolve ingress targets",
-		},
-		{
 			name: "No labels or annotation",
 			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{},

--- a/pkg/platform/kube/test/apigateway/api_gateway_test.go
+++ b/pkg/platform/kube/test/apigateway/api_gateway_test.go
@@ -54,8 +54,7 @@ func (suite *DeployAPIGatewayTestSuite) TestDexAuthMode() {
 		err := suite.DeployAPIGateway(createAPIGatewayOptions, func(ingress *networkingv1.Ingress) {
 			suite.Require().NotContains(ingress.Annotations, "nginx.ingress.kubernetes.io/auth-signin")
 			suite.Require().Contains(ingress.Annotations["nginx.ingress.kubernetes.io/auth-url"], configOauth2ProxyURL)
-			suite.Require().Contains(ingress.Annotations[common.NginxConfigurationSnippetAnnotationKey],
-				fmt.Sprintf(`proxy_set_header X-Nuclio-Target "%s";`, functionName))
+			suite.Require().Equal(ingress.Labels[common.NuclioResourceLabelKeyFunctionName], functionName)
 		})
 		suite.Require().NoError(err)
 


### PR DESCRIPTION
### Description  
Remove usage of the `configuration-snippet` annotation from ingress headers for both API Gateways and functions.

### Changes Made  
- Removed the shared constant for the annotation  
- Removed the part in the API Gateway operator that sets this annotation  
- Removed the corresponding logic in the function operator  

### Testing  
- [x] I have tested the changes in this PR  
- Manually verified: created new API Gateways and functions, and confirmed their ingress resources no longer include the annotation  
- Validated that editing existing ingresses (created before these changes) updates their annotations and removes the deprecated annotation as expected  
- Confirmed that the removal does not impact scale-from-zero functionality  
- Updated existing unit tests to reflect the changes  

### References  
- Ticket link:  https://iguazio.atlassian.net/browse/NUC-458

### Additional Notes  
- There’s still one remaining usage of `configuration-snippet` in the authentication flow — see [[link](https://github.com/nuclio/nuclio/blob/725efcee19d999f4ed34da75f42e8ec996832ba5/pkg/platform/kube/ingress/ingress.go#L448)] and [[link](https://github.com/nuclio/nuclio/blob/725efcee19d999f4ed34da75f42e8ec996832ba5/pkg/platform/kube/ingress/ingress.go#L419)].  