### PR TITLE
[UI] bump DC version `1.2.17` [1.14.x]

### DIFF
--- a/pkg/dashboard/ui/package.json
+++ b/pkg/dashboard/ui/package.json
@@ -48,7 +48,7 @@
     "i18next-chained-backend": "^3.0.2",
     "i18next-localstorage-backend": "^3.1.3",
     "i18next-xhr-backend": "^3.2.2",
-    "iguazio.dashboard-controls": "1.2.13",
+    "iguazio.dashboard-controls": "1.2.17",
     "jquery": ">=3.7.1",
     "jquery-ui": "1.13.2",
     "js-base64": "^2.5.2",


### PR DESCRIPTION
- **UI**: bump DC version `1.2.17`
   Implements: https://github.com/iguazio/dashboard-controls/pull/1660
   Backported to `1.14.x` from `development`
   Jira: https://iguazio.atlassian.net/browse/NUC-526