### PR TITLE
[Projects] Ensure project permissions are applied after creation

### DIFF
--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -337,6 +337,7 @@ func (pr *projectResource) createProject(request *http.Request, projectInfoInsta
 		SessionCookie: sessionCookie,
 		AuthSession:   pr.getCtxSession(ctx),
 		PermissionOptions: opaclient.PermissionOptions{
+			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(pr.getCtxSession(ctx)),
 			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
 		},
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -751,6 +751,18 @@ func (p *Platform) CreateProject(ctx context.Context, createProjectOptions *plat
 		return errors.Wrap(err, "Failed to create project")
 	}
 
+	// ensure project permissions are populated in OPA
+	if err := common.RetryUntilSuccessful(time.Second*10,
+		time.Second*1,
+		func() bool {
+			if err := p.EnsureProjectRead(ctx, createProjectOptions.ProjectConfig.Meta.Name, &createProjectOptions.PermissionOptions); err != nil {
+				return false
+			}
+			return true
+		}); err != nil {
+		return errors.Wrap(err, "Failed to ensure project permissions are populated in OPA")
+	}
+
 	// adding to cache for 30 seconds, allowing
 	p.projectsCache.Set(
 		p.getProjectCacheKey(


### PR DESCRIPTION
## 📝 Description

This PR fixes a race condition where users could not access a newly created project immediately after creation due to OPA (Open Policy Agent) permissions not being synchronized fast enough.

When a project is created, OPA needs to be updated with the permissions for that project. Previously, the `CreateProject` function returned successfully before OPA had the permission data populated, causing subsequent operations on the project (like deploying functions) to fail with permission errors.

---

## 🛠️ Changes Made

- **`pkg/platform/kube/platform.go`**: Added a retry loop after project creation that calls `EnsureProjectRead` to verify OPA permissions are populated before returning. The retry runs for up to 10 seconds with 1-second intervals.

- **`pkg/dashboard/resource/project.go`**: Added `MemberIds` to `PermissionOptions` when creating a project, passing the user and group IDs from the auth session. This enables the OPA permission check to work correctly.

---

## ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

## 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

## 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/IG4-1044
- Design docs links:
- External links:

---

## 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

## 🔍️ Additional Notes

The `EnsureProjectRead` function queries OPA to verify the user has read permissions on the project. By retrying this check after project creation, we ensure OPA has synchronized the permissions before the API returns success to the client. The 10-second timeout with 1-second retry intervals provides a reasonable window for OPA to sync while not blocking indefinitely.