### PR TITLE
[Dashboard] Fix sidecar port naming

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1995,7 +1995,7 @@ func (lc *lazyClient) populateServiceSpec(ctx context.Context,
 		for _, sidecar := range function.Spec.Sidecars {
 			for _, port := range sidecar.Ports {
 				spec.Ports = lc.addOrUpdatePort(spec.Ports, v1.ServicePort{
-					Name:       sidecar.Name,
+					Name:       port.Name,
 					Port:       port.ContainerPort,
 					TargetPort: intstr.FromInt32(port.ContainerPort),
 				})

--- a/pkg/platform/kube/test/function/function_test.go
+++ b/pkg/platform/kube/test/function/function_test.go
@@ -24,7 +24,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	kubeclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
 	"io"
 	"os"
 	"path"
@@ -32,6 +31,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	kubeclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
 
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
@@ -1470,6 +1471,55 @@ func (suite *DeployFunctionTestSuite) TestDeployFunctionWithSidecarSanity() {
 		suite.Require().Equal(sidecarContainerName, pod.Spec.Containers[1].Name)
 		suite.Require().Equal("busybox", pod.Spec.Containers[1].Image)
 		suite.Require().Equal(commands, pod.Spec.Containers[1].Command)
+
+		// get the logs from the sidecar container to validate it ran
+		podLogOpts := v1.PodLogOptions{
+			Container: sidecarContainerName,
+		}
+		err := common.RetryUntilSuccessful(20*time.Second, 1*time.Second, func() bool {
+			return suite.validatePodLogsContainData(pod.Name, &podLogOpts, []string{"Done"})
+		})
+		suite.Require().NoError(err)
+
+		return true
+	})
+}
+
+func (suite *DeployFunctionTestSuite) TestDeployFunctionWithSidecarMultiplePorts() {
+	functionName := "func-with-sidecar"
+	createFunctionOptions := suite.CompileCreateFunctionOptions(functionName)
+
+	sidecarContainerName := "sidecar-test"
+	commands := []string{
+		"sh",
+		"-c",
+		"for i in {1..10}; do echo $i; sleep 10; done; echo 'Done'",
+	}
+
+	// create a busybox sidecar
+	createFunctionOptions.FunctionConfig.Spec.Sidecars = []*v1.Container{
+		{
+			Name:    sidecarContainerName,
+			Image:   "busybox",
+			Command: commands,
+			Ports: []v1.ContainerPort{{Name: "port-1", ContainerPort: 8050, Protocol: v1.ProtocolTCP},
+				{Name: "port-2", ContainerPort: 22, Protocol: v1.ProtocolTCP},
+			},
+		},
+	}
+
+	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+		suite.Require().NotNil(deployResult)
+
+		// get the function pod and validate it has the sidecar
+		pods := suite.GetFunctionPods(functionName)
+		pod := pods[0]
+
+		suite.Require().Len(pod.Spec.Containers, 2)
+		suite.Require().Equal(sidecarContainerName, pod.Spec.Containers[1].Name)
+		suite.Require().Equal("busybox", pod.Spec.Containers[1].Image)
+		suite.Require().Equal(commands, pod.Spec.Containers[1].Command)
+		suite.Require().Equal(2, len(pod.Spec.Containers[1].Ports))
 
 		// get the logs from the sidecar container to validate it ran
 		podLogOpts := v1.PodLogOptions{


### PR DESCRIPTION
### 📝 Description
fixes a bug where instead of taking the port name from a given sidecar spec, which is always validated that [not empty ](https://github.com/nuclio/nuclio/blob/63f8a670f3a6154bebb24840405db236fbdd5ce8/pkg/platform/kube/platform.go#L2113-L2115) and [non-duplicated](https://github.com/nuclio/nuclio/blob/63f8a670f3a6154bebb24840405db236fbdd5ce8/pkg/platform/kube/platform.go#L2125-L2128), we used sidecar name instead. Thus, it led to failing in case of having more than 1 port. 

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
tested on vmdev and via integration test
---

### 🔗 References
- Ticket link:https://iguazio.atlassian.net/browse/NUC-583
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No
