### PR TITLE
[Auth] Fix OPA queries member IDs population for IG4

### DIFF
--- a/pkg/auth/iguazio/abstract.go
+++ b/pkg/auth/iguazio/abstract.go
@@ -257,6 +257,7 @@ func (a *AbstractAuth) buildIdentityRequest(authParams *AuthParameters) (*http.R
 
 type AbstractSession struct {
 	Username string
+	UserID   string
 	GroupIDs []string
 }
 
@@ -273,7 +274,7 @@ func (a *AbstractSession) CompileAuthorizationBasicHeader() string {
 }
 
 func (a *AbstractSession) GetUserID() string {
-	return ""
+	return a.UserID
 }
 
 func (a *AbstractSession) GetPassword() string {

--- a/pkg/auth/iguazio/v4/auth.go
+++ b/pkg/auth/iguazio/v4/auth.go
@@ -94,5 +94,5 @@ func (a *Auth) BuildSessionFromResponse(response *http.Response) (authpkg.Sessio
 		}
 	}
 
-	return NewSession(resp.Metadata.Username, groupIDs), nil
+	return NewSession(resp.Metadata.Username, resp.Metadata.ID, groupIDs), nil
 }

--- a/pkg/auth/iguazio/v4/session.go
+++ b/pkg/auth/iguazio/v4/session.go
@@ -22,10 +22,11 @@ type Session struct {
 	*iguazio.AbstractSession
 }
 
-func NewSession(username string, groupIDs []string) *Session {
+func NewSession(username string, userID string, groupIDs []string) *Session {
 	return &Session{
 		AbstractSession: &iguazio.AbstractSession{
 			Username: username,
+			UserID:   userID,
 			GroupIDs: groupIDs,
 		},
 	}

--- a/pkg/auth/iguazio/v4/types.go
+++ b/pkg/auth/iguazio/v4/types.go
@@ -19,6 +19,7 @@ package v4
 type identityResponse struct {
 	Metadata struct {
 		Username string `json:"username"`
+		ID       string `json:"id"`
 	} `json:"metadata"`
 	Relationships []struct {
 		Type     string `json:"@type"`

--- a/pkg/opa/opa.go
+++ b/pkg/opa/opa.go
@@ -29,9 +29,17 @@ func GetUserAndGroupIdsFromAuthSession(session auth.Session) []string {
 	if session == nil {
 		return []string{}
 	}
-	ids := []string{
-		session.GetUserID(),
+	var ids []string
+
+	userID := session.GetUserID()
+	if userID != "" {
+		ids = append(ids, userID)
 	}
+
+	if username := session.GetUsername(); username != "" && username != userID {
+		ids = append(ids, username)
+	}
+
 	ids = append(ids, session.GetGroupIDs()...)
 	return ids
 }

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -2022,7 +2022,7 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithUserNameLabel(
 		},
 		{
 			name:         "igzV4",
-			session:      authIgzV4.NewSession("another-user", nil),
+			session:      authIgzV4.NewSession("another-user", "", nil),
 			expectedUser: "another-user",
 		},
 	}
@@ -2154,7 +2154,7 @@ func (suite *FunctionKubePlatformTestSuite) TestUsernameLabelsEnrichment() {
 
 			switch testCase.authKind {
 			case auth.KindIguazioV4:
-				session = authIgzV4.NewSession(testCase.fullUsername, nil)
+				session = authIgzV4.NewSession(testCase.fullUsername, "", nil)
 			case auth.KindIguazio:
 				session = authIgzV1.NewSession(testCase.fullUsername, "", "", nil)
 			default:
@@ -2638,7 +2638,7 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayEnrichmentAndValidat
 				}
 				return &apiGatewayConfig
 			}(),
-			authSession: authIgzV4.NewSession("some-username1", nil),
+			authSession: authIgzV4.NewSession("some-username1", "", nil),
 		},
 		{
 			name: "ValidateNamespaceExistence",


### PR DESCRIPTION
### 📝 Description

Fix OPA authorization filtering incorrectly denying access to resources for authenticated users.

When using Iguazio V4 authentication, the user ID was not being extracted from the identity response, causing the OPA permission check to fail even when users had valid permissions. 
The `GetUserID()` method always returned an empty string, so the username (which is the key in the permission manifest) was never included in the member IDs sent to OPA.

---

### 🛠️ Changes Made

- Added `UserID` field to `AbstractSession` struct in `pkg/auth/iguazio/abstract.go`
- Updated `GetUserID()` method in `AbstractSession` to return the actual user ID instead of an empty string
- Added `ID` field to `identityResponse.Metadata` struct in `pkg/auth/iguazio/v4/types.go` to parse the user ID from the identity endpoint response
- Updated `NewSession` in `pkg/auth/iguazio/v4/session.go` to accept and store the user ID
- Updated `BuildSessionFromResponse` in `pkg/auth/iguazio/v4/auth.go` to extract and pass the user ID when creating a session


---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

- Manual testing on a live system with the following scenario:
  - User `admin` with permissions on `/resources/projects/bbb`
  - Before fix: Project `bbb` was filtered out by OPA even though `admin` had read permissions
  - After fix: Project `bbb` is correctly returned in the projects list


---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->