### PR TITLE
[Tests] Increase waiting time for a kafka container start

### DIFF
--- a/pkg/processor/trigger/kafka/test/kafka_test.go
+++ b/pkg/processor/trigger/kafka/test/kafka_test.go
@@ -165,7 +165,7 @@ func (suite *testSuite) WaitForBroker() error {
 	var containerLogs string
 	var containerLogsErr error
 
-	err := common.RetryUntilSuccessful(30*time.Second, 3*time.Second, func() bool {
+	err := common.RetryUntilSuccessful(120*time.Second, 3*time.Second, func() bool {
 		// fetch Kafka container logs
 		containerLogs, containerLogsErr = suite.DockerClient.GetContainerLogs(suite.brokerContainerName)
 		if containerLogsErr != nil {


### PR DESCRIPTION
Long CI fails sometimes on this, so increasing a timeout