### PR TITLE
[Processor] Fix fields processing in http trigger

### DIFF
--- a/pkg/processor/trigger/http/event.go
+++ b/pkg/processor/trigger/http/event.go
@@ -90,13 +90,23 @@ func (e *Event) GetFieldInt(key string) (int, error) {
 	return e.ctx.QueryArgs().GetUint(key)
 }
 
-// GetFields loads all fields into a map of string / interface{}
+// GetFields loads all query parameters into a map of string / interface{}.
+// Repeated query parameters (e.g. ?tags=new&tags=featured) are exposed as
+// []string; single-value parameters are exposed as string for backward compatibility.
 func (e *Event) GetFields() map[string]interface{} {
-	fields := make(map[string]interface{})
+	valuesByKey := make(map[string][]string)
 	for key, value := range e.ctx.QueryArgs().All() {
-		fields[string(key)] = string(value)
+		keyStr := string(key)
+		valuesByKey[keyStr] = append(valuesByKey[keyStr], string(value))
 	}
-
+	fields := make(map[string]interface{}, len(valuesByKey))
+	for key, values := range valuesByKey {
+		if len(values) == 1 {
+			fields[key] = values[0]
+		} else {
+			fields[key] = values
+		}
+	}
 	return fields
 }
 

--- a/pkg/processor/trigger/http/http_test.go
+++ b/pkg/processor/trigger/http/http_test.go
@@ -181,6 +181,32 @@ func (suite *TestSuite) TestCORS() {
 	}
 }
 
+func (suite *TestSuite) TestGetFieldsRepeatedQueryParameters() {
+	// Repeated query params should be exposed as []string; single-value as string
+	requestCtx := &fasthttp.RequestCtx{}
+	requestCtx.Request.SetRequestURI("http://localhost/test?tags=new&tags=featured&tags=sale&limit=10")
+	event := &Event{ctx: requestCtx}
+	fields := event.GetFields()
+
+	suite.Require().Len(fields, 2)
+
+	tags, ok := fields["tags"].([]string)
+	suite.Require().True(ok, "tags should be []string")
+	suite.Require().Equal([]string{"new", "featured", "sale"}, tags)
+
+	limit, ok := fields["limit"].(string)
+	suite.Require().True(ok, "limit should be string")
+	suite.Require().Equal("10", limit)
+
+	// Single-value param must remain string
+	singleCtx := &fasthttp.RequestCtx{}
+	singleCtx.Request.SetRequestURI("http://localhost/?limit=10")
+	singleEvent := &Event{ctx: singleCtx}
+	singleFields := singleEvent.GetFields()
+	suite.Require().Len(singleFields, 1)
+	suite.Require().Equal("10", singleFields["limit"])
+}
+
 func (suite *TestSuite) TestInternalHealthiness() {
 	client := suite.getClient()
 	for _, testCase := range []struct {

--- a/pkg/processor/trigger/http/test/suite/http_test.go
+++ b/pkg/processor/trigger/http/test/suite/http_test.go
@@ -172,6 +172,39 @@ def handler(context, event):
 		})
 }
 
+func (suite *HTTPTestSuite) TestRepeatedQueryParametersInEventFields() {
+	// event.fields must expose repeated query params as arrays (e.g. ?tags=new&tags=featured&tags=sale)
+	functionSourceCode := `import json
+import nuclio_sdk
+
+def handler(context, event):
+    return nuclio_sdk.Response(
+        body=json.dumps(dict(event.fields)),
+        headers={"Content-Type": "application/json"},
+        content_type="application/json",
+        status_code=200,
+    )
+`
+	createFunctionOptions := suite.getHTTPDeployOptions()
+	createFunctionOptions.FunctionConfig.Spec.Handler = "main:handler"
+	createFunctionOptions.FunctionConfig.Spec.Build.Path = ""
+	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = base64.StdEncoding.EncodeToString([]byte(functionSourceCode))
+
+	statusOK := http.StatusOK
+	suite.DeployFunctionAndRequests(createFunctionOptions,
+		[]*Request{
+			{
+				RequestMethod:              "GET",
+				RequestPath:                "/test?tags=new&tags=featured&tags=sale&limit=10",
+				ExpectedResponseStatusCode: &statusOK,
+				ExpectedResponseBody: map[string]interface{}{
+					"tags":  []interface{}{"new", "featured", "sale"},
+					"limit": "10",
+				},
+			},
+		})
+}
+
 func (suite *HTTPTestSuite) TestBatchedProcessing() {
 	functionName := "batch-function"
 	functionPath := path.Join(suite.GetTestFunctionsDir(),


### PR DESCRIPTION
### 📝 Description
HTTP trigger previously exposed only the **last** value for repeated query parameters in `event.fields` (e.g. `?tags=new&tags=featured&tags=sale` resulted in `tags: "sale"`). This PR fixes `GetFields()` so that repeated parameters are exposed as arrays, and single-value parameters remain strings for backward compatibility. Aligns with standard HTTP behavior (e.g. `urllib.parse.parse_qs`, `url.ParseQuery()`).

---

### 🛠️ Changes Made
- **`pkg/processor/trigger/http/event.go`**: Reworked `GetFields()` to iterate over all query pairs via `QueryArgs().All()` and aggregate values per key; single-value keys remain `string`, multi-value keys become `[]string`.
- **`pkg/processor/trigger/http/http_test.go`**: Added unit test `TestGetFieldsRepeatedQueryParameters` (repeated params as slice, single param as string).
- **`pkg/processor/trigger/http/test/suite/http_test.go`**: Added e2e test `TestRepeatedQueryParametersInEventFields` for Python runtime (deploy function that returns `event.fields` as JSON, GET with repeated query params, assert response body).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
unit, intef

---

### 🔗 References
- Ticket link: (https://iguazio.atlassian.net/browse/NUC-745)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

Single-value query params remain exposed as strings; only repeated params become arrays. Handlers that read e.g. `event.fields["tags"]` and previously saw a string will now see a string when there is one value and a list when there are multiple.
