### PR TITLE
[Builder] Take only image name when resolving base image with custom registry [1.14.x]

### DIFF
--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1410,12 +1410,9 @@ func (b *Builder) getProcessorDockerfileBaseImage(runtimeDefaultBaseImage string
 			return runtimeDefaultBaseImage
 		}
 
-		// if a non-empty baseImageRegistry was passed, use it as a registry prefix for the default base image
-		sepIndex := strings.Index(runtimeDefaultBaseImage, "/")
-		if sepIndex != -1 {
-			runtimeDefaultBaseImage = runtimeDefaultBaseImage[sepIndex+1:]
-		}
-		return strings.Join([]string{baseImageRegistry, runtimeDefaultBaseImage}, "/")
+		// get only image name and concatenate it with registry
+		imageName := path.Base(runtimeDefaultBaseImage)
+		return strings.Join([]string{baseImageRegistry, imageName}, "/")
 
 	// if user specified something - use that, as is
 	// see description on https://github.com/nuclio/nuclio/pull/1544 - we don't implicitly mutate the given baseimage

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -1091,6 +1091,60 @@ func (suite *testSuite) TestCreateTempDir() {
 	}
 }
 
+func (suite *testSuite) TestGetProcessorDockerfileBaseImage() {
+	testCases := []struct {
+		name                    string
+		runtimeDefaultBaseImage string
+		baseImageRegistry       string
+		userProvidedBaseImage   string
+		expected                string
+	}{
+		{
+			name:                    "Docker Hub with registry",
+			runtimeDefaultBaseImage: "docker.io/library/python:3.7",
+			baseImageRegistry:       "local-registry:5000",
+			expected:                "local-registry:5000/python:3.7",
+		},
+		{
+			name:                    "Simple image without registry",
+			runtimeDefaultBaseImage: "python:3.8",
+			baseImageRegistry:       "my-registry.io",
+			expected:                "my-registry.io/python:3.8",
+		},
+		{
+			name:                    "Registry and namespace",
+			runtimeDefaultBaseImage: "ghcr.io/nuclio/handler-base:1.0",
+			baseImageRegistry:       "internal.registry",
+			expected:                "internal.registry/handler-base:1.0",
+		},
+		{
+			name:                    "Base image registry empty",
+			runtimeDefaultBaseImage: "ghcr.io/nuclio/handler-base:1.0",
+			baseImageRegistry:       "",
+			expected:                "ghcr.io/nuclio/handler-base:1.0",
+		},
+		{
+			name:                    "User-provided base image takes precedence",
+			runtimeDefaultBaseImage: "should-not-be-used",
+			baseImageRegistry:       "ignored-registry.io",
+			userProvidedBaseImage:   "custom-image:latest",
+			expected:                "custom-image:latest",
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			oldBaseImage := suite.builder.options.FunctionConfig.Spec.Build.BaseImage
+			suite.builder.options.FunctionConfig.Spec.Build.BaseImage = tc.userProvidedBaseImage
+			defer func() {
+				suite.builder.options.FunctionConfig.Spec.Build.BaseImage = oldBaseImage
+			}()
+			result := suite.builder.getProcessorDockerfileBaseImage(tc.runtimeDefaultBaseImage, tc.baseImageRegistry)
+			suite.Require().Equal(tc.expected, result)
+		})
+	}
+}
+
 func (suite *testSuite) testResolveFunctionPathRemoteCodeFile(fileExtension string) {
 
 	// mock http response

--- a/pkg/processor/build/runtime/java/runtime.go
+++ b/pkg/processor/build/runtime/java/runtime.go
@@ -51,7 +51,7 @@ func (j *java) OnAfterStagingDirCreated(runtimeConfig *runtimeconfig.Config, sta
 func (j *java) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
-	processorDockerfileInfo.BaseImage = "openjdk:11-jre-slim"
+	processorDockerfileInfo.BaseImage = "gcr.io/iguazio/openjdk:11-jre-slim"
 
 	// fill onbuild artifact
 	artifact := runtime.Artifact{


### PR DESCRIPTION
backport (#3724)