### PR TITLE
[Streaming] Add streamingFlushPeriodDuration configuration

### DIFF
--- a/docs/reference/triggers/http.md
+++ b/docs/reference/triggers/http.md
@@ -32,6 +32,7 @@ available, a `503` error is returned.
 | cors.preflightMaxAgeSeconds                            | int             | The number of seconds in which the results of a preflight request can be cached in a preflight result cache (`Access-Control-Max-Age` response header); (default: `-1` to indicate no preflight results caching).                                                                                                     |
 | <a id="attributes-serviceType"></a>serviceType         | string          | (Kubernetes only) Kubernetes `ServiceType`, used by the Kubernetes service to expose the trigger. The default `ServiceType` is `ClusterIP`, which means that by default the trigger won't be exposed outside of the cluster unless you configure a proper ingress or manually change the `ServiceType` to `NodePort`. |
 | disablePortPublishing                                  | bool            | (Docker only) Allow disabling publishing the function container port on the host network                                                                                                                                                                                                                              |
+| streamingFlushPeriod                                   | string (duration) | When the response body is streamed, the trigger flushes the response buffer to the client at most every this period (e.g. `"1s"`, `"500ms"`). This allows clients to receive data incrementally instead of only when the stream ends. Must be a positive duration. Default: `"1s"` (set during platform enrichment if omitted). |
 
 <a id="examples"></a>
 ## Examples
@@ -109,4 +110,14 @@ triggers:
           - "PATCH"
         allowCredentials: false
         preflightMaxAgeSeconds: 3600
+```
+
+With streaming flush period (for streamed response bodies) -
+
+```yaml
+triggers:
+  myHttpTrigger:
+    kind: "http"
+    attributes:
+      streamingFlushPeriod: "1s"
 ```

--- a/docs/tasks/stream-response.md
+++ b/docs/tasks/stream-response.md
@@ -17,6 +17,26 @@ Streaming allows a function to send data to the client in chunks as it becomes a
 
 ---
 
+## Streaming flush period
+
+When a function returns a **streamed** response body (e.g. a generator or `io.ReadCloser`), the HTTP trigger copies data to the client through a buffer. By default, the trigger flushes this buffer to the client **at most every 1 second** so that the client receives data incrementally instead of only when the stream ends.
+
+You can configure this interval with the HTTP trigger attribute **`streamingFlushPeriod`** (a duration string, e.g. `"1s"`, `"500ms"`). It must be a positive duration. If omitted, the platform uses the default `"1s"`.
+
+Example (in function spec or nuctl):
+
+```yaml
+triggers:
+  default-http:
+    kind: "http"
+    attributes:
+      streamingFlushPeriod: "1s"
+```
+
+See [HTTP trigger reference](/reference/triggers/http.md#attributes) for the full attributes table.
+
+---
+
 ## Usage Examples
 
 ### Go Runtime

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -166,6 +166,9 @@ const (
 
 	DefaultBatchSize    = 10
 	DefaultBatchTimeout = "1s"
+
+	// DefaultStreamingFlushPeriod is the default period for flushing HTTP response stream to the client
+	DefaultStreamingFlushPeriod = "1s"
 )
 
 func BatchModeEnabled(batchConfiguration *BatchConfiguration) bool {

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1641,6 +1641,9 @@ func (ap *Platform) validateTriggers(functionConfig *functionconfig.Config) erro
 				return nuclio.NewErrBadRequest("There's more than one http trigger (unsupported)")
 			}
 			httpTriggerExists = true
+			if err := ap.validateStreamingFlushPeriod(triggerKey, &triggerInstance); err != nil {
+				return nuclio.WrapErrBadRequest(err)
+			}
 		}
 
 		// explicit ack is only allowed for Static Allocation mode
@@ -1691,6 +1694,34 @@ func (ap *Platform) validateTriggers(functionConfig *functionconfig.Config) erro
 		}
 	}
 
+	return nil
+}
+
+// validateStreamingFlushPeriod validates the HTTP trigger's streamingFlushPeriod attribute.
+// When set, it must be a non-empty string that parses as a positive Go duration (e.g. "1s", "500ms").
+// Invalid or non-positive values cause validation to fail so deploy fails early instead of at stream time.
+func (ap *Platform) validateStreamingFlushPeriod(triggerKey string, triggerInstance *functionconfig.Trigger) error {
+	if triggerInstance.Attributes == nil {
+		return nil
+	}
+	attrValue, exists := triggerInstance.Attributes["streamingFlushPeriod"]
+	if !exists || attrValue == nil {
+		return nil
+	}
+	periodStr, ok := attrValue.(string)
+	if !ok {
+		return errors.Errorf("Invalid streamingFlushPeriod. Must be a string, got %T", attrValue)
+	}
+	if periodStr == "" {
+		return nil
+	}
+	flushPeriod, err := time.ParseDuration(periodStr)
+	if err != nil {
+		return errors.Wrapf(err, "Invalid streamingFlushPeriod %q", periodStr)
+	}
+	if flushPeriod <= 0 {
+		return errors.Errorf("Invalid streamingFlushPeriod. Must be positive, got %q", periodStr)
+	}
 	return nil
 }
 
@@ -1837,6 +1868,9 @@ func (ap *Platform) enrichTriggers(ctx context.Context, functionConfig *function
 		if err := ap.enrichProcessingMode(ctx, triggerName, &triggerInstance, functionConfig); err != nil {
 			return errors.Wrap(err, "Failed to enrich processing mode")
 		}
+		if triggerInstance.Kind == "http" {
+			ap.enrichHTTPTriggerStreamingFlushPeriod(ctx, triggerName, &triggerInstance, functionConfig)
+		}
 		if triggerInstance.Kind == "rabbit-mq" {
 			if err := ap.enrichRabbitMQTrigger(ctx, triggerName, &triggerInstance); err != nil {
 				return errors.Wrap(err, "Failed to enrich RabbitMQ trigger")
@@ -1847,6 +1881,20 @@ func (ap *Platform) enrichTriggers(ctx context.Context, functionConfig *function
 	}
 
 	return nil
+}
+
+func (ap *Platform) enrichHTTPTriggerStreamingFlushPeriod(ctx context.Context, triggerName string, triggerInstance *functionconfig.Trigger, functionConfig *functionconfig.Config) {
+	if triggerInstance.Attributes == nil {
+		triggerInstance.Attributes = make(map[string]interface{})
+	}
+	if _, ok := triggerInstance.Attributes["streamingFlushPeriod"]; !ok || triggerInstance.Attributes["streamingFlushPeriod"] == "" {
+		ap.Logger.DebugWithCtx(ctx,
+			"Enriching streaming flush period for HTTP trigger",
+			"functionName", functionConfig.Meta.Name,
+			"trigger", triggerName,
+			"streamingFlushPeriod", functionconfig.DefaultStreamingFlushPeriod)
+		triggerInstance.Attributes["streamingFlushPeriod"] = functionconfig.DefaultStreamingFlushPeriod
+	}
 }
 
 func (ap *Platform) enrichRabbitMQTrigger(ctx context.Context, triggerName string, triggerInstance *functionconfig.Trigger) error {

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -633,6 +633,103 @@ func (suite *AbstractPlatformTestSuite) TestValidateBatchConfiguration() {
 	}
 }
 
+func (suite *AbstractPlatformTestSuite) TestValidateStreamingFlushPeriod() {
+	for _, testCase := range []struct {
+		name        string
+		triggerKey  string
+		trigger     functionconfig.Trigger
+		expectError bool
+	}{
+		{
+			name:       "no attributes",
+			triggerKey: "http0",
+			trigger:    functionconfig.Trigger{Kind: "http", Name: "http0"},
+		},
+		{
+			name:       "empty attributes",
+			triggerKey: "http0",
+			trigger:    functionconfig.Trigger{Kind: "http", Name: "http0", Attributes: map[string]interface{}{}},
+		},
+		{
+			name:       "streamingFlushPeriod missing",
+			triggerKey: "http0",
+			trigger: functionconfig.Trigger{
+				Kind: "http", Name: "http0",
+				Attributes: map[string]interface{}{"readBufferSize": 4096},
+			},
+		},
+		{
+			name:       "streamingFlushPeriod empty string",
+			triggerKey: "http0",
+			trigger: functionconfig.Trigger{
+				Kind: "http", Name: "http0",
+				Attributes: map[string]interface{}{"streamingFlushPeriod": ""},
+			},
+		},
+		{
+			name:       "streamingFlushPeriod valid 1s",
+			triggerKey: "http0",
+			trigger: functionconfig.Trigger{
+				Kind: "http", Name: "http0",
+				Attributes: map[string]interface{}{"streamingFlushPeriod": "1s"},
+			},
+		},
+		{
+			name:       "streamingFlushPeriod valid 500ms",
+			triggerKey: "http0",
+			trigger: functionconfig.Trigger{
+				Kind: "http", Name: "http0",
+				Attributes: map[string]interface{}{"streamingFlushPeriod": "500ms"},
+			},
+		},
+		{
+			name:       "streamingFlushPeriod invalid duration",
+			triggerKey: "http0",
+			trigger: functionconfig.Trigger{
+				Kind: "http", Name: "http0",
+				Attributes: map[string]interface{}{"streamingFlushPeriod": "not-a-duration"},
+			},
+			expectError: true,
+		},
+		{
+			name:       "streamingFlushPeriod zero",
+			triggerKey: "http0",
+			trigger: functionconfig.Trigger{
+				Kind: "http", Name: "http0",
+				Attributes: map[string]interface{}{"streamingFlushPeriod": "0s"},
+			},
+			expectError: true,
+		},
+		{
+			name:       "streamingFlushPeriod negative",
+			triggerKey: "http0",
+			trigger: functionconfig.Trigger{
+				Kind: "http", Name: "http0",
+				Attributes: map[string]interface{}{"streamingFlushPeriod": "-1s"},
+			},
+			expectError: true,
+		},
+		{
+			name:       "streamingFlushPeriod wrong type",
+			triggerKey: "http0",
+			trigger: functionconfig.Trigger{
+				Kind: "http", Name: "http0",
+				Attributes: map[string]interface{}{"streamingFlushPeriod": 123},
+			},
+			expectError: true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			err := suite.Platform.validateStreamingFlushPeriod(testCase.triggerKey, &testCase.trigger)
+			if testCase.expectError {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+			}
+		})
+	}
+}
+
 func (suite *AbstractPlatformTestSuite) TestValidateDeleteFunctionOptions() {
 	for _, testCase := range []struct {
 		name                  string

--- a/pkg/processor/runtime/python/test/outputter/stream_outputter.py
+++ b/pkg/processor/runtime/python/test/outputter/stream_outputter.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import asyncio
 import os
-import aiofile
 
 file_path = "/tmp/stream_outputter_lines.txt"
 
@@ -25,6 +24,7 @@ def init_context(context):
 
 async def stream_file_lines_async(context, event):
     # Stream the file line by line asynchronously
+    import aiofile
     async with aiofile.AIOFile(file_path, "r") as afp:
         async for line in aiofile.LineReader(afp):
             yield line

--- a/pkg/processor/runtime/python/test/outputter/stream_outputter.py
+++ b/pkg/processor/runtime/python/test/outputter/stream_outputter.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import os
 import aiofile
 
@@ -54,3 +55,20 @@ async def stream_single_yield_async(context, event):
 async def stream_single_yield_sync_as_async(context, event):
     """Sync generator defined as async def that yields only once"""
     yield "single_chunk"
+
+
+async def stream_flush_test(context, event):
+    """Yields chunks with delays to test periodic flush. With 1s flush period, client should see chunks incrementally."""
+    yield "flush1"
+    await asyncio.sleep(0.6)
+    yield "flush2"
+    await asyncio.sleep(0.6)
+    yield "flush3"
+
+
+async def stream_flush_test_as_response(context, event):
+    return context.Response(
+        body=stream_flush_test(context, event),
+        status_code=200,
+        content_type="text/plain",
+    )

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -399,6 +399,86 @@ func (suite *TestSuite) TestStreamingSingleYield() {
 	}
 }
 
+// TestStreamingFlushPeriod is an e2e test for HTTP trigger streaming flush.
+//
+// The HTTP trigger can flush the response stream to the client at most every streamingFlushPeriod (e.g. 1s),
+// so the client sees data incrementally instead of only when the stream ends. This test verifies that behavior.
+//
+// Setup:
+//   - Deploys a function with trigger attribute streamingFlushPeriod: "1s".
+//   - Handler stream_outputter:stream_flush_test_as_response yields "flush1", sleeps 0.6s, "flush2", sleeps 0.6s, "flush3"
+//     (total ~1.2s of producer time).
+//
+// Assertions:
+//   - The client receives at least one byte within 2.5s. Without periodic flush, the first byte would only
+//     arrive after the producer finishes (~1.2s+) and the connection flushes; with 1s flush we expect data sooner.
+//   - The full response body equals "flush1flush2flush3".
+func (suite *TestSuite) TestStreamingFlushPeriod() {
+	createFunctionOptions := suite.GetDeployOptions("stream-flush-outputter", suite.GetFunctionPath("outputter"))
+	createFunctionOptions.FunctionConfig.Spec.Handler = "stream_outputter:stream_flush_test_as_response"
+	httpTrigger := functionconfig.GetDefaultHTTPTrigger()
+	httpTrigger.Attributes = map[string]interface{}{"streamingFlushPeriod": "1s"}
+	createFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{
+		httpTrigger.Name: httpTrigger,
+	}
+
+	suite.DeployFunction(createFunctionOptions, func(deployResults *platform.CreateFunctionResult) bool {
+		suite.Require().NotNil(deployResults)
+		suite.WaitForFunctionReadinessProbe(deployResults, 5*time.Second, 30*time.Second)
+
+		request := &httpsuite.Request{
+			Name:           "streaming flush",
+			RequestBody:    "",
+			RequestMethod:  http.MethodPost,
+			RequestPath:    "/",
+		}
+		request.Enrich(deployResults)
+
+		httpResponse, err := suite.SendRequest(request)
+		suite.Require().NoError(err)
+		defer httpResponse.Body.Close()
+
+		suite.Require().Equal(http.StatusOK, httpResponse.StatusCode)
+
+		// Read body and verify we get first data within 2.5s (proves periodic flush is sending data before stream ends)
+		firstByteCh := make(chan struct{})
+		bodyDoneCh := make(chan struct{})
+		var fullBody []byte
+		var readErr error
+		go func() {
+			defer close(bodyDoneCh)
+			buf := make([]byte, 1)
+			n, err := httpResponse.Body.Read(buf)
+			if n > 0 {
+				fullBody = append(fullBody, buf[:n]...)
+				close(firstByteCh)
+			}
+			if err != nil && err != io.EOF {
+				readErr = err
+				return
+			}
+			rest, err := io.ReadAll(httpResponse.Body)
+			if err != nil {
+				readErr = err
+			} else {
+				fullBody = append(fullBody, rest...)
+			}
+		}()
+
+		select {
+		case <-firstByteCh:
+			// Good: we received at least one byte before timeout
+		case <-time.After(2500 * time.Millisecond):
+			suite.Require().Fail("Did not receive first byte within 2.5s; streaming flush may not be working")
+		}
+
+		<-bodyDoneCh
+		suite.Require().NoError(readErr)
+		suite.Require().Equal("flush1flush2flush3", string(fullBody))
+		return true
+	})
+}
+
 func (suite *TestSuite) TestStress() {
 	if os.Getenv("NUCLIO_CI_SKIP_STRESS_TEST") == "true" {
 		suite.T().Skip("Skipping stress test")

--- a/pkg/processor/runtime/python/test/python_test.go
+++ b/pkg/processor/runtime/python/test/python_test.go
@@ -427,10 +427,10 @@ func (suite *TestSuite) TestStreamingFlushPeriod() {
 		suite.WaitForFunctionReadinessProbe(deployResults, 5*time.Second, 30*time.Second)
 
 		request := &httpsuite.Request{
-			Name:           "streaming flush",
-			RequestBody:    "",
-			RequestMethod:  http.MethodPost,
-			RequestPath:    "/",
+			Name:          "streaming flush",
+			RequestBody:   "",
+			RequestMethod: http.MethodPost,
+			RequestPath:   "/",
 		}
 		request.Enrich(deployResults)
 

--- a/pkg/processor/trigger/http/trigger.go
+++ b/pkg/processor/trigger/http/trigger.go
@@ -631,11 +631,21 @@ func (h *http) handleRequest(ctx *fasthttp.RequestCtx) {
 			// The callback will release the worker after streaming completes.
 			// Mark streaming mode so the outer defer doesn't release early.
 			streamingMode = true
+			flushPeriod := h.configuration.streamingFlushPeriodDuration
 			ctx.SetBodyStreamWriter(func(w *bufio.Writer) {
 				// Ensure worker is released after streaming
 				defer releaseWorker()
 
-				_, copyErr := io.Copy(w, typedResponse)
+				// Copy stream from function (typedResponse) to the response writer (w).
+				// When flushPeriod <= 0 we pass w itself: data is written to the bufio.Writer and
+				// we only flush at the end below. When flushPeriod > 0 we wrap w in periodicFlushWriter
+				// so the buffer is flushed at most every flushPeriod during the copy, giving the client
+				// incremental data instead of only when the stream ends
+				var copyTarget io.Writer = w
+				if flushPeriod > 0 {
+					copyTarget = &periodicFlushWriter{writer: w, flushPeriod: flushPeriod}
+				}
+				_, copyErr := io.Copy(copyTarget, typedResponse)
 				if copyErr != nil {
 					h.Logger.WarnWith("Failed to copy stream to response", "error", copyErr)
 					// In sync mode, mark worker for restart to clean up connection resources
@@ -654,6 +664,10 @@ func (h *http) handleRequest(ctx *fasthttp.RequestCtx) {
 
 				if streamingMode && copyErr == nil {
 					workerInstance.StreamProcessedSuccessfully()
+				}
+				// Flush any remaining buffered data
+				if err := w.Flush(); err != nil {
+					h.Logger.WarnWith("Failed to flush response stream", "error", err)
 				}
 			})
 		}

--- a/pkg/processor/trigger/http/types.go
+++ b/pkg/processor/trigger/http/types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package http
 
 import (
+	"bufio"
+	"time"
+
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
@@ -45,6 +48,13 @@ type Configuration struct {
 	DisablePortPublishing bool `json:"disablePortPublishing,omitempty"`
 
 	Mode TriggerMode `json:"mode,omitempty"`
+
+	// StreamingFlushPeriod is the period for flushing the response stream to the client (e.g. "1s").
+	// Applied when the response body is streamed (io.ReadCloser). Enriched to 1s by default during platform enrichment.
+	StreamingFlushPeriod string `json:"streamingFlushPeriod,omitempty"`
+
+	// streamingFlushPeriodDuration is the parsed StreamingFlushPeriod (set in NewConfiguration).
+	streamingFlushPeriodDuration time.Duration
 }
 
 type TriggerMode string
@@ -92,6 +102,15 @@ func NewConfiguration(id string,
 	if newConfiguration.CORS != nil && newConfiguration.CORS.Enabled {
 		newConfiguration.CORS = createCORSConfiguration(newConfiguration.CORS)
 	}
+	if newConfiguration.StreamingFlushPeriod == "" {
+		newConfiguration.StreamingFlushPeriod = functionconfig.DefaultStreamingFlushPeriod
+	}
+	if d, err := time.ParseDuration(newConfiguration.StreamingFlushPeriod); err == nil && d > 0 {
+		newConfiguration.streamingFlushPeriodDuration = d
+	} else {
+		// fallback to default if unset or invalid
+		newConfiguration.streamingFlushPeriodDuration, _ = time.ParseDuration(functionconfig.DefaultStreamingFlushPeriod)
+	}
 	return &newConfiguration, nil
 }
 
@@ -131,4 +150,26 @@ func createCORSConfiguration(corsConfiguration *cors.CORS) *cors.CORS {
 
 func (c *Configuration) corsEnabled() bool {
 	return c.CORS != nil && c.CORS.Enabled
+}
+
+// periodicFlushWriter wraps a bufio.Writer and flushes it at most every flushPeriod.
+// All writes and flushes happen on the same goroutine (no concurrent use of bufio.Writer).
+type periodicFlushWriter struct {
+	writer      *bufio.Writer
+	flushPeriod time.Duration
+	lastFlush   time.Time
+}
+
+func (p *periodicFlushWriter) Write(b []byte) (numBytes int, err error) {
+	numBytes, err = p.writer.Write(b)
+	if err != nil {
+		return numBytes, err
+	}
+	if p.flushPeriod > 0 && time.Since(p.lastFlush) >= p.flushPeriod {
+		if flushErr := p.writer.Flush(); flushErr != nil {
+			return numBytes, flushErr
+		}
+		p.lastFlush = time.Now()
+	}
+	return numBytes, nil
 }


### PR DESCRIPTION
### 📝 Description
Adds configurable **periodic flushing** of HTTP response streams so that clients receive streamed data incrementally (at most every N seconds) instead of only when the stream ends or the buffer fills.

When a function returns a streamed response body (`io.ReadCloser`), the HTTP trigger copies from the function's stream to the response using a buffered writer. Without periodic flush, data may stay buffered until the stream finishes or the buffer is full, so clients can experience long waits before seeing the first bytes. The new **`streamingFlushPeriod`** HTTP trigger attribute (e.g. `"1s"`, `"500ms"`) controls how often the trigger flushes the response buffer to the client; default is `"1s"` (applied during platform enrichment if omitted).

---

### 🛠️ Changes Made
- **HTTP trigger** – New attribute `streamingFlushPeriod` (duration string); `periodicFlushWriter` wraps the response writer and flushes at most every configured period during stream copy.
- **functionconfig** – `DefaultStreamingFlushPeriod = "1s"`.
- **Platform** – Validation of `streamingFlushPeriod` (non-empty string, valid duration, positive); enrichment to default when missing/empty.
- **Python test** – Handler `stream_flush_test_as_response` in `stream_outputter.py`; E2E test `TestStreamingFlushPeriod` in `python_test.go`.
- **Docs** – `docs/reference/triggers/http.md`: attribute table + example; `docs/tasks/stream-response.md`: "Streaming flush period" section.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- **Unit** – `pkg/platform/abstract/platform_test.go`: cases for missing, empty, valid (`1s`, `500ms`), invalid duration, zero, negative, wrong type for `streamingFlushPeriod`.
- **E2E** – `TestStreamingFlushPeriod`: deploy function with `streamingFlushPeriod: "1s"`, invoke handler that yields chunks with ~0.6s delays; assert client receives at least one byte within 2.5s (proves periodic flush) and full body equals `"flush1flush2flush3"`.

---

### 🔗 References
- Ticket link:https://iguazio.atlassian.net/browse/NUC-720
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Lazy import of `aiofile` in `stream_outputter.py` (only in `stream_file_lines_async`) so the flush test handler loads without the optional dependency.