### PR TITLE
[RabbitMQ] Fix worker allocator initialization

### DIFF
--- a/pkg/processor/trigger/rabbitmq/factory.go
+++ b/pkg/processor/trigger/rabbitmq/factory.go
@@ -50,7 +50,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	workerAllocator, err := f.GetWorkerAllocator(triggerConfiguration.WorkerAllocatorName,
 		namedWorkerAllocators,
 		func() (eventprocessor.Allocator, error) {
-			return worker.WorkerFactorySingleton.CreateNonBlockingWorkerAllocator(triggerLogger, 1,
+			return worker.WorkerFactorySingleton.CreateNonBlockingWorkerAllocator(triggerLogger, configuration.NumWorkers,
 				runtimeConfiguration)
 		})
 

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -246,8 +246,13 @@ func (at *AbstractTrigger) GetStatistics() *Statistics {
 		at.Statistics = &Statistics{}
 	}
 
+	statistics := at.WorkerAllocator.GetStatistics()
+	if statistics == nil {
+		return &Statistics{}
+	}
+
 	// copy worker allocator statistics
-	at.Statistics.WorkerAllocatorStatistics = *at.WorkerAllocator.GetStatistics()
+	at.Statistics.WorkerAllocatorStatistics = *statistics
 
 	return at.Statistics
 }


### PR DESCRIPTION
### 📝 Description
The bug was caused by a nil reference when retrieving allocation metrics (see traceback below). This occurred because the RabbitMQ case is quite unique — unlike Kafka or V3IO queues, acknowledgments (ACKs) in RabbitMQ are message-based rather than partition-based. Therefore, fully asynchronous allocation is possible; in other words, both connection and worker allocations can operate asynchronously.

Originally, there was a single asynchronous worker allocator (before the Nuclio async changes). Later, this allocator was renamed to a non-blocking singleton. However, since we now support both pool and singleton allocators, we can choose between them based on the configured number of workers.

The nil reference happened for two reasons:
* We don’t collect allocation metrics for asynchronous allocators since it’s redundant — those values are already available in the event processing metrics.
* `trigger.GetStatistics()` assumed that statistics are always non-nil. In all other triggers except RabbitMQ, at least one of the allocators in the worker+connection pair is synchronous and therefore provides metrics.

```
2025/09/29 08:07:20 http: panic serving 10.233.92.86:37258: runtime error: invalid memory address or nil pointer dereference
goroutine 41 [running]:
net/http.(*conn).serve.func1()
        /opt/hostedtoolcache/go/1.23.8/x64/src/net/http/server.go:1947 +0xbe
panic({0x1f0fe40?, 0x3a01980?})
        /opt/hostedtoolcache/go/1.23.8/x64/src/runtime/panic.go:791 +0x132
github.com/nuclio/nuclio/pkg/processor/trigger.(*AbstractTrigger).GetStatistics(...)
        /home/runner/work/nuclio/nuclio/pkg/processor/trigger/trigger.go:245
```

---

### 🛠️ Changes Made
This PR includes two fixes:
* Makes worker allocator creation dynamic based on the number of workers.
* Fixes the case where both allocators in the worker+connection pair are asynchronous and metrics are empty.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
vmdev

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-612
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->