### PR TITLE
[Test] Fix missing `streamingFlushPeriod` in unit tests

### DIFF
--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -1321,6 +1321,9 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 					NumWorkers: 1,
 					Name:       "some-trigger",
 					Mode:       functionconfig.SyncTriggerWorkMode,
+					Attributes: map[string]interface{}{
+						"streamingFlushPeriod": functionconfig.DefaultStreamingFlushPeriod,
+					},
 				},
 			},
 		},
@@ -1331,6 +1334,9 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 			triggers: nil,
 			expectedEnrichedTriggers: func() map[string]functionconfig.Trigger {
 				defaultHTTPTrigger := functionconfig.GetDefaultHTTPTrigger()
+				defaultHTTPTrigger.Attributes = map[string]interface{}{
+					"streamingFlushPeriod": functionconfig.DefaultStreamingFlushPeriod,
+				}
 				return map[string]functionconfig.Trigger{
 					defaultHTTPTrigger.Name: defaultHTTPTrigger,
 				}
@@ -1418,6 +1424,9 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 					NumWorkers: 1,
 					Kind:       "http",
 					Mode:       functionconfig.SyncTriggerWorkMode,
+					Attributes: map[string]interface{}{
+						"streamingFlushPeriod": functionconfig.DefaultStreamingFlushPeriod,
+					},
 				},
 				"kafka-trigger": {
 					Kind:                     "kafka-cluster",
@@ -1447,6 +1456,9 @@ func (suite *AbstractPlatformTestSuite) TestEnrichAndValidateFunctionTriggers() 
 					NumWorkers: 1,
 					Name:       "http-trigger",
 					Mode:       functionconfig.SyncTriggerWorkMode,
+					Attributes: map[string]interface{}{
+						"streamingFlushPeriod": functionconfig.DefaultStreamingFlushPeriod,
+					},
 				},
 				"kafka-trigger": {
 					Kind:                     "kafka-cluster",

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -700,7 +700,8 @@ func (suite *FunctionKubePlatformTestSuite) TestFunctionTriggersEnrichmentAndVal
 			expectedEnrichedTriggers: func() map[string]functionconfig.Trigger {
 				defaultHTTPTrigger := functionconfig.GetDefaultHTTPTrigger()
 				defaultHTTPTrigger.Attributes = map[string]interface{}{
-					"serviceType": suite.platformKubeConfig.DefaultServiceType,
+					"serviceType":          suite.platformKubeConfig.DefaultServiceType,
+					"streamingFlushPeriod": functionconfig.DefaultStreamingFlushPeriod,
 				}
 				return map[string]functionconfig.Trigger{
 					defaultHTTPTrigger.Name: defaultHTTPTrigger,


### PR DESCRIPTION
### 📝 Description

In https://github.com/nuclio/nuclio/pull/3995 a new `streamingFlushPeriod` default was added with platform level enrichment.
This PR updates the platform unit test so the expected enriched HTTP trigger matches current enrichment behavior. 

---

### 🛠️ Changes Made

- `pkg/platform/kube/platform_test.go`, `pkg/platform/abstract/platform_test.go`: Add `streamingFlushPeriod` to expected http triggers.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
- Made sure all unit tests pass

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->