### PR TITLE
[CI] Better Go Test Summary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -674,10 +674,6 @@ lint: modules ensure-test-files-annotated ensure-golangci-linter
 	$(GOLANGCI_LINT_BIN) run -v
 	@echo Done.
 
-.PHONY: test-coverage
-test-coverage:
-	go test -tags=test_unit -coverprofile=coverage.out ./pkg/... || go tool cover -html=coverage.out
-
 .PHONY: lint-docs
 lint-docs:
 	vale docs
@@ -737,6 +733,15 @@ govulncheck: modules ensure-govulncheck
 #
 # Testing
 #
+
+GOTESTSUM_VERSION := v1.13.0
+GOTESTSUM_BIN := $(CURDIR)/.bin/gotestsum-$(GOTESTSUM_VERSION)
+
+$(GOTESTSUM_BIN):
+	@echo "$(YELLOW)Installing gotestsum $(GOTESTSUM_VERSION)...$(NC)"
+	GOBIN=$(CURDIR)/.bin go install gotest.tools/gotestsum@$(GOTESTSUM_VERSION) && \
+    mv $(CURDIR)/.bin/gotestsum $(GOTESTSUM_BIN)
+
 .PHONY: benchmarking
 benchmarking:
 	$(eval NUCLIO_BENCHMARKING_RUNTIMES ?= all)
@@ -760,33 +765,38 @@ generate-crds: build-builder
 		--workdir /nuclio \
 		nuclio/crds:latest
 
+.PHONY: test-coverage
+test-coverage: $(GOTESTSUM_BIN)
+	$(GOTESTSUM_BIN) --format testname -- -tags=test_unit -coverprofile=coverage.out ./pkg/... || go tool cover -html=coverage.out
+
+
 .PHONY: test-unit
-test-unit: modules ensure-gopath
-	go test -race -tags=test_unit -v ./cmd/... ./pkg/... -short
+test-unit: modules ensure-gopath $(GOTESTSUM_BIN)
+	$(GOTESTSUM_BIN) --format testname -- -race -tags=test_unit -v ./cmd/... ./pkg/... -short
 
 .PHONY: test-k8s-nuctl
-test-k8s-nuctl:
+test-k8s-nuctl: $(GOTESTSUM_BIN)
 	NUCTL_EXTERNAL_IP_ADDRESSES=$(if $(NUCTL_EXTERNAL_IP_ADDRESSES),$(NUCTL_EXTERNAL_IP_ADDRESSES),"localhost") \
 		NUCTL_RUN_REGISTRY=$(NUCTL_REGISTRY) \
 		NUCTL_PLATFORM=kube \
 		NUCTL_NAMESPACE=$(if $(NUCTL_NAMESPACE),$(NUCTL_NAMESPACE),"default") \
-		go test -tags="test_integration,test_kube" -v github.com/nuclio/nuclio/pkg/nuctl/... -p 1 --timeout $(NUCLIO_GO_TEST_TIMEOUT)
+		$(GOTESTSUM_BIN) --format testname -- -tags="test_integration,test_kube" -v github.com/nuclio/nuclio/pkg/nuctl/... -p 1 --timeout $(NUCLIO_GO_TEST_TIMEOUT)
 
 .PHONY: test-docker-nuctl
-test-docker-nuctl:
+test-docker-nuctl: $(GOTESTSUM_BIN)
 	NUCTL_PLATFORM=local \
-		go test -tags="test_integration,test_local" -v github.com/nuclio/nuclio/pkg/nuctl/... -p 1 --timeout $(NUCLIO_GO_TEST_TIMEOUT)
+		$(GOTESTSUM_BIN) --format testname -- -tags="test_integration,test_local" -v github.com/nuclio/nuclio/pkg/nuctl/... -p 1 --timeout $(NUCLIO_GO_TEST_TIMEOUT)
 
 .PHONY: test-docker-benchmark-python
-test-docker-benchmark-python:
+test-docker-benchmark-python: $(GOTESTSUM_BIN)
 	NUCTL_PLATFORM=local \
 	BENCHMARK_REPORT_PATH=$(BENCHMARK_REPORT_PATH) \
-	go test -tags="test_integration,test_local,test_benchmark" -v github.com/nuclio/nuclio/pkg/processor/runtime/python/... -p 1 --timeout $(NUCLIO_GO_TEST_TIMEOUT)
+	$(GOTESTSUM_BIN) --format testname -- -tags="test_integration,test_local,test_benchmark" -v github.com/nuclio/nuclio/pkg/processor/runtime/python/... -p 1 --timeout $(NUCLIO_GO_TEST_TIMEOUT)
 
 .PHONY: test-undockerized
-test-undockerized: ensure-gopath
+test-undockerized: ensure-gopath $(GOTESTSUM_BIN)
 	${eval LIST=${shell make --no-print-directory $(LIST_TESTS_MAKE_COMMAND)}}
-	go test  \
+	$(GOTESTSUM_BIN) --format testname -- \
 		-tags="test_integration,test_local" \
 		-v \
 		-p 1 \
@@ -794,9 +804,9 @@ test-undockerized: ensure-gopath
 		${LIST}
 
 .PHONY: test-k8s-undockerized
-test-k8s-undockerized: ensure-gopath
+test-k8s-undockerized: ensure-gopath $(GOTESTSUM_BIN)
 	@# nuctl is running by "test-k8s-nuctl" target and requires specific set of env
-	go test \
+	$(GOTESTSUM_BIN) --format testname -- \
 		-tags="test_integration,test_kube" \
  		-v \
  		-p 1 \
@@ -804,9 +814,9 @@ test-k8s-undockerized: ensure-gopath
  		$(shell go list -tags="test_integration,test_kube" ./cmd/... ./pkg/... | grep -v nuctl)
 
 .PHONY: test-functions-k8s-undockerized
-test-functions-k8s-undockerized: ensure-gopath
+test-functions-k8s-undockerized: ensure-gopath $(GOTESTSUM_BIN)
 	@# nuctl is running by "test-k8s-nuctl" target and requires specific set of env
-	go test \
+	$(GOTESTSUM_BIN) --format testname -- \
 		-tags="test_integration,test_functions_kube" \
  		-v \
  		-p 1 \
@@ -814,9 +824,9 @@ test-functions-k8s-undockerized: ensure-gopath
  		$(shell go list -tags="test_integration,test_functions_kube" ./cmd/... ./pkg/... | grep -v nuctl)
 
 .PHONY: test-broken-undockerized
-test-broken-undockerized: ensure-gopath
+test-broken-undockerized: ensure-gopath $(GOTESTSUM_BIN)
 	${eval LIST=${shell make --no-print-directory $(LIST_TESTS_MAKE_COMMAND)}}
-	go test  \
+	$(GOTESTSUM_BIN) --format testname --  \
 		-tags="test_integration,test_broken" \
 		-v \
 		-p 1 \
@@ -872,8 +882,8 @@ test-k8s: build-test
 
 # Runs from host to allow full control over Kubernetes cluster
 .PHONY: test-k8s-functional
-test-k8s-functional:
-	go test \
+test-k8s-functional: $(GOTESTSUM_BIN)
+	$(GOTESTSUM_BIN) --format testname -- \
 		-tags="test_kube,test_functional" \
  		-v \
  		-p 1 \


### PR DESCRIPTION
### 📝 Description
The test output is not ideal to read and find the issues.
We are now using https://github.com/gotestyourself/gotestsum which creates a nicer test summary when running the tests (see example below from orca).

---

### 🛠️ Changes Made
- The go Makefile ensures the gotestsum binary exists in the required version
- The go Makefile

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### Summary Example

(from orca)

```
=== Failed
=== FAIL: frameworks/clients/clients/cache/inmemory TestCacheClientTestSuite/TestDelete (0.00s)
26.01.06 09:58:20.584 (D)                test.cache Setting cache item {"ctx": "952c869a-bdc7-48ea-8ae9-ce0286aed51f", "key": "TestKey", "ttl": "5s"}
26.01.06 09:58:20.584 (D)                test.cache Starting cache invalidation loop {"ctx": "d1ad6493-906a-4f56-a0c4-537a7061b068"}
26.01.06 09:58:20.585 (D)                test.cache Deleting cache key {"ctx": "952c869a-bdc7-48ea-8ae9-ce0286aed51f", "key": "TestKey"}
26.01.06 09:58:20.585 (D)                test.cache Deleting cache key {"ctx": "952c869a-bdc7-48ea-8ae9-ce0286aed51f", "key": "TestKey"}
26.01.06 09:58:20.585 (D)                test.cache Setting cache item {"ctx": "952c869a-bdc7-48ea-8ae9-ce0286aed51f", "key": "TestKey", "ttl": "5s"}
26.01.06 09:58:20.585 (D)                test.cache Getting cache item {"ctx": "952c869a-bdc7-48ea-8ae9-ce0286aed51f", "key": "TestKey"}
26.01.06 09:58:20.585 (D)                test.cache Deleting cache key {"ctx": "952c869a-bdc7-48ea-8ae9-ce0286aed51f", "key": "TestKey"}
    client_test.go:125: 
                Error Trace:    /Users/Adam_Melnick/iguazio/misc_workspace/orca/backend/go/frameworks/clients/clients/cache/inmemory/client_test.go:125
                                                        /Users/Adam_Melnick/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.5.darwin-arm64/src/runtime/asm_arm64.s:1268
                Error:          Not equal: 
                                expected: "TestValuebla"
                                actual  : "TestValue"
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -TestValuebla
                                +TestValue
                Test:           TestCacheClientTestSuite/TestDelete
                Messages:       Expected the popped value to match the inserted value
26.01.06 09:58:20.585 (D)                test.cache Stopping cache client {"ctx": "952c869a-bdc7-48ea-8ae9-ce0286aed51f"}
26.01.06 09:58:20.585 (D)                test.cache Stopping cache invalidation loop {"ctx": "d1ad6493-906a-4f56-a0c4-537a7061b068"}
    --- FAIL: TestCacheClientTestSuite/TestDelete (0.00s)

=== FAIL: frameworks/clients/clients/cache/inmemory TestCacheClientTestSuite (6.01s)

=== FAIL: subdomains/authentication/transport/mappers TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies/Cookie_present_but_wrong_name (0.00s)
    cookie_test.go:224: 
                Error Trace:    /Users/Adam_Melnick/iguazio/misc_workspace/orca/backend/go/subdomains/authentication/transport/mappers/cookie_test.go:224
                                                        /Users/Adam_Melnick/go/pkg/mod/github.com/stretchr/testify@v1.11.1/suite/suite.go:115
                Error:          Not equal: 
                                expected: "asd"
                                actual  : ""
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -asd
                                +
                Test:           TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies/Cookie_present_but_wrong_name
        --- FAIL: TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies/Cookie_present_but_wrong_name (0.00s)

=== FAIL: subdomains/authentication/transport/mappers TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies (0.00s)
    --- FAIL: TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies (0.00s)

=== FAIL: subdomains/authentication/transport/mappers TestCookieMapperTestSuite (0.10s)

DONE 1027 tests, 5 failures in 7.019s
make[1]: *** [test-unit] Error 1
make: *** [test-unit] Error 2
estGetRefreshTokenFromRequestCookies/Cookie_present_but_wrong_name (0.00s)
    cookie_test.go:224: 
                Error Trace:    /Users/Adam_Melnick/iguazio/misc_workspace/orca/backend/go/subdomains/authentication/transport/mappers/cookie_test.go:224
                                                        /Users/Adam_Melnick/go/pkg/mod/github.com/stretchr/testify@v1.11.1/suite/suite.go:115
                Error:          Not equal: 
                                expected: "asd"
                                actual  : ""
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -asd
                                +
                Test:           TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies/Cookie_present_but_wrong_name
        --- FAIL: TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies/Cookie_present_but_wrong_name (0.00s)

=== FAIL: subdomains/authentication/transport/mappers TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies (0.00s)
    --- FAIL: TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies (0.00s)

=== FAIL: subdomains/authentication/transport/mappers TestCookieMapperTestSuite (0.05s)

DONE 1027 tests, 5 failures in 6.984s
make[1]: *** [test-unit] Error 1
make: *** [test-unit] Error 2
```