### PR TITLE
[RabbitMQ] Fail earlier if queue doesn't exist

### DIFF
--- a/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
+++ b/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
@@ -210,6 +210,76 @@ func (suite *testSuite) TestResourcesCreatedByFunction() {
 		nil)
 }
 
+// TestNonExistentQueueFailsToStart verifies that when a user provides a queue name that does not exist
+// (e.g. exchange exists but queue was never created), the trigger fails at startup with
+// a clear error instead of starting consumption and flooding logs with "delivery not initialized" ack errors.
+func (suite *testSuite) TestNonExistentQueueFailsToStart() {
+	exchangeName := "nuclio.rabbitmq_nonexistent_test"
+	nonExistentQueueName := "non-existent-queue-" + xid.New().String()
+
+	suite.initializeBrokerConnection()
+	defer suite.deleteBrokerResources(suite.brokerURL, exchangeName, nonExistentQueueName)
+
+	suite.createExchange(exchangeName, "fanout", true)
+
+	triggerConfig := functionconfig.Trigger{
+		Kind: "rabbit-mq",
+		URL:  suite.containerizedBrokerURL,
+		Attributes: map[string]interface{}{
+			"exchangeName": exchangeName,
+			"queueName":    nonExistentQueueName,
+			"topics":       []string{},
+		},
+	}
+
+	createFunctionOptions := suite.getCreateFunctionOptionsWithRmqTrigger(triggerConfig)
+	createFunctionOptions.FunctionConfig.Meta.Name = "rmq-nonexistent-queue-test"
+
+	_, deployErr := suite.DeployFunctionExpectError(createFunctionOptions, func(result *platform.CreateFunctionResult) bool {
+		containerID := suite.resolveContainerID(result, createFunctionOptions)
+		suite.Require().NotEmpty(containerID, "Expected a container to be created for the function")
+
+		err := common.RetryUntilSuccessful(30*time.Second, 1*time.Second, func() bool {
+			containerLogs, getLogsErr := suite.DockerClient.GetContainerLogs(containerID)
+			if getLogsErr != nil {
+				return false
+			}
+			// Match exact chain: queue missing -> broker resources fail -> trigger fails to start
+			return strings.Contains(containerLogs, "Queue does not exist") &&
+				strings.Contains(containerLogs, "Failed to start trigger") &&
+				!strings.Contains(containerLogs, "delivery not initialized")
+		})
+		suite.Require().NoError(err,
+			"Expected logs: 'Queue does not exist', 'Failed to start trigger', and no 'delivery not initialized'")
+
+		// Processor exits when trigger fails to start; container should eventually stop
+		err = common.RetryUntilSuccessful(15*time.Second, 1*time.Second, func() bool {
+			containers, getContainersErr := suite.DockerClient.GetContainers(&dockerclient.GetContainerOptions{
+				ID:      containerID,
+				Stopped: true,
+			})
+			if getContainersErr != nil || len(containers) == 0 {
+				return false
+			}
+			return containers[0].State != nil && containers[0].State.Status == "exited"
+		})
+		suite.Require().NoError(err, "Expected function container to exit after trigger failed to start")
+
+		containers, getContainersErr := suite.DockerClient.GetContainers(&dockerclient.GetContainerOptions{
+			ID:      containerID,
+			Stopped: true,
+		})
+		suite.Require().NoError(getContainersErr)
+		suite.Require().Len(containers, 1)
+		suite.Require().NotNil(containers[0].State, "Container state should be available")
+		suite.Require().NotZero(containers[0].State.ExitCode,
+			"Expected non-zero exit code when trigger fails to start")
+
+		return true
+	})
+	suite.Require().Error(deployErr)
+}
+
 func (suite *testSuite) TestNackAndRequeue() {
 	expectedRequeued := []string{
 		"success-5",
@@ -337,6 +407,24 @@ func (suite *testSuite) TestNackAndRequeue() {
 	}
 }
 
+// resolveContainerID returns container ID from deploy result or by looking up the function container by name (e.g. when result is nil on failure).
+func (suite *testSuite) resolveContainerID(result *platform.CreateFunctionResult, createFunctionOptions *platform.CreateFunctionOptions) string {
+	if result != nil && result.ContainerID != "" {
+		return result.ContainerID
+	}
+	containerName := fmt.Sprintf("nuclio-%s-%s",
+		createFunctionOptions.FunctionConfig.Meta.Namespace,
+		createFunctionOptions.FunctionConfig.Meta.Name)
+	containers, err := suite.DockerClient.GetContainers(&dockerclient.GetContainerOptions{
+		Name:    containerName,
+		Stopped: true,
+	})
+	if err != nil || len(containers) == 0 {
+		return ""
+	}
+	return containers[0].ID
+}
+
 func (suite *testSuite) getCreateFunctionOptionsWithRmqTrigger(triggerConfig functionconfig.Trigger) *platform.CreateFunctionOptions {
 	createFunctionOptions := suite.GetDeployOptions("event_recorder", "")
 	createFunctionOptions.FunctionConfig.Spec.Runtime = "python"
@@ -357,15 +445,7 @@ func (suite *testSuite) createBrokerResources(topics []string) {
 	// clear stuff before we create stuff
 	suite.deleteBrokerResources(suite.brokerURL, suite.brokerExchangeName, suite.brokerQueueName)
 
-	// create the exchange
-	err = suite.brokerChannel.ExchangeDeclare(suite.brokerExchangeName,
-		"topic",
-		false,
-		false,
-		false,
-		false,
-		nil)
-	suite.Require().NoError(err)
+	suite.createExchange(suite.brokerExchangeName, "topic", false)
 
 	// declare a queue and bind it, if a queue set
 	if suite.brokerQueueName != "" {
@@ -391,6 +471,18 @@ func (suite *testSuite) createBrokerResources(topics []string) {
 			suite.Require().NoError(err, "Failed to bind queue")
 		}
 	}
+}
+
+// createExchange declares an exchange
+func (suite *testSuite) createExchange(exchangeName string, exchangeType string, durable bool) {
+	err := suite.brokerChannel.ExchangeDeclare(exchangeName,
+		exchangeType,
+		durable,
+		false,
+		false,
+		false,
+		nil)
+	suite.Require().NoError(err, "Failed to declare exchange %q", exchangeName)
 }
 
 func (suite *testSuite) deleteBrokerResources(brokerURL string, brokerExchangeName string, queueName string) {

--- a/pkg/processor/trigger/rabbitmq/trigger.go
+++ b/pkg/processor/trigger/rabbitmq/trigger.go
@@ -141,6 +141,11 @@ func (rmq *rabbitMq) createBrokerResources() error {
 		return errors.Wrap(err, "Failed to create topics")
 	}
 
+	// ensure the queue exists before consuming to avoid "delivery not initialized" ack errors
+	if err := rmq.ensureQueueExists(); err != nil {
+		return errors.Wrap(err, "Queue does not exist")
+	}
+
 	// consume from queue
 	if err := rmq.consume(); err != nil {
 		return errors.Wrap(err, "Failed to consume messages")
@@ -295,6 +300,29 @@ func (rmq *rabbitMq) createTopics() error {
 			"topic", topic,
 			"exchangeName", rmq.configuration.ExchangeName)
 
+	}
+	return nil
+}
+
+// ensureQueueExists verifies that the configured queue exists before starting consumption.
+// This prevents "delivery not initialized" ack errors when the queue does not exist.
+func (rmq *rabbitMq) ensureQueueExists() error {
+	checkChannel, err := rmq.brokerConn.Channel()
+	if err != nil {
+		return errors.Wrap(err, "Failed to create channel for queue check")
+	}
+	defer checkChannel.Close()
+	// Passive declare only checks that the queue exists; it does not create or redeclare the queue with these params.
+	_, err = checkChannel.QueueDeclarePassive(
+		rmq.configuration.QueueName,
+		false, // durable
+		false, // autoDelete
+		false, // exclusive
+		false, // noWait
+		nil,   // args
+	)
+	if err != nil {
+		return errors.Wrapf(err, "Queue %q does not exist", rmq.configuration.QueueName)
 	}
 	return nil
 }

--- a/pkg/processor/trigger/rabbitmq/trigger.go
+++ b/pkg/processor/trigger/rabbitmq/trigger.go
@@ -142,8 +142,8 @@ func (rmq *rabbitMq) createBrokerResources() error {
 	}
 
 	// ensure the queue exists before consuming to avoid "delivery not initialized" ack errors
-	if err := rmq.ensureQueueExists(); err != nil {
-		return errors.Wrap(err, "Queue does not exist")
+	if err := rmq.validateQueueExists(); err != nil {
+		return errors.Wrap(err, "Failed to validate queue existence")
 	}
 
 	// consume from queue
@@ -304,9 +304,9 @@ func (rmq *rabbitMq) createTopics() error {
 	return nil
 }
 
-// ensureQueueExists verifies that the configured queue exists before starting consumption.
+// validateQueueExists verifies that the configured queue exists before starting consumption.
 // This prevents "delivery not initialized" ack errors when the queue does not exist.
-func (rmq *rabbitMq) ensureQueueExists() error {
+func (rmq *rabbitMq) validateQueueExists() error {
 	checkChannel, err := rmq.brokerConn.Channel()
 	if err != nil {
 		return errors.Wrap(err, "Failed to create channel for queue check")
@@ -322,7 +322,7 @@ func (rmq *rabbitMq) ensureQueueExists() error {
 		nil,   // args
 	)
 	if err != nil {
-		return errors.Wrapf(err, "Queue %q does not exist", rmq.configuration.QueueName)
+		return errors.Wrapf(err, "Queue does not exist, name: %s", rmq.configuration.QueueName)
 	}
 	return nil
 }


### PR DESCRIPTION
### 📝 Description
Fixes the RabbitMQ trigger when the configured queue does not exist (e.g. an exchange exists but the queue was never created). Previously the processor started consuming anyway and logs were flooded with `Failed to ack message {"error": "delivery not initialized"}`. The trigger now verifies the queue exists before starting consumption and fails startup with a clear error. Adds an integration test.


---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
integ

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-667
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [x] Yes (if anyone was relying on this as on a wait mechanism)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
Function fails with:

```
26.02.19 12:06:26.156 (D) cessor.rabbit-mq.test_rmq Connected to broker {"brokerUrl": "amqp://172.17.0.1:5672"}
26.02.19 12:06:26.163 (D) cessor.rabbit-mq.test_rmq Created broker channel
26.02.19 12:06:26.171 (E)                 processor Failed to start trigger {"kind": "rabbit-mq", "err": "Failed to create broker resources"}

Error - Exception (404) Reason: "NOT_FOUND - no queue 'non-existent-queue-d6bfpf3umbtn8gsarafg' in vhost '/'"
    .../pkg/processor/trigger/rabbitmq/trigger.go:325

Call stack:
Queue "non-existent-queue-d6bfpf3umbtn8gsarafg" does not exist
    .../pkg/processor/trigger/rabbitmq/trigger.go:325
Queue does not exist
    .../pkg/processor/trigger/rabbitmq/trigger.go:146
Failed to create broker resources
    .../pkg/processor/trigger/rabbitmq/trigger.go:92
Failed to start trigger
    .../nuclio/cmd/processor/app/processor.go:220
 ```