### PR TITLE
[Dashboard] Do not concatenate run registry if image already has registry

### DIFF
--- a/cmd/dashboard/app/run.go
+++ b/cmd/dashboard/app/run.go
@@ -103,7 +103,8 @@ func Run(listenAddress string,
 		rootLogger,
 		platformType,
 		platformConfiguration,
-		defaultNamespace)
+		defaultNamespace,
+		defaultRunRegistryURL)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create platform")
 	}

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -690,3 +690,15 @@ func GetFunctionName(function interface{}) string {
 func Pointer[T any](v T) *T {
 	return &v
 }
+
+// ImageHasRegistry returns true if the image string includes an explicit registry domain.
+// A registry is assumed present if the first component contains a '.' or ':' (e.g., "registry.io/image").
+func ImageHasRegistry(image string) bool {
+	image = strings.TrimSpace(image)
+	slashIndex := strings.Index(image, "/")
+	if slashIndex == -1 {
+		return false
+	}
+	firstSegment := image[:slashIndex]
+	return strings.Contains(firstSegment, ".") || strings.Contains(firstSegment, ":")
+}

--- a/pkg/common/helper_test.go
+++ b/pkg/common/helper_test.go
@@ -651,6 +651,59 @@ func (suite *MiscTestSuite) TestSanitizeResponseData() {
 	}
 }
 
+func (suite *MiscTestSuite) TestImageHasRegistry() {
+	for _, testCase := range []struct {
+		name     string
+		image    string
+		expected bool
+	}{
+		{
+			name:     "emptyString",
+			image:    "",
+			expected: false,
+		},
+		{
+			name:     "onlyImageName",
+			image:    "nginx",
+			expected: false,
+		},
+		{
+			name:     "imageWithTag",
+			image:    "nginx:latest",
+			expected: false,
+		},
+		{
+			name:     "imageWithRegistry",
+			image:    "docker.io/nginx:latest",
+			expected: true,
+		},
+		{
+			name:     "imageWithRegistryAndPort",
+			image:    "registry.example.com:5000/repo/nginx:latest",
+			expected: true,
+		},
+		{
+			name:     "imageWithLeadingSlash",
+			image:    "/nginx:latest",
+			expected: false,
+		},
+		{
+			name:     "imageWithOrgAndName",
+			image:    "library/nginx",
+			expected: false,
+		},
+		{
+			name:     "imageWithNestedPath",
+			image:    "ghcr.io/org/project/nginx:1.0",
+			expected: true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Require().Equal(testCase.expected, ImageHasRegistry(testCase.image))
+		})
+	}
+}
+
 func TestHelperTestSuite(t *testing.T) {
 	suite.Run(t, new(RetryUntilSuccessfulTestSuite))
 	suite.Run(t, new(RetryUntilSuccessfulOnErrorPatternsTestSuite))

--- a/pkg/nuctl/command/nuctl.go
+++ b/pkg/nuctl/command/nuctl.go
@@ -148,7 +148,8 @@ func (rc *RootCommandeer) initialize(initPlatform bool) error {
 		rc.loggerInstance,
 		rc.platformName,
 		rc.platformConfiguration,
-		rc.namespace)
+		rc.namespace,
+		"")
 	if err != nil {
 		return errors.Wrap(err, "Failed to create platform")
 	}

--- a/pkg/platform/factory/factory.go
+++ b/pkg/platform/factory/factory.go
@@ -37,7 +37,8 @@ func CreatePlatform(ctx context.Context,
 	parentLogger logger.Logger,
 	platformType string,
 	platformConfiguration *platformconfig.Config,
-	defaultNamespace string) (platform.Platform, error) {
+	defaultNamespace string,
+	defaultRunRegistryURL string) (platform.Platform, error) {
 
 	var newPlatform platform.Platform
 	var err error
@@ -57,7 +58,7 @@ func CreatePlatform(ctx context.Context,
 		newPlatform, err = local.NewPlatform(ctx, parentLogger, platformConfiguration, defaultNamespace)
 
 	case common.KubePlatformName:
-		newPlatform, err = kube.NewPlatform(ctx, parentLogger, platformConfiguration, defaultNamespace)
+		newPlatform, err = kube.NewPlatform(ctx, parentLogger, platformConfiguration, defaultNamespace, defaultRunRegistryURL)
 
 	default:
 

--- a/pkg/platform/kube/clients/nuclio/deployer.go
+++ b/pkg/platform/kube/clients/nuclio/deployer.go
@@ -189,8 +189,8 @@ func (d *Deployer) populateFunction(functionConfig *functionconfig.Config,
 	// if, for some reason, the run registry is specified, prepend that
 	if functionConfig.Spec.RunRegistry != "" {
 
-		// check if the run registry is part of the image already first
-		if !strings.HasPrefix(functionInstance.Spec.Image, fmt.Sprintf("%s/", functionConfig.Spec.RunRegistry)) {
+		// if image doesn't have a registry yet, enrich it with the run registry
+		if !common.ImageHasRegistry(functionInstance.Spec.Image) {
 			functionInstance.Spec.Image = fmt.Sprintf("%s/%s", functionConfig.Spec.RunRegistry, functionInstance.Spec.Image)
 		}
 	}

--- a/pkg/platform/kube/clients/nuclio/deployer.go
+++ b/pkg/platform/kube/clients/nuclio/deployer.go
@@ -195,7 +195,8 @@ func (d *Deployer) populateFunction(functionConfig *functionconfig.Config,
 		// enrich it with the run registry
 		if !common.ImageHasRegistry(functionInstance.Spec.Image) {
 			functionInstance.Spec.Image = fmt.Sprintf("%s/%s", functionConfig.Spec.RunRegistry, functionInstance.Spec.Image)
-		} else if functionConfig.Spec.RunRegistry != d.defaultRunRegistryURL {
+		} else if functionConfig.Spec.RunRegistry != d.defaultRunRegistryURL &&
+			!strings.HasPrefix(functionInstance.Spec.Image, fmt.Sprintf("%s/", functionConfig.Spec.RunRegistry)) {
 			functionInstance.Spec.Image = fmt.Sprintf("%s/%s", functionConfig.Spec.RunRegistry, functionInstance.Spec.Image)
 		}
 	}

--- a/pkg/platform/kube/clients/nuclio/deployer.go
+++ b/pkg/platform/kube/clients/nuclio/deployer.go
@@ -191,7 +191,7 @@ func (d *Deployer) populateFunction(functionConfig *functionconfig.Config,
 	// if, for some reason, the run registry is specified, prepend that
 	if functionConfig.Spec.RunRegistry != "" {
 
-		// if image doesn't have a registry yet OR runRegistry is set explicitly(not the same as default),
+		// if image doesn't have a registry yet OR runRegistry is set explicitly (not the same as default),
 		// enrich it with the run registry
 		if !common.ImageHasRegistry(functionInstance.Spec.Image) || functionConfig.Spec.RunRegistry != d.defaultRunRegistryURL {
 			functionInstance.Spec.Image = fmt.Sprintf("%s/%s", functionConfig.Spec.RunRegistry, functionInstance.Spec.Image)

--- a/pkg/platform/kube/clients/nuclio/deployer.go
+++ b/pkg/platform/kube/clients/nuclio/deployer.go
@@ -39,18 +39,20 @@ import (
 const MaxLogLines = 100
 
 type Deployer struct {
-	logger   logger.Logger
-	consumer *Consumer
-	platform platform.Platform
-	scrubber *functionconfig.Scrubber
+	logger                logger.Logger
+	consumer              *Consumer
+	platform              platform.Platform
+	scrubber              *functionconfig.Scrubber
+	defaultRunRegistryURL string
 }
 
-func NewDeployer(parentLogger logger.Logger, consumer *Consumer, platform platform.Platform) (*Deployer, error) {
+func NewDeployer(parentLogger logger.Logger, consumer *Consumer, platform platform.Platform, defaultRunRegistryURL string) (*Deployer, error) {
 	newDeployer := &Deployer{
-		logger:   parentLogger.GetChild("deployer"),
-		platform: platform,
-		consumer: consumer,
-		scrubber: platform.GetFunctionScrubber(),
+		logger:                parentLogger.GetChild("deployer"),
+		platform:              platform,
+		consumer:              consumer,
+		scrubber:              platform.GetFunctionScrubber(),
+		defaultRunRegistryURL: defaultRunRegistryURL,
 	}
 
 	return newDeployer, nil
@@ -189,8 +191,9 @@ func (d *Deployer) populateFunction(functionConfig *functionconfig.Config,
 	// if, for some reason, the run registry is specified, prepend that
 	if functionConfig.Spec.RunRegistry != "" {
 
-		// if image doesn't have a registry yet, enrich it with the run registry
-		if !common.ImageHasRegistry(functionInstance.Spec.Image) {
+		// if image doesn't have a registry yet OR runRegistry is set explicitly(not the same as default),
+		// enrich it with the run registry
+		if !common.ImageHasRegistry(functionInstance.Spec.Image) || functionConfig.Spec.RunRegistry != d.defaultRunRegistryURL {
 			functionInstance.Spec.Image = fmt.Sprintf("%s/%s", functionConfig.Spec.RunRegistry, functionInstance.Spec.Image)
 		}
 	}

--- a/pkg/platform/kube/clients/nuclio/deployer.go
+++ b/pkg/platform/kube/clients/nuclio/deployer.go
@@ -193,7 +193,9 @@ func (d *Deployer) populateFunction(functionConfig *functionconfig.Config,
 
 		// if image doesn't have a registry yet OR runRegistry is set explicitly (not the same as default),
 		// enrich it with the run registry
-		if !common.ImageHasRegistry(functionInstance.Spec.Image) || functionConfig.Spec.RunRegistry != d.defaultRunRegistryURL {
+		if !common.ImageHasRegistry(functionInstance.Spec.Image) {
+			functionInstance.Spec.Image = fmt.Sprintf("%s/%s", functionConfig.Spec.RunRegistry, functionInstance.Spec.Image)
+		} else if functionConfig.Spec.RunRegistry != d.defaultRunRegistryURL {
 			functionInstance.Spec.Image = fmt.Sprintf("%s/%s", functionConfig.Spec.RunRegistry, functionInstance.Spec.Image)
 		}
 	}

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -98,7 +98,8 @@ func NewProjectsClient(platform *Platform, platformConfiguration *platformconfig
 func NewPlatform(ctx context.Context,
 	parentLogger logger.Logger,
 	platformConfiguration *platformconfig.Config,
-	defaultNamespace string) (*Platform, error) {
+	defaultNamespace string,
+	defaultRunRegistryURL string) (*Platform, error) {
 	newPlatform := &Platform{}
 
 	// create base
@@ -124,7 +125,7 @@ func NewPlatform(ctx context.Context,
 	}
 
 	// create deployer
-	newPlatform.deployer, err = nuclioclient.NewDeployer(newPlatform.Logger, newPlatform.consumer, newPlatform)
+	newPlatform.deployer, err = nuclioclient.NewDeployer(newPlatform.Logger, newPlatform.consumer, newPlatform, defaultRunRegistryURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create a deployer")
 	}

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -155,7 +155,7 @@ func (suite *KubePlatformTestSuite) ResetCRDMocks() {
 	}
 	suite.platform.updater, _ = nuclio.NewUpdater(suite.Logger, suite.platform.consumer, suite.platform)
 	suite.platform.deleter, _ = nuclio.NewDeleter(suite.Logger, suite.platform)
-	suite.platform.deployer, _ = nuclio.NewDeployer(suite.Logger, suite.platform.consumer, suite.platform)
+	suite.platform.deployer, _ = nuclio.NewDeployer(suite.Logger, suite.platform.consumer, suite.platform, "")
 	suite.platform.projectsClient, _ = NewProjectsClient(suite.platform, suite.abstractPlatform.Config)
 	suite.platform.apiGatewayScrubber = platform.NewAPIGatewayScrubber(suite.Logger, platform.GetAPIGatewaySensitiveField(), suite.platform.consumer.KubeClientSet)
 }

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -130,7 +130,8 @@ func (suite *TestSuite) SetupSuite() {
 	suite.Platform, err = factory.CreatePlatform(suite.ctx, suite.Logger,
 		suite.PlatformType,
 		suite.PlatformConfiguration,
-		suite.Namespace)
+		suite.Namespace,
+		"")
 	suite.Require().NoError(err)
 	suite.Require().NotNil(suite.Platform)
 }


### PR DESCRIPTION
### Description  
Refactored logic for enriching the image with the run registry. Previously, the code checked whether the image was already prefixed with the run registry using a string prefix check. This has been replaced with a more robust check using the shared ImageHasRegistry method, which determines whether the image includes a registry component at all.


### Testing  
- [x] I have tested the changes in this PR
Unit tests

### References
- Ticket link: jira https://iguazio.atlassian.net/browse/NUC-552

