### PR TITLE
[Controller] Check for scaling happened within last scalingTimeout even if CurrentReplicas is equal to DesiredReplicas

### DIFF
--- a/pkg/platform/kube/monitoring/function.go
+++ b/pkg/platform/kube/monitoring/function.go
@@ -320,7 +320,7 @@ func (fm *FunctionMonitor) isScaling(ctx context.Context, function *nuclioio.Nuc
 		return false, nil
 	}
 
-	// didn't scale yet, desired replicas are archived
+	// didn't scale yet, desired replicas are achieved
 	if hpa.Status.LastScaleTime == nil {
 		return false, nil
 	}
@@ -346,7 +346,7 @@ func (fm *FunctionMonitor) isScaling(ctx context.Context, function *nuclioio.Nuc
 	// either the previous last scale time doesn't exist or it has not changed since the previous monitoring interval
 	// check if the scaling timeout has passed since the last scale time
 	if hpa.Status.LastScaleTime.Add(scalingTimeout).Before(time.Now()) {
-		fm.logger.WarnWithCtx(context.Background(),
+		fm.logger.WarnWithCtx(ctx,
 			"Function is still scaling passed the scaling timeout",
 			"functionName", function.Name,
 			"scalingTimeout", scalingTimeout)

--- a/pkg/platform/kube/monitoring/function.go
+++ b/pkg/platform/kube/monitoring/function.go
@@ -309,57 +309,56 @@ func (fm *FunctionMonitor) isScaling(ctx context.Context, function *nuclioio.Nuc
 		return false, nil
 	}
 
-	// check if HPA is in progress of scaling
-	if hpa.Status.CurrentReplicas != hpa.Status.DesiredReplicas {
-
-		// if there is an error in the HPA, it is possible that the desired replicas are not achieved,
-		// but the HPA is not scaling anymore
-		if hpa.Status.LastScaleTime == nil {
-			fm.logger.WarnWithCtx(ctx,
-				"Function's desired replicas were not achieved but HPA has no last scale time",
-				"functionName", function.Name,
-				"currentReplicas", hpa.Status.CurrentReplicas,
-				"desiredReplicas", hpa.Status.DesiredReplicas)
-			return false, nil
-		}
-
-		// get the previous last scale time of this function, if exists
-		if previousLastScaleTime, ok := fm.lastScaleTimeMap.Load(function.Name); ok {
-			previousLastScaleTimeInstance, ok := previousLastScaleTime.(*metav1.Time)
-			if !ok {
-				return false, errors.New(fmt.Sprintf("Failed to cast previous last scale time of function %s to time.Time", function.Name))
-			}
-
-			// check if the LastScaleTime has changed since the previous monitoring interval
-			if !hpa.Status.LastScaleTime.Equal(previousLastScaleTimeInstance) {
-
-				// save the last scale time of this function
-				fm.lastScaleTimeMap.Store(function.Name, hpa.Status.LastScaleTime)
-
-				// the HPA is still scaling, we should not change the function state just yet
-				return true, nil
-			}
-		}
-
-		// either the previous last scale time doesn't exist or it has not changed since the previous monitoring interval
-		// check if the scaling timeout has passed since the last scale time
-		if hpa.Status.LastScaleTime.Add(scalingTimeout).Before(time.Now()) {
-			fm.logger.WarnWithCtx(context.Background(),
-				"Function is still scaling passed the scaling timeout",
-				"functionName", function.Name,
-				"scalingTimeout", scalingTimeout)
-
-			// we return false so the function will be set as unhealthy
-			return false, nil
-		}
-
-		// save the last scale time of this function
-		fm.lastScaleTimeMap.Store(function.Name, hpa.Status.LastScaleTime)
-
-		return true, nil
+	// if there is an error in the HPA, it is possible that the desired replicas are not achieved,
+	// but the HPA is not scaling anymore
+	if hpa.Status.CurrentReplicas != hpa.Status.DesiredReplicas && hpa.Status.LastScaleTime == nil {
+		fm.logger.WarnWithCtx(ctx,
+			"Function's desired replicas were not achieved but HPA has no last scale time",
+			"functionName", function.Name,
+			"currentReplicas", hpa.Status.CurrentReplicas,
+			"desiredReplicas", hpa.Status.DesiredReplicas)
+		return false, nil
 	}
 
-	return false, nil
+	// didn't scale yet, desired replicas are archived
+	if hpa.Status.LastScaleTime == nil {
+		return false, nil
+	}
+
+	// get the previous last scale time of this function, if exists
+	if previousLastScaleTime, ok := fm.lastScaleTimeMap.Load(function.Name); ok {
+		previousLastScaleTimeInstance, ok := previousLastScaleTime.(*metav1.Time)
+		if !ok {
+			return false, errors.New(fmt.Sprintf("Failed to cast previous last scale time of function %s to time.Time", function.Name))
+		}
+
+		// check if the LastScaleTime has changed since the previous monitoring interval
+		if !hpa.Status.LastScaleTime.Equal(previousLastScaleTimeInstance) {
+
+			// save the last scale time of this function
+			fm.lastScaleTimeMap.Store(function.Name, hpa.Status.LastScaleTime)
+
+			// the HPA is still scaling, we should not change the function state just yet
+			return true, nil
+		}
+	}
+
+	// either the previous last scale time doesn't exist or it has not changed since the previous monitoring interval
+	// check if the scaling timeout has passed since the last scale time
+	if hpa.Status.LastScaleTime.Add(scalingTimeout).Before(time.Now()) {
+		fm.logger.WarnWithCtx(context.Background(),
+			"Function is still scaling passed the scaling timeout",
+			"functionName", function.Name,
+			"scalingTimeout", scalingTimeout)
+
+		// we return false so the function will be set as unhealthy
+		return false, nil
+	}
+
+	// save the last scale time of this function
+	fm.lastScaleTimeMap.Store(function.Name, hpa.Status.LastScaleTime)
+
+	return true, nil
 }
 
 // We monitor functions that meet the following conditions:


### PR DESCRIPTION
### Description  
This PR fixes an issue where a function was incorrectly marked as unhealthy even though it was in the process of scaling.

The `FunctionMonitor` determines readiness by first checking `isAvailable()`. If the function is not yet available, it checks whether it is currently scaling using the isScaling() method, which inspects the HPA status.

However, the previous logic missed one scenario: when pods had already been created but were not yet ready. In such cases, the condition `hpa.Status.CurrentReplicas != hpa.Status.DesiredReplicas `was bypassed, since `CurrentReplicas ` includes all pods (not just the ready ones). As a result, the function was considered not scaling, which led the monitor to mark it as unhealthy.

This PR adjusts the logic to properly account for this intermediate state, ensuring that the function is recognized as scaling when appropriate and not prematurely marked as unhealthy.

### Testing  
It is quite complicated to test this change, as bug isn't always reproduces, so it will be tested by QA.  

### References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-288


