### PR TITLE
[Projects] Fix auth propagation to MLRun Project Leader in IG4

### DIFF
--- a/pkg/auth/iguazio/abstract.go
+++ b/pkg/auth/iguazio/abstract.go
@@ -98,7 +98,7 @@ func (a *AbstractAuth) Authenticate(request *http.Request, options *authpkg.Opti
 	}
 
 	// Extract the session from the response
-	session, err := a.authenticator.BuildSessionFromResponse(resp)
+	session, err := a.authenticator.BuildSessionFromResponse(resp, authParams)
 	if err != nil {
 		a.Logger.WarnWithCtx(request.Context(),
 			"Failed to extract session from response",
@@ -269,7 +269,7 @@ func (a *AbstractSession) GetGroupIDs() []string {
 	return a.GroupIDs
 }
 
-func (a *AbstractSession) CompileAuthorizationBasicHeader() string {
+func (a *AbstractSession) CompileAuthorizationHeader() string {
 	return ""
 }
 

--- a/pkg/auth/iguazio/types.go
+++ b/pkg/auth/iguazio/types.go
@@ -38,7 +38,7 @@ type Authenticator interface {
 	ValidateResponse(response *http.Response) error
 
 	// BuildSessionFromResponse constructs a session from the response received from the Iguazio session verification endpoint
-	BuildSessionFromResponse(response *http.Response) (authpkg.Session, error)
+	BuildSessionFromResponse(response *http.Response, authParams *AuthParameters) (authpkg.Session, error)
 
 	// VerifySessionType checks if the provided session is of the expected type
 	// and returns (typedValue, true) if valid and (nil, false) otherwise
@@ -69,6 +69,10 @@ func (a *AuthParameters) GenerateCacheKey() ([32]byte, error) {
 	}
 	// generate cache key based on authorization header and URL
 	return sha256.Sum256([]byte(a.authorizationHeader + a.verificationURL)), nil
+}
+
+func (a *AuthParameters) GetAuthorizationHeader() string {
+	return a.authorizationHeader
 }
 
 // TimeUntilExpiration parses the JWT access token from the Authorization header,

--- a/pkg/auth/iguazio/v1/auth.go
+++ b/pkg/auth/iguazio/v1/auth.go
@@ -92,7 +92,7 @@ func (a *Auth) resolveUrl(options *authpkg.Options) string {
 	return a.GetConfig().Iguazio.VerificationURL
 }
 
-func (a *Auth) BuildSessionFromResponse(response *http.Response) (authpkg.Session, error) {
+func (a *Auth) BuildSessionFromResponse(response *http.Response, authParams *iguazio.AuthParameters) (authpkg.Session, error) {
 	encodedResponseBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to read response body")

--- a/pkg/auth/iguazio/v1/auth.go
+++ b/pkg/auth/iguazio/v1/auth.go
@@ -92,7 +92,7 @@ func (a *Auth) resolveUrl(options *authpkg.Options) string {
 	return a.GetConfig().Iguazio.VerificationURL
 }
 
-func (a *Auth) BuildSessionFromResponse(response *http.Response, authParams *iguazio.AuthParameters) (authpkg.Session, error) {
+func (a *Auth) BuildSessionFromResponse(response *http.Response, _ *iguazio.AuthParameters) (authpkg.Session, error) {
 	encodedResponseBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to read response body")

--- a/pkg/auth/iguazio/v1/session.go
+++ b/pkg/auth/iguazio/v1/session.go
@@ -36,7 +36,7 @@ func NewSession(username, sessionKey, userID string, groupIDs []string) *Session
 	}, SessionKey: sessionKey, UserID: userID}
 }
 
-func (s *Session) CompileAuthorizationBasicHeader() string {
+func (s *Session) CompileAuthorizationHeader() string {
 	data := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", s.Username, s.SessionKey)))
 	return fmt.Sprintf("Basic: %s", data)
 }

--- a/pkg/auth/iguazio/v4/auth.go
+++ b/pkg/auth/iguazio/v4/auth.go
@@ -81,7 +81,7 @@ func (a *Auth) ValidateResponse(response *http.Response) error {
 }
 
 // BuildSessionFromResponse parses the response body and builds the session object
-func (a *Auth) BuildSessionFromResponse(response *http.Response) (authpkg.Session, error) {
+func (a *Auth) BuildSessionFromResponse(response *http.Response, authParams *iguazio.AuthParameters) (authpkg.Session, error) {
 	var resp identityResponse
 	if err := json.NewDecoder(response.Body).Decode(&resp); err != nil {
 		return nil, errors.Wrap(err, "Failed to decode identity response")
@@ -94,5 +94,5 @@ func (a *Auth) BuildSessionFromResponse(response *http.Response) (authpkg.Sessio
 		}
 	}
 
-	return NewSession(resp.Metadata.Username, resp.Metadata.ID, groupIDs), nil
+	return NewSession(resp.Metadata.Username, resp.Metadata.ID, groupIDs, authParams.GetAuthorizationHeader()), nil
 }

--- a/pkg/auth/iguazio/v4/session.go
+++ b/pkg/auth/iguazio/v4/session.go
@@ -20,14 +20,20 @@ import "github.com/nuclio/nuclio/pkg/auth/iguazio"
 
 type Session struct {
 	*iguazio.AbstractSession
+	AuthorizationHeader string
 }
 
-func NewSession(username string, userID string, groupIDs []string) *Session {
+func NewSession(username string, userID string, groupIDs []string, authorizationHeader string) *Session {
 	return &Session{
 		AbstractSession: &iguazio.AbstractSession{
 			Username: username,
 			UserID:   userID,
 			GroupIDs: groupIDs,
 		},
+		AuthorizationHeader: authorizationHeader,
 	}
+}
+
+func (s *Session) CompileAuthorizationHeader() string {
+	return s.AuthorizationHeader
 }

--- a/pkg/auth/nop/session.go
+++ b/pkg/auth/nop/session.go
@@ -23,7 +23,7 @@ func (s *Session) GetUsername() string {
 	return ""
 }
 
-func (s *Session) CompileAuthorizationBasicHeader() string {
+func (s *Session) CompileAuthorizationHeader() string {
 	return ""
 }
 

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -91,7 +91,7 @@ type Session interface {
 	GetPassword() string
 	GetUserID() string
 	GetGroupIDs() []string
-	CompileAuthorizationBasicHeader() string
+	CompileAuthorizationHeader() string
 	GetUserLabels() map[string]string
 }
 

--- a/pkg/platform/abstract/project/external/leader/client/client.go
+++ b/pkg/platform/abstract/project/external/leader/client/client.go
@@ -19,6 +19,7 @@ package client
 import (
 	"context"
 	"crypto/tls"
+	"io"
 	"net/http"
 	"time"
 
@@ -244,20 +245,31 @@ func (c *Client) logLeaderResponseError(ctx context.Context,
 		c.logger.WarnWithCtx(ctx, "Got an empty response", "errMessage", errMessage)
 		return
 	}
+
+	// Try to read response body for additional context
+	var responseBody string
+	if response.Body != nil {
+		bodyBytes, err := io.ReadAll(response.Body)
+		if err == nil {
+			responseBody = string(bodyBytes)
+		}
+		// Close the body after reading
+		response.Body.Close() // nolint: errcheck
+	}
+
+	logFields := []interface{}{
+		"statusCode", response.StatusCode,
+	}
+	if responseBody != "" {
+		logFields = append(logFields, "responseBody", responseBody)
+	}
+
 	if response.StatusCode >= 500 {
-		c.logger.WarnWithCtx(ctx,
-			errMessage,
-			"statusCode", response.StatusCode,
-			"response", response,
-		)
+		c.logger.WarnWithCtx(ctx, errMessage, logFields...)
 		return
 	}
 
-	c.logger.DebugWithCtx(ctx,
-		errMessage,
-		"statusCode", response.StatusCode,
-		"response", response,
-	)
+	c.logger.DebugWithCtx(ctx, errMessage, logFields...)
 }
 
 func (c *Client) generateCommonRequestHeaders() map[string]string {

--- a/pkg/platform/abstract/project/external/leader/iguazio/leader.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/leader.go
@@ -234,7 +234,7 @@ func (l *LeaderOps) GetAuthSessionCookie(authSession auth.Session) *http.Cookie 
 }
 
 func (l *LeaderOps) AddAuthSessionHeaders(headers map[string]string, authSession auth.Session) {
-	headers["authorization"] = authSession.CompileAuthorizationBasicHeader()
+	headers["authorization"] = authSession.CompileAuthorizationHeader()
 }
 
 func (l *LeaderOps) projectRequestURL(apiAddress string) string {

--- a/pkg/platform/abstract/project/external/leader/mlrun/leader.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/leader.go
@@ -140,10 +140,11 @@ func (l *LeaderOps) GetDeleteStrategyHeaderName() string {
 }
 
 func (l *LeaderOps) GenerateGetProjectsRequestURL(apiAddress, projectName string) string {
+	url := fmt.Sprintf("%s/%s/projects", apiAddress, APIVersionV1)
 	if projectName != "" {
-		projectName = fmt.Sprintf("/%s", projectName)
+		url += fmt.Sprintf("/%s", projectName)
 	}
-	return fmt.Sprintf("%s/%s/projects%s", apiAddress, APIVersionV1, projectName)
+	return url
 }
 
 func (l *LeaderOps) GenerateGetUpdatedAfterRequestURL(apiAddress string) string {

--- a/pkg/platform/abstract/project/external/leader/mlrun/leader.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/leader.go
@@ -33,6 +33,13 @@ import (
 	"github.com/nuclio/nuclio-sdk-go"
 )
 
+type APIVersion string
+
+const (
+	APIVersionV1 APIVersion = "v1"
+	APIVersionV2 APIVersion = "v2"
+)
+
 type LeaderOps struct {
 	logger logger.Logger
 	// namespace is used to enrich the MLRun responses, which omit the namespace
@@ -89,7 +96,7 @@ func (l *LeaderOps) ParseJobStatusResponse(_ context.Context, _ []byte) (leaderC
 }
 
 func (l *LeaderOps) GenerateCreateProjectRequestURL(apiAddress string) string {
-	return fmt.Sprintf("%s/%s", apiAddress, "projects")
+	return fmt.Sprintf("%s/%s/%s", apiAddress, APIVersionV1, "projects")
 }
 
 func (l *LeaderOps) HandleCreateResponseErr(ctx context.Context, responseBody []byte, response *http.Response, err error) error {
@@ -121,7 +128,7 @@ func (l *LeaderOps) IsJobCompleted(_ context.Context, _ leaderCommon.JobResponse
 }
 
 func (l *LeaderOps) GenerateUpdateProjectRequestURL(apiAddress, projectName string) string {
-	return l.projectRequestURL(apiAddress, projectName)
+	return l.projectRequestURL(apiAddress, projectName, APIVersionV1)
 }
 
 func (l *LeaderOps) GetDeleteExpectedStatusCode() int {
@@ -132,8 +139,11 @@ func (l *LeaderOps) GetDeleteStrategyHeaderName() string {
 	return "x-mlrun-deletion-strategy"
 }
 
-func (l *LeaderOps) GenerateGetProjectsRequestURL(_, _ string) string {
-	return ""
+func (l *LeaderOps) GenerateGetProjectsRequestURL(apiAddress, projectName string) string {
+	if projectName != "" {
+		projectName = fmt.Sprintf("/%s", projectName)
+	}
+	return fmt.Sprintf("%s/%s/projects%s", apiAddress, APIVersionV1, projectName)
 }
 
 func (l *LeaderOps) GenerateGetUpdatedAfterRequestURL(apiAddress string) string {
@@ -142,7 +152,7 @@ func (l *LeaderOps) GenerateGetUpdatedAfterRequestURL(apiAddress string) string 
 }
 
 func (l *LeaderOps) GenerateDeleteProjectRequestURL(apiAddress, projectName string) string {
-	return l.projectRequestURL(apiAddress, projectName)
+	return l.projectRequestURL(apiAddress, projectName, APIVersionV2)
 }
 
 func (l *LeaderOps) ShouldWaitForCreateCompletion() bool { return false }
@@ -153,8 +163,10 @@ func (l *LeaderOps) GetJobRequestFilter(_ *time.Time) string { return "" }
 
 func (l *LeaderOps) GetAuthSessionCookie(_ auth.Session) *http.Cookie { return nil }
 
-func (l *LeaderOps) AddAuthSessionHeaders(_ map[string]string, _ auth.Session) {}
+func (l *LeaderOps) AddAuthSessionHeaders(headers map[string]string, authSession auth.Session) {
+	headers["authorization"] = authSession.CompileAuthorizationHeader()
+}
 
-func (l *LeaderOps) projectRequestURL(apiAddress, projectName string) string {
-	return fmt.Sprintf("%s/%s/%s", apiAddress, "projects", projectName)
+func (l *LeaderOps) projectRequestURL(apiAddress, projectName string, version APIVersion) string {
+	return fmt.Sprintf("%s/%s/%s/%s", apiAddress, version, "projects", projectName)
 }

--- a/pkg/platform/abstract/project/external/leader/mlrun/leader_test.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/leader_test.go
@@ -180,13 +180,13 @@ func (suite *LeaderTestSuite) TestGenerateCreateProjectRequestURL() {
 	}{
 		{
 			name:     "Basic",
-			address:  "http://localhost",
-			expected: "http://localhost/projects",
+			address:  "http://localhost/api",
+			expected: "http://localhost/api/v1/projects",
 		},
 		{
 			name:     "WithoutHttpPrefix",
 			address:  "some-address",
-			expected: "some-address/projects",
+			expected: "some-address/v1/projects",
 		},
 	}
 
@@ -256,15 +256,15 @@ func (suite *LeaderTestSuite) TestGenerateUpdateProjectRequestURL() {
 	}{
 		{
 			name:        "Basic",
-			address:     "http://localhost",
+			address:     "http://localhost/api",
 			projectName: "test-project",
-			expected:    "http://localhost/projects/test-project",
+			expected:    "http://localhost/api/v1/projects/test-project",
 		},
 		{
 			name:        "WithEmptyUrl",
 			address:     "",
 			projectName: "test-project",
-			expected:    "/projects/test-project",
+			expected:    "/v1/projects/test-project",
 		},
 	}
 
@@ -289,8 +289,8 @@ func (suite *LeaderTestSuite) TestGetDeleteStrategyHeaderName() {
 }
 
 func (suite *LeaderTestSuite) TestGenerateGetProjectsRequestURL() {
-	url := suite.leaderOps.GenerateGetProjectsRequestURL("a", "b")
-	suite.Require().Equal("", url)
+	url := suite.leaderOps.GenerateGetProjectsRequestURL("http://localhost/api", "b")
+	suite.Require().Equal("http://localhost/api/v1/projects/b", url)
 }
 
 func (suite *LeaderTestSuite) TestGenerateGetUpdatedAfterRequestURL() {
@@ -299,8 +299,8 @@ func (suite *LeaderTestSuite) TestGenerateGetUpdatedAfterRequestURL() {
 }
 
 func (suite *LeaderTestSuite) TestGenerateDeleteProjectRequestURL() {
-	url := suite.leaderOps.GenerateDeleteProjectRequestURL("http://localhost", "test-project")
-	suite.Require().Equal("http://localhost/projects/test-project", url)
+	url := suite.leaderOps.GenerateDeleteProjectRequestURL("http://localhost/api", "test-project")
+	suite.Require().Equal("http://localhost/api/v2/projects/test-project", url)
 }
 
 func (suite *LeaderTestSuite) TestShouldWaitForCreateCompletion() {

--- a/pkg/platform/abstract/project/external/leader/mock/leader.go
+++ b/pkg/platform/abstract/project/external/leader/mock/leader.go
@@ -45,8 +45,8 @@ func (l *LeaderOps) GenerateProjectRequestBody(projectConfig *platform.ProjectCo
 	return args.Get(0).([]byte), args.Error(1)
 }
 
-func (l *LeaderOps) GenerateCreateProjectRequestURL(projectName string) string {
-	args := l.Called(projectName)
+func (l *LeaderOps) GenerateCreateProjectRequestURL(apiAddress string) string {
+	args := l.Called(apiAddress)
 	return args.String(0)
 }
 

--- a/pkg/platform/abstract/project/external/leader/types.go
+++ b/pkg/platform/abstract/project/external/leader/types.go
@@ -107,7 +107,7 @@ type LeaderOps interface {
 
 	// Get operations
 
-	// GenerateGetProjectsRequestURL generates the request URL for getting projects
+	// GenerateGetProjectsRequestURL generates the request URL for getting projects or a single project
 	GenerateGetProjectsRequestURL(string, string) string
 
 	// ResolveGetProjectResponse resolves the response from getting projects

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -2022,7 +2022,7 @@ func (suite *FunctionKubePlatformTestSuite) TestEnrichFunctionWithUserNameLabel(
 		},
 		{
 			name:         "igzV4",
-			session:      authIgzV4.NewSession("another-user", "", nil),
+			session:      authIgzV4.NewSession("another-user", "", nil, ""),
 			expectedUser: "another-user",
 		},
 	}
@@ -2154,7 +2154,7 @@ func (suite *FunctionKubePlatformTestSuite) TestUsernameLabelsEnrichment() {
 
 			switch testCase.authKind {
 			case auth.KindIguazioV4:
-				session = authIgzV4.NewSession(testCase.fullUsername, "", nil)
+				session = authIgzV4.NewSession(testCase.fullUsername, "", nil, "")
 			case auth.KindIguazio:
 				session = authIgzV1.NewSession(testCase.fullUsername, "", "", nil)
 			default:
@@ -2638,7 +2638,7 @@ func (suite *APIGatewayKubePlatformTestSuite) TestAPIGatewayEnrichmentAndValidat
 				}
 				return &apiGatewayConfig
 			}(),
-			authSession: authIgzV4.NewSession("some-username1", "", nil),
+			authSession: authIgzV4.NewSession("some-username1", "", nil, ""),
 		},
 		{
 			name: "ValidateNamespaceExistence",


### PR DESCRIPTION
### 📝 Description

This PR adds support for MLRun Project Leader in Iguazio 4 (IG4) by fixing authorization header propagation and adding API versioning to MLRun project endpoints. 
Additionally, it fixes a JSON serialization error in error logging.

### 🛠️ Changes Made

#### 1. Fix Iguazio 4 Authorization Issue

**Problem**: Authorization headers were not being passed to the MLRun leader client when using Iguazio 4 authentication, causing requests to fail with authorization errors.

**Solution**:
- **MLRun Leader Client**: Implemented `AddAuthSessionHeaders` method in `mlrun/leader.go` to properly set the authorization header (previously was a no-op)
- **Iguazio v4 Session**: Enhanced `v4/session.go` to store and return the authorization header:
  - Added `AuthorizationHeader` field to `Session` struct
  - Updated `NewSession` to accept and store the authorization header from auth parameters
  - Implemented `CompileAuthorizationHeader()` to return the stored authorization header
- **Auth Flow**: Updated `v4/auth.go` to pass the authorization header from `AuthParameters` to the session during creation
- **API Consistency**: Renamed `CompileAuthorizationBasicHeader()` to `CompileAuthorizationHeader()` across all auth implementations (v1, v4, nop) for consistency

#### 2. Add Versioning to MLRun Projects Endpoints

**Changes**:
- Added `APIVersion` type with `APIVersionV1` and `APIVersionV2` constants
- Updated all MLRun project endpoint URLs to include API versioning:
  - **Create**: `/v1/projects` (was `/projects`)
  - **Update**: `/v1/projects/{name}` (was `/projects/{name}`)
  - **Get**: `/v1/projects` or `/v1/projects/{name}` (was empty string - now properly implemented)
  - **Delete**: `/v2/projects/{name}` (was `/projects/{name}`)
- Refactored `projectRequestURL` helper to accept version parameter for consistency

#### 3. Fix JSON Serialization Error in Error Logging

**Problem**: Logging the entire `*http.Response` object caused JSON serialization errors: `json: unsupported type: func() (io.ReadCloser, error)`

**Solution**:
- Updated `logLeaderResponseError` in `client.go` to read and log only serializable fields
- Added reading of `response.Body` and included it in logs when available for better debugging
- Replaced direct logging of `response` object with structured fields: `statusCode` and `responseBody`

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

### 🧪 Testing

- Manual tests - verified all project operation work in IG4 when invoking nuclio directly.

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/IG4-1147 https://iguazio.atlassian.net/browse/IG4-1138

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

This is a bug fix and feature enhancement that maintains backward compatibility:
- The authorization header fix only affects Iguazio 4 sessions (which were previously broken)
- API versioning changes are internal to the MLRun leader client implementation
- Method renaming (`CompileAuthorizationBasicHeader` → `CompileAuthorizationHeader`) is internal to the auth package

### 🔍️ Additional Notes

Fixes error logging issue where logs showed:
```
{"level":"debug","time":"2026-01-11T12:56:39.326Z","name":"dashboard.platform.project-leader","message":"Failed to create project on leader","requestID":"9c2c8e93fde8989b345bce3a45e8f0ec","moreError":"json: unsupported type: func() (io.ReadCloser, error)"}
```