### PR TITLE
[Dashboard] Allow nuclio logs header in invocation endpoint

### DIFF
--- a/pkg/common/headers/headers.go
+++ b/pkg/common/headers/headers.go
@@ -83,3 +83,24 @@ const (
 func IsNuclioHeader(headerName string) bool {
 	return strings.HasPrefix(headerName, HeaderPrefix)
 }
+
+// GetAllowedResponseHeaderNames returns a slice of X-Nuclio header names that are
+// allowed to pass through in function invocation responses. This is useful for
+// CORS ExposedHeaders configuration.
+func GetAllowedResponseHeaderNames() []string {
+	return []string{
+		Logs, // Function logs can be returned to client
+	}
+}
+
+// GetAllowedResponseHeaders returns a map of X-Nuclio headers that are allowed
+// to pass through in function invocation responses. This ensures consistency
+// between response filtering and CORS exposed headers configuration.
+func GetAllowedResponseHeaders() map[string]bool {
+	allowedHeaderNames := GetAllowedResponseHeaderNames()
+	allowedHeaders := make(map[string]bool, len(allowedHeaderNames))
+	for _, headerName := range allowedHeaderNames {
+		allowedHeaders[headerName] = true
+	}
+	return allowedHeaders
+}

--- a/pkg/dashboard/resource/invocation.go
+++ b/pkg/dashboard/resource/invocation.go
@@ -127,9 +127,7 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 
 	// set headers
 	for headerName, headerValue := range invocationResult.Headers {
-
-		// don't send nuclio headers to the actual function
-		if !headers.IsNuclioHeader(headerName) {
+		if tr.shouldPassThroughResponseHeader(headerName) {
 			responseWriter.Header().Set(headerName, headerValue[0])
 		}
 	}
@@ -164,6 +162,19 @@ func (tr *invocationResource) resolveInvokeTimeout(invokeTimeout string) (time.D
 		return 0, nuclio.NewErrBadRequest("Invalid invoke timeout")
 	}
 	return parsedDuration, nil
+}
+
+// shouldPassThroughResponseHeader determines if an X-Nuclio header from the function response
+// should be passed through to the client. Only specific headers that are safe to expose are allowed.
+func (tr *invocationResource) shouldPassThroughResponseHeader(headerName string) bool {
+	// Allow all non-X-Nuclio headers
+	if !headers.IsNuclioHeader(headerName) {
+		return true
+	}
+
+	// Use shared list of allowed response headers to ensure consistency
+	allowedResponseHeaders := headers.GetAllowedResponseHeaders()
+	return allowedResponseHeaders[headerName]
 }
 
 // register the resource

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -247,10 +247,10 @@ func (s *Server) InstallMiddleware(router chi.Router) error {
 			headers.CreationStateUpdatedTimeout,
 			headers.ProjectsRole,
 		},
-		ExposedHeaders: []string{
-			"Content-Length",
-			headers.Logs,
-		},
+		ExposedHeaders: append(
+			[]string{"Content-Length"},
+			headers.GetAllowedResponseHeaderNames()...,
+		),
 		AllowCredentials: true,
 		MaxAge:           300,
 	}


### PR DESCRIPTION
### 📝 Description
The reason why it didn't work from UI was the fact the UI uses dashboard's invocation endpoint, which filtered out all Nuclio custom headers. This PR adds logs header to list of allowed headers and aligned the allowed headers list with the one we have in `ExposedHeaders`, so that if we need to modify it, we can modify it in a single place. 

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
Tested on vmdev, see the attached screenshor
---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-670
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<img width="833" height="1046" alt="image" src="https://github.com/user-attachments/assets/88bab99a-1068-4402-8e59-fde8e058922b" />