### PR TITLE
[CI] Improve dependency checker

### DIFF
--- a/.github/workflows/dependencies_checker.yaml
+++ b/.github/workflows/dependencies_checker.yaml
@@ -20,13 +20,25 @@ on:
   schedule:
     # At 00:00 UTC every Monday
     - cron: '0 0 * * 1'
+  pull_request:  # Add pull request trigger for debugging
+    branches:
+      - development
 
 jobs:
-  check-docker-cli-version:
+  check-dependencies:
+    if: github.repository == 'nuclio/nuclio'  # Run only in the nuclio/nuclio repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
 
-      - name: Run make check-docker-cli-version
-        run: make check-docker-cli-version
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r hack/scripts/dependency-checker/requirements.txt
+
+      - name: Run dependency check
+        run: make check-dependencies

--- a/.github/workflows/dependencies_checker.yaml
+++ b/.github/workflows/dependencies_checker.yaml
@@ -20,9 +20,6 @@ on:
   schedule:
     # At 00:00 UTC every Monday
     - cron: '0 0 * * 1'
-  pull_request:  # Add pull request trigger for debugging
-    branches:
-      - development
 
 jobs:
   check-dependencies:

--- a/Makefile
+++ b/Makefile
@@ -375,11 +375,11 @@ NUCLIO_DOCKER_DASHBOARD_UHTTPC_ARCH  		?= $(NUCLIO_ARCH)
 NUCLIO_DOCKER_DASHBOARD_UHTTPC_IMAGE   		?= gcr.io/iguazio/uhttpc:0.0.3
 
 ifeq ($(NUCLIO_ARCH), armhf)
-	NUCLIO_DOCKER_DASHBOARD_NGINX_BASE_IMAGE  ?= gcr.io/iguazio/arm32v7/nginx:1.27-alpine
+	NUCLIO_DOCKER_DASHBOARD_NGINX_BASE_IMAGE  ?= gcr.io/iguazio/arm32v7/nginx:1.29-alpine
 else ifeq ($(NUCLIO_ARCH), arm64)
-	NUCLIO_DOCKER_DASHBOARD_NGINX_BASE_IMAGE  ?= gcr.io/iguazio/arm64v8/nginx:1.27-alpine
+	NUCLIO_DOCKER_DASHBOARD_NGINX_BASE_IMAGE  ?= gcr.io/iguazio/arm64v8/nginx:1.29-alpine
 else
-	NUCLIO_DOCKER_DASHBOARD_NGINX_BASE_IMAGE  ?= gcr.io/iguazio/nginx:1.27-alpine
+	NUCLIO_DOCKER_DASHBOARD_NGINX_BASE_IMAGE  ?= gcr.io/iguazio/nginx:1.29-alpine
 endif
 
 .PHONY: dashboard
@@ -715,28 +715,6 @@ ensure-golangci-linter:
 			$(GOLANGCI_LINT_INSTALL_COMMAND); \
 		fi \
 	fi
-
-
-check-docker-cli-version:
-	@LATEST_TAG=$$(curl -s https://api.github.com/repos/docker/cli/tags | jq -r '.[].name' | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$$' | sort -V | tail -1) && \
-	LATEST_VERSION=$${LATEST_TAG#v} && \
-	echo "🔍 Latest Docker CLI version: $$LATEST_VERSION" && \
-	\
-	VERSION_DASHBOARD=$$(grep '^ARG DOCKER_CLI_VERSION=' cmd/dashboard/docker/Dockerfile | cut -d= -f2 | tr -d '"') && \
-	VERSION_TEST=$$(grep '^ARG DOCKER_CLI_VERSION=' test/docker/Dockerfile | cut -d= -f2 | tr -d '"') && \
-	VERSION_MAKEFILE=$$(grep '^NUCLIO_DOCKER_CLIENT_VERSION' Makefile | cut -d= -f2 | tr -d ' ?') && \
-	\
-	echo "📦 Dashboard Dockerfile:     $$VERSION_DASHBOARD" && \
-	echo "📦 Test Dockerfile:          $$VERSION_TEST" && \
-	echo "📦 Makefile:                 $$VERSION_MAKEFILE" && \
-	\
-	[ "$$VERSION_DASHBOARD" = "$$LATEST_VERSION" ] && \
-	[ "$$VERSION_TEST" = "$$LATEST_VERSION" ] && \
-	[ "$$VERSION_MAKEFILE" = "$$LATEST_VERSION" ] && \
-	echo "✅ All Docker CLI versions are up-to-date and consistent ($$LATEST_VERSION)" || \
-	( echo "❌ One or more versions are outdated or inconsistent."; exit 1 )
-
-
 #
 # Testing
 #
@@ -1025,3 +1003,12 @@ patch-remote-nuclio: hack/scripts/patch-remote/.ssh/key_$(PATCH_HOST_IP)_$(PATCH
 	./hack/scripts/patch-remote/patch_remote.py \
 		--private-key-file hack/scripts/patch-remote/.ssh/key_$(PATCH_HOST_IP)_$(PATCH_USERNAME) \
 		--config hack/scripts/patch-remote/patch_env.yml
+
+.PHONY: check-dependencies
+check-dependencies:
+	@python3 hack/scripts/dependency-checker/check-versions.py --makefile-path Makefile
+
+.PHONY: bump-dependencies
+bump-dependencies:
+	@python3 hack/scripts/dependency-checker/check-versions.py --makefile-path Makefile --bump-to-the-latest
+

--- a/cmd/dashboard/docker/Dockerfile
+++ b/cmd/dashboard/docker/Dockerfile
@@ -15,7 +15,7 @@
 #
 # Build assets stage: builds the dashboard assets (js, html, css, etc)
 #
-ARG NGINX_IMAGE=gcr.io/iguazio/nginx:1.25-alpine
+ARG NGINX_IMAGE
 ARG NUCLIO_DOCKER_IMAGE_TAG
 ARG UHTTPC_IMAGE=gcr.io/iguazio/uhttpc:0.0.3
 ARG UHTTPC_ARCH=amd64
@@ -58,7 +58,7 @@ FROM $NUCLIO_DOCKER_ALPINE_IMAGE as downloaddocker
 
 # docker client
 ARG DOCKER_CLI_ARCH=x86_64
-ARG DOCKER_CLI_VERSION="28.3.3"
+ARG DOCKER_CLI_VERSION
 ENV DOCKER_CLI_DOWNLOAD_URL="https://download.docker.com/linux/static/stable/$DOCKER_CLI_ARCH/docker-$DOCKER_CLI_VERSION.tgz"
 
 RUN apk --update --no-cache add curl \

--- a/hack/scripts/dependency-checker/check-versions.py
+++ b/hack/scripts/dependency-checker/check-versions.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# Copyright 2025 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import re
+import sys
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+from packaging.version import Version
+from pathlib import Path
+import argparse
+import time
+
+
+class Dependency:
+    """Base class for a dependency/version checker."""
+
+    def __init__(self, name, regex_pattern):
+        self.name = name
+        # Compile the regex pattern to extract version information from the Makefile
+        self.regex_pattern = re.compile(regex_pattern)
+
+    def get_makefile_versions(self, makefile_content):
+        """Extract all matching versions from Makefile content using regex."""
+        # Use regex to find all matches in the Makefile content
+        matches = self.regex_pattern.findall(makefile_content)
+        if not matches:
+            raise ValueError(f"Version for {self.name} not found in Makefile")
+        # Ensure only the version part (group 2) is returned
+        return [match if isinstance(match, str) else match[1] for match in matches]
+
+    def get_latest_version(self):
+        """Override in subclass."""
+        raise NotImplementedError
+
+    def check_versions(self, makefile_content):
+        """Compare all Makefile versions with the latest version."""
+        # Extract all versions from the Makefile
+        makefile_versions = self.get_makefile_versions(makefile_content)
+        # Check if there are inconsistent versions in the Makefile
+        if len(set(makefile_versions)) > 1:
+            raise ValueError(
+                f"Inconsistent versions for {self.name} in Makefile: {', '.join(makefile_versions)}"
+            )
+        # Fetch the latest version from the source (e.g., GitHub)
+        latest_version = self.get_latest_version()
+        print(f"🔍 Latest {self.name} version: {latest_version}")
+        print(f"📦 Makefile version:          {makefile_versions[0]}")
+        # Compare the Makefile version with the latest version
+        if makefile_versions[0] == latest_version:
+            print(f"✅ {self.name} version is up-to-date\n")
+        else:
+            print(f"❌ {self.name} version is outdated or inconsistent\n")
+            sys.exit(1)
+
+    def bump_to_latest(self, makefile_content):
+        """
+        Replace all occurrences of the version in the Makefile with the latest version.
+
+        Match groups:
+        - group(1): The part of the line before the version (e.g., "NUCLIO_DOCKER_CLIENT_VERSION ?= ").
+        - group(2): The current version (e.g., "28.3.3").
+        - group(3): The part of the line after the version (if applicable, e.g., "-alpine").
+        """
+        latest_version = self.get_latest_version()
+        updated_content = makefile_content
+
+        # Iterate over all matches in the Makefile
+        for match in self.regex_pattern.finditer(makefile_content):
+            old_version = match.group(2)  # Extract the current version
+            if old_version == latest_version:
+                # Skip if the version is already up-to-date
+                print(f"✅ {self.name} is already up-to-date: {old_version}")
+                continue
+
+            new_line = f"{match.group(1)}{latest_version}{match.group(3) if len(match.groups()) > 2 else ''}"
+            old_line = f"{match.group(1)}{old_version}{match.group(3) if len(match.groups()) > 2 else ''}"
+
+            # Log the change
+            print(f"🔄 Updating {self.name}:")
+            print(f"   Old: {old_line}")
+            print(f"   New: {new_line}")
+
+            # Replace the old version with the latest version while preserving the surrounding text
+            updated_content = updated_content.replace(old_line, new_line)
+
+        return updated_content
+
+
+def create_session_with_retries(retries=3, backoff_factor=0.3, status_forcelist=(500, 502, 503, 504)):
+    """Create a requests session with retry logic."""
+    session = requests.Session()
+    retry = Retry(
+        total=retries,
+        read=retries,
+        connect=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
+class GitHubDependency(Dependency):
+    """Dependency checker for GitHub-hosted projects."""
+
+    def __init__(self, name, repo, tag_regex, makefile_regex):
+        super().__init__(name, makefile_regex)
+        self.repo = repo
+        # Compile the regex pattern to extract version tags from GitHub
+        self.tag_regex = re.compile(tag_regex)
+        # Create a session with retry logic for API requests
+        self.session = create_session_with_retries()
+
+    def get_latest_version(self):
+        """
+        Fetch the latest version from GitHub tags with retry and wait.
+
+        The GitHub API returns a list of tags, and we use the tag_regex to extract valid version tags.
+        """
+        url = f"https://api.github.com/repos/{self.repo}/tags"
+        retries = 3
+        for attempt in range(retries):
+            try:
+                # Make a GET request to fetch tags
+                response = self.session.get(url, timeout=10)
+                response.raise_for_status()
+                tags = response.json()
+                # Extract valid versions using the tag_regex
+                versions = [
+                    match.group(1)
+                    for tag in tags
+                    if (match := self.tag_regex.match(tag["name"]))
+                ]
+                if not versions:
+                    raise RuntimeError(f"No valid tags found for {self.name} in {self.repo}")
+                # Return the highest version
+                return str(max(Version(v) for v in versions))
+            except requests.RequestException as e:
+                if attempt < retries - 1:
+                    print(f"Warning: Failed to fetch tags for {self.name} (attempt {attempt + 1}/{retries}). Retrying in 5 seconds...")
+                    time.sleep(5)
+                else:
+                    raise RuntimeError(f"Failed to fetch tags for {self.name} after {retries} attempts: {e}")
+
+            except Exception as e:
+                raise RuntimeError(f"Error processing tags for {self.name}: {e}")
+
+
+
+def load_makefile_content(makefile_path):
+    """Load the content of the Makefile."""
+    try:
+        with open(makefile_path, "r") as f:
+            return f.read()
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Makefile not found at {makefile_path}")
+
+
+def save_makefile_content(makefile_path, content):
+    """Save the updated content back to the Makefile."""
+    with open(makefile_path, "w") as f:
+        f.write(content)
+
+
+def main(makefile_path=None, bump_to_latest=False):
+    """Main function to check or bump dependency versions."""
+    # Load Makefile content in one line
+    makefile_content = load_makefile_content(
+        Path(makefile_path) if makefile_path else Path(__file__).resolve().parent.parent.parent.parent / "Makefile"
+    )
+
+    # Define dependencies to check
+    dependencies = [
+        GitHubDependency(
+            name="docker-cli",
+            repo="docker/cli",
+            tag_regex=r"^v?(\d+\.\d+\.\d+)$",  # Match version tags like "v28.3.3" or "28.3.3"
+            makefile_regex=r"(NUCLIO_DOCKER_CLIENT_VERSION\s*\?=\s*)([\d.]+)",  # Match Makefile lines for Docker CLI
+        ),
+        GitHubDependency(
+            name="nginx",
+            repo="nginx/nginx",
+            tag_regex=r"^release-(\d+\.\d+)\.\d+$",  # Match version tags like "release-1.29.0"
+            makefile_regex=r"(NUCLIO_DOCKER_DASHBOARD_NGINX_BASE_IMAGE.*nginx:)([\d.]+)(-.*)",  # Match Makefile lines for NGINX
+        ),
+    ]
+
+    if bump_to_latest:
+        # Bump all dependencies to their latest versions
+        for dep in dependencies:
+            makefile_content = dep.bump_to_latest(makefile_content)
+        save_makefile_content(makefile_path, makefile_content)
+        print(f"✅ Makefile updated to the latest versions.")
+    else:
+        # Check each dependency
+        for dep in dependencies:
+            dep.check_versions(makefile_content)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Check or bump dependency versions.")
+    parser.add_argument(
+        "--makefile-path",
+        type=str,
+        default=None,
+        help="Path to the Makefile (default: project root Makefile)",
+    )
+    parser.add_argument(
+        "--bump-to-the-latest",
+        action="store_true",
+        help="Bump all dependencies in the Makefile to their latest versions",
+    )
+    args = parser.parse_args()
+
+    try:
+        main(args.makefile_path, args.bump_to_the_latest)
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)

--- a/hack/scripts/dependency-checker/check-versions.py
+++ b/hack/scripts/dependency-checker/check-versions.py
@@ -15,6 +15,8 @@
 #
 import re
 import sys
+from abc import abstractmethod
+
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -51,9 +53,9 @@ class Dependency:
         makefile_versions = self.get_makefile_versions(makefile_content)
         # Check if there are inconsistent versions in the Makefile
         if len(set(makefile_versions)) > 1:
-            raise ValueError(
-                f"Inconsistent versions for {self.name} in Makefile: {', '.join(makefile_versions)}"
-            )
+            print(f"❌ Inconsistent versions for {self.name} in Makefile: {', '.join(makefile_versions)}")
+            return False
+
         # Fetch the latest version from the source (e.g., GitHub)
         latest_version = self.get_latest_version()
         print(f"🔍 Latest {self.name} version: {latest_version}")
@@ -61,9 +63,10 @@ class Dependency:
         # Compare the Makefile version with the latest version
         if makefile_versions[0] == latest_version:
             print(f"✅ {self.name} version is up-to-date\n")
+            return True
         else:
             print(f"❌ {self.name} version is outdated or inconsistent\n")
-            sys.exit(1)
+            return False
 
     def bump_to_latest(self, makefile_content):
         """
@@ -126,6 +129,7 @@ class GitHubDependency(Dependency):
         # Create a session with retry logic for API requests
         self.session = create_session_with_retries()
 
+    @abstractmethod
     def get_latest_version(self):
         """
         Fetch the latest version from GitHub tags with retry and wait.
@@ -179,12 +183,10 @@ def save_makefile_content(makefile_path, content):
 
 def main(makefile_path=None, bump_to_latest=False):
     """Main function to check or bump dependency versions."""
-    # Load Makefile content in one line
     makefile_content = load_makefile_content(
         Path(makefile_path) if makefile_path else Path(__file__).resolve().parent.parent.parent.parent / "Makefile"
     )
 
-    # Define dependencies to check
     dependencies = [
         GitHubDependency(
             name="docker-cli",
@@ -201,15 +203,21 @@ def main(makefile_path=None, bump_to_latest=False):
     ]
 
     if bump_to_latest:
-        # Bump all dependencies to their latest versions
         for dep in dependencies:
             makefile_content = dep.bump_to_latest(makefile_content)
         save_makefile_content(makefile_path, makefile_content)
         print(f"✅ Makefile updated to the latest versions.")
     else:
-        # Check each dependency
+        all_checks_passed = True
         for dep in dependencies:
-            dep.check_versions(makefile_content)
+            if not dep.check_versions(makefile_content):
+                all_checks_passed = False
+
+        if not all_checks_passed:
+            print("❌ One or more dependencies are outdated or inconsistent.")
+            sys.exit(1)
+        else:
+            print("✅ All dependencies are up-to-date.")
 
 
 if __name__ == "__main__":

--- a/hack/scripts/dependency-checker/requirements.txt
+++ b/hack/scripts/dependency-checker/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31.0
+packaging>=23.1

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -20,7 +20,7 @@ FROM $ALPINE_IMAGE as builder
 
 # docker
 ARG DOCKER_CLI_ARCH=x86_64
-ARG DOCKER_CLI_VERSION="28.3.3"
+ARG DOCKER_CLI_VERSION
 ENV DOCKER_CLI_DOWNLOAD_URL="https://download.docker.com/linux/static/stable/$DOCKER_CLI_ARCH/docker-$DOCKER_CLI_VERSION.tgz"
 
 # kubectl


### PR DESCRIPTION
### 📝 Description
Using python script instead of bash command, just to make it easier to support.

Script can be run in 2 modes:
1. check  - `check-dependencies`
2. fix - `bump-dependencies`

When running in the 1st mode, script shows the difference between the latest and actual:

```
🔍 Latest docker-cli version: 28.3.3
📦 Makefile version:          28.3.3
✅ docker-cli version is up-to-date

🔍 Latest nginx version: 1.29
📦 Makefile version:          1.27
❌ nginx version is outdated or inconsistent
```

it is also possible, that, as in the case with nginx, we have multiple images mentioned in the Makefile. They all will be checked and if there is inconsistency in the Makefile itself, we will also be informed about that:

```
✗ make check-dependencies  
🔍 Latest docker-cli version: 28.3.3
📦 Makefile version:          28.3.3
✅ docker-cli version is up-to-date

Error: Inconsistent versions for nginx in Makefile: 1.28, 1.29, 1.29
make: *** [check-dependencies] Error 1
```

When running in the 2nd mode, dependencies will be fixed automatically. Example:

```
✅ docker-cli is already up-to-date: 28.3.3
🔄 Updating nginx:
   Old: NUCLIO_DOCKER_DASHBOARD_NGINX_BASE_IMAGE  ?= gcr.io/iguazio/arm32v7/nginx:1.27-alpine
   New: NUCLIO_DOCKER_DASHBOARD_NGINX_BASE_IMAGE  ?= gcr.io/iguazio/arm32v7/nginx:1.29-alpine
🔄 Updating nginx:
   Old: NUCLIO_DOCKER_DASHBOARD_NGINX_BASE_IMAGE  ?= gcr.io/iguazio/arm64v8/nginx:1.27-alpine
   New: NUCLIO_DOCKER_DASHBOARD_NGINX_BASE_IMAGE  ?= gcr.io/iguazio/arm64v8/nginx:1.29-alpine
🔄 Updating nginx:
   Old: NUCLIO_DOCKER_DASHBOARD_NGINX_BASE_IMAGE  ?= gcr.io/iguazio/nginx:1.27-alpine
   New: NUCLIO_DOCKER_DASHBOARD_NGINX_BASE_IMAGE  ?= gcr.io/iguazio/nginx:1.29-alpine
✅ Makefile updated to the latest versions.
```
---

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR https://github.com/nuclio/nuclio/actions/runs/17154988838/job/48669634050?pr=3777

---

### 🧪 Testing
tested locally + by running once on the pr 

---

### 🔗 References
- Ticket link:https://iguazio.atlassian.net/browse/NUC-578
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No
