### PR TITLE
[Docs] Fix proxy logs params formatting

### DIFF
--- a/docs/reference/api/README.md
+++ b/docs/reference/api/README.md
@@ -359,22 +359,20 @@ Extended Response (includeOffline=true):
 #### Request
 
 * URL: `GET /api/functions/<function name>/proxy-logs`
-    * Headers:
+* Headers:
     * `x-nuclio-function-namespace`: Namespace (required)
-    * Params:
-    | Parameter      | Type       | Description                                                                 |
-    |----------------|------------|-----------------------------------------------------------------------------|
-    | `timeFilter`   | object     | Time range to filter logs (optional). See `TimeFilter` structure below.     |
-    | `substring`    | string     | Filter logs containing a specific substring (optional).                     |
-    | `regexp`       | string     | Filter logs matching a regular expression (optional).                       |
-    | `replicaNames` | string[]   | Filter logs by specific replica names (optional).                           |
-    | `logLevels`    | string[]   | Filter logs by log levels (e.g. `debug`, `info`, `error`) (optional).       |
-    | `size`         | integer    | Max number of log entries to return (optional).                             |
-    | `searchAfter`  | [types.FieldValue[]](https://github.com/elastic/elasticsearch-specification/blob/52c473efb1fb5320a5bac12572d0b285882862fb/specification/_types/common.ts#L25-L31)   | For paginated log fetching (optional).                                      |
-    | `source`       | string     | Source to retrieve logs from (e.g. `elasticsearch`) (optional).             |
-    | `from`         | int        | From parameter for pagination. Should be used in pair with `size`           |
+* Params:
+    * `timeFilter` (object): Time range to filter logs (optional). See `TimeFilter` structure below.
+    * `substring` (string): Filter logs containing a specific substring (optional).
+    * `regexp` (string): Filter logs matching a regular expression (optional).
+    * `replicaNames` (string[]): Filter logs by specific replica names (optional).
+    * `logLevels` (string[]): Filter logs by log levels (e.g. `debug`, `info`, `error`) (optional).
+    * `size` (integer): Max number of log entries to return (optional).
+    * `searchAfter` ([types.FieldValue[]](https://github.com/elastic/elasticsearch-specification/blob/52c473efb1fb5320a5bac12572d0b285882862fb/specification/_types/common.ts#L25-L31)): For paginated log fetching (optional).
+    * `source` (string): Source to retrieve logs from (e.g. `elasticsearch`) (optional).
+    * `from` (int): From parameter for pagination. Should be used in pair with `size`.
 
-timeFilter example:
+`timeFilter` example:
 ```
 {
   "since": "2025-05-01T00:00:00Z",   // ISO 8601 format, optional
@@ -385,8 +383,8 @@ timeFilter example:
 
 #### Response
 
-    * Status code: 200
-    * Body:
+* Status code: 200
+* Body:
 
 ```text
 ...Stream logs...


### PR DESCRIPTION
### 📝 Description
Fix broken markdown formatting in the API documentation for the "Proxy logs from a source" endpoint.

---

### 🛠️ Changes Made
- Fixed incorrect nesting of `Headers` and `Params` sections under `URL` - moved them to be top-level bullet points
- Converted indented table format (which was breaking markdown rendering) to bullet point format consistent with the rest of the document
- Fixed the `Response` section which had incorrect indentation (4 spaces) that would render as a code block

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Manual verification of markdown rendering in IDE preview
- Compared formatting with other similar sections in the document to ensure consistency

---

### 🔗 References
- Ticket link: N/A
- Design docs links: N/A
- External links: N/A

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

Before the changes:
<img width="847" height="651" alt="image" src="https://github.com/user-attachments/assets/20d411fe-7ee5-427b-8ea4-2d372c460751" />

After the changes:
<img width="651" height="605" alt="image" src="https://github.com/user-attachments/assets/0bc9e76d-dd3e-46af-983e-1bcd60e1506d" />
