### PR TITLE
[Dashboard] Support project sync when MLRun is the leader

### DIFF
--- a/pkg/common/k8s.go
+++ b/pkg/common/k8s.go
@@ -32,6 +32,7 @@ import (
 )
 
 const (
+	// NuclioSelfNamespace is used to get the namespace in which Nuclio is running
 	NuclioSelfNamespace = "@nuclio.selfNamespace"
 )
 

--- a/pkg/common/k8s.go
+++ b/pkg/common/k8s.go
@@ -31,6 +31,10 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+const (
+	NuclioSelfNamespace = "@nuclio.selfNamespace"
+)
+
 func IsInKubernetesCluster() bool {
 	return len(os.Getenv("KUBERNETES_SERVICE_HOST")) != 0 && len(os.Getenv("KUBERNETES_SERVICE_PORT")) != 0
 }
@@ -73,7 +77,7 @@ func ResolveNamespace(namespaceArgument string, defaultEnvVarKey string) string 
 	}
 
 	// if the namespace exists in env, use that, else, assume "this" namespace
-	return ResolveDefaultNamespace(GetEnvOrDefaultString(defaultEnvVarKey, "@nuclio.selfNamespace"))
+	return ResolveDefaultNamespace(GetEnvOrDefaultString(defaultEnvVarKey, NuclioSelfNamespace))
 }
 
 // ResolveDefaultNamespace returns the proper default resource namespace, given the current default namespace
@@ -81,7 +85,7 @@ func ResolveDefaultNamespace(namespace string) string {
 
 	defaultNamespace := "default"
 	switch namespace {
-	case "@nuclio.selfNamespace":
+	case NuclioSelfNamespace:
 
 		// for k8s
 		if IsInKubernetesCluster() {

--- a/pkg/platform/abstract/project/external/client.go
+++ b/pkg/platform/abstract/project/external/client.go
@@ -35,7 +35,7 @@ import (
 
 type Client struct {
 	platformConfiguration *platformconfig.Config
-	synchronizer          *iguazio.Synchronizer
+	synchronizer          *client.Synchronizer
 	internalClient        project.Client
 	leaderClient          leader.Client
 }
@@ -67,7 +67,7 @@ func NewClient(parentLogger logger.Logger,
 		namespaces = append(namespaces, common.ResolveDefaultNamespace("@nuclio.selfNamespace"))
 	}
 
-	newClient.synchronizer, err = iguazio.NewSynchronizer(parentLogger,
+	newClient.synchronizer, err = client.NewSynchronizer(parentLogger,
 		synchronizationIntervalStr,
 		namespaces,
 		newClient.leaderClient,

--- a/pkg/platform/abstract/project/external/client.go
+++ b/pkg/platform/abstract/project/external/client.go
@@ -51,7 +51,12 @@ func NewClient(parentLogger logger.Logger,
 	// use the internal client (for now), so projects will be modified both on leader's side and internally by nuclio
 	newClient.internalClient = internalClient
 
-	newClient.leaderClient, err = newLeaderClient(parentLogger, platformConfiguration)
+	namespaces := platformConfiguration.ManagedNamespaces
+	if len(namespaces) == 0 {
+		namespaces = append(namespaces, common.ResolveDefaultNamespace(common.NuclioSelfNamespace))
+	}
+
+	newClient.leaderClient, err = newLeaderClient(parentLogger, platformConfiguration, namespaces[0])
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create leader client")
 	}
@@ -60,11 +65,6 @@ func NewClient(parentLogger logger.Logger,
 	synchronizationIntervalStr := "0"
 	if platformConfiguration.ProjectsLeader != nil {
 		synchronizationIntervalStr = platformConfiguration.ProjectsLeader.SynchronizationInterval
-	}
-
-	namespaces := platformConfiguration.ManagedNamespaces
-	if len(namespaces) == 0 {
-		namespaces = append(namespaces, common.ResolveDefaultNamespace("@nuclio.selfNamespace"))
 	}
 
 	newClient.synchronizer, err = client.NewSynchronizer(parentLogger,
@@ -139,7 +139,7 @@ func (c *Client) Delete(ctx context.Context, deleteProjectOptions *platform.Dele
 	}
 }
 
-func newLeaderClient(parentLogger logger.Logger, platformConfiguration *platformconfig.Config) (leader.Client, error) {
+func newLeaderClient(parentLogger logger.Logger, platformConfiguration *platformconfig.Config, namespace string) (leader.Client, error) {
 	var skipTLSVerification bool
 	var leaderOps leader.LeaderOps
 	switch platformConfiguration.ProjectsLeader.Kind {
@@ -147,7 +147,7 @@ func newLeaderClient(parentLogger logger.Logger, platformConfiguration *platform
 	// mlrun projects leader
 	case platformconfig.ProjectsLeaderKindMlrun:
 		skipTLSVerification = true
-		leaderOps = mlrun.NewLeaderOps(parentLogger)
+		leaderOps = mlrun.NewLeaderOps(parentLogger, namespace)
 
 	// iguazio projects leader
 	case platformconfig.ProjectsLeaderKindIguazio:

--- a/pkg/platform/abstract/project/external/leader/client/synchronizer.go
+++ b/pkg/platform/abstract/project/external/leader/client/synchronizer.go
@@ -73,7 +73,6 @@ func (c *Synchronizer) Start() error {
 
 	// start synchronization loop in the background
 	go c.startSynchronizationLoop(ctx, synchronizationInterval, c.managedNamespaces)
-
 	return nil
 }
 
@@ -81,7 +80,7 @@ func (c *Synchronizer) startSynchronizationLoop(ctx context.Context,
 	interval time.Duration, namespaces []string) {
 	namespaceToMostRecentUpdatedProjectTimeMap := map[string]*time.Time{}
 
-	// fil it up with default
+	// fill it up with default
 	for _, namespace := range namespaces {
 		namespaceToMostRecentUpdatedProjectTimeMap[namespace] = nil
 	}

--- a/pkg/platform/abstract/project/external/leader/client/synchronizer.go
+++ b/pkg/platform/abstract/project/external/leader/client/synchronizer.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package iguazio
+package client
 
 import (
 	"context"

--- a/pkg/platform/abstract/project/external/leader/client/synchronizer.go
+++ b/pkg/platform/abstract/project/external/leader/client/synchronizer.go
@@ -133,8 +133,7 @@ func (c *Synchronizer) getModifiedProjects(leaderProjects []platform.Project, in
 
 		// skip projects that their status is not online
 		if leaderProjectConfig == nil ||
-			leaderProjectConfig.Status.OperationalStatus != "online" ||
-			leaderProjectConfig.Status.AdminStatus != "online" {
+			leaderProject.IsProjectNotOnline() {
 			continue
 		}
 

--- a/pkg/platform/abstract/project/external/leader/client/synchronizer.go
+++ b/pkg/platform/abstract/project/external/leader/client/synchronizer.go
@@ -133,7 +133,7 @@ func (c *Synchronizer) getModifiedProjects(leaderProjects []platform.Project, in
 
 		// skip projects that their status is not online
 		if leaderProjectConfig == nil ||
-			leaderProject.IsProjectNotOnline() {
+			!leaderProject.IsProjectOnline() {
 			continue
 		}
 

--- a/pkg/platform/abstract/project/external/leader/client/synchronizer_test.go
+++ b/pkg/platform/abstract/project/external/leader/client/synchronizer_test.go
@@ -34,7 +34,7 @@ limitations under the License.
 	            	  ext: (int64) 63761762082,
 */
 
-package iguazio
+package client
 
 import (
 	"context"
@@ -43,6 +43,7 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/platform"
 	common "github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader"
+	"github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader/iguazio"
 	leadermock "github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader/mock"
 	internalmock "github.com/nuclio/nuclio/pkg/platform/abstract/project/mock"
 
@@ -151,13 +152,13 @@ func (suite *SynchronizerTestSuite) TestLeaderProjectsNotUpdatedInternally() {
 		"updated",
 		"online",
 		testBeginningTime.Format(common.ProjectTimeLayout))
-	updatedProject.(*IguazioProject).Data.Attributes.Namespace = "some-namespace"
+	updatedProject.(*iguazio.IguazioProject).Data.Attributes.Namespace = "some-namespace"
 	notUpdatedProject := suite.compileProject("leader-project",
 		namespace,
 		"not-updated",
 		"online",
 		testBeginningTime.Format(common.ProjectTimeLayout))
-	notUpdatedProject.(*IguazioProject).Data.Attributes.Namespace = "some-namespace"
+	notUpdatedProject.(*iguazio.IguazioProject).Data.Attributes.Namespace = "some-namespace"
 	suite.testSynchronizeProjectsFromLeader(
 		namespace,
 		[]platform.Project{updatedProject},
@@ -269,9 +270,9 @@ func (suite *SynchronizerTestSuite) compileProject(name string,
 	status string,
 	updatedAt string) platform.Project {
 
-	return &IguazioProject{
-		Data: ProjectData{
-			Attributes: ProjectAttributes{
+	return &iguazio.IguazioProject{
+		Data: iguazio.ProjectData{
+			Attributes: iguazio.ProjectAttributes{
 				Name:              name,
 				Namespace:         namespace,
 				Description:       description,

--- a/pkg/platform/abstract/project/external/leader/iguazio/types.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/types.go
@@ -66,6 +66,10 @@ func (pl *IguazioProject) GetConfig() *platform.ProjectConfig {
 	}
 }
 
+func (pl *IguazioProject) IsProjectNotOnline() bool {
+	return pl.Data.Attributes.AdminStatus != common.ProjectOnlineStatus || pl.Data.Attributes.OperationalStatus != common.ProjectOnlineStatus
+}
+
 type ResponseMeta struct {
 	Ctx string `json:"ctx"`
 }

--- a/pkg/platform/abstract/project/external/leader/iguazio/types.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/types.go
@@ -44,30 +44,30 @@ func NewProjectFromProjectConfig(projectConfig *platform.ProjectConfig) IguazioP
 	}
 }
 
-func (pl *IguazioProject) GetConfig() *platform.ProjectConfig {
-	updatedAt := common.ParseTimeFromTimestamp(pl.Data.Attributes.UpdatedAt)
+func (ip *IguazioProject) GetConfig() *platform.ProjectConfig {
+	updatedAt := common.ParseTimeFromTimestamp(ip.Data.Attributes.UpdatedAt)
 	return &platform.ProjectConfig{
 		Meta: platform.ProjectMeta{
-			Name:        pl.Data.Attributes.Name,
-			Namespace:   pl.Data.Attributes.Namespace,
-			Annotations: labelListToMap(pl.Data.Attributes.Annotations),
-			Labels:      labelListToMap(pl.Data.Attributes.Labels),
+			Name:        ip.Data.Attributes.Name,
+			Namespace:   ip.Data.Attributes.Namespace,
+			Annotations: labelListToMap(ip.Data.Attributes.Annotations),
+			Labels:      labelListToMap(ip.Data.Attributes.Labels),
 		},
 		Spec: platform.ProjectSpec{
-			Description:                 pl.Data.Attributes.Description,
-			Owner:                       pl.Data.Attributes.OwnerUsername,
-			DefaultFunctionNodeSelector: labelListToMap(pl.Data.Attributes.DefaultFunctionNodeSelector),
+			Description:                 ip.Data.Attributes.Description,
+			Owner:                       ip.Data.Attributes.OwnerUsername,
+			DefaultFunctionNodeSelector: labelListToMap(ip.Data.Attributes.DefaultFunctionNodeSelector),
 		},
 		Status: platform.ProjectStatus{
-			AdminStatus:       pl.Data.Attributes.AdminStatus,
-			OperationalStatus: pl.Data.Attributes.OperationalStatus,
+			AdminStatus:       ip.Data.Attributes.AdminStatus,
+			OperationalStatus: ip.Data.Attributes.OperationalStatus,
 			UpdatedAt:         &updatedAt,
 		},
 	}
 }
 
-func (pl *IguazioProject) IsProjectNotOnline() bool {
-	return pl.Data.Attributes.AdminStatus != common.ProjectOnlineStatus || pl.Data.Attributes.OperationalStatus != common.ProjectOnlineStatus
+func (ip *IguazioProject) IsProjectOnline() bool {
+	return ip.Data.Attributes.AdminStatus == common.ProjectOnlineStatus && ip.Data.Attributes.OperationalStatus == common.ProjectOnlineStatus
 }
 
 type ResponseMeta struct {
@@ -194,8 +194,8 @@ func (pd *ProjectDetailResponse) GetLastJobID() string {
 }
 
 // ToSingleProjectList returns list of IguazioProject
-func (pl *ProjectDetail) ToSingleProjectList() []platform.Project {
+func (pd *ProjectDetail) ToSingleProjectList() []platform.Project {
 	return []platform.Project{
-		&IguazioProject{Data: pl.Data},
+		&IguazioProject{Data: pd.Data},
 	}
 }

--- a/pkg/platform/abstract/project/external/leader/mlrun/leader.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/leader.go
@@ -71,9 +71,12 @@ func (l *LeaderOps) ResolveCreateProjectResponse(ctx context.Context, body []byt
 	return &project, nil
 }
 
-func (l *LeaderOps) ResolveGetProjectResponse(_ bool, _ []byte) ([]platform.Project, error) {
-	// will be implemented as part of synchronizer task
-	return nil, nuclio.ErrNotImplemented
+func (l *LeaderOps) ResolveGetProjectResponse(_ bool, body []byte) ([]platform.Project, error) {
+	var projects MLRunProjectList
+	if err := json.Unmarshal(body, &projects); err != nil {
+		return nil, errors.Wrap(err, "Failed to unmarshal response body")
+	}
+	return projects.ToProjectList(), nil
 }
 
 func (l *LeaderOps) ParseJobStatusResponse(_ context.Context, _ []byte) (leaderCommon.JobResponse, bool) {
@@ -129,8 +132,9 @@ func (l *LeaderOps) GenerateGetProjectsRequestURL(_, _ string) string {
 	return ""
 }
 
-func (l *LeaderOps) GenerateGetUpdatedAfterRequestURL(_ string) string {
-	return ""
+func (l *LeaderOps) GenerateGetUpdatedAfterRequestURL(apiAddress string) string {
+	// TODO - for now there is no filter addition to the URL, should be added when MLRun supports updated_at
+	return fmt.Sprintf("%s/%s", apiAddress, "projects")
 }
 
 func (l *LeaderOps) GenerateDeleteProjectRequestURL(apiAddress, projectName string) string {

--- a/pkg/platform/abstract/project/external/leader/mlrun/leader.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/leader.go
@@ -34,12 +34,14 @@ import (
 )
 
 type LeaderOps struct {
-	logger logger.Logger
+	logger    logger.Logger
+	namespace string
 }
 
-func NewLeaderOps(parentLogger logger.Logger) *LeaderOps {
+func NewLeaderOps(parentLogger logger.Logger, namespace string) *LeaderOps {
 	return &LeaderOps{
-		logger: parentLogger.GetChild("mlrun"),
+		logger:    parentLogger.GetChild("mlrun"),
+		namespace: namespace,
 	}
 }
 
@@ -76,7 +78,8 @@ func (l *LeaderOps) ResolveGetProjectResponse(_ bool, body []byte) ([]platform.P
 	if err := json.Unmarshal(body, &projects); err != nil {
 		return nil, errors.Wrap(err, "Failed to unmarshal response body")
 	}
-	return projects.ToProjectList(), nil
+
+	return projects.ToProjectList(l.namespace), nil
 }
 
 func (l *LeaderOps) ParseJobStatusResponse(_ context.Context, _ []byte) (leaderCommon.JobResponse, bool) {

--- a/pkg/platform/abstract/project/external/leader/mlrun/leader.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/leader.go
@@ -34,7 +34,8 @@ import (
 )
 
 type LeaderOps struct {
-	logger    logger.Logger
+	logger logger.Logger
+	// namespace is used to enrich the MLRun responses, which omit the namespace
 	namespace string
 }
 

--- a/pkg/platform/abstract/project/external/leader/mlrun/leader_test.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/leader_test.go
@@ -42,7 +42,7 @@ func (suite *LeaderTestSuite) SetupSuite() {
 	var err error
 	suite.logger, err = nucliozap.NewNuclioZapTest("test-mlrun-leader")
 	suite.Require().NoError(err)
-	suite.leaderOps = NewLeaderOps(suite.logger)
+	suite.leaderOps = NewLeaderOps(suite.logger, "test-namespace")
 }
 
 func (suite *LeaderTestSuite) TestGenerateProjectRequestBody() {

--- a/pkg/platform/abstract/project/external/leader/mlrun/leader_test.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/leader_test.go
@@ -131,31 +131,33 @@ func (suite *LeaderTestSuite) TestResolveCreateProjectResponse() {
 
 func (suite *LeaderTestSuite) TestResolveGetProjectResponse() {
 	testCases := []struct {
-		name   string
-		body   []byte
-		detail bool
+		name        string
+		body        []byte
+		expectedLen int
 	}{
 		{
-			name:   "DetailTrue",
-			detail: true,
-			body:   []byte(`{}`),
+			name:        "multipleProjects",
+			body:        []byte(`{"projects":[{"kind":"project","metadata":{"name":"curl-test","created":"2025-08-18T14:51:52.330000","labels":{},"annotations":{}},"spec":{"description":null,"owner":"admin","goals":null,"params":{},"functions":[],"workflows":[],"artifacts":[],"artifact_path":null,"conda":null,"source":null,"subpath":null,"origin_url":null,"desired_state":"online","custom_packagers":null,"default_image":null,"build":null},"status":{"state":"online"}},{"kind":"project","metadata":{"name":"curl-test2","created":"2025-08-20T06:25:30.227000","labels":{},"annotations":{}},"spec":{"description":null,"owner":"admin","goals":null,"params":{},"functions":[],"workflows":[],"artifacts":[],"artifact_path":null,"conda":null,"source":null,"subpath":null,"origin_url":null,"desired_state":"online","custom_packagers":null,"default_image":null,"build":null},"status":{"state":"online"}},{"kind":"project","metadata":{"name":"default","created":"2025-05-12T11:18:51.038000","labels":{},"annotations":{}},"spec":{"description":"Default Project","owner":null,"goals":null,"params":{},"functions":[],"workflows":[],"artifacts":[],"artifact_path":null,"conda":null,"source":null,"subpath":null,"origin_url":null,"desired_state":"online","custom_packagers":null,"default_image":null,"build":null},"status":{"state":"online"}}]}`),
+			expectedLen: 3,
 		},
 		{
-			name:   "DetailFalse",
-			detail: false,
-			body:   []byte(`{}`),
+			name:        "noProjects",
+			body:        []byte(`{"projects":[]}`),
+			expectedLen: 0,
 		},
 		{
-			name:   "EmptyBody",
-			detail: false,
-			body:   nil,
+			name:        "singleProject",
+			body:        []byte(`{"projects":[{"kind":"project","metadata":{"name":"asd","created":"2025-09-03T06:55:30.824045","labels":{},"annotations":{},"namespace":"mlrun"},"spec":{"description":null,"owner":null,"goals":null,"params":{},"functions":[],"workflows":[],"artifacts":[],"artifact_path":null,"conda":null,"source":null,"subpath":null,"origin_url":null,"desired_state":"online","custom_packagers":null,"default_image":null,"build":null,"default_function_node_selector":{}},"status":{"state":"online"}}]}`),
+			expectedLen: 1,
 		},
 	}
 
 	for _, testCase := range testCases {
-		projects, err := suite.leaderOps.ResolveGetProjectResponse(testCase.detail, testCase.body)
-		suite.Require().Error(err)
-		suite.Require().Nil(projects)
+		suite.Run(testCase.name, func() {
+			projects, err := suite.leaderOps.ResolveGetProjectResponse(false, testCase.body)
+			suite.Require().NoError(err)
+			suite.Require().Len(projects, testCase.expectedLen)
+		})
 	}
 }
 
@@ -288,7 +290,7 @@ func (suite *LeaderTestSuite) TestGenerateGetProjectsRequestURL() {
 
 func (suite *LeaderTestSuite) TestGenerateGetUpdatedAfterRequestURL() {
 	url := suite.leaderOps.GenerateGetUpdatedAfterRequestURL("test")
-	suite.Require().Equal("", url)
+	suite.Require().Equal("test/projects", url)
 }
 
 func (suite *LeaderTestSuite) TestGenerateDeleteProjectRequestURL() {

--- a/pkg/platform/abstract/project/external/leader/mlrun/leader_test.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/leader_test.go
@@ -36,13 +36,15 @@ type LeaderTestSuite struct {
 	suite.Suite
 	logger    logger.Logger
 	leaderOps *LeaderOps
+	namespace string
 }
 
 func (suite *LeaderTestSuite) SetupSuite() {
 	var err error
 	suite.logger, err = nucliozap.NewNuclioZapTest("test-mlrun-leader")
 	suite.Require().NoError(err)
-	suite.leaderOps = NewLeaderOps(suite.logger, "test-namespace")
+	suite.namespace = "test-namespace"
+	suite.leaderOps = NewLeaderOps(suite.logger, suite.namespace)
 }
 
 func (suite *LeaderTestSuite) TestGenerateProjectRequestBody() {
@@ -157,6 +159,9 @@ func (suite *LeaderTestSuite) TestResolveGetProjectResponse() {
 			projects, err := suite.leaderOps.ResolveGetProjectResponse(false, testCase.body)
 			suite.Require().NoError(err)
 			suite.Require().Len(projects, testCase.expectedLen)
+			for _, project := range projects {
+				suite.Require().Equal(suite.namespace, project.GetConfig().Meta.Namespace)
+			}
 		})
 	}
 }

--- a/pkg/platform/abstract/project/external/leader/mlrun/types.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/types.go
@@ -87,3 +87,20 @@ func NewProjectFromProjectConfig(projectConfig *platform.ProjectConfig) (MLRunPr
 		},
 	}, nil
 }
+
+type MLRunProjectList struct {
+	Projects []MLRunProject `json:"projects"`
+}
+
+// ToProjectList returns list of MLRunProject
+func (mpl *MLRunProjectList) ToProjectList() []platform.Project {
+	var projects []platform.Project
+	for _, mlrunProject := range mpl.Projects {
+		projects = append(projects, &MLRunProject{
+			Metadata: mlrunProject.Metadata,
+			Spec:     mlrunProject.Spec,
+			Status:   mlrunProject.Status,
+		})
+	}
+	return projects
+}

--- a/pkg/platform/abstract/project/external/leader/mlrun/types.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/types.go
@@ -70,6 +70,10 @@ func (p *MLRunProject) GetConfig() *platform.ProjectConfig {
 	}
 }
 
+func (p *MLRunProject) IsProjectNotOnline() bool {
+	return p.Status.State != common.ProjectOnlineStatus
+}
+
 func NewProjectFromProjectConfig(projectConfig *platform.ProjectConfig) (MLRunProject, error) {
 	if projectConfig == nil {
 		return MLRunProject{}, errors.New("ProjectConfig is nil")

--- a/pkg/platform/abstract/project/external/leader/mlrun/types.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/types.go
@@ -71,8 +71,8 @@ func (p *MLRunProject) GetConfig() *platform.ProjectConfig {
 	}
 }
 
-func (p *MLRunProject) IsProjectNotOnline() bool {
-	return p.Status.State != common.ProjectOnlineStatus
+func (p *MLRunProject) IsProjectOnline() bool {
+	return p.Status.State == common.ProjectOnlineStatus
 }
 
 func NewProjectFromProjectConfig(projectConfig *platform.ProjectConfig) (MLRunProject, error) {

--- a/pkg/platform/abstract/project/external/leader/mlrun/types.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/types.go
@@ -60,6 +60,7 @@ func (p *MLRunProject) GetConfig() *platform.ProjectConfig {
 	return &platform.ProjectConfig{
 		Meta: platform.ProjectMeta{
 			Name:        p.Metadata.Name,
+			Namespace:   p.Metadata.Namespace,
 			Annotations: p.Metadata.Annotations,
 			Labels:      p.Metadata.Labels,
 		},
@@ -97,14 +98,18 @@ type MLRunProjectList struct {
 }
 
 // ToProjectList returns list of MLRunProject
-func (mpl *MLRunProjectList) ToProjectList() []platform.Project {
+func (mpl *MLRunProjectList) ToProjectList(namespace string) []platform.Project {
 	var projects []platform.Project
 	for _, mlrunProject := range mpl.Projects {
-		projects = append(projects, &MLRunProject{
+		project := &MLRunProject{
 			Metadata: mlrunProject.Metadata,
 			Spec:     mlrunProject.Spec,
 			Status:   mlrunProject.Status,
-		})
+		}
+
+		// set the namespace since MLRun doesn't return it in the response
+		project.Metadata.Namespace = namespace
+		projects = append(projects, project)
 	}
 	return projects
 }

--- a/pkg/platform/abstract/project/external/leader/mock/client.go
+++ b/pkg/platform/abstract/project/external/leader/mock/client.go
@@ -35,7 +35,7 @@ func (c *MockProject) GetConfig() *platform.ProjectConfig {
 	return args.Get(0).(*platform.ProjectConfig)
 }
 
-func (c *MockProject) IsProjectNotOnline() bool {
+func (c *MockProject) IsProjectOnline() bool {
 	args := c.Called()
 	return args.Bool(0)
 }

--- a/pkg/platform/abstract/project/external/leader/mock/client.go
+++ b/pkg/platform/abstract/project/external/leader/mock/client.go
@@ -35,6 +35,11 @@ func (c *MockProject) GetConfig() *platform.ProjectConfig {
 	return args.Get(0).(*platform.ProjectConfig)
 }
 
+func (c *MockProject) IsProjectNotOnline() bool {
+	args := c.Called()
+	return args.Bool(0)
+}
+
 type CreateProjectResponseMock struct {
 	mock.Mock
 }

--- a/pkg/platform/abstract/project/external/leader/types.go
+++ b/pkg/platform/abstract/project/external/leader/types.go
@@ -139,6 +139,7 @@ const (
 
 const (
 	ProjectTimeLayout = "2006-01-02T15:04:05.000000+00:00"
+	ProjectOnlineStatus = "online"
 )
 
 func ParseTimeFromTimestamp(timestamp string) time.Time {

--- a/pkg/platform/abstract/project/external/leader/types.go
+++ b/pkg/platform/abstract/project/external/leader/types.go
@@ -138,7 +138,7 @@ const (
 )
 
 const (
-	ProjectTimeLayout = "2006-01-02T15:04:05.000000+00:00"
+	ProjectTimeLayout   = "2006-01-02T15:04:05.000000+00:00"
 	ProjectOnlineStatus = "online"
 )
 

--- a/pkg/platform/project.go
+++ b/pkg/platform/project.go
@@ -36,6 +36,9 @@ type Project interface {
 
 	// GetConfig returns the project config
 	GetConfig() *ProjectConfig
+
+	// IsProjectNotOnline returns true if the project is offline
+	IsProjectNotOnline() bool
 }
 
 type AbstractProject struct {
@@ -58,6 +61,10 @@ func NewAbstractProject(parentLogger logger.Logger,
 // GetConfig returns the project config
 func (ap *AbstractProject) GetConfig() *ProjectConfig {
 	return &ap.ProjectConfig
+}
+
+func (ap *AbstractProject) IsProjectNotOnline() bool {
+	return ap.ProjectConfig.Status.AdminStatus != "online" || ap.ProjectConfig.Status.OperationalStatus != "online"
 }
 
 func (ap *AbstractProject) CreateAndWait(ctx context.Context, createProjectOptions *CreateProjectOptions) error {

--- a/pkg/platform/project.go
+++ b/pkg/platform/project.go
@@ -37,8 +37,8 @@ type Project interface {
 	// GetConfig returns the project config
 	GetConfig() *ProjectConfig
 
-	// IsProjectNotOnline returns true if the project is offline
-	IsProjectNotOnline() bool
+	// IsProjectOnline returns true if the project is offline
+	IsProjectOnline() bool
 }
 
 type AbstractProject struct {
@@ -63,8 +63,8 @@ func (ap *AbstractProject) GetConfig() *ProjectConfig {
 	return &ap.ProjectConfig
 }
 
-func (ap *AbstractProject) IsProjectNotOnline() bool {
-	return ap.ProjectConfig.Status.AdminStatus != "online" || ap.ProjectConfig.Status.OperationalStatus != "online"
+func (ap *AbstractProject) IsProjectOnline() bool {
+	return ap.ProjectConfig.Status.AdminStatus == "online" && ap.ProjectConfig.Status.OperationalStatus == "online"
 }
 
 func (ap *AbstractProject) CreateAndWait(ctx context.Context, createProjectOptions *CreateProjectOptions) error {


### PR DESCRIPTION
### 📝 Description
Refactor Nuclio’s project synchronizer to align projects with an MLRun leader.

---

### 🛠️ Changes Made
- Moved `iguazio/synchronizer` to the `client` directory
- Implement relevant fuinctionalities (`GenerateGetUpdatedAfterRequestURL` and `ResolveGetProjectResponse`) in the MLRun leader in order to support the `GetUpdatedAfter` of the `clinet/client.go` [[link](https://github.com/nuclio/nuclio/blob/development/pkg/platform/abstract/project/external/leader/client/client.go#L219)]

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Added unit test for MLRun's response handling
- Load test 
    - Run on my local MLRun-CE for testing the synchronization cycle duration:
        - 2 projects - `12 ms`
        - 10 projects - `13 ms`
        - 100 projects - `180 ms`
        - 1,000 projects - `670 ms `
    - The test cycle only fetched and unmarshaled the response, without performing any project creation or update [[link](https://github.com/nuclio/nuclio/blob/development/pkg/platform/abstract/project/external/leader/iguazio/synchronizer.go#L191)], so actual runtimes may be longer in a real setup cycle.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-576

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
- follow-up task - For now, MLRun will return all of the existing project in each iteration, since it's not support `updated_at` filtering. Once it will be implemented, need to support the filtering in the URL [here](https://github.com/nuclio/nuclio/pull/3785/files#diff-1d1663a166d89a9a8f9ecf818bc10cf5cc85a1431aa052a06d6cca02bab6ef35R136)
- Due to the current MLRun filtering limitation, and although load tests showed that a 1k-project cycle takes less than a second, we should consider increasing the `projectsLeader.synchronizationInterval` timeout from 1m when MLRun is set to be the leader.