### PR TITLE
[RabbitMQ] Mask credentials from url

### DIFF
--- a/docs/reference/triggers/rabbitmq.md
+++ b/docs/reference/triggers/rabbitmq.md
@@ -62,3 +62,5 @@ durableQueue: true
 Both configurations are supported.
 During the enrichment stage, if credentials are provided within the URL, they are automatically extracted and assigned to `username` and `password` fields in the trigger configuration.
 The URL is then sanitized (i.e., credentials are removed) to prevent sensitive data from being exposed in logs or configurations.
+
+> Note: If both the URL and the trigger configuration specify credentials, the credentials from the URL take precedence and will override any existing username or password values in the trigger specification.

--- a/docs/reference/triggers/rabbitmq.md
+++ b/docs/reference/triggers/rabbitmq.md
@@ -40,3 +40,25 @@ triggers:
       durableExchange: true
       durableQueue: true
 ```
+OR
+
+```yaml
+triggers:
+myRabbit:
+kind: "rabbit-mq"
+url: "amqp://10.0.0.1:5672"
+username: "user"
+password: "pass"
+attributes:
+exchangeName: "myExchangeName"
+queueName: "myQueueName"
+reconnectDuration: "10m"
+reconnectInterval: "60s"
+prefetchCount: 1
+durableExchange: true
+durableQueue: true
+```
+
+Both configurations are supported.
+During the enrichment stage, if credentials are provided within the URL, they are automatically extracted and assigned to `username` and `password` fields in the trigger configuration.
+The URL is then sanitized (i.e., credentials are removed) to prevent sensitive data from being exposed in logs or configurations.

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -1831,11 +1832,46 @@ func (ap *Platform) enrichTriggers(ctx context.Context, functionConfig *function
 		if err := ap.enrichProcessingMode(ctx, triggerName, &triggerInstance, functionConfig); err != nil {
 			return errors.Wrap(err, "Failed to enrich processing mode")
 		}
+		if triggerInstance.Kind == "rabbit-mq" {
+			ap.enrichRabbitMQTrigger(ctx, triggerName, &triggerInstance)
+		}
 
 		functionConfig.Spec.Triggers[triggerName] = triggerInstance
 	}
 
 	return nil
+}
+func (ap *Platform) enrichRabbitMQTrigger(ctx context.Context, triggerName string, triggerInstance *functionconfig.Trigger) {
+	// Parse the broker URL
+	parsedURL, err := url.Parse(triggerInstance.URL)
+	if err != nil {
+		ap.Logger.WarnWith("Failed to parse RabbitMQ URL", "url", triggerInstance.URL, "error", err.Error())
+		return
+	}
+
+	// Extract credentials if present
+	if parsedURL.User != nil {
+		if user := parsedURL.User.Username(); user != "" {
+			triggerInstance.Username = user
+		}
+
+		if pass, found := parsedURL.User.Password(); found {
+			triggerInstance.Password = pass
+		}
+
+		// Remove credentials from URL for security reasons
+		parsedURL.User = nil
+
+		triggerInstance.URL = parsedURL.String()
+
+		ap.Logger.DebugWithCtx(ctx,
+			"Extracted RabbitMQ credentials from URL",
+			"trigger", triggerName,
+			"brokerUrl", triggerInstance.URL,
+			"isUsernameSet", triggerInstance.Username != "",
+			"passwordSet", triggerInstance.Password != "",
+		)
+	}
 }
 
 func (ap *Platform) enrichExplicitAckParams(ctx context.Context, functionConfig *functionconfig.Config) error {

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1833,7 +1833,9 @@ func (ap *Platform) enrichTriggers(ctx context.Context, functionConfig *function
 			return errors.Wrap(err, "Failed to enrich processing mode")
 		}
 		if triggerInstance.Kind == "rabbit-mq" {
-			ap.enrichRabbitMQTrigger(ctx, triggerName, &triggerInstance)
+			if err := ap.enrichRabbitMQTrigger(ctx, triggerName, &triggerInstance); err != nil {
+				return errors.Wrap(err, "Failed to enrich RabbitMQ trigger")
+			}
 		}
 
 		functionConfig.Spec.Triggers[triggerName] = triggerInstance
@@ -1841,12 +1843,11 @@ func (ap *Platform) enrichTriggers(ctx context.Context, functionConfig *function
 
 	return nil
 }
-func (ap *Platform) enrichRabbitMQTrigger(ctx context.Context, triggerName string, triggerInstance *functionconfig.Trigger) {
+func (ap *Platform) enrichRabbitMQTrigger(ctx context.Context, triggerName string, triggerInstance *functionconfig.Trigger) error {
 	// Parse the broker URL
 	parsedURL, err := url.Parse(triggerInstance.URL)
 	if err != nil {
-		ap.Logger.WarnWith("Failed to parse RabbitMQ URL", "url", triggerInstance.URL, "error", err.Error())
-		return
+		return errors.Wrap(err, "Failed to parse RabbitMQ URL")
 	}
 
 	// Extract credentials if present
@@ -1872,6 +1873,7 @@ func (ap *Platform) enrichRabbitMQTrigger(ctx context.Context, triggerName strin
 			"passwordSet", triggerInstance.Password != "",
 		)
 	}
+	return nil
 }
 
 func (ap *Platform) enrichExplicitAckParams(ctx context.Context, functionConfig *functionconfig.Config) error {

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1843,6 +1843,7 @@ func (ap *Platform) enrichTriggers(ctx context.Context, functionConfig *function
 
 	return nil
 }
+
 func (ap *Platform) enrichRabbitMQTrigger(ctx context.Context, triggerName string, triggerInstance *functionconfig.Trigger) error {
 	// Parse the broker URL
 	parsedURL, err := url.Parse(triggerInstance.URL)

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -375,6 +375,69 @@ func (suite *AbstractPlatformTestSuite) TestEnrichDefaultHttpTrigger() {
 	}
 }
 
+func (suite *AbstractPlatformTestSuite) TestEnrichRabbitMQTrigger() {
+	for _, testCase := range []struct {
+		Name             string
+		URL              string
+		InitialUsername  string
+		InitialPassword  string
+		ExpectedURL      string
+		ExpectedUsername string
+		ExpectedPassword string
+	}{
+		{
+			Name:             "URL overrides explicit credentials",
+			URL:              "amqp://userFromURL:passFromURL@localhost:5672/",
+			InitialUsername:  "explicitUser",
+			InitialPassword:  "explicitPass",
+			ExpectedURL:      "amqp://localhost:5672/",
+			ExpectedUsername: "userFromURL",
+			ExpectedPassword: "passFromURL",
+		},
+		{
+			Name:             "URL without credentials keeps explicit credentials",
+			URL:              "amqp://localhost:5672/",
+			InitialUsername:  "explicitUser",
+			InitialPassword:  "explicitPass",
+			ExpectedURL:      "amqp://localhost:5672/",
+			ExpectedUsername: "explicitUser",
+			ExpectedPassword: "explicitPass",
+		},
+		{
+			Name:             "URL with only username overrides explicit username",
+			URL:              "amqp://userOnly@localhost:5672/",
+			InitialUsername:  "explicitUser",
+			InitialPassword:  "explicitPass",
+			ExpectedURL:      "amqp://localhost:5672/",
+			ExpectedUsername: "userOnly",
+			ExpectedPassword: "explicitPass",
+		},
+		{
+			Name:             "Empty URL keeps explicit credentials",
+			URL:              "",
+			InitialUsername:  "explicitUser",
+			InitialPassword:  "explicitPass",
+			ExpectedURL:      "",
+			ExpectedUsername: "explicitUser",
+			ExpectedPassword: "explicitPass",
+		},
+	} {
+		suite.Run(testCase.Name, func() {
+			trigger := &functionconfig.Trigger{
+				URL:      testCase.URL,
+				Username: testCase.InitialUsername,
+				Password: testCase.InitialPassword,
+			}
+
+			suite.Platform.enrichRabbitMQTrigger(context.Background(), testCase.Name, trigger)
+
+			suite.Require().Equal(testCase.ExpectedURL, trigger.URL, "Unexpected URL after enrichment")
+			suite.Require().Equal(testCase.ExpectedUsername, trigger.Username, "Unexpected username")
+			suite.Require().Equal(testCase.ExpectedPassword, trigger.Password, "Unexpected password")
+		})
+	}
+}
+
 func (suite *AbstractPlatformTestSuite) TestEnrichBatchConfiguration() {
 	for _, testCase := range []struct {
 		name                       string

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -384,6 +384,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichRabbitMQTrigger() {
 		ExpectedURL      string
 		ExpectedUsername string
 		ExpectedPassword string
+		ExpectError      bool
 	}{
 		{
 			Name:             "URL overrides explicit credentials",
@@ -421,6 +422,16 @@ func (suite *AbstractPlatformTestSuite) TestEnrichRabbitMQTrigger() {
 			ExpectedUsername: "explicitUser",
 			ExpectedPassword: "explicitPass",
 		},
+		{
+			Name:             "Malformed URL returns error and keeps original values",
+			URL:              "://bad_url",
+			InitialUsername:  "explicitUser",
+			InitialPassword:  "explicitPass",
+			ExpectedURL:      "://bad_url",
+			ExpectedUsername: "explicitUser",
+			ExpectedPassword: "explicitPass",
+			ExpectError:      true,
+		},
 	} {
 		suite.Run(testCase.Name, func() {
 			trigger := &functionconfig.Trigger{
@@ -429,11 +440,17 @@ func (suite *AbstractPlatformTestSuite) TestEnrichRabbitMQTrigger() {
 				Password: testCase.InitialPassword,
 			}
 
-			suite.Platform.enrichRabbitMQTrigger(context.Background(), testCase.Name, trigger)
+			err := suite.Platform.enrichRabbitMQTrigger(context.Background(), testCase.Name, trigger)
+
+			if testCase.ExpectError {
+				suite.Require().Error(err, "Expected error but got none")
+			} else {
+				suite.Require().NoError(err, "Unexpected error while enriching trigger")
+			}
 
 			suite.Require().Equal(testCase.ExpectedURL, trigger.URL, "Unexpected URL after enrichment")
-			suite.Require().Equal(testCase.ExpectedUsername, trigger.Username, "Unexpected username")
-			suite.Require().Equal(testCase.ExpectedPassword, trigger.Password, "Unexpected password")
+			suite.Require().Equal(testCase.ExpectedUsername, trigger.Username, "Unexpected username after enrichment")
+			suite.Require().Equal(testCase.ExpectedPassword, trigger.Password, "Unexpected password after enrichment")
 		})
 	}
 }

--- a/pkg/processor/trigger/rabbitmq/trigger.go
+++ b/pkg/processor/trigger/rabbitmq/trigger.go
@@ -153,6 +153,15 @@ func (rmq *rabbitMq) createBrokerResources() error {
 func (rmq *rabbitMq) getConnectionConfig() *amqp.Config {
 	config := amqp.Config{Properties: amqp.NewConnectionProperties()}
 
+	if rmq.configuration.Username != "" && rmq.configuration.Password != "" {
+		config.SASL = []amqp.Authentication{
+			&amqp.PlainAuth{
+				Username: rmq.configuration.Username,
+				Password: rmq.configuration.Password,
+			},
+		}
+	}
+
 	connectionName := rmq.FunctionName + "-" + rmq.ID
 
 	// when running processor locally, there might be no function name.


### PR DESCRIPTION
### 📝 Description
In RabbitMQ, credentials can be included directly in the URL, which may raise security concerns for some users. This PR addresses the issue by parsing the URL during the enrichment stage and removing any credentials. Extracted username and password are then securely set in triggerConfiguration.Username and triggerConfiguration.Password. 

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
vmdev and unit test

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-611
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
Function was deployed as usually with creds specified in URL. After deployment, URL doesn't have creds and password and username are in separate fields (password masked - both in UI and CRD):

UI:
<img width="608" height="225" alt="Screenshot 2025-10-14 at 14 29 21" src="https://github.com/user-attachments/assets/4927592b-112c-469f-bb0c-546e32cefa80" />

CRD:
```    rabbit-trigger:
      attributes:
        exchangeName: test_ex
        prefetchCount: 2
        queueName: task_queue
      class: ""
      kind: rabbit-mq
      mode: sync
      name: rabbit-trigger
      password: $ref:/spec/triggers/rabbit-trigger/password
      url: amqp://my-rabbitmq.default-tenant.svc.cluster.local:5672
      username: user     
 ```
