### PR TITLE
[Batcher] Block until first event in the batch

### DIFF
--- a/pkg/processor/trigger/batcher.go
+++ b/pkg/processor/trigger/batcher.go
@@ -51,7 +51,7 @@ func (b *Batcher) Add(event nuclio.Event, responseChan *common.ChannelWithRecove
 
 	// if batchIsFull, Write to `batchIsFull` chan, so that we send batch to worker right when batch len reached the maximum
 	// plus one, because we read the first event in WaitForBatch separately
-	if cap(b.currentBatch)+1 == len(b.currentBatch) {
+	if len(b.currentBatch)+1 == cap(b.currentBatch) {
 		b.batchIsFull <- true
 	}
 }

--- a/pkg/processor/trigger/batcher.go
+++ b/pkg/processor/trigger/batcher.go
@@ -50,36 +50,44 @@ func (b *Batcher) Add(event nuclio.Event, responseChan *common.ChannelWithRecove
 	b.currentBatch <- &BatchedEventWithResponse{event: event, responseChan: responseChan}
 
 	// if batchIsFull, Write to `batchIsFull` chan, so that we send batch to worker right when batch len reached the maximum
-	if cap(b.currentBatch) == len(b.currentBatch) {
+	// plus one, because we read the first event in WaitForBatch separately
+	if cap(b.currentBatch)+1 == len(b.currentBatch) {
 		b.batchIsFull <- true
 	}
 }
 
 func (b *Batcher) WaitForBatch(batchTimeout time.Duration) ([]nuclio.Event, map[string]*common.ChannelWithRecover) {
 	for {
-		if b.batchIsEmpty() {
-			continue
-		}
+		// Block until the first event arrives
+		firstEvent := <-b.currentBatch
+
 		select {
 		case <-b.batchIsFull:
-			return b.extractBatch()
+			return b.extractBatch(firstEvent)
 		case <-time.After(batchTimeout):
-			return b.extractBatch()
+			return b.extractBatch(firstEvent)
 		}
 	}
 }
 
-func (b *Batcher) batchIsEmpty() bool {
-	return len(b.currentBatch) == 0
-}
+func (b *Batcher) extractBatch(firstEvent *BatchedEventWithResponse) ([]nuclio.Event, map[string]*common.ChannelWithRecover) {
 
-func (b *Batcher) extractBatch() ([]nuclio.Event, map[string]*common.ChannelWithRecover) {
-
-	batchLength := len(b.currentBatch)
+	// +1 because we already read the first event
+	batchLength := len(b.currentBatch) + 1
 	responseChans := make(map[string]*common.ChannelWithRecover)
 	batch := make([]nuclio.Event, batchLength)
 
-	for i := 0; i < batchLength; i++ {
+	// Add the first event
+	eventID := firstEvent.event.GetID()
+	if eventID == "" {
+		eventID = nuclio.ID(uuid.New().String())
+		firstEvent.event.SetID(eventID)
+	}
+
+	batch[0] = firstEvent.event
+	responseChans[string(eventID)] = firstEvent.responseChan
+
+	for i := 1; i < batchLength; i++ {
 		batchedEventWithResponse := <-b.currentBatch
 		batch[i] = batchedEventWithResponse.event
 		eventId := batchedEventWithResponse.event.GetID()

--- a/pkg/processor/trigger/batcher.go
+++ b/pkg/processor/trigger/batcher.go
@@ -79,7 +79,7 @@ func (b *Batcher) extractBatch(firstEvent *BatchedEventWithResponse) ([]nuclio.E
 	if batchLength > cap(b.currentBatch) {
 		batchLength = cap(b.currentBatch)
 	}
-	
+
 	responseChans := make(map[string]*common.ChannelWithRecover)
 	batch := make([]nuclio.Event, batchLength)
 

--- a/pkg/processor/trigger/batcher.go
+++ b/pkg/processor/trigger/batcher.go
@@ -51,7 +51,7 @@ func (b *Batcher) Add(event nuclio.Event, responseChan *common.ChannelWithRecove
 
 	// if batchIsFull, Write to `batchIsFull` chan, so that we send batch to worker right when batch len reached the maximum
 	// plus one, because we read the first event in WaitForBatch separately
-	if len(b.currentBatch)+1 == cap(b.currentBatch) {
+	if len(b.currentBatch)+1 >= cap(b.currentBatch) {
 		b.batchIsFull <- true
 	}
 }
@@ -74,6 +74,12 @@ func (b *Batcher) extractBatch(firstEvent *BatchedEventWithResponse) ([]nuclio.E
 
 	// +1 because we already read the first event
 	batchLength := len(b.currentBatch) + 1
+
+	// ensure that batchLength is not bigger than the capacity of the channel
+	if batchLength > cap(b.currentBatch) {
+		batchLength = cap(b.currentBatch)
+	}
+	
 	responseChans := make(map[string]*common.ChannelWithRecover)
 	batch := make([]nuclio.Event, batchLength)
 


### PR DESCRIPTION
### 📝 Description
Fixes the cpu usage issue when events are not coming.

---

### 🛠️ Changes Made
Now we always blockingly wait for the first event in the batch

```
Before:
nuclio-async-nuclio-admin-batch-nuclio-675c7b7cc7-ktd9s   998m         24Mi

After: 
nuclio-async-nuclio-admin-batch-nuclio-c69c49f85-vmjkm   1m           24Mi
```
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
Tested on vmdev

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-554

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No
