### PR TITLE
[UI] Deleting a function from UI should allow deleting its related API gateway

### DIFF
--- a/pkg/dashboard/ui/src/app/app.run.js
+++ b/pkg/dashboard/ui/src/app/app.run.js
@@ -89,7 +89,7 @@ limitations under the License.
                 backendOptions: [
                     {
                         expirationTime: ConfigService.i18nextExpirationTime,
-                        defaultVersion: 'v0.72'
+                        defaultVersion: 'v0.73'
                     },
                     {
                         loadPath: 'assets/i18n/{{lng}}/{{ns}}.json',

--- a/pkg/dashboard/ui/src/app/components/data-wrappers/functions-data-wrapper/functions-data-wrapper.component.js
+++ b/pkg/dashboard/ui/src/app/components/data-wrappers/functions-data-wrapper/functions-data-wrapper.component.js
@@ -83,10 +83,11 @@ limitations under the License.
          * Deletes function
          * @param {Object} functionToDelete
          * @param {Boolean} ignoreValidation - determines whether to forcibly remove the function
+         * @param {Boolean} deleteApiGateway - determines whether to delete API Gateway
          * @returns {Promise}
          */
-        function deleteFunction(functionToDelete, ignoreValidation) {
-            return NuclioFunctionsDataService.deleteFunction(functionToDelete, ignoreValidation);
+        function deleteFunction(functionToDelete, ignoreValidation, deleteApiGateway) {
+            return NuclioFunctionsDataService.deleteFunction(functionToDelete, ignoreValidation, deleteApiGateway);
         }
 
         /**

--- a/pkg/dashboard/ui/src/app/components/data-wrappers/functions-data-wrapper/functions-data-wrapper.tpl.html
+++ b/pkg/dashboard/ui/src/app/components/data-wrappers/functions-data-wrapper/functions-data-wrapper.tpl.html
@@ -1,5 +1,5 @@
 <ncl-functions data-create-function="$ctrl.createFunction(version, projectId)"
-               data-delete-function="$ctrl.deleteFunction(functionData, ignoreValidation)"
+               data-delete-function="$ctrl.deleteFunction(functionData, ignoreValidation, deleteApiGateway)"
                data-get-functions="$ctrl.getFunctions(id, enrichApiGateways)"
                data-get-function="$ctrl.getFunction(metadata, enrichApiGateways)"
                data-get-statistics="$ctrl.getStatistics()"

--- a/pkg/dashboard/ui/src/app/components/data-wrappers/version-data-wrapper/version-data-wrapper.component.js
+++ b/pkg/dashboard/ui/src/app/components/data-wrappers/version-data-wrapper/version-data-wrapper.component.js
@@ -55,10 +55,11 @@ limitations under the License.
          * Deletes function
          * @param {Object} functionToDelete
          * @param {Boolean} ignoreValidation - determines whether to forcibly remove the function
+         * @param {Boolean} deleteApiGateway - determines whether to delete API Gateway
          * @returns {Promise}
          */
-        function deleteFunction(functionToDelete, ignoreValidation) {
-            return NuclioFunctionsDataService.deleteFunction(functionToDelete, ignoreValidation);
+        function deleteFunction(functionToDelete, ignoreValidation, deleteApiGateway) {
+            return NuclioFunctionsDataService.deleteFunction(functionToDelete, ignoreValidation, deleteApiGateway);
         }
 
         /**

--- a/pkg/dashboard/ui/src/app/components/data-wrappers/version-data-wrapper/version-data-wrapper.tpl.html
+++ b/pkg/dashboard/ui/src/app/components/data-wrappers/version-data-wrapper/version-data-wrapper.tpl.html
@@ -1,6 +1,6 @@
 <ncl-version data-version="$ctrl.version"
              data-create-version="$ctrl.createFunction(version, projectId, withTimeoutHeader)"
-             data-delete-function="$ctrl.deleteFunction(functionData, ignoreValidation)"
+             data-delete-function="$ctrl.deleteFunction(functionData, ignoreValidation, deleteApiGateway)"
              data-get-function="$ctrl.getFunction(metadata, enrichApiGateways)"
              data-get-functions="$ctrl.getFunctions(id, enrichApiGateways)"
              data-project="$ctrl.project"

--- a/pkg/dashboard/ui/src/app/shared/services/nuclio-functions-data.service.js
+++ b/pkg/dashboard/ui/src/app/shared/services/nuclio-functions-data.service.js
@@ -103,9 +103,10 @@ limitations under the License.
          * Deletes function
          * @param {Object} functionData
          * @param {Boolean} ignoreValidation - determines whether to forcibly remove the function
+         * @param {Boolean} deleteApiGateway - determines whether to delete API Gateway
          * @returns {Promise}
          */
-        function deleteFunction(functionData, ignoreValidation) {
+        function deleteFunction(functionData, ignoreValidation, deleteApiGateway) {
             var headers = {
                 'Content-Type': 'application/json'
             };
@@ -117,6 +118,10 @@ limitations under the License.
 
             if (ignoreValidation) {
                 headers['x-nuclio-delete-function-ignore-state-validation'] = true;
+            }
+
+            if (deleteApiGateway) {
+                headers['x-nuclio-delete-function-with-api-gateways'] = true;
             }
 
             var config = {


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

[Fix] Deleting a function from UI should allow deleting its related API gateway

---

### 🛠️ Changes Made

<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

Added a popup informing the user that an API Gateway is connected to the function and asking whether both the Gateway and the function should be deleted.


---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-258
- Design docs links:
- External links:
https://github.com/iguazio/dashboard-controls/pull/1681
---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->