### PR TITLE
[Dependencies] Bump nuclio-sdk-py to v0.6.2

### DIFF
--- a/pkg/processor/runtime/python/py/requirements/common.txt
+++ b/pkg/processor/runtime/python/py/requirements/common.txt
@@ -1,4 +1,4 @@
 mock==2.0.0
-nuclio-sdk==0.6.1
+nuclio-sdk==0.6.2
 pip==25.3
 msgpack==1.1.0


### PR DESCRIPTION
### 📝 Description
Bump nuclio-sdk-py to v0.6.2

---

### 🧪 Testing
ci

---

### 🔗 References
- Ticket link: part https://iguazio.atlassian.net/browse/NUC-679
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->