### PR TITLE
[Dependencies] Bump Scaler version to v0.10.2 [1.15.x]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.10.0
 	github.com/tsenart/vegeta/v12 v12.11.1
-	github.com/v3io/scaler v0.10.1
+	github.com/v3io/scaler v0.10.2
 	github.com/v3io/v3io-go v0.3.13
 	github.com/v3io/v3io-go-http v0.0.1
 	github.com/v3io/version-go v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -468,8 +468,8 @@ github.com/tsenart/vegeta/v12 v12.11.1/go.mod h1:swiFmrgpqj2llHURgHYFRFN0tfrIrln
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.14 h1:uv/0Bq533iFdnMHZdRBTOlaNMdb1+ZxXIlHDZHIHcvg=
 github.com/ulikunitz/xz v0.5.14/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/v3io/scaler v0.10.1 h1:ep9zqtdrG4gO2X+57COZpnSrnsV7y5WF/ceSSh8LG28=
-github.com/v3io/scaler v0.10.1/go.mod h1:kuHwF/ZfXPqwOjkMtRHjJOE23xYmPIxltqS1wcBLweo=
+github.com/v3io/scaler v0.10.2 h1:rzOXkSTbgMPr6GzPcqntkwxVPfD4iZzOEBdkSrLSs6Y=
+github.com/v3io/scaler v0.10.2/go.mod h1:kuHwF/ZfXPqwOjkMtRHjJOE23xYmPIxltqS1wcBLweo=
 github.com/v3io/v3io-go v0.3.13 h1:+d4/hNdkjwjRBA5bSoV2UMga+9dtIsWyEXf0WyA+NGM=
 github.com/v3io/v3io-go v0.3.13/go.mod h1:2yxhXiw3dI+tufu5Kk09TS82q/jyJKASEFqfmi5dQHU=
 github.com/v3io/v3io-go-http v0.0.1 h1:uE+PmPkVfGi6vIMpoFgrSot4yIow5Id48Gj9ZPt02pU=


### PR DESCRIPTION
backport https://github.com/nuclio/nuclio/pull/3815