### PR TITLE
[DLX] Fix health check retries routing to DLX instead of function pod

### DIFF
--- a/pkg/platform/kube/resourcescaler/resourcescaler.go
+++ b/pkg/platform/kube/resourcescaler/resourcescaler.go
@@ -361,6 +361,7 @@ func (n *NuclioResourceScaler) waitFunctionReadiness(ctx context.Context, namesp
 func (n *NuclioResourceScaler) verifyReadiness(ctx context.Context, function *nuclioio.NuclioFunction) error {
 	if !n.functionReadinessVerificationEnabled {
 		n.logger.DebugWithCtx(ctx, "Skipping function readiness verification")
+		return nil
 	}
 
 	url := fmt.Sprintf("http://%s.%s.svc.cluster.local:8080%s",

--- a/pkg/platform/kube/resourcescaler/resourcescaler.go
+++ b/pkg/platform/kube/resourcescaler/resourcescaler.go
@@ -376,6 +376,8 @@ func (n *NuclioResourceScaler) verifyReadiness(ctx context.Context, function *nu
 	// Create a new TCP connection on each retry to avoid routing requests to the DLX pod
 	// when the Service still points to DLX. Reusing a single TCP connection can cause all
 	// retries to be routed to DLX instead of the function pod.
+	// Note: Safe because this is a GET with a nil body. If the request had a non-nil,
+	// non-rewindable body, reusing the same http.Request would fail on the second attempt
 	request.Close = true
 
 	startTime := time.Now()

--- a/pkg/platform/kube/resourcescaler/resourcescaler.go
+++ b/pkg/platform/kube/resourcescaler/resourcescaler.go
@@ -373,6 +373,10 @@ func (n *NuclioResourceScaler) verifyReadiness(ctx context.Context, function *nu
 	if err != nil {
 		return errors.Wrap(err, "Failed to create request")
 	}
+	// Create a new TCP connection on each retry to avoid routing requests to the DLX pod
+	// when the Service still points to DLX. Reusing a single TCP connection can cause all
+	// retries to be routed to DLX instead of the function pod.
+	request.Close = true
 
 	startTime := time.Now()
 	if err := common.RetryUntilSuccessful(time.Minute,


### PR DESCRIPTION
### 📝 Description
Force a new TCP connection on each retry to avoid sticky routing to the DLX pod when the Service still points to DLX. By setting request.Close = true, we prevent HTTP keep-alive reuse so each retry re-resolves through the Service and can reach the function pod once it’s ready.

---

### 🛠️ Changes Made
- Set request.Close = true to disable keep-alive on retries and force a new TCP connection per attempt.
- Added inline comments explaining the DLX routing issue and rationale.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
Extra context: https://github.com/nuclio/nuclio/pull/3887#issuecomment-3490580877

> - When the first health check call was made, service was pointing to DLX.
> - Go's http client keeps the connection alive by default
> - This results in subsequent calls using the same connection which routes to DLX.