### PR TITLE
[Processor] Improve atomic usage in trigger

### DIFF
--- a/pkg/processor/metricsink/appinsights/trigger.go
+++ b/pkg/processor/metricsink/appinsights/trigger.go
@@ -31,8 +31,8 @@ type TriggerGatherer struct {
 func newTriggerGatherer(t trigger.Trigger, client appinsights.TelemetryClient) (*TriggerGatherer, error) {
 
 	newTriggerGatherer := &TriggerGatherer{
-		trigger: t,
-		client:  client,
+		trigger:        t,
+		client:         client,
 		prevStatistics: &trigger.Statistics{},
 	}
 

--- a/pkg/processor/metricsink/appinsights/trigger.go
+++ b/pkg/processor/metricsink/appinsights/trigger.go
@@ -24,15 +24,16 @@ import (
 
 type TriggerGatherer struct {
 	trigger        trigger.Trigger
-	prevStatistics trigger.Statistics
+	prevStatistics *trigger.Statistics
 	client         appinsights.TelemetryClient
 }
 
-func newTriggerGatherer(trigger trigger.Trigger, client appinsights.TelemetryClient) (*TriggerGatherer, error) {
+func newTriggerGatherer(t trigger.Trigger, client appinsights.TelemetryClient) (*TriggerGatherer, error) {
 
 	newTriggerGatherer := &TriggerGatherer{
-		trigger: trigger,
+		trigger: t,
 		client:  client,
+		prevStatistics: &trigger.Statistics{},
 	}
 
 	return newTriggerGatherer, nil
@@ -41,15 +42,15 @@ func newTriggerGatherer(trigger trigger.Trigger, client appinsights.TelemetryCli
 func (esg *TriggerGatherer) Gather() error {
 
 	// read current stats
-	currentStatistics := *esg.trigger.GetStatistics()
+	currentStatistics := esg.trigger.GetStatistics()
 
 	// diff from previous to get this period
-	diffStatistics := currentStatistics.DiffFrom(&esg.prevStatistics)
+	diffStatistics := currentStatistics.DiffFrom(esg.prevStatistics)
 
 	esg.prevStatistics = currentStatistics
 
-	esg.track("EventsHandledSuccessTotal", float64(diffStatistics.EventsHandledSuccessTotal))
-	esg.track("EventsHandledFailureTotal", float64(diffStatistics.EventsHandledFailureTotal))
+	esg.track("EventsHandledSuccessTotal", float64(diffStatistics.EventsHandledSuccessTotal.Load()))
+	esg.track("EventsHandledFailureTotal", float64(diffStatistics.EventsHandledFailureTotal.Load()))
 
 	return nil
 }

--- a/pkg/processor/metricsink/prometheus/trigger.go
+++ b/pkg/processor/metricsink/prometheus/trigger.go
@@ -32,27 +32,28 @@ type TriggerGatherer struct {
 	workerAllocationTotal                       *prometheus.CounterVec
 	workerAllocationWaitDurationMilliSecondsSum prometheus.Counter
 	workerAllocationWorkersAvailablePercentage  prometheus.Counter
-	prevStatistics                              trigger.Statistics
+	prevStatistics                              *trigger.Statistics
 }
 
 func NewTriggerGatherer(instanceName string,
-	trigger trigger.Trigger,
+	t trigger.Trigger,
 	logger logger.Logger,
 	metricRegistry *prometheus.Registry) (*TriggerGatherer, error) {
 
 	newTriggerGatherer := &TriggerGatherer{
-		trigger: trigger,
-		logger:  logger.GetChild("gatherer"),
+		trigger:        t,
+		logger:         logger.GetChild("gatherer"),
+		prevStatistics: &trigger.Statistics{},
 	}
 
 	// base labels for handle events
 	labels := prometheus.Labels{
 		"instance":     instanceName,
-		"trigger_kind": trigger.GetKind(),
-		"trigger_id":   trigger.GetID(),
-		"namespace":    trigger.GetNamespace(),
-		"function":     trigger.GetFunctionName(),
-		"project":      trigger.GetProjectName(),
+		"trigger_kind": t.GetKind(),
+		"trigger_id":   t.GetID(),
+		"namespace":    t.GetNamespace(),
+		"function":     t.GetFunctionName(),
+		"project":      t.GetProjectName(),
 	}
 
 	newTriggerGatherer.handledEventsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -98,8 +99,8 @@ func NewTriggerGatherer(instanceName string,
 	}
 
 	newTriggerGatherer.logger.DebugWith("Trigger gatherer created",
-		"triggerID", trigger.GetID(),
-		"triggerKind", trigger.GetKind())
+		"triggerID", t.GetID(),
+		"triggerKind", t.GetKind())
 
 	return newTriggerGatherer, nil
 }
@@ -107,19 +108,19 @@ func NewTriggerGatherer(instanceName string,
 func (tg *TriggerGatherer) Gather() error {
 
 	// read current stats
-	currentStatistics := *tg.trigger.GetStatistics()
+	currentStatistics := tg.trigger.GetStatistics()
 
 	// diff from previous to get this period, DiffFrom returns a full copy of statistics,
 	// which can be accessed without atomicity concerns
-	diffStatistics := currentStatistics.DiffFrom(&tg.prevStatistics)
+	diffStatistics := currentStatistics.DiffFrom(tg.prevStatistics)
 
 	tg.handledEventsTotal.With(prometheus.Labels{
 		"result": "success",
-	}).Add(float64(diffStatistics.EventsHandledSuccessTotal))
+	}).Add(float64(diffStatistics.EventsHandledSuccessTotal.Load()))
 
 	tg.handledEventsTotal.With(prometheus.Labels{
 		"result": "failure",
-	}).Add(float64(diffStatistics.EventsHandledFailureTotal))
+	}).Add(float64(diffStatistics.EventsHandledFailureTotal.Load()))
 
 	tg.workerAllocationCount.Add(
 		float64(diffStatistics.WorkerAllocatorStatistics.AllocationCount))

--- a/pkg/processor/statistics/gatherer/trigger.go
+++ b/pkg/processor/statistics/gatherer/trigger.go
@@ -37,8 +37,8 @@ func newTriggerGatherer(instanceName string,
 	metricRegistry *prometheus.Registry) (*triggerGatherer, error) {
 
 	newTriggerGatherer := &triggerGatherer{
-		trigger: t,
-		logger:  logger.GetChild("gatherer"),
+		trigger:        t,
+		logger:         logger.GetChild("gatherer"),
 		prevStatistics: &trigger.Statistics{},
 	}
 

--- a/pkg/processor/statistics/gatherer/trigger.go
+++ b/pkg/processor/statistics/gatherer/trigger.go
@@ -17,8 +17,6 @@ limitations under the License.
 package gatherer
 
 import (
-	"sync/atomic"
-
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
 
 	"github.com/nuclio/errors"
@@ -29,29 +27,30 @@ import (
 type triggerGatherer struct {
 	trigger            trigger.Trigger
 	handledEventsTotal *prometheus.CounterVec
-	prevStatistics     trigger.Statistics
+	prevStatistics     *trigger.Statistics
 	logger             logger.Logger
 }
 
 func newTriggerGatherer(instanceName string,
 	logger logger.Logger,
-	trigger trigger.Trigger,
+	t trigger.Trigger,
 	metricRegistry *prometheus.Registry) (*triggerGatherer, error) {
 
 	newTriggerGatherer := &triggerGatherer{
-		trigger: trigger,
+		trigger: t,
 		logger:  logger.GetChild("gatherer"),
+		prevStatistics: &trigger.Statistics{},
 	}
 
 	// base labels for handle events
 	labels := prometheus.Labels{
 		"instance":      instanceName,
-		"trigger_class": trigger.GetClass(),
-		"trigger_kind":  trigger.GetKind(),
-		"trigger_id":    trigger.GetID(),
-		"function":      trigger.GetFunctionName(),
-		"project":       trigger.GetProjectName(),
-		"namespace":     trigger.GetNamespace(),
+		"trigger_class": t.GetClass(),
+		"trigger_kind":  t.GetKind(),
+		"trigger_id":    t.GetID(),
+		"function":      t.GetFunctionName(),
+		"project":       t.GetProjectName(),
+		"namespace":     t.GetNamespace(),
 	}
 
 	newTriggerGatherer.handledEventsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -70,13 +69,13 @@ func newTriggerGatherer(instanceName string,
 func (esg *triggerGatherer) Gather() error {
 
 	// read current stats
-	currentStatistics := *esg.trigger.GetStatistics()
+	currentStatistics := esg.trigger.GetStatistics()
 
 	// diff from previous to get this period
-	diffStatistics := currentStatistics.DiffFrom(&esg.prevStatistics)
+	diffStatistics := currentStatistics.DiffFrom(esg.prevStatistics)
 
-	eventsHandledSuccessTotal := atomic.LoadUint64(&diffStatistics.EventsHandledSuccessTotal)
-	eventsHandledFailureTotal := atomic.LoadUint64(&diffStatistics.EventsHandledFailureTotal)
+	eventsHandledSuccessTotal := diffStatistics.EventsHandledSuccessTotal.Load()
+	eventsHandledFailureTotal := diffStatistics.EventsHandledFailureTotal.Load()
 
 	esg.handledEventsTotal.With(prometheus.Labels{
 		"result": "success",

--- a/pkg/processor/trigger/http/http_test.go
+++ b/pkg/processor/trigger/http/http_test.go
@@ -51,7 +51,8 @@ func (suite *TestSuite) SetupSuite() {
 	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
 	suite.trigger = http{
 		AbstractTrigger: trigger.AbstractTrigger{
-			Logger: suite.logger,
+			Logger:     suite.logger,
+			Statistics: &trigger.Statistics{},
 		},
 		configuration: &Configuration{},
 		status:        status.NewSafeStatus(status.Ready),
@@ -137,8 +138,8 @@ func (suite *TestSuite) TestCORS() {
 		suite.trigger.configuration.CORS = corsInstance
 
 		// reset statistics
-		suite.trigger.Statistics.EventsHandledSuccessTotal = 0
-		suite.trigger.Statistics.EventsHandledFailureTotal = 0
+		suite.trigger.Statistics.EventsHandledSuccessTotal.Store(0)
+		suite.trigger.Statistics.EventsHandledFailureTotal.Store(0)
 
 		// ensure trigger is ready
 		suite.trigger.status.SetStatus(status.Ready)
@@ -171,11 +172,11 @@ func (suite *TestSuite) TestCORS() {
 
 		// check statistic were update correspondingly
 		suite.Equal(testCase.ExpectedEventsHandledSuccessTotal,
-			suite.trigger.Statistics.EventsHandledSuccessTotal)
+			suite.trigger.Statistics.EventsHandledSuccessTotal.Load())
 
 		// check statistic were update correspondingly
 		suite.Equal(testCase.ExpectedEventsHandledFailureTotal,
-			suite.trigger.Statistics.EventsHandledFailureTotal)
+			suite.trigger.Statistics.EventsHandledFailureTotal.Load())
 
 	}
 }

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -245,7 +245,7 @@ func (at *AbstractTrigger) GetStatistics() *Statistics {
 	if at.Statistics == nil {
 		at.Statistics = &Statistics{}
 	}
-	
+
 	// copy worker allocator statistics
 	at.Statistics.WorkerAllocatorStatistics = *at.WorkerAllocator.GetStatistics()
 

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -144,6 +144,7 @@ func NewAbstractTrigger(logger logger.Logger,
 		FunctionName:    configuration.RuntimeConfiguration.Meta.Name,
 		ProjectName:     configuration.RuntimeConfiguration.Meta.Labels[common.NuclioResourceLabelKeyProjectName],
 		restartChan:     restartTriggerChan,
+		Statistics:      &Statistics{},
 	}
 	if functionconfig.BatchModeEnabled(configuration.Batch) {
 		trigger.Batcher = NewBatcher(logger, configuration.Batch.BatchSize)
@@ -241,7 +242,10 @@ func (at *AbstractTrigger) GetWorkers() []eventprocessor.EventProcessor {
 
 // GetStatistics returns trigger statistics
 func (at *AbstractTrigger) GetStatistics() *Statistics {
-
+	if at.Statistics == nil {
+		at.Statistics = &Statistics{}
+	}
+	
 	// copy worker allocator statistics
 	at.Statistics.WorkerAllocatorStatistics = *at.WorkerAllocator.GetStatistics()
 
@@ -314,7 +318,7 @@ func (at *AbstractTrigger) SubmitEventToWorker(functionLogger logger.Logger,
 }
 
 // UpdateStatistics updates the trigger statistics
-func (at *AbstractTrigger) UpdateStatistics(success bool, times int64) {
+func (at *AbstractTrigger) UpdateStatistics(success bool, times uint64) {
 	if success {
 		at.Statistics.EventsHandledSuccessTotal.Add(times)
 	} else {
@@ -476,7 +480,7 @@ func (at *AbstractTrigger) StartBatcher(batchTimeout time.Duration, workerAvaila
 		// allocate a worker
 		workerInstance, err := at.WorkerAllocator.Allocate(workerAvailabilityTimeout)
 		if err != nil {
-			at.UpdateStatistics(false, int64(len(batch)))
+			at.UpdateStatistics(false, uint64(len(batch)))
 			workerError := errors.Wrap(err, "Failed to allocate worker")
 			for _, channel := range responseChans {
 				go channel.Write(at.Logger, &runtime.ResponseWithErrors{SubmitError: workerError})
@@ -530,7 +534,7 @@ func (at *AbstractTrigger) SubmitBatchAndSendResponses(batch []nuclio.Event, res
 		for _, channel := range responseChans {
 			go channel.Write(at.Logger, &runtime.ResponseWithErrors{ProcessError: err})
 		}
-		at.UpdateStatistics(false, int64(len(responseChans)))
+		at.UpdateStatistics(false, uint64(len(responseChans)))
 		return
 	} else {
 		for _, response := range responses.Results {

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"runtime/debug"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
@@ -101,7 +100,7 @@ type AbstractTrigger struct {
 	Trigger Trigger
 
 	// accessed atomically, keep as first field for alignment
-	Statistics Statistics
+	Statistics *Statistics
 
 	ID              string
 	Logger          logger.Logger
@@ -246,7 +245,7 @@ func (at *AbstractTrigger) GetStatistics() *Statistics {
 	// copy worker allocator statistics
 	at.Statistics.WorkerAllocatorStatistics = *at.WorkerAllocator.GetStatistics()
 
-	return &at.Statistics
+	return at.Statistics
 }
 
 // GetID returns user given ID for this trigger
@@ -315,11 +314,11 @@ func (at *AbstractTrigger) SubmitEventToWorker(functionLogger logger.Logger,
 }
 
 // UpdateStatistics updates the trigger statistics
-func (at *AbstractTrigger) UpdateStatistics(success bool, times uint64) {
+func (at *AbstractTrigger) UpdateStatistics(success bool, times int64) {
 	if success {
-		atomic.AddUint64(&at.Statistics.EventsHandledSuccessTotal, times)
+		at.Statistics.EventsHandledSuccessTotal.Add(times)
 	} else {
-		atomic.AddUint64(&at.Statistics.EventsHandledFailureTotal, times)
+		at.Statistics.EventsHandledFailureTotal.Add(times)
 	}
 }
 
@@ -477,7 +476,7 @@ func (at *AbstractTrigger) StartBatcher(batchTimeout time.Duration, workerAvaila
 		// allocate a worker
 		workerInstance, err := at.WorkerAllocator.Allocate(workerAvailabilityTimeout)
 		if err != nil {
-			at.UpdateStatistics(false, uint64(len(batch)))
+			at.UpdateStatistics(false, int64(len(batch)))
 			workerError := errors.Wrap(err, "Failed to allocate worker")
 			for _, channel := range responseChans {
 				go channel.Write(at.Logger, &runtime.ResponseWithErrors{SubmitError: workerError})
@@ -531,7 +530,7 @@ func (at *AbstractTrigger) SubmitBatchAndSendResponses(batch []nuclio.Event, res
 		for _, channel := range responseChans {
 			go channel.Write(at.Logger, &runtime.ResponseWithErrors{ProcessError: err})
 		}
-		at.UpdateStatistics(false, uint64(len(responseChans)))
+		at.UpdateStatistics(false, int64(len(responseChans)))
 		return
 	} else {
 		for _, response := range responses.Results {

--- a/pkg/processor/trigger/types.go
+++ b/pkg/processor/trigger/types.go
@@ -188,22 +188,16 @@ type Statistics struct {
 
 func (s *Statistics) DiffFrom(prev *Statistics) *Statistics {
 	workerAllocatorStatisticsDiff := s.WorkerAllocatorStatistics.DiffFrom(&prev.WorkerAllocatorStatistics)
-
-	// atomically load the counters
 	currEventsHandledSuccessTotal := s.EventsHandledSuccessTotal.Load()
 	currEventsHandledFailureTotal := s.EventsHandledFailureTotal.Load()
-
 	prevEventsHandledSuccessTotal := prev.EventsHandledSuccessTotal.Load()
 	prevEventsHandledFailureTotal := prev.EventsHandledFailureTotal.Load()
-
-	eventsHandledSuccessDiff := currEventsHandledSuccessTotal - prevEventsHandledSuccessTotal
-	eventsHandledFailureDiff := currEventsHandledFailureTotal - prevEventsHandledFailureTotal
 
 	diffStatistics := &Statistics{
 		WorkerAllocatorStatistics: workerAllocatorStatisticsDiff,
 	}
-	diffStatistics.EventsHandledSuccessTotal.Store(eventsHandledSuccessDiff)
-	diffStatistics.EventsHandledFailureTotal.Store(eventsHandledFailureDiff)
+	diffStatistics.EventsHandledSuccessTotal.Store(currEventsHandledSuccessTotal - prevEventsHandledSuccessTotal)
+	diffStatistics.EventsHandledFailureTotal.Store(currEventsHandledFailureTotal - prevEventsHandledFailureTotal)
 	return diffStatistics
 }
 

--- a/pkg/processor/trigger/types.go
+++ b/pkg/processor/trigger/types.go
@@ -181,26 +181,30 @@ func (c *Configuration) ResolveWorkerAllocationMode(modeFromAttributes, modeFrom
 }
 
 type Statistics struct {
-	EventsHandledSuccessTotal uint64
-	EventsHandledFailureTotal uint64
+	EventsHandledSuccessTotal atomic.Uint64
+	EventsHandledFailureTotal atomic.Uint64
 	WorkerAllocatorStatistics statistics.AllocatorStatistics
 }
 
-func (s *Statistics) DiffFrom(prev *Statistics) Statistics {
+func (s *Statistics) DiffFrom(prev *Statistics) *Statistics {
 	workerAllocatorStatisticsDiff := s.WorkerAllocatorStatistics.DiffFrom(&prev.WorkerAllocatorStatistics)
 
 	// atomically load the counters
-	currEventsHandledSuccessTotal := atomic.LoadUint64(&s.EventsHandledSuccessTotal)
-	currEventsHandledFailureTotal := atomic.LoadUint64(&s.EventsHandledFailureTotal)
+	currEventsHandledSuccessTotal := s.EventsHandledSuccessTotal.Load()
+	currEventsHandledFailureTotal := s.EventsHandledFailureTotal.Load()
 
-	prevEventsHandledSuccessTotal := atomic.LoadUint64(&prev.EventsHandledSuccessTotal)
-	prevEventsHandledFailureTotal := atomic.LoadUint64(&prev.EventsHandledFailureTotal)
+	prevEventsHandledSuccessTotal := prev.EventsHandledSuccessTotal.Load()
+	prevEventsHandledFailureTotal := prev.EventsHandledFailureTotal.Load()
 
-	return Statistics{
-		EventsHandledSuccessTotal: currEventsHandledSuccessTotal - prevEventsHandledSuccessTotal,
-		EventsHandledFailureTotal: currEventsHandledFailureTotal - prevEventsHandledFailureTotal,
+	eventsHandledSuccessDiff := currEventsHandledSuccessTotal - prevEventsHandledSuccessTotal
+	eventsHandledFailureDiff := currEventsHandledFailureTotal - prevEventsHandledFailureTotal
+
+	diffStatistics := &Statistics{
 		WorkerAllocatorStatistics: workerAllocatorStatisticsDiff,
 	}
+	diffStatistics.EventsHandledSuccessTotal.Store(eventsHandledSuccessDiff)
+	diffStatistics.EventsHandledFailureTotal.Store(eventsHandledFailureDiff)
+	return diffStatistics
 }
 
 type Secret struct {


### PR DESCRIPTION
### 📝 Description
Refactor trigger statistics handling to use `atomic.Uint64` and pointers instead of raw `uint64` values.  
This ensures thread-safety, simplifies updates, and avoids data races when accessing or modifying statistics concurrently.  

---

### 🛠️ Changes Made
- Changed `Statistics` fields (`EventsHandledSuccessTotal`, `EventsHandledFailureTotal`) from `uint64` to `atomic.Uint64`.
- Refactored AbstractTrigger and related gatherers (`appinsights`, `prometheus`, `statistics`) to use *Statistics instead of value copies, because copying atomic.Uint64 (which embeds sync.Locker) is unsafe and discouraged.
- Adjusted all relevant functionalities to use the proper atomic operation instead of `atomic.AddUint64`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Fixed relevant UTs
- Performed benchmark testing to ensure the changes work as expected - [[link](https://github.com/nuclio/nuclio/blob/development/hack/scripts/benchmark/bench.go#L27)]

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-591
- Design docs links:
- External links: https://pkg.go.dev/sync/atomic#Uint64

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 📸 Screenshots
The dashboard with a benchmark test
<img width="1881" height="993" alt="image" src="https://github.com/user-attachments/assets/ef27ee09-f061-4501-8f45-d94f39124340" />
