### PR TITLE
[Controller] Remove affect deployment.spec during function update if not needed

### DIFF
--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -568,10 +568,10 @@ type Spec struct {
 	// Init containers can contain utilities or setup scripts not present in an app image
 	InitContainers []*v1.Container `json:"initContainers,omitempty"`
 
-	// LastRedeployTimestamp used by the controller to set the nuclio.io/last-redeploy-timestamp annotation.
+	// LastDeployTimestamp used by the controller to set the nuclio.io/last-deploy-timestamp annotation.
 	// Ensures that when an image is redeployed, the deployment/pod template is updated
 	// so the image is pulled again.
-	LastRedeployTimestamp string `json:"lastRedeployTimestamp,omitempty"`
+	LastDeployTimestamp string `json:"lastDeployTimestamp,omitempty"`
 }
 
 type RunOnPreemptibleNodeMode string

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -765,9 +765,6 @@ func NewConfig() *Config {
 		Meta: Meta{
 			Namespace: "default",
 		},
-		Spec: Spec{
-			LastRedeployTimestamp: strconv.Itoa(int(time.Now().UnixNano())),
-		},
 	}
 }
 

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -568,9 +568,9 @@ type Spec struct {
 	// Init containers can contain utilities or setup scripts not present in an app image
 	InitContainers []*v1.Container `json:"initContainers,omitempty"`
 
-	// ImageTimeStampHash refer to the dashboard update time.
+	// LastRedeployTimestamp refer to the dashboard update time.
 	// It is used to determine if the function image needs to be pulled
-	ImageTimeStampHash string `json:"imageTimeStampHash,omitempty"`
+	LastRedeployTimestamp string `json:"lastRedeployTimestamp,omitempty"`
 }
 
 type RunOnPreemptibleNodeMode string
@@ -766,7 +766,7 @@ func NewConfig() *Config {
 			Namespace: "default",
 		},
 		Spec: Spec{
-			ImageTimeStampHash: strconv.Itoa(int(time.Now().UnixNano())),
+			LastRedeployTimestamp: strconv.Itoa(int(time.Now().UnixNano())),
 		},
 	}
 }

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -567,6 +567,10 @@ type Spec struct {
 	// InitContainers are specialized containers that run before app containers in a Pod
 	// Init containers can contain utilities or setup scripts not present in an app image
 	InitContainers []*v1.Container `json:"initContainers,omitempty"`
+
+	// ImageTimeStampHash refer to the dashboard update time.
+	// It is used to determine if the function image needs to be pulled
+	ImageTimeStampHash string `json:"imageTimeStampHash,omitempty"`
 }
 
 type RunOnPreemptibleNodeMode string
@@ -760,6 +764,9 @@ func NewConfig() *Config {
 	return &Config{
 		Meta: Meta{
 			Namespace: "default",
+		},
+		Spec: Spec{
+			ImageTimeStampHash: strconv.Itoa(int(time.Now().UnixNano())),
 		},
 	}
 }

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -568,8 +568,9 @@ type Spec struct {
 	// Init containers can contain utilities or setup scripts not present in an app image
 	InitContainers []*v1.Container `json:"initContainers,omitempty"`
 
-	// LastRedeployTimestamp refer to the dashboard update time.
-	// It is used to determine if the function image needs to be pulled
+	// LastRedeployTimestamp used by the controller to set the nuclio.io/last-redeploy-timestamp annotation.
+	// Ensures that when an image is redeployed, the deployment/pod template is updated
+	// so the image is pulled again.
 	LastRedeployTimestamp string `json:"lastRedeployTimestamp,omitempty"`
 }
 

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -480,7 +480,6 @@ type Spec struct {
 	EnvFrom                 []v1.EnvFromSource      `json:"envFrom,omitempty"`
 	Resources               v1.ResourceRequirements `json:"resources,omitempty"`
 	Image                   string                  `json:"image,omitempty"`
-	ImageHash               string                  `json:"imageHash,omitempty"`
 	Replicas                *int                    `json:"replicas,omitempty"`
 	MinReplicas             *int                    `json:"minReplicas,omitempty"`
 	MaxReplicas             *int                    `json:"maxReplicas,omitempty"`

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -306,7 +306,7 @@ func (ap *Platform) EnrichFunctionConfig(ctx context.Context, functionConfig *fu
 	ap.Config.EnrichFunctionContainerResources(ctx, ap.Logger, &functionConfig.Spec.Resources)
 
 	// enrich timestamp hash to update the deployment
-	functionConfig.Spec.LastRedeployTimestamp = strconv.Itoa(int(time.Now().UnixNano()))
+	functionConfig.Spec.LastDeployTimestamp = strconv.Itoa(int(time.Now().UnixNano()))
 
 	return nil
 }

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -303,6 +304,9 @@ func (ap *Platform) EnrichFunctionConfig(ctx context.Context, functionConfig *fu
 	ap.enrichEnvVars(functionConfig)
 
 	ap.Config.EnrichFunctionContainerResources(ctx, ap.Logger, &functionConfig.Spec.Resources)
+
+	// enrich timestamp hash to update the deployment
+	functionConfig.Spec.ImageTimeStampHash = strconv.Itoa(int(time.Now().UnixNano()))
 
 	return nil
 }

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -306,7 +306,7 @@ func (ap *Platform) EnrichFunctionConfig(ctx context.Context, functionConfig *fu
 	ap.Config.EnrichFunctionContainerResources(ctx, ap.Logger, &functionConfig.Spec.Resources)
 
 	// enrich timestamp hash to update the deployment
-	functionConfig.Spec.ImageTimeStampHash = strconv.Itoa(int(time.Now().UnixNano()))
+	functionConfig.Spec.LastRedeployTimestamp = strconv.Itoa(int(time.Now().UnixNano()))
 
 	return nil
 }

--- a/pkg/platform/kube/clients/nuclio/deployer.go
+++ b/pkg/platform/kube/clients/nuclio/deployer.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -202,10 +201,6 @@ func (d *Deployer) populateFunction(functionConfig *functionconfig.Config,
 			functionInstance.Spec.Image = fmt.Sprintf("%s/%s", functionConfig.Spec.RunRegistry, functionInstance.Spec.Image)
 		}
 	}
-
-	// update the spec with a new image hash to trigger pod restart. in the future this can be removed,
-	// assuming the processor can reload configuration
-	functionConfig.Spec.ImageHash = strconv.Itoa(int(time.Now().UnixNano()))
 
 	// update status
 	functionInstance.Status = *functionStatus

--- a/pkg/platform/kube/clients/nuclio/updater.go
+++ b/pkg/platform/kube/clients/nuclio/updater.go
@@ -74,10 +74,6 @@ func (u *Updater) Update(ctx context.Context, updateFunctionOptions *platform.Up
 	// update it with spec if passed
 	if updateFunctionOptions.FunctionSpec != nil {
 		function.Spec = *updateFunctionOptions.FunctionSpec
-
-		// update the spec with a new image hash to trigger pod restart. in the future this can be removed,
-		// assuming the processor can reload configuration
-		function.Spec.ImageHash = strconv.Itoa(int(time.Now().UnixNano()))
 	}
 
 	// update it with status if passed

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1840,9 +1840,7 @@ func (lc *lazyClient) getFunctionLabels(function *nuclioio.NuclioFunction) label
 }
 
 func (lc *lazyClient) getPodAnnotations(function *nuclioio.NuclioFunction) (map[string]string, error) {
-	annotations := map[string]string{
-		"nuclio.io/image-hash": function.Spec.ImageHash,
-	}
+	annotations := map[string]string{}
 
 	// add annotations for prometheus pull
 	if lc.functionsHaveMetricSink(lc.platformConfigurationProvider.GetPlatformConfiguration(), "prometheusPull") {

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1841,7 +1841,7 @@ func (lc *lazyClient) getFunctionLabels(function *nuclioio.NuclioFunction) label
 
 func (lc *lazyClient) getPodAnnotations(function *nuclioio.NuclioFunction) (map[string]string, error) {
 	annotations := map[string]string{
-		"nuclio.io/last-redeploy-timestamp": function.Spec.LastRedeployTimestamp,
+		"nuclio.io/last-deploy-timestamp": function.Spec.LastDeployTimestamp,
 	}
 
 	// add annotations for prometheus pull

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1841,7 +1841,7 @@ func (lc *lazyClient) getFunctionLabels(function *nuclioio.NuclioFunction) label
 
 func (lc *lazyClient) getPodAnnotations(function *nuclioio.NuclioFunction) (map[string]string, error) {
 	annotations := map[string]string{
-		"nuclio.io/dashboard_updated_at": function.Spec.ImageTimeStampHash,
+		"nuclio.io/last-redeploy-timestamp": function.Spec.LastRedeployTimestamp,
 	}
 
 	// add annotations for prometheus pull

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1840,7 +1840,9 @@ func (lc *lazyClient) getFunctionLabels(function *nuclioio.NuclioFunction) label
 }
 
 func (lc *lazyClient) getPodAnnotations(function *nuclioio.NuclioFunction) (map[string]string, error) {
-	annotations := map[string]string{}
+	annotations := map[string]string{
+		"nuclio.io/dashboard_updated_at": function.Spec.ImageTimeStampHash,
+	}
 
 	// add annotations for prometheus pull
 	if lc.functionsHaveMetricSink(lc.platformConfigurationProvider.GetPlatformConfiguration(), "prometheusPull") {

--- a/pkg/platform/kube/monitoring/function.go
+++ b/pkg/platform/kube/monitoring/function.go
@@ -227,8 +227,15 @@ func (fm *FunctionMonitor) updateFunctionStatus(ctx context.Context, function *n
 			"Failed to update function",
 			"functionName", function.Name,
 			"functionStatus", function.Status,
-			"functionNamespace", function.Namespace)
+			"functionNamespace", function.Namespace,
+			"err", err.Error())
 	}
+	fm.logger.DebugWithCtx(ctx,
+		"Successfully updated the function",
+		"functionName", function.Name,
+		"functionStatus", function.Status,
+		"functionNamespace", function.Namespace,
+	)
 	return nil
 }
 

--- a/pkg/platform/kube/test/function/function_test.go
+++ b/pkg/platform/kube/test/function/function_test.go
@@ -2107,7 +2107,7 @@ func (suite *UpdateFunctionTestSuite) TestSanity() {
 				cmpopts.IgnoreFields(createFunctionOptions.FunctionConfig.Meta,
 					"ResourceVersion"), // kubernetes opaque value
 				cmpopts.IgnoreFields(createFunctionOptions.FunctionConfig.Spec,
-					"Image", "ImageHash", "Resources"), // auto generated during deploy
+					"Image", "Resources"), // auto generated during deploy
 
 				// TODO: compare triggers as well
 				// currently block due to serviceType being converted to string during get functions)

--- a/pkg/platform/kube/test/function/function_test.go
+++ b/pkg/platform/kube/test/function/function_test.go
@@ -2107,7 +2107,7 @@ func (suite *UpdateFunctionTestSuite) TestSanity() {
 				cmpopts.IgnoreFields(createFunctionOptions.FunctionConfig.Meta,
 					"ResourceVersion"), // kubernetes opaque value
 				cmpopts.IgnoreFields(createFunctionOptions.FunctionConfig.Spec,
-					"Image", "ImageTimeStampHash", "Resources"), // auto generated during deploy
+					"Image", "LastRedeployTimestamp", "Resources"), // auto generated during deploy
 
 				// TODO: compare triggers as well
 				// currently block due to serviceType being converted to string during get functions)

--- a/pkg/platform/kube/test/function/function_test.go
+++ b/pkg/platform/kube/test/function/function_test.go
@@ -2107,7 +2107,7 @@ func (suite *UpdateFunctionTestSuite) TestSanity() {
 				cmpopts.IgnoreFields(createFunctionOptions.FunctionConfig.Meta,
 					"ResourceVersion"), // kubernetes opaque value
 				cmpopts.IgnoreFields(createFunctionOptions.FunctionConfig.Spec,
-					"Image", "Resources"), // auto generated during deploy
+					"Image", "ImageTimeStampHash", "Resources"), // auto generated during deploy
 
 				// TODO: compare triggers as well
 				// currently block due to serviceType being converted to string during get functions)

--- a/pkg/platform/kube/test/function/function_test.go
+++ b/pkg/platform/kube/test/function/function_test.go
@@ -2107,7 +2107,7 @@ func (suite *UpdateFunctionTestSuite) TestSanity() {
 				cmpopts.IgnoreFields(createFunctionOptions.FunctionConfig.Meta,
 					"ResourceVersion"), // kubernetes opaque value
 				cmpopts.IgnoreFields(createFunctionOptions.FunctionConfig.Spec,
-					"Image", "LastRedeployTimestamp", "Resources"), // auto generated during deploy
+					"Image", "LastDeployTimestamp", "Resources"), // auto generated during deploy
 
 				// TODO: compare triggers as well
 				// currently block due to serviceType being converted to string during get functions)


### PR DESCRIPTION
### 📝 Description
Remove `function.spec.imageHash`, as changes to this annotation cause unnecessary deployment spin-ups.

---

### 🛠️ Changes Made
- Removed the imageHash from the function.spec
- Remove handling the `nuclio.io/image-hash`

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Dev test
  - **Scenario validation** – Deployed a new function that reproduces the issue (details in the ticket) and verified that only a single Deployment/ReplicaSet was created from initial deployment until the function reached the ready state.
  - **Backward compatibility** – Updated existing functions (created before this fix) and confirmed that valid spec changes still trigger deployments as expected, while the controller code changes do not affect this flow.
- Updated integration tests
---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-590
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 📸 Screenshots / Logs
- Function's deployment before changes:
```
$ kubectl -n default-tenant rollout history deployment nuclio-my-projects1-admin-test5
deployment.apps/nuclio-my-projects1-admin-test5 
REVISION  CHANGE-CAUSE
1         <none>
2         <none>

$ kubectl -n default-tenant rollout history deployment nuclio-my-projects1-admin-test5 --revision=1 > rev_1.yaml
$ kubectl -n default-tenant rollout history deployment nuclio-my-projects1-admin-test5 --revision=2 > rev_2.yaml
$ diff rev_1.yaml rev_2.yaml 
1c1
< deployment.apps/nuclio-my-projects1-admin-test5 with revision #1
---
> deployment.apps/nuclio-my-projects1-admin-test5 with revision #2
10c10
< 	pod-template-hash=67c85485
---
> 	pod-template-hash=84b649f8c5
13c13
< 	nuclio.io/image-hash: 1757577587234196535
---
> 	nuclio.io/image-hash: 1757577682450587155
```
- Function deployment with code changes:
```
$ kubectl -n default-tenant rollout history deployment nuclio-my-projects1-admin-test5
deployment.apps/nuclio-my-projects1-admin-test5 
REVISION  CHANGE-CAUSE
1         <none>
```