### PR TITLE
[Processor] Fix sync function streaming

### DIFF
--- a/pkg/processor/runtime/python/py/wrapper_common.py
+++ b/pkg/processor/runtime/python/py/wrapper_common.py
@@ -14,6 +14,7 @@
 import signal
 import re
 import socket
+import types
 import time
 import msgpack
 import inspect
@@ -225,7 +226,11 @@ class AbstractWrapper(object):
             entrypoint_output = await self._entrypoint(self._context, event)
         else:
             entrypoint_output = self._entrypoint(self._context, event)
-            if asyncio.iscoroutine(entrypoint_output):
+            # for most of the use cases the entrypoint output is not a coroutine if the function is sync
+            # however, there is such use case in MLRun serving graph
+            # however, we need to make sure that the entrypoint output is not a generator to be able to process
+            # streaming flow as expected
+            if asyncio.iscoroutine(entrypoint_output) and not isinstance(entrypoint_output,  types.GeneratorType):
                 entrypoint_output = await entrypoint_output
         return entrypoint_output
 

--- a/pkg/processor/runtime/python/py/wrapper_common.py
+++ b/pkg/processor/runtime/python/py/wrapper_common.py
@@ -227,9 +227,8 @@ class AbstractWrapper(object):
         else:
             entrypoint_output = self._entrypoint(self._context, event)
             # for most of the use cases the entrypoint output is not a coroutine if the function is sync
-            # however, there is such use case in MLRun serving graph
-            # however, we need to make sure that the entrypoint output is not a generator to be able to process
-            # streaming flow as expected
+            # in mlrun serving graphs, this scenario may occur
+            # ensure the entrypoint output is not a generator to allow proper handling of streaming flows
             if asyncio.iscoroutine(entrypoint_output) and not isinstance(entrypoint_output,  types.GeneratorType):
                 entrypoint_output = await entrypoint_output
         return entrypoint_output

--- a/pkg/processor/runtime/python/test/outputter/stream_outputter.py
+++ b/pkg/processor/runtime/python/test/outputter/stream_outputter.py
@@ -31,10 +31,18 @@ async def stream_file_lines_async(context, event):
 async def stream_file_lines_as_response_async(context, event):
     return context.Response(body=stream_file_lines_async(context, event))
 
-async def stream_file_lines_sync(context, event):
+async def stream_file_lines_sync_as_async(context, event):
     with open(file_path, "r") as f:
         for line in f:
             yield line
 
-async def stream_file_lines_as_response_sync(context, event):
+async def stream_file_lines_as_response_sync_as_async(context, event):
+    return context.Response(body=stream_file_lines_sync(context, event))
+
+def stream_file_lines_sync(context, event):
+    with open(file_path, "r") as f:
+        for line in f:
+            yield line
+
+def stream_file_lines_as_response_sync(context, event):
     return context.Response(body=stream_file_lines_sync(context, event))

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -141,7 +141,7 @@ func (suite *TestSuite) TestStreamingHandler() {
 			handler: "stream_outputter:stream_file_lines_as_response_sync",
 		},
 		{
-			name:    "sync_handler_as_response_with_sync_gen",
+			name:    "sync_handler_as_response_with_sync_gen_as_async",
 			mode:    functionconfig.SyncTriggerWorkMode,
 			handler: "stream_outputter:stream_file_lines_as_response_sync_as_async",
 		},
@@ -156,7 +156,7 @@ func (suite *TestSuite) TestStreamingHandler() {
 			handler: "stream_outputter:stream_file_lines_as_response_async",
 		},
 		{
-			name:    "async_handler_as_response_with_sync_gen",
+			name:    "async_handler_as_response_with_sync_gen_as_async",
 			mode:    functionconfig.AsyncTriggerWorkMode,
 			handler: "stream_outputter:stream_file_lines_as_response_sync_as_async",
 		},
@@ -176,12 +176,12 @@ func (suite *TestSuite) TestStreamingHandler() {
 			handler: "stream_outputter:stream_file_lines_async",
 		},
 		{
-			name:    "async_handler_as_sync_gen",
+			name:    "async_handler_as_sync_gen_as_async",
 			mode:    functionconfig.AsyncTriggerWorkMode,
 			handler: "stream_outputter:stream_file_lines_sync_as_async",
 		},
 		{
-			name:    "async_handler_as_sync_gen",
+			name:    "sync_handler_as_sync_gen_as_async_sync_mode",
 			mode:    functionconfig.SyncTriggerWorkMode,
 			handler: "stream_outputter:stream_file_lines_sync_as_async",
 		},

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -141,6 +141,11 @@ func (suite *TestSuite) TestStreamingHandler() {
 			handler: "stream_outputter:stream_file_lines_as_response_sync",
 		},
 		{
+			name:    "sync_handler_as_response_with_sync_gen",
+			mode:    functionconfig.SyncTriggerWorkMode,
+			handler: "stream_outputter:stream_file_lines_as_response_sync_as_async",
+		},
+		{
 			name:    "sync_handler_as_response_with_async_gen",
 			mode:    functionconfig.SyncTriggerWorkMode,
 			handler: "stream_outputter:stream_file_lines_as_response_async",
@@ -153,7 +158,7 @@ func (suite *TestSuite) TestStreamingHandler() {
 		{
 			name:    "async_handler_as_response_with_sync_gen",
 			mode:    functionconfig.AsyncTriggerWorkMode,
-			handler: "stream_outputter:stream_file_lines_as_response_sync",
+			handler: "stream_outputter:stream_file_lines_as_response_sync_as_async",
 		},
 		{
 			name:    "sync_handler_as_sync_gen",
@@ -173,7 +178,12 @@ func (suite *TestSuite) TestStreamingHandler() {
 		{
 			name:    "async_handler_as_sync_gen",
 			mode:    functionconfig.AsyncTriggerWorkMode,
-			handler: "stream_outputter:stream_file_lines_sync",
+			handler: "stream_outputter:stream_file_lines_sync_as_async",
+		},
+		{
+			name:    "async_handler_as_sync_gen",
+			mode:    functionconfig.SyncTriggerWorkMode,
+			handler: "stream_outputter:stream_file_lines_sync_as_async",
 		},
 	} {
 		suite.Run(testCase.name, func() {

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -135,13 +135,24 @@ func (suite *TestSuite) TestStreamingHandler() {
 		mode    functionconfig.TriggerWorkMode
 		handler string
 	}{
+		// namings of these tests might be a bit confusing, but here is how they are structured:
+		// * <trigger_mode>_handler_as_<handler_type>[_as_<optional_python_handler_type>]
+		// * <trigger_mode> - sync / async trigger mode, same as testcase.mode
+		// <handler_type>
+		// * response_with_sync_gen - handler returns a response object whose body is a sync generator
+		// * response_with_async_gen - handler returns a response object whose body is an async generator
+		// * sync_gen - handler yields synchronously
+		// * async_gen - handler yields asynchronously
+		// <optional_python_handler_type>: - only set for those where we test both types of function definitions in python (async def / def)
+		// async_def - the python handler is defined as async def, even though it yields synchronously
+		// sync_def - the python handler is defined as def
 		{
 			name:    "sync_handler_as_response_with_sync_gen",
 			mode:    functionconfig.SyncTriggerWorkMode,
 			handler: "stream_outputter:stream_file_lines_as_response_sync",
 		},
 		{
-			name:    "sync_handler_as_response_with_sync_gen_as_async",
+			name:    "sync_handler_as_response_with_sync_gen_as_async_def",
 			mode:    functionconfig.SyncTriggerWorkMode,
 			handler: "stream_outputter:stream_file_lines_as_response_sync_as_async",
 		},
@@ -156,7 +167,7 @@ func (suite *TestSuite) TestStreamingHandler() {
 			handler: "stream_outputter:stream_file_lines_as_response_async",
 		},
 		{
-			name:    "async_handler_as_response_with_sync_gen_as_async",
+			name:    "async_handler_as_response_with_sync_gen_as_async_def",
 			mode:    functionconfig.AsyncTriggerWorkMode,
 			handler: "stream_outputter:stream_file_lines_as_response_sync_as_async",
 		},
@@ -176,12 +187,12 @@ func (suite *TestSuite) TestStreamingHandler() {
 			handler: "stream_outputter:stream_file_lines_async",
 		},
 		{
-			name:    "async_handler_as_sync_gen_as_async",
+			name:    "async_handler_as_sync_gen_as_async_def",
 			mode:    functionconfig.AsyncTriggerWorkMode,
 			handler: "stream_outputter:stream_file_lines_sync_as_async",
 		},
 		{
-			name:    "sync_handler_as_sync_gen_as_async_sync_mode",
+			name:    "sync_handler_as_sync_gen_as_async_as_sync_def",
 			mode:    functionconfig.SyncTriggerWorkMode,
 			handler: "stream_outputter:stream_file_lines_sync_as_async",
 		},

--- a/pkg/processor/runtime/python/test/timeout_test.go
+++ b/pkg/processor/runtime/python/test/timeout_test.go
@@ -183,9 +183,10 @@ func (suite *timeoutSuite) TestTimeoutAsync() {
 func (suite *timeoutSuite) TestStreamChunkTimeout() {
 	chunkTimeout := 500 * time.Millisecond
 	okStatusCode := http.StatusOK
-	timeoutStatusCode := http.StatusRequestTimeout
 	sleepChunkShort := 10 * time.Millisecond
 	sleepChunkLong := 2 * time.Second
+
+	expectedFullBody := "chunk-0chunk-1chunk-2"
 
 	for _, testCase := range []struct {
 		name            string
@@ -222,14 +223,21 @@ func (suite *timeoutSuite) TestStreamChunkTimeout() {
 						err := json.Unmarshal(body, response)
 						suite.Require().NoErrorf(err, "Can't parse response - %q", string(body))
 						oldPID = response.PID
-						suite.Require().Equal("chunk-0chunk-1chunk-2", response.Data)
+						suite.Require().Equal(expectedFullBody, response.Data)
 					},
 				},
 				// sending request long timeout expected
+				// it will still be successful status code
+				// but we should expect getting only partial data
 				{
-					RequestBody:                suite.genTimeoutRequest(sleepChunkLong, false),
-					RequestHeaders:             requestHeaders,
-					ExpectedResponseStatusCode: &timeoutStatusCode,
+					RequestBody:    suite.genTimeoutRequest(sleepChunkLong, false),
+					RequestHeaders: requestHeaders,
+					ExpectedResponseBody: func(body []byte) {
+						response := &timeoutResponse{}
+						err := json.Unmarshal(body, response)
+						suite.Require().Error(err, "unexpected end of JSON input")
+						suite.Require().NotEqual(len("chunk-0chunk-1chunk-2"), len(body))
+					},
 				},
 				// retry until runtime is back
 				{

--- a/pkg/processor/trigger/http/test/suite/suite.go
+++ b/pkg/processor/trigger/http/test/suite/suite.go
@@ -75,7 +75,6 @@ type Request struct {
 	ExpectedResponseHeaders       map[string]string
 	ExpectedResponseHeadersValues map[string][]string
 	ExpectedResponseStatusCode    *int
-	ExpectStreamingTimeout        bool
 
 	RetryUntilSuccessfulStatusCode *int
 	RetryUntilSuccessfulDuration   time.Duration

--- a/pkg/processor/trigger/http/test/suite/suite.go
+++ b/pkg/processor/trigger/http/test/suite/suite.go
@@ -75,6 +75,7 @@ type Request struct {
 	ExpectedResponseHeaders       map[string]string
 	ExpectedResponseHeadersValues map[string][]string
 	ExpectedResponseStatusCode    *int
+	ExpectStreamingTimeout        bool
 
 	RetryUntilSuccessfulStatusCode *int
 	RetryUntilSuccessfulDuration   time.Duration

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -582,6 +582,17 @@ func (h *http) handleRequest(ctx *fasthttp.RequestCtx) {
 		}
 	}
 
+	// should be set before body is set
+	// set content type if set
+	if response.GetContentType() != "" {
+		ctx.SetContentType(response.GetContentType())
+	}
+
+	// set status code if set
+	if response.GetStatusCode() != 0 {
+		ctx.Response.SetStatusCode(response.GetStatusCode())
+	}
+
 	if fileStreamPath != "" {
 		fileResponse, err := newFileResponse(h.Logger, fileStreamPath, fileStreamDeleteAfterSend)
 		if err != nil {
@@ -601,6 +612,10 @@ func (h *http) handleRequest(ctx *fasthttp.RequestCtx) {
 		case []byte:
 			ctx.Response.SetBodyRaw(response.GetBody().([]byte))
 		case io.ReadCloser:
+			// set status code if set
+			if response.GetStatusCode() != 0 {
+				ctx.Response.SetStatusCode(response.GetStatusCode())
+			}
 			ctx.Response.SetBodyStream(typedResponse, -1)
 		}
 	}
@@ -616,16 +631,6 @@ func (h *http) handleRequest(ctx *fasthttp.RequestCtx) {
 		// if code won't get here (because of the error, then the defer will take care of it)
 		h.WorkerAllocator.Release(workerInstance)
 		workerReleased = true
-	}
-
-	// set content type if set
-	if response.GetContentType() != "" {
-		ctx.SetContentType(response.GetContentType())
-	}
-
-	// set status code if set
-	if response.GetStatusCode() != 0 {
-		ctx.Response.SetStatusCode(response.GetStatusCode())
 	}
 }
 

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -612,10 +612,6 @@ func (h *http) handleRequest(ctx *fasthttp.RequestCtx) {
 		case []byte:
 			ctx.Response.SetBodyRaw(response.GetBody().([]byte))
 		case io.ReadCloser:
-			// set status code if set
-			if response.GetStatusCode() != 0 {
-				ctx.Response.SetStatusCode(response.GetStatusCode())
-			}
 			ctx.Response.SetBodyStream(typedResponse, -1)
 		}
 	}


### PR DESCRIPTION
### 📝 Description
I. #3810 broke sync yield flow of streaming 

This PR:
1. fixes the breakage
2. ensures that these flows are covered by adding integration tests and making sure that without the change, they fail https://github.com/nuclio/nuclio/actions/runs/18725119036

```
--- FAIL: TestIntegrationSuite/python:3.11/TestStreamingHandler/sync_handler_as_sync_gen (15.96s)
```
II. This PR also includes a fix for long CI, because content type and status code should be set before the body is set
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
integration tests
---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-631
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->
