### PR TITLE
[Test] Fix closing connections in rabbitmq for CLIv2

### DIFF
--- a/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
+++ b/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
@@ -427,31 +427,16 @@ func (suite *testSuite) initializeBrokerConnection() {
 }
 
 func (suite *testSuite) closeAllBrokerConnections() {
-
+	// default user
+	user := "guest"
 	var stdout string
-	// stdout will be something like "[{"name":"192.168.101.3:57931 -> 172.17.0.2:5672"}]"
 	err := suite.DockerClient.ExecInContainer(suite.BrokerContainerID,
 		&dockerclient.ExecOptions{
-			Command: `rabbitmqadmin list connections name --format raw_json`,
+			Command: fmt.Sprintf(`rabbitmqadmin close user_connections --username '%s'`, user),
 			Stdout:  &stdout,
 		})
-	suite.Require().NoError(err)
 
-	// unmarshal the json
-	var connections []struct {
-		Name string `json:"name"`
-	}
-	err = json.Unmarshal([]byte(stdout), &connections)
 	suite.Require().NoError(err)
-	for _, connection := range connections {
-		stdout = ""
-		err = suite.DockerClient.ExecInContainer(suite.BrokerContainerID,
-			&dockerclient.ExecOptions{
-				Command: fmt.Sprintf(`rabbitmqadmin close connection name='%s'`, connection.Name),
-				Stdout:  &stdout,
-			})
-		suite.Require().NoError(err)
-	}
 }
 
 func TestIntegrationSuite(t *testing.T) {


### PR DESCRIPTION
### 📝 Description
Long ci fails because rabbitmq v4 image now defaults to v2 of rabbitmq cli which works differently and doesn't support filtering by name while listing connections. So now we just close all connections for specific user which is always the same.

---

### 🧪 Testing
run locally + running long ci on the pr

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-684
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->