### PR TITLE
[Local] Allow for graceful termination

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -291,7 +291,8 @@ jobs:
 
           # write function host to /etc/hosts
           echo "${NUCTL_EXTERNAL_IP_ADDRESSES} ${NUCLIO_TEST_KUBE_DEFAULT_INGRESS_HOST}" | sudo tee -a /etc/hosts
-          # hardcode host1.com and host2.com
+          # hardcode nuclio-host1.com and nuclio-host2.com
+          # we use them to invoke api gateways in tests
           echo "${NUCTL_EXTERNAL_IP_ADDRESSES} nuclio-host1.com" | sudo tee -a /etc/hosts
           echo "${NUCTL_EXTERNAL_IP_ADDRESSES} nuclio-host2.com" | sudo tee -a /etc/hosts
 
@@ -411,6 +412,9 @@ jobs:
       - name: Write ingress host to /etc/hosts
         run: |
           echo "${NUCLIO_EXTERNAL_IP_ADDRESS} ${NUCLIO_TEST_KUBE_DEFAULT_INGRESS_HOST}" | sudo tee -a /etc/hosts
+          # we use them to invoke api gateways in tests
+          echo "${NUCTL_EXTERNAL_IP_ADDRESSES} nuclio-host1.com" | sudo tee -a /etc/hosts
+          echo "${NUCTL_EXTERNAL_IP_ADDRESSES} nuclio-host2.com" | sudo tee -a /etc/hosts
 
       - name: Run k8s tests
         run: NUCLIO_K8S_TEST_MAKE_TARGET=${{ matrix.test-target }} make test-k8s

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -413,8 +413,8 @@ jobs:
         run: |
           echo "${NUCLIO_EXTERNAL_IP_ADDRESS} ${NUCLIO_TEST_KUBE_DEFAULT_INGRESS_HOST}" | sudo tee -a /etc/hosts
           # we use them to invoke api gateways in tests
-          echo "${NUCTL_EXTERNAL_IP_ADDRESSES} nuclio-host1.com" | sudo tee -a /etc/hosts
-          echo "${NUCTL_EXTERNAL_IP_ADDRESSES} nuclio-host2.com" | sudo tee -a /etc/hosts
+          echo "${NUCLIO_EXTERNAL_IP_ADDRESS} nuclio-host1.com" | sudo tee -a /etc/hosts
+          echo "${NUCLIO_EXTERNAL_IP_ADDRESS} nuclio-host2.com" | sudo tee -a /etc/hosts
 
       - name: Run k8s tests
         run: NUCLIO_K8S_TEST_MAKE_TARGET=${{ matrix.test-target }} make test-k8s

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -291,6 +291,9 @@ jobs:
 
           # write function host to /etc/hosts
           echo "${NUCTL_EXTERNAL_IP_ADDRESSES} ${NUCLIO_TEST_KUBE_DEFAULT_INGRESS_HOST}" | sudo tee -a /etc/hosts
+          # hardcode host1.com and host2.com
+          echo "${NUCTL_EXTERNAL_IP_ADDRESSES} nuclio-host1.com" | sudo tee -a /etc/hosts
+          echo "${NUCTL_EXTERNAL_IP_ADDRESSES} nuclio-host2.com" | sudo tee -a /etc/hosts
 
           # run test
           make test-k8s-nuctl

--- a/pkg/dockerclient/dockerclient.go
+++ b/pkg/dockerclient/dockerclient.go
@@ -54,7 +54,7 @@ type Client interface {
 	RemoveContainer(containerID string) error
 
 	// StopContainer removes a container given a container ID
-	StopContainer(containerID string) error
+	StopContainer(containerID string, timeoutSeconds int) error
 
 	// StartContainer starts a container given a container ID
 	StartContainer(containerID string) error

--- a/pkg/dockerclient/mock.go
+++ b/pkg/dockerclient/mock.go
@@ -84,7 +84,7 @@ func (mdc *MockDockerClient) RemoveContainer(containerID string) error {
 }
 
 // StopContainer stops a container given a container ID
-func (mdc *MockDockerClient) StopContainer(containerID string) error {
+func (mdc *MockDockerClient) StopContainer(containerID string, timeoutSeconds int) error {
 	return nil
 }
 

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -467,15 +467,27 @@ func (c *ShellClient) RemoveContainer(containerID string) error {
 }
 
 // StopContainer stops a container given a container ID
-func (c *ShellClient) StopContainer(containerID string) error {
+func (c *ShellClient) StopContainer(containerID string, timeoutSeconds int) error {
 	c.logger.DebugWith("Stopping container", "containerID", containerID)
 
 	// containerID is ID or name
 	if !containerIDRegex.MatchString(containerID) && !restrictedNameRegex.MatchString(containerID) {
 		return errors.New("Invalid container ID to stop")
 	}
+	var err error
 
-	_, err := c.runCommand(nil, "docker stop %s", containerID)
+	// stop the container gracefully
+	// use -t <seconds> to give the container a chance to cleanup (same as the default kubernetes timeout)
+	// If the container does not exit after the timeout elapses, it's forcibly killed with a SIGKILL signal
+	// if no timeout is given, docker waits indefinitely
+	// https://docs.docker.com/reference/cli/docker/container/stop/
+	// this command doesn't wait for the container to be actually stopped, it just sends the signal
+	if timeoutSeconds == 0 {
+		_, err = c.runCommand(nil, "docker stop %s", containerID)
+	} else {
+		_, err = c.runCommand(nil, "docker stop -t %d %s", timeoutSeconds, containerID)
+	}
+
 	return err
 }
 

--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -481,7 +481,7 @@ func (c *ShellClient) StopContainer(containerID string, timeoutSeconds int) erro
 	// If the container does not exit after the timeout elapses, it's forcibly killed with a SIGKILL signal
 	// if no timeout is given, docker waits indefinitely
 	// https://docs.docker.com/reference/cli/docker/container/stop/
-	// this command doesn't wait for the container to be actually stopped, it just sends the signal
+	// this command waits for the container to be actually stopped
 	if timeoutSeconds == 0 {
 		_, err = c.runCommand(nil, "docker stop %s", containerID)
 	} else {

--- a/pkg/platform/kube/test/apigateway/api_gateway_test.go
+++ b/pkg/platform/kube/test/apigateway/api_gateway_test.go
@@ -192,7 +192,7 @@ func (suite *DeployAPIGatewayTestSuite) TestUpdate() {
 
 func (suite *DeployAPIGatewayTestSuite) TestSetSpecificPort() {
 	functionName := "some-function-name"
-	apiGatewayName := "api-gateway-1"
+	apiGatewayName := "api-gateway-with-specific-port"
 	sidecarPort := 8050
 	createFunctionOptions := suite.CompileCreateFunctionOptions(functionName)
 	createFunctionOptions.FunctionConfig.Spec.Sidecars = []*v1.Container{

--- a/pkg/platform/kube/test/apigateway/api_gateway_test.go
+++ b/pkg/platform/kube/test/apigateway/api_gateway_test.go
@@ -88,13 +88,13 @@ func (suite *DeployAPIGatewayTestSuite) TestFunctionWithTwoGateways() {
 		// create first api gateway on top of given function
 		createAPIGatewayOptions1 := suite.CompileCreateAPIGatewayOptions(apiGatewayName1, functionName)
 		createAPIGatewayOptions1.APIGatewayConfig.Spec.AuthenticationMode = ingress.AuthenticationModeNone
-		createAPIGatewayOptions1.APIGatewayConfig.Spec.Host = "host1.com"
+		createAPIGatewayOptions1.APIGatewayConfig.Spec.Host = "nuclio-host1.com"
 
 		err := suite.DeployAPIGateway(createAPIGatewayOptions1, func(ingressObj *networkingv1.Ingress) {
 			// create second api gateway on top of the same function
 			createAPIGatewayOptions2 := suite.CompileCreateAPIGatewayOptions(apiGatewayName2, functionName)
 			createAPIGatewayOptions2.APIGatewayConfig.Spec.AuthenticationMode = ingress.AuthenticationModeNone
-			createAPIGatewayOptions2.APIGatewayConfig.Spec.Host = "host2.com"
+			createAPIGatewayOptions2.APIGatewayConfig.Spec.Host = "nuclio-host2.com"
 
 			err := suite.DeployAPIGateway(createAPIGatewayOptions2, func(ingress *networkingv1.Ingress) {
 				// check that both gateways are invokable
@@ -213,7 +213,7 @@ func (suite *DeployAPIGatewayTestSuite) TestSetSpecificPort() {
 		// create an api gateway on top of the function with a specific port to the sidecar
 		createAPIGatewayOptions1 := suite.CompileCreateAPIGatewayOptions(apiGatewayName, functionName)
 		createAPIGatewayOptions1.APIGatewayConfig.Spec.AuthenticationMode = ingress.AuthenticationModeNone
-		createAPIGatewayOptions1.APIGatewayConfig.Spec.Host = "host1.com"
+		createAPIGatewayOptions1.APIGatewayConfig.Spec.Host = "nuclio-host1.com"
 		createAPIGatewayOptions1.APIGatewayConfig.Spec.Upstreams[0].Port = sidecarPort
 
 		err := suite.DeployAPIGateway(createAPIGatewayOptions1, func(ingressObj *networkingv1.Ingress) {

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -1082,7 +1082,6 @@ func (p *Platform) deleteFunctionContainers(ctx context.Context, functionName, n
 	// there are a few instances of this function in the namespace
 	for _, containerInfo := range containersInfo {
 		wg.Go(func() {
-			defer wg.Done()
 			p.Logger.DebugWithCtx(ctx, "Stopping function container", "containerName", containerInfo.Name)
 			// no need to fail the entire operation if stopping failed
 			// we will retry to stop with SIGKILL below

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -1106,6 +1106,10 @@ func (p *Platform) deleteFunctionContainers(ctx context.Context, functionName, n
 	if errPtr := errDuringStop.Load(); errPtr != nil {
 		return *errPtr
 	}
+	p.Logger.DebugWithCtx(ctx, "Successfully deleted function",
+		"name", functionName,
+		"namespace", namespace)
+
 	return nil
 }
 

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -1081,8 +1081,7 @@ func (p *Platform) deleteFunctionContainers(ctx context.Context, functionName, n
 	// iterate over contains and delete them. It's possible that under some weird circumstances
 	// there are a few instances of this function in the namespace
 	for _, containerInfo := range containersInfo {
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			defer wg.Done()
 			p.Logger.DebugWithCtx(ctx, "Stopping function container", "containerName", containerInfo.Name)
 			// no need to fail the entire operation if stopping failed
@@ -1100,8 +1099,7 @@ func (p *Platform) deleteFunctionContainers(ctx context.Context, functionName, n
 					"containerId", containerInfo.ID,
 					"error", err.Error())
 			}
-		}()
-
+		})
 	}
 	wg.Wait()
 

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -29,6 +29,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
@@ -1073,50 +1075,41 @@ func (p *Platform) deleteFunctionContainers(ctx context.Context, functionName, n
 
 	p.Logger.DebugWithCtx(ctx, "Got function containers", "containersInfoLength", len(containersInfo))
 
+	var wg sync.WaitGroup
+	var errDuringStop atomic.Pointer[error]
+
 	// iterate over contains and delete them. It's possible that under some weird circumstances
 	// there are a few instances of this function in the namespace
 	for _, containerInfo := range containersInfo {
-		p.Logger.DebugWithCtx(ctx, "Stopping function container", "containerName", containerInfo.Name)
-
-		// no need to fail the entire operation if stopping failed
-		// we will retry to stop with SIGKILL below
-		if err = p.dockerClient.StopContainer(containerInfo.ID, int(p.GetConfig().Local.FunctionContainersGracefulTerminationTimeout.Seconds())); err != nil {
-			p.Logger.WarnWith("Failed to stop container, will retry with SIGKILL", "containerId", containerInfo.ID)
-		}
-	}
-
-	// wait until all containers are deleted
-	err = common.RetryUntilSuccessful(p.GetConfig().Local.FunctionContainersGracefulTerminationTimeout+1*time.Second, 3*time.Second, func() bool {
-		containers, err := p.dockerClient.GetContainers(getContainerOptions)
-		if err != nil {
-			return false
-		}
-		if len(containers) == 0 {
-			return true
-		}
-		return false
-	})
-	var errDuringForceStop error
-	if err != nil {
-		p.Logger.WarnWith("Failed to wait until all function containers are deleted, removing containers with SIGKILL")
-		containersInfo, err = p.dockerClient.GetContainers(getContainerOptions)
-		if err != nil {
-			return errors.Wrap(err, "Failed to get containers")
-		}
-		for _, containerInfo := range containersInfo {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
 			p.Logger.DebugWithCtx(ctx, "Stopping function container", "containerName", containerInfo.Name)
-
-			// no need to fail the entire operation if remove failed, just keep the error and continue
+			// no need to fail the entire operation if stopping failed
+			// we will retry to stop with SIGKILL below
 			if err = p.dockerClient.StopContainer(containerInfo.ID, int(p.GetConfig().Local.FunctionContainersGracefulTerminationTimeout.Seconds())); err != nil {
+				errDuringStop.CompareAndSwap(nil, &err)
+				p.Logger.WarnWith("Failed to stop container, will retry with SIGKILL", "containerId", containerInfo.ID)
+			}
+
+			// now remove the container
+			// to ensure that it doesn't use any ports/volumes and etc
+			if err = p.dockerClient.RemoveContainer(containerInfo.ID); err != nil {
+				// no need to fail the entire operation if remove failed, just keep the error and continue
 				p.Logger.WarnWith("Failed to stop container, will retry with SIGKILL",
 					"containerId", containerInfo.ID,
 					"error", err.Error())
-
-				errDuringForceStop = err
 			}
-		}
+		}()
+
 	}
-	return errDuringForceStop
+	wg.Wait()
+
+	// load possible error
+	if errPtr := errDuringStop.Load(); errPtr != nil {
+		return *errPtr
+	}
+	return nil
 }
 
 func (p *Platform) resolveAndCreateFunctionMounts(

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -301,7 +301,7 @@ func (p *Platform) CreateFunction(ctx context.Context, createFunctionOptions *pl
 		var functionStatus functionconfig.Status
 
 		// delete existing function containers
-		previousHTTPPort, err := p.deleteOrStopFunctionContainers(createFunctionOptions)
+		previousHTTPPort, err := p.deleteOrStopFunctionContainers(ctx, createFunctionOptions)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to delete previous containers")
 		}
@@ -426,7 +426,7 @@ func (p *Platform) RedeployFunction(ctx context.Context, redeployFunctionOptions
 		"functionName", redeployFunctionOptions.FunctionMeta.Name)
 
 	// delete existing function containers
-	previousHTTPPort, err := p.deleteOrStopFunctionContainers(&platform.CreateFunctionOptions{
+	previousHTTPPort, err := p.deleteOrStopFunctionContainers(ctx, &platform.CreateFunctionOptions{
 		Logger: p.Logger,
 		FunctionConfig: functionconfig.Config{
 			Meta: *redeployFunctionOptions.FunctionMeta,
@@ -1033,12 +1033,32 @@ func (p *Platform) delete(ctx context.Context, deleteFunctionOptions *platform.D
 		p.Logger.WarnWithCtx(ctx, "Failed to delete a function from the local store", "err", err.Error())
 	}
 
+	if err := p.deleteFunctionContainers(ctx,
+		deleteFunctionOptions.FunctionConfig.Meta.Name,
+		deleteFunctionOptions.FunctionConfig.Meta.Namespace,
+		true); err != nil {
+		return errors.Wrap(err, "Failed to delete function containers")
+	}
+
+	// delete function volume mount after containers are deleted
+	functionVolumeMountName := p.GetFunctionVolumeMountName(&deleteFunctionOptions.FunctionConfig)
+	p.Logger.DebugWithCtx(ctx, "Removing function volume", "functionVolumeMountName", functionVolumeMountName)
+	if err := p.dockerClient.DeleteVolume(functionVolumeMountName); err != nil {
+		return errors.Wrapf(err, "Failed to delete a function volume %s", functionVolumeMountName)
+	}
+
+	p.Logger.InfoWithCtx(ctx, "Successfully deleted function",
+		"name", deleteFunctionOptions.FunctionConfig.Meta.Name)
+	return nil
+}
+
+func (p *Platform) deleteFunctionContainers(ctx context.Context, functionName, namespace string, waitForDeletion bool) error {
 	getContainerOptions := &dockerclient.GetContainerOptions{
 		Stopped: true,
 		Labels: map[string]string{
 			"nuclio.io/platform":                      common.LocalPlatformName,
-			"nuclio.io/namespace":                     deleteFunctionOptions.FunctionConfig.Meta.Namespace,
-			common.NuclioResourceLabelKeyFunctionName: deleteFunctionOptions.FunctionConfig.Meta.Name,
+			"nuclio.io/namespace":                     namespace,
+			common.NuclioResourceLabelKeyFunctionName: functionName,
 		},
 	}
 
@@ -1047,15 +1067,35 @@ func (p *Platform) delete(ctx context.Context, deleteFunctionOptions *platform.D
 		return errors.Wrap(err, "Failed to get containers")
 	}
 
+	if len(containersInfo) == 0 {
+		p.Logger.DebugWithCtx(ctx, "No function containers were found", "functionName", functionName, "namespace", namespace)
+		return nil
+	}
+
 	p.Logger.DebugWithCtx(ctx, "Got function containers", "containersInfoLength", len(containersInfo))
 
+	var errorDuringFunctionStopping error
 	// iterate over contains and delete them. It's possible that under some weird circumstances
 	// there are a few instances of this function in the namespace
 	for _, containerInfo := range containersInfo {
-		p.Logger.DebugWithCtx(ctx, "Removing function container", "containerName", containerInfo.Name)
-		if err := p.dockerClient.StopContainer(containerInfo.ID, int(p.GetConfig().Local.FunctionContainersGracefulTerminationTimeout.Seconds())); err != nil {
-			return errors.Wrapf(err, "Failed to remove container %s", containerInfo.ID)
+		p.Logger.DebugWithCtx(ctx, "Stopping function container", "containerName", containerInfo.Name)
+
+		// no need to fail the entire operation if stopping failed
+		// we will retry to stop with SIGKILL below
+		if err = p.dockerClient.StopContainer(containerInfo.ID, int(p.GetConfig().Local.FunctionContainersGracefulTerminationTimeout.Seconds())); err != nil {
+			p.Logger.WarnWith("Failed to stop container, will retry with SIGKILL", "containerId", containerInfo.ID)
+
+			// if not wait for deletion, then try to remove the container right away
+			// otherwise will be retried below after waiting for a timeout
+			if !waitForDeletion {
+				err = p.dockerClient.RemoveContainer(containerInfo.ID)
+			}
+			errorDuringFunctionStopping = err
 		}
+	}
+
+	if !waitForDeletion {
+		return errorDuringFunctionStopping
 	}
 
 	// wait until all containers are deleted
@@ -1069,32 +1109,27 @@ func (p *Platform) delete(ctx context.Context, deleteFunctionOptions *platform.D
 		}
 		return false
 	})
-
+	var errDuringForceStop error
 	if err != nil {
 		p.Logger.WarnWith("Failed to wait until all function containers are deleted, removing containers with SIGKILL")
 		containersInfo, err = p.dockerClient.GetContainers(getContainerOptions)
 		if err != nil {
 			return errors.Wrap(err, "Failed to get containers")
 		}
-		// there are a few instances of this function in the namespace
 		for _, containerInfo := range containersInfo {
-			p.Logger.DebugWithCtx(ctx, "Removing function container", "containerName", containerInfo.Name)
-			if err := p.dockerClient.RemoveContainer(containerInfo.ID); err != nil {
-				return errors.Wrapf(err, "Failed to remove container %s", containerInfo.ID)
+			p.Logger.DebugWithCtx(ctx, "Stopping function container", "containerName", containerInfo.Name)
+
+			// no need to fail the entire operation if remove failed, just keep the error and continue
+			if err = p.dockerClient.StopContainer(containerInfo.ID, int(p.GetConfig().Local.FunctionContainersGracefulTerminationTimeout.Seconds())); err != nil {
+				p.Logger.WarnWith("Failed to stop container, will retry with SIGKILL",
+					"containerId", containerInfo.ID,
+					"error", err.Error())
+
+				errDuringForceStop = err
 			}
 		}
 	}
-
-	// delete function volume mount after containers are deleted
-	functionVolumeMountName := p.GetFunctionVolumeMountName(&deleteFunctionOptions.FunctionConfig)
-	p.Logger.DebugWithCtx(ctx, "Removing function volume", "functionVolumeMountName", functionVolumeMountName)
-	if err := p.dockerClient.DeleteVolume(functionVolumeMountName); err != nil {
-		return errors.Wrapf(err, "Failed to delete a function volume %s", functionVolumeMountName)
-	}
-
-	p.Logger.InfoWithCtx(ctx, "Successfully deleted function",
-		"name", deleteFunctionOptions.FunctionConfig.Meta.Name)
-	return nil
+	return errDuringForceStop
 }
 
 func (p *Platform) resolveAndCreateFunctionMounts(
@@ -1223,7 +1258,7 @@ func (p *Platform) marshallAnnotations(annotations map[string]string) []byte {
 	return marshalledAnnotations
 }
 
-func (p *Platform) deleteOrStopFunctionContainers(createFunctionOptions *platform.CreateFunctionOptions) (int, error) {
+func (p *Platform) deleteOrStopFunctionContainers(ctx context.Context, createFunctionOptions *platform.CreateFunctionOptions) (int, error) {
 	var previousHTTPPort int
 
 	createFunctionOptions.Logger.InfoWith("Cleaning up before deployment",
@@ -1242,16 +1277,9 @@ func (p *Platform) deleteOrStopFunctionContainers(createFunctionOptions *platfor
 		createFunctionOptions.Logger.InfoWith("Disabling function",
 			"functionName", createFunctionOptions.FunctionConfig.Meta.Name)
 
-		// if function is disabled, stop all containers
-		for _, container := range containers {
-			createFunctionOptions.Logger.DebugWith("Stop function container",
-				"functionName", createFunctionOptions.FunctionConfig.Meta.Name,
-				"containerID", container.ID)
-			if err := p.dockerClient.StopContainer(container.ID, int(p.GetConfig().Local.FunctionContainersGracefulTerminationTimeout.Seconds())); err != nil {
-				return 0, errors.Wrap(err, "Failed to stop a container")
-			}
-		}
-		return 0, nil
+		return 0, p.deleteFunctionContainers(ctx,
+			createFunctionOptions.FunctionConfig.Meta.Name,
+			createFunctionOptions.FunctionConfig.Meta.Namespace, true)
 	}
 
 	// if the function exists, delete it
@@ -1269,13 +1297,14 @@ func (p *Platform) deleteOrStopFunctionContainers(createFunctionOptions *platfor
 		if err != nil {
 			return 0, errors.Wrap(err, "Failed to get a container's HTTP-trigger port")
 		}
-
-		if err := p.dockerClient.RemoveContainer(container.ID); err != nil {
-			return 0, errors.Wrap(err, "Failed to delete a function container")
-		}
 	}
 
-	return previousHTTPPort, nil
+	return previousHTTPPort, p.deleteFunctionContainers(ctx,
+		createFunctionOptions.FunctionConfig.Meta.Name,
+		createFunctionOptions.FunctionConfig.Meta.Namespace,
+		// do not wait for deletion in case of redeploying the function
+		false)
+
 }
 
 func (p *Platform) checkAndSetFunctionUnhealthy(containerID string, function platform.Function) error {

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -1035,8 +1035,7 @@ func (p *Platform) delete(ctx context.Context, deleteFunctionOptions *platform.D
 
 	if err := p.deleteFunctionContainers(ctx,
 		deleteFunctionOptions.FunctionConfig.Meta.Name,
-		deleteFunctionOptions.FunctionConfig.Meta.Namespace,
-		true); err != nil {
+		deleteFunctionOptions.FunctionConfig.Meta.Namespace); err != nil {
 		return errors.Wrap(err, "Failed to delete function containers")
 	}
 
@@ -1052,7 +1051,7 @@ func (p *Platform) delete(ctx context.Context, deleteFunctionOptions *platform.D
 	return nil
 }
 
-func (p *Platform) deleteFunctionContainers(ctx context.Context, functionName, namespace string, waitForDeletion bool) error {
+func (p *Platform) deleteFunctionContainers(ctx context.Context, functionName, namespace string) error {
 	getContainerOptions := &dockerclient.GetContainerOptions{
 		Stopped: true,
 		Labels: map[string]string{
@@ -1074,7 +1073,6 @@ func (p *Platform) deleteFunctionContainers(ctx context.Context, functionName, n
 
 	p.Logger.DebugWithCtx(ctx, "Got function containers", "containersInfoLength", len(containersInfo))
 
-	var errorDuringFunctionStopping error
 	// iterate over contains and delete them. It's possible that under some weird circumstances
 	// there are a few instances of this function in the namespace
 	for _, containerInfo := range containersInfo {
@@ -1084,18 +1082,7 @@ func (p *Platform) deleteFunctionContainers(ctx context.Context, functionName, n
 		// we will retry to stop with SIGKILL below
 		if err = p.dockerClient.StopContainer(containerInfo.ID, int(p.GetConfig().Local.FunctionContainersGracefulTerminationTimeout.Seconds())); err != nil {
 			p.Logger.WarnWith("Failed to stop container, will retry with SIGKILL", "containerId", containerInfo.ID)
-
-			// if not wait for deletion, then try to remove the container right away
-			// otherwise will be retried below after waiting for a timeout
-			if !waitForDeletion {
-				err = p.dockerClient.RemoveContainer(containerInfo.ID)
-			}
-			errorDuringFunctionStopping = err
 		}
-	}
-
-	if !waitForDeletion {
-		return errorDuringFunctionStopping
 	}
 
 	// wait until all containers are deleted
@@ -1279,7 +1266,7 @@ func (p *Platform) deleteOrStopFunctionContainers(ctx context.Context, createFun
 
 		return 0, p.deleteFunctionContainers(ctx,
 			createFunctionOptions.FunctionConfig.Meta.Name,
-			createFunctionOptions.FunctionConfig.Meta.Namespace, true)
+			createFunctionOptions.FunctionConfig.Meta.Namespace)
 	}
 
 	// if the function exists, delete it
@@ -1301,9 +1288,7 @@ func (p *Platform) deleteOrStopFunctionContainers(ctx context.Context, createFun
 
 	return previousHTTPPort, p.deleteFunctionContainers(ctx,
 		createFunctionOptions.FunctionConfig.Meta.Name,
-		createFunctionOptions.FunctionConfig.Meta.Namespace,
-		// do not wait for deletion in case of redeploying the function
-		false)
+		createFunctionOptions.FunctionConfig.Meta.Namespace)
 
 }
 

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -1053,8 +1053,35 @@ func (p *Platform) delete(ctx context.Context, deleteFunctionOptions *platform.D
 	// there are a few instances of this function in the namespace
 	for _, containerInfo := range containersInfo {
 		p.Logger.DebugWithCtx(ctx, "Removing function container", "containerName", containerInfo.Name)
-		if err := p.dockerClient.RemoveContainer(containerInfo.ID); err != nil {
+		if err := p.dockerClient.StopContainer(containerInfo.ID, int(p.GetConfig().Local.FunctionContainersGracefulTerminationTimeout.Seconds())); err != nil {
 			return errors.Wrapf(err, "Failed to remove container %s", containerInfo.ID)
+		}
+	}
+
+	// wait until all containers are deleted
+	err = common.RetryUntilSuccessful(p.GetConfig().Local.FunctionContainersGracefulTerminationTimeout+1*time.Second, 3*time.Second, func() bool {
+		containers, err := p.dockerClient.GetContainers(getContainerOptions)
+		if err != nil {
+			return false
+		}
+		if len(containers) == 0 {
+			return true
+		}
+		return false
+	})
+
+	if err != nil {
+		p.Logger.WarnWith("Failed to wait until all function containers are deleted, removing containers with SIGKILL")
+		containersInfo, err = p.dockerClient.GetContainers(getContainerOptions)
+		if err != nil {
+			return errors.Wrap(err, "Failed to get containers")
+		}
+		// there are a few instances of this function in the namespace
+		for _, containerInfo := range containersInfo {
+			p.Logger.DebugWithCtx(ctx, "Removing function container", "containerName", containerInfo.Name)
+			if err := p.dockerClient.RemoveContainer(containerInfo.ID); err != nil {
+				return errors.Wrapf(err, "Failed to remove container %s", containerInfo.ID)
+			}
 		}
 	}
 
@@ -1220,7 +1247,7 @@ func (p *Platform) deleteOrStopFunctionContainers(createFunctionOptions *platfor
 			createFunctionOptions.Logger.DebugWith("Stop function container",
 				"functionName", createFunctionOptions.FunctionConfig.Meta.Name,
 				"containerID", container.ID)
-			if err := p.dockerClient.StopContainer(container.ID); err != nil {
+			if err := p.dockerClient.StopContainer(container.ID, int(p.GetConfig().Local.FunctionContainersGracefulTerminationTimeout.Seconds())); err != nil {
 				return 0, errors.Wrap(err, "Failed to stop a container")
 			}
 		}

--- a/pkg/platform/local/test/platform_test.go
+++ b/pkg/platform/local/test/platform_test.go
@@ -129,7 +129,7 @@ func (suite *TestSuite) TestValidateFunctionContainersHealthiness() {
 			}, functionconfig.FunctionStateReady, time.Second)
 
 			// Stop the container
-			err := suite.DockerClient.StopContainer(deployResult.ContainerID)
+			err := suite.DockerClient.StopContainer(deployResult.ContainerID, 10)
 			suite.Require().NoError(err, "Could not stop container")
 
 			// Trigger function containers healthiness validation

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -465,6 +465,10 @@ func (c *Config) enrichLocalPlatform() {
 	if c.Local.FunctionContainersHealthinessTimeout == 0 {
 		c.Local.FunctionContainersHealthinessTimeout = time.Second * 5
 	}
+
+	if c.Local.FunctionContainersGracefulTerminationTimeout == 0 {
+		c.Local.FunctionContainersGracefulTerminationTimeout = time.Second * 10
+	}
 }
 
 func (c *Config) enrichOpaConfig() {

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -293,12 +293,13 @@ func (p *PreemptibleNodes) CompileAntiAffinityByLabelSelectorNoScheduleOnMatchin
 }
 
 type PlatformLocalConfig struct {
-	FunctionContainersHealthinessEnabled  bool                        `json:"functionContainersHealthinessEnabled"`
-	FunctionContainersHealthinessTimeout  time.Duration               `json:"functionContainersHealthinessTimeout,omitempty"`
-	FunctionContainersHealthinessInterval time.Duration               `json:"functionContainersHealthinessInterval,omitempty"`
-	DefaultFunctionContainerNetworkName   string                      `json:"defaultFunctionContainerNetworkName,omitempty"`
-	DefaultFunctionRestartPolicy          *dockerclient.RestartPolicy `json:"defaultFunctionRestartPolicy,omitempty"`
-	DefaultFunctionVolumes                []functionconfig.Volume     `json:"defaultFunctionVolumes,omitempty"`
+	FunctionContainersHealthinessEnabled         bool                        `json:"functionContainersHealthinessEnabled"`
+	FunctionContainersHealthinessTimeout         time.Duration               `json:"functionContainersHealthinessTimeout,omitempty"`
+	FunctionContainersHealthinessInterval        time.Duration               `json:"functionContainersHealthinessInterval,omitempty"`
+	FunctionContainersGracefulTerminationTimeout time.Duration               `json:"functionContainersGracefulTerminationTimeout,omitempty"`
+	DefaultFunctionContainerNetworkName          string                      `json:"defaultFunctionContainerNetworkName,omitempty"`
+	DefaultFunctionRestartPolicy                 *dockerclient.RestartPolicy `json:"defaultFunctionRestartPolicy,omitempty"`
+	DefaultFunctionVolumes                       []functionconfig.Volume     `json:"defaultFunctionVolumes,omitempty"`
 }
 
 type ImageRegistryOverridesConfig struct {

--- a/pkg/processor/test/suite/suite.go
+++ b/pkg/processor/test/suite/suite.go
@@ -408,7 +408,7 @@ func (suite *TestSuite) WithFunctionContainerRestart(deployResult *platform.Crea
 	handler func()) {
 
 	// stop container
-	err := suite.DockerClient.StopContainer(deployResult.ContainerID)
+	err := suite.DockerClient.StopContainer(deployResult.ContainerID, 10)
 	suite.Require().NoError(err)
 
 	handler()


### PR DESCRIPTION
### 📝 Description
Bug was found during writing tests in https://github.com/nuclio/nuclio/pull/3821

We did `docker rm -f` instead of `docker stop`, which didn’t allow to run termination callback properly 

Docker stop docs: [docker container stop](https://docs.docker.com/reference/cli/docker/container/stop/) 
docker rm docs: [docker container rm](https://docs.docker.com/reference/cli/docker/container/rm/)

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
tested as part of https://github.com/nuclio/nuclio/pull/3821

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-609
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---