### PR TITLE
[Java] Fix SDK downloading

### DIFF
--- a/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
@@ -53,7 +53,7 @@ COPY pkg/processor/build/runtime/java/docker/onbuild/build-user-handler.sh /home
 RUN chmod +x /home/gradle/src/userHandler/build-user-handler.sh
 
 # Download the nuclio SDK Jar
-RUN curl -LO https://repo1.maven.org/fromsearch?filepath=io/nuclio/nuclio-sdk-java/1.1.0/nuclio-sdk-java-1.1.0.jar
+RUN curl -LO https://repo1.maven.org/maven2/io/nuclio/nuclio-sdk-java/1.1.0/nuclio-sdk-java-1.1.0.jar
 
 # Copy the downloaded SDK Jar to the userHandler folder
 RUN cp nuclio-sdk-java-1.1.0.jar /home/gradle/src/userHandler/nuclio-sdk-java-1.1.0.jar


### PR DESCRIPTION
### 📝 Description
All the latest builds fail because:

```
curl -LO https://repo1.maven.org/fromsearch\?filepath\=io/nuclio/nuclio-sdk-java/1.1.0/nuclio-sdk-java-1.1.0.jar
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   167  100   167    0     0    808      0 --:--:-- --:--:-- --:--:--   808
100   129  100   129    0     0    379      0 --:--:-- --:--:-- --:--:--   379
```
doesn't return the package anymore. 

I didn't fine any information why, but here is what works:

```
curl -LO https://repo1.maven.org/maven2/io/nuclio/nuclio-sdk-java/1.1.0/nuclio-sdk-java-1.1.0.jar
```

---

### 🛠️ Changes Made
Fixed to 

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
CI

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->