### PR TITLE
[Dashboard] Add explicit log proxy kind

### DIFF
--- a/pkg/platform/kube/logProxy/elastic/factory.go
+++ b/pkg/platform/kube/logProxy/elastic/factory.go
@@ -31,6 +31,32 @@ import (
 // CreateLogProxy connects to the given endpoint and resolves whether it is an OpenSearch or Elasticsearch instance
 // It returns a LogProxy implementation accordingly
 func CreateLogProxy(logger logger.Logger, config *platformconfig.ElasticSearchConfig) (logProxy.LogProxy, error) {
+
+	// If kind is explicitly set, use it directly without auto-detection
+	if config.Kind != "" {
+		return createLogProxyByKind(logger, config, config.Kind)
+	}
+
+	// Auto-detect the backend type by querying the search engine
+	return createLogProxyWithAutoDetection(logger, config)
+}
+
+// createLogProxyByKind creates a log proxy based on the explicitly configured kind
+func createLogProxyByKind(logger logger.Logger, config *platformconfig.ElasticSearchConfig, kind platformconfig.LogProxyKind) (logProxy.LogProxy, error) {
+	switch kind {
+	case platformconfig.LogProxyKindOpenSearch:
+		logger.InfoWith("Creating log proxy client with explicit kind",
+			"kind", platformconfig.LogProxyKindOpenSearch)
+		return NewOpenSearchLogProxy(config)
+	default:
+		logger.InfoWith("Creating log proxy client with explicit kind",
+			"kind", platformconfig.LogProxyKindElasticSearch)
+		return NewElasticSearchLogProxy(config)
+	}
+}
+
+// createLogProxyWithAutoDetection auto-detects the backend type by querying the search engine version endpoint
+func createLogProxyWithAutoDetection(logger logger.Logger, config *platformconfig.ElasticSearchConfig) (logProxy.LogProxy, error) {
 	versionInfoInstance, err := getVersionFromSearchEngineWithRetries(config, 3, 2*time.Second, 15*time.Second)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get version from search engine")

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -347,6 +347,16 @@ type ServiceAccountConfig struct {
 	TokenRefreshRatio      float64 `json:"tokenRefreshRatio,omitempty"`
 }
 
+// LogProxyKind represents the type of log proxy backend (elasticsearch or opensearch)
+type LogProxyKind string
+
+const (
+	// LogProxyKindElasticSearch indicates an Elasticsearch backend
+	LogProxyKindElasticSearch LogProxyKind = "elasticsearch"
+	// LogProxyKindOpenSearch indicates an OpenSearch backend
+	LogProxyKindOpenSearch LogProxyKind = "opensearch"
+)
+
 type ElasticSearchConfig struct {
 	URL                  string `json:"url,omitempty"`
 	SSLVerificationMode  string `json:"sslVerificationMode,omitempty"`
@@ -354,6 +364,11 @@ type ElasticSearchConfig struct {
 	Password             string `json:"password,omitempty"`
 	Index                string `json:"index,omitempty"`
 	CustomQueryParameter string `json:"customQueryParameter,omitempty"`
+
+	// Kind specifies the log proxy backend type explicitly.
+	// If not set, the backend type is auto-detected by querying the search engine.
+	// Valid values: "elasticsearch", "opensearch"
+	Kind LogProxyKind `json:"kind,omitempty"`
 }
 
 type CronTriggerCreationMode string


### PR DESCRIPTION
### 📝 Description
* Add explicit kind configuration to ElasticSearchConfig to allow users to manually specify the log proxy backend type (`elasticsearch` or `opensearch`)
* When kind is set, bypass auto-detection and use the specified backend directly
* When kind is not set, fall back to existing auto-detection logic (query the search engine's version endpoint)
This fixes an issue where OpenSearch running in elastic-compatibility mode doesn't return the distribution field in its version response, causing the auto-detection to incorrectly default to Elasticsearch.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-734
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->