### PR TITLE
[Processor] Set status code before closing stream

### DIFF
--- a/pkg/processor/runtime/rpc/connection/abstract.go
+++ b/pkg/processor/runtime/rpc/connection/abstract.go
@@ -385,6 +385,9 @@ func (be *AbstractEventConnection) ProcessEventBatch(batch []nuclio.Event, funct
 }
 
 func (be *AbstractEventConnection) ProcessStream(stream *result.StreamStart) (err error) {
+	// always close stream when processing is done
+	defer be.postProcessStreaming(stream.ResponseStream)
+
 	// first defer: set status code from error if any
 	defer func() {
 		if err != nil {
@@ -394,9 +397,6 @@ func (be *AbstractEventConnection) ProcessStream(stream *result.StreamStart) (er
 			be.SetStatus(status.RestartRequired)
 		}
 	}()
-
-	// always close stream when processing is done
-	defer be.postProcessStreaming(stream.ResponseStream)
 
 	// start with writing a first chunk
 	// this is blocking operation, so it will wait until the reader is ready to receive data


### PR DESCRIPTION
### Description  
Fixes not always reproducable bug, found by long CI. We should mark the status code before closing the stream, not after, so that it is handled in time

### Testing

Should be tested by running couple of times in Long CI (locally I wasn't able to reproduce the problem)
Successful runs of Long CI:

* https://github.com/nuclio/nuclio/actions/runs/16523261411
* https://github.com/nuclio/nuclio/actions/runs/16523476969
* https://github.com/nuclio/nuclio/actions/runs/16524110003
* https://github.com/nuclio/nuclio/actions/runs/16524112162
* https://github.com/nuclio/nuclio/actions/runs/16524114847