### PR TITLE
[Dependencies] Bump Go to 1.25.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nuclio/nuclio
 
-go 1.25.0
+go 1.25.3
 
 require (
 	cloud.google.com/go/pubsub/v2 v2.0.0


### PR DESCRIPTION
### 📝 Description
Bump Go to version 1.25.3 due to vulnerabilities identified in Go 1.25.

---

### 🛠️ Changes Made
- Update `go.mod`
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-645
- Design docs links:
- External links: https://github.com/nuclio/nuclio/actions/runs/18931491126/job/54054700560#step:4:15

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
1. Before:
```
make govulncheck                                                                                             ()
nuclio/.bin/govulncheck cmd/... pkg/...
=== Symbol Results ===

Vulnerability #1: GO-2025-4013
    Panic when validating certificates with DSA public keys in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-4013
  Standard library
    Found in: crypto/x509@go1.25
    Fixed in: crypto/x509@go1.25.2
    Example traces found:
      #1: src/cmd/link/internal/loadpe/ldpe.go:160:18: loadpe.peBiobuf.ReadAt calls bufio.Reader.Read, which eventually calls x509.Certificate.Verify

...

Your code is affected by 7 vulnerabilities from the Go standard library.
This scan also found 3 vulnerabilities in packages you import and 1
vulnerability in modules you require, but your code doesn't appear to call these
vulnerabilities.
Use '-show verbose' for more details.
make: *** [govulncheck] Error 3
```

After:
```
make govulncheck                                                                                             ()
nuclio/.bin/govulncheck cmd/... pkg/...
No vulnerabilities found.

```

2. No need to update the Makefile and base image in the `gcr.io/iguazio/golang`, since it's already configured to take the latest patch version for `1.25`:
<img width="1562" height="809" alt="image" src="https://github.com/user-attachments/assets/12a8bb30-27fe-4aa8-9e90-2a5f8150c731" />
