### PR TITLE
[Dashboard] Update default python to 312

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -26,7 +26,7 @@ on:
         default: ''
         required: false
       runtimes:
-        description: 'Comma delimited list of runtimes (e.g.: java,golang,python:3.11, default: all)'
+        description: 'Comma delimited list of runtimes (e.g.: java,golang,python:3.12, default: all)'
         default: 'all'
         required: true
 
@@ -82,7 +82,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/dependencies_checker.yaml
+++ b/.github/workflows/dependencies_checker.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: pip install -r hack/scripts/dependency-checker/requirements.txt

--- a/docs/concepts/best-practices-and-common-pitfalls.md
+++ b/docs/concepts/best-practices-and-common-pitfalls.md
@@ -65,7 +65,7 @@ To prevent such 503 errors, tweak the values of your function's number of worker
 <a id="ca-certificates-for-alpine-w-https"></a>
 ## Install CA certificates for alpine with HTTPS
 
-Nuclio tries to default to the smallest image possible (except for Python, which currently defaults to a hefty python:3.11 base image). Therefore, where possible, the base image for your functions will be the [alpine](https://hub.docker.com/_/alpine) Docker image. To use HTTPS in alpine, you must include the following code in the build commands to install root CA certificates:
+Nuclio tries to default to the smallest image possible (except for Python, which currently defaults to a hefty python:3.12 base image). Therefore, where possible, the base image for your functions will be the [alpine](https://hub.docker.com/_/alpine) Docker image. To use HTTPS in alpine, you must include the following code in the build commands to install root CA certificates:
 ```sh
 apk --update --nocache add ca-certificates
 ```

--- a/docs/reference/nuctl/cli/nuctl_build.md
+++ b/docs/reference/nuctl/cli/nuctl_build.md
@@ -26,7 +26,7 @@ nuctl build function-name [options] [flags]
   -p, --path string                     Path to the function's source code
       --project-name string             The name of the function's parent project
   -r, --registry string                 URL of a container registry (env: NUCTL_REGISTRY)
-      --runtime string                  Runtime (for example, "golang", "python:3.11")
+      --runtime string                  Runtime (for example, "golang", "python:3.12")
       --source string                   The function's source code (overrides "path")
 ```
 

--- a/docs/reference/nuctl/cli/nuctl_deploy.md
+++ b/docs/reference/nuctl/cli/nuctl_deploy.md
@@ -51,7 +51,7 @@ nuctl deploy function-name [flags]
       --run-as-user int                    Run function process with user ID (default -1)
       --run-image string                   Name of an existing image to deploy (default - build a new image to deploy)
       --run-registry string                URL of a registry for pulling the image, if differs from -r/--registry (env: NUCTL_RUN_REGISTRY)
-      --runtime string                     Runtime (for example, "golang", "python:3.11")
+      --runtime string                     Runtime (for example, "golang", "python:3.12")
       --runtime-attrs string               JSON-encoded runtime attributes for the function
       --source string                      The function's source code (overrides "path")
       --target-cpu int                     Target CPU-usage percentage when auto-scaling (default -1)

--- a/docs/reference/runtimes/python/python-reference.md
+++ b/docs/reference/runtimes/python/python-reference.md
@@ -137,7 +137,7 @@ The following Python versions are no longer supported in Nuclio, due to their En
 For more information, see the [Python version status](https://devguide.python.org/versions/) page.
 
 To keep using latest Nuclio, and reach better performance and message throughput, we strongly suggest migrating your
-code to Python 3.11 or higher.
+code to Python 3.12 or higher.
 
 <a id="function-configuration"></a>
 ## Function configuration

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -497,7 +497,7 @@ platform: {}
 #    defaultHTTPIngressClassName: ""
 #  imageRegistryOverrides:
 #    baseImageRegistries:
-#      "python:3.11": "myregistry"
+#      "python:3.12": "myregistry"
 #    onbuildImageRegistries:
 #      "golang": "myregistry"
 #  functionReadinessTimeout: 120s

--- a/pkg/nuctl/command/build.go
+++ b/pkg/nuctl/command/build.go
@@ -117,7 +117,7 @@ func addBuildFlags(cmd *cobra.Command, functionBuild *functionconfig.Build, func
 	cmd.Flags().StringVarP(functionConfigPath, "file", "f", "", "Path to a function-configuration file")
 	cmd.Flags().StringVarP(&functionBuild.Image, "image", "i", "", "Name of a container image (default - the function name)")
 	cmd.Flags().StringVarP(&functionBuild.Registry, "registry", "r", os.Getenv("NUCTL_REGISTRY"), "URL of a container registry (env: NUCTL_REGISTRY)")
-	cmd.Flags().StringVarP(runtime, "runtime", "", "", "Runtime (for example, \"golang\", \"python:3.11\")")
+	cmd.Flags().StringVarP(runtime, "runtime", "", "", "Runtime (for example, \"golang\", \"python:3.12\")")
 	cmd.Flags().StringVarP(handler, "handler", "", "", "Name of a function handler")
 	cmd.Flags().BoolVarP(&functionBuild.NoBaseImagesPull, "no-pull", "", false, "Don't pull base images - use local versions")
 	cmd.Flags().BoolVarP(&functionBuild.NoCleanup, "no-cleanup", "", false, "Don't clean up temporary directories")

--- a/pkg/nuctl/test/function_test.go
+++ b/pkg/nuctl/test/function_test.go
@@ -1077,7 +1077,7 @@ func (suite *functionDeployTestSuite) TestDeployFromLocalDirPath() {
 	err := suite.ExecuteNuctl([]string{"deploy", functionName, "--verbose", "--no-pull"},
 		map[string]string{
 			"path":         path.Join(suite.GetFunctionsDir(), "common", "reverser", "python"),
-			"runtime":      "python:3.11",
+			"runtime":      "python:3.12",
 			"handler":      "reverser:handler",
 			"project-name": suite.projectName,
 		})

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -275,7 +275,7 @@ func (ap *Platform) EnrichFunctionConfig(ctx context.Context, functionConfig *fu
 
 	// `python` is just an alias
 	if functionConfig.Spec.Runtime == "python" {
-		functionConfig.Spec.Runtime = "python:3.11"
+		functionConfig.Spec.Runtime = "python:3.12"
 	}
 
 	if functionConfig.Spec.DisableDefaultHTTPTrigger == nil {

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -432,7 +432,7 @@ func (suite *AbstractPlatformTestSuite) TestValidateBatchConfiguration() {
 				BatchSize: -3,
 				Timeout:   "1s",
 			},
-			runtime:     "python:3.11",
+			runtime:     "python:3.12",
 			triggerKind: "http",
 			expectError: true,
 		},
@@ -443,7 +443,7 @@ func (suite *AbstractPlatformTestSuite) TestValidateBatchConfiguration() {
 				BatchSize: 1,
 				Timeout:   "test",
 			},
-			runtime:     "python:3.11",
+			runtime:     "python:3.12",
 			triggerKind: "http",
 			expectError: true,
 		},
@@ -474,7 +474,7 @@ func (suite *AbstractPlatformTestSuite) TestValidateBatchConfiguration() {
 				BatchSize: 1,
 				Timeout:   "1ms",
 			},
-			runtime:     "python:3.11",
+			runtime:     "python:3.12",
 			triggerKind: "cron",
 		},
 	} {
@@ -2324,7 +2324,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichPythonVersion() {
 	suite.Require().NoError(err, "Failed to enrich function")
 
 	// check that the python version is set to the default value
-	suite.Require().Equal("python:3.11",
+	suite.Require().Equal("python:3.12",
 		functionConfig.Spec.Runtime,
 		"Python version was not set to the default value")
 }

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -511,7 +511,7 @@ func (b *Builder) validateAndEnrichConfiguration() error {
 
 	// python is just a reference
 	if b.options.FunctionConfig.Spec.Runtime == "python" {
-		b.options.FunctionConfig.Spec.Runtime = "python:3.11"
+		b.options.FunctionConfig.Spec.Runtime = "python:3.12"
 	}
 
 	if _, err := b.options.FunctionConfig.GetProjectName(); err != nil {

--- a/pkg/processor/runtime/python/runtime.go
+++ b/pkg/processor/runtime/python/runtime.go
@@ -66,7 +66,7 @@ func (py *python) RunWrapper(eventSocketPaths []string, controlSocketPath string
 	_, runtimeVersion := common.GetRuntimeNameAndVersion(py.configuration.Spec.Runtime)
 	if runtimeVersion == "" || runtimeVersion == "3.7" || runtimeVersion == "3.8" {
 		py.Logger.Warn("Python 3.7 and 3.8 runtimes are deprecated and will soon not be supported. " +
-			"Migrate your code and use Python 3.12 runtime (`python:3.12`)")
+			"Migrate your code and use Python 3.11 runtime (`python:3.11`) or higher")
 	}
 
 	wrapperScriptPath := py.getWrapperScriptPath()

--- a/pkg/processor/runtime/python/runtime.go
+++ b/pkg/processor/runtime/python/runtime.go
@@ -66,7 +66,7 @@ func (py *python) RunWrapper(eventSocketPaths []string, controlSocketPath string
 	_, runtimeVersion := common.GetRuntimeNameAndVersion(py.configuration.Spec.Runtime)
 	if runtimeVersion == "" || runtimeVersion == "3.7" || runtimeVersion == "3.8" {
 		py.Logger.Warn("Python 3.7 and 3.8 runtimes are deprecated and will soon not be supported. " +
-			"Migrate your code and use Python 3.12 runtime (`python:3.12`) or higher")
+			"Migrate your code and use Python 3.12 runtime (`python:3.12`)")
 	}
 
 	wrapperScriptPath := py.getWrapperScriptPath()

--- a/pkg/processor/runtime/python/runtime.go
+++ b/pkg/processor/runtime/python/runtime.go
@@ -63,11 +63,10 @@ func NewRuntime(parentLogger logger.Logger, configuration *runtime.Configuration
 }
 
 func (py *python) RunWrapper(eventSocketPaths []string, controlSocketPath string) (*os.Process, error) {
-
 	_, runtimeVersion := common.GetRuntimeNameAndVersion(py.configuration.Spec.Runtime)
 	if runtimeVersion == "" || runtimeVersion == "3.7" || runtimeVersion == "3.8" {
 		py.Logger.Warn("Python 3.7 and 3.8 runtimes are deprecated and will soon not be supported. " +
-			"Migrate your code and use Python 3.11 runtime (`python:3.11`) or higher")
+			"Migrate your code and use Python 3.12 runtime (`python:3.12`) or higher")
 	}
 
 	wrapperScriptPath := py.getWrapperScriptPath()


### PR DESCRIPTION
### 📝 Description
Update default enrichment of python from 3.11 to 3.12

---

### 🛠️ Changes Made
- Update the enrichments where Python was selected, but with no specific version

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Updated UTs and integration tests
- Dev test:
    - Patched the `nuclio-dashboard` with the changes into IGZ setup
    - Created this function:


```
    import sys
    import platform

    def handler(context, event):
        context.logger.info('This is the python version:')
        context.logger.info("Python version by sys:"+ sys.version)
        context.logger.info("Python version by platform:"+ platform.python_version())
        return context.Response(body='Hello, from nuclio :]',
                            headers={},
                            content_type='text/plain',
                            status_code=200)
```
 
- The function created with python 3.12:

```
{"level":"info","time":"2025-09-04T16:45:30.266Z","name":"processor.http","message":"This is the python version:"}
{"level":"info","time":"2025-09-04T16:45:30.266Z","name":"processor.http","message":"Python version by sys:3.12.11 (main, Aug 12 2025, 23:10:44) [GCC 14.2.0]"}
{"level":"info","time":"2025-09-04T16:45:30.266Z","name":"processor.http","message":"Python version by platform:3.12.11"}
```


---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-546

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
- 📸 Screenshots
<img width="779" height="644" alt="image" src="https://github.com/user-attachments/assets/e582f773-00f7-436f-a772-a66b3fe425b1" />
