### PR TITLE
[CI] Integrate govulncheck

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,0 +1,55 @@
+# Copyright 2025 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Govulncheck
+
+on:
+  pull_request:
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/govulncheck.yaml'
+  push:
+    branches:
+      - development
+      - 'feature/*'
+      - "\d+.\d+.x"
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/govulncheck.yaml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run govulncheck
+        run: make govulncheck
+
+

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -25,7 +25,7 @@ on:
     branches:
       - development
       - 'feature/*'
-      - "\d+.\d+.x"
+      - '*.*.x'
     paths:
       - '**/*.go'
       - 'go.mod'

--- a/Makefile
+++ b/Makefile
@@ -715,6 +715,25 @@ ensure-golangci-linter:
 			$(GOLANGCI_LINT_INSTALL_COMMAND); \
 		fi \
 	fi
+
+#
+# Security scanning (govulncheck)
+#
+
+GOVULNCHECK_VERSION := latest
+GOVULNCHECK_BIN := $(CURDIR)/.bin/govulncheck
+GOVULNCHECK_INSTALL_COMMAND := GOBIN=$(CURDIR)/.bin go install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
+
+.PHONY: ensure-govulncheck
+ensure-govulncheck:
+	@if ! command -v $(GOVULNCHECK_BIN) >/dev/null 2>&1; then \
+		echo "govulncheck not found. Installing..."; \
+		$(GOVULNCHECK_INSTALL_COMMAND); \
+	fi
+
+.PHONY: govulncheck
+govulncheck: modules ensure-govulncheck
+	$(GOVULNCHECK_BIN) cmd/... pkg/...
 #
 # Testing
 #


### PR DESCRIPTION
### 📝 Description

Integrates [`govulncheck`](https://go.dev/doc/tutorial/govulncheck) into CI.

Can also be run locally via `make govulncheck`

No vulns for now with 1.23.12. Here is an example how report looks (got it by running with `1.24.0`):
```
Vulnerability #1: GO-2025-3751
    Sensitive headers not cleared on cross-origin redirect in net/http
  More info: https://pkg.go.dev/vuln/GO-2025-3751
  Standard library
    Found in: net/http@go1.24
    Fixed in: net/http@go1.24.4
    Example traces found:
      #1: src/cmd/go/internal/web/api.go:186:12: web.Get calls web.get, which eventually calls http.Client.Do
      #2: src/cmd/pprof/pprof.go:43:21: pprof.main calls driver.PProf, which eventually calls http.Client.Get
      #3: src/cmd/pprof/pprof.go:43:21: pprof.main calls driver.PProf, which eventually calls http.Client.Post
      #4: src/cmd/internal/telemetry/telemetry.go:44:22: telemetry.MaybeChild calls telemetry.MaybeChild, which eventually calls http.Post
 ```
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
locally + CI
---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No
