### PR TITLE
[Processor] Set `chunked` content-type when streaming

### DIFF
--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -601,12 +601,7 @@ func (h *http) handleRequest(ctx *fasthttp.RequestCtx) {
 		case []byte:
 			ctx.Response.SetBodyRaw(response.GetBody().([]byte))
 		case io.ReadCloser:
-			if _, err := io.Copy(ctx.Response.BodyWriter(), typedResponse); err != nil {
-				h.Logger.ErrorWith("Failed to copy response body",
-					"error", err)
-				ctx.Response.SetStatusCode(nethttp.StatusInternalServerError)
-				return
-			}
+			ctx.Response.SetBodyStream(typedResponse, -1)
 		}
 	}
 


### PR DESCRIPTION
### 📝 Description
`SetBodyStream` is the same as io.Body, but it also sets all headers that are required for browser to process stream correctly. 

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
tested in chrome

---

### 🔗 References
- Ticket link: part of https://iguazio.atlassian.net/browse/NUC-631
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---
