### PR TITLE
[DLX] Fix health check retries routing to DLX instead of function pod [1.15.x]

### DIFF
--- a/pkg/platform/kube/resourcescaler/resourcescaler.go
+++ b/pkg/platform/kube/resourcescaler/resourcescaler.go
@@ -373,6 +373,12 @@ func (n *NuclioResourceScaler) verifyReadiness(ctx context.Context, function *nu
 	if err != nil {
 		return errors.Wrap(err, "Failed to create request")
 	}
+	// Create a new TCP connection on each retry to avoid routing requests to the DLX pod
+	// when the Service still points to DLX. Reusing a single TCP connection can cause all
+	// retries to be routed to DLX instead of the function pod.
+	// Note: Safe because this is a GET with a nil body. If the request had a non-nil,
+	// non-rewindable body, reusing the same http.Request would fail on the second attempt
+	request.Close = true
 
 	startTime := time.Now()
 	if err := common.RetryUntilSuccessful(time.Minute,


### PR DESCRIPTION
backport (#3891)
