### PR TITLE
[OPA] Add prefix to multi resource OPA queries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ env:
   CACHE_REPO_NAME: ${{ github.repository_owner }}
   NUCLIO_LABEL: ${{ github.run_number }}
   NAMESPACE: nuclio
-  NUCLIO_GO_TEST_TIMEOUT: "30m"
+  NUCLIO_GO_TEST_TIMEOUT: "35m"
   DOCKER_BUILDKIT: 1
   GITHUB_ACTIONS_BOT_NAME: github-actions[bot]
   GITHUB_ACTIONS_BOT_EMAIL: github-actions[bot]@users.noreply.github.com

--- a/Makefile
+++ b/Makefile
@@ -1007,8 +1007,8 @@ generate-nuctl-docs:
 #
 
 PATCH_ENV_FILE_PATH = hack/scripts/patch-remote/patch_env.yml
-PATCH_HOST_IP ?= $(shell [ -f $(PATCH_ENV_FILE_PATH) ] && awk '/HOST_IP/ {print $$2}' $(PATCH_ENV_FILE_PATH))
-PATCH_USERNAME ?= $(shell [ -f $(PATCH_ENV_FILE_PATH) ] && awk '/SSH_USER/ {print $$2}' $(PATCH_ENV_FILE_PATH))
+PATCH_HOST_IP ?= $(shell [ -f $(PATCH_ENV_FILE_PATH) ] && awk '/^HOST_IP:/ {print $$2}' $(PATCH_ENV_FILE_PATH))
+PATCH_USERNAME ?= $(shell [ -f $(PATCH_ENV_FILE_PATH) ] && awk '/^SSH_USER:/ {print $$2}' $(PATCH_ENV_FILE_PATH))
 
 hack/scripts/patch-remote/.ssh/key_$(PATCH_HOST_IP)_$(PATCH_USERNAME):
 	mkdir -p hack/scripts/patch-remote/.ssh

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -657,7 +657,7 @@ func (ap *Platform) FilterProjectsByPermissions(ctx context.Context,
 	resources := make([]string, len(projects))
 	for idx, project := range projects {
 		projectName := project.GetConfig().Meta.Name
-		resources[idx] = opa.GenerateProjectResourceString(projectName, "")
+		resources[idx] = opa.GenerateProjectResourceString(projectName, ap.getOPAResourcesPrefix())
 	}
 
 	allowedList, err := ap.QueryOPAMultipleResources(ctx, resources, opaclient.ActionRead, permissionOptions)
@@ -699,7 +699,7 @@ func (ap *Platform) FilterFunctionsByPermissions(ctx context.Context,
 	for idx, function := range functions {
 		functionName := function.GetConfig().Meta.Name
 		projectName := function.GetConfig().Meta.Labels[common.NuclioResourceLabelKeyProjectName]
-		resources[idx] = opa.GenerateFunctionResourceString(projectName, functionName, "")
+		resources[idx] = opa.GenerateFunctionResourceString(projectName, functionName, ap.getOPAResourcesPrefix())
 	}
 
 	allowedList, err := ap.QueryOPAMultipleResources(ctx, resources, opaclient.ActionRead, permissionOptions)
@@ -744,7 +744,7 @@ func (ap *Platform) FilterFunctionEventsByPermissions(ctx context.Context,
 		resources = append(resources, opa.GenerateFunctionEventResourceString(projectName,
 			functionName,
 			functionEventName,
-			""))
+			ap.getOPAResourcesPrefix()))
 	}
 	allowedList, err := ap.QueryOPAMultipleResources(ctx, resources, opaclient.ActionRead, permissionOptions)
 	if err != nil {


### PR DESCRIPTION
### 📝 Description

The resource prefix (which is required for IG4) was only added to single OPA permission queries and was missing for multiple resources queries.

---

### 🛠️ Changes Made

- Add the prefix from the platform configuration to:
  - `FilterProjectsByPermissions`
  - `FilterFunctionsByPermissions`
  - `FilterFunctionEventsByPermissions`
- Fix Makefile's patch host IP and username resolution to allow having extra commented out keys without failing (look for the line that **starts** with the key, skipping comment characters).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
Tested manually on live IG4 VM.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->