### PR TITLE
[Platform] Validate project secret

### DIFF
--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1401,6 +1401,10 @@ func (p *Platform) ValidateFunctionConfig(ctx context.Context, functionConfig *f
 		return errors.Wrap(err, "Service account validation failed")
 	}
 
+	if err := p.validateSecretsAllowed(ctx, functionConfig); err != nil {
+		return errors.Wrap(err, "Secrets validation failed")
+	}
+
 	if err := p.validateInitContainersSpec(functionConfig); err != nil {
 		return errors.Wrap(err, "Init containers validation failed")
 	}
@@ -1961,6 +1965,62 @@ func (p *Platform) validateServiceAccount(ctx context.Context, functionConfig *f
 		functionConfig.Meta.Namespace,
 		false); err != nil {
 		return errors.Wrap(err, "Failed to validate service account")
+	}
+	return nil
+}
+
+func (p *Platform) validateSecretsAllowed(ctx context.Context, functionConfig *functionconfig.Config) error {
+	if p.GetConfig().Kube.ProjectSecretTemplate == "" {
+		return nil
+	}
+
+	projectName, ok := functionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName]
+	if !ok {
+		return errors.New("Function does not have a project label, cannot validate secrets")
+	}
+
+	projectSecretName, err := utils.RenderProjectSecretName(p.GetConfig().Kube.ProjectSecretTemplate, projectName)
+	if err != nil {
+		return errors.Wrap(err, "Failed to render project secret name")
+	}
+
+	projectSecretPrefix, err := utils.RenderProjectSecretName(p.GetConfig().Kube.ProjectSecretTemplate, "")
+	if err != nil {
+		return errors.Wrap(err, "Failed to render project secret prefix")
+	}
+
+	for _, secret := range functionConfig.Spec.EnvFrom {
+		if secret.SecretRef != nil {
+			secretName := secret.SecretRef.Name
+			if err = p.validateSecretIsAllowed(secretName, projectSecretPrefix, projectSecretName); err != nil {
+				return errors.Wrap(err, "Failed to validate Spec.EnvFrom")
+			}
+		}
+	}
+
+	for _, secret := range functionConfig.Spec.Env {
+		if secret.ValueFrom != nil && secret.ValueFrom.SecretKeyRef != nil {
+			secretName := secret.ValueFrom.SecretKeyRef.Name
+			if err = p.validateSecretIsAllowed(secretName, projectSecretPrefix, projectSecretName); err != nil {
+				return errors.Wrap(err, "Failed to validate spec.Env")
+			}
+		}
+	}
+
+	for _, volume := range functionConfig.Spec.Volumes {
+		if volume.Volume.Secret != nil {
+			secretName := volume.Volume.Secret.SecretName
+			if err = p.validateSecretIsAllowed(secretName, projectSecretPrefix, projectSecretName); err != nil {
+				return errors.Wrap(err, "Failed to validate spec.Volumes")
+			}
+		}
+	}
+	return nil
+}
+
+func (p *Platform) validateSecretIsAllowed(secretName, projectSecretPrefix, projectSecretName string) error {
+	if strings.HasPrefix(secretName, projectSecretPrefix) && secretName != projectSecretName {
+		return errors.New(fmt.Sprintf("Secret %s is not allowed. It belongs to a different project", secretName))
 	}
 	return nil
 }

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1969,6 +1969,9 @@ func (p *Platform) validateServiceAccount(ctx context.Context, functionConfig *f
 	return nil
 }
 
+// validateSecretsAllowed ensures that the function does not reference any project secrets
+// that belong to a different project. It checks all secret references defined in EnvFrom,
+// Env, and Volumes
 func (p *Platform) validateSecretsAllowed(ctx context.Context, functionConfig *functionconfig.Config) error {
 	if p.GetConfig().Kube.ProjectSecretTemplate == "" {
 		return nil

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/nuclio/opa-client"
 	"github.com/nuclio/zap"
 	"github.com/rs/xid"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/api/core/v1"
@@ -1210,6 +1211,200 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateServiceAccount() {
 			err := suite.platform.validateServiceAccount(suite.ctx, functionConfig)
 			if testcase.expectedError != "" {
 				suite.Require().Error(err, testcase.expectedError)
+			} else {
+				suite.Require().NoError(err)
+			}
+		})
+	}
+}
+
+func (suite *FunctionKubePlatformTestSuite) TestValidateSecretsAllowed_EnvFrom() {
+	projectName := "test-project-name"
+
+	for _, testCase := range []struct {
+		name          string
+		template      string
+		envFrom       []string
+		expectedError string
+	}{
+		{
+			template: "nuclio-project-secrets-{{ .ProjectName }}",
+			name:     "with-project-secret",
+			envFrom:  []string{"nuclio-project-secrets-test-project-name"},
+		},
+		{
+			template:      "nuclio-project-secrets-{{ .ProjectName }}",
+			name:          "with-another-project-secret",
+			envFrom:       []string{"nuclio-project-secrets-test1"},
+			expectedError: "Failed to validate Spec.EnvFrom",
+		},
+		{
+			name:    "with-another-project-secret",
+			envFrom: []string{"nuclio-project-secrets-test1"},
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			oldProjectSecretTemplate := suite.platform.Config.Kube.ProjectSecretTemplate
+			defer func() {
+				suite.platform.Config.Kube.ProjectSecretTemplate = oldProjectSecretTemplate
+			}()
+			suite.platform.Config.Kube.ProjectSecretTemplate = testCase.template
+
+			functionConfig := &functionconfig.Config{
+				Meta: functionconfig.Meta{
+					Name:      "test-func",
+					Namespace: suite.Namespace,
+					Labels: map[string]string{
+						common.NuclioResourceLabelKeyProjectName: projectName,
+					},
+				},
+				Spec: functionconfig.Spec{
+					EnvFrom: lo.Map(testCase.envFrom, func(secret string, _ int) v1.EnvFromSource {
+						return v1.EnvFromSource{
+							SecretRef: &v1.SecretEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: secret}},
+						}
+					}),
+				},
+			}
+
+			err := suite.platform.validateSecretsAllowed(suite.ctx, functionConfig)
+			if testCase.expectedError != "" {
+				suite.Require().ErrorContains(err, testCase.expectedError)
+			} else {
+				suite.Require().NoError(err)
+			}
+		})
+	}
+}
+
+func (suite *FunctionKubePlatformTestSuite) TestValidateSecretsAllowed_Env() {
+	projectName := "test-project-name"
+
+	for _, testCase := range []struct {
+		name          string
+		template      string
+		envSecrets    []string
+		expectedError string
+	}{
+		{
+			template:   "nuclio-project-secrets-{{ .ProjectName }}",
+			name:       "with-project-secret",
+			envSecrets: []string{"nuclio-project-secrets-test-project-name"},
+		},
+		{
+			template:      "nuclio-project-secrets-{{ .ProjectName }}",
+			name:          "with-another-project-secret",
+			envSecrets:    []string{"nuclio-project-secrets-test1"},
+			expectedError: "Failed to validate spec.Env",
+		},
+		{
+			name:       "with-another-project-secret-no-template",
+			envSecrets: []string{"nuclio-project-secrets-test1"},
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			oldProjectSecretTemplate := suite.platform.Config.Kube.ProjectSecretTemplate
+			defer func() {
+				suite.platform.Config.Kube.ProjectSecretTemplate = oldProjectSecretTemplate
+			}()
+			suite.platform.Config.Kube.ProjectSecretTemplate = testCase.template
+
+			functionConfig := &functionconfig.Config{
+				Meta: functionconfig.Meta{
+					Name:      "test-func",
+					Namespace: suite.Namespace,
+					Labels: map[string]string{
+						common.NuclioResourceLabelKeyProjectName: projectName,
+					},
+				},
+				Spec: functionconfig.Spec{
+					Env: lo.Map(testCase.envSecrets, func(secret string, _ int) v1.EnvVar {
+						return v1.EnvVar{
+							Name: "MY_SECRET",
+							ValueFrom: &v1.EnvVarSource{
+								SecretKeyRef: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{Name: secret},
+									Key:                  "key",
+								},
+							},
+						}
+					}),
+				},
+			}
+
+			err := suite.platform.validateSecretsAllowed(suite.ctx, functionConfig)
+			if testCase.expectedError != "" {
+				suite.Require().ErrorContains(err, testCase.expectedError)
+			} else {
+				suite.Require().NoError(err)
+			}
+		})
+	}
+}
+
+func (suite *FunctionKubePlatformTestSuite) TestValidateSecretsAllowed_Volumes() {
+	projectName := "test-project-name"
+
+	for _, testCase := range []struct {
+		name          string
+		template      string
+		volumeSecrets []string
+		expectedError string
+	}{
+		{
+			template:      "nuclio-project-secrets-{{ .ProjectName }}",
+			name:          "with-project-secret",
+			volumeSecrets: []string{"nuclio-project-secrets-test-project-name"},
+		},
+		{
+			template:      "nuclio-project-secrets-{{ .ProjectName }}",
+			name:          "with-another-project-secret",
+			volumeSecrets: []string{"nuclio-project-secrets-test1"},
+			expectedError: "Failed to validate spec.Volumes",
+		},
+		{
+			name:          "with-another-project-secret-no-template",
+			volumeSecrets: []string{"nuclio-project-secrets-test1"},
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			oldProjectSecretTemplate := suite.platform.Config.Kube.ProjectSecretTemplate
+			defer func() {
+				suite.platform.Config.Kube.ProjectSecretTemplate = oldProjectSecretTemplate
+			}()
+			suite.platform.Config.Kube.ProjectSecretTemplate = testCase.template
+
+			functionConfig := &functionconfig.Config{
+				Meta: functionconfig.Meta{
+					Name:      "test-func",
+					Namespace: suite.Namespace,
+					Labels: map[string]string{
+						common.NuclioResourceLabelKeyProjectName: projectName,
+					},
+				},
+				Spec: functionconfig.Spec{
+					Volumes: lo.Map(testCase.volumeSecrets, func(secret string, _ int) functionconfig.Volume {
+						return functionconfig.Volume{
+							Volume: v1.Volume{
+								Name: secret,
+								VolumeSource: v1.VolumeSource{
+									Secret: &v1.SecretVolumeSource{
+										SecretName: secret,
+									},
+								},
+							},
+							VolumeMount: v1.VolumeMount{
+								Name:      secret,
+								MountPath: fmt.Sprintf("/etc/secrets/%s", secret),
+							},
+						}
+					}),
+				},
+			}
+
+			err := suite.platform.validateSecretsAllowed(suite.ctx, functionConfig)
+			if testCase.expectedError != "" {
+				suite.Require().ErrorContains(err, testCase.expectedError)
 			} else {
 				suite.Require().NoError(err)
 			}

--- a/pkg/platform/kube/utils/utils.go
+++ b/pkg/platform/kube/utils/utils.go
@@ -183,10 +183,7 @@ func GetProjectSecret(ctx context.Context, kubeClient kube.Client, projectSecret
 	}
 
 	// render the project secret name using the template
-	templateData := map[string]interface{}{
-		"ProjectName": projectName,
-	}
-	secretName, err := renderProjectSecretName(projectSecretTemplate, templateData)
+	secretName, err := RenderProjectSecretName(projectSecretTemplate, projectName)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to render project secret name")
 	}
@@ -272,7 +269,10 @@ func getAllowedServiceAccountsFromSecret(secret *v1.Secret, secretAllowedService
 	return
 }
 
-func renderProjectSecretName(projectSecretTemplate string, templateData map[string]interface{}) (string, error) {
+func RenderProjectSecretName(projectSecretTemplate string, projectName string) (string, error) {
+	templateData := map[string]interface{}{
+		"ProjectName": projectName,
+	}
 	renderedIngressHost, err := common.RenderTemplate(projectSecretTemplate, templateData)
 	if err != nil {
 		return "", err

--- a/pkg/platform/kube/utils/utils_test.go
+++ b/pkg/platform/kube/utils/utils_test.go
@@ -161,9 +161,7 @@ func (suite *utilsTestSuite) newTestProbe(value int32) *v1.Probe {
 }
 
 func (suite *utilsTestSuite) TestRenderProjectSecretName() {
-	templateData := map[string]interface{}{
-		"ProjectName": "myproj",
-	}
+	projectName := "myproj"
 	testCases := []struct {
 		name               string
 		template           string
@@ -183,7 +181,7 @@ func (suite *utilsTestSuite) TestRenderProjectSecretName() {
 	for _, testCase := range testCases {
 		suite.Run(testCase.name, func() {
 
-			secretName, err := renderProjectSecretName(testCase.template, templateData)
+			secretName, err := RenderProjectSecretName(testCase.template, projectName)
 			suite.Require().NoError(err)
 			suite.Require().Equal(testCase.expectedSecretName, secretName)
 		})
@@ -195,9 +193,7 @@ func (suite *utilsTestSuite) TestGetProjectSecret() {
 	namespace := "ns1"
 	projectName := "myproj"
 	template := "nuclio-project-secrets-{{ .ProjectName }}"
-	secretName, _ := renderProjectSecretName(template, map[string]interface{}{
-		"ProjectName": projectName,
-	})
+	secretName, _ := RenderProjectSecretName(template, projectName)
 
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -454,9 +450,7 @@ func (suite *utilsTestSuite) TestEnrichAndValidateServiceAccount() {
 	allowedKey := "allowed"
 	defaultPlatformServiceAccount := "sa-platform-default"
 
-	secretName, _ := renderProjectSecretName(template, map[string]interface{}{
-		"ProjectName": projectName,
-	})
+	secretName, _ := RenderProjectSecretName(template, projectName)
 
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
### 📝 Description
Doesn't allow mounting of project secrets that doesn't associate with current project.

---

### 🛠️ Changes Made
Add validation to dashboard for env, envFrom and volume mounts

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
unit 

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-622
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [x] Yes (only if existing functions rely on other project secret, which at the 1st place should have been the case)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->