### PR TITLE
[RabbitMQ] Add ability to NACk on errors

### DIFF
--- a/hack/examples/golang/rabbitmq/rabbitmq.go
+++ b/hack/examples/golang/rabbitmq/rabbitmq.go
@@ -36,7 +36,7 @@ func Handler(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
 	context.Logger.InfoWith("Received event", "body", string(event.GetBody()))
 
 	// if we got the event from rabbit
-	if event.GetTriggerInfo().GetClass() == "async" && event.GetTriggerInfo().GetKind() == "rabbitMq" {
+	if event.GetTriggerInfo().GetClass() == "async" && event.GetTriggerInfo().GetKind() == "rabbit-mq" {
 
 		eventLogFile, err := os.OpenFile(eventLogFilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 		if err != nil {

--- a/pkg/common/version.go
+++ b/pkg/common/version.go
@@ -17,6 +17,8 @@ limitations under the License.
 package common
 
 import (
+	"runtime"
+
 	"github.com/v3io/version-go"
 )
 
@@ -26,7 +28,7 @@ func SetVersionFromEnv() {
 		Label:     GetEnvOrDefaultString("NUCLIO_LABEL", version.Get().Label),
 		GitCommit: "c",
 		OS:        GetEnvOrDefaultString("NUCLIO_OS", "linux"),
-		Arch:      GetEnvOrDefaultString("NUCLIO_ARCH", "amd64"),
+		Arch:      GetEnvOrDefaultString("NUCLIO_ARCH", runtime.GOARCH),
 		GoVersion: version.Get().GoVersion,
 	})
 }

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -42,6 +42,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/build"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
+	"github.com/nuclio/nuclio/pkg/processor/trigger/rabbitmq"
 	"github.com/nuclio/nuclio/pkg/processor/util/partitionworker"
 
 	"github.com/distribution/reference"
@@ -1874,6 +1875,21 @@ func (ap *Platform) enrichRabbitMQTrigger(ctx context.Context, triggerName strin
 			"passwordSet", triggerInstance.Password != "",
 		)
 	}
+
+	return ap.enrichRabbitMQAckConfig(triggerInstance)
+}
+
+func (ap *Platform) enrichRabbitMQAckConfig(triggerInstance *functionconfig.Trigger) error {
+	if triggerInstance.Attributes == nil {
+		triggerInstance.Attributes = make(map[string]interface{})
+	}
+	if _, ok := triggerInstance.Attributes["onError"]; !ok {
+		triggerInstance.Attributes["onError"] = rabbitmq.OnProcessErrorNack
+	}
+	if _, ok := triggerInstance.Attributes["requeueOnError"]; !ok {
+		triggerInstance.Attributes["requeueOnError"] = false
+	}
+
 	return nil
 }
 

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -37,6 +37,7 @@ import (
 	mockedplatform "github.com/nuclio/nuclio/pkg/platform/mock"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
+	"github.com/nuclio/nuclio/pkg/processor/trigger/rabbitmq"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/nuclio/errors"
@@ -451,6 +452,58 @@ func (suite *AbstractPlatformTestSuite) TestEnrichRabbitMQTrigger() {
 			suite.Require().Equal(testCase.ExpectedURL, trigger.URL, "Unexpected URL after enrichment")
 			suite.Require().Equal(testCase.ExpectedUsername, trigger.Username, "Unexpected username after enrichment")
 			suite.Require().Equal(testCase.ExpectedPassword, trigger.Password, "Unexpected password after enrichment")
+		})
+	}
+}
+
+func (suite *AbstractPlatformTestSuite) TestEnrichRabbitMQAckConfig() {
+	for _, testCase := range []struct {
+		Name               string
+		InitialAttributes  map[string]interface{}
+		ExpectedAttributes map[string]interface{}
+	}{
+		{
+			Name:              "Nil Attributes is filled with defaults",
+			InitialAttributes: nil,
+			ExpectedAttributes: map[string]interface{}{
+				"onError":        rabbitmq.OnProcessErrorNack,
+				"requeueOnError": false,
+			},
+		},
+		{
+			Name:              "Partial Attributes fills missing fields",
+			InitialAttributes: map[string]interface{}{"onError": rabbitmq.OnProcessErrorNack},
+			ExpectedAttributes: map[string]interface{}{
+				"onError":        rabbitmq.OnProcessErrorNack,
+				"requeueOnError": false,
+			},
+		},
+		{
+			Name: "Full Attributes remains unchanged",
+			InitialAttributes: map[string]interface{}{
+				"onError":        rabbitmq.OnProcessErrorNack,
+				"requeueOnError": true,
+			},
+			ExpectedAttributes: map[string]interface{}{
+				"onError":        rabbitmq.OnProcessErrorNack,
+				"requeueOnError": true,
+			},
+		},
+	} {
+		suite.Run(testCase.Name, func() {
+			trigger := &functionconfig.Trigger{
+				Attributes: make(map[string]interface{}),
+			}
+
+			if testCase.InitialAttributes != nil {
+				for k, v := range testCase.InitialAttributes {
+					trigger.Attributes[k] = v
+				}
+			}
+
+			err := suite.Platform.enrichRabbitMQAckConfig(trigger)
+			suite.Require().NoError(err)
+			suite.Require().Equal(testCase.ExpectedAttributes, trigger.Attributes)
 		})
 	}
 }

--- a/pkg/processor/trigger/rabbitmq/factory.go
+++ b/pkg/processor/trigger/rabbitmq/factory.go
@@ -50,7 +50,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	workerAllocator, err := f.GetWorkerAllocator(triggerConfiguration.WorkerAllocatorName,
 		namedWorkerAllocators,
 		func() (eventprocessor.Allocator, error) {
-			return worker.WorkerFactorySingleton.CreateNonBlockingWorkerAllocator(triggerLogger, configuration.NumWorkers,
+			return worker.WorkerFactorySingleton.CreateFixedPoolWorkerAllocator(triggerLogger, configuration.NumWorkers,
 				runtimeConfiguration)
 		})
 
@@ -77,5 +77,4 @@ func (f *factory) Create(parentLogger logger.Logger,
 // register factory
 func init() {
 	trigger.RegistrySingleton.Register("rabbit-mq", &factory{})
-	trigger.RegistrySingleton.Register("rabbitMq", &factory{})
 }

--- a/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
+++ b/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
@@ -22,6 +22,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,6 +33,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/processor/trigger/rabbitmq"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/test"
 
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -48,6 +53,14 @@ type testSuite struct {
 	containerizedBrokerURL string
 }
 
+// Event represents the structure of each event returned by your Nuclio function.
+// Adjust the fields according to your actual event structure.
+type Event struct {
+	ID      string                 `json:"id"`
+	Body    string                 `json:"body"`
+	Headers map[string]interface{} `json:"headers"`
+}
+
 func (suite *testSuite) SetupSuite() {
 	suite.brokerURL = fmt.Sprintf("amqp://%s:%d", suite.GetTestHost(), suite.brokerPort)
 	suite.containerizedBrokerURL = fmt.Sprintf("amqp://guest:guest@172.17.0.1:%d", suite.brokerPort)
@@ -63,7 +76,7 @@ func (suite *testSuite) TearDownTest() {
 
 // GetContainerRunInfo returns information about the broker container
 func (suite *testSuite) GetContainerRunInfo() (string, *dockerclient.RunOptions) {
-	return "rabbitmq:3-management", &dockerclient.RunOptions{
+	return "rabbitmq:4-management", &dockerclient.RunOptions{
 		Ports: map[int]int{suite.brokerPort: suite.brokerPort, 15671: 15671},
 	}
 }
@@ -195,6 +208,133 @@ func (suite *testSuite) TestResourcesCreatedByFunction() {
 		},
 		suite.publishMessageToTopic,
 		nil)
+}
+
+func (suite *testSuite) TestNackAndRequeue() {
+	expectedRequeued := []string{
+		"success-5",
+		"success-6",
+		"success-7",
+		"success-8",
+		"success-9",
+		"nack-once-0",
+		"nack-once-1",
+		"nack-once-2",
+		"nack-once-3",
+		"nack-once-4",
+	}
+
+	expectedNotRequeued := []string{
+		"success-5",
+		"success-6",
+		"success-7",
+		"success-8",
+		"success-9",
+	}
+
+	testCases := []struct {
+		name           string
+		onError        string
+		requeueOnError bool
+		expectedEvents []string
+	}{
+		{
+			name:           "NackWithRequeueOnError",
+			onError:        string(rabbitmq.OnProcessErrorNack),
+			requeueOnError: true,
+			expectedEvents: expectedRequeued,
+		},
+		{
+			name:           "NackWithoutRequeueOnError",
+			onError:        string(rabbitmq.OnProcessErrorNack),
+			requeueOnError: false,
+			expectedEvents: expectedNotRequeued,
+		},
+		{
+			name:           "AckOnError",
+			onError:        string(rabbitmq.OnProcessErrorAck),
+			expectedEvents: expectedNotRequeued,
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			functionName := fmt.Sprintf("nack-requeue-%s", strings.ToLower(tc.name))
+			functionPath := path.Join(
+				suite.GetTestFunctionsDir(),
+				"python",
+				"rabbitmq",
+				"ack-test.py",
+			)
+			topicName := "t1"
+			suite.createBrokerResources([]string{topicName})
+
+			triggerConfig := functionconfig.Trigger{
+				Kind: "rabbit-mq",
+				URL:  fmt.Sprintf("amqp://guest:guest@172.17.0.1:%d", suite.brokerPort),
+				Attributes: map[string]interface{}{
+					"exchangeName":   suite.brokerExchangeName,
+					"queueName":      suite.brokerQueueName,
+					"topics":         []string{"t1"},
+					"onError":        tc.onError,
+					"requeueOnError": tc.requeueOnError,
+				},
+			}
+
+			createFunctionOptions := suite.GetDeployOptions(functionName, functionPath)
+			createFunctionOptions.FunctionConfig.Spec.Build.Commands = []string{"pip install nuclio-sdk"}
+			createFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{
+				"my-rabbit-mq": triggerConfig,
+				"my-http": {
+					Kind:       "http",
+					Attributes: map[string]interface{}{},
+				},
+			}
+
+			suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+				suite.Require().NotNil(deployResult, "Unexpected empty deploy results")
+
+				for index := 0; index < 10; index++ {
+					message := fmt.Sprintf("success-%d", index)
+					if index < 5 {
+						message = fmt.Sprintf("nack-once-%d", index)
+					}
+					err := suite.publishMessageToTopic(topicName, message)
+					suite.Require().NoError(err, "Failed to publish message to topic")
+				}
+
+				var events []Event
+				err := common.RetryUntilSuccessful(30*time.Second, 3*time.Second, func() bool {
+					url := fmt.Sprintf("http://%s:%d", suite.GetTestHost(), deployResult.Port)
+					resp, err := http.Get(url)
+					if err != nil {
+						return false
+					}
+					defer resp.Body.Close()
+					bodyBytes, err := io.ReadAll(resp.Body)
+					if err != nil {
+						return false
+					}
+					if err := json.Unmarshal(bodyBytes, &events); err != nil {
+						return false
+					}
+					return len(events) >= len(tc.expectedEvents)
+				})
+				suite.Require().NoError(err, "Failed to wait for all events to arrive")
+
+				// Validate order and count
+				suite.Require().Equal(len(tc.expectedEvents), len(events),
+					"Unexpected number of events for %s", tc.name)
+
+				for i, expected := range tc.expectedEvents {
+					suite.Require().Equal(expected, events[i].Body,
+						"Unexpected message order at index %d: expected %s, got %s", i, expected, events[i].Body)
+				}
+
+				return true
+			})
+		})
+	}
 }
 
 func (suite *testSuite) getCreateFunctionOptionsWithRmqTrigger(triggerConfig functionconfig.Trigger) *platform.CreateFunctionOptions {

--- a/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
+++ b/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
@@ -53,9 +53,9 @@ type testSuite struct {
 	containerizedBrokerURL string
 }
 
-// Event represents the structure of each event returned by your Nuclio function.
+// TestEvent represents the structure of each event returned by your Nuclio function.
 // Adjust the fields according to your actual event structure.
-type Event struct {
+type TestEvent struct {
 	ID      string                 `json:"id"`
 	Body    string                 `json:"body"`
 	Headers map[string]interface{} `json:"headers"`
@@ -303,7 +303,7 @@ func (suite *testSuite) TestNackAndRequeue() {
 					suite.Require().NoError(err, "Failed to publish message to topic")
 				}
 
-				var events []Event
+				var events []TestEvent
 				err := common.RetryUntilSuccessful(30*time.Second, 3*time.Second, func() bool {
 					url := fmt.Sprintf("http://%s:%d", suite.GetTestHost(), deployResult.Port)
 					resp, err := http.Get(url)

--- a/pkg/processor/trigger/rabbitmq/trigger.go
+++ b/pkg/processor/trigger/rabbitmq/trigger.go
@@ -35,7 +35,6 @@ import (
 
 type rabbitMq struct {
 	trigger.AbstractTrigger
-	event                      Event
 	configuration              *Configuration
 	consumerName               string
 	brokerConn                 *amqp.Connection
@@ -55,20 +54,20 @@ func newTrigger(parentLogger logger.Logger,
 		workerAllocator,
 		&configuration.Configuration,
 		"async",
-		"rabbitMq",
+		"rabbit-mq",
 		configuration.Name,
 		restartTriggerChan)
 	if err != nil {
 		return nil, errors.New("Failed to create abstract trigger")
 	}
 
-	newTrigger := rabbitMq{
+	triggerInstance := rabbitMq{
 		AbstractTrigger: abstractTrigger,
 		configuration:   configuration,
 	}
-	newTrigger.Trigger = &newTrigger
+	triggerInstance.Trigger = &triggerInstance
 
-	return &newTrigger, nil
+	return &triggerInstance, nil
 }
 
 func (rmq *rabbitMq) Initialize() error {
@@ -349,20 +348,64 @@ func (rmq *rabbitMq) handleConnectionError(handleErr *amqp.Error) error {
 
 func (rmq *rabbitMq) processMessage(message *amqp.Delivery) {
 
-	// bind to delivery
-
-	// TODO: when moving to multiworkers - need to create event per message
-	rmq.event.message = message
-	rmq.event.SetID(nuclio.ID(message.MessageId))
+	event := rmq.createEventFromMessage(message)
 
 	// submit to worker
-	_, submitError, _ := rmq.AllocateWorkerAndSubmitEvent(&rmq.event, nil, 10*time.Second)
+	response, submitError, processError := rmq.AllocateWorkerAndSubmitEvent(event,
+		nil, time.Duration(*rmq.configuration.WorkerAvailabilityTimeoutMilliseconds)*time.Millisecond)
 
-	// ack the message if we didn't fail to submit
-	if submitError == nil {
-		message.Ack(false) // nolint: errcheck
-	} else {
-		rmq.Logger.WarnWith("Failed to submit to worker", "err", submitError)
+	// if submission failed, nack the message so it can be redelivered
+	if submitError != nil {
+		rmq.Logger.DebugWith("Failed to submit event, message will be nacked and requeued",
+			"err", submitError.Error())
+
+		err := message.Nack(false, true)
+		if err != nil {
+			rmq.Logger.WarnWith("Failed to nack message",
+				"error", err.Error())
+		}
+		return
+	}
+
+	if processError == nil && response.GetStatusCode() >= 400 {
+		processError = errors.New(fmt.Sprintf("Function returned error status code: %d", response.GetStatusCode()))
+	}
+
+	// if processing failed, we can choose to nack or ack based on the configuration
+	if processError != nil {
+		rmq.Logger.DebugWith("Event processing failed, handling according to ACK configuration",
+			"err", processError.Error())
+		rmq.ackOnProcessError(message)
+		return
+	}
+
+	// ack the message if processing succeeded
+	if err := message.Ack(false); err != nil {
+		rmq.Logger.WarnWith("Failed to ack message",
+			"error", err.Error())
+	}
+}
+
+func (rmq *rabbitMq) createEventFromMessage(message *amqp.Delivery) *Event {
+	event := &Event{
+		message: message,
+	}
+	event.SetID(nuclio.ID(message.MessageId))
+	return event
+}
+
+func (rmq *rabbitMq) ackOnProcessError(message *amqp.Delivery) {
+	switch rmq.configuration.OnError {
+	case OnProcessErrorAck:
+		if err := message.Ack(rmq.configuration.RequeueOnError); err != nil {
+			rmq.Logger.WarnWith("Failed to ack message",
+				"error", err.Error())
+		}
+	default:
+		if err := message.Nack(false, rmq.configuration.RequeueOnError); err != nil {
+			rmq.Logger.WarnWith("Failed to nack message",
+				"error", err.Error())
+		}
 	}
 }
 

--- a/pkg/processor/trigger/rabbitmq/trigger.go
+++ b/pkg/processor/trigger/rabbitmq/trigger.go
@@ -359,8 +359,7 @@ func (rmq *rabbitMq) processMessage(message *amqp.Delivery) {
 		rmq.Logger.DebugWith("Failed to submit event, message will be nacked and requeued",
 			"err", submitError.Error())
 
-		err := message.Nack(false, true)
-		if err != nil {
+		if err := message.Nack(false, true); err != nil {
 			rmq.Logger.WarnWith("Failed to nack message",
 				"error", err.Error())
 		}

--- a/pkg/processor/trigger/rabbitmq/types.go
+++ b/pkg/processor/trigger/rabbitmq/types.go
@@ -27,6 +27,13 @@ import (
 	"github.com/nuclio/errors"
 )
 
+type OnProcessError string
+
+const (
+	OnProcessErrorAck  OnProcessError = "ack"
+	OnProcessErrorNack OnProcessError = "nack"
+)
+
 type Configuration struct {
 	trigger.Configuration
 	ExchangeName      string
@@ -37,7 +44,8 @@ type Configuration struct {
 	PrefetchCount     int
 	DurableExchange   bool
 	DurableQueue      bool
-
+	OnError           OnProcessError
+	RequeueOnError    bool
 	reconnectDuration time.Duration
 	reconnectInterval time.Duration
 }

--- a/pkg/processor/trigger/rabbitmq/types_test.go
+++ b/pkg/processor/trigger/rabbitmq/types_test.go
@@ -1,0 +1,77 @@
+//go:build test_unit
+
+/*
+Copyright 2025 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbitmq
+
+import (
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/processor/runtime"
+
+	"github.com/nuclio/logger"
+	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type ConfigurationTestSuite struct {
+	suite.Suite
+	logger logger.Logger
+}
+
+func (suite *ConfigurationTestSuite) SetupSuite() {
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
+}
+
+func (suite *ConfigurationTestSuite) TestParseACKConfig() {
+	testCases := []struct {
+		name           string
+		onError        OnProcessError
+		requeueOnError bool
+	}{
+		{"Ack_True", OnProcessErrorAck, true},
+		{"Ack_False", OnProcessErrorAck, false},
+		{"Nack_True", OnProcessErrorNack, true},
+		{"Nack_False", OnProcessErrorNack, false},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			triggerConfig := &functionconfig.Trigger{
+				Attributes: map[string]interface{}{
+					"exchangeName":      "my-exchange",
+					"queueName":         "my-queue",
+					"reconnectDuration": "10m",
+					"reconnectInterval": "20s",
+					"onError":           string(tc.onError),
+					"requeueOnError":    tc.requeueOnError,
+				},
+			}
+
+			cfg, err := NewConfiguration("test-id", triggerConfig, &runtime.Configuration{})
+			suite.Require().NoError(err, "Expected configuration parsing to succeed")
+
+			suite.Equal(tc.onError, cfg.OnError)
+			suite.Equal(tc.requeueOnError, cfg.RequeueOnError)
+		})
+	}
+}
+
+func TestConfigurationSuite(t *testing.T) {
+	suite.Run(t, new(ConfigurationTestSuite))
+}

--- a/test/_functions/python/rabbitmq/ack-test.py
+++ b/test/_functions/python/rabbitmq/ack-test.py
@@ -51,7 +51,7 @@ async def handler(context, event):
 def init_context(context):
     context.logger.info('Initializing context')
     context.already_nacked = set()
-    # create file - first line is queue size, second line is last commit offset
+    # create file
     if not os.path.exists(events_file_path):
         with open(events_file_path, 'w'):
             pass

--- a/test/_functions/python/rabbitmq/ack-test.py
+++ b/test/_functions/python/rabbitmq/ack-test.py
@@ -1,0 +1,67 @@
+# Copyright 2023 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import nuclio_sdk
+
+events_file_path = '/tmp/events.json'
+
+
+async def handler(context, event):
+    context.logger.debug('Received event! event.body: {0}, event.headers: {1}, kind: {2}'.format(event.body, event.headers, event.trigger.kind))
+
+    if event.trigger.kind == "rabbit-mq":
+        body = event.body.decode('utf-8')
+        if "nack-once" in body and event.body not in context.already_nacked:
+            context.logger.info("Simulating failure for event: {}".format(body))
+            context.already_nacked.add(event.body)
+            raise Exception("Simulated failure")
+        write_event_to_file(event)
+        response = nuclio_sdk.Response()
+        response.status_code = 200
+        return response
+    else:
+        try:
+            with open(events_file_path, 'r') as events_log_file:
+                events_log_file_contents = events_log_file.read()
+        except IOError:
+            events_log_file_contents = ''
+
+        # make this valid JSON by removing last two chars (, ) and enclosing in [ ]
+        encoded_event_log = '[' + events_log_file_contents[:-2] + ']'
+
+        context.logger.info('Returning events: {0}'.format(encoded_event_log))
+
+        return encoded_event_log
+
+
+
+def init_context(context):
+    context.logger.info('Initializing context')
+    context.already_nacked = set()
+    # create file - first line is queue size, second line is last commit offset
+    if not os.path.exists(events_file_path):
+        with open(events_file_path, 'w'):
+            pass
+
+
+def write_event_to_file(event: nuclio_sdk.Event):
+
+    with open(events_file_path, 'a') as file:
+        qualified_offset_json = json.dumps({
+            'topic': event.path,
+            'body': event.body.decode('utf-8')
+        })
+        file.write(qualified_offset_json + ', ')


### PR DESCRIPTION
### 📝 Description
* Adds custom configuration to `rabbit-mq` trigger to set whether to nack and requeue on failure. 
* Also, in order to be able to get a failure, we need to wait for response. Thus, there is a need to use Blocking worker allocation for that. 
* During testing I found out that in python trigger rabbit-mq trigger was always `rabbitMq` (not `rabbit-mq` as user specifies in config which might be very confusing), so removed that for clarity
* Added an integration test covering new functionality
* Upgraded rabbitmq in tests to `v4` (see [rabbitMq release info](https://www.rabbitmq.com/release-information))

---

### ✅ Checklist
- [ ] I updated the documentation (TBD)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
Unit and integration tests

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-619, https://iguazio.atlassian.net/browse/NUC-617
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [x] Yes (from now on we always create only `rabbit-mq` trigger (not `rabbitMQ` to avoid confusion amd since rabbitMQ is tech preview yet)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->