### PR TITLE
[APIGW] Log error upon creation failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -699,7 +699,7 @@ ensure-test-files-annotated:
 	@echo "All go test files have //go:build test_X annotation"
 	@exit $(.SHELLSTATUS)
 
-GOLANGCI_LINT_VERSION := 2.5.0
+GOLANGCI_LINT_VERSION := 2.7.2
 GOLANGCI_LINT_BIN := $(CURDIR)/.bin/golangci-lint
 GOLANGCI_LINT_INSTALL_COMMAND := GOBIN=$(CURDIR)/.bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(GOLANGCI_LINT_VERSION)
 

--- a/hack/scripts/patch-remote/patch_remote.py
+++ b/hack/scripts/patch-remote/patch_remote.py
@@ -191,6 +191,7 @@ class NuclioPatcher:
     def _docker_login_if_configured(self):
         registry_username = self._config.get("REGISTRY_USERNAME")
         registry_password = self._config.get("REGISTRY_PASSWORD")
+        registry_url = self._config.get("DOCKER_REGISTRY")
         if registry_username is not None:
             self._exec_local(
                 [
@@ -200,6 +201,7 @@ class NuclioPatcher:
                     registry_username,
                     "--password",
                     registry_password,
+                    registry_url,
                 ],
                 live=True,
             )

--- a/pkg/platform/kube/controller/apigateway.go
+++ b/pkg/platform/kube/controller/apigateway.go
@@ -114,6 +114,8 @@ func (ago *apiGatewayOperator) CreateOrUpdate(ctx context.Context, object runtim
 			"Failed to create/update api gateway. Updating state accordingly",
 			"err", errors.GetErrorStackString(err, 10),
 		)
+
+		// deferring to ensure apigw status is updated
 		defer func() {
 			if err := ago.setAPIGatewayState(ctx, apiGateway, platform.APIGatewayStateError, err); err != nil {
 				ago.logger.WarnWithCtx(ctx,

--- a/pkg/platform/kube/controller/apigateway.go
+++ b/pkg/platform/kube/controller/apigateway.go
@@ -77,7 +77,6 @@ func newAPIGatewayOperator(ctx context.Context,
 
 // CreateOrUpdate handles creation/update of an object
 func (ago *apiGatewayOperator) CreateOrUpdate(ctx context.Context, object runtime.Object) error {
-	var err error
 
 	apiGateway, objectIsAPIGateway := object.(*nuclioio.NuclioAPIGateway)
 	if !objectIsAPIGateway {
@@ -110,12 +109,19 @@ func (ago *apiGatewayOperator) CreateOrUpdate(ctx context.Context, object runtim
 	}
 
 	// create/update the api gateway
-	if _, err = ago.controller.apigatewayresClient.CreateOrUpdate(ctx, *apiGateway); err != nil {
-		ago.logger.WarnWithCtx(ctx, "Failed to create/update api gateway. Updating state accordingly")
-		if err := ago.setAPIGatewayState(ctx, apiGateway, platform.APIGatewayStateError, err); err != nil {
-			ago.logger.WarnWithCtx(ctx, "Failed to set api gateway state as error", "err", err)
-		}
-
+	if _, err := ago.controller.apigatewayresClient.CreateOrUpdate(ctx, *apiGateway); err != nil {
+		ago.logger.WarnWithCtx(ctx,
+			"Failed to create/update api gateway. Updating state accordingly",
+			"err", errors.GetErrorStackString(err, 10),
+		)
+		defer func() {
+			if err := ago.setAPIGatewayState(ctx, apiGateway, platform.APIGatewayStateError, err); err != nil {
+				ago.logger.WarnWithCtx(ctx,
+					"Failed to set api gateway state as error",
+					"err", errors.GetErrorStackString(err, 10),
+				)
+			}
+		}()
 		return errors.Wrap(err, "Failed to create/update api gateway")
 	}
 


### PR DESCRIPTION
### 📝 Description
Fix apigateway responses so user-facing error messages are surfaced instead of being swallowed, plus tidy patch-remote flow and Makefile helpers.

---

### 🛠️ Changes Made

- Restore/propagate apigateway error messages to clients so failures are visible.
- Patch remote flow adjustments (path handling/defaults) to match current deployment expectations.
- Bumped golang linter version
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Manual: exercised apigateway error path and verified returned message visible to caller.

---

### 🔗 References
- Ticket link: None

---

### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- None.
