### PR TITLE
[CI] Exclude handler-builder-dotnetcore-onbuild arm64 from tagging

### DIFF
--- a/.github/workflows/mark-stable.yaml
+++ b/.github/workflows/mark-stable.yaml
@@ -69,6 +69,10 @@ jobs:
           - arm64
           - amd64
         docker_image_rule: ${{ fromJson(needs.image_matrix_prep.outputs.matrix) }}
+        # issues with building on qemu
+        exclude:
+          - arch: arm64
+            docker_image_rule: handler-builder-dotnetcore-onbuild
     steps:
       - name: Prepare environment
         run: |


### PR DESCRIPTION
### 📝 Description
We never release it at the 1st place https://github.com/nuclio/nuclio/blob/e89d719eccdade579bed797c7da8359b3e913c09/.github/workflows/release.yaml#L250-L253

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
test after merge

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->
