### PR TITLE
[Trigger] Nats Jetstream Options

### DIFF
--- a/docs/reference/triggers/natsjetstream.md
+++ b/docs/reference/triggers/natsjetstream.md
@@ -14,7 +14,7 @@ Reads messages from [NATS](https://docs.nats.io/nats-concepts/jetstream) streams
 ### Optional
 | **Path** | **Type** | **Default** | **Description** |
 | :--- | :--- | :--- | :--- |
-| allowReconnect | bool | true | Enables reconnection logic to be used when we encounter a disconnect from the current server. |
+| allowReconnect | bool | false | Enables reconnection logic to be used when we encounter a disconnect from the current server. |
 | maxReconnect | int | 60 | Sets the number of reconnect attempts that will be tried before giving up. If negative, then it will never give up trying to reconnect. |
 | reconnectWait | duration | 2s | Sets the time to backoff after attempting a reconnect to a server that we were already connected to previously. |
 | reconnectJitter | duration | 100ms | Sets the upper bound for a random delay added to reconnectWait during a reconnect when no TLS is used. |

--- a/docs/reference/triggers/natsjetstream.md
+++ b/docs/reference/triggers/natsjetstream.md
@@ -11,6 +11,19 @@ Reads messages from [NATS](https://docs.nats.io/nats-concepts/jetstream) streams
 | stream | string | The name of the JetStream stream. |
 | consumer | string | The name of the consumer associated to the stream. |
 
+### Optional
+| **Path** | **Type** | **Default** | **Description** |
+| :--- | :--- | :--- | :--- |
+| allowReconnect | bool | true | Enables reconnection logic to be used when we encounter a disconnect from the current server. |
+| maxReconnect | int | 60 | Sets the number of reconnect attempts that will be tried before giving up. If negative, then it will never give up trying to reconnect. |
+| reconnectWait | duration | 2s | Sets the time to backoff after attempting a reconnect to a server that we were already connected to previously. |
+| reconnectJitter | duration | 100ms | Sets the upper bound for a random delay added to reconnectWait during a reconnect when no TLS is used. |
+| timeout | duration | 2s | Sets the timeout for a Dial operation on a connection. |
+| drainTimeout | duration | 30s | Sets the timeout for a Drain Operation to complete. |
+| flusherTimeout | duration | 1m | The maximum time to wait for write operations to the underlying connection to complete (including the flusher loop). |
+| pingInterval | duration | 2m | The period at which the client will be sending ping commands to the server, disabled if 0 or negative. |
+| maxPingsOut | int | 2 | The maximum number of pending ping commands that can be awaiting a response before raising an ErrStaleConnection error. |
+
 ### Example
 
 ```yaml
@@ -21,4 +34,14 @@ triggers:
     attributes:
       stream: "mystream"
       consumer: "myconsumer"
+      # optional
+      allowReconnect: true
+      maxReconnect: -1
+      reconnectWait: "2m"
+      reconnectJitter: "200ms"
+      timeout: "5s"
+      drainTimeout: "1m"
+      flusherTimeout: "45s"
+      pingInterval: "1m"
+      maxPingsOut: 3
 ```

--- a/pkg/processor/trigger/nats/jetstream/factory.go
+++ b/pkg/processor/trigger/nats/jetstream/factory.go
@@ -41,7 +41,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	// create logger parent
 	triggerLogger := parentLogger.GetChild(triggerConfiguration.Kind)
 
-	configuration, err := NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
+	configuration, err := NewConfiguration(id, triggerConfiguration, runtimeConfiguration, triggerLogger)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create configuration")
 	}

--- a/pkg/processor/trigger/nats/jetstream/factory.go
+++ b/pkg/processor/trigger/nats/jetstream/factory.go
@@ -41,7 +41,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	// create logger parent
 	triggerLogger := parentLogger.GetChild(triggerConfiguration.Kind)
 
-	configuration, err := NewConfiguration(triggerLogger, id, triggerConfiguration, runtimeConfiguration)
+	configuration, err := NewConfiguration(id, triggerConfiguration, runtimeConfiguration, triggerLogger)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create configuration")
 	}

--- a/pkg/processor/trigger/nats/jetstream/factory.go
+++ b/pkg/processor/trigger/nats/jetstream/factory.go
@@ -41,7 +41,7 @@ func (f *factory) Create(parentLogger logger.Logger,
 	// create logger parent
 	triggerLogger := parentLogger.GetChild(triggerConfiguration.Kind)
 
-	configuration, err := NewConfiguration(id, triggerConfiguration, runtimeConfiguration, triggerLogger)
+	configuration, err := NewConfiguration(triggerLogger, id, triggerConfiguration, runtimeConfiguration)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create configuration")
 	}

--- a/pkg/processor/trigger/nats/jetstream/natsjetstream_test.go
+++ b/pkg/processor/trigger/nats/jetstream/natsjetstream_test.go
@@ -68,14 +68,14 @@ func (suite *TestSuite) TestStreamAndConsumerConfiguration() {
 			},
 		}
 		suite.Run(testCase.name, func() {
-			configuration, err := NewConfiguration(testCase.name,
+			configuration, err := NewConfiguration(suite.logger,
+				testCase.name,
 				triggerInstance,
 				&runtime.Configuration{
 					Configuration: &processor.Configuration{
 						Config: functionconfig.Config{},
 					},
-				},
-				suite.logger)
+				})
 			if testCase.expectedFailure {
 				suite.Require().Error(err)
 			} else {
@@ -127,14 +127,14 @@ func (suite *TestSuite) TestReconnectConfiguration() {
 			},
 		}
 		suite.Run(testCase.name, func() {
-			configuration, err := NewConfiguration(testCase.name,
+			configuration, err := NewConfiguration(suite.logger,
+				testCase.name,
 				triggerInstance,
 				&runtime.Configuration{
 					Configuration: &processor.Configuration{
 						Config: functionconfig.Config{},
 					},
-				},
-				suite.logger)
+				})
 			suite.Require().NoError(err)
 			suite.Require().Equal(testCase.expectedMaxReconnect, configuration.MaxReconnect, "Bad maxReconnect value")
 			suite.Require().Equal(testCase.allowReconnect, configuration.AllowReconnect, "Bad allowReconnect value")
@@ -187,14 +187,14 @@ func (suite *TestSuite) TestReconnectWaitConfiguration() {
 			},
 		}
 		suite.Run(testCase.name, func() {
-			configuration, err := NewConfiguration(testCase.name,
+			configuration, err := NewConfiguration(suite.logger,
+				testCase.name,
 				triggerInstance,
 				&runtime.Configuration{
 					Configuration: &processor.Configuration{
 						Config: functionconfig.Config{},
 					},
-				},
-				suite.logger)
+				})
 			if testCase.expectedFailure {
 				suite.Require().Error(err)
 			} else {
@@ -263,14 +263,14 @@ func (suite *TestSuite) TestTimeoutConfiguration() {
 			},
 		}
 		suite.Run(testCase.name, func() {
-			configuration, err := NewConfiguration(testCase.name,
+			configuration, err := NewConfiguration(suite.logger,
+				testCase.name,
 				triggerInstance,
 				&runtime.Configuration{
 					Configuration: &processor.Configuration{
 						Config: functionconfig.Config{},
 					},
-				},
-				suite.logger)
+				})
 			if testCase.expectedFailure {
 				suite.Require().Error(err)
 			} else {
@@ -331,14 +331,14 @@ func (suite *TestSuite) TestPingConfiguration() {
 			},
 		}
 		suite.Run(testCase.name, func() {
-			configuration, err := NewConfiguration(testCase.name,
+			configuration, err := NewConfiguration(suite.logger,
+				testCase.name,
 				triggerInstance,
 				&runtime.Configuration{
 					Configuration: &processor.Configuration{
 						Config: functionconfig.Config{},
 					},
-				},
-				suite.logger)
+				})
 			if testCase.expectedFailure {
 				suite.Require().Error(err)
 			} else {

--- a/pkg/processor/trigger/nats/jetstream/natsjetstream_test.go
+++ b/pkg/processor/trigger/nats/jetstream/natsjetstream_test.go
@@ -1,0 +1,354 @@
+/*
+Copyright 2023 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package natsjetstream
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/processor"
+	"github.com/nuclio/nuclio/pkg/processor/runtime"
+
+	"github.com/nuclio/logger"
+	"github.com/stretchr/testify/suite"
+)
+
+type TestSuite struct {
+	suite.Suite
+	trigger natsjetstream
+	logger  logger.Logger
+}
+
+func (suite *TestSuite) TestStreamAndConsumerConfiguration() {
+	for _, testCase := range []struct {
+		name                   string
+		stream                 string
+		consumer               string
+		expectedFailure        bool
+	}{
+		{
+			name:                   "Stream and Consumer specified",
+			stream:                 "mystream",
+			consumer:               "myconsumer",
+			expectedFailure:        false,
+		},
+		{
+			name:                   "Stream not specified",
+			stream:                 "",
+			consumer:               "myconsumer",
+			expectedFailure:        true,
+		},
+		{
+			name:            	"Consumer not specified",
+			stream:                 "mystream",
+			consumer:               "",
+			expectedFailure: 	true,
+		},
+	} {
+		triggerInstance := &functionconfig.Trigger{
+			Attributes: map[string]interface{}{
+				"stream":   testCase.stream,
+				"consumer": testCase.consumer,
+			},
+		}
+		suite.Run(testCase.name, func() {
+			configuration, err := NewConfiguration(testCase.name,
+				triggerInstance,
+				&runtime.Configuration{
+					Configuration: &processor.Configuration{
+						Config: functionconfig.Config{},
+					},
+				},
+				suite.logger)
+			if testCase.expectedFailure {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(testCase.stream, configuration.Stream, "Bad stream value")
+				suite.Require().Equal(testCase.consumer, configuration.Consumer, "Bad consumer value")
+			}
+		})
+	}
+}
+func (suite *TestSuite) TestReconnectConfiguration() {
+	for _, testCase := range []struct {
+		name                   string
+		allowReconnect         bool
+		maxReconnect           int
+		expectedMaxReconnect   int
+	}{
+		{
+			name:                   "MaxReconnect specified",
+			allowReconnect:         true,
+			maxReconnect:           2,
+			expectedMaxReconnect:   2,
+		},
+		{
+			name:                   "MaxReconnect not specified",
+			allowReconnect:         true,
+			maxReconnect:           0,
+			expectedMaxReconnect:   60,
+		},
+		{
+			name:                   "MaxReconnect negative",
+			allowReconnect:         true,
+			maxReconnect:           -1,
+			expectedMaxReconnect:   -1,
+		},
+		{
+			name:                   "No Reconnect",
+			allowReconnect:         false,
+			maxReconnect:           -1,
+			expectedMaxReconnect:   -1,
+		},
+	} {
+		triggerInstance := &functionconfig.Trigger{
+			Attributes: map[string]interface{}{
+				"stream":   "mystream",
+				"consumer": "myconsumer",
+				"allowReconnect": testCase.allowReconnect,
+				"maxReconnect": testCase.maxReconnect,
+			},
+		}
+		suite.Run(testCase.name, func() {
+			configuration, err := NewConfiguration(testCase.name,
+				triggerInstance,
+				&runtime.Configuration{
+					Configuration: &processor.Configuration{
+						Config: functionconfig.Config{},
+					},
+				},
+				suite.logger)
+			suite.Require().NoError(err)
+			suite.Require().Equal(testCase.expectedMaxReconnect, configuration.MaxReconnect, "Bad maxReconnect value")
+			suite.Require().Equal(testCase.allowReconnect, configuration.AllowReconnect, "Bad allowReconnect value")
+		})
+	}
+}
+
+func (suite *TestSuite) TestReconnectWaitConfiguration() {
+	for _, testCase := range []struct {
+		name                   string
+		reconnectWait          string
+		reconnectJitter        string
+		expectedReconnectWait  time.Duration
+		expectedReconnectJitter time.Duration
+		expectedFailure 	bool
+	}{
+		{
+			name:                   "Time specified",
+			reconnectWait:          "2s",
+			reconnectJitter:        "3s",
+			expectedReconnectWait:  2 * time.Second,
+			expectedReconnectJitter:  3 * time.Second,
+			expectedFailure: false,
+		},
+		{
+			name:                   "Time not specified",
+			reconnectWait:          "",
+			reconnectJitter:        "",
+			expectedReconnectWait:  2 * time.Second,
+			expectedReconnectJitter:  100 * time.Millisecond,
+			expectedFailure: false,
+		},
+		{
+			name:            "Wrong wait value",
+			reconnectWait:          "wait",
+			expectedFailure: true,
+		},
+		{
+			name:            "Wrong jitter value",
+			reconnectJitter:        "jitter",
+			expectedFailure: true,
+		},
+	} {
+		triggerInstance := &functionconfig.Trigger{
+			Attributes: map[string]interface{}{
+				"stream":   "mystream",
+				"consumer": "myconsumer",
+				"reconnectWait": testCase.reconnectWait,
+				"reconnectJitter": testCase.reconnectJitter,
+			},
+		}
+		suite.Run(testCase.name, func() {
+			configuration, err := NewConfiguration(testCase.name,
+				triggerInstance,
+				&runtime.Configuration{
+					Configuration: &processor.Configuration{
+						Config: functionconfig.Config{},
+					},
+				},
+				suite.logger)
+			if testCase.expectedFailure {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(testCase.expectedReconnectWait, configuration.reconnectWait, "Bad reconnectWait value")
+				suite.Require().Equal(testCase.expectedReconnectJitter, configuration.reconnectJitter, "Bad reconnectJitter value")
+			}
+		})
+	}
+}
+
+func (suite *TestSuite) TestTimeoutConfiguration() {
+	for _, testCase := range []struct {
+		name                   string
+		timeout                string
+		drainTimeout           string
+		flusherTimeout         string
+		expectedTimeout        time.Duration
+		expectedDrainTimeout   time.Duration
+		expectedFlusherTimeout time.Duration
+		expectedFailure        bool
+	}{
+		{
+			name:                   "Time specified",
+			timeout:                "2s",
+			drainTimeout:           "3s",
+			flusherTimeout:         "4s",
+			expectedTimeout:        2 * time.Second,
+			expectedDrainTimeout:   3 * time.Second,
+			expectedFlusherTimeout: 4 * time.Second,
+			expectedFailure: false,
+		},
+		{
+			name:                   "Time not specified",
+			timeout:                "",
+			drainTimeout:           "",
+			flusherTimeout:         "",
+			expectedTimeout:        2 * time.Second,
+			expectedDrainTimeout:   30 * time.Second,
+			expectedFlusherTimeout: 1 * time.Minute,
+			expectedFailure: false,
+		},
+		{
+			name:            "Wrong timeout value",
+			timeout:         "timeout",
+			expectedFailure: true,
+		},
+		{
+			name:            "Wrong drainTimeout value",
+			drainTimeout:    "timeout",
+			expectedFailure: true,
+		},
+		{
+			name:            "Wrong flusherTimeout value",
+			flusherTimeout:  "timeout",
+			expectedFailure: true,
+		},
+	} {
+		triggerInstance := &functionconfig.Trigger{
+			Attributes: map[string]interface{}{
+				"stream":   "mystream",
+				"consumer": "myconsumer",
+				"timeout": testCase.timeout,
+				"drainTimeout": testCase.drainTimeout,
+				"flusherTimeout": testCase.flusherTimeout,
+			},
+		}
+		suite.Run(testCase.name, func() {
+			configuration, err := NewConfiguration(testCase.name,
+				triggerInstance,
+				&runtime.Configuration{
+					Configuration: &processor.Configuration{
+						Config: functionconfig.Config{},
+					},
+				},
+				suite.logger)
+			if testCase.expectedFailure {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(testCase.expectedTimeout, configuration.timeout, "Bad timeout value")
+				suite.Require().Equal(testCase.expectedDrainTimeout, configuration.drainTimeout, "Bad drainTimeout value")
+				suite.Require().Equal(testCase.expectedFlusherTimeout, configuration.flusherTimeout, "Bad flusherTimeout value")
+			}
+		})
+	}
+}
+
+func (suite *TestSuite) TestPingConfiguration() {
+	for _, testCase := range []struct {
+		name                   string
+		pingInterval           string
+		maxPingsOut            int
+		expectedPingInterval   time.Duration
+		expectedMaxPingsOut    int
+		expectedFailure        bool
+	}{
+		{
+			name:                   "Ping specified",
+			pingInterval:           "2s",
+			maxPingsOut:            5,
+			expectedPingInterval:   2 * time.Second,
+			expectedMaxPingsOut:    5,
+			expectedFailure: false,
+		},
+		{
+			name:                   "PingInterval not specified",
+			pingInterval:           "",
+			maxPingsOut:            5,
+			expectedPingInterval:   2 * time.Minute,
+			expectedMaxPingsOut:    5,
+			expectedFailure: false,
+		},
+		{
+			name:                   "MaxPingsOut not specified",
+			pingInterval:           "2s",
+			maxPingsOut:            0,
+			expectedPingInterval:   2 * time.Second,
+			expectedMaxPingsOut:    2,
+			expectedFailure: false,
+		},
+		{
+			name:            "Wrong pingInterval value",
+			pingInterval:          "pingInterval",
+			expectedFailure: true,
+		},
+	} {
+		triggerInstance := &functionconfig.Trigger{
+			Attributes: map[string]interface{}{
+				"stream":   "mystream",
+				"consumer": "myconsumer",
+				"pingInterval": testCase.pingInterval,
+				"maxPingsOut": testCase.maxPingsOut,
+			},
+		}
+		suite.Run(testCase.name, func() {
+			configuration, err := NewConfiguration(testCase.name,
+				triggerInstance,
+				&runtime.Configuration{
+					Configuration: &processor.Configuration{
+						Config: functionconfig.Config{},
+					},
+				},
+				suite.logger)
+			if testCase.expectedFailure {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(testCase.expectedPingInterval, configuration.pingInterval, "Bad pingInterval value")
+				suite.Require().Equal(testCase.expectedMaxPingsOut, configuration.MaxPingsOut, "Bad maxPingsOut value")
+			}
+		})
+	}
+}
+
+func TestNatsJetstreamSuite(t *testing.T) {
+	suite.Run(t, new(TestSuite))
+}

--- a/pkg/processor/trigger/nats/jetstream/natsjetstream_test.go
+++ b/pkg/processor/trigger/nats/jetstream/natsjetstream_test.go
@@ -1,3 +1,5 @@
+//go:build test_unit
+
 /*
 Copyright 2023 The Nuclio Authors.
 
@@ -30,34 +32,33 @@ import (
 
 type TestSuite struct {
 	suite.Suite
-	trigger natsjetstream
-	logger  logger.Logger
+	logger logger.Logger
 }
 
 func (suite *TestSuite) TestStreamAndConsumerConfiguration() {
 	for _, testCase := range []struct {
-		name                   string
-		stream                 string
-		consumer               string
-		expectedFailure        bool
+		name            string
+		stream          string
+		consumer        string
+		expectedFailure bool
 	}{
 		{
-			name:                   "Stream and Consumer specified",
-			stream:                 "mystream",
-			consumer:               "myconsumer",
-			expectedFailure:        false,
+			name:            "Stream and Consumer specified",
+			stream:          "mystream",
+			consumer:        "myconsumer",
+			expectedFailure: false,
 		},
 		{
-			name:                   "Stream not specified",
-			stream:                 "",
-			consumer:               "myconsumer",
-			expectedFailure:        true,
+			name:            "Stream not specified",
+			stream:          "",
+			consumer:        "myconsumer",
+			expectedFailure: true,
 		},
 		{
-			name:            	"Consumer not specified",
-			stream:                 "mystream",
-			consumer:               "",
-			expectedFailure: 	true,
+			name:            "Consumer not specified",
+			stream:          "mystream",
+			consumer:        "",
+			expectedFailure: true,
 		},
 	} {
 		triggerInstance := &functionconfig.Trigger{
@@ -87,42 +88,42 @@ func (suite *TestSuite) TestStreamAndConsumerConfiguration() {
 }
 func (suite *TestSuite) TestReconnectConfiguration() {
 	for _, testCase := range []struct {
-		name                   string
-		allowReconnect         bool
-		maxReconnect           int
-		expectedMaxReconnect   int
+		name                 string
+		allowReconnect       bool
+		maxReconnect         int
+		expectedMaxReconnect int
 	}{
 		{
-			name:                   "MaxReconnect specified",
-			allowReconnect:         true,
-			maxReconnect:           2,
-			expectedMaxReconnect:   2,
+			name:                 "MaxReconnect specified",
+			allowReconnect:       true,
+			maxReconnect:         2,
+			expectedMaxReconnect: 2,
 		},
 		{
-			name:                   "MaxReconnect not specified",
-			allowReconnect:         true,
-			maxReconnect:           0,
-			expectedMaxReconnect:   60,
+			name:                 "MaxReconnect not specified",
+			allowReconnect:       true,
+			maxReconnect:         0,
+			expectedMaxReconnect: 60,
 		},
 		{
-			name:                   "MaxReconnect negative",
-			allowReconnect:         true,
-			maxReconnect:           -1,
-			expectedMaxReconnect:   -1,
+			name:                 "MaxReconnect negative",
+			allowReconnect:       true,
+			maxReconnect:         -1,
+			expectedMaxReconnect: -1,
 		},
 		{
-			name:                   "No Reconnect",
-			allowReconnect:         false,
-			maxReconnect:           -1,
-			expectedMaxReconnect:   -1,
+			name:                 "No Reconnect",
+			allowReconnect:       false,
+			maxReconnect:         -1,
+			expectedMaxReconnect: -1,
 		},
 	} {
 		triggerInstance := &functionconfig.Trigger{
 			Attributes: map[string]interface{}{
-				"stream":   "mystream",
-				"consumer": "myconsumer",
+				"stream":         "mystream",
+				"consumer":       "myconsumer",
 				"allowReconnect": testCase.allowReconnect,
-				"maxReconnect": testCase.maxReconnect,
+				"maxReconnect":   testCase.maxReconnect,
 			},
 		}
 		suite.Run(testCase.name, func() {
@@ -143,45 +144,45 @@ func (suite *TestSuite) TestReconnectConfiguration() {
 
 func (suite *TestSuite) TestReconnectWaitConfiguration() {
 	for _, testCase := range []struct {
-		name                   string
-		reconnectWait          string
-		reconnectJitter        string
-		expectedReconnectWait  time.Duration
+		name                    string
+		reconnectWait           string
+		reconnectJitter         string
+		expectedReconnectWait   time.Duration
 		expectedReconnectJitter time.Duration
-		expectedFailure 	bool
+		expectedFailure         bool
 	}{
 		{
-			name:                   "Time specified",
-			reconnectWait:          "2s",
-			reconnectJitter:        "3s",
-			expectedReconnectWait:  2 * time.Second,
-			expectedReconnectJitter:  3 * time.Second,
-			expectedFailure: false,
+			name:                    "Time specified",
+			reconnectWait:           "2s",
+			reconnectJitter:         "3s",
+			expectedReconnectWait:   2 * time.Second,
+			expectedReconnectJitter: 3 * time.Second,
+			expectedFailure:         false,
 		},
 		{
-			name:                   "Time not specified",
-			reconnectWait:          "",
-			reconnectJitter:        "",
-			expectedReconnectWait:  2 * time.Second,
-			expectedReconnectJitter:  100 * time.Millisecond,
-			expectedFailure: false,
+			name:                    "Time not specified",
+			reconnectWait:           "",
+			reconnectJitter:         "",
+			expectedReconnectWait:   2 * time.Second,
+			expectedReconnectJitter: 100 * time.Millisecond,
+			expectedFailure:         false,
 		},
 		{
 			name:            "Wrong wait value",
-			reconnectWait:          "wait",
+			reconnectWait:   "wait",
 			expectedFailure: true,
 		},
 		{
 			name:            "Wrong jitter value",
-			reconnectJitter:        "jitter",
+			reconnectJitter: "jitter",
 			expectedFailure: true,
 		},
 	} {
 		triggerInstance := &functionconfig.Trigger{
 			Attributes: map[string]interface{}{
-				"stream":   "mystream",
-				"consumer": "myconsumer",
-				"reconnectWait": testCase.reconnectWait,
+				"stream":          "mystream",
+				"consumer":        "myconsumer",
+				"reconnectWait":   testCase.reconnectWait,
 				"reconnectJitter": testCase.reconnectJitter,
 			},
 		}
@@ -224,7 +225,7 @@ func (suite *TestSuite) TestTimeoutConfiguration() {
 			expectedTimeout:        2 * time.Second,
 			expectedDrainTimeout:   3 * time.Second,
 			expectedFlusherTimeout: 4 * time.Second,
-			expectedFailure: false,
+			expectedFailure:        false,
 		},
 		{
 			name:                   "Time not specified",
@@ -234,7 +235,7 @@ func (suite *TestSuite) TestTimeoutConfiguration() {
 			expectedTimeout:        2 * time.Second,
 			expectedDrainTimeout:   30 * time.Second,
 			expectedFlusherTimeout: 1 * time.Minute,
-			expectedFailure: false,
+			expectedFailure:        false,
 		},
 		{
 			name:            "Wrong timeout value",
@@ -254,10 +255,10 @@ func (suite *TestSuite) TestTimeoutConfiguration() {
 	} {
 		triggerInstance := &functionconfig.Trigger{
 			Attributes: map[string]interface{}{
-				"stream":   "mystream",
-				"consumer": "myconsumer",
-				"timeout": testCase.timeout,
-				"drainTimeout": testCase.drainTimeout,
+				"stream":         "mystream",
+				"consumer":       "myconsumer",
+				"timeout":        testCase.timeout,
+				"drainTimeout":   testCase.drainTimeout,
 				"flusherTimeout": testCase.flusherTimeout,
 			},
 		}
@@ -284,49 +285,49 @@ func (suite *TestSuite) TestTimeoutConfiguration() {
 
 func (suite *TestSuite) TestPingConfiguration() {
 	for _, testCase := range []struct {
-		name                   string
-		pingInterval           string
-		maxPingsOut            int
-		expectedPingInterval   time.Duration
-		expectedMaxPingsOut    int
-		expectedFailure        bool
+		name                 string
+		pingInterval         string
+		maxPingsOut          int
+		expectedPingInterval time.Duration
+		expectedMaxPingsOut  int
+		expectedFailure      bool
 	}{
 		{
-			name:                   "Ping specified",
-			pingInterval:           "2s",
-			maxPingsOut:            5,
-			expectedPingInterval:   2 * time.Second,
-			expectedMaxPingsOut:    5,
-			expectedFailure: false,
+			name:                 "Ping specified",
+			pingInterval:         "2s",
+			maxPingsOut:          5,
+			expectedPingInterval: 2 * time.Second,
+			expectedMaxPingsOut:  5,
+			expectedFailure:      false,
 		},
 		{
-			name:                   "PingInterval not specified",
-			pingInterval:           "",
-			maxPingsOut:            5,
-			expectedPingInterval:   2 * time.Minute,
-			expectedMaxPingsOut:    5,
-			expectedFailure: false,
+			name:                 "PingInterval not specified",
+			pingInterval:         "",
+			maxPingsOut:          5,
+			expectedPingInterval: 2 * time.Minute,
+			expectedMaxPingsOut:  5,
+			expectedFailure:      false,
 		},
 		{
-			name:                   "MaxPingsOut not specified",
-			pingInterval:           "2s",
-			maxPingsOut:            0,
-			expectedPingInterval:   2 * time.Second,
-			expectedMaxPingsOut:    2,
-			expectedFailure: false,
+			name:                 "MaxPingsOut not specified",
+			pingInterval:         "2s",
+			maxPingsOut:          0,
+			expectedPingInterval: 2 * time.Second,
+			expectedMaxPingsOut:  2,
+			expectedFailure:      false,
 		},
 		{
 			name:            "Wrong pingInterval value",
-			pingInterval:          "pingInterval",
+			pingInterval:    "pingInterval",
 			expectedFailure: true,
 		},
 	} {
 		triggerInstance := &functionconfig.Trigger{
 			Attributes: map[string]interface{}{
-				"stream":   "mystream",
-				"consumer": "myconsumer",
+				"stream":       "mystream",
+				"consumer":     "myconsumer",
 				"pingInterval": testCase.pingInterval,
-				"maxPingsOut": testCase.maxPingsOut,
+				"maxPingsOut":  testCase.maxPingsOut,
 			},
 		}
 		suite.Run(testCase.name, func() {

--- a/pkg/processor/trigger/nats/jetstream/trigger.go
+++ b/pkg/processor/trigger/nats/jetstream/trigger.go
@@ -82,7 +82,10 @@ func (n *natsjetstream) validateConfiguration() error {
 }
 
 func (n *natsjetstream) Start(checkpoint functionconfig.Checkpoint) error {
-	natsConnection, err := natsio.Connect(n.configuration.URL)
+
+	natsOptions := n.configuration.GetNATSOptions()
+
+	natsConnection, err := natsio.Connect(n.configuration.URL, natsOptions...)
 	if err != nil {
 		return errors.Wrapf(err, "Can't connect to NATS server %s", n.configuration.URL)
 	}

--- a/pkg/processor/trigger/nats/jetstream/types.go
+++ b/pkg/processor/trigger/nats/jetstream/types.go
@@ -17,8 +17,8 @@ limitations under the License.
 package natsjetstream
 
 import (
-	"time"
 	"fmt"
+	"time"
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"

--- a/pkg/processor/trigger/nats/jetstream/types.go
+++ b/pkg/processor/trigger/nats/jetstream/types.go
@@ -55,10 +55,10 @@ type Configuration struct {
 	pingInterval    time.Duration
 }
 
-func NewConfiguration(logger logger.Logger,
-	id string,
+func NewConfiguration(id string,
 	triggerConfiguration *functionconfig.Trigger,
-	runtimeConfiguration *runtime.Configuration) (*Configuration, error) {
+	runtimeConfiguration *runtime.Configuration,
+	logger logger.Logger) (*Configuration, error) {
 	newConfiguration := Configuration{}
 
 	// create base
@@ -89,10 +89,6 @@ func NewConfiguration(logger logger.Logger,
 	}
 
 	// set default values and parse durations
-	if !newConfiguration.AllowReconnect {
-		newConfiguration.AllowReconnect = true
-	}
-
 	if newConfiguration.MaxReconnect == 0 {
 		newConfiguration.MaxReconnect = 60
 	}

--- a/pkg/processor/trigger/nats/jetstream/types.go
+++ b/pkg/processor/trigger/nats/jetstream/types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package natsjetstream
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
@@ -157,7 +156,6 @@ func (c *Configuration) GetNATSOptions() []nats.Option {
 	if !c.AllowReconnect {
 		opts = append(opts, nats.NoReconnect())
 	}
-	fmt.Println(c.pingInterval)
 
 	opts = append(opts, nats.MaxReconnects(c.MaxReconnect))
 	opts = append(opts, nats.ReconnectWait(c.reconnectWait))

--- a/pkg/processor/trigger/nats/jetstream/types.go
+++ b/pkg/processor/trigger/nats/jetstream/types.go
@@ -17,38 +17,163 @@ limitations under the License.
 package natsjetstream
 
 import (
+	"time"
+
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
 
 	"github.com/mitchellh/mapstructure"
+	nats "github.com/nats-io/nats.go"
 	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
 )
 
 type Configuration struct {
 	trigger.Configuration
 	Stream   string
 	Consumer string
+
+	// NATS connection configuration
+	AllowReconnect  bool
+	MaxReconnect    int
+	ReconnectWait   string
+	ReconnectJitter string
+	Timeout         string
+	DrainTimeout    string
+	FlusherTimeout  string
+	PingInterval    string
+	MaxPingsOut     int
+
+	// resolved fields
+	allowReconnect  bool
+	maxReconnect    int
+	reconnectWait   time.Duration
+	reconnectJitter time.Duration
+	timeout         time.Duration
+	drainTimeout    time.Duration
+	flusherTimeout  time.Duration
+	pingInterval    time.Duration
+	maxPingsOut     int
 }
 
 func NewConfiguration(id string,
 	triggerConfiguration *functionconfig.Trigger,
-	runtimeConfiguration *runtime.Configuration) (*Configuration, error) {
+	runtimeConfiguration *runtime.Configuration,
+	logger logger.Logger) (*Configuration, error) {
 	newConfiguration := Configuration{}
 
-	// create base
 	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create trigger configuration")
 	}
 	newConfiguration.Configuration = *baseConfiguration
 
-	// parse attributes
 	if err := mapstructure.Decode(newConfiguration.Attributes, &newConfiguration); err != nil {
 		return nil, errors.Wrap(err, "Failed to decode attributes")
 	}
 
-	// TODO: validate
+	err = newConfiguration.PopulateConfigurationFromAnnotations([]trigger.AnnotationConfigField{
+		{Key: "nuclio.io/nats-allow-reconnect", ValueBool: &newConfiguration.AllowReconnect},
+		{Key: "nuclio.io/nats-max-reconnect", ValueInt: &newConfiguration.MaxReconnect},
+		{Key: "nuclio.io/nats-reconnect-wait", ValueString: &newConfiguration.ReconnectWait},
+		{Key: "nuclio.io/nats-reconnect-jitter", ValueString: &newConfiguration.ReconnectJitter},
+		{Key: "nuclio.io/nats-timeout", ValueString: &newConfiguration.Timeout},
+		{Key: "nuclio.io/nats-drain-timeout", ValueString: &newConfiguration.DrainTimeout},
+		{Key: "nuclio.io/nats-flusher-timeout", ValueString: &newConfiguration.FlusherTimeout},
+		{Key: "nuclio.io/nats-ping-interval", ValueString: &newConfiguration.PingInterval},
+		{Key: "nuclio.io/nats-max-pings-out", ValueInt: &newConfiguration.MaxPingsOut},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to populate configuration from annotations")
+	}
+
+	// set default values and parse durations
+	newConfiguration.allowReconnect = newConfiguration.AllowReconnect
+	newConfiguration.maxReconnect = newConfiguration.MaxReconnect
+	newConfiguration.maxPingsOut = newConfiguration.MaxPingsOut
+
+	if !newConfiguration.AllowReconnect {
+		newConfiguration.allowReconnect = true
+	}
+
+	if newConfiguration.maxReconnect == 0 {
+		newConfiguration.maxReconnect = 60
+	}
+
+	if newConfiguration.maxPingsOut == 0 {
+		newConfiguration.maxPingsOut = 2
+	}
+
+	for _, durationConfigField := range []trigger.DurationConfigField{
+		{
+			Name:    "reconnect wait",
+			Value:   newConfiguration.ReconnectWait,
+			Field:   &newConfiguration.reconnectWait,
+			Default: 2 * time.Second,
+		},
+		{
+			Name:    "reconnect jitter",
+			Value:   newConfiguration.ReconnectJitter,
+			Field:   &newConfiguration.reconnectJitter,
+			Default: 100 * time.Millisecond,
+		},
+		{
+			Name:    "timeout",
+			Value:   newConfiguration.Timeout,
+			Field:   &newConfiguration.timeout,
+			Default: 2 * time.Second,
+		},
+		{
+			Name:    "drain timeout",
+			Value:   newConfiguration.DrainTimeout,
+			Field:   &newConfiguration.drainTimeout,
+			Default: 30 * time.Second,
+		},
+		{
+			Name:    "flusher timeout",
+			Value:   newConfiguration.FlusherTimeout,
+			Field:   &newConfiguration.flusherTimeout,
+			Default: 1 * time.Minute,
+		},
+		{
+			Name:    "ping interval",
+			Value:   newConfiguration.PingInterval,
+			Field:   &newConfiguration.pingInterval,
+			Default: 2 * time.Minute,
+		},
+	} {
+		if err = newConfiguration.ParseDurationOrDefault(&durationConfigField); err != nil {
+			return nil, err
+		}
+	}
+
+	if newConfiguration.Stream == "" {
+		return nil, errors.New("Stream must be set")
+	}
+
+	if newConfiguration.Consumer == "" {
+		return nil, errors.New("Consumer must be set")
+	}
 
 	return &newConfiguration, nil
+}
+
+func (c *Configuration) GetNATSOptions() []nats.Option {
+	var opts []nats.Option
+
+	if !c.allowReconnect {
+		opts = append(opts, nats.NoReconnect())
+	}
+
+	opts = append(opts, nats.MaxReconnects(c.maxReconnect))
+	opts = append(opts, nats.ReconnectWait(c.reconnectWait))
+	opts = append(opts, nats.ReconnectJitter(c.reconnectJitter, c.reconnectJitter*10)) // second argument is used if TLS is enabled
+	opts = append(opts, nats.Timeout(c.timeout))
+	opts = append(opts, nats.DrainTimeout(c.drainTimeout))
+	opts = append(opts, nats.FlusherTimeout(c.flusherTimeout))
+	opts = append(opts, nats.PingInterval(c.pingInterval))
+	opts = append(opts, nats.MaxPingsOutstanding(c.maxPingsOut))
+
+	return opts
 }

--- a/pkg/processor/trigger/nats/jetstream/types.go
+++ b/pkg/processor/trigger/nats/jetstream/types.go
@@ -18,6 +18,7 @@ package natsjetstream
 
 import (
 	"time"
+	"fmt"
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
@@ -46,21 +47,18 @@ type Configuration struct {
 	MaxPingsOut     int
 
 	// resolved fields
-	allowReconnect  bool
-	maxReconnect    int
 	reconnectWait   time.Duration
 	reconnectJitter time.Duration
 	timeout         time.Duration
 	drainTimeout    time.Duration
 	flusherTimeout  time.Duration
 	pingInterval    time.Duration
-	maxPingsOut     int
 }
 
-func NewConfiguration(id string,
+func NewConfiguration(logger logger.Logger,
+	id string,
 	triggerConfiguration *functionconfig.Trigger,
-	runtimeConfiguration *runtime.Configuration,
-	logger logger.Logger) (*Configuration, error) {
+	runtimeConfiguration *runtime.Configuration) (*Configuration, error) {
 	newConfiguration := Configuration{}
 
 	// create base
@@ -76,35 +74,31 @@ func NewConfiguration(id string,
 	}
 
 	err = newConfiguration.PopulateConfigurationFromAnnotations([]trigger.AnnotationConfigField{
-		{Key: "nuclio.io/nats-allow-reconnect", ValueBool: &newConfiguration.AllowReconnect},
-		{Key: "nuclio.io/nats-max-reconnect", ValueInt: &newConfiguration.MaxReconnect},
-		{Key: "nuclio.io/nats-reconnect-wait", ValueString: &newConfiguration.ReconnectWait},
-		{Key: "nuclio.io/nats-reconnect-jitter", ValueString: &newConfiguration.ReconnectJitter},
-		{Key: "nuclio.io/nats-timeout", ValueString: &newConfiguration.Timeout},
-		{Key: "nuclio.io/nats-drain-timeout", ValueString: &newConfiguration.DrainTimeout},
-		{Key: "nuclio.io/nats-flusher-timeout", ValueString: &newConfiguration.FlusherTimeout},
-		{Key: "nuclio.io/nats-ping-interval", ValueString: &newConfiguration.PingInterval},
-		{Key: "nuclio.io/nats-max-pings-out", ValueInt: &newConfiguration.MaxPingsOut},
+		{Key: "nuclio.io/nats-jetstream-allow-reconnect", ValueBool: &newConfiguration.AllowReconnect},
+		{Key: "nuclio.io/nats-jetstream-max-reconnect", ValueInt: &newConfiguration.MaxReconnect},
+		{Key: "nuclio.io/nats-jetstream-reconnect-wait", ValueString: &newConfiguration.ReconnectWait},
+		{Key: "nuclio.io/nats-jetstream-reconnect-jitter", ValueString: &newConfiguration.ReconnectJitter},
+		{Key: "nuclio.io/nats-jetstream-timeout", ValueString: &newConfiguration.Timeout},
+		{Key: "nuclio.io/nats-jetstream-drain-timeout", ValueString: &newConfiguration.DrainTimeout},
+		{Key: "nuclio.io/nats-jetstream-flusher-timeout", ValueString: &newConfiguration.FlusherTimeout},
+		{Key: "nuclio.io/nats-jetstream-ping-interval", ValueString: &newConfiguration.PingInterval},
+		{Key: "nuclio.io/nats-jetstream-max-pings-out", ValueInt: &newConfiguration.MaxPingsOut},
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to populate configuration from annotations")
 	}
 
 	// set default values and parse durations
-	newConfiguration.allowReconnect = newConfiguration.AllowReconnect
-	newConfiguration.maxReconnect = newConfiguration.MaxReconnect
-	newConfiguration.maxPingsOut = newConfiguration.MaxPingsOut
-
 	if !newConfiguration.AllowReconnect {
-		newConfiguration.allowReconnect = true
+		newConfiguration.AllowReconnect = true
 	}
 
-	if newConfiguration.maxReconnect == 0 {
-		newConfiguration.maxReconnect = 60
+	if newConfiguration.MaxReconnect == 0 {
+		newConfiguration.MaxReconnect = 60
 	}
 
-	if newConfiguration.maxPingsOut == 0 {
-		newConfiguration.maxPingsOut = 2
+	if newConfiguration.MaxPingsOut == 0 {
+		newConfiguration.MaxPingsOut = 2
 	}
 
 	for _, durationConfigField := range []trigger.DurationConfigField{
@@ -164,18 +158,19 @@ func NewConfiguration(id string,
 func (c *Configuration) GetNATSOptions() []nats.Option {
 	var opts []nats.Option
 
-	if !c.allowReconnect {
+	if !c.AllowReconnect {
 		opts = append(opts, nats.NoReconnect())
 	}
+	fmt.Println(c.pingInterval)
 
-	opts = append(opts, nats.MaxReconnects(c.maxReconnect))
+	opts = append(opts, nats.MaxReconnects(c.MaxReconnect))
 	opts = append(opts, nats.ReconnectWait(c.reconnectWait))
 	opts = append(opts, nats.ReconnectJitter(c.reconnectJitter, c.reconnectJitter*10)) // second argument is used if TLS is enabled
 	opts = append(opts, nats.Timeout(c.timeout))
 	opts = append(opts, nats.DrainTimeout(c.drainTimeout))
 	opts = append(opts, nats.FlusherTimeout(c.flusherTimeout))
 	opts = append(opts, nats.PingInterval(c.pingInterval))
-	opts = append(opts, nats.MaxPingsOutstanding(c.maxPingsOut))
+	opts = append(opts, nats.MaxPingsOutstanding(c.MaxPingsOut))
 
 	return opts
 }

--- a/pkg/processor/trigger/nats/jetstream/types.go
+++ b/pkg/processor/trigger/nats/jetstream/types.go
@@ -55,10 +55,10 @@ type Configuration struct {
 	pingInterval    time.Duration
 }
 
-func NewConfiguration(id string,
+func NewConfiguration(logger logger.Logger,
+	id string,
 	triggerConfiguration *functionconfig.Trigger,
-	runtimeConfiguration *runtime.Configuration,
-	logger logger.Logger) (*Configuration, error) {
+	runtimeConfiguration *runtime.Configuration) (*Configuration, error) {
 	newConfiguration := Configuration{}
 
 	// create base

--- a/pkg/processor/trigger/nats/jetstream/types.go
+++ b/pkg/processor/trigger/nats/jetstream/types.go
@@ -63,12 +63,14 @@ func NewConfiguration(id string,
 	logger logger.Logger) (*Configuration, error) {
 	newConfiguration := Configuration{}
 
+	// create base
 	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create trigger configuration")
 	}
 	newConfiguration.Configuration = *baseConfiguration
 
+	// parse attributes
 	if err := mapstructure.Decode(newConfiguration.Attributes, &newConfiguration); err != nil {
 		return nil, errors.Wrap(err, "Failed to decode attributes")
 	}


### PR DESCRIPTION
### 📝 Description
I've been using nuclio with the nats jetstream trigger. However, sometimes, my nats instance goes down for a few minutes. By default the nats client will attempt to reconnect for 2 minutes which often is not enough for my use case. This means I end up with dead nuclio functions that must be restarted. My solution is to add a way to configure the nats client through the nuclio trigger configuration.

---

### 🛠️ Changes Made
Add Nats client options in the types.go for the nats jetstream trigger.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
I performed manual testing to make sure that the options are passed successfully to the nats client. 
I also intentionally crashed my nats instance to see if nuclio functions would reconnect after an extend amount of time.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links: https://github.com/nats-io/nats.go/blob/main/nats.go#L285

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No
---

### 🔍️ Additional Notes