### PR TITLE
[RabbitMQ] Fix ack on error configuration and add docs

### DIFF
--- a/.github/styles/Nuclio/ignore.txt
+++ b/.github/styles/Nuclio/ignore.txt
@@ -76,3 +76,5 @@ substring
 kafka
 Kafka
 configs
+requeue
+requeued

--- a/docs/reference/triggers/rabbitmq.md
+++ b/docs/reference/triggers/rabbitmq.md
@@ -6,16 +6,18 @@ Reads messages from [RabbitMQ](https://www.rabbitmq.com/) queues.
 
 ## Attributes
 
-| **Path**          | **Type**           | **Description**                                                                                |
-|:------------------|:-------------------|:-----------------------------------------------------------------------------------------------|
-| exchangeName      | string             | The exchange that contains the queue                                                           |
-| queueName         | string             | If specified, the trigger reads messages from this queue                                       |
-| topics            | list of strings    | If specified, the trigger creates a queue with a unique name and subscribes it to these topics |
-| reconnectDuration | string of duration | The timeout when trying to reconnect to RabbitMQ. Default is 5 minutes.                        |
-| reconnectInterval | string of duration | The interval to wait before reconnecting to RabbitMQ. Default is 15 seconds.                   |
-| prefetchCount     | int                | The prefetch count of the broker channel. Default is 0.                                        |
-| durableExchange   | bool               | Define if the exchange is durable. Default is false.                                           |
-| durableQueue      | bool               | Define if the queue is durable. Default is false.                                              |
+| **Path**          | **Type**           | **Description**                                                                                                                                                 |
+|:------------------|:-------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| exchangeName      | string             | The exchange that contains the queue                                                                                                                            |
+| queueName         | string             | If specified, the trigger reads messages from this queue                                                                                                        |
+| topics            | list of strings    | If specified, the trigger creates a queue with a unique name and subscribes it to these topics                                                                  |
+| reconnectDuration | string of duration | The timeout when trying to reconnect to RabbitMQ. Default is 5 minutes.                                                                                         |
+| reconnectInterval | string of duration | The interval to wait before reconnecting to RabbitMQ. Default is 15 seconds.                                                                                    |
+| prefetchCount     | int                | The prefetch count of the broker channel. Default is 0.                                                                                                         |
+| durableExchange   | bool               | Define if the exchange is durable. Default is false.                                                                                                            |
+| durableQueue      | bool               | Define if the queue is durable. Default is false.                                                                                                               |
+| onError           | string (enum)      | Determines the behaviour when a message processing error occurs. Possible values: `"ack"` (acknowledge and remove) or `"nack"` (reject and optionally requeue). |
+| requeueOnError    | bool               | If `true`, messages that fail processing are requeued when `onError` is set to `"nack"`. Default is false.                                                      |
 
 > **Note:** `topics` and `queueName` are mutually exclusive.
 > The trigger can either create to an existing queue specified by `queueName` or create its own queue, subscribing it to `topics` 
@@ -39,6 +41,8 @@ triggers:
       prefetchCount: 1
       durableExchange: true
       durableQueue: true
+      onError: "nack"
+      requeueOnError: true
 ```
 OR
 
@@ -57,6 +61,8 @@ reconnectInterval: "60s"
 prefetchCount: 1
 durableExchange: true
 durableQueue: true
+onError: "nack"
+requeueOnError: true
 ```
 
 Both configurations are supported.

--- a/docs/reference/triggers/rabbitmq.md
+++ b/docs/reference/triggers/rabbitmq.md
@@ -16,7 +16,7 @@ Reads messages from [RabbitMQ](https://www.rabbitmq.com/) queues.
 | prefetchCount     | int                | The prefetch count of the broker channel. Default is 0.                                                                                                         |
 | durableExchange   | bool               | Define if the exchange is durable. Default is false.                                                                                                            |
 | durableQueue      | bool               | Define if the queue is durable. Default is false.                                                                                                               |
-| onError           | string (enum)      | Determines the behaviour when a message processing error occurs. Possible values: `"ack"` (acknowledge and remove) or `"nack"` (reject and optionally requeue). |
+| onError           | string             | Determines the behaviour when a message processing error occurs. Possible values: `"ack"` (acknowledge and remove) or `"nack"` (reject and optionally requeue). |
 | requeueOnError    | bool               | If `true`, messages that fail processing are requeued when `onError` is set to `"nack"`. Default is false.                                                      |
 
 > **Note:** `topics` and `queueName` are mutually exclusive.

--- a/pkg/processor/trigger/rabbitmq/trigger.go
+++ b/pkg/processor/trigger/rabbitmq/trigger.go
@@ -396,7 +396,7 @@ func (rmq *rabbitMq) createEventFromMessage(message *amqp.Delivery) *Event {
 func (rmq *rabbitMq) ackOnProcessError(message *amqp.Delivery) {
 	switch rmq.configuration.OnError {
 	case OnProcessErrorAck:
-		if err := message.Ack(rmq.configuration.RequeueOnError); err != nil {
+		if err := message.Ack(false); err != nil {
 			rmq.Logger.WarnWith("Failed to ack message",
 				"error", err.Error())
 		}


### PR DESCRIPTION
### 📝 Description
Fixes configuration of ack on processError, where requeue option was used as multiple, which is incorrect. Also, added new rabbitmq params into docs.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
unit, integration
---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->