### PR TITLE
[Chart] Bump to 1.15.7

### DIFF
--- a/hack/k8s/helm/nuclio/Chart.yaml
+++ b/hack/k8s/helm/nuclio/Chart.yaml
@@ -15,8 +15,8 @@
 apiVersion: v1
 description: Serverless for Real-Time and Data-Driven Applications
 name: nuclio
-version: 0.21.3
-appVersion: 1.15.3
+version: 0.21.7
+appVersion: 1.15.7
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://nuclio.io
 sources:

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -24,7 +24,7 @@ controller:
   enabled: true
   image:
     repository: quay.io/nuclio/controller
-    tag: 1.15.3-amd64
+    tag: 1.15.7-amd64
     pullPolicy: IfNotPresent
   resources: {}
 
@@ -97,7 +97,7 @@ dashboard:
   replicas: 1
   image:
     repository: quay.io/nuclio/dashboard
-    tag: 1.15.3-amd64
+    tag: 1.15.7-amd64
     pullPolicy: IfNotPresent
   resources: {}
 
@@ -302,7 +302,7 @@ autoscaler:
   replicas: 1
   image:
     repository: quay.io/nuclio/autoscaler
-    tag: 1.15.3-amd64
+    tag: 1.15.7-amd64
     pullPolicy: IfNotPresent
   resources: {}
 
@@ -336,7 +336,7 @@ dlx:
   replicas: 1
   image:
     repository: quay.io/nuclio/dlx
-    tag: 1.15.3-amd64
+    tag: 1.15.7-amd64
     pullPolicy: IfNotPresent
   resources: {}
 


### PR DESCRIPTION
Since we decided to proceed 1.15.x development in development branch, we need to backport chart changes from 1.15.x to be able to release charts properly
(cherry picked from commit 092a7d848d91d6cab8fdae0b43fa7b86483615a3)