### PR TITLE
[Dashboard] Do not persist enriched imagePullSecret in a function config

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -274,12 +274,6 @@ func (ap *Platform) EnrichFunctionConfig(ctx context.Context, functionConfig *fu
 
 	ap.enrichMinMaxReplicas(functionConfig)
 
-	// enrich with registry credential secret name
-	if functionConfig.Spec.ImagePullSecrets == "" {
-		functionConfig.Spec.ImagePullSecrets =
-			ap.GetDefaultRegistryCredentialsSecretName()
-	}
-
 	// `python` is just an alias
 	if functionConfig.Spec.Runtime == "python" {
 		functionConfig.Spec.Runtime = "python:3.11"

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1122,7 +1122,7 @@ func (b *Builder) buildProcessorImage(ctx context.Context) (string, error) {
 			BuildArgs:           buildArgs,
 			RegistryURL:         registryURL,
 			RepoName:            b.resolveRepoName(registryURL),
-			SecretName:          b.options.FunctionConfig.Spec.ImagePullSecrets,
+			SecretName:          b.resolveImagePullSecrets(),
 			OutputImageFile:     b.options.OutputImageFile,
 			BuildTimeoutSeconds: b.resolveBuildTimeoutSeconds(),
 
@@ -1147,6 +1147,13 @@ func (b *Builder) buildProcessorImage(ctx context.Context) (string, error) {
 		})
 
 	return taggedImageName, err
+}
+
+func (b *Builder) resolveImagePullSecrets() string {
+	if b.options.FunctionConfig.Spec.ImagePullSecrets == "" {
+		return b.platform.GetDefaultRegistryCredentialsSecretName()
+	}
+	return b.options.FunctionConfig.Spec.ImagePullSecrets
 }
 
 func (b *Builder) resolveRepoName(registryURL string) string {


### PR DESCRIPTION
### 📝 Description
Users can configure image pull secrets using the following:

1. `function.spec.imagePullSecrets` – set explicitly on the function
2. `NUCLIO_REGISTRY_CREDENTIALS_SECRET_NAME` – environment variable on the **Dashboard**
3. `NUCLIO_CONTROLLER_IMAGE_PULL_SECRETS` – environment variable on the **Controller**

---

### 🛠️ Changes Made
🔄 Updated Resolution Logic

1. ✅ If `function.spec.imagePullSecrets` is set, it takes precedence and is always used.

2. ⚠️ If not set on the function and `NUCLIO_REGISTRY_CREDENTIALS_SECRET_NAME` is defined on the **Dashboard**:
   - This value will be used **only** by the **Dashboard's builder**.
   - ❌ **No longer persisted** in the function config (previously it was).

3. ➡️ If neither of the above is set, the system will fallback to `NUCLIO_CONTROLLER_IMAGE_PULL_SECRETS` (Controller-side):
   - 📌 This value is used **implicitly** and **never saved** to the function config.

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-557
---

### 🚨 Breaking Changes?

- [x] Yes 
Breaks the cases where controller relies on the fact that imagePullSecret is enriched from dashboard env. In all the igz deployment it wont' be the case since controller and dashboard values are configured to the same value usually. 

<!-- If yes, describe what needs to be changed downstream: -->

---
