### PR TITLE
[Processor] Add explicit error depending on whether allocation waited on timeout

### DIFF
--- a/pkg/processor/eventprocessor/pool.go
+++ b/pkg/processor/eventprocessor/pool.go
@@ -70,7 +70,7 @@ func (a *blockingPoolAllocator) Allocate(timeout time.Duration) (EventProcessor,
 		// if there's no timeout, return now
 		if timeout == 0 {
 			a.statistics.AllocationSuccessAfterWaitTotal.Add(1)
-			return nil, ErrNoAvailableObjects
+			return nil, ErrNoAvailableObjectsImmediately
 		}
 
 		waitStartAt := time.Now()
@@ -86,7 +86,7 @@ func (a *blockingPoolAllocator) Allocate(timeout time.Duration) (EventProcessor,
 			a.statistics.AllocationTimeoutTotal.Add(1)
 			a.logger.DebugWith("Timed out waiting for objects to be available",
 				"timeout", timeout)
-			return nil, ErrNoAvailableObjects
+			return nil, ErrNoAvailableObjectsTimeout
 		}
 	}
 }
@@ -224,7 +224,10 @@ func (nba *nonBlockingPoolAllocator) Allocate(timeout time.Duration) (EventProce
 		}
 	}
 
-	return nil, ErrNoAvailableObjects
+	if timeout == 0 {
+		return nil, ErrNoAvailableObjectsImmediately
+	}
+	return nil, ErrNoAvailableObjectsTimeout
 }
 
 func (nba *nonBlockingPoolAllocator) allocate() EventProcessor {

--- a/pkg/processor/eventprocessor/types.go
+++ b/pkg/processor/eventprocessor/types.go
@@ -31,7 +31,8 @@ import (
 	"github.com/nuclio/nuclio-sdk-go"
 )
 
-var ErrNoAvailableObjects = errors.New("No available objects")
+var ErrNoAvailableObjectsImmediately = errors.New("No available objects, function configured not to wait. Failed immediately")
+var ErrNoAvailableObjectsTimeout = errors.New("No available objects in the given timeout")
 var ErrAllObjectsAreTerminated = errors.New("All objects are terminated")
 
 type Allocator interface {

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -527,7 +527,7 @@ func (h *http) handleRequest(ctx *fasthttp.RequestCtx) {
 		switch errors.Cause(submitError) {
 
 		// no available workers
-		case eventprocessor.ErrNoAvailableObjects, eventprocessor.ErrAllObjectsAreTerminated:
+		case eventprocessor.ErrNoAvailableObjectsImmediately, eventprocessor.ErrNoAvailableObjectsTimeout, eventprocessor.ErrAllObjectsAreTerminated:
 			h.Logger.WarnWith("No workers available",
 				"err", submitError.Error())
 			ctx.Response.SetStatusCode(nethttp.StatusServiceUnavailable)

--- a/pkg/processor/util/partitionworker/allocator.go
+++ b/pkg/processor/util/partitionworker/allocator.go
@@ -145,7 +145,7 @@ func (wa *StaticWorkerAllocator) AllocateWorker(topic string,
 
 			// if there's no timeout, return now
 			if *timeout == 0 {
-				return nil, nil, eventprocessor.ErrNoAvailableObjects
+				return nil, nil, eventprocessor.ErrNoAvailableObjectsImmediately
 			}
 
 			// if there is a timeout, try to allocate while waiting for the time
@@ -153,7 +153,7 @@ func (wa *StaticWorkerAllocator) AllocateWorker(topic string,
 			select {
 			case workerInstance = <-workerChan:
 			case <-time.After(*timeout):
-				return nil, nil, eventprocessor.ErrNoAvailableObjects
+				return nil, nil, eventprocessor.ErrNoAvailableObjectsTimeout
 			}
 		}
 	}
@@ -204,7 +204,7 @@ func (wa *StaticWorkerAllocator) assignTopicPartitionWorkers(workerAllocator eve
 	// can only contain one item and add that to a slice
 	for {
 		workerInstance, err := workerAllocator.Allocate(0)
-		if errors.Is(err, eventprocessor.ErrNoAvailableObjects) {
+		if errors.Is(err, eventprocessor.ErrNoAvailableObjectsImmediately) || errors.Is(err, eventprocessor.ErrNoAvailableObjectsTimeout) {
 			break
 		}
 

--- a/pkg/processor/util/partitionworker/allocator_test.go
+++ b/pkg/processor/util/partitionworker/allocator_test.go
@@ -66,14 +66,14 @@ func (suite *partitionWorkerAllocatorTestSuite) TestAllocationBlocking() {
 	// allocate a worker for the same partition with no timeout - should fail immediately
 	noTimeout := time.Duration(0)
 	failedWorkerInstance, failedCookie, err := partitionWorkerAllocator.AllocateWorker("t1", 0, &noTimeout)
-	suite.Require().Equal(err, eventprocessor.ErrNoAvailableObjects)
+	suite.Require().Equal(err, eventprocessor.ErrNoAvailableObjectsImmediately)
 	suite.Require().Nil(failedCookie)
 	suite.Require().Nil(failedWorkerInstance)
 
 	// allocate a worker for the same partition with a timeout - should fail after a while
 	smallTimeout := 2 * time.Second
 	failedWorkerInstance, failedCookie, err = partitionWorkerAllocator.AllocateWorker("t1", 0, &smallTimeout)
-	suite.Require().Equal(err, eventprocessor.ErrNoAvailableObjects)
+	suite.Require().Equal(err, eventprocessor.ErrNoAvailableObjectsTimeout)
 	suite.Require().Nil(failedCookie)
 	suite.Require().Nil(failedWorkerInstance)
 

--- a/pkg/processor/worker/allocator_test.go
+++ b/pkg/processor/worker/allocator_test.go
@@ -124,7 +124,7 @@ func (suite *AllocatorTestSuite) TestNonBlockingPoolAllocator() {
 
 	// both processors are not ready, should fail
 	allocatedEventProcessor, err = allocator.Allocate(100 * time.Millisecond)
-	suite.Require().ErrorIs(err, eventprocessor.ErrNoAvailableObjects)
+	suite.Require().ErrorIs(err, eventprocessor.ErrNoAvailableObjectsTimeout)
 	suite.Require().Nil(allocatedEventProcessor)
 
 	allocator.Release(eventProcessor1)


### PR DESCRIPTION
### 📝 Description
This helps during debugs when we see only logs and not a nuclio funtion config

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->