### PR TITLE
[Dashboard] Fix getting pod logs when deployment failed

### DIFF
--- a/pkg/common/consts.go
+++ b/pkg/common/consts.go
@@ -66,3 +66,5 @@ const DefaultIngressHostTemplate = "@nuclio.fromDefault"
 const FunctionTagLatest = "latest"
 
 const FunctionContainerName = "nuclio"
+
+const AnnotationKubectlDefaultContainer = "kubectl.kubernetes.io/default-container"

--- a/pkg/common/consts.go
+++ b/pkg/common/consts.go
@@ -64,3 +64,5 @@ const FunctionConfigFileName = "function.yaml"
 const DefaultIngressHostTemplate = "@nuclio.fromDefault"
 
 const FunctionTagLatest = "latest"
+
+const FunctionContainerName = "nuclio"

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -33,7 +33,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/opa"
 	"github.com/nuclio/nuclio/pkg/platform"
-	nuclioclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio"
 	"github.com/nuclio/nuclio/pkg/restful"
 
 	"github.com/nuclio/errors"
@@ -454,7 +453,7 @@ func (fr *functionResource) validateLogStreamOptions(ctx context.Context,
 	}
 
 	// ensure container name is valid for the replica (if provided)
-	if getFunctionReplicaLogsStreamOptions.ContainerName != nuclioclient.FunctionContainerName {
+	if getFunctionReplicaLogsStreamOptions.ContainerName != common.FunctionContainerName {
 		// get the replica's containers
 		replicaContainers, err := fr.getPlatform().GetFunctionReplicaContainers(ctx, function.GetConfig(), getFunctionReplicaLogsStreamOptions.Name)
 		if err != nil {
@@ -811,7 +810,7 @@ func (fr *functionResource) populateGetFunctionReplicaLogsStreamOptions(request 
 		Name:          replicaName,
 		Namespace:     namespace,
 		Follow:        fr.GetURLParamBoolOrDefault(request, "follow", true),
-		ContainerName: fr.GetURLParamStringOrDefault(request, "containerName", nuclioclient.FunctionContainerName),
+		ContainerName: fr.GetURLParamStringOrDefault(request, "containerName", common.FunctionContainerName),
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fr.getCtxSession(request.Context())),
 			RaiseForbidden:      true,

--- a/pkg/platform/kube/clients/nuclio/deployer.go
+++ b/pkg/platform/kube/clients/nuclio/deployer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+	"github.com/nuclio/nuclio/pkg/platform/kube/utils"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -152,7 +153,8 @@ func (d *Deployer) Deploy(ctx context.Context,
 		functionInstance.Namespace,
 		functionInstance.Name)
 	if err != nil {
-		podLogs, briefErrorsMessage := d.getFunctionPodLogsAndEvents(ctx, functionInstance.Namespace, functionInstance.Name)
+		defaultContainerName := utils.GetDefaultContainerName(functionInstance.Annotations)
+		podLogs, briefErrorsMessage := d.getFunctionPodLogsAndEvents(ctx, functionInstance.Namespace, functionInstance.Name, defaultContainerName)
 		return nil, updatedFunctionInstance, briefErrorsMessage, errors.Wrapf(err, "Failed to wait for function readiness.\n%s", podLogs)
 	}
 
@@ -211,7 +213,7 @@ func (d *Deployer) populateFunction(functionConfig *functionconfig.Config,
 
 }
 
-func (d *Deployer) getFunctionPodLogsAndEvents(ctx context.Context, namespace string, name string) (string, string) {
+func (d *Deployer) getFunctionPodLogsAndEvents(ctx context.Context, namespace, name, containerName string) (string, string) {
 	var briefErrorsMessage string
 	podLogsMessage := "\nPod logs:\n"
 
@@ -241,11 +243,12 @@ func (d *Deployer) getFunctionPodLogsAndEvents(ctx context.Context, namespace st
 	podLogsMessage += "\n* " + pod.Name + "\n"
 
 	maxLogLines := int64(MaxLogLines)
+	options := &v1.PodLogOptions{TailLines: &maxLogLines, Container: containerName}
 	if logsRequest, getLogsErr := d.consumer.KubeClientSet.StreamPodLogs(
 		ctx,
 		namespace,
 		pod.Name,
-		&v1.PodLogOptions{TailLines: &maxLogLines}); getLogsErr != nil {
+		options); getLogsErr != nil {
 		podLogsMessage += "Failed to read logs: " + getLogsErr.Error() + "\n"
 	} else {
 		scanner := bufio.NewScanner(logsRequest)

--- a/pkg/platform/kube/clients/nuclio/function.go
+++ b/pkg/platform/kube/clients/nuclio/function.go
@@ -34,8 +34,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const FunctionContainerName = "nuclio"
-
 type Function struct {
 	platform.AbstractFunction
 	function           *nuclioio.NuclioFunction

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1856,7 +1856,7 @@ func (lc *lazyClient) getPodAnnotations(function *nuclioio.NuclioFunction) (map[
 	}
 
 	// set default container annotation if not exists, for logging purposes
-	defaultContainerAnnotation := "kubectl.kubernetes.io/default-container"
+	defaultContainerAnnotation := common.AnnotationKubectlDefaultContainer
 	if _, ok := annotations[defaultContainerAnnotation]; !ok {
 		annotations[defaultContainerAnnotation] = common.FunctionContainerName
 	}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1205,7 +1205,7 @@ func (lc *lazyClient) createOrUpdateDeployment(ctx context.Context,
 
 	createDeployment := func() (interface{}, error) {
 		method := createDeploymentResourceMethod
-		container := v1.Container{Name: nuclio.FunctionContainerName}
+		container := v1.Container{Name: common.FunctionContainerName}
 		lc.populateDeploymentContainer(ctx, functionLabels, function, &container)
 		container.VolumeMounts = volumeMounts
 
@@ -1858,7 +1858,7 @@ func (lc *lazyClient) getPodAnnotations(function *nuclioio.NuclioFunction) (map[
 	// set default container annotation if not exists, for logging purposes
 	defaultContainerAnnotation := "kubectl.kubernetes.io/default-container"
 	if _, ok := annotations[defaultContainerAnnotation]; !ok {
-		annotations[defaultContainerAnnotation] = nuclio.FunctionContainerName
+		annotations[defaultContainerAnnotation] = common.FunctionContainerName
 	}
 
 	return annotations, nil

--- a/pkg/platform/kube/utils/utils.go
+++ b/pkg/platform/kube/utils/utils.go
@@ -204,6 +204,15 @@ func GetProjectSecret(ctx context.Context, kubeClient kube.Client, projectSecret
 	return projectSecret, nil
 }
 
+func GetDefaultContainerName(annotations map[string]string) string {
+	defaultContainerAnnotation := "kubectl.kubernetes.io/default-container"
+	annotation, ok := annotations[defaultContainerAnnotation]
+	if ok {
+		return annotation
+	}
+	return common.FunctionContainerName
+}
+
 func IsServiceAccountAllowed(secret *v1.Secret, secretAllowedServiceAccountsKey string, serviceAccount string) error {
 	if serviceAccount == "" {
 		return nil

--- a/pkg/platform/kube/utils/utils.go
+++ b/pkg/platform/kube/utils/utils.go
@@ -205,10 +205,10 @@ func GetProjectSecret(ctx context.Context, kubeClient kube.Client, projectSecret
 }
 
 func GetDefaultContainerName(annotations map[string]string) string {
-	defaultContainerAnnotation := "kubectl.kubernetes.io/default-container"
-	annotation, ok := annotations[defaultContainerAnnotation]
+	defaultContainerAnnotation := common.AnnotationKubectlDefaultContainer
+	containerName, ok := annotations[defaultContainerAnnotation]
 	if ok {
-		return annotation
+		return containerName
 	}
 	return common.FunctionContainerName
 }


### PR DESCRIPTION
### 📝 Description
Fixes the bug when logs request to k8s failed because function had more than 1 container in a pod and container wasn't specified in options. Annotation of default container doesn't help in this case. 

Before:
<img width="3410" height="1668" alt="image" src="https://github.com/user-attachments/assets/926fa246-77bc-4259-a1d6-166df8556500" />

After(logs are empty because container runs with non-existent command): 

<img width="1365" height="428" alt="image" src="https://github.com/user-attachments/assets/7eb4b101-3c0f-4205-825d-ed4e7b63cb3d" />


---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
On vmdev

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-586
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No
