### PR TITLE
[DLX] Skip waiting for readiness if functionReadinessVerificationEnabled disabled

### DIFF
--- a/pkg/platform/kube/resourcescaler/resourcescaler.go
+++ b/pkg/platform/kube/resourcescaler/resourcescaler.go
@@ -361,6 +361,7 @@ func (n *NuclioResourceScaler) waitFunctionReadiness(ctx context.Context, namesp
 func (n *NuclioResourceScaler) verifyReadiness(ctx context.Context, function *nuclioio.NuclioFunction) error {
 	if !n.functionReadinessVerificationEnabled {
 		n.logger.DebugWithCtx(ctx, "Skipping function readiness verification")
+		return nil
 	}
 
 	url := fmt.Sprintf("http://%s.%s.svc.cluster.local:8080%s",


### PR DESCRIPTION
### 📝 Description
`dlx.functionReadinessVerificationEnabled` value does not matter because it is missing an early return. Currently it just logs "Skipping function readiness verification" but does not actually skip it.

---

### 🛠️ Changes Made
Added early return

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->