### PR TITLE
[Controller] Deprecate default project handling

### DIFF
--- a/docs/reference/nuctl/cli/nuctl_build.md
+++ b/docs/reference/nuctl/cli/nuctl_build.md
@@ -24,6 +24,7 @@ nuctl build function-name [options] [flags]
       --onbuild-image string            The runtime onbuild image used to build the processor image
       --output-image-file string        Path to output container image of the build
   -p, --path string                     Path to the function's source code
+      --project-name string             The name of the function's parent project
   -r, --registry string                 URL of a container registry (env: NUCTL_REGISTRY)
       --runtime string                  Runtime (for example, "golang", "python:3.11")
       --source string                   The function's source code (overrides "path")

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -19,9 +19,9 @@ package command
 import (
 	"context"
 	"encoding/json"
-	"github.com/nuclio/nuclio/pkg/common"
 	"os"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -139,5 +139,4 @@ func (b *buildCommandeer) enrichLabels() {
 	if b.projectName != "" {
 		b.functionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName] = b.projectName
 	}
-
 }

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -19,6 +19,7 @@ package command
 import (
 	"context"
 	"encoding/json"
+	"github.com/nuclio/nuclio/pkg/common"
 	"os"
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
@@ -39,6 +40,7 @@ type buildCommandeer struct {
 	encodedRuntimeAttributes   string
 	encodedCodeEntryAttributes string
 	outputImageFile            string
+	projectName                string
 }
 
 func newBuildCommandeer(rootCommandeer *RootCommandeer) *buildCommandeer {
@@ -68,6 +70,8 @@ func newBuildCommandeer(rootCommandeer *RootCommandeer) *buildCommandeer {
 			commandeer.functionConfig.Spec.Build.FunctionConfigPath = commandeer.functionConfigPath
 			commandeer.functionConfig.Spec.Runtime = commandeer.runtime
 			commandeer.functionConfig.Spec.Handler = commandeer.handler
+
+			commandeer.enrichLabels()
 
 			// decode the JSON build runtime attributes
 			if err := json.Unmarshal([]byte(commandeer.encodedRuntimeAttributes),
@@ -100,6 +104,7 @@ func newBuildCommandeer(rootCommandeer *RootCommandeer) *buildCommandeer {
 
 	addBuildFlags(cmd, &commandeer.functionConfig.Spec.Build, &commandeer.functionConfigPath, &commandeer.runtime, &commandeer.handler, &commandeer.commands, &commandeer.encodedRuntimeAttributes, &commandeer.encodedCodeEntryAttributes)
 	cmd.Flags().StringVarP(&commandeer.outputImageFile, "output-image-file", "", "", "Path to output container image of the build")
+	cmd.Flags().StringVar(&commandeer.projectName, "project-name", "", "The name of the function's parent project")
 
 	commandeer.cmd = cmd
 
@@ -123,4 +128,16 @@ func addBuildFlags(cmd *cobra.Command, functionBuild *functionconfig.Build, func
 	cmd.Flags().StringVar(encodedRuntimeAttributes, "build-runtime-attrs", "{}", "JSON-encoded build runtime attributes for the function")
 	cmd.Flags().StringVar(encodedCodeEntryAttributes, "build-code-entry-attrs", "{}", "JSON-encoded build code entry attributes for the function")
 	cmd.Flags().StringVar(&functionBuild.CodeEntryType, "code-entry-type", "", "Type of code entry (for example, \"url\", \"github\", \"image\")")
+}
+
+func (b *buildCommandeer) enrichLabels() {
+	if b.functionConfig.Meta.Labels == nil {
+		b.functionConfig.Meta.Labels = map[string]string{}
+	}
+
+	// if the project name was set, add it as a label (not in string enrichment, because it's part of the labels)
+	if b.projectName != "" {
+		b.functionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName] = b.projectName
+	}
+
 }

--- a/pkg/nuctl/test/apigagteway_test.go
+++ b/pkg/nuctl/test/apigagteway_test.go
@@ -160,10 +160,10 @@ func (suite *apiGatewayCreateGetAndDeleteTestSuite) TestList() {
 		err = suite.ExecuteNuctl([]string{"get", "apigateway", "--function-name", functionName},
 			nil)
 		suite.Require().NoError(err)
-		suite.Require().Contains(suite.outputBuffer.String(), apiGatewayName)
+		suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), apiGatewayName)
 
 		for _, gateway := range apiGatewayNames {
-			suite.Require().NotContains(suite.outputBuffer.String(), gateway)
+			suite.Require().NotContains(suite.nuctlRunner.outputBuffer.String(), gateway)
 		}
 
 		// delete api gateway
@@ -178,7 +178,7 @@ func (suite *apiGatewayCreateGetAndDeleteTestSuite) TestList() {
 		err = suite.ExecuteNuctl([]string{"get", "apigateway"}, nil)
 		suite.Require().NoError(err)
 		for _, gateway := range apiGatewayNames {
-			suite.Require().Contains(suite.outputBuffer.String(), gateway)
+			suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), gateway)
 		}
 	}
 }
@@ -342,8 +342,8 @@ func (suite *apiGatewayInvokeTestSuite) deployFunction() string {
 	suite.Require().NoError(err)
 
 	// make sure reverser worked
-	suite.Require().Contains(suite.outputBuffer.String(), "+gnirts siht esrever-")
-	suite.outputBuffer.Reset()
+	suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), "+gnirts siht esrever-")
+	suite.nuctlRunner.outputBuffer.Reset()
 
 	return functionName
 }

--- a/pkg/nuctl/test/apigagteway_test.go
+++ b/pkg/nuctl/test/apigagteway_test.go
@@ -318,9 +318,10 @@ func (suite *apiGatewayInvokeTestSuite) deployFunction() string {
 	imageName := "nuclio/processor-" + functionName
 
 	namedArgs := map[string]string{
-		"path":    path.Join(suite.GetFunctionsDir(), "common", "reverser", "python"),
-		"runtime": "python",
-		"handler": "reverser:handler",
+		"path":         path.Join(suite.GetFunctionsDir(), "common", "reverser", "python"),
+		"runtime":      "python",
+		"handler":      "reverser:handler",
+		"project-name": suite.projectName,
 	}
 
 	err := suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"}, namedArgs)

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -277,12 +277,12 @@ func (suite *functionDeployTestSuite) TestDeployWithMetadata() {
 
 	err := suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"},
 		map[string]string{
-			"path":        path.Join(suite.GetFunctionsDir(), "common", "envprinter", "python"),
-			"env":         "FIRST_ENV=11223344,SECOND_ENV=0099887766",
-			"labels":      "label1=first,label2=second",
-			"annotations": "annotation1=third,annotation2=fourth",
-			"runtime":     "python",
-			"handler":     "envprinter:handler",
+			"path":         path.Join(suite.GetFunctionsDir(), "common", "envprinter", "python"),
+			"env":          "FIRST_ENV=11223344,SECOND_ENV=0099887766",
+			"labels":       "label1=first,label2=second",
+			"annotations":  "annotation1=third,annotation2=fourth",
+			"runtime":      "python",
+			"handler":      "envprinter:handler",
 			"project-name": suite.projectName,
 		})
 
@@ -322,8 +322,8 @@ func (suite *functionDeployTestSuite) TestDeployFromFunctionConfig() {
 
 	err = suite.ExecuteNuctl([]string{"deploy", "--verbose", "--no-pull"},
 		map[string]string{
-			"path":  path.Join(suite.GetFunctionsDir(), "common", "json-parser-with-function-config", "python"),
-			"image": imageName,
+			"path":         path.Join(suite.GetFunctionsDir(), "common", "json-parser-with-function-config", "python"),
+			"image":        imageName,
 			"project-name": suite.projectName,
 		})
 
@@ -544,9 +544,9 @@ func (suite *functionDeployTestSuite) TestDeployShellViaHandler() {
 
 	err := suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"},
 		map[string]string{
-			"image":   imageName,
-			"runtime": "shell",
-			"handler": "rev",
+			"image":        imageName,
+			"runtime":      "shell",
+			"handler":      "rev",
 			"project-name": suite.projectName,
 		})
 
@@ -580,9 +580,9 @@ func (suite *functionDeployTestSuite) TestDeployWithFunctionEvent() {
 
 	err := suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"},
 		map[string]string{
-			"image":   imageName,
-			"runtime": "shell",
-			"handler": "rev",
+			"image":        imageName,
+			"runtime":      "shell",
+			"handler":      "rev",
 			"project-name": suite.projectName,
 		})
 
@@ -859,8 +859,8 @@ func (suite *functionDeployTestSuite) TestDeployWithResourceVersion() {
 	// deploy with temp, expect to pass
 	err = suite.ExecuteNuctl([]string{"deploy", functionConfig.Meta.Name, "--verbose", "--no-pull"},
 		map[string]string{
-			"path": functionPath,
-			"file": functionConfigPath,
+			"path":         functionPath,
+			"file":         functionConfigPath,
 			"project-name": suite.projectName,
 		})
 
@@ -1004,9 +1004,10 @@ func (suite *functionDeployTestSuite) TestDeployAndRedeployHTTPTriggerPortChange
 
 	desiredHTTPPort := 30555
 	namedArgs = map[string]string{
-		"path":    path.Join(suite.GetFunctionsDir(), "common", "event-recorder", "python"),
-		"runtime": "python",
-		"handler": "event_recorder:handler",
+		"path":         path.Join(suite.GetFunctionsDir(), "common", "event-recorder", "python"),
+		"runtime":      "python",
+		"handler":      "event_recorder:handler",
+		"project-name": suite.projectName,
 		"triggers": fmt.Sprintf(`{
 	   "http": {
 	       "kind": "http",
@@ -1059,9 +1060,9 @@ func (suite *functionDeployTestSuite) TestDeployFromLocalDirPath() {
 
 	err := suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"},
 		map[string]string{
-			"path":    path.Join(suite.GetFunctionsDir(), "common", "reverser", "python"),
-			"runtime": "python:3.11",
-			"handler": "reverser:handler",
+			"path":         path.Join(suite.GetFunctionsDir(), "common", "reverser", "python"),
+			"runtime":      "python:3.11",
+			"handler":      "reverser:handler",
 			"project-name": suite.projectName,
 		})
 	suite.Require().NoError(err)
@@ -1155,7 +1156,10 @@ func (suite *functionDeployTestSuite) TestDeployWithSecurityContext() {
 
 	// try a few times to invoke, until it succeeds
 	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"invoke", functionName},
-		map[string]string{"method": "POST"},
+		map[string]string{
+			"method":       "POST",
+			"project-name": suite.projectName,
+		},
 		false)
 	suite.Require().NoError(err)
 
@@ -1312,7 +1316,7 @@ func (suite *functionDeployTestSuite) TestDeployWithOverrideServiceTypeFlag() {
 		"runtime":                   "golang",
 		"handler":                   "main:Reverse",
 		"http-trigger-service-type": string(corev1.ServiceTypeClusterIP),
-		"project-name": suite.projectName,
+		"project-name":              suite.projectName,
 	}
 
 	err := suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"}, namedArgs)

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -162,9 +162,10 @@ func (suite *functionDeployTestSuite) TestDeploy() {
 				flect.Dasherize(runtimeInfo.runtime),
 				xid.New().String())
 			namedArgs := map[string]string{
-				"path":    path.Join(suite.GetExamples(), runtimeName, "empty", runtimeInfo.filename),
-				"runtime": runtimeInfo.runtime,
-				"handler": runtimeInfo.handler,
+				"path":         path.Join(suite.GetExamples(), runtimeName, "empty", runtimeInfo.filename),
+				"runtime":      runtimeInfo.runtime,
+				"handler":      runtimeInfo.handler,
+				"project-name": suite.projectName,
 			}
 			suite.logger.DebugWith("Deploying function",
 				"functionName", functionName,
@@ -192,9 +193,10 @@ func (suite *functionDeployTestSuite) TestInvokeWithBodyFromStdin() {
 	functionName := "invoke-body-stdin-reverser" + uniqueSuffix
 	imageName := "nuclio/processor-" + functionName
 	namedArgs := map[string]string{
-		"path":    path.Join(suite.GetFunctionsDir(), "common", "reverser", "python"),
-		"runtime": "python",
-		"handler": "reverser:handler",
+		"path":         path.Join(suite.GetFunctionsDir(), "common", "reverser", "python"),
+		"runtime":      "python",
+		"handler":      "reverser:handler",
+		"project-name": suite.projectName,
 	}
 
 	err := suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"}, namedArgs)
@@ -229,10 +231,11 @@ func (suite *functionDeployTestSuite) TestInvokeWithTimeout() {
 	timeoutSeconds := 3
 	timeoutSourceCode := fmt.Sprintf("sleep %d\necho done", timeoutSeconds)
 	namedArgs := map[string]string{
-		"image":   imageName,
-		"runtime": "shell",
-		"handler": "main.sh",
-		"source":  base64.StdEncoding.EncodeToString([]byte(timeoutSourceCode)),
+		"image":        imageName,
+		"runtime":      "shell",
+		"handler":      "main.sh",
+		"source":       base64.StdEncoding.EncodeToString([]byte(timeoutSourceCode)),
+		"project-name": suite.projectName,
 	}
 
 	// deploy function
@@ -391,9 +394,10 @@ func (suite *functionDeployTestSuite) TestInvokeWithLogging() {
 	imageName := "nuclio/processor-" + functionName
 
 	namedArgs := map[string]string{
-		"path":    path.Join(suite.GetFunctionsDir(), "common", "logging", "golang"),
-		"runtime": "golang",
-		"handler": "main:Logging",
+		"path":         path.Join(suite.GetFunctionsDir(), "common", "logging", "golang"),
+		"runtime":      "golang",
+		"handler":      "main:Logging",
+		"project-name": suite.projectName,
 	}
 
 	err := suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"}, namedArgs)
@@ -964,9 +968,10 @@ func (suite *functionDeployTestSuite) TestDeployAndRedeployHTTPTriggerPortChange
 	imageName := "nuclio/processor-" + functionName
 
 	namedArgs := map[string]string{
-		"path":    path.Join(suite.GetFunctionsDir(), "common", "event-recorder", "python"),
-		"runtime": "python",
-		"handler": "event_recorder:handler",
+		"path":         path.Join(suite.GetFunctionsDir(), "common", "event-recorder", "python"),
+		"runtime":      "python",
+		"handler":      "event_recorder:handler",
+		"project-name": suite.projectName,
 	}
 
 	err := suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"}, namedArgs)
@@ -1227,6 +1232,7 @@ func (suite *functionDeployTestSuite) TestDeployServiceTypeClusterIPWithInvocati
 	        }
 	    }
 	}`,
+		"project-name": suite.projectName,
 	}
 
 	err := suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"}, namedArgs)
@@ -1357,9 +1363,10 @@ func (suite *functionGetTestSuite) TestGet() {
 		functionNames = append(functionNames, functionName)
 
 		namedArgs := map[string]string{
-			"path":    path.Join(suite.GetFunctionsDir(), "common", "reverser", "golang"),
-			"runtime": "golang",
-			"handler": "main:Reverse",
+			"path":         path.Join(suite.GetFunctionsDir(), "common", "reverser", "golang"),
+			"runtime":      "golang",
+			"handler":      "main:Reverse",
+			"project-name": suite.projectName,
 		}
 
 		// cleanup
@@ -1431,9 +1438,10 @@ func (suite *functionDeleteTestSuite) TestDelete() {
 	imageName := "nuclio/processor-" + functionName
 
 	namedArgs := map[string]string{
-		"path":    path.Join(suite.GetFunctionsDir(), "common", "reverser", "golang"),
-		"runtime": "golang",
-		"handler": "main:Reverse",
+		"path":         path.Join(suite.GetFunctionsDir(), "common", "reverser", "golang"),
+		"runtime":      "golang",
+		"handler":      "main:Reverse",
+		"project-name": suite.projectName,
 	}
 
 	err = suite.ExecuteNuctl([]string{
@@ -1699,9 +1707,10 @@ func (suite *functionExportImportTestSuite) TestExportImportRoundTripFromStdin()
 	functionName := "export-import-stdin" + uniqueSuffix
 	imageName := "nuclio/processor-" + functionName
 	namedArgs := map[string]string{
-		"path":    path.Join(suite.GetFunctionsDir(), "common", "reverser", "python"),
-		"runtime": "python",
-		"handler": "reverser:handler",
+		"path":         path.Join(suite.GetFunctionsDir(), "common", "reverser", "python"),
+		"runtime":      "python",
+		"handler":      "reverser:handler",
+		"project-name": suite.projectName,
 	}
 
 	err := suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"}, namedArgs)
@@ -1772,9 +1781,10 @@ func (suite *functionExportImportTestSuite) TestExportImportRoundTrip() {
 	imageName := "nuclio/processor-" + functionName
 
 	namedArgs := map[string]string{
-		"path":    path.Join(suite.GetFunctionsDir(), "common", "reverser", "golang"),
-		"runtime": "golang",
-		"handler": "main:Reverse",
+		"path":         path.Join(suite.GetFunctionsDir(), "common", "reverser", "golang"),
+		"runtime":      "golang",
+		"handler":      "main:Reverse",
+		"project-name": suite.projectName,
 	}
 
 	err := suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"}, namedArgs)

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -101,6 +101,18 @@ type functionDeployTestSuite struct {
 	Suite
 }
 
+func (suite *functionDeployTestSuite) SetupSuite(){
+	suite.Suite.SetupSuite()
+	// static project name created here for consistency across test files within this suite
+	suite.CreateTestProject("test-project")
+}
+
+func (suite *functionDeployTestSuite) TearDownSuite(){
+	suite.Suite.TearDownSuite()
+	// static project name created here for consistency across test files within this suite
+	suite.DeleteTestProject("test-project")
+}
+
 func (suite *functionDeployTestSuite) TestDeploy() {
 	for _, runtimeInfo := range []struct {
 		runtime  string
@@ -1602,6 +1614,18 @@ type functionExportImportTestSuite struct {
 	Suite
 }
 
+func (suite *functionExportImportTestSuite) SetupSuite(){
+	suite.Suite.SetupSuite()
+	// static project name created here for consistency across test files within this suite
+	suite.CreateTestProject("test-project")
+}
+
+func (suite *functionExportImportTestSuite) TearDownSuite(){
+	suite.Suite.TearDownSuite()
+	// static project name created here for consistency across test files within this suite
+	suite.DeleteTestProject("test-project")
+}
+
 func (suite *functionExportImportTestSuite) TestFailToImportFunctionNoInput() {
 
 	// import function without input
@@ -1963,6 +1987,18 @@ func (suite *functionExportImportTestSuite) TestExportImportRoundTripFailingFunc
 
 type functionRedeployTestSuite struct {
 	Suite
+}
+
+func (suite *functionRedeployTestSuite) SetupSuite(){
+	suite.Suite.SetupSuite()
+	// static project name created here for consistency across test files within this suite
+	suite.CreateTestProject("test-project")
+}
+
+func (suite *functionRedeployTestSuite) TearDownSuite(){
+	suite.Suite.TearDownSuite()
+	// static project name created here for consistency across test files within this suite
+	suite.DeleteTestProject("test-project")
 }
 
 func (suite *functionRedeployTestSuite) TestRedeploy() {

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -283,6 +283,7 @@ func (suite *functionDeployTestSuite) TestDeployWithMetadata() {
 			"annotations": "annotation1=third,annotation2=fourth",
 			"runtime":     "python",
 			"handler":     "envprinter:handler",
+			"project-name": suite.projectName,
 		})
 
 	suite.Require().NoError(err)
@@ -323,6 +324,7 @@ func (suite *functionDeployTestSuite) TestDeployFromFunctionConfig() {
 		map[string]string{
 			"path":  path.Join(suite.GetFunctionsDir(), "common", "json-parser-with-function-config", "python"),
 			"image": imageName,
+			"project-name": suite.projectName,
 		})
 
 	suite.Require().NoError(err)
@@ -545,6 +547,7 @@ func (suite *functionDeployTestSuite) TestDeployShellViaHandler() {
 			"image":   imageName,
 			"runtime": "shell",
 			"handler": "rev",
+			"project-name": suite.projectName,
 		})
 
 	suite.Require().NoError(err)
@@ -580,6 +583,7 @@ func (suite *functionDeployTestSuite) TestDeployWithFunctionEvent() {
 			"image":   imageName,
 			"runtime": "shell",
 			"handler": "rev",
+			"project-name": suite.projectName,
 		})
 
 	suite.Require().NoError(err)
@@ -857,6 +861,7 @@ func (suite *functionDeployTestSuite) TestDeployWithResourceVersion() {
 		map[string]string{
 			"path": functionPath,
 			"file": functionConfigPath,
+			"project-name": suite.projectName,
 		})
 
 	// delete the function when we're done
@@ -1057,6 +1062,7 @@ func (suite *functionDeployTestSuite) TestDeployFromLocalDirPath() {
 			"path":    path.Join(suite.GetFunctionsDir(), "common", "reverser", "python"),
 			"runtime": "python:3.11",
 			"handler": "reverser:handler",
+			"project-name": suite.projectName,
 		})
 	suite.Require().NoError(err)
 
@@ -1136,6 +1142,7 @@ func (suite *functionDeployTestSuite) TestDeployWithSecurityContext() {
 			"run-as-user":  runAsUserID,
 			"run-as-group": runAsGroupID,
 			"fsgroup":      fsGroup,
+			"project-name": suite.projectName,
 		})
 
 	suite.Require().NoError(err)
@@ -1305,6 +1312,7 @@ func (suite *functionDeployTestSuite) TestDeployWithOverrideServiceTypeFlag() {
 		"runtime":                   "golang",
 		"handler":                   "main:Reverse",
 		"http-trigger-service-type": string(corev1.ServiceTypeClusterIP),
+		"project-name": suite.projectName,
 	}
 
 	err := suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"}, namedArgs)

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -637,6 +637,7 @@ func (suite *functionDeployTestSuite) TestBuildWithSaveDeployWithLoad() {
 			"image":             imageName,
 			"runtime":           "golang",
 			"output-image-file": tarName,
+			"project-name":      suite.projectName,
 		})
 
 	suite.Require().NoError(err)
@@ -691,8 +692,9 @@ func (suite *functionDeployTestSuite) TestBuildAndDeployFromFile() {
 
 	err = suite.ExecuteNuctl([]string{"build", functionName, "--verbose", "--no-pull"},
 		map[string]string{
-			"path":  path.Join(suite.GetFunctionsDir(), "common", "json-parser-with-function-config", "python"),
-			"image": imageName,
+			"path":         path.Join(suite.GetFunctionsDir(), "common", "json-parser-with-function-config", "python"),
+			"image":        imageName,
+			"project-name": suite.projectName,
 		})
 
 	suite.Require().NoError(err)
@@ -762,8 +764,9 @@ func (suite *functionDeployTestSuite) TestBuildAndDeployFromFileWithOverriddenAr
 
 	err = suite.ExecuteNuctl([]string{"build", functionName, "--verbose", "--no-pull"},
 		map[string]string{
-			"path":  functionPath,
-			"image": imageName,
+			"path":         functionPath,
+			"image":        imageName,
+			"project-name": suite.projectName,
 		})
 
 	suite.Require().NoError(err)

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -59,8 +59,8 @@ func (suite *functionBuildTestSuite) TestBuild() {
 
 	err := suite.ExecuteNuctl([]string{"build", functionName, "--verbose", "--no-pull"},
 		map[string]string{
-			"path":    path.Join(suite.GetFunctionsDir(), "common", "reverser", "golang"),
-			"runtime": "golang",
+			"path":         path.Join(suite.GetFunctionsDir(), "common", "reverser", "golang"),
+			"runtime":      "golang",
 			"project-name": suite.projectName,
 		})
 
@@ -72,9 +72,9 @@ func (suite *functionBuildTestSuite) TestBuild() {
 	// use deploy with the image we just created
 	err = suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose"},
 		map[string]string{
-			"run-image": imageName,
-			"runtime":   "golang",
-			"handler":   "main:Reverse",
+			"run-image":    imageName,
+			"runtime":      "golang",
+			"handler":      "main:Reverse",
 			"project-name": suite.projectName,
 		})
 

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -661,6 +661,7 @@ func (suite *functionDeployTestSuite) TestBuildWithSaveDeployWithLoad() {
 			"runtime":          "golang",
 			"handler":          "main:Reverse",
 			"input-image-file": tarName,
+			"project-name":     suite.projectName,
 		})
 
 	suite.Require().NoError(err)
@@ -709,8 +710,9 @@ func (suite *functionDeployTestSuite) TestBuildAndDeployFromFile() {
 	// use deploy with the image we just created
 	err = suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose"},
 		map[string]string{
-			"run-image": imageName,
-			"file":      path.Join(suite.GetFunctionsDir(), "common", "json-parser-with-function-config", "python", "function-different-spec.yaml"),
+			"run-image":    imageName,
+			"file":         path.Join(suite.GetFunctionsDir(), "common", "json-parser-with-function-config", "python", "function-different-spec.yaml"),
+			"project-name": suite.projectName,
 		})
 
 	suite.Require().NoError(err)
@@ -784,6 +786,7 @@ func (suite *functionDeployTestSuite) TestBuildAndDeployFromFileWithOverriddenAr
 			"run-image":    imageName,
 			"file":         path.Join(suite.GetFunctionsDir(), "common", "json-parser-with-function-config", "python", "function-different-spec.yaml"),
 			"min-replicas": fmt.Sprintf("%d", minReplicas),
+			"project-name": suite.projectName,
 		})
 
 	suite.Require().NoError(err)
@@ -1156,10 +1159,7 @@ func (suite *functionDeployTestSuite) TestDeployWithSecurityContext() {
 
 	// try a few times to invoke, until it succeeds
 	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"invoke", functionName},
-		map[string]string{
-			"method":       "POST",
-			"project-name": suite.projectName,
-		},
+		map[string]string{"method": "POST"},
 		false)
 	suite.Require().NoError(err)
 
@@ -1192,6 +1192,7 @@ func (suite *functionDeployTestSuite) TestDeployWithSecurityContext() {
 			"run-as-user":  runAsUserID,
 			"run-as-group": runAsGroupID,
 			"fsgroup":      fsGroup,
+			"project-name": suite.projectName,
 		})
 
 	suite.Require().NoError(err)
@@ -1273,10 +1274,11 @@ wget -O - --post-data "$body" $url 2> /dev/null
 
 	err = suite.ExecuteNuctl([]string{"deploy", wgetFunctionName, "--verbose", "--no-pull"},
 		map[string]string{
-			"image":   wgetImageName,
-			"runtime": "shell",
-			"handler": "main.sh",
-			"source":  base64.StdEncoding.EncodeToString([]byte(wgetSourceCode)),
+			"image":        wgetImageName,
+			"runtime":      "shell",
+			"handler":      "main.sh",
+			"source":       base64.StdEncoding.EncodeToString([]byte(wgetSourceCode)),
+			"project-name": suite.projectName,
 		})
 
 	suite.Require().NoError(err)
@@ -1337,6 +1339,7 @@ func (suite *functionDeployTestSuite) TestDeployWithOverrideServiceTypeFlag() {
 		"runtime":                   "golang",
 		"handler":                   "main:Reverse",
 		"http-trigger-service-type": string(corev1.ServiceTypeNodePort),
+		"project-name":              suite.projectName,
 	}
 
 	err = suite.ExecuteNuctl([]string{"deploy", functionName2, "--verbose", "--no-pull"}, namedArgs)

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -101,16 +101,17 @@ type functionDeployTestSuite struct {
 	Suite
 }
 
-func (suite *functionDeployTestSuite) SetupSuite(){
+func (suite *functionDeployTestSuite) SetupSuite() {
 	suite.Suite.SetupSuite()
-	// static project name created here for consistency across test files within this suite
-	suite.CreateTestProject("test-project")
+	// create test-project for tests that import static files
+	if err := suite.ExecuteNuctl([]string{"create", "project", "test-project"}, map[string]string{}); err != nil {
+		suite.Contains(errors.Cause(err).Error(), "already exists")
+	}
 }
 
-func (suite *functionDeployTestSuite) TearDownSuite(){
+func (suite *functionDeployTestSuite) TearDownSuite() {
 	suite.Suite.TearDownSuite()
-	// static project name created here for consistency across test files within this suite
-	suite.DeleteTestProject("test-project")
+	suite.ExecuteNuctl([]string{"delete", "project", "test-project"}, map[string]string{}) // nolint: errcheck
 }
 
 func (suite *functionDeployTestSuite) TestDeploy() {
@@ -1614,16 +1615,17 @@ type functionExportImportTestSuite struct {
 	Suite
 }
 
-func (suite *functionExportImportTestSuite) SetupSuite(){
+func (suite *functionExportImportTestSuite) SetupSuite() {
 	suite.Suite.SetupSuite()
-	// static project name created here for consistency across test files within this suite
-	suite.CreateTestProject("test-project")
+	// create test-project for tests that import static files
+	if err := suite.ExecuteNuctl([]string{"create", "project", "test-project"}, map[string]string{}); err != nil {
+		suite.Contains(errors.Cause(err).Error(), "already exists")
+	}
 }
 
-func (suite *functionExportImportTestSuite) TearDownSuite(){
+func (suite *functionExportImportTestSuite) TearDownSuite() {
 	suite.Suite.TearDownSuite()
-	// static project name created here for consistency across test files within this suite
-	suite.DeleteTestProject("test-project")
+	suite.ExecuteNuctl([]string{"delete", "project", "test-project"}, map[string]string{}) // nolint: errcheck
 }
 
 func (suite *functionExportImportTestSuite) TestFailToImportFunctionNoInput() {
@@ -1989,16 +1991,17 @@ type functionRedeployTestSuite struct {
 	Suite
 }
 
-func (suite *functionRedeployTestSuite) SetupSuite(){
+func (suite *functionRedeployTestSuite) SetupSuite() {
 	suite.Suite.SetupSuite()
-	// static project name created here for consistency across test files within this suite
-	suite.CreateTestProject("test-project")
+	// create test-project for tests that import static files
+	if err := suite.ExecuteNuctl([]string{"create", "project", "test-project"}, map[string]string{}); err != nil {
+		suite.Contains(errors.Cause(err).Error(), "already exists")
+	}
 }
 
-func (suite *functionRedeployTestSuite) TearDownSuite(){
+func (suite *functionRedeployTestSuite) TearDownSuite() {
 	suite.Suite.TearDownSuite()
-	// static project name created here for consistency across test files within this suite
-	suite.DeleteTestProject("test-project")
+	suite.ExecuteNuctl([]string{"delete", "project", "test-project"}, map[string]string{}) // nolint: errcheck
 }
 
 func (suite *functionRedeployTestSuite) TestRedeploy() {

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -61,6 +61,7 @@ func (suite *functionBuildTestSuite) TestBuild() {
 		map[string]string{
 			"path":    path.Join(suite.GetFunctionsDir(), "common", "reverser", "golang"),
 			"runtime": "golang",
+			"project-name": suite.projectName,
 		})
 
 	suite.Require().NoError(err)
@@ -74,6 +75,7 @@ func (suite *functionBuildTestSuite) TestBuild() {
 			"run-image": imageName,
 			"runtime":   "golang",
 			"handler":   "main:Reverse",
+			"project-name": suite.projectName,
 		})
 
 	suite.Require().NoError(err)
@@ -92,7 +94,7 @@ func (suite *functionBuildTestSuite) TestBuild() {
 	suite.Require().NoError(err)
 
 	// make sure reverser worked
-	suite.Require().Contains(suite.outputBuffer.String(), "+gnirts siht esrever-")
+	suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), "+gnirts siht esrever-")
 }
 
 type functionDeployTestSuite struct {
@@ -209,7 +211,7 @@ func (suite *functionDeployTestSuite) TestInvokeWithBodyFromStdin() {
 	// cleanup
 	defer suite.ExecuteNuctl([]string{"delete", "fu", functionName}, nil) // nolint: errcheck
 
-	suite.stdinReader = strings.NewReader("-reverse this string+")
+	suite.nuctlRunner.stdinReader = strings.NewReader("-reverse this string+")
 
 	// try a few times to invoke, until it succeeds
 	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"invoke", functionName},
@@ -221,7 +223,7 @@ func (suite *functionDeployTestSuite) TestInvokeWithBodyFromStdin() {
 	suite.Require().NoError(err)
 
 	// make sure reverser worked
-	suite.Require().Contains(suite.outputBuffer.String(), "+gnirts siht esrever-")
+	suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), "+gnirts siht esrever-")
 }
 
 func (suite *functionDeployTestSuite) TestInvokeWithTimeout() {
@@ -301,8 +303,8 @@ func (suite *functionDeployTestSuite) TestDeployWithMetadata() {
 	suite.Require().NoError(err)
 
 	// make sure reverser worked
-	suite.Require().Contains(suite.outputBuffer.String(), "11223344")
-	suite.Require().Contains(suite.outputBuffer.String(), "0099887766")
+	suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), "11223344")
+	suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), "0099887766")
 }
 
 func (suite *functionDeployTestSuite) TestDeployFromFunctionConfig() {
@@ -329,7 +331,7 @@ func (suite *functionDeployTestSuite) TestDeployFromFunctionConfig() {
 	defer suite.dockerClient.RemoveImage(imageName) // nolint: errcheck
 
 	// clear output buffer from last invocation
-	suite.outputBuffer.Reset()
+	suite.nuctlRunner.outputBuffer.Reset()
 
 	// get the function
 	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"get", "fu", functionName}, map[string]string{
@@ -338,7 +340,7 @@ func (suite *functionDeployTestSuite) TestDeployFromFunctionConfig() {
 	suite.Require().NoError(err)
 
 	deployedFunctionConfig := functionconfig.Config{}
-	err = yaml.Unmarshal(suite.outputBuffer.Bytes(), &deployedFunctionConfig)
+	err = yaml.Unmarshal(suite.nuctlRunner.outputBuffer.Bytes(), &deployedFunctionConfig)
 	suite.Require().NoError(err)
 
 	// the function has 1 http trigger - api. here we are verifying the default HTTP trigger wasn't added
@@ -363,7 +365,7 @@ func (suite *functionDeployTestSuite) TestDeployFromFunctionConfig() {
 	suite.Require().NoError(err)
 
 	// check that invoke printed the value
-	suite.Require().Contains(suite.outputBuffer.String(), randomString)
+	suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), randomString)
 }
 
 func (suite *functionDeployTestSuite) TestDeployFromCodeEntryTypeS3InvalidValues() {
@@ -467,7 +469,7 @@ func (suite *functionDeployTestSuite) TestInvokeWithLogging() {
 		},
 	} {
 		// clear output buffer from last invocation
-		suite.outputBuffer.Reset()
+		suite.nuctlRunner.outputBuffer.Reset()
 
 		// invoke the function
 		err = suite.RetryExecuteNuctlUntilSuccessful([]string{"invoke", functionName},
@@ -480,12 +482,12 @@ func (suite *functionDeployTestSuite) TestInvokeWithLogging() {
 
 		// make sure expected strings are in output
 		for _, expectedMessage := range testCase.expectedMessages {
-			suite.Require().Contains(suite.outputBuffer.String(), expectedMessage)
+			suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), expectedMessage)
 		}
 
 		// make sure unexpected strings are NOT in output
 		for _, unexpectedMessage := range testCase.unexpectedMessages {
-			suite.Require().NotContains(suite.outputBuffer.String(), unexpectedMessage)
+			suite.Require().NotContains(suite.nuctlRunner.outputBuffer.String(), unexpectedMessage)
 		}
 	}
 }
@@ -564,7 +566,7 @@ func (suite *functionDeployTestSuite) TestDeployShellViaHandler() {
 	suite.Require().NoError(err)
 
 	// make sure reverser worked
-	suite.Require().Contains(suite.outputBuffer.String(), "+gnirts siht esrever-")
+	suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), "+gnirts siht esrever-")
 }
 
 func (suite *functionDeployTestSuite) TestDeployWithFunctionEvent() {
@@ -613,7 +615,7 @@ func (suite *functionDeployTestSuite) TestDeployWithFunctionEvent() {
 	suite.Require().NoError(err)
 
 	// reset buffer
-	suite.outputBuffer.Reset()
+	suite.nuctlRunner.outputBuffer.Reset()
 
 	// get function events
 	err = suite.ExecuteNuctl([]string{"get", "functionevent"}, nil)
@@ -672,7 +674,7 @@ func (suite *functionDeployTestSuite) TestBuildWithSaveDeployWithLoad() {
 	suite.Require().NoError(err)
 
 	// make sure reverser worked
-	suite.Require().Contains(suite.outputBuffer.String(), "+gnirts siht esrever-")
+	suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), "+gnirts siht esrever-")
 }
 
 func (suite *functionDeployTestSuite) TestBuildAndDeployFromFile() {
@@ -711,14 +713,14 @@ func (suite *functionDeployTestSuite) TestBuildAndDeployFromFile() {
 	defer suite.ExecuteNuctl([]string{"delete", "fu", functionName}, nil) // nolint: errcheck
 
 	// reset output buffer for reading the nex output cleanly
-	suite.outputBuffer.Reset()
+	suite.nuctlRunner.outputBuffer.Reset()
 
 	// export the function
 	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"export", "fu", functionName}, nil, false)
 	suite.Require().NoError(err)
 
 	deployedFunctionConfig := functionconfig.Config{}
-	err = yaml.Unmarshal(suite.outputBuffer.Bytes(), &deployedFunctionConfig)
+	err = yaml.Unmarshal(suite.nuctlRunner.outputBuffer.Bytes(), &deployedFunctionConfig)
 	suite.Require().NoError(err)
 
 	// assert data from different spec and not original spec
@@ -741,7 +743,7 @@ func (suite *functionDeployTestSuite) TestBuildAndDeployFromFile() {
 	suite.Require().NoError(err)
 
 	// check that invoke printed the value
-	suite.Require().Contains(suite.outputBuffer.String(), randomString)
+	suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), randomString)
 }
 
 func (suite *functionDeployTestSuite) TestBuildAndDeployFromFileWithOverriddenArgs() {
@@ -783,14 +785,14 @@ func (suite *functionDeployTestSuite) TestBuildAndDeployFromFileWithOverriddenAr
 	defer suite.ExecuteNuctl([]string{"delete", "fu", functionName}, nil) // nolint: errcheck
 
 	// reset output buffer for reading the nex output cleanly
-	suite.outputBuffer.Reset()
+	suite.nuctlRunner.outputBuffer.Reset()
 
 	// export the function
 	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"export", "fu", functionName}, nil, false)
 	suite.Require().NoError(err)
 
 	deployedFunctionConfig := functionconfig.Config{}
-	err = yaml.Unmarshal(suite.outputBuffer.Bytes(), &deployedFunctionConfig)
+	err = yaml.Unmarshal(suite.nuctlRunner.outputBuffer.Bytes(), &deployedFunctionConfig)
 	suite.Require().NoError(err)
 
 	// assert data from different spec and not original spec
@@ -815,7 +817,7 @@ func (suite *functionDeployTestSuite) TestBuildAndDeployFromFileWithOverriddenAr
 	suite.Require().NoError(err)
 
 	// check that invoke printed the value
-	suite.Require().Contains(suite.outputBuffer.String(), randomString)
+	suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), randomString)
 }
 
 func (suite *functionDeployTestSuite) TestDeployWithResourceVersion() {
@@ -1014,7 +1016,7 @@ func (suite *functionDeployTestSuite) TestDeployAndRedeployHTTPTriggerPortChange
 	// wait for function to become ready again
 	suite.waitForFunctionState(functionName, functionconfig.FunctionStateReady)
 
-	suite.outputBuffer.Reset()
+	suite.nuctlRunner.outputBuffer.Reset()
 
 	deployedFunctionConfig, err = suite.getFunctionInFormat(functionName, nuctlcommon.OutputFormatYAML)
 	suite.Require().NoError(err)
@@ -1068,7 +1070,7 @@ func (suite *functionDeployTestSuite) TestDeployFromLocalDirPath() {
 		},
 		false)
 	suite.Require().NoError(err)
-	suite.Require().Contains(suite.outputBuffer.String(), "codeEntryType: image")
+	suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), "codeEntryType: image")
 
 	// try a few times to invoke, until it succeeds
 	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"invoke", functionName},
@@ -1080,7 +1082,7 @@ func (suite *functionDeployTestSuite) TestDeployFromLocalDirPath() {
 	suite.Require().NoError(err)
 
 	// check that invoke printed the value
-	suite.Require().Contains(suite.outputBuffer.String(), "+gnirts siht esrever-")
+	suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), "+gnirts siht esrever-")
 }
 
 // Expect the deployment to fail fast (instead of waiting for readiness timeout to pass)
@@ -1149,15 +1151,15 @@ func (suite *functionDeployTestSuite) TestDeployWithSecurityContext() {
 
 	// make sure the id command from the handler, returns the correct uid and gids
 	suite.Require().Condition(func() (success bool) {
-		uidGid := strings.Contains(suite.outputBuffer.String(),
+		uidGid := strings.Contains(suite.nuctlRunner.outputBuffer.String(),
 			fmt.Sprintf(`uid=%s gid=%s`,
 				runAsUserID,
 				runAsGroupID))
-		groups := strings.Contains(suite.outputBuffer.String(),
+		groups := strings.Contains(suite.nuctlRunner.outputBuffer.String(),
 			fmt.Sprintf(`groups=%s`, fsGroup))
 
 		// it is observed that on azure's docker flavor, the groups are set with both fsGroup and group ID
-		extendedGroups := strings.Contains(suite.outputBuffer.String(),
+		extendedGroups := strings.Contains(suite.nuctlRunner.outputBuffer.String(),
 			fmt.Sprintf(`groups=%s`, runAsGroupID+","+fsGroup))
 		return uidGid && (groups || extendedGroups)
 	})
@@ -1194,15 +1196,15 @@ func (suite *functionDeployTestSuite) TestDeployWithSecurityContext() {
 
 	// make sure the id command from the handler, returns the correct uid and gids
 	suite.Require().Condition(func() (success bool) {
-		uidGid := strings.Contains(suite.outputBuffer.String(),
+		uidGid := strings.Contains(suite.nuctlRunner.outputBuffer.String(),
 			fmt.Sprintf(`uid=%s gid=%s`,
 				runAsUserID,
 				runAsGroupID))
-		groups := strings.Contains(suite.outputBuffer.String(),
+		groups := strings.Contains(suite.nuctlRunner.outputBuffer.String(),
 			fmt.Sprintf(`groups=%s`, fsGroup))
 
 		// it is observed that on azure's docker flavor, the groups are set with both fsGroup and group ID
-		extendedGroups := strings.Contains(suite.outputBuffer.String(),
+		extendedGroups := strings.Contains(suite.nuctlRunner.outputBuffer.String(),
 			fmt.Sprintf(`groups=%s`, runAsGroupID+","+fsGroup))
 		return uidGid && (groups || extendedGroups)
 	})
@@ -1283,7 +1285,7 @@ wget -O - --post-data "$body" $url 2> /dev/null
 	suite.Require().NoError(err)
 
 	// make sure reverser worked
-	suite.Require().Contains(suite.outputBuffer.String(), "+gnirts siht esrever-")
+	suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), "+gnirts siht esrever-")
 }
 
 func (suite *functionDeployTestSuite) TestDeployWithOverrideServiceTypeFlag() {
@@ -1414,7 +1416,7 @@ func (suite *functionGetTestSuite) TestGet() {
 		},
 	} {
 		// reset buffer
-		suite.outputBuffer.Reset()
+		suite.nuctlRunner.outputBuffer.Reset()
 
 		parsedFunction, err := suite.getFunctionInFormat(testCase.FunctionName, testCase.OutputFormat)
 
@@ -1518,7 +1520,7 @@ func (suite *functionDeleteTestSuite) TestDeleteBrokenFunction() {
 
 	err = suite.ExecuteNuctl([]string{"get", "functions"}, nil)
 	suite.Require().NoError(err)
-	suite.Require().NotContains(suite.outputBuffer.String(), functionName)
+	suite.Require().NotContains(suite.nuctlRunner.outputBuffer.String(), functionName)
 }
 
 func (suite *functionDeleteTestSuite) TestForceDelete() {
@@ -1727,8 +1729,8 @@ func (suite *functionExportImportTestSuite) TestExportImportRoundTripFromStdin()
 	suite.Require().NoError(err)
 
 	// make a copy, use later
-	exportedFunctionBody := make([]byte, len(suite.outputBuffer.Bytes()))
-	copy(exportedFunctionBody, suite.outputBuffer.Bytes())
+	exportedFunctionBody := make([]byte, len(suite.nuctlRunner.outputBuffer.Bytes()))
+	copy(exportedFunctionBody, suite.nuctlRunner.outputBuffer.Bytes())
 
 	// delete original function in order to resolve conflict while importing the function
 	err = suite.ExecuteNuctl([]string{"delete", "fu", functionName}, nil)
@@ -1739,14 +1741,14 @@ func (suite *functionExportImportTestSuite) TestExportImportRoundTripFromStdin()
 	suite.Require().NoError(err)
 
 	// import the function from stdin
-	suite.stdinReader = strings.NewReader(string(exportedFunctionBody))
+	suite.nuctlRunner.stdinReader = strings.NewReader(string(exportedFunctionBody))
 	err = suite.ExecuteNuctl([]string{"import", "fu"}, nil)
 	suite.Require().NoError(err)
 
 	// wait until able to get the function
 	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"get", "function", functionName}, nil, false)
 	suite.Require().NoError(err)
-	suite.Require().Contains(suite.outputBuffer.String(), "imported")
+	suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), "imported")
 
 	// try to invoke, and ensure it fails - because it is imported and not deployed
 	err = suite.ExecuteNuctl([]string{"invoke", functionName},
@@ -1772,7 +1774,7 @@ func (suite *functionExportImportTestSuite) TestExportImportRoundTripFromStdin()
 	suite.Require().NoError(err)
 
 	// make sure reverser worked
-	suite.Require().Contains(suite.outputBuffer.String(), "+gnirts siht esrever-")
+	suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), "+gnirts siht esrever-")
 }
 
 func (suite *functionExportImportTestSuite) TestExportImportRoundTrip() {
@@ -1798,7 +1800,7 @@ func (suite *functionExportImportTestSuite) TestExportImportRoundTrip() {
 	suite.Require().NoError(err)
 
 	exportedFunctionConfig := functionconfig.Config{}
-	err = yaml.Unmarshal(suite.outputBuffer.Bytes(), &exportedFunctionConfig)
+	err = yaml.Unmarshal(suite.nuctlRunner.outputBuffer.Bytes(), &exportedFunctionConfig)
 	suite.Require().NoError(err)
 
 	// assert skip annotations
@@ -1860,7 +1862,7 @@ func (suite *functionExportImportTestSuite) TestExportImportRoundTrip() {
 	suite.Require().NoError(err)
 
 	// make sure reverser worked
-	suite.Require().Contains(suite.outputBuffer.String(), "+gnirts siht esrever-")
+	suite.Require().Contains(suite.nuctlRunner.outputBuffer.String(), "+gnirts siht esrever-")
 }
 
 func (suite *functionExportImportTestSuite) TestExportImportRoundTripFailingFunction() {
@@ -1881,14 +1883,14 @@ func (suite *functionExportImportTestSuite) TestExportImportRoundTripFailingFunc
 	suite.Require().Error(err)
 
 	// reset output buffer for reading the nex output cleanly
-	suite.outputBuffer.Reset()
+	suite.nuctlRunner.outputBuffer.Reset()
 
 	// export the function
 	err = suite.RetryExecuteNuctlUntilSuccessful([]string{"export", "fu", functionName}, nil, false)
 	suite.Require().NoError(err)
 
 	exportedFunctionConfig := functionconfig.Config{}
-	err = yaml.Unmarshal(suite.outputBuffer.Bytes(), &exportedFunctionConfig)
+	err = yaml.Unmarshal(suite.nuctlRunner.outputBuffer.Bytes(), &exportedFunctionConfig)
 	suite.Require().NoError(err)
 
 	// assert skip annotations

--- a/pkg/nuctl/test/functionevent_test.go
+++ b/pkg/nuctl/test/functionevent_test.go
@@ -44,9 +44,10 @@ func (suite *functionEventGetTestSuite) TestGet() {
 		runtimeName, _ := common.GetRuntimeNameAndVersion("shell")
 		functionName := fmt.Sprintf("function-%d", functionEventIdx)
 		namedArgs := map[string]string{
-			"path":    path.Join(suite.GetExamples(), runtimeName, "empty", "empty.sh"),
-			"runtime": "shell",
-			"handler": "empty.sh:main",
+			"path":         path.Join(suite.GetExamples(), runtimeName, "empty", "empty.sh"),
+			"runtime":      "shell",
+			"handler":      "empty.sh:main",
+			"project-name": suite.projectName,
 		}
 		suite.logger.DebugWith("Deploying function",
 			"functionName", functionName,

--- a/pkg/nuctl/test/nuctlRunner.go
+++ b/pkg/nuctl/test/nuctlRunner.go
@@ -1,4 +1,4 @@
-//go:build test_integration && (test_kube || test_local || test_functions_kube)
+//go:build test_unit || (test_integration && (test_kube || test_local || test_functions_kube))
 
 /*
 Copyright 2025 The Nuclio Authors.

--- a/pkg/nuctl/test/nuctlRunner.go
+++ b/pkg/nuctl/test/nuctlRunner.go
@@ -1,0 +1,106 @@
+//go:build test_integration && (test_kube || test_local || test_functions_kube)
+
+/*
+Copyright 2025 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/nuctl/command"
+
+	"github.com/nuclio/logger"
+)
+
+type NuctlRunner struct {
+	outputBuffer bytes.Buffer
+	stdinReader  *strings.Reader
+	Namespace    string
+	Logger       logger.Logger
+}
+
+func NewNuctlRunner(namespace string, logger logger.Logger) *NuctlRunner {
+	return &NuctlRunner{
+		Namespace: namespace,
+		Logger:    logger.GetChild("nuctl.runner"),
+	}
+}
+
+// --- NuctlRunner methods ---
+
+func (nr *NuctlRunner) namespaceInArgs(positionalArgs []string, namedArgs map[string]string) bool {
+	if common.StringSliceContainsString(positionalArgs, "--namespace") || common.StringSliceContainsString(positionalArgs, "-n") {
+		return true
+	}
+
+	if _, ok := namedArgs["namespace"]; ok {
+		return true
+	}
+
+	return false
+}
+
+func (nr *NuctlRunner) isNamespaceRequired() bool {
+	return nr.Namespace != "" && common.GetKubeconfigPath("") != ""
+}
+
+// Run executes nuctl command with the given positional and named arguments
+func (nr *NuctlRunner) Run(positionalArgs []string,
+	namedArgs map[string]string) error {
+
+	// reset buffer to ensure it contains only last executed command
+	nr.outputBuffer.Reset()
+	rootCommandeer := command.NewRootCommandeer()
+
+	// set the output, so we can capture it (but also output to stdout)
+	rootCommandeer.GetCmd().SetOut(io.MultiWriter(os.Stdout, &nr.outputBuffer))
+
+	// set the input so we can write to stdin
+	if nr.stdinReader != nil {
+		rootCommandeer.GetCmd().SetIn(nr.stdinReader)
+	}
+
+	var argsStringSlice []string
+
+	// add positional arguments
+	argsStringSlice = append(argsStringSlice, positionalArgs...)
+
+	for argName, argValue := range namedArgs {
+		argsStringSlice = append(argsStringSlice, fmt.Sprintf("--%s", argName), argValue)
+	}
+
+	if nr.isNamespaceRequired() && !nr.namespaceInArgs(positionalArgs, namedArgs) {
+		// prepend namespace to args
+		argsStringSlice = common.PrependStringsToStringSlice(argsStringSlice, "--namespace", nr.Namespace)
+	}
+
+	// since args[0] is the executable name, just shove the binary there
+	argsStringSlice = common.PrependStringToStringSlice(argsStringSlice, "nuctl")
+
+	// override os.Args (this can't go wrong horribly, can it?)
+	os.Args = argsStringSlice
+
+	nr.Logger.InfoWith("Executing nuctl", "args", argsStringSlice)
+
+	// execute
+	return rootCommandeer.Execute()
+}

--- a/pkg/nuctl/test/nuctlRunner.go
+++ b/pkg/nuctl/test/nuctlRunner.go
@@ -78,7 +78,9 @@ func (nr *NuctlRunner) Run(positionalArgs []string,
 	// since args[0] is the executable name, just shove the binary there
 	argsStringSlice = common.PrependStringToStringSlice(argsStringSlice, "nuctl")
 
-	// override os.Args (this can't go wrong horribly, can it?)
+	// override os.Args to simulate command-line arguments in tests,
+	// allowing Cobra to parse the nuctl command as if run from the terminal.
+	// override is required because Cobra reads os.Args directly for command parsing.
 	os.Args = argsStringSlice
 
 	nr.Logger.InfoWith("Executing nuctl", "args", argsStringSlice)

--- a/pkg/nuctl/test/nuctlRunner.go
+++ b/pkg/nuctl/test/nuctlRunner.go
@@ -45,24 +45,6 @@ func NewNuctlRunner(namespace string, logger logger.Logger) *NuctlRunner {
 	}
 }
 
-// --- NuctlRunner methods ---
-
-func (nr *NuctlRunner) namespaceInArgs(positionalArgs []string, namedArgs map[string]string) bool {
-	if common.StringSliceContainsString(positionalArgs, "--namespace") || common.StringSliceContainsString(positionalArgs, "-n") {
-		return true
-	}
-
-	if _, ok := namedArgs["namespace"]; ok {
-		return true
-	}
-
-	return false
-}
-
-func (nr *NuctlRunner) isNamespaceRequired() bool {
-	return nr.Namespace != "" && common.GetKubeconfigPath("") != ""
-}
-
 // Run executes nuctl command with the given positional and named arguments
 func (nr *NuctlRunner) Run(positionalArgs []string,
 	namedArgs map[string]string) error {
@@ -103,4 +85,22 @@ func (nr *NuctlRunner) Run(positionalArgs []string,
 
 	// execute
 	return rootCommandeer.Execute()
+}
+
+// --- NuctlRunner methods ---
+
+func (nr *NuctlRunner) namespaceInArgs(positionalArgs []string, namedArgs map[string]string) bool {
+	if common.StringSliceContainsString(positionalArgs, "--namespace") || common.StringSliceContainsString(positionalArgs, "-n") {
+		return true
+	}
+
+	if _, ok := namedArgs["namespace"]; ok {
+		return true
+	}
+
+	return false
+}
+
+func (nr *NuctlRunner) isNamespaceRequired() bool {
+	return nr.Namespace != "" && common.GetKubeconfigPath("") != ""
 }

--- a/pkg/nuctl/test/nuctlrunner.go
+++ b/pkg/nuctl/test/nuctlrunner.go
@@ -89,8 +89,6 @@ func (nr *NuctlRunner) Run(positionalArgs []string,
 	return rootCommandeer.Execute()
 }
 
-// --- NuctlRunner methods ---
-
 func (nr *NuctlRunner) namespaceInArgs(positionalArgs []string, namedArgs map[string]string) bool {
 	if common.StringSliceContainsString(positionalArgs, "--namespace") || common.StringSliceContainsString(positionalArgs, "-n") {
 		return true

--- a/pkg/nuctl/test/project_test.go
+++ b/pkg/nuctl/test/project_test.go
@@ -275,7 +275,7 @@ func (suite *projectExportImportTestSuite) createImportedFunctions(projectName s
 		functionToImportEncoded := fmt.Sprintf(functionToImportTemplate, functionName, projectName)
 		functionsToImportEncoded += fmt.Sprintf("\n%s", functionToImportEncoded)
 	}
-	suite.stdinReader = strings.NewReader(functionsToImportEncoded)
+	suite.nuctlRunner.stdinReader = strings.NewReader(functionsToImportEncoded)
 
 	// import the project
 	err := suite.ExecuteNuctl([]string{
@@ -450,7 +450,7 @@ func (suite *projectExportImportTestSuite) TestImportProjectSkipBySelectors() {
 			suite.Require().NoError(err)
 
 			// import project from stdin
-			suite.stdinReader = strings.NewReader(string(encodedProjectImportConfig))
+			suite.nuctlRunner.stdinReader = strings.NewReader(string(encodedProjectImportConfig))
 
 			// import
 			err = suite.ExecuteNuctl([]string{"import", "project", "--verbose"}, map[string]string{
@@ -787,14 +787,14 @@ func (suite *projectExportImportTestSuite) createAPIGateway(apiGatewayName, func
 func (suite *projectExportImportTestSuite) assertProjectImported(projectName string) {
 
 	// reset output buffer for reading the nex output cleanly
-	suite.outputBuffer.Reset()
+	suite.nuctlRunner.outputBuffer.Reset()
 	err := suite.RetryExecuteNuctlUntilSuccessful([]string{"get", "project", projectName}, map[string]string{
 		"output": nuctlCommon.OutputFormatYAML,
 	}, false)
 	suite.Require().NoError(err)
 
 	project := platform.ProjectConfig{}
-	err = yaml.Unmarshal(suite.outputBuffer.Bytes(), &project)
+	err = yaml.Unmarshal(suite.nuctlRunner.outputBuffer.Bytes(), &project)
 	suite.Require().NoError(err)
 
 	suite.Assert().Equal(projectName, project.Meta.Name)
@@ -804,7 +804,7 @@ func (suite *projectExportImportTestSuite) assertFunctionEventExistenceByFunctio
 	functionName string) string {
 
 	// reset output buffer for reading the nex output cleanly
-	suite.outputBuffer.Reset()
+	suite.nuctlRunner.outputBuffer.Reset()
 	err := suite.RetryExecuteNuctlUntilSuccessful([]string{"get", "functionevent"}, map[string]string{
 		"output":   nuctlCommon.OutputFormatYAML,
 		"function": functionName,
@@ -812,7 +812,7 @@ func (suite *projectExportImportTestSuite) assertFunctionEventExistenceByFunctio
 	suite.Require().NoError(err)
 
 	functionEvent := platform.FunctionEventConfig{}
-	err = yaml.Unmarshal(suite.outputBuffer.Bytes(), &functionEvent)
+	err = yaml.Unmarshal(suite.nuctlRunner.outputBuffer.Bytes(), &functionEvent)
 	suite.Require().NoError(err)
 
 	suite.Assert().Equal(functionEventDisplayName, functionEvent.Spec.DisplayName)
@@ -832,7 +832,7 @@ func (suite *projectExportImportTestSuite) exportProject(projectName string,
 	suite.Require().NoError(err)
 
 	projectImportConfig := &command.ProjectImportConfig{}
-	err = yaml.Unmarshal(suite.outputBuffer.Bytes(), &projectImportConfig)
+	err = yaml.Unmarshal(suite.nuctlRunner.outputBuffer.Bytes(), &projectImportConfig)
 	suite.Require().NoError(err)
 
 	return projectImportConfig

--- a/pkg/nuctl/test/suite.go
+++ b/pkg/nuctl/test/suite.go
@@ -111,11 +111,7 @@ func (suite *Suite) SetupSuite() {
 	// create nuctl executor
 	suite.nuctlRunner = NewNuctlRunner(suite.namespace, suite.logger)
 
-	// create project
-	err = suite.ExecuteNuctl([]string{"create", "project", suite.projectName}, map[string]string{})
-	suite.Require().NoError(err, "Failed to create project")
-
-	suite.logger.WarnWith("KAWABANGA: SetupSuite called", "project-name", suite.projectName)
+	suite.CreateTestProject(suite.projectName)
 }
 
 func (suite *Suite) SetupTest() {
@@ -134,12 +130,7 @@ func (suite *Suite) TearDownSuite() {
 
 	err = os.RemoveAll(suite.tempDir)
 	suite.Require().NoError(err, "Failed to remove temp dir - %s", suite.tempDir)
-	// remove project
-	if err = suite.ExecuteNuctl([]string{"delete", "project", suite.projectName}, map[string]string{}); err != nil {
-		suite.logger.WarnWith("Failed to delete project",
-			"projectName", suite.projectName,
-			"err", err.Error())
-	}
+	suite.DeleteTestProject(suite.projectName)
 
 	suite.logger.Debug("Suite tear down completed")
 }
@@ -204,6 +195,21 @@ func (suite *Suite) GetExamples() string {
 
 func (suite *Suite) GetImportsDir() string {
 	return path.Join(suite.GetNuclioSourceDir(), "test", "_imports")
+}
+
+func (suite *Suite) CreateTestProject(projectName string) {
+	// create project
+	err := suite.ExecuteNuctl([]string{"create", "project", projectName}, map[string]string{})
+	suite.Require().NoError(err, "Failed to create project")
+}
+
+func (suite *Suite) DeleteTestProject(projectName string) {
+	// delete project
+	if err := suite.ExecuteNuctl([]string{"delete", "project", projectName}, map[string]string{}); err != nil {
+		suite.logger.WarnWith("Failed to delete project",
+			"projectName", suite.projectName,
+			"err", err.Error())
+	}
 }
 
 func (suite *Suite) findPatternsInOutput(patternsMustExist []string, patternsMustNotExist []string) {

--- a/pkg/nuctl/test/suite.go
+++ b/pkg/nuctl/test/suite.go
@@ -109,7 +109,7 @@ func (suite *Suite) SetupSuite() {
 	suite.ctx = context.Background()
 
 	// create project
-	suite.ExecuteNuctl([]string{"create", "project", platform.DefaultProjectName}, map[string]string{}) // nolint: errcheck
+	suite.ExecuteNuctl([]string{"create", "project", "test-project"}, map[string]string{}) // nolint: errcheck
 }
 
 func (suite *Suite) SetupTest() {
@@ -129,7 +129,7 @@ func (suite *Suite) TearDownSuite() {
 	err = os.RemoveAll(suite.tempDir)
 	suite.Require().NoError(err, "Failed to remove temp dir - %s", suite.tempDir)
 	// remove project
-	suite.ExecuteNuctl([]string{"delete", "project", platform.DefaultProjectName}, map[string]string{}) // nolint: errcheck
+	suite.ExecuteNuctl([]string{"delete", "project", "test-project"}, map[string]string{}) // nolint: errcheck
 
 	suite.logger.Debug("Suite tear down completed")
 }

--- a/pkg/nuctl/test/suite.go
+++ b/pkg/nuctl/test/suite.go
@@ -114,6 +114,8 @@ func (suite *Suite) SetupSuite() {
 	// create project
 	err = suite.ExecuteNuctl([]string{"create", "project", suite.projectName}, map[string]string{})
 	suite.Require().NoError(err, "Failed to create project")
+
+	suite.logger.WarnWith("KAWABANGA: SetupSuite called", "project-name", suite.projectName)
 }
 
 func (suite *Suite) SetupTest() {

--- a/pkg/nuctl/test/suite.go
+++ b/pkg/nuctl/test/suite.go
@@ -62,6 +62,7 @@ type Suite struct {
 	defaultWaitInterval  time.Duration
 	tempDir              string
 	namespace            string
+	projectName          string
 	ctx                  context.Context
 }
 
@@ -108,8 +109,10 @@ func (suite *Suite) SetupSuite() {
 
 	suite.ctx = context.Background()
 
+	suite.projectName = "test-project"
+
 	// create project
-	suite.ExecuteNuctl([]string{"create", "project", "test-project"}, map[string]string{}) // nolint: errcheck
+	suite.ExecuteNuctl([]string{"create", "project", suite.projectName}, map[string]string{}) // nolint: errcheck
 }
 
 func (suite *Suite) SetupTest() {
@@ -129,7 +132,7 @@ func (suite *Suite) TearDownSuite() {
 	err = os.RemoveAll(suite.tempDir)
 	suite.Require().NoError(err, "Failed to remove temp dir - %s", suite.tempDir)
 	// remove project
-	suite.ExecuteNuctl([]string{"delete", "project", "test-project"}, map[string]string{}) // nolint: errcheck
+	suite.ExecuteNuctl([]string{"delete", "project", suite.projectName}, map[string]string{}) // nolint: errcheck
 
 	suite.logger.Debug("Suite tear down completed")
 }

--- a/pkg/nuctl/test/suite.go
+++ b/pkg/nuctl/test/suite.go
@@ -107,11 +107,9 @@ func (suite *Suite) SetupSuite() {
 	suite.ctx = context.Background()
 
 	suite.projectName = "test-project-" + xid.New().String()
-
-	// create nuctl executor
 	suite.nuctlRunner = NewNuctlRunner(suite.namespace, suite.logger)
-
-	suite.CreateTestProject(suite.projectName)
+	err = suite.ExecuteNuctl([]string{"create", "project", suite.projectName}, map[string]string{})
+	suite.Require().NoError(err, "Failed to create project")
 }
 
 func (suite *Suite) SetupTest() {
@@ -130,7 +128,8 @@ func (suite *Suite) TearDownSuite() {
 
 	err = os.RemoveAll(suite.tempDir)
 	suite.Require().NoError(err, "Failed to remove temp dir - %s", suite.tempDir)
-	suite.DeleteTestProject(suite.projectName)
+	err = suite.ExecuteNuctl([]string{"delete", "project", suite.projectName}, map[string]string{})
+	suite.Require().NoError(err, "Failed to delete project")
 
 	suite.logger.Debug("Suite tear down completed")
 }
@@ -195,21 +194,6 @@ func (suite *Suite) GetExamples() string {
 
 func (suite *Suite) GetImportsDir() string {
 	return path.Join(suite.GetNuclioSourceDir(), "test", "_imports")
-}
-
-func (suite *Suite) CreateTestProject(projectName string) {
-	// create project
-	err := suite.ExecuteNuctl([]string{"create", "project", projectName}, map[string]string{})
-	suite.Require().NoError(err, "Failed to create project")
-}
-
-func (suite *Suite) DeleteTestProject(projectName string) {
-	// delete project
-	if err := suite.ExecuteNuctl([]string{"delete", "project", projectName}, map[string]string{}); err != nil {
-		suite.logger.WarnWith("Failed to delete project",
-			"projectName", suite.projectName,
-			"err", err.Error())
-	}
 }
 
 func (suite *Suite) findPatternsInOutput(patternsMustExist []string, patternsMustNotExist []string) {

--- a/pkg/nuctl/test/suite.go
+++ b/pkg/nuctl/test/suite.go
@@ -20,10 +20,8 @@ package test
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"path"
@@ -34,7 +32,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
-	"github.com/nuclio/nuclio/pkg/nuctl/command"
 	nuctlcommon "github.com/nuclio/nuclio/pkg/nuctl/command/common"
 	"github.com/nuclio/nuclio/pkg/platform"
 
@@ -56,14 +53,13 @@ type Suite struct {
 	logger               logger.Logger
 	dockerClient         dockerclient.Client
 	shellClient          *cmdrunner.ShellRunner
-	outputBuffer         bytes.Buffer
-	stdinReader          *strings.Reader
 	defaultWaitDuration  time.Duration
 	defaultWaitInterval  time.Duration
 	tempDir              string
 	namespace            string
 	projectName          string
 	ctx                  context.Context
+	nuctlRunner          *NuctlRunner
 }
 
 func (suite *Suite) SetupSuite() {
@@ -111,15 +107,18 @@ func (suite *Suite) SetupSuite() {
 
 	suite.projectName = "test-project"
 
+	// create nuctl executor
+	suite.nuctlRunner = NewNuctlRunner(suite.namespace, suite.logger)
+
 	// create project
 	suite.ExecuteNuctl([]string{"create", "project", suite.projectName}, map[string]string{}) // nolint: errcheck
 }
 
 func (suite *Suite) SetupTest() {
-	suite.outputBuffer.Reset()
+	suite.nuctlRunner.outputBuffer.Reset()
 
 	// each test initializes it upon usage
-	suite.stdinReader = nil
+	suite.nuctlRunner.stdinReader = nil
 }
 
 func (suite *Suite) TearDownSuite() {
@@ -140,43 +139,7 @@ func (suite *Suite) TearDownSuite() {
 // ExecuteNuctl populates os.Args and executes nuctl as if it were executed from shell
 func (suite *Suite) ExecuteNuctl(positionalArgs []string,
 	namedArgs map[string]string) error {
-
-	// reset buffer to ensure it contains only last executed command
-	suite.outputBuffer.Reset()
-	rootCommandeer := command.NewRootCommandeer()
-
-	// set the output, so we can capture it (but also output to stdout)
-	rootCommandeer.GetCmd().SetOut(io.MultiWriter(os.Stdout, &suite.outputBuffer))
-
-	// set the input so we can write to stdin
-	if suite.stdinReader != nil {
-		rootCommandeer.GetCmd().SetIn(suite.stdinReader)
-	}
-
-	var argsStringSlice []string
-
-	// add positional arguments
-	argsStringSlice = append(argsStringSlice, positionalArgs...)
-
-	for argName, argValue := range namedArgs {
-		argsStringSlice = append(argsStringSlice, fmt.Sprintf("--%s", argName), argValue)
-	}
-
-	if suite.isNamespaceRequired() && !suite.namespaceInArgs(positionalArgs, namedArgs) {
-		// prepend namespace to args
-		argsStringSlice = common.PrependStringsToStringSlice(argsStringSlice, "--namespace", suite.namespace)
-	}
-
-	// since args[0] is the executable name, just shove the binary there
-	argsStringSlice = common.PrependStringToStringSlice(argsStringSlice, "nuctl")
-
-	// override os.Args (this can't go wrong horribly, can it?)
-	os.Args = argsStringSlice
-
-	suite.logger.DebugWith("Executing nuctl", "args", argsStringSlice)
-
-	// execute
-	return rootCommandeer.Execute()
+	return suite.nuctlRunner.Run(positionalArgs, namedArgs)
 }
 
 // RetryExecuteNuctlUntilSuccessful executes nuctl until expectFailure is met
@@ -191,8 +154,8 @@ func (suite *Suite) RetryExecuteNuctlUntilSuccessful(positionalArgs []string,
 			defer func() {
 
 				// upon retry, ensure stdin data is readable again
-				if suite.stdinReader != nil {
-					suite.stdinReader.Seek(0, io.SeekStart) // nolint: errcheck
+				if suite.nuctlRunner.stdinReader != nil {
+					suite.nuctlRunner.stdinReader.Seek(0, io.SeekStart) // nolint: errcheck
 				}
 			}()
 
@@ -240,7 +203,7 @@ func (suite *Suite) findPatternsInOutput(patternsMustExist []string, patternsMus
 	foundPatternsMustNotExist := make([]bool, len(patternsMustNotExist))
 
 	// iterate over all lines in result
-	scanner := bufio.NewScanner(&suite.outputBuffer)
+	scanner := bufio.NewScanner(&suite.nuctlRunner.outputBuffer)
 	for scanner.Scan() {
 
 		for patternIdx, patternName := range patternsMustExist {
@@ -273,14 +236,14 @@ func (suite *Suite) findPatternsInOutput(patternsMustExist []string, patternsMus
 func (suite *Suite) verifyAPIGatewayExists(apiGatewayName, primaryFunctionName string) {
 
 	// reset output buffer for reading the nex output cleanly
-	suite.outputBuffer.Reset()
+	suite.nuctlRunner.outputBuffer.Reset()
 	err := suite.RetryExecuteNuctlUntilSuccessful([]string{"get", "agw", apiGatewayName}, map[string]string{
 		"output": nuctlcommon.OutputFormatYAML,
 	}, false)
 	suite.Require().NoError(err)
 
 	apiGateway := platform.APIGatewayConfig{}
-	apiGatewayBodyBytes := suite.outputBuffer.Bytes()
+	apiGatewayBodyBytes := suite.nuctlRunner.outputBuffer.Bytes()
 	err = yaml.Unmarshal(apiGatewayBodyBytes, &apiGateway)
 	suite.Require().NoError(err)
 
@@ -291,14 +254,14 @@ func (suite *Suite) verifyAPIGatewayExists(apiGatewayName, primaryFunctionName s
 func (suite *Suite) assertFunctionImported(functionName string, imported bool) {
 
 	// reset output buffer for reading the nex output cleanly
-	suite.outputBuffer.Reset()
+	suite.nuctlRunner.outputBuffer.Reset()
 	err := suite.RetryExecuteNuctlUntilSuccessful([]string{"get", "function", functionName}, map[string]string{
 		"output": nuctlcommon.OutputFormatYAML,
 	}, false)
 	suite.Require().NoError(err)
 
 	function := functionconfig.Config{}
-	functionBodyBytes := suite.outputBuffer.Bytes()
+	functionBodyBytes := suite.nuctlRunner.outputBuffer.Bytes()
 	err = yaml.Unmarshal(functionBodyBytes, &function)
 	suite.Require().NoError(err)
 
@@ -316,7 +279,7 @@ func (suite *Suite) assertFunctionImported(functionName string, imported bool) {
 
 func (suite *Suite) getFunctionInFormat(functionName string,
 	outputFormat string) (*functionconfig.ConfigWithStatus, error) {
-	suite.outputBuffer.Reset()
+	suite.nuctlRunner.outputBuffer.Reset()
 	var err error
 
 	suite.Require().NotEmpty(outputFormat, "Output format must not be empty")
@@ -335,9 +298,9 @@ func (suite *Suite) getFunctionInFormat(functionName string,
 	// unmarshal response correspondingly to output format
 	switch outputFormat {
 	case nuctlcommon.OutputFormatJSON:
-		err = json.Unmarshal(suite.outputBuffer.Bytes(), &parsedFunction)
+		err = json.Unmarshal(suite.nuctlRunner.outputBuffer.Bytes(), &parsedFunction)
 	case nuctlcommon.OutputFormatYAML:
-		err = yaml.Unmarshal(suite.outputBuffer.Bytes(), &parsedFunction)
+		err = yaml.Unmarshal(suite.nuctlRunner.outputBuffer.Bytes(), &parsedFunction)
 	default:
 		return nil, errors.Errorf("Invalid output format %s", outputFormat)
 	}
@@ -396,20 +359,4 @@ func (suite *Suite) ensureRunningOnPlatform(expectedPlatformKind string) {
 			expectedPlatformKind,
 			suite.origPlatformKind)
 	}
-}
-
-func (suite *Suite) namespaceInArgs(positionalArgs []string, namedArgs map[string]string) bool {
-	if common.StringSliceContainsString(positionalArgs, "--namespace") || common.StringSliceContainsString(positionalArgs, "-n") {
-		return true
-	}
-
-	if _, ok := namedArgs["namespace"]; ok {
-		return true
-	}
-
-	return false
-}
-
-func (suite *Suite) isNamespaceRequired() bool {
-	return suite.namespace != "" && common.GetKubeconfigPath("") != ""
 }

--- a/pkg/nuctl/test/suite.go
+++ b/pkg/nuctl/test/suite.go
@@ -38,6 +38,7 @@ import (
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
+	"github.com/rs/xid"
 	"github.com/stretchr/testify/suite"
 	"sigs.k8s.io/yaml"
 )
@@ -105,13 +106,14 @@ func (suite *Suite) SetupSuite() {
 
 	suite.ctx = context.Background()
 
-	suite.projectName = "test-project"
+	suite.projectName = "test-project-" + xid.New().String()
 
 	// create nuctl executor
 	suite.nuctlRunner = NewNuctlRunner(suite.namespace, suite.logger)
 
 	// create project
-	suite.ExecuteNuctl([]string{"create", "project", suite.projectName}, map[string]string{}) // nolint: errcheck
+	err = suite.ExecuteNuctl([]string{"create", "project", suite.projectName}, map[string]string{})
+	suite.Require().NoError(err, "Failed to create project")
 }
 
 func (suite *Suite) SetupTest() {
@@ -131,7 +133,11 @@ func (suite *Suite) TearDownSuite() {
 	err = os.RemoveAll(suite.tempDir)
 	suite.Require().NoError(err, "Failed to remove temp dir - %s", suite.tempDir)
 	// remove project
-	suite.ExecuteNuctl([]string{"delete", "project", suite.projectName}, map[string]string{}) // nolint: errcheck
+	if err = suite.ExecuteNuctl([]string{"delete", "project", suite.projectName}, map[string]string{}); err != nil {
+		suite.logger.WarnWith("Failed to delete project",
+			"projectName", suite.projectName,
+			"err", err.Error())
+	}
 
 	suite.logger.Debug("Suite tear down completed")
 }

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -51,7 +51,6 @@ import (
 	"github.com/samber/lo"
 	autosv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -310,10 +309,6 @@ func (ap *Platform) EnrichFunctionConfig(ctx context.Context, functionConfig *fu
 
 // EnrichLabels enriches labels with default project name
 func (ap *Platform) EnrichLabels(ctx context.Context, labels map[string]string) {
-	if labels[common.NuclioResourceLabelKeyProjectName] == "" {
-		labels[common.NuclioResourceLabelKeyProjectName] = platform.DefaultProjectName
-		ap.Logger.DebugCtx(ctx, "No project name specified. Setting to default")
-	}
 	ap.enrichUsernameAndDomainLabels(ctx, labels)
 }
 
@@ -1217,52 +1212,6 @@ func (ap *Platform) GetProjectResources(ctx context.Context,
 		return nil, nil, errors.Wrap(err, "Failed to get project resources")
 	}
 	return functions, apiGateways, nil
-}
-
-func (ap *Platform) EnsureDefaultProjectExistence(ctx context.Context) error {
-	projects, err := ap.platform.GetProjects(ctx, &platform.GetProjectsOptions{
-		Meta: platform.ProjectMeta{
-			Name:      platform.DefaultProjectName,
-			Namespace: ap.DefaultNamespace,
-		},
-	})
-	if err != nil {
-		return errors.Wrap(err, "Failed to get projects")
-	}
-
-	if len(projects) == 0 {
-
-		// if we're here the default project doesn't exist. create it
-		projectConfig := platform.ProjectConfig{
-			Meta: platform.ProjectMeta{
-				Name:      platform.DefaultProjectName,
-				Namespace: ap.DefaultNamespace,
-			},
-			Spec: platform.ProjectSpec{},
-		}
-		newProject, err := platform.NewAbstractProject(ap.Logger, ap.platform, projectConfig)
-		if err != nil {
-			return errors.Wrap(err, "Failed to create abstract default project")
-		}
-
-		if err := ap.platform.CreateProject(ctx, &platform.CreateProjectOptions{
-			ProjectConfig: newProject.GetConfig(),
-		}); err != nil {
-
-			// if project already exists, return
-			if apierrors.IsAlreadyExists(errors.RootCause(err)) {
-				return nil
-			}
-
-			return errors.Wrap(err, "Failed to create default project")
-		}
-
-		ap.Logger.DebugWithCtx(ctx, "Default project was successfully created",
-			"name", platform.DefaultProjectName,
-			"namespace", ap.DefaultNamespace)
-	}
-
-	return nil
 }
 
 // ResolveProjectNameFromLabelsStr resolves first project name from label string

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -531,14 +531,7 @@ func (ap *Platform) ValidateDeleteProjectOptions(ctx context.Context,
 	deleteProjectOptions *platform.DeleteProjectOptions) error {
 	projectName := deleteProjectOptions.Meta.Name
 
-	switch projectName {
-	case platform.DefaultProjectName:
-
-		// projects is controlled by a leader. when not set, do not allow deleting the only project
-		if ap.Config.ProjectsLeader == nil {
-			return nuclio.NewErrPreconditionFailed("Cannot delete the default project")
-		}
-	case "":
+	if projectName == "" {
 		return nuclio.NewErrBadRequest("Project name cannot be empty")
 	}
 

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -848,6 +848,9 @@ func (ap *Platform) GetFunctionProject(ctx context.Context, functionConfig *func
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get projects")
 	}
+
+	ap.Logger.DebugWith("KAWABANGA4", "projectName", projectName, "projects", projects)
+
 	switch len(projects) {
 	case 1:
 		return projects[0], nil

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -849,8 +849,6 @@ func (ap *Platform) GetFunctionProject(ctx context.Context, functionConfig *func
 		return nil, errors.Wrap(err, "Failed to get projects")
 	}
 
-	ap.Logger.DebugWith("KAWABANGA4", "projectName", projectName, "projects", projects)
-
 	switch len(projects) {
 	case 1:
 		return projects[0], nil

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -852,9 +852,9 @@ func (ap *Platform) GetFunctionProject(ctx context.Context, functionConfig *func
 	case 1:
 		return projects[0], nil
 	case 0:
-		return nil, errors.Wrap(err, "Project was not found for given function")
+		return nil, errors.New("Project was not found for given function")
 	default:
-		return nil, errors.Wrap(err, "More than one project were found for given function")
+		return nil, errors.New("More than one project were found for given function")
 	}
 }
 

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -222,7 +222,7 @@ func (suite *AbstractPlatformTestSuite) TestValidationFailOnMalformedIngressesSt
 	functionConfig.Meta.Name = "f1"
 	functionConfig.Meta.Namespace = "default"
 	functionConfig.Meta.Labels = map[string]string{
-		common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
+		common.NuclioResourceLabelKeyProjectName: "test-project",
 	}
 
 	for _, testCase := range []struct {
@@ -283,7 +283,7 @@ func (suite *AbstractPlatformTestSuite) TestValidationFailOnMalformedIngressesSt
 
 		suite.mockedPlatform.On("GetProjects", mock.Anything, &platform.GetProjectsOptions{
 			Meta: platform.ProjectMeta{
-				Name:      platform.DefaultProjectName,
+				Name:      "test-project",
 				Namespace: "default",
 			},
 		}).Return([]platform.Project{
@@ -342,7 +342,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichDefaultHttpTrigger() {
 
 		suite.mockedPlatform.On("GetProjects", mock.Anything, &platform.GetProjectsOptions{
 			Meta: platform.ProjectMeta{
-				Name:      platform.DefaultProjectName,
+				Name:      "test-project",
 				Namespace: "default",
 			},
 		}).Return([]platform.Project{
@@ -353,7 +353,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichDefaultHttpTrigger() {
 		functionConfig.Meta.Name = "f1"
 		functionConfig.Meta.Namespace = "default"
 		functionConfig.Meta.Labels = map[string]string{
-			common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
+			common.NuclioResourceLabelKeyProjectName: "test-project",
 		}
 		suite.Platform.Config.DisableDefaultHTTPTrigger = testCase.PlatformDisableDefaultHttpTrigger
 		functionConfig.Spec.DisableDefaultHTTPTrigger = testCase.FunctionDisableDefaultHttpTrigger
@@ -687,14 +687,13 @@ func (suite *AbstractPlatformTestSuite) TestValidateDeleteProjectOptions() {
 			expectedFailure: true,
 		},
 		{
-			name: "FailDeletingDefaultProject",
+			name: "DeletingDefaultProjectShouldNotFail",
 			deleteProjectOptions: &platform.DeleteProjectOptions{
 				Meta: platform.ProjectMeta{
 					Namespace: suite.DefaultNamespace,
-					Name:      platform.DefaultProjectName,
+					Name:      "default",
 				},
 			},
-			expectedFailure: true,
 		},
 		{
 			name: "FailDeletingProjectWithFunctions",
@@ -1006,7 +1005,7 @@ func (suite *AbstractPlatformTestSuite) TestMinMaxReplicas() {
 
 		suite.mockedPlatform.On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 			Meta: platform.ProjectMeta{
-				Name:      platform.DefaultProjectName,
+				Name:      "test-project",
 				Namespace: "default",
 			},
 		}).Return([]platform.Project{
@@ -1024,7 +1023,7 @@ func (suite *AbstractPlatformTestSuite) TestMinMaxReplicas() {
 
 		createFunctionOptions.FunctionConfig.Meta.Name = functionName
 		createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-			common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
+			common.NuclioResourceLabelKeyProjectName: "test-project",
 		}
 		createFunctionOptions.FunctionConfig.Spec.MinReplicas = MinMaxReplicas.MinReplicas
 		createFunctionOptions.FunctionConfig.Spec.MaxReplicas = MinMaxReplicas.MaxReplicas
@@ -1235,7 +1234,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 		suite.Run(testCase.name, func() {
 			suite.mockedPlatform.On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 				Meta: platform.ProjectMeta{
-					Name:      platform.DefaultProjectName,
+					Name:      "test-project",
 					Namespace: "default",
 				},
 			}).Return([]platform.Project{
@@ -1255,7 +1254,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 			}
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
+				common.NuclioResourceLabelKeyProjectName: "test-project",
 			}
 			createFunctionOptions.FunctionConfig.Spec.Triggers = testCase.triggers
 			suite.Logger.DebugWith("Checking function ", "functionName", functionName)
@@ -1339,7 +1338,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichEnvVars() {
 
 			functionConfig.Meta.Name = testCase.name
 			functionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
+				common.NuclioResourceLabelKeyProjectName: "test-project",
 			}
 			functionConfig.Spec.EnvFrom = testCase.FunctionEnvFrom
 			suite.Platform.Config.Runtime = &runtimeconfig.Config{
@@ -1360,7 +1359,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichNumWorkersFromMaxWorkers() {
 
 	functionConfig.Meta.Name = "some-function"
 	functionConfig.Meta.Labels = map[string]string{
-		common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
+		common.NuclioResourceLabelKeyProjectName: "test-project",
 	}
 
 	numWorkers := 5
@@ -1651,7 +1650,7 @@ func (suite *AbstractPlatformTestSuite) TestValidateNodeSelector() {
 		suite.Run(testCase.name, func() {
 			suite.mockedPlatform.On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 				Meta: platform.ProjectMeta{
-					Name:      platform.DefaultProjectName,
+					Name:      "test-project",
 					Namespace: "default",
 				},
 			}).Return([]platform.Project{
@@ -1669,7 +1668,7 @@ func (suite *AbstractPlatformTestSuite) TestValidateNodeSelector() {
 			}
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
+				common.NuclioResourceLabelKeyProjectName: "test-project",
 			}
 			suite.Logger.DebugWith("Checking function ", "functionName", functionName)
 
@@ -1730,7 +1729,7 @@ func (suite *AbstractPlatformTestSuite) TestValidatePriorityClassName() {
 		suite.Run(testCase.name, func() {
 			suite.mockedPlatform.On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 				Meta: platform.ProjectMeta{
-					Name:      platform.DefaultProjectName,
+					Name:      "test-project",
 					Namespace: "default",
 				},
 			}).Return([]platform.Project{
@@ -1748,7 +1747,7 @@ func (suite *AbstractPlatformTestSuite) TestValidatePriorityClassName() {
 			}
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
+				common.NuclioResourceLabelKeyProjectName: "test-project",
 			}
 			suite.Platform.Config.Kube.ValidFunctionPriorityClassNames = testCase.validFunctionPriorityClassNames
 			suite.Logger.DebugWith("Checking function ", "functionName", functionName)
@@ -1895,7 +1894,7 @@ func (suite *AbstractPlatformTestSuite) TestValidateVolumes() {
 			suite.mockedPlatform.
 				On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 					Meta: platform.ProjectMeta{
-						Name:      platform.DefaultProjectName,
+						Name:      "test-project",
 						Namespace: "default",
 					},
 				}).
@@ -1915,7 +1914,7 @@ func (suite *AbstractPlatformTestSuite) TestValidateVolumes() {
 			}
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
+				common.NuclioResourceLabelKeyProjectName: "test-project",
 			}
 			suite.Logger.DebugWith("Checking function", "functionName", functionName)
 
@@ -2031,7 +2030,7 @@ func (suite *AbstractPlatformTestSuite) TestValidateFunctionConfigAutoScaleMetri
 		suite.Run(testCase.name, func() {
 			suite.mockedPlatform.On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 				Meta: platform.ProjectMeta{
-					Name:      platform.DefaultProjectName,
+					Name:      "test-project",
 					Namespace: "default",
 				},
 			}).Return([]platform.Project{
@@ -2048,7 +2047,7 @@ func (suite *AbstractPlatformTestSuite) TestValidateFunctionConfigAutoScaleMetri
 			}
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
+				common.NuclioResourceLabelKeyProjectName: "test-project",
 			}
 			createFunctionOptions.FunctionConfig.Spec.AutoScaleMetrics = testCase.AutoScaleMetrics
 

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -56,6 +56,7 @@ const (
 	FunctionLogsFile                         = "function_logs.txt"
 	FormattedFunctionLogsFile                = "formatted_function_logs.txt"
 	BriefErrorsMessageFile                   = "brief_errors_message.txt"
+	testProjectName                          = "test-project"
 )
 
 type AbstractPlatformTestSuite struct {
@@ -222,7 +223,7 @@ func (suite *AbstractPlatformTestSuite) TestValidationFailOnMalformedIngressesSt
 	functionConfig.Meta.Name = "f1"
 	functionConfig.Meta.Namespace = "default"
 	functionConfig.Meta.Labels = map[string]string{
-		common.NuclioResourceLabelKeyProjectName: "test-project",
+		common.NuclioResourceLabelKeyProjectName: testProjectName,
 	}
 
 	for _, testCase := range []struct {
@@ -283,7 +284,7 @@ func (suite *AbstractPlatformTestSuite) TestValidationFailOnMalformedIngressesSt
 
 		suite.mockedPlatform.On("GetProjects", mock.Anything, &platform.GetProjectsOptions{
 			Meta: platform.ProjectMeta{
-				Name:      "test-project",
+				Name:      testProjectName,
 				Namespace: "default",
 			},
 		}).Return([]platform.Project{
@@ -342,7 +343,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichDefaultHttpTrigger() {
 
 		suite.mockedPlatform.On("GetProjects", mock.Anything, &platform.GetProjectsOptions{
 			Meta: platform.ProjectMeta{
-				Name:      "test-project",
+				Name:      testProjectName,
 				Namespace: "default",
 			},
 		}).Return([]platform.Project{
@@ -353,7 +354,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichDefaultHttpTrigger() {
 		functionConfig.Meta.Name = "f1"
 		functionConfig.Meta.Namespace = "default"
 		functionConfig.Meta.Labels = map[string]string{
-			common.NuclioResourceLabelKeyProjectName: "test-project",
+			common.NuclioResourceLabelKeyProjectName: testProjectName,
 		}
 		suite.Platform.Config.DisableDefaultHTTPTrigger = testCase.PlatformDisableDefaultHttpTrigger
 		functionConfig.Spec.DisableDefaultHTTPTrigger = testCase.FunctionDisableDefaultHttpTrigger
@@ -1005,7 +1006,7 @@ func (suite *AbstractPlatformTestSuite) TestMinMaxReplicas() {
 
 		suite.mockedPlatform.On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 			Meta: platform.ProjectMeta{
-				Name:      "test-project",
+				Name:      testProjectName,
 				Namespace: "default",
 			},
 		}).Return([]platform.Project{
@@ -1023,7 +1024,7 @@ func (suite *AbstractPlatformTestSuite) TestMinMaxReplicas() {
 
 		createFunctionOptions.FunctionConfig.Meta.Name = functionName
 		createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-			common.NuclioResourceLabelKeyProjectName: "test-project",
+			common.NuclioResourceLabelKeyProjectName: testProjectName,
 		}
 		createFunctionOptions.FunctionConfig.Spec.MinReplicas = MinMaxReplicas.MinReplicas
 		createFunctionOptions.FunctionConfig.Spec.MaxReplicas = MinMaxReplicas.MaxReplicas
@@ -1234,7 +1235,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 		suite.Run(testCase.name, func() {
 			suite.mockedPlatform.On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 				Meta: platform.ProjectMeta{
-					Name:      "test-project",
+					Name:      testProjectName,
 					Namespace: "default",
 				},
 			}).Return([]platform.Project{
@@ -1254,7 +1255,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 			}
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: "test-project",
+				common.NuclioResourceLabelKeyProjectName: testProjectName,
 			}
 			createFunctionOptions.FunctionConfig.Spec.Triggers = testCase.triggers
 			suite.Logger.DebugWith("Checking function ", "functionName", functionName)
@@ -1338,7 +1339,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichEnvVars() {
 
 			functionConfig.Meta.Name = testCase.name
 			functionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: "test-project",
+				common.NuclioResourceLabelKeyProjectName: testProjectName,
 			}
 			functionConfig.Spec.EnvFrom = testCase.FunctionEnvFrom
 			suite.Platform.Config.Runtime = &runtimeconfig.Config{
@@ -1359,7 +1360,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichNumWorkersFromMaxWorkers() {
 
 	functionConfig.Meta.Name = "some-function"
 	functionConfig.Meta.Labels = map[string]string{
-		common.NuclioResourceLabelKeyProjectName: "test-project",
+		common.NuclioResourceLabelKeyProjectName: testProjectName,
 	}
 
 	numWorkers := 5
@@ -1650,7 +1651,7 @@ func (suite *AbstractPlatformTestSuite) TestValidateNodeSelector() {
 		suite.Run(testCase.name, func() {
 			suite.mockedPlatform.On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 				Meta: platform.ProjectMeta{
-					Name:      "test-project",
+					Name:      testProjectName,
 					Namespace: "default",
 				},
 			}).Return([]platform.Project{
@@ -1668,7 +1669,7 @@ func (suite *AbstractPlatformTestSuite) TestValidateNodeSelector() {
 			}
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: "test-project",
+				common.NuclioResourceLabelKeyProjectName: testProjectName,
 			}
 			suite.Logger.DebugWith("Checking function ", "functionName", functionName)
 
@@ -1729,7 +1730,7 @@ func (suite *AbstractPlatformTestSuite) TestValidatePriorityClassName() {
 		suite.Run(testCase.name, func() {
 			suite.mockedPlatform.On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 				Meta: platform.ProjectMeta{
-					Name:      "test-project",
+					Name:      testProjectName,
 					Namespace: "default",
 				},
 			}).Return([]platform.Project{
@@ -1747,7 +1748,7 @@ func (suite *AbstractPlatformTestSuite) TestValidatePriorityClassName() {
 			}
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: "test-project",
+				common.NuclioResourceLabelKeyProjectName: testProjectName,
 			}
 			suite.Platform.Config.Kube.ValidFunctionPriorityClassNames = testCase.validFunctionPriorityClassNames
 			suite.Logger.DebugWith("Checking function ", "functionName", functionName)
@@ -1894,7 +1895,7 @@ func (suite *AbstractPlatformTestSuite) TestValidateVolumes() {
 			suite.mockedPlatform.
 				On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 					Meta: platform.ProjectMeta{
-						Name:      "test-project",
+						Name:      testProjectName,
 						Namespace: "default",
 					},
 				}).
@@ -1914,7 +1915,7 @@ func (suite *AbstractPlatformTestSuite) TestValidateVolumes() {
 			}
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: "test-project",
+				common.NuclioResourceLabelKeyProjectName: testProjectName,
 			}
 			suite.Logger.DebugWith("Checking function", "functionName", functionName)
 
@@ -2030,7 +2031,7 @@ func (suite *AbstractPlatformTestSuite) TestValidateFunctionConfigAutoScaleMetri
 		suite.Run(testCase.name, func() {
 			suite.mockedPlatform.On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 				Meta: platform.ProjectMeta{
-					Name:      "test-project",
+					Name:      testProjectName,
 					Namespace: "default",
 				},
 			}).Return([]platform.Project{
@@ -2047,7 +2048,7 @@ func (suite *AbstractPlatformTestSuite) TestValidateFunctionConfigAutoScaleMetri
 			}
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: "test-project",
+				common.NuclioResourceLabelKeyProjectName: testProjectName,
 			}
 			createFunctionOptions.FunctionConfig.Spec.AutoScaleMetrics = testCase.AutoScaleMetrics
 

--- a/pkg/platform/kube/controller/apigateway.go
+++ b/pkg/platform/kube/controller/apigateway.go
@@ -98,9 +98,8 @@ func (ago *apiGatewayOperator) CreateOrUpdate(ctx context.Context, object runtim
 		apiGateway.Labels = map[string]string{}
 	}
 
-	// set default project-name if none given
 	if apiGateway.Labels[common.NuclioResourceLabelKeyProjectName] == "" {
-		apiGateway.Labels[common.NuclioResourceLabelKeyProjectName] = platform.DefaultProjectName
+		return errors.New("API gateway must have a project name label set")
 	}
 
 	// validate api gateway name is according to k8s convention

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -180,16 +180,9 @@ func NewPlatform(ctx context.Context,
 	return newPlatform, nil
 }
 
-func (p *Platform) Initialize(ctx context.Context) error {
+func (p *Platform) Initialize(_ context.Context) error {
 	if err := p.projectsClient.Initialize(); err != nil {
 		return errors.Wrap(err, "Failed to initialize projects client")
-	}
-
-	// ensure default project existence only when projects aren't managed by external leader
-	if p.Config.ProjectsLeader == nil {
-		if err := p.EnsureDefaultProjectExistence(ctx); err != nil {
-			return errors.Wrap(err, "Failed to ensure default project existence")
-		}
 	}
 
 	return nil

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/nuclio/logger"
 	"github.com/nuclio/opa-client"
 	"github.com/nuclio/zap"
+	"github.com/rs/xid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/api/core/v1"
@@ -77,6 +78,7 @@ type KubePlatformTestSuite struct {
 	mockedOpaClient                  *opaclient.MockClient
 	opaOverrideHeaderValue           string
 	ctx                              context.Context
+	projectName                      string
 }
 
 func (suite *KubePlatformTestSuite) SetupSuite() {
@@ -111,6 +113,7 @@ func (suite *KubePlatformTestSuite) SetupSuite() {
 		"external-ip",
 	}
 	suite.kubeClientSet = *fake.NewSimpleClientset()
+	suite.projectName = "test-project-" + xid.New().String()
 }
 
 func (suite *KubePlatformTestSuite) SetupTest() {
@@ -306,7 +309,7 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateServiceType() {
 			suite.mockedPlatform.
 				On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 					Meta: platform.ProjectMeta{
-						Name:      "test-project",
+						Name:      suite.projectName,
 						Namespace: "default",
 					},
 				}).
@@ -326,7 +329,7 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateServiceType() {
 			}
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: "test-project",
+				common.NuclioResourceLabelKeyProjectName: suite.projectName,
 			}
 			suite.Logger.DebugWith("Checking function ", "functionName", functionName)
 
@@ -590,7 +593,7 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateSidecarContainers() {
 			suite.mockedPlatform.
 				On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 					Meta: platform.ProjectMeta{
-						Name:      "test-project",
+						Name:      suite.projectName,
 						Namespace: "default",
 					},
 				}).
@@ -610,7 +613,7 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateSidecarContainers() {
 			}
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: "test-project",
+				common.NuclioResourceLabelKeyProjectName: suite.projectName,
 			}
 			err := suite.platform.validateSidecarSpec(&createFunctionOptions.FunctionConfig)
 			if testCase.shouldFailValidation {
@@ -805,7 +808,7 @@ func (suite *FunctionKubePlatformTestSuite) TestFunctionTriggersEnrichmentAndVal
 			// mock get projects
 			suite.mockedPlatform.On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 				Meta: platform.ProjectMeta{
-					Name:      "test-project",
+					Name:      suite.projectName,
 					Namespace: suite.Namespace,
 				},
 			}).Return([]platform.Project{
@@ -822,7 +825,7 @@ func (suite *FunctionKubePlatformTestSuite) TestFunctionTriggersEnrichmentAndVal
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Namespace = suite.Namespace
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: "test-project",
+				common.NuclioResourceLabelKeyProjectName: suite.projectName,
 			}
 			createFunctionOptions.FunctionConfig.Spec.Triggers = testCase.triggers
 			suite.Logger.DebugWith("Enriching and validating function", "functionName", functionName)
@@ -1119,7 +1122,7 @@ func (suite *FunctionKubePlatformTestSuite) TestGetFunctionsPermissions() {
 
 func (suite *FunctionKubePlatformTestSuite) TestValidateServiceAccount() {
 
-	projectName := "test-project"
+	projectName := suite.projectName
 	secretName := fmt.Sprintf("nuclio-project-secrets-%s", projectName)
 	allowedKey := "allowed-sa-key"
 	allowedSAs := []string{"sa1", "sa2"}
@@ -1838,7 +1841,7 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithUserNameLabel(
 			suite.mockedPlatform.
 				On("GetProjects", ctx, &platform.GetProjectsOptions{
 					Meta: platform.ProjectMeta{
-						Name:      "test-project",
+						Name:      suite.projectName,
 						Namespace: suite.Namespace,
 					},
 				}).
@@ -1855,7 +1858,7 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithUserNameLabel(
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Namespace = suite.Namespace
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: "test-project",
+				common.NuclioResourceLabelKeyProjectName: suite.projectName,
 			}
 
 			suite.Logger.DebugWith("Enriching function", "functionName", functionName)

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -306,7 +306,7 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateServiceType() {
 			suite.mockedPlatform.
 				On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 					Meta: platform.ProjectMeta{
-						Name:      platform.DefaultProjectName,
+						Name:      "test-project",
 						Namespace: "default",
 					},
 				}).
@@ -326,7 +326,7 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateServiceType() {
 			}
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
+				common.NuclioResourceLabelKeyProjectName: "test-project",
 			}
 			suite.Logger.DebugWith("Checking function ", "functionName", functionName)
 
@@ -590,7 +590,7 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateSidecarContainers() {
 			suite.mockedPlatform.
 				On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 					Meta: platform.ProjectMeta{
-						Name:      platform.DefaultProjectName,
+						Name:      "test-project",
 						Namespace: "default",
 					},
 				}).
@@ -610,7 +610,7 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateSidecarContainers() {
 			}
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
+				common.NuclioResourceLabelKeyProjectName: "test-project",
 			}
 			err := suite.platform.validateSidecarSpec(&createFunctionOptions.FunctionConfig)
 			if testCase.shouldFailValidation {
@@ -805,7 +805,7 @@ func (suite *FunctionKubePlatformTestSuite) TestFunctionTriggersEnrichmentAndVal
 			// mock get projects
 			suite.mockedPlatform.On("GetProjects", suite.ctx, &platform.GetProjectsOptions{
 				Meta: platform.ProjectMeta{
-					Name:      platform.DefaultProjectName,
+					Name:      "test-project",
 					Namespace: suite.Namespace,
 				},
 			}).Return([]platform.Project{
@@ -822,7 +822,7 @@ func (suite *FunctionKubePlatformTestSuite) TestFunctionTriggersEnrichmentAndVal
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Namespace = suite.Namespace
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
+				common.NuclioResourceLabelKeyProjectName: "test-project",
 			}
 			createFunctionOptions.FunctionConfig.Spec.Triggers = testCase.triggers
 			suite.Logger.DebugWith("Enriching and validating function", "functionName", functionName)
@@ -1838,7 +1838,7 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithUserNameLabel(
 			suite.mockedPlatform.
 				On("GetProjects", ctx, &platform.GetProjectsOptions{
 					Meta: platform.ProjectMeta{
-						Name:      platform.DefaultProjectName,
+						Name:      "test-project",
 						Namespace: suite.Namespace,
 					},
 				}).
@@ -1855,7 +1855,7 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithUserNameLabel(
 			createFunctionOptions.FunctionConfig.Meta.Name = functionName
 			createFunctionOptions.FunctionConfig.Meta.Namespace = suite.Namespace
 			createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-				common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
+				common.NuclioResourceLabelKeyProjectName: "test-project",
 			}
 
 			suite.Logger.DebugWith("Enriching function", "functionName", functionName)

--- a/pkg/platform/kube/test/function/function_test.go
+++ b/pkg/platform/kube/test/function/function_test.go
@@ -606,7 +606,7 @@ func (suite *DeployFunctionTestSuite) TestAugmentedConfig() {
 	}
 	functionName := "augmented-config"
 	createFunctionOptions := suite.CompileCreateFunctionOptions(functionName)
-	createFunctionOptions.FunctionConfig.Meta.Labels = functionLabels
+	createFunctionOptions.FunctionConfig.Meta.Labels["my-function"] = "is-labeled"
 	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
 		deploymentInstance := &appsv1.Deployment{}
 		functionInstance := &nuclioio.NuclioFunction{}
@@ -2012,9 +2012,6 @@ func (suite *UpdateFunctionTestSuite) TestSanity() {
 	ctx := suite.Ctx
 
 	createFunctionOptions := suite.CompileCreateFunctionOptions("update-sanity")
-	createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-		"something": "here",
-	}
 	createFunctionOptions.FunctionConfig.Meta.Annotations = map[string]string{
 		"annotation-key": "annotation-value",
 	}

--- a/pkg/platform/kube/test/project/project_test.go
+++ b/pkg/platform/kube/test/project/project_test.go
@@ -39,7 +39,7 @@ type ProjectTestSuite struct {
 func (suite *ProjectTestSuite) TestCreate() {
 	projectConfig := platform.ProjectConfig{
 		Meta: platform.ProjectMeta{
-			Name:      "test-project",
+			Name:      "test-create",
 			Namespace: suite.Namespace,
 			Labels: map[string]string{
 				"label-key": "label-value",
@@ -83,7 +83,7 @@ func (suite *ProjectTestSuite) TestCreateFromLeaderIgnoreInvalidLabels() {
 	invalidLabelKey2 := "the-key-is-invalid"
 	projectConfig := platform.ProjectConfig{
 		Meta: platform.ProjectMeta{
-			Name:      "test-project",
+			Name:      "test-create-from-leader",
 			Namespace: suite.Namespace,
 			Labels: map[string]string{
 				invalidLabelKey1: "label-value",
@@ -130,7 +130,7 @@ func (suite *ProjectTestSuite) TestCreateFromLeaderIgnoreInvalidLabels() {
 func (suite *ProjectTestSuite) TestUpdate() {
 	projectConfig := platform.ProjectConfig{
 		Meta: platform.ProjectMeta{
-			Name:      "test-project",
+			Name:      "test-update",
 			Namespace: suite.Namespace,
 			Labels: map[string]string{
 				"something": "here",
@@ -186,7 +186,7 @@ func (suite *ProjectTestSuite) TestUpdate() {
 func (suite *ProjectTestSuite) TestDelete() {
 	projectConfig := platform.ProjectConfig{
 		Meta: platform.ProjectMeta{
-			Name:      "test-project",
+			Name:      "test-delete",
 			Namespace: suite.Namespace,
 			Labels: map[string]string{
 				"something": "here",

--- a/pkg/platform/kube/test/suite/suite.go
+++ b/pkg/platform/kube/test/suite/suite.go
@@ -145,10 +145,6 @@ func (suite *KubeTestSuite) SetupSuite() {
 
 func (suite *KubeTestSuite) SetupTest() {
 	suite.TestSuite.SetupTest()
-
-	// default project gets deleted during testings, ensure it is being recreated
-	err := suite.Platform.EnsureDefaultProjectExistence(suite.Ctx)
-	suite.Require().NoError(err, "Failed to ensure default project exists")
 }
 
 func (suite *KubeTestSuite) TearDownTest() {

--- a/pkg/platform/kube/test/suite/suite.go
+++ b/pkg/platform/kube/test/suite/suite.go
@@ -33,6 +33,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/errgroup"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
+	nuctlSuite "github.com/nuclio/nuclio/pkg/nuctl/test"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/abstract"
 	"github.com/nuclio/nuclio/pkg/platform/kube"
@@ -63,12 +64,14 @@ type OnAfterIngressCreated func(*networkingv1.Ingress)
 
 type KubeTestSuite struct {
 	processorsuite.TestSuite
+	nuctlRunner       *nuctlSuite.NuctlRunner
 	CmdRunner         cmdrunner.CmdRunner
 	RegistryURL       string
 	Controller        *controller.Controller
 	KubeClientSet     *kubernetes.Clientset
 	FunctionClientSet *nuclioioclient.Clientset
 	FunctionClient    functionres.Client
+	projectName       string
 
 	DisableControllerStart bool
 	Ctx                    context.Context
@@ -131,6 +134,13 @@ func (suite *KubeTestSuite) SetupSuite() {
 	// create controller instance
 	suite.Controller = suite.createController()
 
+	// create project
+	suite.projectName = "test-project"
+
+	suite.nuctlRunner = nuctlSuite.NewNuctlRunner(suite.Namespace, suite.Logger)
+
+	suite.nuctlRunner.Run([]string{"create", "project", suite.projectName}, map[string]string{}) // nolint: errcheck
+
 	if !suite.DisableControllerStart {
 
 		// start controller
@@ -170,7 +180,6 @@ func (suite *KubeTestSuite) TearDownTest() {
 	errGroup, _ := errgroup.WithContext(suite.Ctx, suite.Logger)
 	for _, resourceKind := range []string{
 		"nucliofunctions",
-		"nuclioprojects",
 		"nucliofunctionevents",
 		"nuclioapigateways",
 	} {
@@ -203,6 +212,11 @@ func (suite *KubeTestSuite) TearDownTest() {
 	suite.Require().NoError(err, "Not all nuclio resources were deleted")
 }
 
+func (suite *KubeTestSuite) TearDownSuite() {
+	// remove project
+	suite.nuctlRunner.Run([]string{"delete", "project", suite.projectName}, map[string]string{}) // nolint: errcheck
+}
+
 func (suite *KubeTestSuite) CompileCreateFunctionOptions(functionName string) *platform.CreateFunctionOptions {
 	createFunctionOptions := &platform.CreateFunctionOptions{
 		Logger: suite.Logger,
@@ -210,7 +224,9 @@ func (suite *KubeTestSuite) CompileCreateFunctionOptions(functionName string) *p
 			Meta: functionconfig.Meta{
 				Name:      functionName,
 				Namespace: suite.Namespace,
-				Labels:    map[string]string{},
+				Labels: map[string]string{
+					common.NuclioResourceLabelKeyProjectName: suite.projectName,
+				},
 			},
 			Spec: functionconfig.Spec{
 				Build: functionconfig.Build{
@@ -734,7 +750,9 @@ func (suite *KubeTestSuite) CompileCreateAPIGatewayOptions(apiGatewayName string
 			Meta: platform.APIGatewayMeta{
 				Name:      apiGatewayName,
 				Namespace: suite.Namespace,
-				Labels:    map[string]string{},
+				Labels: map[string]string{
+					common.NuclioResourceLabelKeyProjectName: suite.projectName,
+				},
 			},
 			Spec: platform.APIGatewaySpec{
 				Host:               "some-host",

--- a/pkg/platform/kube/test/suite/suite.go
+++ b/pkg/platform/kube/test/suite/suite.go
@@ -135,11 +135,12 @@ func (suite *KubeTestSuite) SetupSuite() {
 	suite.Controller = suite.createController()
 
 	// create project
-	suite.projectName = "test-project"
+	suite.projectName = "test-project-" + xid.New().String()
 
 	suite.nuctlRunner = nuctlSuite.NewNuctlRunner(suite.Namespace, suite.Logger)
 
-	suite.nuctlRunner.Run([]string{"create", "project", suite.projectName}, map[string]string{}) // nolint: errcheck
+	err = suite.nuctlRunner.Run([]string{"create", "project", suite.projectName}, map[string]string{})
+	suite.Require().NoError(err, "Failed to create project")
 
 	if !suite.DisableControllerStart {
 
@@ -214,7 +215,11 @@ func (suite *KubeTestSuite) TearDownTest() {
 
 func (suite *KubeTestSuite) TearDownSuite() {
 	// remove project
-	suite.nuctlRunner.Run([]string{"delete", "project", suite.projectName}, map[string]string{}) // nolint: errcheck
+	if err := suite.nuctlRunner.Run([]string{"delete", "project", suite.projectName}, map[string]string{}); err != nil {
+		suite.Logger.WarnWith("Failed to delete project",
+			"projectName", suite.projectName,
+			"err", err.Error())
+	}
 }
 
 func (suite *KubeTestSuite) CompileCreateFunctionOptions(functionName string) *platform.CreateFunctionOptions {

--- a/pkg/platform/kube/test/suite/suite.go
+++ b/pkg/platform/kube/test/suite/suite.go
@@ -214,12 +214,8 @@ func (suite *KubeTestSuite) TearDownTest() {
 }
 
 func (suite *KubeTestSuite) TearDownSuite() {
-	// remove project
-	if err := suite.nuctlRunner.Run([]string{"delete", "project", suite.projectName}, map[string]string{}); err != nil {
-		suite.Logger.WarnWith("Failed to delete project",
-			"projectName", suite.projectName,
-			"err", err.Error())
-	}
+	err := suite.nuctlRunner.Run([]string{"delete", "project", suite.projectName}, map[string]string{})
+	suite.Require().NoError(err, "Failed to delete project")
 }
 
 func (suite *KubeTestSuite) CompileCreateFunctionOptions(functionName string) *platform.CreateFunctionOptions {

--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -440,25 +440,34 @@ func (s *Store) runCommand(env map[string]string, format string, args ...interfa
 			return "", "", errors.Wrapf(err, "Failed to execute command: %s", command)
 		}
 
-		// run a container that simply volumizes the volume with the storage and sleeps for 6 hours
-		// using alpine mirrored to gcr.io/iguazio for stability
-		if _, err := s.dockerClient.RunContainer(s.imageName, &dockerclient.RunOptions{
-			Volumes:          map[string]string{volumeName: baseDir},
-			Remove:           true,
-			Command:          `/bin/sh -c "/bin/sleep 6h"`,
-			Stdout:           &commandStdout,
-			ImageMayNotExist: true,
-			ContainerName:    containerName,
-		}); err != nil &&
-			!strings.Contains(err.Error(), "is already in use by container") {
-
-			// if we failed and the error is not that it already exists, return the error
-
-			return "", "", errors.Wrap(err, "Failed to run container with storage volume")
+		commandStdout, err = s.Init()
+		if err != nil {
+			return commandStdout, "", errors.Wrapf(err, "Failed to init container for command: %s", command)
 		}
 	}
 
 	return commandStdout, commandStderr, nil
+}
+
+func (s *Store) Init() (string, error) {
+	var commandStdout string
+
+	// run a container that simply volumizes the volume with the storage and sleeps for 6 hours
+	// using alpine mirrored to gcr.io/iguazio for stability
+	if _, err := s.dockerClient.RunContainer(s.imageName, &dockerclient.RunOptions{
+		Volumes:          map[string]string{volumeName: baseDir},
+		Remove:           true,
+		Command:          `/bin/sh -c "/bin/sleep 6h"`,
+		Stdout:           &commandStdout,
+		ImageMayNotExist: true,
+		ContainerName:    containerName,
+	}); err != nil &&
+		!strings.Contains(err.Error(), "is already in use by container") {
+
+		// if we failed and the error is not that it already exists, return the error
+		return commandStdout, errors.Wrap(err, "Failed to run container with storage volume")
+	}
+	return commandStdout, nil
 }
 
 func (s *Store) deleteResource(resourceDir string, resourceNamespace string, resourceName string) error {

--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -440,7 +440,7 @@ func (s *Store) runCommand(env map[string]string, format string, args ...interfa
 			return "", "", errors.Wrapf(err, "Failed to execute command: %s", command)
 		}
 
-		commandStdout, err = s.Init()
+		commandStdout, err = s.Initialize()
 		if err != nil {
 			return commandStdout, "", errors.Wrapf(err, "Failed to init container for command: %s", command)
 		}
@@ -449,7 +449,7 @@ func (s *Store) runCommand(env map[string]string, format string, args ...interfa
 	return commandStdout, commandStderr, nil
 }
 
-func (s *Store) Init() (string, error) {
+func (s *Store) Initialize() (string, error) {
 	var commandStdout string
 
 	isExists, err := s.containerExists()

--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -442,7 +442,7 @@ func (s *Store) runCommand(env map[string]string, format string, args ...interfa
 
 		commandStdout, err = s.Initialize()
 		if err != nil {
-			return commandStdout, "", errors.Wrapf(err, "Failed to init container for command: %s", command)
+			return commandStdout, "", errors.Wrapf(err, "Failed to initialize container for command: %s", command)
 		}
 	}
 

--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -452,7 +452,7 @@ func (s *Store) runCommand(env map[string]string, format string, args ...interfa
 func (s *Store) Init() (string, error) {
 	var commandStdout string
 
-	isExists, err := s.isContainerExists()
+	isExists, err := s.containerExists()
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to check if container exists")
 	}
@@ -480,7 +480,7 @@ func (s *Store) Init() (string, error) {
 	return commandStdout, nil
 }
 
-func (s *Store) isContainerExists() (bool, error) {
+func (s *Store) containerExists() (bool, error) {
 	containers, err := s.dockerClient.GetContainers(&dockerclient.GetContainerOptions{
 		Name: containerName,
 	})
@@ -488,7 +488,7 @@ func (s *Store) isContainerExists() (bool, error) {
 		return false, errors.Wrap(err, "Failed to get containers")
 	}
 
-	return len(containers) > 0 , nil
+	return len(containers) > 0, nil
 }
 
 func (s *Store) deleteResource(resourceDir string, resourceNamespace string, resourceName string) error {

--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -452,6 +452,16 @@ func (s *Store) runCommand(env map[string]string, format string, args ...interfa
 func (s *Store) Init() (string, error) {
 	var commandStdout string
 
+	isExists, err := s.isContainerExists()
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to check if container exists")
+	}
+
+	if isExists {
+		s.logger.DebugWith("Container already exists, not running again", "containerName", containerName)
+		return "", nil
+	}
+
 	// run a container that simply volumizes the volume with the storage and sleeps for 6 hours
 	// using alpine mirrored to gcr.io/iguazio for stability
 	if _, err := s.dockerClient.RunContainer(s.imageName, &dockerclient.RunOptions{
@@ -468,6 +478,17 @@ func (s *Store) Init() (string, error) {
 		return commandStdout, errors.Wrap(err, "Failed to run container with storage volume")
 	}
 	return commandStdout, nil
+}
+
+func (s *Store) isContainerExists() (bool, error) {
+	containers, err := s.dockerClient.GetContainers(&dockerclient.GetContainerOptions{
+		Name: containerName,
+	})
+	if err != nil {
+		return false, errors.Wrap(err, "Failed to get containers")
+	}
+
+	return len(containers) > 0 , nil
 }
 
 func (s *Store) deleteResource(resourceDir string, resourceNamespace string, resourceName string) error {

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -153,9 +153,13 @@ func NewPlatform(ctx context.Context,
 	return newPlatform, nil
 }
 
-func (p *Platform) Initialize(ctx context.Context) error {
+func (p *Platform) Initialize(_ context.Context) error {
 	if err := p.projectsClient.Initialize(); err != nil {
 		return errors.Wrap(err, "Failed to initialize projects client")
+	}
+
+	if _, err := p.localStore.Init(); err != nil {
+		return errors.Wrap(err, "Failed to initialize local store")
 	}
 
 	return nil

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -158,13 +158,6 @@ func (p *Platform) Initialize(ctx context.Context) error {
 		return errors.Wrap(err, "Failed to initialize projects client")
 	}
 
-	// ensure default project existence only when projects aren't managed by external leader
-	if p.Config.ProjectsLeader == nil {
-		if err := p.EnsureDefaultProjectExistence(ctx); err != nil {
-			return errors.Wrap(err, "Failed to ensure default project existence")
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -158,7 +158,7 @@ func (p *Platform) Initialize(_ context.Context) error {
 		return errors.Wrap(err, "Failed to initialize projects client")
 	}
 
-	if _, err := p.localStore.Init(); err != nil {
+	if _, err := p.localStore.Initialize(); err != nil {
 		return errors.Wrap(err, "Failed to initialize local store")
 	}
 

--- a/pkg/platform/local/test/platform_test.go
+++ b/pkg/platform/local/test/platform_test.go
@@ -30,15 +30,13 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform/local"
 	processorsuite "github.com/nuclio/nuclio/pkg/processor/test/suite"
 
-	"github.com/rs/xid"
 	"github.com/stretchr/testify/suite"
 )
 
 type TestSuite struct {
 	processorsuite.TestSuite
-	namespace   string
-	ctx         context.Context
-	projectName string
+	namespace string
+	ctx       context.Context
 }
 
 func (suite *TestSuite) SetupSuite() {
@@ -52,10 +50,8 @@ func (suite *TestSuite) SetupSuite() {
 	// we will work on the first one
 	suite.namespace = namespaces[0]
 
-	suite.projectName = "test-project-" + xid.New().String()
-
 	getProjectsOptions := &platform.CreateProjectOptions{
-		ProjectConfig: &platform.ProjectConfig{Meta: platform.ProjectMeta{Name: suite.projectName, Namespace: suite.namespace}, Spec: platform.ProjectSpec{
+		ProjectConfig: &platform.ProjectConfig{Meta: platform.ProjectMeta{Name: suite.ProjectName, Namespace: suite.namespace}, Spec: platform.ProjectSpec{
 			Description: "just a description",
 		}},
 	}
@@ -66,7 +62,7 @@ func (suite *TestSuite) SetupSuite() {
 func (suite *TestSuite) TearDownSuite() {
 	err := suite.Platform.DeleteProject(suite.ctx, &platform.DeleteProjectOptions{
 		Meta: platform.ProjectMeta{
-			Name:      suite.projectName,
+			Name:      suite.ProjectName,
 			Namespace: suite.namespace,
 		},
 	})

--- a/pkg/platform/local/test/platform_test.go
+++ b/pkg/platform/local/test/platform_test.go
@@ -51,7 +51,7 @@ func (suite *TestSuite) SetupSuite() {
 	suite.namespace = namespaces[0]
 
 	getProjectsOptions := &platform.CreateProjectOptions{
-		ProjectConfig: &platform.ProjectConfig{Meta: platform.ProjectMeta{Name: platform.DefaultProjectName, Namespace: suite.namespace}, Spec: platform.ProjectSpec{
+		ProjectConfig: &platform.ProjectConfig{Meta: platform.ProjectMeta{Name: "test-project", Namespace: suite.namespace}, Spec: platform.ProjectSpec{
 			Description: "just a description",
 		}},
 	}

--- a/pkg/platform/local/test/platform_test.go
+++ b/pkg/platform/local/test/platform_test.go
@@ -30,13 +30,15 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform/local"
 	processorsuite "github.com/nuclio/nuclio/pkg/processor/test/suite"
 
+	"github.com/rs/xid"
 	"github.com/stretchr/testify/suite"
 )
 
 type TestSuite struct {
 	processorsuite.TestSuite
-	namespace string
-	ctx       context.Context
+	namespace   string
+	ctx         context.Context
+	projectName string
 }
 
 func (suite *TestSuite) SetupSuite() {
@@ -50,13 +52,25 @@ func (suite *TestSuite) SetupSuite() {
 	// we will work on the first one
 	suite.namespace = namespaces[0]
 
+	suite.projectName = "test-project-" + xid.New().String()
+
 	getProjectsOptions := &platform.CreateProjectOptions{
-		ProjectConfig: &platform.ProjectConfig{Meta: platform.ProjectMeta{Name: "test-project", Namespace: suite.namespace}, Spec: platform.ProjectSpec{
+		ProjectConfig: &platform.ProjectConfig{Meta: platform.ProjectMeta{Name: suite.projectName, Namespace: suite.namespace}, Spec: platform.ProjectSpec{
 			Description: "just a description",
 		}},
 	}
 	err = suite.Platform.CreateProject(suite.ctx, getProjectsOptions)
 	suite.Require().NoError(err, "Failed to create project")
+}
+
+func (suite *TestSuite) TearDownSuite() {
+	err := suite.Platform.DeleteProject(suite.ctx, &platform.DeleteProjectOptions{
+		Meta: platform.ProjectMeta{
+			Name:      suite.projectName,
+			Namespace: suite.namespace,
+		},
+	})
+	suite.Require().NoError(err, "Failed to delete project")
 }
 
 // Test function containers healthiness validation

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -383,10 +383,6 @@ func (mp *Platform) Initialize(ctx context.Context) error {
 	return nil
 }
 
-func (mp *Platform) EnsureDefaultProjectExistence(ctx context.Context) error {
-	return nil
-}
-
 func (mp *Platform) GetProcessorLogsAndBriefError(scanner *bufio.Scanner) (string, string) {
 	return "", ""
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -115,9 +115,6 @@ type Platform interface {
 	// GetProjects will list existing projects
 	GetProjects(ctx context.Context, getProjectsOptions *GetProjectsOptions) ([]Project, error)
 
-	// EnsureDefaultProjectExistence ensure default project exists, creates it otherwise
-	EnsureDefaultProjectExistence(ctx context.Context) error
-
 	// WaitForProjectResourcesDeletion waits for all the project's resources to be deleted
 	WaitForProjectResourcesDeletion(ctx context.Context, projectMeta *ProjectMeta, duration time.Duration) error
 

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -242,8 +242,6 @@ type CreateFunctionInvocationResult struct {
 // Project
 //
 
-const DefaultProjectName string = "default"
-
 type ProjectMeta struct {
 	Name        string            `json:"name,omitempty"`
 	Namespace   string            `json:"namespace,omitempty"`

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -516,7 +516,7 @@ func (b *Builder) validateAndEnrichConfiguration() error {
 
 	// enrich project name
 	if _, err := b.options.FunctionConfig.GetProjectName(); err != nil {
-		b.options.FunctionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName] = platform.DefaultProjectName
+		return errors.New("Function name can not be empty")
 	}
 
 	// if the function handler isn't set, ask runtime

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -514,7 +514,6 @@ func (b *Builder) validateAndEnrichConfiguration() error {
 		b.options.FunctionConfig.Spec.Runtime = "python:3.11"
 	}
 
-	// enrich project name
 	if _, err := b.options.FunctionConfig.GetProjectName(); err != nil {
 		return errors.New("Function name can not be empty")
 	}

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -515,7 +515,7 @@ func (b *Builder) validateAndEnrichConfiguration() error {
 	}
 
 	if _, err := b.options.FunctionConfig.GetProjectName(); err != nil {
-		return errors.New("Function name can not be empty")
+		return errors.Wrap(err, "Failed to get project name")
 	}
 
 	// if the function handler isn't set, ask runtime
@@ -1902,7 +1902,7 @@ func (b *Builder) resolveFunctionHealthCheckInterval() (time.Duration, error) {
 // resolveNodeSelector resolves builder NodeSelector from function, project and platform NodeSelectors,
 // where function values take precedence over project values, and project values take precedence over platform values
 func (b *Builder) resolveNodeSelector(ctx context.Context) (map[string]string, error) {
-	// if the platform is not Kube, nodeSelector resolution is not relevant
+	// if the platform is not Kube, nodeSelector should not be resolved
 	if b.platform.GetConfig().Kind != common.KubePlatformName {
 		b.logger.Debug("NodeSelector resolution is only applicable for Kube platform, skipping")
 		return nil, nil
@@ -1913,16 +1913,6 @@ func (b *Builder) resolveNodeSelector(ctx context.Context) (map[string]string, e
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get project for the function")
 	}
-	b.logger.Debug("KAWABANGA")
-
-	b.logger.DebugWith("KAWABANGA2",
-		"project.GetConfig", project.GetConfig(),
-		"b.platform.GetConfig", b.platform.GetConfig(),
-	)
-	b.logger.DebugWith("KAWABANGA3",
-		"project.GetConfig().Spec", project.GetConfig().Spec,
-		"b.platform.GetConfig().Kube", b.platform.GetConfig().Kube,
-	)
 	// enriching from both project and platform
 	builderNodeSelector = utils.MergeNodeSelector(b.options.FunctionConfig.Spec.NodeSelector,
 		project.GetConfig().Spec.DefaultFunctionNodeSelector,

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1908,7 +1908,13 @@ func (b *Builder) resolveNodeSelector(ctx context.Context) (map[string]string, e
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get project for the function")
 	}
-	b.logger.DebugWith("KAWABANGA",
+	b.logger.Debug("KAWABANGA")
+
+	b.logger.DebugWith("KAWABANGA2",
+		"project.GetConfig", project.GetConfig(),
+		"b.platform.GetConfig", b.platform.GetConfig(),
+	)
+	b.logger.DebugWith("KAWABANGA3",
 		"project.GetConfig().Spec", project.GetConfig().Spec,
 		"b.platform.GetConfig().Kube", b.platform.GetConfig().Kube,
 	)

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1902,6 +1902,12 @@ func (b *Builder) resolveFunctionHealthCheckInterval() (time.Duration, error) {
 // resolveNodeSelector resolves builder NodeSelector from function, project and platform NodeSelectors,
 // where function values take precedence over project values, and project values take precedence over platform values
 func (b *Builder) resolveNodeSelector(ctx context.Context) (map[string]string, error) {
+	// if the platform is not Kube, nodeSelector resolution is not relevant
+	if b.platform.GetConfig().Kind != common.KubePlatformName {
+		b.logger.Debug("NodeSelector resolution is only applicable for Kube platform, skipping")
+		return nil, nil
+	}
+
 	var builderNodeSelector map[string]string
 	project, err := b.platform.GetFunctionProject(ctx, &b.options.FunctionConfig)
 	if err != nil {

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1908,6 +1908,10 @@ func (b *Builder) resolveNodeSelector(ctx context.Context) (map[string]string, e
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get project for the function")
 	}
+	b.logger.DebugWith("KAWABANGA",
+		"project.GetConfig().Spec", project.GetConfig().Spec,
+		"b.platform.GetConfig().Kube", b.platform.GetConfig().Kube,
+	)
 	// enriching from both project and platform
 	builderNodeSelector = utils.MergeNodeSelector(b.options.FunctionConfig.Spec.NodeSelector,
 		project.GetConfig().Spec.DefaultFunctionNodeSelector,

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -86,7 +86,7 @@ func (suite *testSuite) SetupTest() {
 
 	functionConfig := functionconfig.NewConfig()
 	functionConfig.Meta.Labels = map[string]string{
-		common.NuclioResourceLabelKeyProjectName: platform.DefaultProjectName,
+		common.NuclioResourceLabelKeyProjectName: "test-project",
 	}
 
 	createFunctionOptions := &platform.CreateFunctionOptions{

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -55,6 +55,7 @@ type testSuite struct {
 	logger       logger.Logger
 	builder      *Builder
 	testID       string
+	projectName  string
 	mockS3Client *common.MockS3Client
 	mockPlatform *mockplatform.Platform
 	ctx          context.Context
@@ -66,6 +67,7 @@ func (suite *testSuite) SetupSuite() {
 
 	suite.logger, err = nucliozap.NewNuclioZapTest("test")
 	suite.Require().NoError(err)
+	suite.projectName = "test-project-" + xid.New().String()
 
 	suite.mockS3Client = &common.MockS3Client{
 		FilePath: FunctionsArchiveFilePath,
@@ -86,7 +88,7 @@ func (suite *testSuite) SetupTest() {
 
 	functionConfig := functionconfig.NewConfig()
 	functionConfig.Meta.Labels = map[string]string{
-		common.NuclioResourceLabelKeyProjectName: "test-project",
+		common.NuclioResourceLabelKeyProjectName: suite.projectName,
 	}
 
 	createFunctionOptions := &platform.CreateFunctionOptions{
@@ -115,10 +117,11 @@ func (suite *testSuite) TestGetRuntimeNameFromConfig() {
 }
 
 func (suite *testSuite) TestGetBuildFlags() {
-	suite.builder.options.FunctionConfig.Spec.Build.Flags = []string{"--insecure-pull", "-f && whoami &&", "--label key=value"}
+	projectFlag := fmt.Sprintf("--project-name %s", suite.projectName)
+	suite.builder.options.FunctionConfig.Spec.Build.Flags = []string{"--insecure-pull", "-f && whoami &&", "--label key=value", projectFlag}
 	flags := suite.builder.getBuildFlags()
 
-	suite.Require().Equal(map[string]bool{"'--label key=value'": true, "'-f && whoami &&'": true, "--insecure-pull": true}, flags)
+	suite.Require().Equal(map[string]bool{"'--label key=value'": true, "'-f && whoami &&'": true, "--insecure-pull": true, fmt.Sprintf("'%s'", projectFlag): true}, flags)
 }
 
 // Make sure that "Builder.getRuntimeName" properly reads the runtime name from the build path if not set by the user

--- a/pkg/processor/build/test/build_test.go
+++ b/pkg/processor/build/test/build_test.go
@@ -87,6 +87,14 @@ echo 'test'`
 func (suite *testSuite) TestBuildFunctionFromSourceCodeMaintainsSource() {
 	createFunctionOptions := &platform.CreateFunctionOptions{
 		Logger: suite.Logger,
+		FunctionConfig: functionconfig.Config{
+			Meta: functionconfig.Meta{
+				Namespace: suite.Namespace,
+				Labels: map[string]string{
+					common.NuclioResourceLabelKeyProjectName: suite.ProjectName,
+				},
+			},
+		},
 	}
 
 	functionSourceCode := base64.StdEncoding.EncodeToString([]byte(`def handler(context, event):
@@ -105,7 +113,7 @@ func (suite *testSuite) TestBuildFunctionFromSourceCodeMaintainsSource() {
 	suite.Require().NoError(err)
 
 	createFunctionOptions.FunctionConfig.Meta.Name = "funcsource-test"
-	createFunctionOptions.FunctionConfig.Meta.Namespace = "default"
+	createFunctionOptions.FunctionConfig.Meta.Namespace = suite.Namespace
 	createFunctionOptions.FunctionConfig.Spec.Handler = "main:handler"
 	createFunctionOptions.FunctionConfig.Spec.Runtime = "python"
 	createFunctionOptions.FunctionConfig.Spec.Build.Path = tempFile.Name()
@@ -139,7 +147,7 @@ func (suite *testSuite) TestBuildFunctionFromSourceCodeDeployOnceNeverBuild() {
 `))
 
 	createFunctionOptions.FunctionConfig.Meta.Name = "neverbuild-test"
-	createFunctionOptions.FunctionConfig.Meta.Namespace = "default"
+	createFunctionOptions.FunctionConfig.Meta.Namespace = suite.Namespace
 	createFunctionOptions.FunctionConfig.Spec.Handler = "main:handler"
 	createFunctionOptions.FunctionConfig.Spec.Runtime = "python"
 	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = functionSourceCode
@@ -173,6 +181,14 @@ func (suite *testSuite) TestBuildFunctionFromSourceCodeNeverBuildRedeploy() {
 
 	createFunctionOptions := &platform.CreateFunctionOptions{
 		Logger: suite.Logger,
+		FunctionConfig: functionconfig.Config{
+			Meta: functionconfig.Meta{
+				Namespace: suite.Namespace,
+				Labels: map[string]string{
+					common.NuclioResourceLabelKeyProjectName: suite.ProjectName,
+				},
+			},
+		},
 	}
 
 	functionSourceCode := base64.StdEncoding.EncodeToString([]byte(`def handler(context, event):
@@ -180,7 +196,7 @@ func (suite *testSuite) TestBuildFunctionFromSourceCodeNeverBuildRedeploy() {
 `))
 
 	createFunctionOptions.FunctionConfig.Meta.Name = "neverbuild-redeploy-func"
-	createFunctionOptions.FunctionConfig.Meta.Namespace = "default"
+	createFunctionOptions.FunctionConfig.Meta.Namespace = suite.Namespace
 	createFunctionOptions.FunctionConfig.Spec.Handler = "main:handler"
 	createFunctionOptions.FunctionConfig.Spec.Runtime = "python"
 	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = functionSourceCode
@@ -312,6 +328,10 @@ func (suite *testSuite) TestDockerCacheUtilized() {
 	}
 
 	createFunctionOptions.FunctionConfig.Meta.Name = "cache-test"
+	createFunctionOptions.FunctionConfig.Meta.Namespace = suite.Namespace
+	createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
+		common.NuclioResourceLabelKeyProjectName: suite.ProjectName,
+	}
 	createFunctionOptions.FunctionConfig.Spec.Runtime = "python"
 	createFunctionOptions.FunctionConfig.Spec.Handler = "cachetest:handler"
 	createFunctionOptions.FunctionConfig.Spec.Build.TempDir = suite.CreateTempDir()
@@ -501,7 +521,10 @@ func (suite *testSuite) TestBuildFuncFromRemoteArchiveRedeploy() {
 		FunctionConfig: functionconfig.Config{
 			Meta: functionconfig.Meta{
 				Name:      "build-from-local",
-				Namespace: "default",
+				Namespace: suite.Namespace,
+				Labels: map[string]string{
+					common.NuclioResourceLabelKeyProjectName: suite.ProjectName,
+				},
 			},
 			Spec: functionconfig.Spec{
 				Env: []v1.EnvVar{
@@ -551,7 +574,10 @@ func (suite *testSuite) TestBuildFuncFromLocalArchiveRedeployUsesSameImage() {
 		FunctionConfig: functionconfig.Config{
 			Meta: functionconfig.Meta{
 				Name:      "build-from-local",
-				Namespace: "default",
+				Namespace: suite.Namespace,
+				Labels: map[string]string{
+					common.NuclioResourceLabelKeyProjectName: suite.ProjectName,
+				},
 			},
 			Spec: functionconfig.Spec{
 				Handler: "main:handler",
@@ -610,7 +636,10 @@ func (suite *testSuite) TestBuildWithFlags() {
 			FunctionConfig: functionconfig.Config{
 				Meta: functionconfig.Meta{
 					Name:      "build-from-local",
-					Namespace: "default",
+					Namespace: suite.Namespace,
+					Labels: map[string]string{
+						common.NuclioResourceLabelKeyProjectName: suite.ProjectName,
+					},
 				},
 				Spec: functionconfig.Spec{
 					Env: []v1.EnvVar{
@@ -930,7 +959,10 @@ func (suite *testSuite) createShellFunctionFromSourceCode(functionName string,
 		FunctionConfig: functionconfig.Config{
 			Meta: functionconfig.Meta{
 				Name:      functionName,
-				Namespace: "default",
+				Namespace: suite.Namespace,
+				Labels: map[string]string{
+					common.NuclioResourceLabelKeyProjectName: suite.ProjectName,
+				},
 			},
 			Spec: functionconfig.Spec{
 				Handler: fmt.Sprintf("%s.sh", functionName),
@@ -952,13 +984,15 @@ func (suite *testSuite) createShellFunctionWithResponse(responseMessage string) 
 # function.yaml:
 #   metadata:
 #     name: %s
-#     namespace: default
+#     namespace: %s
+#	  labels:
+#     - %s: %s
 #   spec:
 #     env:
 #     - name: MESSAGE
 #       value: %s
 echo ${MESSAGE}
-`, functionName, responseMessage)
+`, functionName, suite.Namespace, common.NuclioResourceLabelKeyProjectName, suite.ProjectName, responseMessage)
 
 	return suite.createShellFunctionFromSourceCode(functionName, functionSourceCode,
 		&httpsuite.Request{

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -29,6 +29,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
+	nuctlSuite "github.com/nuclio/nuclio/pkg/nuctl/test"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/abstract"
 	"github.com/nuclio/nuclio/pkg/platform/factory"
@@ -76,6 +77,7 @@ type TestSuite struct {
 	containerID            string
 	createdTempDirs        []string
 	cleanupCreatedTempDirs bool
+	nuctlRunner            *nuctlSuite.NuctlRunner
 }
 
 // BlastConfiguration holds information for BlastHTTP function
@@ -119,6 +121,10 @@ func (suite *TestSuite) SetupSuite() {
 	suite.Require().NoError(err)
 
 	suite.ctx = context.Background()
+
+	suite.nuctlRunner = nuctlSuite.NewNuctlRunner(suite.Namespace, suite.Logger)
+	err = suite.nuctlRunner.Run([]string{"create", "project", suite.ProjectName}, map[string]string{})
+	suite.Require().NoError(err, "Failed to create project")
 
 	suite.DockerClient, err = dockerclient.NewShellClient(suite.Logger, nil)
 	suite.Require().NoError(err)
@@ -279,6 +285,11 @@ func (suite *TestSuite) TearDownTest() {
 			}
 		}
 	}
+}
+
+func (suite *TestSuite) TearDownSuite() {
+	err := suite.nuctlRunner.Run([]string{"delete", "project", suite.ProjectName}, map[string]string{})
+	suite.Require().NoError(err, "Failed to delete project")
 }
 
 // GetFunction will return the first function it finds

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -123,8 +123,6 @@ func (suite *TestSuite) SetupSuite() {
 	suite.ctx = context.Background()
 
 	suite.nuctlRunner = nuctlSuite.NewNuctlRunner(suite.Namespace, suite.Logger)
-	err = suite.nuctlRunner.Run([]string{"create", "project", suite.ProjectName}, map[string]string{})
-	suite.Require().NoError(err, "Failed to create project")
 
 	suite.DockerClient, err = dockerclient.NewShellClient(suite.Logger, nil)
 	suite.Require().NoError(err)
@@ -140,6 +138,9 @@ func (suite *TestSuite) SetupSuite() {
 		"")
 	suite.Require().NoError(err)
 	suite.Require().NotNil(suite.Platform)
+
+	err = suite.nuctlRunner.Run([]string{"create", "project", suite.ProjectName}, map[string]string{})
+	suite.Require().NoError(err, "Failed to create project")
 }
 
 // SetupTest is called before each test in the suite

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -26,10 +26,10 @@ import (
 	"path"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/auth/nop"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
-	nuctlSuite "github.com/nuclio/nuclio/pkg/nuctl/test"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/abstract"
 	"github.com/nuclio/nuclio/pkg/platform/factory"
@@ -77,7 +77,6 @@ type TestSuite struct {
 	containerID            string
 	createdTempDirs        []string
 	cleanupCreatedTempDirs bool
-	nuctlRunner            *nuctlSuite.NuctlRunner
 }
 
 // BlastConfiguration holds information for BlastHTTP function
@@ -122,8 +121,6 @@ func (suite *TestSuite) SetupSuite() {
 
 	suite.ctx = context.Background()
 
-	suite.nuctlRunner = nuctlSuite.NewNuctlRunner(suite.Namespace, suite.Logger)
-
 	suite.DockerClient, err = dockerclient.NewShellClient(suite.Logger, nil)
 	suite.Require().NoError(err)
 
@@ -139,7 +136,16 @@ func (suite *TestSuite) SetupSuite() {
 	suite.Require().NoError(err)
 	suite.Require().NotNil(suite.Platform)
 
-	err = suite.nuctlRunner.Run([]string{"create", "project", suite.ProjectName}, map[string]string{})
+	// create project
+	err = suite.Platform.CreateProject(suite.ctx, &platform.CreateProjectOptions{
+		AuthSession: &nop.Session{},
+		ProjectConfig: &platform.ProjectConfig{
+			Meta: platform.ProjectMeta{
+				Name:      suite.ProjectName,
+				Namespace: suite.Namespace,
+			},
+		},
+	})
 	suite.Require().NoError(err, "Failed to create project")
 }
 
@@ -289,8 +295,16 @@ func (suite *TestSuite) TearDownTest() {
 }
 
 func (suite *TestSuite) TearDownSuite() {
-	err := suite.nuctlRunner.Run([]string{"delete", "project", suite.ProjectName}, map[string]string{})
-	suite.Require().NoError(err, "Failed to delete project")
+	if err := suite.Platform.DeleteProject(suite.ctx, &platform.DeleteProjectOptions{
+		AuthSession: &nop.Session{},
+		Meta: platform.ProjectMeta{
+			Name:      suite.ProjectName,
+			Namespace: suite.Namespace,
+		},
+		Strategy: platform.DeleteProjectStrategyRestricted,
+	}); err != nil {
+		suite.Logger.WarnWith("Failed to delete project","projectName", suite.ProjectName, "error", err)
+	}
 }
 
 // GetFunction will return the first function it finds

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -137,6 +137,7 @@ func (suite *TestSuite) SetupSuite() {
 	suite.Require().NotNil(suite.Platform)
 
 	// create project
+	suite.Logger.DebugWith("KAWABANGA creating project","projectName", suite.ProjectName, "namespace", suite.Namespace)
 	err = suite.Platform.CreateProject(suite.ctx, &platform.CreateProjectOptions{
 		AuthSession: &nop.Session{},
 		ProjectConfig: &platform.ProjectConfig{
@@ -295,6 +296,7 @@ func (suite *TestSuite) TearDownTest() {
 }
 
 func (suite *TestSuite) TearDownSuite() {
+	suite.Logger.DebugWith("KAWABANGA deleting project","projectName", suite.ProjectName, "namespace", suite.Namespace)
 	if err := suite.Platform.DeleteProject(suite.ctx, &platform.DeleteProjectOptions{
 		AuthSession: &nop.Session{},
 		Meta: platform.ProjectMeta{

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -137,7 +137,6 @@ func (suite *TestSuite) SetupSuite() {
 	suite.Require().NotNil(suite.Platform)
 
 	// create project
-	suite.Logger.DebugWith("KAWABANGA creating project","projectName", suite.ProjectName, "namespace", suite.Namespace)
 	err = suite.Platform.CreateProject(suite.ctx, &platform.CreateProjectOptions{
 		AuthSession: &nop.Session{},
 		ProjectConfig: &platform.ProjectConfig{
@@ -296,7 +295,6 @@ func (suite *TestSuite) TearDownTest() {
 }
 
 func (suite *TestSuite) TearDownSuite() {
-	suite.Logger.DebugWith("KAWABANGA deleting project","projectName", suite.ProjectName, "namespace", suite.Namespace)
 	if err := suite.Platform.DeleteProject(suite.ctx, &platform.DeleteProjectOptions{
 		AuthSession: &nop.Session{},
 		Meta: platform.ProjectMeta{
@@ -305,7 +303,7 @@ func (suite *TestSuite) TearDownSuite() {
 		},
 		Strategy: platform.DeleteProjectStrategyRestricted,
 	}); err != nil {
-		suite.Logger.WarnWith("Failed to delete project","projectName", suite.ProjectName, "error", err)
+		suite.Logger.WarnWith("Failed to delete project", "projectName", suite.ProjectName, "error", err)
 	}
 }
 

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -59,20 +59,20 @@ type OnAfterContainerRun func(deployResult *platform.CreateFunctionResult) bool
 // function container (through an trigger of some sort)
 type TestSuite struct {
 	suite.Suite
-	Logger                logger.Logger
-	LoggerName            string
-	ctx                   context.Context
-	DockerClient          dockerclient.Client
-	Platform              platform.Platform
-	TestID                string
-	Runtime               string
-	RuntimeDir            string
-	FunctionDir           string
-	PlatformType          string
-	Namespace             string
-	PlatformConfiguration *platformconfig.Config
-	FunctionNameUniquify  bool
-
+	Logger                 logger.Logger
+	LoggerName             string
+	ctx                    context.Context
+	DockerClient           dockerclient.Client
+	Platform               platform.Platform
+	TestID                 string
+	Runtime                string
+	RuntimeDir             string
+	FunctionDir            string
+	PlatformType           string
+	Namespace              string
+	PlatformConfiguration  *platformconfig.Config
+	FunctionNameUniquify   bool
+	ProjectName            string
 	containerID            string
 	createdTempDirs        []string
 	cleanupCreatedTempDirs bool
@@ -114,7 +114,7 @@ func (suite *TestSuite) SetupSuite() {
 
 	// this will preserve the current behavior where function names are renamed to be unique upon deployment
 	suite.FunctionNameUniquify = true
-
+	suite.ProjectName = "test-project-" + xid.New().String()
 	suite.Logger, err = nucliozap.NewNuclioZapTest(suite.LoggerName)
 	suite.Require().NoError(err)
 
@@ -439,7 +439,7 @@ func (suite *TestSuite) GetDeployOptions(functionName, functionPath string) *pla
 
 	createFunctionOptions.FunctionConfig.Meta.Name = functionName
 	createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
-		common.NuclioResourceLabelKeyProjectName: "test-project",
+		common.NuclioResourceLabelKeyProjectName: suite.ProjectName,
 	}
 	createFunctionOptions.FunctionConfig.Spec.Runtime = suite.Runtime
 	createFunctionOptions.FunctionConfig.Spec.Build.Path = functionPath

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -438,6 +438,9 @@ func (suite *TestSuite) GetDeployOptions(functionName, functionPath string) *pla
 	}
 
 	createFunctionOptions.FunctionConfig.Meta.Name = functionName
+	createFunctionOptions.FunctionConfig.Meta.Labels = map[string]string{
+		common.NuclioResourceLabelKeyProjectName: "test-project",
+	}
 	createFunctionOptions.FunctionConfig.Spec.Runtime = suite.Runtime
 	createFunctionOptions.FunctionConfig.Spec.Build.Path = functionPath
 	createFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{}

--- a/test/_functions/common/json-parser-with-function-config/dotnetcore/function.yaml
+++ b/test/_functions/common/json-parser-with-function-config/dotnetcore/function.yaml
@@ -14,6 +14,8 @@
 #
 metadata:
   name: parser
+  labels:
+    nuclio.io/project-name: test-project
 spec:
   runtime: dotnetcore
   handler: nuclio:parser

--- a/test/_functions/common/json-parser-with-function-config/golang/function.yaml
+++ b/test/_functions/common/json-parser-with-function-config/golang/function.yaml
@@ -14,6 +14,8 @@
 
 metadata:
   name: parser
+  labels:
+    nuclio.io/project-name: test-project
 spec:
   runtime: golang
   handler: main:Parser

--- a/test/_functions/common/json-parser-with-function-config/java/function.yaml
+++ b/test/_functions/common/json-parser-with-function-config/java/function.yaml
@@ -14,6 +14,8 @@
 
 metadata:
   name: parser
+  labels:
+    nuclio.io/project-name: test-project
 spec:
   runtime: java
   handler: JsonParser

--- a/test/_functions/common/json-parser-with-function-config/nodejs/function.yaml
+++ b/test/_functions/common/json-parser-with-function-config/nodejs/function.yaml
@@ -14,6 +14,8 @@
 
 metadata:
   name: parser
+  labels:
+    nuclio.io/project-name: test-project
 spec:
   runtime: nodejs
   handler: handler

--- a/test/_functions/common/json-parser-with-function-config/python/function.yaml
+++ b/test/_functions/common/json-parser-with-function-config/python/function.yaml
@@ -14,6 +14,8 @@
 
 metadata:
   name: parser
+  labels:
+    nuclio.io/project-name: test-project
 spec:
   runtime: python
   minReplicas: 1

--- a/test/_functions/common/json-parser-with-function-config/ruby/function.yaml
+++ b/test/_functions/common/json-parser-with-function-config/ruby/function.yaml
@@ -14,6 +14,8 @@
 
 metadata:
   name: parser
+  labels:
+    nuclio.io/project-name: test-project
 spec:
   runtime: ruby
   handler: 'parser:main'

--- a/test/_functions/common/json-parser-with-function-config/shell/function.yaml
+++ b/test/_functions/common/json-parser-with-function-config/shell/function.yaml
@@ -14,6 +14,8 @@
 
 metadata:
   name: parser
+  labels:
+    nuclio.io/project-name: test-project
 spec:
   runtime: shell
   handler: parser.sh:main

--- a/test/_imports/autofixable_function.yaml
+++ b/test/_imports/autofixable_function.yaml
@@ -18,6 +18,8 @@ metadata:
     skip-build: "true"
     skip-deploy: "true"
   name: test-function
+  labels:
+    nuclio.io/project-name: test-project
 spec:
   alias: latest
   build:

--- a/test/_imports/function.yaml
+++ b/test/_imports/function.yaml
@@ -17,6 +17,8 @@ metadata:
     skip-build: "true"
     skip-deploy: "true"
   name: test-function
+  labels:
+    nuclio.io/project-name: test-project
 spec:
   build:
     codeEntryType: sourceCode

--- a/test/_imports/functions.yaml
+++ b/test/_imports/functions.yaml
@@ -18,6 +18,8 @@ test-function-1:
       skip-build: "true"
       skip-deploy: "true"
     name: test-function-1
+    labels:
+      nuclio.io/project-name: test-project
   spec:
     build:
       codeEntryType: sourceCode
@@ -31,6 +33,8 @@ test-function-2:
       skip-build: "true"
       skip-deploy: "true"
     name: test-function-2
+    labels:
+      nuclio.io/project-name: test-project
   spec:
     build:
       codeEntryType: sourceCode

--- a/test/_imports/redeploy-test-function.yaml
+++ b/test/_imports/redeploy-test-function.yaml
@@ -17,6 +17,8 @@ metadata:
     skip-build: "true"
     skip-deploy: "true"
   name: redeploy-test-function
+  labels:
+    nuclio.io/project-name: test-project
 spec:
   build:
     codeEntryType: sourceCode


### PR DESCRIPTION
### 📝 Description
This PR removes Nuclio’s special handling of the default project, eliminating its automatic creation, disable deletion, and explicit enrichments to the default project.

As a result of this change, the nuctl CLI was updated to allow specifying a project when building functions.
Test infrastructure was also refactored to create and manage dedicated projects per suite, ensuring tests remain isolated and independent of the default project.

---

### 🛠️ Changes Made
- Platform
  - Removed automatic enrichment of default project name.
  - Removed `EnsureDefaultProjectExistence()` logic that created the default project implicitly.
  - Removed restriction preventing deletion of the default project.
  - Adjusted `GetFunctionProject()` error handling for clearer messages when no or multiple projects are found.

- nuctl CLI
  - Added `--project-name` flag to `nuctl` build for explicitly setting a function’s project.
  - Updated CLI docs to include the new flag.

- Tests & Infrastructure
  - Introduced `NuctlRunner` helper for common nuctl CLI execution in tests.
  - Updated all tests to use dynamically created `suite.projectName` instead of `platform.DefaultProjectName`.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- [x] I have tested the changes in this PR  (details is the JIRA)
- [x] Passed long-ci - https://github.com/nuclio/nuclio/actions/runs/16901405003
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-543

---

### 🚨 Breaking Changes?

- [x] Yes (explain below)

- The addition of the `--project-name` flag to `nuctl` is a breaking change that affects the execution of `nuctl build` and `nuctl deploy`.

---

### 🔍️ Additional Notes
- Function cleanup in long-CI is required and should be handled in a separate task.

