### PR TITLE
[Dashboard] Add explicit base image

### DIFF
--- a/docs/tasks/configuring-a-platform.md
+++ b/docs/tasks/configuring-a-platform.md
@@ -317,42 +317,28 @@ kubectl patch deployment nuclio-dashboard \
 
 The `baseImages` configuration allows you to override the default base images used for building function processor images on a per-runtime basis.
 This is useful when you need to use custom base images, such as in air-gapped environments or when using private registries.
+If a runtime is not specified in the `baseImages` map, Nuclio will use the default base image for that runtime.
 
 The configuration is a map where:
-- **Key**: Runtime name (e.g., `python`, `nodejs`) or runtime name with version (e.g., `python:3.12`, `nodejs:20`)
+- **Key**: Runtime name (e.g., `golang`, `nodejs`); for Python, include both the name and version (e.g., `python:3.11`, `python:3.12`)
 - **Value**: The base image to use for that runtime
-
-When both a version-specific key (e.g., `golang:1.21`) and a runtime-name-only key (e.g., `golang`) are present, the version-specific key takes precedence.
-
-Example:
-```yaml
-baseImages:
-  nodejs: "custom-registry.io/node:20"
-  golang:1.21: "custom-registry.io/golang:1.21"
-  golang: "custom-registry.io/golang:latest"
-```
-
-In this example:
-- All Node.js functions will use `custom-registry.io/node:20` by default
-- Go 1.21 functions will specifically use `custom-registry.io/golang:1.21` (version-specific override takes precedence)
-- Other Go functions (without a version-specific match) will use `custom-registry.io/golang:latest` (the general `golang` setting)
 
 Best practice example with explicit versions:
 ```yaml
-baseImages:
-  nodejs:20: "custom-registry.io/node:20"
-  nodejs:22: "custom-registry.io/node:22"
-  golang:1.21: "custom-registry.io/golang:1.21"
-  golang:1.22: "custom-registry.io/golang:1.22"
-  python:3.12: "custom-registry.io/python:3.12"
+runtimeBaseImages:
+  nodejs: "custom-registry.io/node:20"
   python:3.11: "custom-registry.io/python:3.11"
+  python:3.12: "custom-registry.io/python:3.12"
 ```
 
-If a runtime is not specified in the `baseImages` map, Nuclio will use the default base image for that runtime.
+In this example:
+- All Node.js functions will use `custom-registry.io/node:20` by default 
+- All Golang functions will use the default Nuclio Go base image (`gcr.io/iguazio/alpine:3.20`), since no image is explicitly specified
+- Python 3.11 functions will specifically use `custom-registry.io/python:3.11`
+- Python 3.12 functions will specifically use `custom-registry.io/python:3.12`
+- Other python functions (without a version-specific match) will use `custom-registry.io/python:3.12`, since `3.12` is the current default Python version
 
-> **Note:** We recommend using explicit version-specific keys (e.g., `nodejs:20`, `python:3.12`) instead of runtime-name-only keys (e.g., `nodejs`, `python`). When using a runtime-name-only key, function updates may result in unexpected base image changes. For example, if the default base image for Node.js is `node:20` and you configure `baseImages: { nodejs: "node:22" }`, when you update a function, it will be rebuilt with `node:22` instead of the original `node:20`, since there is no per-version explicit configuration in the `baseImages` map.
-
-> **Important - Python Version Compatibility:** Python base images are **not backward compatible** across versions. Each Python version has its own wheel files (`.whl`), which are breaking compatible. Therefore, **avoid using a default Python base image** (i.e., `python` without a version). Always specify explicit Python versions (e.g., `python:3.12`, `python:3.11`). If you provide a generic `python` key, Nuclio will automatically migrate it to `python:3.12` (the current default Python version).
+> **Important - Python Version Compatibility:** Python base images are **not backward compatible** across versions. Each Python version requires its own wheel (.whl) files, and these wheels are not compatible across different Python versions.. Therefore, **avoid using a default Python base image** (i.e., `python` without a version). Always specify explicit Python versions (e.g., `python:3.12`, `python:3.11`).
 
 ## Project Secret-Based Service Account Enrichment and Validation
 

--- a/docs/tasks/configuring-a-platform.md
+++ b/docs/tasks/configuring-a-platform.md
@@ -322,25 +322,37 @@ The configuration is a map where:
 - **Key**: Runtime name (e.g., `python`, `nodejs`) or runtime name with version (e.g., `python:3.12`, `nodejs:20`)
 - **Value**: The base image to use for that runtime
 
-When both a version-specific key (e.g., `python:3.12`) and a runtime-name-only key (e.g., `python`) are present, the version-specific key takes precedence.
+When both a version-specific key (e.g., `golang:1.21`) and a runtime-name-only key (e.g., `golang`) are present, the version-specific key takes precedence.
 
 Example:
 ```yaml
 baseImages:
-  python: "custom-registry.io/python:3.12"
-  python:3.12: "custom-registry.io/python-3.12:latest"
   nodejs: "custom-registry.io/node:20"
-  golang: "custom-registry.io/golang:1.21"
+  golang:1.21: "custom-registry.io/golang:1.21"
+  golang: "custom-registry.io/golang:latest"
 ```
 
 In this example:
-- All Python functions will use `custom-registry.io/python:3.12` by default
-- Python 3.12 functions will specifically use `custom-registry.io/python-3.12:latest` (overriding the general `python` setting)
-- Node.js functions will use `custom-registry.io/node:20`
-- Go functions will use `custom-registry.io/golang:1.21`
+- All Node.js functions will use `custom-registry.io/node:20` by default
+- Go 1.21 functions will specifically use `custom-registry.io/golang:1.21` (version-specific override takes precedence)
+- Other Go functions (without a version-specific match) will use `custom-registry.io/golang:latest` (the general `golang` setting)
+
+Best practice example with explicit versions:
+```yaml
+baseImages:
+  nodejs:20: "custom-registry.io/node:20"
+  nodejs:22: "custom-registry.io/node:22"
+  golang:1.21: "custom-registry.io/golang:1.21"
+  golang:1.22: "custom-registry.io/golang:1.22"
+  python:3.12: "custom-registry.io/python:3.12"
+  python:3.11: "custom-registry.io/python:3.11"
+```
 
 If a runtime is not specified in the `baseImages` map, Nuclio will use the default base image for that runtime.
 
+> **Note:** We recommend using explicit version-specific keys (e.g., `nodejs:20`, `python:3.12`) instead of runtime-name-only keys (e.g., `nodejs`, `python`). When using a runtime-name-only key, function updates may result in unexpected base image changes. For example, if the default base image for Node.js is `node:20` and you configure `baseImages: { nodejs: "node:22" }`, when you update a function, it will be rebuilt with `node:22` instead of the original `node:20`, since there is no per-version explicit configuration in the `baseImages` map.
+
+> **Important - Python Version Compatibility:** Python base images are **not backward compatible** across versions. Each Python version has its own wheel files (`.whl`), which are breaking compatible. Therefore, **avoid using a default Python base image** (i.e., `python` without a version). Always specify explicit Python versions (e.g., `python:3.12`, `python:3.11`). If you provide a generic `python` key, Nuclio will automatically migrate it to `python:3.12` (the current default Python version).
 
 ## Project Secret-Based Service Account Enrichment and Validation
 

--- a/docs/tasks/configuring-a-platform.md
+++ b/docs/tasks/configuring-a-platform.md
@@ -4,6 +4,7 @@
 - [Overview](#overview)
 - [Creating a platform configuration in Kubernetes](#creating-a-platform-configuration-in-kubernetes)
 - [Configuration elements](#configuration-elements)
+- [Base Images (`baseImages`)](#base-images-baseimages)
 
 ### Overview
 
@@ -310,6 +311,36 @@ kubectl patch deployment nuclio-dashboard \
     }
   ]'
 ```
+
+<a id="base-images"></a>
+### Base Images (`baseImages`)
+
+The `baseImages` configuration allows you to override the default base images used for building function processor images on a per-runtime basis.
+This is useful when you need to use custom base images, such as in air-gapped environments or when using private registries.
+
+The configuration is a map where:
+- **Key**: Runtime name (e.g., `python`, `nodejs`) or runtime name with version (e.g., `python:3.12`, `nodejs:20`)
+- **Value**: The base image to use for that runtime
+
+When both a version-specific key (e.g., `python:3.12`) and a runtime-name-only key (e.g., `python`) are present, the version-specific key takes precedence.
+
+Example:
+```yaml
+baseImages:
+  python: "custom-registry.io/python:3.12"
+  python:3.12: "custom-registry.io/python-3.12:latest"
+  nodejs: "custom-registry.io/node:20"
+  golang: "custom-registry.io/golang:1.21"
+```
+
+In this example:
+- All Python functions will use `custom-registry.io/python:3.12` by default
+- Python 3.12 functions will specifically use `custom-registry.io/python-3.12:latest` (overriding the general `python` setting)
+- Node.js functions will use `custom-registry.io/node:20`
+- Go functions will use `custom-registry.io/golang:1.21`
+
+If a runtime is not specified in the `baseImages` map, Nuclio will use the default base image for that runtime.
+
 
 ## Project Secret-Based Service Account Enrichment and Validation
 

--- a/pkg/common/consts.go
+++ b/pkg/common/consts.go
@@ -68,3 +68,18 @@ const FunctionTagLatest = "latest"
 const FunctionContainerName = "nuclio"
 
 const AnnotationKubectlDefaultContainer = "kubectl.kubernetes.io/default-container"
+
+// Runtime identifiers
+const (
+	RuntimeShell      = "shell"
+	RuntimeGolang     = "golang"
+	RuntimePython     = "python"
+	RuntimePython39   = "python:3.9"
+	RuntimePython310  = "python:3.10"
+	RuntimePython311  = "python:3.11"
+	RuntimePython312  = "python:3.12"
+	RuntimeNodejs     = "nodejs"
+	RuntimeJava       = "java"
+	RuntimeRuby       = "ruby"
+	RuntimeDotnetcore = "dotnetcore"
+)

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -2051,7 +2051,7 @@ func (ap *Platform) getBaseImagesOverrides() map[string]string {
 
 // returns explicit base images per runtime
 func (ap *Platform) getBaseImages() map[string]string {
-	if baseImages := ap.Config.BaseImages; baseImages != nil {
+	if baseImages := ap.Config.RuntimeBaseImages; baseImages != nil {
 		return baseImages
 	}
 	return map[string]string{}

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1066,6 +1066,14 @@ func (ap *Platform) GetBaseImageRegistry(registry string, runtime runtime.Runtim
 	return ap.ContainerBuilder.GetBaseImageRegistry(registry), nil
 }
 
+// GetBaseImage returns the base image resolved for the runtime (explicit or default)
+func (ap *Platform) GetBaseImage(runtime runtime.Runtime) string {
+	baseImages := ap.getBaseImages()
+	defaultBaseImage := runtime.GetDefaultBaseImage()
+
+	return runtime.GetBaseImageFromMap(baseImages, defaultBaseImage)
+}
+
 // GetOnbuildImageRegistry returns onbuild image registry
 func (ap *Platform) GetOnbuildImageRegistry(registry string, runtime runtime.Runtime) (string, error) {
 	onbuildImagesOverrides := ap.getOnbuildImagesOverrides()
@@ -2039,6 +2047,14 @@ func (ap *Platform) enrichProcessingMode(
 // returns overrides for base images per runtime
 func (ap *Platform) getBaseImagesOverrides() map[string]string {
 	return ap.Config.ImageRegistryOverrides.BaseImageRegistries
+}
+
+// returns explicit base images per runtime
+func (ap *Platform) getBaseImages() map[string]string {
+	if baseImages := ap.Config.BaseImages; baseImages != nil {
+		return baseImages
+	}
+	return map[string]string{}
 }
 
 // returns overrides for base images per runtime

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1069,9 +1069,8 @@ func (ap *Platform) GetBaseImageRegistry(registry string, runtime runtime.Runtim
 // GetBaseImage returns the base image resolved for the runtime (explicit or default)
 func (ap *Platform) GetBaseImage(runtime runtime.Runtime) string {
 	baseImages := ap.getBaseImages()
-	defaultBaseImage := runtime.GetDefaultBaseImage()
 
-	return runtime.GetBaseImageFromMap(baseImages, defaultBaseImage)
+	return runtime.GetBaseImageFromMap(baseImages, "")
 }
 
 // GetOnbuildImageRegistry returns onbuild image registry
@@ -2054,7 +2053,7 @@ func (ap *Platform) getBaseImages() map[string]string {
 	if baseImages := ap.Config.RuntimeBaseImages; baseImages != nil {
 		return baseImages
 	}
-	return map[string]string{}
+	return ap.Config.GetDefaultRuntimeBaseImages()
 }
 
 // returns overrides for base images per runtime

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1070,7 +1070,7 @@ func (ap *Platform) GetBaseImageRegistry(registry string, runtime runtime.Runtim
 func (ap *Platform) GetBaseImage(runtime runtime.Runtime) string {
 	baseImages := ap.getBaseImages()
 
-	return runtime.GetBaseImageFromMap(baseImages, "")
+	return runtime.GetBaseImageFromMap(baseImages)
 }
 
 // GetOnbuildImageRegistry returns onbuild image registry
@@ -2050,10 +2050,7 @@ func (ap *Platform) getBaseImagesOverrides() map[string]string {
 
 // returns explicit base images per runtime
 func (ap *Platform) getBaseImages() map[string]string {
-	if baseImages := ap.Config.RuntimeBaseImages; baseImages != nil {
-		return baseImages
-	}
-	return ap.Config.GetDefaultRuntimeBaseImages()
+	return ap.Config.RuntimeBaseImages
 }
 
 // returns overrides for base images per runtime

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1068,9 +1068,7 @@ func (ap *Platform) GetBaseImageRegistry(registry string, runtime runtime.Runtim
 
 // GetBaseImage returns the base image resolved for the runtime (explicit or default)
 func (ap *Platform) GetBaseImage(runtime runtime.Runtime) string {
-	baseImages := ap.getBaseImages()
-
-	return runtime.GetBaseImageFromMap(baseImages)
+	return runtime.GetBaseImageFromMap(ap.Config.RuntimeBaseImages)
 }
 
 // GetOnbuildImageRegistry returns onbuild image registry
@@ -2046,11 +2044,6 @@ func (ap *Platform) enrichProcessingMode(
 // returns overrides for base images per runtime
 func (ap *Platform) getBaseImagesOverrides() map[string]string {
 	return ap.Config.ImageRegistryOverrides.BaseImageRegistries
-}
-
-// returns explicit base images per runtime
-func (ap *Platform) getBaseImages() map[string]string {
-	return ap.Config.RuntimeBaseImages
 }
 
 // returns overrides for base images per runtime

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform"
 	mockedplatform "github.com/nuclio/nuclio/pkg/platform/mock"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/rabbitmq"
 
@@ -60,6 +61,16 @@ const (
 	BriefErrorsMessageFile                   = "brief_errors_message.txt"
 	testProjectName                          = "test-project"
 )
+
+// mockRuntime wraps a concrete Runtime and overrides GetDefaultBaseImage for testing
+type mockRuntime struct {
+	runtime.Runtime
+	defaultBaseImage string
+}
+
+func (m *mockRuntime) GetDefaultBaseImage() string {
+	return m.defaultBaseImage
+}
 
 type AbstractPlatformTestSuite struct {
 	suite.Suite
@@ -2460,6 +2471,116 @@ func (suite *AbstractPlatformTestSuite) TestEnrichPythonVersion() {
 	suite.Require().Equal("python:3.12",
 		functionConfig.Spec.Runtime,
 		"Python version was not set to the default value")
+}
+
+func (suite *AbstractPlatformTestSuite) TestGetBaseImage() {
+	testCases := []struct {
+		name              string
+		baseImages        map[string]string
+		specRuntime       string
+		defaultBaseImage  string
+		expectedBaseImage string
+	}{
+		{
+			name:              "No base images configured - returns default",
+			baseImages:        nil,
+			specRuntime:       "python:3.12",
+			defaultBaseImage:  "gcr.io/iguazio/python:3.12",
+			expectedBaseImage: "gcr.io/iguazio/python:3.12",
+		},
+		{
+			name:              "Empty base images map - returns default",
+			baseImages:        map[string]string{},
+			specRuntime:       "nodejs",
+			defaultBaseImage:  "gcr.io/iguazio/node:20",
+			expectedBaseImage: "gcr.io/iguazio/node:20",
+		},
+		{
+			name: "Base image configured for runtime name only",
+			baseImages: map[string]string{
+				"nodejs": "custom-nodejs:20",
+			},
+			specRuntime:       "nodejs:22",
+			defaultBaseImage:  "gcr.io/iguazio/nodejs:22",
+			expectedBaseImage: "custom-nodejs:20",
+		},
+		{
+			name: "Base image configured for runtime name and version",
+			baseImages: map[string]string{
+				"python:3.12": "custom-python-3.12:latest",
+			},
+			specRuntime:       "python:3.12",
+			defaultBaseImage:  "gcr.io/iguazio/python:3.12",
+			expectedBaseImage: "custom-python-3.12:latest",
+		},
+		{
+			name: "Version-specific override takes precedence over name-only",
+			baseImages: map[string]string{
+				"nodejs":    "nodejs-base:latest",
+				"nodejs:20": "nodejs-20-specific:latest",
+			},
+			specRuntime:       "nodejs:20",
+			defaultBaseImage:  "gcr.io/iguazio/nodejs:20",
+			expectedBaseImage: "nodejs-20-specific:latest",
+		},
+		{
+			name: "No matching base image - returns default when runtime is not explicit",
+			baseImages: map[string]string{
+				"golang": "custom-golang:latest",
+			},
+			specRuntime:       "python",
+			defaultBaseImage:  "gcr.io/iguazio/python:3.12",
+			expectedBaseImage: "gcr.io/iguazio/python:3.12",
+		},
+		{
+			name: "No matching base image - returns default when runtime is explicit",
+			baseImages: map[string]string{
+				"golang": "custom-golang:latest",
+			},
+			specRuntime:       "python:3.11",
+			defaultBaseImage:  "gcr.io/iguazio/python:3.11",
+			expectedBaseImage: "gcr.io/iguazio/python:3.11",
+		},
+	}
+
+	for _, testCase := range testCases {
+		suite.Run(testCase.name, func() {
+			functionConfig := &functionconfig.Config{
+				Spec: functionconfig.Spec{
+					Runtime: testCase.specRuntime,
+				},
+			}
+			runtimeInstance := suite.createTestRuntime(functionConfig)
+			testRuntime := &mockRuntime{
+				Runtime:          runtimeInstance,
+				defaultBaseImage: testCase.defaultBaseImage,
+			}
+
+			platformConfig := &platformconfig.Config{
+				BaseImages: testCase.baseImages,
+			}
+
+			backupBaseImages := suite.Platform.Config.BaseImages
+			suite.Platform.Config.BaseImages = platformConfig.BaseImages
+			defer func() {
+				suite.Platform.Config.BaseImages = backupBaseImages
+			}()
+
+			result := suite.Platform.GetBaseImage(testRuntime)
+			suite.Require().Equal(testCase.expectedBaseImage, result)
+		})
+	}
+}
+
+func (suite *AbstractPlatformTestSuite) createTestRuntime(functionConfig *functionconfig.Config) runtime.Runtime {
+	runtimeName, _ := common.GetRuntimeNameAndVersion(functionConfig.Spec.Runtime)
+	factory, err := runtime.RuntimeRegistrySingleton.Get(runtimeName)
+	suite.Require().NoError(err)
+
+	runtimeInstance, err := factory.(runtime.Factory).Create(suite.Logger, "nop", "/tmp", functionConfig)
+	suite.Require().NoError(err)
+
+	return runtimeInstance
 }
 
 // Test that GetProcessorLogs() generates the expected formattedPodLogs and briefErrorsMessage

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -2503,15 +2503,6 @@ func (suite *AbstractPlatformTestSuite) TestGetBaseImage() {
 			expectedBaseImage: "custom-python-3.12:latest",
 		},
 		{
-			name: "Version-specific override takes precedence over name-only",
-			baseImages: map[string]string{
-				"python":      "bad example: only for testing",
-				"python:3.12": "python-3.12-specific:latest",
-			},
-			specRuntime:       "python:3.12",
-			expectedBaseImage: "python-3.12-specific:latest",
-		},
-		{
 			name: "No matching base image - returns default when runtime is not explicit",
 			baseImages: map[string]string{
 				"golang": "custom-golang:latest",

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -2557,13 +2557,13 @@ func (suite *AbstractPlatformTestSuite) TestGetBaseImage() {
 			}
 
 			platformConfig := &platformconfig.Config{
-				BaseImages: testCase.baseImages,
+				RuntimeBaseImages: testCase.baseImages,
 			}
 
-			backupBaseImages := suite.Platform.Config.BaseImages
-			suite.Platform.Config.BaseImages = platformConfig.BaseImages
+			backupBaseImages := suite.Platform.Config.RuntimeBaseImages
+			suite.Platform.Config.RuntimeBaseImages = platformConfig.RuntimeBaseImages
 			defer func() {
-				suite.Platform.Config.BaseImages = backupBaseImages
+				suite.Platform.Config.RuntimeBaseImages = backupBaseImages
 			}()
 
 			result := suite.Platform.GetBaseImage(testRuntime)

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -68,10 +68,6 @@ type mockRuntime struct {
 	defaultBaseImage string
 }
 
-func (m *mockRuntime) GetDefaultBaseImage() string {
-	return m.defaultBaseImage
-}
-
 type AbstractPlatformTestSuite struct {
 	suite.Suite
 	mockedPlatform *mockedplatform.Platform
@@ -2478,21 +2474,16 @@ func (suite *AbstractPlatformTestSuite) TestGetBaseImage() {
 		name              string
 		baseImages        map[string]string
 		specRuntime       string
-		defaultBaseImage  string
 		expectedBaseImage string
 	}{
 		{
 			name:              "No base images configured - returns default",
-			baseImages:        nil,
 			specRuntime:       "python:3.12",
-			defaultBaseImage:  "gcr.io/iguazio/python:3.12",
 			expectedBaseImage: "gcr.io/iguazio/python:3.12",
 		},
 		{
 			name:              "Empty base images map - returns default",
-			baseImages:        map[string]string{},
 			specRuntime:       "nodejs",
-			defaultBaseImage:  "gcr.io/iguazio/node:20",
 			expectedBaseImage: "gcr.io/iguazio/node:20",
 		},
 		{
@@ -2500,8 +2491,7 @@ func (suite *AbstractPlatformTestSuite) TestGetBaseImage() {
 			baseImages: map[string]string{
 				"nodejs": "custom-nodejs:20",
 			},
-			specRuntime:       "nodejs:22",
-			defaultBaseImage:  "gcr.io/iguazio/nodejs:22",
+			specRuntime:       "nodejs",
 			expectedBaseImage: "custom-nodejs:20",
 		},
 		{
@@ -2510,36 +2500,24 @@ func (suite *AbstractPlatformTestSuite) TestGetBaseImage() {
 				"python:3.12": "custom-python-3.12:latest",
 			},
 			specRuntime:       "python:3.12",
-			defaultBaseImage:  "gcr.io/iguazio/python:3.12",
 			expectedBaseImage: "custom-python-3.12:latest",
 		},
 		{
 			name: "Version-specific override takes precedence over name-only",
 			baseImages: map[string]string{
-				"nodejs":    "nodejs-base:latest",
-				"nodejs:20": "nodejs-20-specific:latest",
+				"python":      "bad example: only for testing",
+				"python:3.12": "python-3.12-specific:latest",
 			},
-			specRuntime:       "nodejs:20",
-			defaultBaseImage:  "gcr.io/iguazio/nodejs:20",
-			expectedBaseImage: "nodejs-20-specific:latest",
+			specRuntime:       "python:3.12",
+			expectedBaseImage: "python-3.12-specific:latest",
 		},
 		{
 			name: "No matching base image - returns default when runtime is not explicit",
 			baseImages: map[string]string{
 				"golang": "custom-golang:latest",
 			},
-			specRuntime:       "python",
-			defaultBaseImage:  "gcr.io/iguazio/python:3.12",
+			specRuntime:       "python:3.12",
 			expectedBaseImage: "gcr.io/iguazio/python:3.12",
-		},
-		{
-			name: "No matching base image - returns default when runtime is explicit",
-			baseImages: map[string]string{
-				"golang": "custom-golang:latest",
-			},
-			specRuntime:       "python:3.11",
-			defaultBaseImage:  "gcr.io/iguazio/python:3.11",
-			expectedBaseImage: "gcr.io/iguazio/python:3.11",
 		},
 	}
 
@@ -2553,12 +2531,14 @@ func (suite *AbstractPlatformTestSuite) TestGetBaseImage() {
 			runtimeInstance := suite.createTestRuntime(functionConfig)
 			testRuntime := &mockRuntime{
 				Runtime:          runtimeInstance,
-				defaultBaseImage: testCase.defaultBaseImage,
+				defaultBaseImage: "",
 			}
 
 			platformConfig := &platformconfig.Config{
 				RuntimeBaseImages: testCase.baseImages,
 			}
+			err := platformConfig.EnrichPlatformConfig()
+			suite.Require().NoError(err)
 
 			backupBaseImages := suite.Platform.Config.RuntimeBaseImages
 			suite.Platform.Config.RuntimeBaseImages = platformConfig.RuntimeBaseImages

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -363,6 +363,10 @@ func (mp *Platform) GetBaseImageRegistry(registry string, runtime runtime.Runtim
 	return "quay.io", nil
 }
 
+func (mp *Platform) GetBaseImage(_ runtime.Runtime) string {
+	return "testBaseImage"
+}
+
 func (mp *Platform) GetOnbuildImageRegistry(registry string, runtime runtime.Runtime) (string, error) {
 	return "", nil
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -211,6 +211,9 @@ type Platform interface {
 	// GetBaseImageRegistry returns base image registry
 	GetBaseImageRegistry(registry string, runtime runtime.Runtime) (string, error)
 
+	// GetBaseImage returns the base image resolved for the runtime (explicit or default)
+	GetBaseImage(runtime runtime.Runtime) string
+
 	// GetDefaultRegistryCredentialsSecretName returns secret with credentials to push/pull from docker registry
 	GetDefaultRegistryCredentialsSecretName() string
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -189,9 +189,7 @@ func (c *Config) EnrichPlatformConfig() error {
 	utils.EnrichProbe(&c.Kube.DefaultReadinessProbe, defaultPlatformConfiguration.Kube.DefaultReadinessProbe)
 	utils.EnrichProbe(&c.Kube.DefaultLivenessProbe, defaultPlatformConfiguration.Kube.DefaultLivenessProbe)
 	c.enrichElasticSearchConfig()
-	if err = c.enrichRuntimeBaseImages(); err != nil {
-		return errors.Wrap(err, "Failed to enrich runtime base images")
-	}
+	c.enrichRuntimeBaseImages()
 
 	return nil
 }
@@ -531,32 +529,22 @@ func (c *Config) getDefaultRuntimeBaseImages() map[string]string {
 	}
 }
 
-func (c *Config) enrichRuntimeBaseImages() error {
+func (c *Config) enrichRuntimeBaseImages() {
 	if c.RuntimeBaseImages == nil {
 		c.RuntimeBaseImages = c.getDefaultRuntimeBaseImages()
-		return nil
+		return
 	}
 
-	// validate that each runtime has a non-empty base image
-	for runtimeName, baseImage := range c.RuntimeBaseImages {
-		if baseImage == "" {
-			return errors.Errorf("Runtime base image cannot be empty, problematic runtime: %s", runtimeName)
-		}
-	}
+	// Python runtime base image keys must specify a version (e.g. `python:3.11`)
+	// remove general python version if exists
+	delete(c.RuntimeBaseImages, common.RuntimePython)
 
-	// validate that specific python versions are used
-	if _, genericPythonExists := c.RuntimeBaseImages[common.RuntimePython]; genericPythonExists {
-		return errors.New("Python runtime base image keys must specify a version (e.g. `python:3.11`)")
-	}
-
-	// fill in any missing runtime base images with defaults
+	// fill in any missing runtime base images with defaults and runtimes with an empty base image value
 	for runtimeName, defaultBaseImage := range c.getDefaultRuntimeBaseImages() {
-		if _, exists := c.RuntimeBaseImages[runtimeName]; !exists {
+		if baseImage, exists := c.RuntimeBaseImages[runtimeName]; !exists || baseImage == "" {
 			c.RuntimeBaseImages[runtimeName] = defaultBaseImage
 		}
 	}
-
-	return nil
 }
 
 func GetDefaultPlatformConfiguration() *Config {

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -385,7 +385,7 @@ func (c *Config) validateRuntimeBaseImages() error {
 
 	// validate that specific python versions are used
 	if _, genericPythonExists := c.RuntimeBaseImages[common.RuntimePython]; genericPythonExists {
-		return errors.New("python runtime base image keys must specify a version (e.g. `python:3.11`)")
+		return errors.New("Python runtime base image keys must specify a version (e.g. `python:3.11`)")
 	}
 
 	// validate there is no empty base image value

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -55,6 +55,7 @@ type Config struct {
 	IngressConfig             IngressConfig                    `json:"ingressConfig,omitempty"`
 	Kube                      PlatformKubeConfig               `json:"kube,omitempty"`
 	Local                     PlatformLocalConfig              `json:"local,omitempty"`
+	BaseImages                map[string]string                `json:"baseImages,omitempty"`
 	ImageRegistryOverrides    ImageRegistryOverridesConfig     `json:"imageRegistryOverrides,omitempty"`
 	Runtime                   *runtimeconfig.Config            `json:"runtime,omitempty"`
 	ProjectsLeader            *ProjectsLeader                  `json:"projectsLeader,omitempty"`

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -189,7 +189,9 @@ func (c *Config) EnrichPlatformConfig() error {
 	utils.EnrichProbe(&c.Kube.DefaultReadinessProbe, defaultPlatformConfiguration.Kube.DefaultReadinessProbe)
 	utils.EnrichProbe(&c.Kube.DefaultLivenessProbe, defaultPlatformConfiguration.Kube.DefaultLivenessProbe)
 	c.enrichElasticSearchConfig()
-	c.enrichRuntimeBaseImages()
+	if err = c.enrichRuntimeBaseImages(); err != nil {
+		return errors.Wrap(err, "Failed to enrich runtime base images")
+	}
 
 	return nil
 }
@@ -513,17 +515,41 @@ func (c *Config) enrichElasticSearchConfig() {
 	}
 }
 
-func (c *Config) enrichRuntimeBaseImages() {
+// GetDefaultRuntimeBaseImages returns the default runtime base images
+func (c *Config) GetDefaultRuntimeBaseImages() map[string]string {
+	return map[string]string{
+		common.RuntimeShell:      "gcr.io/iguazio/alpine:3.20",
+		common.RuntimeGolang:     "gcr.io/iguazio/alpine:3.20",
+		common.RuntimePython39:   "gcr.io/iguazio/python:3.9",
+		common.RuntimePython310:  "gcr.io/iguazio/python:3.10",
+		common.RuntimePython311:  "gcr.io/iguazio/python:3.11",
+		common.RuntimePython312:  "gcr.io/iguazio/python:3.12",
+		common.RuntimeNodejs:     "gcr.io/iguazio/node:20",
+		common.RuntimeJava:       "gcr.io/iguazio/openjdk:11-jre-slim",
+		common.RuntimeRuby:       "gcr.io/iguazio/ruby:2.4.4-alpine",
+		common.RuntimeDotnetcore: "gcr.io/iguazio/dotnet/runtime:9.0",
+	}
+}
+
+func (c *Config) enrichRuntimeBaseImages() error {
 	if c.RuntimeBaseImages == nil {
-		c.RuntimeBaseImages = map[string]string{}
+		c.RuntimeBaseImages = c.GetDefaultRuntimeBaseImages()
+		return nil
 	}
 
-	// since python base images are not backward compatible, explicit version per base image is crucial
-	// migrate the generic "python" key to the specific "python:3.12" key (our current default python version)
-	if pythonBaseImage, exists := c.RuntimeBaseImages["python"]; exists {
-		c.RuntimeBaseImages["python:3.12"] = pythonBaseImage
-		delete(c.RuntimeBaseImages, "python")
+	// validate that specific python versions are used
+	if _, genericPythonExists := c.RuntimeBaseImages[common.RuntimePython]; genericPythonExists {
+		return errors.New("python runtime base image keys must specify a version (e.g., python:3.11)")
 	}
+
+	// fill in any missing runtime base images with defaults
+	for runtimeName, defaultBaseImage := range c.GetDefaultRuntimeBaseImages() {
+		if _, exists := c.RuntimeBaseImages[runtimeName]; !exists {
+			c.RuntimeBaseImages[runtimeName] = defaultBaseImage
+		}
+	}
+
+	return nil
 }
 
 func GetDefaultPlatformConfiguration() *Config {

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -55,7 +55,7 @@ type Config struct {
 	IngressConfig             IngressConfig                    `json:"ingressConfig,omitempty"`
 	Kube                      PlatformKubeConfig               `json:"kube,omitempty"`
 	Local                     PlatformLocalConfig              `json:"local,omitempty"`
-	BaseImages                map[string]string                `json:"baseImages,omitempty"`
+	RuntimeBaseImages         map[string]string                `json:"runtimeBaseImages,omitempty"`
 	ImageRegistryOverrides    ImageRegistryOverridesConfig     `json:"imageRegistryOverrides,omitempty"`
 	Runtime                   *runtimeconfig.Config            `json:"runtime,omitempty"`
 	ProjectsLeader            *ProjectsLeader                  `json:"projectsLeader,omitempty"`
@@ -189,7 +189,7 @@ func (c *Config) EnrichPlatformConfig() error {
 	utils.EnrichProbe(&c.Kube.DefaultReadinessProbe, defaultPlatformConfiguration.Kube.DefaultReadinessProbe)
 	utils.EnrichProbe(&c.Kube.DefaultLivenessProbe, defaultPlatformConfiguration.Kube.DefaultLivenessProbe)
 	c.enrichElasticSearchConfig()
-	c.enrichBaseImages()
+	c.enrichRuntimeBaseImages()
 
 	return nil
 }
@@ -513,16 +513,16 @@ func (c *Config) enrichElasticSearchConfig() {
 	}
 }
 
-func (c *Config) enrichBaseImages() {
-	if c.BaseImages == nil {
-		c.BaseImages = map[string]string{}
+func (c *Config) enrichRuntimeBaseImages() {
+	if c.RuntimeBaseImages == nil {
+		c.RuntimeBaseImages = map[string]string{}
 	}
 
 	// since python base images are not backward compatible, explicit version per base image is crucial
 	// migrate the generic "python" key to the specific "python:3.12" key (our current default python version)
-	if pythonBaseImage, exists := c.BaseImages["python"]; exists {
-		c.BaseImages["python:3.12"] = pythonBaseImage
-		delete(c.BaseImages, "python")
+	if pythonBaseImage, exists := c.RuntimeBaseImages["python"]; exists {
+		c.RuntimeBaseImages["python:3.12"] = pythonBaseImage
+		delete(c.RuntimeBaseImages, "python")
 	}
 }
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -189,6 +189,7 @@ func (c *Config) EnrichPlatformConfig() error {
 	utils.EnrichProbe(&c.Kube.DefaultReadinessProbe, defaultPlatformConfiguration.Kube.DefaultReadinessProbe)
 	utils.EnrichProbe(&c.Kube.DefaultLivenessProbe, defaultPlatformConfiguration.Kube.DefaultLivenessProbe)
 	c.enrichElasticSearchConfig()
+	c.enrichBaseImages()
 
 	return nil
 }
@@ -509,6 +510,19 @@ func (c *Config) enrichElasticSearchConfig() {
 	// override with environment variable if set
 	if envPassword := os.Getenv("NUCLIO_ELASTIC_SEARCH_PASSWORD"); envPassword != "" {
 		c.Kube.ElasticSearchConfig.Password = envPassword
+	}
+}
+
+func (c *Config) enrichBaseImages() {
+	if c.BaseImages == nil {
+		c.BaseImages = map[string]string{}
+	}
+
+	// since python base images are not backward compatible, explicit version per base image is crucial
+	// migrate the generic "python" key to the specific "python:3.12" key (our current default python version)
+	if pythonBaseImage, exists := c.BaseImages["python"]; exists {
+		c.BaseImages["python:3.12"] = pythonBaseImage
+		delete(c.BaseImages, "python")
 	}
 }
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -99,6 +99,10 @@ func NewPlatformConfig(configurationPath string) (*Config, error) {
 		return nil, errors.Wrap(err, "Failed to enrich platform configurations")
 	}
 
+	if err = config.ValidatePlatformConfig(); err != nil {
+		return nil, errors.Wrap(err, "Failed to validate platform configuration")
+	}
+
 	return config, nil
 }
 
@@ -366,6 +370,34 @@ func (c *Config) DisableSensitiveFieldMasking() {
 	c.SensitiveFields.MaskSensitiveFields = false
 }
 
+func (c *Config) ValidatePlatformConfig() error {
+	if err := c.validateRuntimeBaseImages(); err != nil {
+		return errors.Wrap(err, "Failed to validate runtime base images")
+	}
+
+	return nil
+}
+
+func (c *Config) validateRuntimeBaseImages() error {
+	if c.RuntimeBaseImages == nil {
+		return errors.New("No runtime base images specified")
+	}
+
+	// validate that specific python versions are used
+	if _, genericPythonExists := c.RuntimeBaseImages[common.RuntimePython]; genericPythonExists {
+		return errors.New("python runtime base image keys must specify a version (e.g. `python:3.11`)")
+	}
+
+	// validate there is no empty base image value
+	for runtimeName, baseImage := range c.RuntimeBaseImages {
+		if baseImage == "" {
+			return errors.Errorf("Runtime has an empty base image value. Runtime: %s", runtimeName)
+		}
+	}
+
+	return nil
+}
+
 // enrichContainerResources enriches an object's requests and limits with the default
 // resources defined in the platform config, only if they are not already configured
 func (c *Config) enrichContainerResources(ctx context.Context,
@@ -535,13 +567,9 @@ func (c *Config) enrichRuntimeBaseImages() {
 		return
 	}
 
-	// Python runtime base image keys must specify a version (e.g. `python:3.11`)
-	// remove general python version if exists
-	delete(c.RuntimeBaseImages, common.RuntimePython)
-
 	// fill in any missing runtime base images with defaults and runtimes with an empty base image value
 	for runtimeName, defaultBaseImage := range c.getDefaultRuntimeBaseImages() {
-		if baseImage, exists := c.RuntimeBaseImages[runtimeName]; !exists || baseImage == "" {
+		if _, exists := c.RuntimeBaseImages[runtimeName]; !exists {
 			c.RuntimeBaseImages[runtimeName] = defaultBaseImage
 		}
 	}

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -515,8 +515,8 @@ func (c *Config) enrichElasticSearchConfig() {
 	}
 }
 
-// GetDefaultRuntimeBaseImages returns the default runtime base images
-func (c *Config) GetDefaultRuntimeBaseImages() map[string]string {
+// getDefaultRuntimeBaseImages returns the default runtime base images
+func (c *Config) getDefaultRuntimeBaseImages() map[string]string {
 	return map[string]string{
 		common.RuntimeShell:      "gcr.io/iguazio/alpine:3.20",
 		common.RuntimeGolang:     "gcr.io/iguazio/alpine:3.20",
@@ -533,8 +533,15 @@ func (c *Config) GetDefaultRuntimeBaseImages() map[string]string {
 
 func (c *Config) enrichRuntimeBaseImages() error {
 	if c.RuntimeBaseImages == nil {
-		c.RuntimeBaseImages = c.GetDefaultRuntimeBaseImages()
+		c.RuntimeBaseImages = c.getDefaultRuntimeBaseImages()
 		return nil
+	}
+
+	// validate that each runtime has a non-empty base image
+	for runtimeName, baseImage := range c.RuntimeBaseImages {
+		if baseImage == "" {
+			return errors.Errorf("Runtime base image cannot be empty, problematic runtime: %s", runtimeName)
+		}
 	}
 
 	// validate that specific python versions are used
@@ -543,7 +550,7 @@ func (c *Config) enrichRuntimeBaseImages() error {
 	}
 
 	// fill in any missing runtime base images with defaults
-	for runtimeName, defaultBaseImage := range c.GetDefaultRuntimeBaseImages() {
+	for runtimeName, defaultBaseImage := range c.getDefaultRuntimeBaseImages() {
 		if _, exists := c.RuntimeBaseImages[runtimeName]; !exists {
 			c.RuntimeBaseImages[runtimeName] = defaultBaseImage
 		}

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -31,10 +31,10 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
-	"github.com/nuclio/opa-client"
+	opaclient "github.com/nuclio/opa-client"
 	"github.com/v3io/scaler/pkg/scalertypes"
 	autosv2 "k8s.io/api/autoscaling/v2"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -546,7 +546,7 @@ func (c *Config) enrichRuntimeBaseImages() error {
 
 	// validate that specific python versions are used
 	if _, genericPythonExists := c.RuntimeBaseImages[common.RuntimePython]; genericPythonExists {
-		return errors.New("python runtime base image keys must specify a version (e.g., python:3.11)")
+		return errors.New("Python runtime base image keys must specify a version (e.g. `python:3.11`)")
 	}
 
 	// fill in any missing runtime base images with defaults

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -821,12 +821,11 @@ func (suite *PlatformConfigTestSuite) TestEnrichNewPlatformConfig() {
 	}
 }
 
-func (suite *PlatformConfigTestSuite) TestEnrichBaseImages() {
+func (suite *PlatformConfigTestSuite) TestEnrichRuntimeBaseImages() {
 	testCases := []struct {
 		name               string
 		baseImages         map[string]string
 		expectedBaseImages map[string]string
-		expectedError      bool
 	}{
 		{
 			name:               "no base images configured",
@@ -843,11 +842,10 @@ func (suite *PlatformConfigTestSuite) TestEnrichBaseImages() {
 			},
 		},
 		{
-			name: "not explicit version python base image",
+			name: "not explicit version python base image- should remove the general python runtime",
 			baseImages: map[string]string{
 				"python": "custom-python:latest",
 			},
-			expectedError: true,
 		},
 		{
 			name: "python with multiple explicit versions",
@@ -873,18 +871,23 @@ func (suite *PlatformConfigTestSuite) TestEnrichBaseImages() {
 				"nodejs":      "custom-nodejs:latest",
 			},
 		},
+		{
+			name: "empty base image for a runtime- should be override default",
+			baseImages: map[string]string{
+				"python:3.11": "",
+				"python:3.12": "custom-python:latest",
+			},
+			expectedBaseImages: map[string]string{
+				"python:3.12": "custom-python:latest",
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
 		suite.Run(testCase.name, func() {
 			testConfig := &Config{RuntimeBaseImages: testCase.baseImages}
-			err := testConfig.enrichRuntimeBaseImages()
-			if testCase.expectedError {
-				suite.Require().Error(err)
-			} else {
-				suite.Require().NoError(err)
-				suite.Require().Equal(suite.getTestExpectedRuntimeBaseImages(testCase.expectedBaseImages), testConfig.RuntimeBaseImages)
-			}
+			testConfig.enrichRuntimeBaseImages()
+			suite.Require().Equal(suite.getTestExpectedRuntimeBaseImages(testCase.expectedBaseImages), testConfig.RuntimeBaseImages)
 		})
 	}
 }

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -891,7 +891,7 @@ func (suite *PlatformConfigTestSuite) TestEnrichBaseImages() {
 
 func (suite *PlatformConfigTestSuite) getTestExpectedRuntimeBaseImages(testRuntimeBaseImages map[string]string) map[string]string {
 	config := Config{}
-	expectedImages := config.GetDefaultRuntimeBaseImages()
+	expectedImages := config.getDefaultRuntimeBaseImages()
 	for runtimeName, defaultRuntime := range testRuntimeBaseImages {
 		expectedImages[runtimeName] = defaultRuntime
 	}

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -899,9 +899,9 @@ func (suite *PlatformConfigTestSuite) TestEnrichBaseImages() {
 
 	for _, testCase := range testCases {
 		suite.Run(testCase.name, func() {
-			testConfig := &Config{BaseImages: testCase.baseImages}
-			testConfig.enrichBaseImages()
-			suite.Require().Equal(testCase.expectedBaseImages, testConfig.BaseImages)
+			testConfig := &Config{RuntimeBaseImages: testCase.baseImages}
+			testConfig.enrichRuntimeBaseImages()
+			suite.Require().Equal(testCase.expectedBaseImages, testConfig.RuntimeBaseImages)
 		})
 	}
 }

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -821,6 +821,91 @@ func (suite *PlatformConfigTestSuite) TestEnrichNewPlatformConfig() {
 	}
 }
 
+func (suite *PlatformConfigTestSuite) TestEnrichBaseImages() {
+	testCases := []struct {
+		name               string
+		baseImages         map[string]string
+		expectedBaseImages map[string]string
+	}{
+		{
+			name:               "no base images configured",
+			baseImages:         nil,
+			expectedBaseImages: map[string]string{},
+		},
+		{
+			name: "base images configured",
+			baseImages: map[string]string{
+				"python:3.12": "custom-python:3.12",
+			},
+			expectedBaseImages: map[string]string{
+				"python:3.12": "custom-python:3.12",
+			},
+		},
+		{
+			name: "not explicit version python base image",
+			baseImages: map[string]string{
+				"python": "custom-python:latest",
+			},
+			expectedBaseImages: map[string]string{
+				"python:3.12": "custom-python:latest",
+			},
+		},
+		{
+			name: "python base image overlap python:3.12",
+			baseImages: map[string]string{
+				"python":      "custom-python:latest",
+				"python:3.12": "custom-python:3.12",
+			},
+			expectedBaseImages: map[string]string{
+				"python:3.12": "custom-python:latest",
+			},
+		},
+		{
+			name: "python with multiple explicit versions",
+			baseImages: map[string]string{
+				"python:3.9":  "custom-python:3.9",
+				"python:3.10": "custom-python:3.10",
+			},
+			expectedBaseImages: map[string]string{
+				"python:3.9":  "custom-python:3.9",
+				"python:3.10": "custom-python:3.10",
+			},
+		},
+		{
+			name: "python base image and explicit version - base image takes precedence",
+			baseImages: map[string]string{
+				"python":      "custom-python:latest",
+				"python:3.10": "custom-python:3.10",
+			},
+			expectedBaseImages: map[string]string{
+				"python:3.10": "custom-python:3.10",
+				"python:3.12": "custom-python:latest",
+			},
+		},
+		{
+			name: "multiple runtimes with and without overlaps",
+			baseImages: map[string]string{
+				"python":      "custom-python:latest",
+				"golang:1.20": "custom-golang:1.20",
+				"nodejs":      "custom-nodejs:latest",
+			},
+			expectedBaseImages: map[string]string{
+				"python:3.12": "custom-python:latest",
+				"golang:1.20": "custom-golang:1.20",
+				"nodejs":      "custom-nodejs:latest",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		suite.Run(testCase.name, func() {
+			testConfig := &Config{BaseImages: testCase.baseImages}
+			testConfig.enrichBaseImages()
+			suite.Require().Equal(testCase.expectedBaseImages, testConfig.BaseImages)
+		})
+	}
+}
+
 func (suite *PlatformConfigTestSuite) getTestProbeWithInitialDelayConfigured(testDefaultProbe *corev1.Probe, initialDelaySeconds int32) *corev1.Probe {
 	return &corev1.Probe{
 		InitialDelaySeconds: initialDelaySeconds,

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -842,8 +842,11 @@ func (suite *PlatformConfigTestSuite) TestEnrichRuntimeBaseImages() {
 			},
 		},
 		{
-			name: "not explicit version python base image- should remove the general python runtime",
+			name: "not explicit version python base image",
 			baseImages: map[string]string{
+				"python": "custom-python:latest",
+			},
+			expectedBaseImages: map[string]string{
 				"python": "custom-python:latest",
 			},
 		},
@@ -869,16 +872,6 @@ func (suite *PlatformConfigTestSuite) TestEnrichRuntimeBaseImages() {
 				"python:3.12": "custom-python:latest",
 				"golang:1.20": "custom-golang:1.20",
 				"nodejs":      "custom-nodejs:latest",
-			},
-		},
-		{
-			name: "empty base image for a runtime- should be override default",
-			baseImages: map[string]string{
-				"python:3.11": "",
-				"python:3.12": "custom-python:latest",
-			},
-			expectedBaseImages: map[string]string{
-				"python:3.12": "custom-python:latest",
 			},
 		},
 	}

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -826,6 +826,7 @@ func (suite *PlatformConfigTestSuite) TestEnrichBaseImages() {
 		name               string
 		baseImages         map[string]string
 		expectedBaseImages map[string]string
+		expectedError      bool
 	}{
 		{
 			name:               "no base images configured",
@@ -846,19 +847,7 @@ func (suite *PlatformConfigTestSuite) TestEnrichBaseImages() {
 			baseImages: map[string]string{
 				"python": "custom-python:latest",
 			},
-			expectedBaseImages: map[string]string{
-				"python:3.12": "custom-python:latest",
-			},
-		},
-		{
-			name: "python base image overlap python:3.12",
-			baseImages: map[string]string{
-				"python":      "custom-python:latest",
-				"python:3.12": "custom-python:3.12",
-			},
-			expectedBaseImages: map[string]string{
-				"python:3.12": "custom-python:latest",
-			},
+			expectedError: true,
 		},
 		{
 			name: "python with multiple explicit versions",
@@ -872,20 +861,9 @@ func (suite *PlatformConfigTestSuite) TestEnrichBaseImages() {
 			},
 		},
 		{
-			name: "python base image and explicit version - base image takes precedence",
-			baseImages: map[string]string{
-				"python":      "custom-python:latest",
-				"python:3.10": "custom-python:3.10",
-			},
-			expectedBaseImages: map[string]string{
-				"python:3.10": "custom-python:3.10",
-				"python:3.12": "custom-python:latest",
-			},
-		},
-		{
 			name: "multiple runtimes with and without overlaps",
 			baseImages: map[string]string{
-				"python":      "custom-python:latest",
+				"python:3.12": "custom-python:latest",
 				"golang:1.20": "custom-golang:1.20",
 				"nodejs":      "custom-nodejs:latest",
 			},
@@ -900,10 +878,25 @@ func (suite *PlatformConfigTestSuite) TestEnrichBaseImages() {
 	for _, testCase := range testCases {
 		suite.Run(testCase.name, func() {
 			testConfig := &Config{RuntimeBaseImages: testCase.baseImages}
-			testConfig.enrichRuntimeBaseImages()
-			suite.Require().Equal(testCase.expectedBaseImages, testConfig.RuntimeBaseImages)
+			err := testConfig.enrichRuntimeBaseImages()
+			if testCase.expectedError {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(suite.getTestExpectedRuntimeBaseImages(testCase.expectedBaseImages), testConfig.RuntimeBaseImages)
+			}
 		})
 	}
+}
+
+func (suite *PlatformConfigTestSuite) getTestExpectedRuntimeBaseImages(testRuntimeBaseImages map[string]string) map[string]string {
+	config := Config{}
+	expectedImages := config.GetDefaultRuntimeBaseImages()
+	for runtimeName, defaultRuntime := range testRuntimeBaseImages {
+		expectedImages[runtimeName] = defaultRuntime
+	}
+
+	return expectedImages
 }
 
 func (suite *PlatformConfigTestSuite) getTestProbeWithInitialDelayConfigured(testDefaultProbe *corev1.Probe, initialDelaySeconds int32) *corev1.Probe {

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1095,6 +1095,8 @@ func (b *Builder) buildProcessorImage(ctx context.Context) (string, error) {
 	}
 
 	baseImage := b.platform.GetBaseImage(b.runtime)
+	baseImage = b.overrideBaseImageIfSpecified(baseImage, baseImageRegistry)
+	baseImage = b.renderDependantImageURL(baseImage, b.options.DependantImagesRegistryURL)
 
 	imageConfig := &processorImageBuildConfig{
 		baseImageRegistry:    baseImageRegistry,
@@ -1385,15 +1387,7 @@ func (b *Builder) resolveProcessorDockerfileInfo(imageConfig *processorImageBuil
 		OnbuildArtifacts:   runtimeProcessorDockerfileInfo.OnbuildArtifacts,
 		ImageArtifactPaths: runtimeProcessorDockerfileInfo.ImageArtifactPaths,
 		Directives:         runtimeProcessorDockerfileInfo.Directives,
-	}
-
-	// set the base image
-	processorDockerfileInfo.BaseImage = b.getProcessorDockerfileBaseImage(runtimeProcessorDockerfileInfo.BaseImage,
-		imageConfig.baseImageRegistry)
-	processorDockerfileInfo.BaseImage, err = b.renderDependantImageURL(processorDockerfileInfo.BaseImage,
-		b.options.DependantImagesRegistryURL)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to render base image")
+		BaseImage:          runtimeProcessorDockerfileInfo.BaseImage,
 	}
 
 	// set the onbuild images
@@ -1404,11 +1398,8 @@ func (b *Builder) resolveProcessorDockerfileInfo(imageConfig *processorImageBuil
 			return nil, errors.Wrap(err, "Failed to get onbuild image")
 		}
 
-		processorDockerfileInfo.OnbuildArtifacts[idx].Image, err = b.renderDependantImageURL(onbuildArtifact.Image,
+		processorDockerfileInfo.OnbuildArtifacts[idx].Image = b.renderDependantImageURL(onbuildArtifact.Image,
 			b.options.DependantImagesRegistryURL)
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to render onbuild image")
-		}
 	}
 
 	// if the platform requires an internal healthcheck client - add health check artifact
@@ -1428,10 +1419,10 @@ func (b *Builder) resolveProcessorDockerfileInfo(imageConfig *processorImageBuil
 	return &processorDockerfileInfo, nil
 }
 
-func (b *Builder) getProcessorDockerfileBaseImage(runtimeDefaultBaseImage string, baseImageRegistry string) string {
-
+func (b *Builder) overrideBaseImageIfSpecified(runtimeDefaultBaseImage string, baseImageRegistry string) string {
+	functionSpecBaseImage := b.options.FunctionConfig.Spec.Build.BaseImage
 	// override base image, if required
-	switch b.options.FunctionConfig.Spec.Build.BaseImage {
+	switch functionSpecBaseImage {
 
 	// if user didn't pass anything, use default as specified in Dockerfile
 	case "":
@@ -1447,8 +1438,8 @@ func (b *Builder) getProcessorDockerfileBaseImage(runtimeDefaultBaseImage string
 	// see description on https://github.com/nuclio/nuclio/pull/1544 - we don't implicitly mutate the given baseimage
 	default:
 		b.logger.WarnWith("Using user provided base image, runtime interpreter version is provided by the base image",
-			"baseImage", b.options.FunctionConfig.Spec.Build.BaseImage)
-		return b.options.FunctionConfig.Spec.Build.BaseImage
+			"baseImage", functionSpecBaseImage)
+		return functionSpecBaseImage
 	}
 }
 
@@ -1640,9 +1631,9 @@ func (b *Builder) getSourceCodeFromFilePath() (string, error) {
 }
 
 // replaces the registry url if applicable. e.g. quay.io/nuclio/some-image:0.0.1 -> 10.0.0.1:2000/some-image:0.0.1
-func (b *Builder) renderDependantImageURL(imageURL string, dependantImagesRegistryURL string) (string, error) {
+func (b *Builder) renderDependantImageURL(imageURL string, dependantImagesRegistryURL string) string {
 	if dependantImagesRegistryURL == "" {
-		return imageURL, nil
+		return imageURL
 	}
 
 	// be tolerant of trailing slash in dependantImagesRegistryURL
@@ -1659,7 +1650,7 @@ func (b *Builder) renderDependantImageURL(imageURL string, dependantImagesRegist
 		"dependantImagesRegistryURL", dependantImagesRegistryURL,
 		"renderedImageURL", renderedImageURL)
 
-	return renderedImageURL, nil
+	return renderedImageURL
 }
 
 func (b *Builder) resolveFunctionPathFromURL(ctx context.Context, functionPath string, codeEntryType string) (string, error) {

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1089,7 +1089,7 @@ func (b *Builder) buildProcessorImage(ctx context.Context) (string, error) {
 
 	baseImage := b.platform.GetBaseImage(b.runtime)
 
-	processorDockerfileInfo, err := b.createProcessorDockerfile(ctx, baseImageRegistry, onbuildImageRegistry)
+	processorDockerfileInfo, err := b.createProcessorDockerfile(ctx, baseImageRegistry, onbuildImageRegistry, baseImage)
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to create processor dockerfile")
 	}
@@ -1174,11 +1174,12 @@ func (b *Builder) resolveRepoName(registryURL string) string {
 
 func (b *Builder) createProcessorDockerfile(ctx context.Context,
 	baseImageRegistry string,
-	onbuildImageRegistry string) (
+	onbuildImageRegistry string,
+	baseImage string) (
 	*runtime.ProcessorDockerfileInfo, error) {
 
 	// get the contents of the processor dockerfile from the runtime
-	processorDockerfileInfo, err := b.getRuntimeProcessorDockerfileInfo(baseImageRegistry, onbuildImageRegistry)
+	processorDockerfileInfo, err := b.getRuntimeProcessorDockerfileInfo(baseImageRegistry, onbuildImageRegistry, baseImage)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get Dockerfile contents")
 	}
@@ -1307,11 +1308,11 @@ func (b *Builder) getHandlerDir(stagingDir string) string {
 	return path.Join(stagingDir, "handler")
 }
 
-func (b *Builder) getRuntimeProcessorDockerfileInfo(baseImageRegistry string, onbuildImageRegistry string) (
+func (b *Builder) getRuntimeProcessorDockerfileInfo(baseImageRegistry, onbuildImageRegistry, baseImage string) (
 	*runtime.ProcessorDockerfileInfo, error) {
 
 	// gather the processor dockerfile info
-	processorDockerfileInfo, err := b.resolveProcessorDockerfileInfo(baseImageRegistry, onbuildImageRegistry)
+	processorDockerfileInfo, err := b.resolveProcessorDockerfileInfo(baseImageRegistry, onbuildImageRegistry, baseImage)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get processor Dockerfile info")
 	}
@@ -1360,12 +1361,11 @@ func (b *Builder) getRuntimeProcessorDockerfileInfo(baseImageRegistry string, on
 	return processorDockerfileInfo, nil
 }
 
-func (b *Builder) resolveProcessorDockerfileInfo(baseImageRegistry string,
-	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
+func (b *Builder) resolveProcessorDockerfileInfo(baseImageRegistry, onbuildImageRegistry, baseImage string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	// get defaults from the runtime
 	runtimeProcessorDockerfileInfo, err := b.runtime.GetProcessorDockerfileInfo(b.platform.GetConfig().Runtime,
-		onbuildImageRegistry)
+		onbuildImageRegistry, baseImage)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get processor Dockerfile info")
 	}

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1087,6 +1087,8 @@ func (b *Builder) buildProcessorImage(ctx context.Context) (string, error) {
 		}
 	}
 
+	baseImage := b.platform.GetBaseImage(b.runtime)
+
 	processorDockerfileInfo, err := b.createProcessorDockerfile(ctx, baseImageRegistry, onbuildImageRegistry)
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to create processor dockerfile")
@@ -1103,7 +1105,8 @@ func (b *Builder) buildProcessorImage(ctx context.Context) (string, error) {
 	b.logger.InfoWithCtx(ctx,
 		"Building processor image",
 		"registryURL", registryURL,
-		"taggedImageName", taggedImageName)
+		"taggedImageName", taggedImageName,
+		"baseImage", baseImage)
 
 	err = b.platform.BuildAndPushContainerImage(ctx,
 		&containerimagebuilderpusher.BuildOptions{

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1095,10 +1095,7 @@ func (b *Builder) buildProcessorImage(ctx context.Context) (string, error) {
 	}
 
 	baseImage := b.platform.GetBaseImage(b.runtime)
-	baseImage, err = b.overrideBaseImageIfSpecified(baseImage, baseImageRegistry)
-	if err != nil {
-		return "", errors.Wrap(err, "Failed to set base image")
-	}
+	baseImage = b.overrideBaseImageIfSpecified(baseImage, baseImageRegistry)
 	baseImage = b.renderDependantImageURL(baseImage, b.options.DependantImagesRegistryURL)
 
 	imageConfig := &processorImageBuildConfig{
@@ -1422,7 +1419,7 @@ func (b *Builder) resolveProcessorDockerfileInfo(imageConfig *processorImageBuil
 	return &processorDockerfileInfo, nil
 }
 
-func (b *Builder) overrideBaseImageIfSpecified(runtimeBaseImage string, baseImageRegistry string) (string, error) {
+func (b *Builder) overrideBaseImageIfSpecified(runtimeBaseImage string, baseImageRegistry string) string {
 	functionSpecBaseImage := b.options.FunctionConfig.Spec.Build.BaseImage
 	// override base image, if required
 	switch functionSpecBaseImage {
@@ -1430,24 +1427,19 @@ func (b *Builder) overrideBaseImageIfSpecified(runtimeBaseImage string, baseImag
 	// if user didn't pass anything, use default as specified in Dockerfile
 	case "":
 		if baseImageRegistry == "" {
-			return runtimeBaseImage, nil
-		}
-
-		// Validation occurs here because the function spec may override the runtime base image; if both are empty, raise an error
-		if runtimeBaseImage == "" {
-			return "", errors.Errorf("Base image not specified")
+			return runtimeBaseImage
 		}
 
 		// get only image name and concatenate it with registry
 		imageName := path.Base(runtimeBaseImage)
-		return strings.Join([]string{baseImageRegistry, imageName}, "/"), nil
+		return strings.Join([]string{baseImageRegistry, imageName}, "/")
 
 	// if user specified something - use that, as is
 	// see description on https://github.com/nuclio/nuclio/pull/1544 - we don't implicitly mutate the given baseimage
 	default:
 		b.logger.WarnWith("Using user provided base image, runtime interpreter version is provided by the base image",
 			"baseImage", functionSpecBaseImage)
-		return functionSpecBaseImage, nil
+		return functionSpecBaseImage
 	}
 }
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -441,17 +441,17 @@ func (b *Builder) initializeSupportedRuntimes() {
 	slashSlashParser := inlineparser.NewParser(b.logger, "//")
 	poundParser := inlineparser.NewParser(b.logger, "#")
 
-	b.runtimeInfo["shell"] = runtimeInfo{"sh", poundParser, 0}
-	b.runtimeInfo["golang"] = runtimeInfo{"go", slashSlashParser, 0}
-	b.runtimeInfo["python"] = runtimeInfo{"py", poundParser, 10}
-	b.runtimeInfo["python:3.9"] = runtimeInfo{"py", poundParser, 5}
-	b.runtimeInfo["python:3.10"] = runtimeInfo{"py", poundParser, 5}
-	b.runtimeInfo["python:3.11"] = runtimeInfo{"py", poundParser, 5}
-	b.runtimeInfo["python:3.12"] = runtimeInfo{"py", poundParser, 5}
-	b.runtimeInfo["nodejs"] = runtimeInfo{"js", slashSlashParser, 0}
-	b.runtimeInfo["java"] = runtimeInfo{"java", slashSlashParser, 0}
-	b.runtimeInfo["ruby"] = runtimeInfo{"rb", poundParser, 0}
-	b.runtimeInfo["dotnetcore"] = runtimeInfo{"cs", slashSlashParser, 0}
+	b.runtimeInfo[common.RuntimeShell] = runtimeInfo{"sh", poundParser, 0}
+	b.runtimeInfo[common.RuntimeGolang] = runtimeInfo{"go", slashSlashParser, 0}
+	b.runtimeInfo[common.RuntimePython] = runtimeInfo{"py", poundParser, 10}
+	b.runtimeInfo[common.RuntimePython39] = runtimeInfo{"py", poundParser, 5}
+	b.runtimeInfo[common.RuntimePython310] = runtimeInfo{"py", poundParser, 5}
+	b.runtimeInfo[common.RuntimePython311] = runtimeInfo{"py", poundParser, 5}
+	b.runtimeInfo[common.RuntimePython312] = runtimeInfo{"py", poundParser, 5}
+	b.runtimeInfo[common.RuntimeNodejs] = runtimeInfo{"js", slashSlashParser, 0}
+	b.runtimeInfo[common.RuntimeJava] = runtimeInfo{"java", slashSlashParser, 0}
+	b.runtimeInfo[common.RuntimeRuby] = runtimeInfo{"rb", poundParser, 0}
+	b.runtimeInfo[common.RuntimeDotnetcore] = runtimeInfo{"cs", slashSlashParser, 0}
 }
 
 func (b *Builder) readConfiguration() (string, error) {

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1095,7 +1095,10 @@ func (b *Builder) buildProcessorImage(ctx context.Context) (string, error) {
 	}
 
 	baseImage := b.platform.GetBaseImage(b.runtime)
-	baseImage = b.overrideBaseImageIfSpecified(baseImage, baseImageRegistry)
+	baseImage, err = b.overrideBaseImageIfSpecified(baseImage, baseImageRegistry)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to set base image")
+	}
 	baseImage = b.renderDependantImageURL(baseImage, b.options.DependantImagesRegistryURL)
 
 	imageConfig := &processorImageBuildConfig{
@@ -1419,7 +1422,7 @@ func (b *Builder) resolveProcessorDockerfileInfo(imageConfig *processorImageBuil
 	return &processorDockerfileInfo, nil
 }
 
-func (b *Builder) overrideBaseImageIfSpecified(runtimeDefaultBaseImage string, baseImageRegistry string) string {
+func (b *Builder) overrideBaseImageIfSpecified(runtimeBaseImage string, baseImageRegistry string) (string, error) {
 	functionSpecBaseImage := b.options.FunctionConfig.Spec.Build.BaseImage
 	// override base image, if required
 	switch functionSpecBaseImage {
@@ -1427,19 +1430,24 @@ func (b *Builder) overrideBaseImageIfSpecified(runtimeDefaultBaseImage string, b
 	// if user didn't pass anything, use default as specified in Dockerfile
 	case "":
 		if baseImageRegistry == "" {
-			return runtimeDefaultBaseImage
+			return runtimeBaseImage, nil
+		}
+
+		// Validation occurs here because the function spec may override the runtime base image; if both are empty, raise an error
+		if runtimeBaseImage == "" {
+			return "", errors.Errorf("Base image not specified")
 		}
 
 		// get only image name and concatenate it with registry
-		imageName := path.Base(runtimeDefaultBaseImage)
-		return strings.Join([]string{baseImageRegistry, imageName}, "/")
+		imageName := path.Base(runtimeBaseImage)
+		return strings.Join([]string{baseImageRegistry, imageName}, "/"), nil
 
 	// if user specified something - use that, as is
 	// see description on https://github.com/nuclio/nuclio/pull/1544 - we don't implicitly mutate the given baseimage
 	default:
 		b.logger.WarnWith("Using user provided base image, runtime interpreter version is provided by the base image",
 			"baseImage", functionSpecBaseImage)
-		return functionSpecBaseImage
+		return functionSpecBaseImage, nil
 	}
 }
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -89,6 +89,13 @@ type runtimeInfo struct {
 	weight int
 }
 
+// processorImageBuildConfig holds configuration for processor image building
+type processorImageBuildConfig struct {
+	baseImageRegistry    string
+	onbuildImageRegistry string
+	baseImage            string
+}
+
 // Builder builds user handlers
 type Builder struct {
 	logger logger.Logger
@@ -1089,7 +1096,13 @@ func (b *Builder) buildProcessorImage(ctx context.Context) (string, error) {
 
 	baseImage := b.platform.GetBaseImage(b.runtime)
 
-	processorDockerfileInfo, err := b.createProcessorDockerfile(ctx, baseImageRegistry, onbuildImageRegistry, baseImage)
+	imageConfig := &processorImageBuildConfig{
+		baseImageRegistry:    baseImageRegistry,
+		onbuildImageRegistry: onbuildImageRegistry,
+		baseImage:            baseImage,
+	}
+
+	processorDockerfileInfo, err := b.createProcessorDockerfile(ctx, imageConfig)
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to create processor dockerfile")
 	}
@@ -1173,13 +1186,11 @@ func (b *Builder) resolveRepoName(registryURL string) string {
 }
 
 func (b *Builder) createProcessorDockerfile(ctx context.Context,
-	baseImageRegistry string,
-	onbuildImageRegistry string,
-	baseImage string) (
+	imageConfig *processorImageBuildConfig) (
 	*runtime.ProcessorDockerfileInfo, error) {
 
 	// get the contents of the processor dockerfile from the runtime
-	processorDockerfileInfo, err := b.getRuntimeProcessorDockerfileInfo(baseImageRegistry, onbuildImageRegistry, baseImage)
+	processorDockerfileInfo, err := b.getRuntimeProcessorDockerfileInfo(imageConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get Dockerfile contents")
 	}
@@ -1188,8 +1199,8 @@ func (b *Builder) createProcessorDockerfile(ctx context.Context,
 	b.logger.DebugWithCtx(ctx,
 		"Created processor Dockerfile",
 		"dockerfileInfo", processorDockerfileInfo.DockerfileContents,
-		"baseImageRegistry", baseImageRegistry,
-		"onbuildImageRegistry", onbuildImageRegistry)
+		"baseImageRegistry", imageConfig.baseImageRegistry,
+		"onbuildImageRegistry", imageConfig.onbuildImageRegistry)
 
 	// write the contents to the path
 	if err := os.WriteFile(processorDockerfileInfo.DockerfilePath,
@@ -1308,11 +1319,11 @@ func (b *Builder) getHandlerDir(stagingDir string) string {
 	return path.Join(stagingDir, "handler")
 }
 
-func (b *Builder) getRuntimeProcessorDockerfileInfo(baseImageRegistry, onbuildImageRegistry, baseImage string) (
+func (b *Builder) getRuntimeProcessorDockerfileInfo(imageConfig *processorImageBuildConfig) (
 	*runtime.ProcessorDockerfileInfo, error) {
 
 	// gather the processor dockerfile info
-	processorDockerfileInfo, err := b.resolveProcessorDockerfileInfo(baseImageRegistry, onbuildImageRegistry, baseImage)
+	processorDockerfileInfo, err := b.resolveProcessorDockerfileInfo(imageConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get processor Dockerfile info")
 	}
@@ -1361,11 +1372,11 @@ func (b *Builder) getRuntimeProcessorDockerfileInfo(baseImageRegistry, onbuildIm
 	return processorDockerfileInfo, nil
 }
 
-func (b *Builder) resolveProcessorDockerfileInfo(baseImageRegistry, onbuildImageRegistry, baseImage string) (*runtime.ProcessorDockerfileInfo, error) {
+func (b *Builder) resolveProcessorDockerfileInfo(imageConfig *processorImageBuildConfig) (*runtime.ProcessorDockerfileInfo, error) {
 
 	// get defaults from the runtime
 	runtimeProcessorDockerfileInfo, err := b.runtime.GetProcessorDockerfileInfo(b.platform.GetConfig().Runtime,
-		onbuildImageRegistry, baseImage)
+		imageConfig.onbuildImageRegistry, imageConfig.baseImage)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get processor Dockerfile info")
 	}
@@ -1378,7 +1389,7 @@ func (b *Builder) resolveProcessorDockerfileInfo(baseImageRegistry, onbuildImage
 
 	// set the base image
 	processorDockerfileInfo.BaseImage = b.getProcessorDockerfileBaseImage(runtimeProcessorDockerfileInfo.BaseImage,
-		baseImageRegistry)
+		imageConfig.baseImageRegistry)
 	processorDockerfileInfo.BaseImage, err = b.renderDependantImageURL(processorDockerfileInfo.BaseImage,
 		b.options.DependantImagesRegistryURL)
 	if err != nil {

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -492,8 +492,7 @@ func (suite *testSuite) TestRenderDependantImageURL() {
 		{"base/" + imageNameAndTag, replacementURL + "/", replacementURL + "/" + imageNameAndTag},
 		{"base/sub/" + imageNameAndTag, replacementURL, replacementURL + "/" + imageNameAndTag},
 	} {
-		renderedImageURL, err := suite.builder.renderDependantImageURL(testCase.imageURL, testCase.replacementURL)
-		suite.Require().NoError(err)
+		renderedImageURL := suite.builder.renderDependantImageURL(testCase.imageURL, testCase.replacementURL)
 		suite.Require().Equal(testCase.expectedImageURL, renderedImageURL)
 	}
 }
@@ -1142,7 +1141,7 @@ func (suite *testSuite) TestGetProcessorDockerfileBaseImage() {
 			defer func() {
 				suite.builder.options.FunctionConfig.Spec.Build.BaseImage = oldBaseImage
 			}()
-			result := suite.builder.getProcessorDockerfileBaseImage(tc.runtimeDefaultBaseImage, tc.baseImageRegistry)
+			result := suite.builder.overrideBaseImageIfSpecified(tc.runtimeDefaultBaseImage, tc.baseImageRegistry)
 			suite.Require().Equal(tc.expected, result)
 		})
 	}

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -1141,7 +1141,8 @@ func (suite *testSuite) TestGetProcessorDockerfileBaseImage() {
 			defer func() {
 				suite.builder.options.FunctionConfig.Spec.Build.BaseImage = oldBaseImage
 			}()
-			result := suite.builder.overrideBaseImageIfSpecified(tc.runtimeDefaultBaseImage, tc.baseImageRegistry)
+			result, err := suite.builder.overrideBaseImageIfSpecified(tc.runtimeDefaultBaseImage, tc.baseImageRegistry)
+			suite.Require().NoError(err)
 			suite.Require().Equal(tc.expected, result)
 		})
 	}

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -1141,8 +1141,7 @@ func (suite *testSuite) TestGetProcessorDockerfileBaseImage() {
 			defer func() {
 				suite.builder.options.FunctionConfig.Spec.Build.BaseImage = oldBaseImage
 			}()
-			result, err := suite.builder.overrideBaseImageIfSpecified(tc.runtimeDefaultBaseImage, tc.baseImageRegistry)
-			suite.Require().NoError(err)
+			result := suite.builder.overrideBaseImageIfSpecified(tc.runtimeDefaultBaseImage, tc.baseImageRegistry)
 			suite.Require().Equal(tc.expected, result)
 		})
 	}

--- a/pkg/processor/build/runtime/dotnetcore/runtime.go
+++ b/pkg/processor/build/runtime/dotnetcore/runtime.go
@@ -23,6 +23,8 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 )
 
+const defaultBaseImage = "gcr.io/iguazio/dotnet/runtime:9.0"
+
 type dotnetcore struct {
 	*runtime.AbstractRuntime
 }
@@ -54,6 +56,11 @@ func (d *dotnetcore) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Con
 	processorDockerfileInfo.OnbuildArtifacts = []runtime.Artifact{artifact}
 
 	// set the default base image
-	processorDockerfileInfo.BaseImage = "gcr.io/iguazio/dotnet/runtime:9.0"
+	processorDockerfileInfo.BaseImage = defaultBaseImage
 	return &processorDockerfileInfo, nil
+}
+
+// GetDefaultBaseImage returns the default base image for dotnetcore runtime
+func (d *dotnetcore) GetDefaultBaseImage() string {
+	return defaultBaseImage
 }

--- a/pkg/processor/build/runtime/dotnetcore/runtime.go
+++ b/pkg/processor/build/runtime/dotnetcore/runtime.go
@@ -35,7 +35,8 @@ func (d *dotnetcore) GetName() string {
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (d *dotnetcore) GetProcessorDockerfileInfo(
 	_ *runtimeconfig.Config,
-	onbuildImageRegistry, baseImage string,
+	onbuildImageRegistry string,
+	baseImage string,
 ) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}

--- a/pkg/processor/build/runtime/dotnetcore/runtime.go
+++ b/pkg/processor/build/runtime/dotnetcore/runtime.go
@@ -23,8 +23,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 )
 
-const defaultBaseImage = "gcr.io/iguazio/dotnet/runtime:9.0"
-
 type dotnetcore struct {
 	*runtime.AbstractRuntime
 }
@@ -60,9 +58,4 @@ func (d *dotnetcore) GetProcessorDockerfileInfo(
 
 	processorDockerfileInfo.BaseImage = baseImage
 	return &processorDockerfileInfo, nil
-}
-
-// GetDefaultBaseImage returns the default base image for dotnetcore runtime
-func (d *dotnetcore) GetDefaultBaseImage() string {
-	return defaultBaseImage
 }

--- a/pkg/processor/build/runtime/dotnetcore/runtime.go
+++ b/pkg/processor/build/runtime/dotnetcore/runtime.go
@@ -35,7 +35,10 @@ func (d *dotnetcore) GetName() string {
 }
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-func (d *dotnetcore) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
+func (d *dotnetcore) GetProcessorDockerfileInfo(
+	_ *runtimeconfig.Config,
+	onbuildImageRegistry, baseImage string,
+) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
@@ -55,8 +58,7 @@ func (d *dotnetcore) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Con
 	}
 	processorDockerfileInfo.OnbuildArtifacts = []runtime.Artifact{artifact}
 
-	// set the default base image
-	processorDockerfileInfo.BaseImage = defaultBaseImage
+	processorDockerfileInfo.BaseImage = baseImage
 	return &processorDockerfileInfo, nil
 }
 

--- a/pkg/processor/build/runtime/golang/runtime.go
+++ b/pkg/processor/build/runtime/golang/runtime.go
@@ -62,7 +62,8 @@ func (g *golang) GetName() string {
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (g *golang) GetProcessorDockerfileInfo(
 	_ *runtimeconfig.Config,
-	onbuildImageRegistry, baseImage string,
+	onbuildImageRegistry string,
+	baseImage string,
 ) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{

--- a/pkg/processor/build/runtime/golang/runtime.go
+++ b/pkg/processor/build/runtime/golang/runtime.go
@@ -27,6 +27,8 @@ import (
 	"github.com/nuclio/errors"
 )
 
+const defaultBaseImage = "gcr.io/iguazio/alpine:3.20"
+
 type golang struct {
 	*runtime.AbstractRuntime
 }
@@ -63,7 +65,7 @@ func (g *golang) GetName() string {
 func (g *golang) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{
-		BaseImage: "gcr.io/iguazio/alpine:3.20",
+		BaseImage: defaultBaseImage,
 	}
 
 	// if the base image is not default (which is alpine) and is not alpine based, must use the non-alpine onbuild image
@@ -91,4 +93,9 @@ func (g *golang) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config,
 	processorDockerfileInfo.OnbuildArtifacts = []runtime.Artifact{artifact}
 
 	return &processorDockerfileInfo, nil
+}
+
+// GetDefaultBaseImage returns the default base image for golang runtime
+func (g *golang) GetDefaultBaseImage() string {
+	return defaultBaseImage
 }

--- a/pkg/processor/build/runtime/golang/runtime.go
+++ b/pkg/processor/build/runtime/golang/runtime.go
@@ -62,10 +62,13 @@ func (g *golang) GetName() string {
 }
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-func (g *golang) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
+func (g *golang) GetProcessorDockerfileInfo(
+	_ *runtimeconfig.Config,
+	onbuildImageRegistry, baseImage string,
+) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{
-		BaseImage: defaultBaseImage,
+		BaseImage: baseImage,
 	}
 
 	// if the base image is not default (which is alpine) and is not alpine based, must use the non-alpine onbuild image

--- a/pkg/processor/build/runtime/golang/runtime.go
+++ b/pkg/processor/build/runtime/golang/runtime.go
@@ -27,8 +27,6 @@ import (
 	"github.com/nuclio/errors"
 )
 
-const defaultBaseImage = "gcr.io/iguazio/alpine:3.20"
-
 type golang struct {
 	*runtime.AbstractRuntime
 }
@@ -96,9 +94,4 @@ func (g *golang) GetProcessorDockerfileInfo(
 	processorDockerfileInfo.OnbuildArtifacts = []runtime.Artifact{artifact}
 
 	return &processorDockerfileInfo, nil
-}
-
-// GetDefaultBaseImage returns the default base image for golang runtime
-func (g *golang) GetDefaultBaseImage() string {
-	return defaultBaseImage
 }

--- a/pkg/processor/build/runtime/java/runtime.go
+++ b/pkg/processor/build/runtime/java/runtime.go
@@ -50,7 +50,8 @@ func (j *java) OnAfterStagingDirCreated(runtimeConfig *runtimeconfig.Config, sta
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (j *java) GetProcessorDockerfileInfo(
 	_ *runtimeconfig.Config,
-	onbuildImageRegistry, baseImage string,
+	onbuildImageRegistry string,
+	baseImage string,
 ) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}

--- a/pkg/processor/build/runtime/java/runtime.go
+++ b/pkg/processor/build/runtime/java/runtime.go
@@ -50,10 +50,13 @@ func (j *java) OnAfterStagingDirCreated(runtimeConfig *runtimeconfig.Config, sta
 }
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-func (j *java) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
+func (j *java) GetProcessorDockerfileInfo(
+	_ *runtimeconfig.Config,
+	onbuildImageRegistry, baseImage string,
+) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
-	processorDockerfileInfo.BaseImage = defaultBaseImage
+	processorDockerfileInfo.BaseImage = baseImage
 
 	// fill onbuild artifact
 	artifact := runtime.Artifact{

--- a/pkg/processor/build/runtime/java/runtime.go
+++ b/pkg/processor/build/runtime/java/runtime.go
@@ -31,8 +31,6 @@ import (
 	"github.com/nuclio/errors"
 )
 
-const defaultBaseImage = "gcr.io/iguazio/openjdk:11-jre-slim"
-
 type java struct {
 	*runtime.AbstractRuntime
 }
@@ -73,11 +71,6 @@ func (j *java) GetProcessorDockerfileInfo(
 	processorDockerfileInfo.OnbuildArtifacts = []runtime.Artifact{artifact}
 
 	return &processorDockerfileInfo, nil
-}
-
-// GetDefaultBaseImage returns the default base image for java runtime
-func (j *java) GetDefaultBaseImage() string {
-	return defaultBaseImage
 }
 
 func (j *java) createGradleBuildScript(stagingBuildDir string) error {

--- a/pkg/processor/build/runtime/java/runtime.go
+++ b/pkg/processor/build/runtime/java/runtime.go
@@ -31,6 +31,8 @@ import (
 	"github.com/nuclio/errors"
 )
 
+const defaultBaseImage = "gcr.io/iguazio/openjdk:11-jre-slim"
+
 type java struct {
 	*runtime.AbstractRuntime
 }
@@ -51,7 +53,7 @@ func (j *java) OnAfterStagingDirCreated(runtimeConfig *runtimeconfig.Config, sta
 func (j *java) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
-	processorDockerfileInfo.BaseImage = "gcr.io/iguazio/openjdk:11-jre-slim"
+	processorDockerfileInfo.BaseImage = defaultBaseImage
 
 	// fill onbuild artifact
 	artifact := runtime.Artifact{
@@ -68,6 +70,11 @@ func (j *java) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, o
 	processorDockerfileInfo.OnbuildArtifacts = []runtime.Artifact{artifact}
 
 	return &processorDockerfileInfo, nil
+}
+
+// GetDefaultBaseImage returns the default base image for java runtime
+func (j *java) GetDefaultBaseImage() string {
+	return defaultBaseImage
 }
 
 func (j *java) createGradleBuildScript(stagingBuildDir string) error {

--- a/pkg/processor/build/runtime/nodejs/runtime.go
+++ b/pkg/processor/build/runtime/nodejs/runtime.go
@@ -24,8 +24,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 )
 
-const defaultBaseImage = "gcr.io/iguazio/node:20"
-
 type nodejs struct {
 	*runtime.AbstractRuntime
 }
@@ -71,9 +69,4 @@ func (n *nodejs) GetProcessorDockerfileInfo(
 	}
 
 	return &processorDockerfileInfo, nil
-}
-
-// GetDefaultBaseImage returns the default base image for nodejs runtime
-func (n *nodejs) GetDefaultBaseImage() string {
-	return defaultBaseImage
 }

--- a/pkg/processor/build/runtime/nodejs/runtime.go
+++ b/pkg/processor/build/runtime/nodejs/runtime.go
@@ -36,12 +36,15 @@ func (n *nodejs) GetName() string {
 }
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-func (n *nodejs) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
+func (n *nodejs) GetProcessorDockerfileInfo(
+	_ *runtimeconfig.Config,
+	onbuildImageRegistry, baseImage string,
+) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
 	// set the default base image
-	processorDockerfileInfo.BaseImage = defaultBaseImage
+	processorDockerfileInfo.BaseImage = baseImage
 
 	processorDockerfileInfo.ImageArtifactPaths = map[string]string{
 		"handler": "/opt/nuclio",

--- a/pkg/processor/build/runtime/nodejs/runtime.go
+++ b/pkg/processor/build/runtime/nodejs/runtime.go
@@ -24,6 +24,8 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 )
 
+const defaultBaseImage = "gcr.io/iguazio/node:20"
+
 type nodejs struct {
 	*runtime.AbstractRuntime
 }
@@ -39,7 +41,7 @@ func (n *nodejs) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config,
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
 	// set the default base image
-	processorDockerfileInfo.BaseImage = "gcr.io/iguazio/node:20"
+	processorDockerfileInfo.BaseImage = defaultBaseImage
 
 	processorDockerfileInfo.ImageArtifactPaths = map[string]string{
 		"handler": "/opt/nuclio",
@@ -66,4 +68,9 @@ func (n *nodejs) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config,
 	}
 
 	return &processorDockerfileInfo, nil
+}
+
+// GetDefaultBaseImage returns the default base image for nodejs runtime
+func (n *nodejs) GetDefaultBaseImage() string {
+	return defaultBaseImage
 }

--- a/pkg/processor/build/runtime/nodejs/runtime.go
+++ b/pkg/processor/build/runtime/nodejs/runtime.go
@@ -36,7 +36,8 @@ func (n *nodejs) GetName() string {
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (n *nodejs) GetProcessorDockerfileInfo(
 	_ *runtimeconfig.Config,
-	onbuildImageRegistry, baseImage string,
+	onbuildImageRegistry string,
+	baseImage string,
 ) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -181,3 +181,9 @@ func (p *python) OnAfterStagingDirCreated(runtimeConfig *runtimeconfig.Config, s
 	}
 	return p.AbstractRuntime.OnAfterStagingDirCreated(runtimeConfig, stagingDir)
 }
+
+// GetDefaultBaseImage returns the default base image for python runtime
+func (p *python) GetDefaultBaseImage() string {
+	_, runtimeVersion := common.GetRuntimeNameAndVersion(p.FunctionConfig.Spec.Runtime)
+	return fmt.Sprintf("gcr.io/iguazio/python:%s", runtimeVersion)
+}

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -50,7 +50,8 @@ func (p *python) GetName() string {
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (p *python) GetProcessorDockerfileInfo(
 	runtimeConfig *runtimeconfig.Config,
-	onbuildImageRegistry, baseImage string,
+	onbuildImageRegistry string,
+	baseImage string,
 ) (*runtime.ProcessorDockerfileInfo, error) {
 	var installSDKDependenciesCommand string
 

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -180,9 +180,3 @@ func (p *python) OnAfterStagingDirCreated(runtimeConfig *runtimeconfig.Config, s
 	}
 	return p.AbstractRuntime.OnAfterStagingDirCreated(runtimeConfig, stagingDir)
 }
-
-// GetDefaultBaseImage returns the default base image for python runtime
-func (p *python) GetDefaultBaseImage() string {
-	_, runtimeVersion := common.GetRuntimeNameAndVersion(p.FunctionConfig.Spec.Runtime)
-	return fmt.Sprintf("gcr.io/iguazio/python:%s", runtimeVersion)
-}

--- a/pkg/processor/build/runtime/python/runtime.go
+++ b/pkg/processor/build/runtime/python/runtime.go
@@ -48,10 +48,11 @@ func (p *python) GetName() string {
 }
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-func (p *python) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config,
-	onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
+func (p *python) GetProcessorDockerfileInfo(
+	runtimeConfig *runtimeconfig.Config,
+	onbuildImageRegistry, baseImage string,
+) (*runtime.ProcessorDockerfileInfo, error) {
 	var installSDKDependenciesCommand string
-	var baseImage string
 
 	destOnbuildWheelsPath := "/opt/nuclio/whl"
 	pythonCommonModules := []string{
@@ -66,11 +67,9 @@ func (p *python) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config,
 		return nil, errors.New("Python 3.6 runtime is deprecated and is not supported anymore." +
 			"Migrate your code and use Python 3.9 runtime (`python:3.9`) or higher")
 	case "3.7", "3.8":
-		baseImage = fmt.Sprintf("gcr.io/iguazio/python:%s", runtimeVersion)
 		p.Logger.Warn(fmt.Sprintf("Python %s runtime is deprecated and will soon not be supported. ", runtimeVersion) +
 			"Migrate your code and use Python 3.9 runtime (`python:3.9`) or higher")
 	default:
-		baseImage = fmt.Sprintf("gcr.io/iguazio/python:%s", runtimeVersion)
 	}
 	srcOnbuildWheelsPath := fmt.Sprintf("/home/nuclio/bin/py%s-whl", runtimeVersion)
 

--- a/pkg/processor/build/runtime/ruby/runtime.go
+++ b/pkg/processor/build/runtime/ruby/runtime.go
@@ -35,7 +35,8 @@ func (r *ruby) GetName() string {
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (r *ruby) GetProcessorDockerfileInfo(
 	_ *runtimeconfig.Config,
-	onbuildImageRegistry, baseImage string,
+	onbuildImageRegistry string,
+	baseImage string,
 ) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}

--- a/pkg/processor/build/runtime/ruby/runtime.go
+++ b/pkg/processor/build/runtime/ruby/runtime.go
@@ -23,6 +23,8 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 )
 
+const defaultBaseImage = "gcr.io/iguazio/ruby:2.4.4-alpine"
+
 type ruby struct {
 	*runtime.AbstractRuntime
 }
@@ -37,7 +39,7 @@ func (r *ruby) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, o
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
-	processorDockerfileInfo.BaseImage = "gcr.io/iguazio/ruby:2.4.4-alpine"
+	processorDockerfileInfo.BaseImage = defaultBaseImage
 
 	processorDockerfileInfo.ImageArtifactPaths = map[string]string{
 		"handler": "/opt/nuclio",
@@ -58,4 +60,9 @@ func (r *ruby) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, o
 	processorDockerfileInfo.OnbuildArtifacts = []runtime.Artifact{artifact}
 
 	return &processorDockerfileInfo, nil
+}
+
+// GetDefaultBaseImage returns the default base image for ruby runtime
+func (r *ruby) GetDefaultBaseImage() string {
+	return defaultBaseImage
 }

--- a/pkg/processor/build/runtime/ruby/runtime.go
+++ b/pkg/processor/build/runtime/ruby/runtime.go
@@ -23,8 +23,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 )
 
-const defaultBaseImage = "gcr.io/iguazio/ruby:2.4.4-alpine"
-
 type ruby struct {
 	*runtime.AbstractRuntime
 }
@@ -63,9 +61,4 @@ func (r *ruby) GetProcessorDockerfileInfo(
 	processorDockerfileInfo.OnbuildArtifacts = []runtime.Artifact{artifact}
 
 	return &processorDockerfileInfo, nil
-}
-
-// GetDefaultBaseImage returns the default base image for ruby runtime
-func (r *ruby) GetDefaultBaseImage() string {
-	return defaultBaseImage
 }

--- a/pkg/processor/build/runtime/ruby/runtime.go
+++ b/pkg/processor/build/runtime/ruby/runtime.go
@@ -35,11 +35,14 @@ func (r *ruby) GetName() string {
 }
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-func (r *ruby) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
+func (r *ruby) GetProcessorDockerfileInfo(
+	_ *runtimeconfig.Config,
+	onbuildImageRegistry, baseImage string,
+) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
-	processorDockerfileInfo.BaseImage = defaultBaseImage
+	processorDockerfileInfo.BaseImage = baseImage
 
 	processorDockerfileInfo.ImageArtifactPaths = map[string]string{
 		"handler": "/opt/nuclio",

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -73,6 +73,12 @@ type Runtime interface {
 
 	// GetRuntimeBuildArgs returns building arguments
 	GetRuntimeBuildArgs(runtimeConfig *runtimeconfig.Config) map[string]string
+
+	// GetBaseImageFromMap returns explicit base image from provided map if exists, otherwise default
+	GetBaseImageFromMap(baseImagesMap map[string]string, defaultBaseImage string) string
+
+	// GetDefaultBaseImage returns the runtime's default base image
+	GetDefaultBaseImage() string
 }
 
 type Factory interface {
@@ -159,23 +165,7 @@ func (ar *AbstractRuntime) DetectFunctionHandlers(functionPath string) ([]string
 }
 
 func (ar *AbstractRuntime) GetOverrideImageRegistryFromMap(imagesOverrideMap map[string]string) string {
-	runtimeName, runtimeVersion := common.GetRuntimeNameAndVersion(ar.FunctionConfig.Spec.Runtime)
-
-	// supports both overrides per runtimeName and per runtimeName + runtimeVersion
-	if runtimeVersion != "" {
-		key := runtimeName + ":" + runtimeVersion
-		if imageOverride, ok := imagesOverrideMap[key]; ok {
-			return imageOverride
-		}
-	}
-
-	// no version-specific override, or no known version for our runtime, try for runtimeName only
-	if imageOverride, ok := imagesOverrideMap[runtimeName]; ok {
-		return imageOverride
-	}
-
-	// no override found
-	return ""
+	return ar.getImageFromMapOrDefault(imagesOverrideMap, "")
 }
 
 func (ar *AbstractRuntime) GetRuntimeBuildArgs(runtimeConfig *runtimeconfig.Config) map[string]string {
@@ -183,4 +173,29 @@ func (ar *AbstractRuntime) GetRuntimeBuildArgs(runtimeConfig *runtimeconfig.Conf
 		return runtimeConfig.Common.BuildArgs
 	}
 	return map[string]string{}
+}
+
+func (ar *AbstractRuntime) GetBaseImageFromMap(baseImagesMap map[string]string, defaultBaseImage string) string {
+	return ar.getImageFromMapOrDefault(baseImagesMap, defaultBaseImage)
+}
+
+// getImageFromMapOrDefault returns an image from the provided map based on the runtime name and version
+// if no image is found, returns the provided default value
+func (ar *AbstractRuntime) getImageFromMapOrDefault(imagesMap map[string]string, defaultValue string) string {
+	runtimeName, runtimeVersion := common.GetRuntimeNameAndVersion(ar.FunctionConfig.Spec.Runtime)
+
+	// supports both values per runtimeName and per runtimeName + runtimeVersion
+	if runtimeVersion != "" {
+		key := runtimeName + ":" + runtimeVersion
+		if image, ok := imagesMap[key]; ok {
+			return image
+		}
+	}
+
+	// no version-specific value, or no known version for our runtime, try for runtimeName only
+	if image, ok := imagesMap[runtimeName]; ok {
+		return image
+	}
+
+	return defaultValue
 }

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -59,7 +59,7 @@ type Runtime interface {
 	OnAfterStagingDirCreated(runtimeConfig *runtimeconfig.Config, stagingDir string) error
 
 	// GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-	GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*ProcessorDockerfileInfo, error)
+	GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry, baseImage string) (*ProcessorDockerfileInfo, error)
 
 	// GetName returns the name of the runtime, including version if applicable
 	GetName() string

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -74,8 +74,8 @@ type Runtime interface {
 	// GetRuntimeBuildArgs returns building arguments
 	GetRuntimeBuildArgs(runtimeConfig *runtimeconfig.Config) map[string]string
 
-	// GetBaseImageFromMap returns explicit base image from provided map if exists, otherwise default
-	GetBaseImageFromMap(baseImagesMap map[string]string, defaultBaseImage string) string
+	// GetBaseImageFromMap returns explicit base image from provided map if exists, otherwise empty string
+	GetBaseImageFromMap(baseImagesMap map[string]string) string
 }
 
 type Factory interface {
@@ -162,7 +162,7 @@ func (ar *AbstractRuntime) DetectFunctionHandlers(functionPath string) ([]string
 }
 
 func (ar *AbstractRuntime) GetOverrideImageRegistryFromMap(imagesOverrideMap map[string]string) string {
-	return ar.getImageFromMapOrDefault(imagesOverrideMap, "")
+	return ar.getImageFromMap(imagesOverrideMap)
 }
 
 func (ar *AbstractRuntime) GetRuntimeBuildArgs(runtimeConfig *runtimeconfig.Config) map[string]string {
@@ -172,13 +172,13 @@ func (ar *AbstractRuntime) GetRuntimeBuildArgs(runtimeConfig *runtimeconfig.Conf
 	return map[string]string{}
 }
 
-func (ar *AbstractRuntime) GetBaseImageFromMap(baseImagesMap map[string]string, defaultBaseImage string) string {
-	return ar.getImageFromMapOrDefault(baseImagesMap, defaultBaseImage)
+func (ar *AbstractRuntime) GetBaseImageFromMap(baseImagesMap map[string]string) string {
+	return ar.getImageFromMap(baseImagesMap)
 }
 
-// getImageFromMapOrDefault returns an image from the provided map based on the runtime name and version
+// getImageFromMap returns an image from the provided map based on the runtime name and version
 // if no image is found, returns the provided default value
-func (ar *AbstractRuntime) getImageFromMapOrDefault(imagesMap map[string]string, defaultValue string) string {
+func (ar *AbstractRuntime) getImageFromMap(imagesMap map[string]string) string {
 	runtimeName, runtimeVersion := common.GetRuntimeNameAndVersion(ar.FunctionConfig.Spec.Runtime)
 
 	// supports both values per runtimeName and per runtimeName + runtimeVersion
@@ -194,5 +194,9 @@ func (ar *AbstractRuntime) getImageFromMapOrDefault(imagesMap map[string]string,
 		return image
 	}
 
-	return defaultValue
+	ar.Logger.WarnWith("Failed to find image for runtime",
+		"runtime name", runtimeName,
+		"runtime version", runtimeVersion,
+	)
+	return ""
 }

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -76,9 +76,6 @@ type Runtime interface {
 
 	// GetBaseImageFromMap returns explicit base image from provided map if exists, otherwise default
 	GetBaseImageFromMap(baseImagesMap map[string]string, defaultBaseImage string) string
-
-	// GetDefaultBaseImage returns the runtime's default base image
-	GetDefaultBaseImage() string
 }
 
 type Factory interface {

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -161,8 +161,8 @@ func (ar *AbstractRuntime) DetectFunctionHandlers(functionPath string) ([]string
 	return []string{fmt.Sprintf("%s:%s", functionFileName, "handler")}, nil
 }
 
-func (ar *AbstractRuntime) GetOverrideImageRegistryFromMap(imagesOverrideMap map[string]string) string {
-	return ar.getImageFromMap(imagesOverrideMap)
+func (ar *AbstractRuntime) GetOverrideImageRegistryFromMap(imageRegistriesMap map[string]string) string {
+	return ar.getImageFromMap(imageRegistriesMap)
 }
 
 func (ar *AbstractRuntime) GetRuntimeBuildArgs(runtimeConfig *runtimeconfig.Config) map[string]string {

--- a/pkg/processor/build/runtime/runtime_test.go
+++ b/pkg/processor/build/runtime/runtime_test.go
@@ -104,7 +104,7 @@ func (suite *AbstractRuntimeTestSuite) TestGetBaseImageFromMap() {
 			testAbstractRuntime, err := NewAbstractRuntime(suite.logger, "nop", "/tmp", functionConfig)
 			suite.Require().NoError(err)
 
-			result := testAbstractRuntime.GetBaseImageFromMap(testCase.baseImages, defaultPythonBaseImage)
+			result := testAbstractRuntime.GetBaseImageFromMap(testCase.baseImages)
 
 			suite.Require().Equal(testCase.expectedBaseImage, result)
 		})

--- a/pkg/processor/build/runtime/runtime_test.go
+++ b/pkg/processor/build/runtime/runtime_test.go
@@ -1,0 +1,116 @@
+//go:build test_unit
+
+/*
+Copyright 2025 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+
+	"github.com/nuclio/logger"
+	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type AbstractRuntimeTestSuite struct {
+	suite.Suite
+	logger logger.Logger
+}
+
+func (suite *AbstractRuntimeTestSuite) SetupSuite() {
+	var err error
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+}
+
+func (suite *AbstractRuntimeTestSuite) TestGetBaseImageFromMap() {
+	defaultPythonBaseImage := "python:3.12"
+	testCases := []struct {
+		name              string
+		baseImages        map[string]string
+		runtime           string
+		expectedBaseImage string
+	}{
+		{
+			name:              "No base images configured - returns default",
+			baseImages:        nil,
+			runtime:           "python:3.12",
+			expectedBaseImage: defaultPythonBaseImage,
+		},
+		{
+			name:              "Empty base images map - returns default",
+			baseImages:        map[string]string{},
+			runtime:           "python",
+			expectedBaseImage: defaultPythonBaseImage,
+		},
+		{
+			name: "Base image configured for runtime name only",
+			baseImages: map[string]string{
+				"node": "custom-node:20",
+			},
+			runtime:           "node:20",
+			expectedBaseImage: "custom-node:20",
+		},
+		{
+			name: "Base image configured for runtime name and version",
+			baseImages: map[string]string{
+				"python:3.12": "custom-python-3.12:latest",
+			},
+			runtime:           "python:3.12",
+			expectedBaseImage: "custom-python-3.12:latest",
+		},
+		{
+			name: "Version-specific override takes precedence over name-only",
+			baseImages: map[string]string{
+				"node":    "nodejs-base:latest",
+				"node:20": "nodejs-20-specific:latest",
+			},
+			runtime:           "node:20",
+			expectedBaseImage: "nodejs-20-specific:latest",
+		},
+		{
+			name: "No matching base image - returns default",
+			baseImages: map[string]string{
+				"golang": "custom-golang:latest",
+			},
+			runtime:           "python",
+			expectedBaseImage: defaultPythonBaseImage,
+		},
+	}
+
+	for _, testCase := range testCases {
+		suite.Run(testCase.name, func() {
+			functionConfig := &functionconfig.Config{
+				Spec: functionconfig.Spec{
+					Runtime: testCase.runtime,
+				},
+			}
+			testAbstractRuntime, err := NewAbstractRuntime(suite.logger, "nop", "/tmp", functionConfig)
+			suite.Require().NoError(err)
+
+			result := testAbstractRuntime.GetBaseImageFromMap(testCase.baseImages, defaultPythonBaseImage)
+
+			suite.Require().Equal(testCase.expectedBaseImage, result)
+		})
+	}
+}
+
+func TestAbstractRuntimeTestSuite(t *testing.T) {
+	suite.Run(t, new(AbstractRuntimeTestSuite))
+}

--- a/pkg/processor/build/runtime/runtime_test.go
+++ b/pkg/processor/build/runtime/runtime_test.go
@@ -40,25 +40,12 @@ func (suite *AbstractRuntimeTestSuite) SetupSuite() {
 }
 
 func (suite *AbstractRuntimeTestSuite) TestGetBaseImageFromMap() {
-	defaultPythonBaseImage := "python:3.12"
 	testCases := []struct {
 		name              string
 		baseImages        map[string]string
 		runtime           string
 		expectedBaseImage string
 	}{
-		{
-			name:              "No base images configured - returns default",
-			baseImages:        nil,
-			runtime:           "python:3.12",
-			expectedBaseImage: defaultPythonBaseImage,
-		},
-		{
-			name:              "Empty base images map - returns default",
-			baseImages:        map[string]string{},
-			runtime:           "python",
-			expectedBaseImage: defaultPythonBaseImage,
-		},
 		{
 			name: "Base image configured for runtime name only",
 			baseImages: map[string]string{
@@ -89,8 +76,8 @@ func (suite *AbstractRuntimeTestSuite) TestGetBaseImageFromMap() {
 			baseImages: map[string]string{
 				"golang": "custom-golang:latest",
 			},
-			runtime:           "python",
-			expectedBaseImage: defaultPythonBaseImage,
+			runtime:           "python:3.12",
+			expectedBaseImage: "",
 		},
 	}
 

--- a/pkg/processor/build/runtime/shell/runtime.go
+++ b/pkg/processor/build/runtime/shell/runtime.go
@@ -23,6 +23,8 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 )
 
+const defaultBaseImage = "gcr.io/iguazio/alpine:3.20"
+
 type shell struct {
 	*runtime.AbstractRuntime
 }
@@ -38,7 +40,7 @@ func (s *shell) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
 	// set the default base image
-	processorDockerfileInfo.BaseImage = "gcr.io/iguazio/alpine:3.20"
+	processorDockerfileInfo.BaseImage = defaultBaseImage
 
 	// fill onbuild artifact
 	artifact := runtime.Artifact{
@@ -68,4 +70,9 @@ func (s *shell) GetHandlerDirObjectPaths() []string {
 	}
 
 	return []string{}
+}
+
+// GetDefaultBaseImage returns the default base image for shell runtime
+func (s *shell) GetDefaultBaseImage() string {
+	return defaultBaseImage
 }

--- a/pkg/processor/build/runtime/shell/runtime.go
+++ b/pkg/processor/build/runtime/shell/runtime.go
@@ -23,8 +23,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 )
 
-const defaultBaseImage = "gcr.io/iguazio/alpine:3.20"
-
 type shell struct {
 	*runtime.AbstractRuntime
 }
@@ -73,9 +71,4 @@ func (s *shell) GetHandlerDirObjectPaths() []string {
 	}
 
 	return []string{}
-}
-
-// GetDefaultBaseImage returns the default base image for shell runtime
-func (s *shell) GetDefaultBaseImage() string {
-	return defaultBaseImage
 }

--- a/pkg/processor/build/runtime/shell/runtime.go
+++ b/pkg/processor/build/runtime/shell/runtime.go
@@ -35,12 +35,15 @@ func (s *shell) GetName() string {
 }
 
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
-func (s *shell) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
+func (s *shell) GetProcessorDockerfileInfo(
+	_ *runtimeconfig.Config,
+	onbuildImageRegistry, baseImage string,
+) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
 	// set the default base image
-	processorDockerfileInfo.BaseImage = defaultBaseImage
+	processorDockerfileInfo.BaseImage = baseImage
 
 	// fill onbuild artifact
 	artifact := runtime.Artifact{

--- a/pkg/processor/build/runtime/shell/runtime.go
+++ b/pkg/processor/build/runtime/shell/runtime.go
@@ -35,7 +35,8 @@ func (s *shell) GetName() string {
 // GetProcessorDockerfileInfo returns information required to build the processor Dockerfile
 func (s *shell) GetProcessorDockerfileInfo(
 	_ *runtimeconfig.Config,
-	onbuildImageRegistry, baseImage string,
+	onbuildImageRegistry string,
+	baseImage string,
 ) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}


### PR DESCRIPTION
### 📝 Description
This PR introduces support for configuring runtime-specific base images for processor builds.
Until now, processor base images were hardcoded inside each runtime implementation, with no way to override them via platform configuration.
This change adds a unified mechanism for resolving the base image by combining:
- Explicit `baseImages` configuration provided in `platform config`
- Runtime-specific defaults defined in each runtime
- Version-specific and non-version-specific overrides (e.g. `ruby:2.4.4-alpine` or `ruby`)

This allows users and integrators to customize the processor base image per runtime in a consistent and predictable way.

---

### 🛠️ Changes Made
- Added `GetBaseImage(runtime)` to Platform interface
- Added support for `baseImages` in `platformconfig`, including enriching baseIamge ot avoid `python` without explicit version
- Added `GetBaseImageFromMap()` to `runtime.Runtime` and implemented in the abstract runtime.
- Updated builder flow to pass the resolved base image into Dockerfile generation.
- Introduced `processorImageBuildConfig` to bundle base image–related parameters.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Added unit tests:
  - Platform-level base image resolution tests
  - `AbstractRuntime` base image resolution tests 
- Dev test:
  - Created All runtimes in the iguazio system (validate default base image backward compatibility)
  
<img width="1843" height="590" alt="image" src="https://github.com/user-attachments/assets/88fc442d-d87d-4225-85f7-b3d70ab92f94" />

  - Created funciton using a pre-configured base image to test overlapping
  ```
  k -n default-tenant get cm nuclio-platform-config -oyaml 
apiVersion: v1
data:
  platform.yaml: |
    ...
    baseImages:
      java: eclipse-temurin:21
    imageRegistryOverrides:
      baseImageRegistries: # Removed Java
        golang: datanode-registry.iguazio-platform.app.vmdev5.lab.iguazeng.com:80
        python: datanode-registry.iguazio-platform.app.vmdev5.lab.iguazeng.com:80
        shell: datanode-registry.iguazio-platform.app.vmdev5.lab.iguazeng.com:80
      onbuildImageRegistries: # Removed Java
        dotnet: datanode-registry.iguazio-platform.app.vmdev5.lab.iguazeng.com:80/quay.io
        golang: datanode-registry.iguazio-platform.app.vmdev5.lab.iguazeng.com:80/quay.io
        nodejs: datanode-registry.iguazio-platform.app.vmdev5.lab.iguazeng.com:80/quay.io
        python: datanode-registry.iguazio-platform.app.vmdev5.lab.iguazeng.com:80/quay.io
        ruby: datanode-registry.iguazio-platform.app.vmdev5.lab.iguazeng.com:80/quay.io
        shell: datanode-registry.iguazio-platform.app.vmdev5.lab.iguazeng.com:80/quay.io
  ```
  
  
<img width="1837" height="627" alt="image" src="https://github.com/user-attachments/assets/9dc2cd5b-c99f-4713-95e1-42a585406944" />

  
  
  - Created function using the build-in base image overlapping ( for backward compatibility)
<img width="504" height="297" alt="image" src="https://github.com/user-attachments/assets/ff2425ab-4ee8-4843-9ac2-c2a7994324db" />
  
<img width="1835" height="541" alt="image" src="https://github.com/user-attachments/assets/0974ec6c-137b-49cc-abc4-71683f5bc46c" />

  - Created runtime via Jupiter notebook for testing SDK deployment
  
<img width="1854" height="588" alt="image" src="https://github.com/user-attachments/assets/e0f139b4-b5b1-4bce-8680-9a722ed27996" />


---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-620
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
- The only limitation applies when Python versions are non-explicit in `platformconfig.baseImages`. 
  - If a value is simply python, it will be removed from the `runtimeBaseImages`
  - A more detailed explanation is available in the documentation.