### PR TITLE
[Dashboard] Handle empty base image in it's proper function

### DIFF
--- a/pkg/common/testutils/mocks/logger.go
+++ b/pkg/common/testutils/mocks/logger.go
@@ -16,7 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
 package mocks
 
 import (

--- a/pkg/common/testutils/mocks/logger.go
+++ b/pkg/common/testutils/mocks/logger.go
@@ -1,0 +1,105 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package mocks
+
+import (
+	"context"
+
+	"github.com/nuclio/logger"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockLogger is a mock implementation of the logger.Logger interface for testing purposes.
+type MockLogger struct {
+	mock.Mock
+}
+
+func (m *MockLogger) Error(format interface{}, vars ...interface{}) {
+	m.Called(format, vars)
+}
+
+func (m *MockLogger) Warn(format interface{}, vars ...interface{}) {
+	m.Called(format, vars)
+}
+
+func (m *MockLogger) Info(format interface{}, vars ...interface{}) {
+	m.Called(format, vars)
+}
+
+func (m *MockLogger) Debug(format interface{}, vars ...interface{}) {
+	m.Called(format, vars)
+}
+
+func (m *MockLogger) ErrorCtx(ctx context.Context, format interface{}, vars ...interface{}) {
+	m.Called(ctx, format, vars)
+}
+
+func (m *MockLogger) WarnCtx(ctx context.Context, format interface{}, vars ...interface{}) {
+	m.Called(ctx, format, vars)
+}
+
+func (m *MockLogger) InfoCtx(ctx context.Context, format interface{}, vars ...interface{}) {
+	m.Called(ctx, format, vars)
+}
+
+func (m *MockLogger) DebugCtx(ctx context.Context, format interface{}, vars ...interface{}) {
+	m.Called(ctx, format, vars)
+}
+
+func (m *MockLogger) ErrorWith(format interface{}, vars ...interface{}) {
+	m.Called(format, vars)
+}
+
+func (m *MockLogger) WarnWith(format interface{}, vars ...interface{}) {
+	m.Called(format, vars)
+}
+
+func (m *MockLogger) InfoWith(format interface{}, vars ...interface{}) {
+	m.Called(format, vars)
+}
+
+func (m *MockLogger) DebugWith(format interface{}, vars ...interface{}) {
+	m.Called(format, vars)
+}
+
+func (m *MockLogger) ErrorWithCtx(ctx context.Context, format interface{}, vars ...interface{}) {
+	m.Called(ctx, format, vars)
+}
+
+func (m *MockLogger) WarnWithCtx(ctx context.Context, format interface{}, vars ...interface{}) {
+	m.Called(ctx, format, vars)
+}
+
+func (m *MockLogger) InfoWithCtx(ctx context.Context, format interface{}, vars ...interface{}) {
+	m.Called(ctx, format, vars)
+}
+
+func (m *MockLogger) DebugWithCtx(ctx context.Context, format interface{}, vars ...interface{}) {
+	m.Called(ctx, format, vars)
+}
+
+func (m *MockLogger) Flush() {
+	m.Called()
+}
+
+func (m *MockLogger) GetChild(name string) logger.Logger {
+	args := m.Called(name)
+	return args.Get(0).(logger.Logger)
+}

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -162,7 +162,8 @@ func (ar *AbstractRuntime) DetectFunctionHandlers(functionPath string) ([]string
 }
 
 func (ar *AbstractRuntime) GetOverrideImageRegistryFromMap(imageRegistriesMap map[string]string) string {
-	return ar.getImageFromMap(imageRegistriesMap)
+	image, _, _ := ar.getImageFromMap(imageRegistriesMap)
+	return image
 }
 
 func (ar *AbstractRuntime) GetRuntimeBuildArgs(runtimeConfig *runtimeconfig.Config) map[string]string {
@@ -173,30 +174,36 @@ func (ar *AbstractRuntime) GetRuntimeBuildArgs(runtimeConfig *runtimeconfig.Conf
 }
 
 func (ar *AbstractRuntime) GetBaseImageFromMap(baseImagesMap map[string]string) string {
-	return ar.getImageFromMap(baseImagesMap)
+	image, runtimeName, runtimeVersion := ar.getImageFromMap(baseImagesMap)
+	// empty base image after enrichment should be logged as a warning.
+	if image == "" {
+		ar.Logger.WarnWith("Failed to find base image for runtime",
+			"runtime name", runtimeName,
+			"runtime version", runtimeVersion,
+			"base images map", baseImagesMap,
+		)
+	}
+	return image
 }
 
-// getImageFromMap returns an image from the provided map based on the runtime name and version
-// if no image is found, returns the provided default value
-func (ar *AbstractRuntime) getImageFromMap(imagesMap map[string]string) string {
+// getImageFromMap returns an image from the provided map based on the runtime name and version,
+// along with the runtime name and version used for the lookup.
+// If no image is found, returns empty string with the runtime lookup info.
+func (ar *AbstractRuntime) getImageFromMap(imagesMap map[string]string) (string, string, string) {
 	runtimeName, runtimeVersion := common.GetRuntimeNameAndVersion(ar.FunctionConfig.Spec.Runtime)
 
 	// supports both values per runtimeName and per runtimeName + runtimeVersion
 	if runtimeVersion != "" {
 		key := runtimeName + ":" + runtimeVersion
 		if image, ok := imagesMap[key]; ok {
-			return image
+			return image, runtimeName, runtimeVersion
 		}
 	}
 
 	// no version-specific value, or no known version for our runtime, try for runtimeName only
 	if image, ok := imagesMap[runtimeName]; ok {
-		return image
+		return image, runtimeName, runtimeVersion
 	}
 
-	ar.Logger.WarnWith("Failed to find image for runtime",
-		"runtime name", runtimeName,
-		"runtime version", runtimeVersion,
-	)
-	return ""
+	return "", runtimeName, runtimeVersion
 }

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -162,8 +162,7 @@ func (ar *AbstractRuntime) DetectFunctionHandlers(functionPath string) ([]string
 }
 
 func (ar *AbstractRuntime) GetOverrideImageRegistryFromMap(imageRegistriesMap map[string]string) string {
-	image, _, _ := ar.getImageFromMap(imageRegistriesMap)
-	return image
+	return ar.getImageFromMap(imageRegistriesMap, false)
 }
 
 func (ar *AbstractRuntime) GetRuntimeBuildArgs(runtimeConfig *runtimeconfig.Config) map[string]string {
@@ -174,36 +173,35 @@ func (ar *AbstractRuntime) GetRuntimeBuildArgs(runtimeConfig *runtimeconfig.Conf
 }
 
 func (ar *AbstractRuntime) GetBaseImageFromMap(baseImagesMap map[string]string) string {
-	image, runtimeName, runtimeVersion := ar.getImageFromMap(baseImagesMap)
-	// empty base image after enrichment should be logged as a warning.
-	if image == "" {
-		ar.Logger.WarnWith("Failed to find base image for runtime",
-			"runtime name", runtimeName,
-			"runtime version", runtimeVersion,
-			"base images map", baseImagesMap,
-		)
-	}
-	return image
+	return ar.getImageFromMap(baseImagesMap, true)
 }
 
-// getImageFromMap returns an image from the provided map based on the runtime name and version,
-// along with the runtime name and version used for the lookup.
-// If no image is found, returns empty string with the runtime lookup info.
-func (ar *AbstractRuntime) getImageFromMap(imagesMap map[string]string) (string, string, string) {
+// getImageFromMap returns an image from the provided map based on the runtime name and version.
+// If no image is found and isEnriched is true, a warning is logged before returning an empty string.
+func (ar *AbstractRuntime) getImageFromMap(imagesMap map[string]string, isEnriched bool) string {
 	runtimeName, runtimeVersion := common.GetRuntimeNameAndVersion(ar.FunctionConfig.Spec.Runtime)
 
 	// supports both values per runtimeName and per runtimeName + runtimeVersion
 	if runtimeVersion != "" {
 		key := runtimeName + ":" + runtimeVersion
 		if image, ok := imagesMap[key]; ok {
-			return image, runtimeName, runtimeVersion
+			return image
 		}
 	}
 
 	// no version-specific value, or no known version for our runtime, try for runtimeName only
 	if image, ok := imagesMap[runtimeName]; ok {
-		return image, runtimeName, runtimeVersion
+		return image
 	}
 
-	return "", runtimeName, runtimeVersion
+	// if the map was enriched before, we expected to find a matching image for this runtime
+	if isEnriched {
+		ar.Logger.WarnWith("Failed to find base image for runtime",
+			"runtime name", runtimeName,
+			"runtime version", runtimeVersion,
+			"base images map", imagesMap,
+		)
+	}
+
+	return ""
 }

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -173,12 +173,13 @@ func (ar *AbstractRuntime) GetRuntimeBuildArgs(runtimeConfig *runtimeconfig.Conf
 }
 
 func (ar *AbstractRuntime) GetBaseImageFromMap(baseImagesMap map[string]string) string {
+	// base images map is pre-enriched, so a missing entry is unexpected and worth warning about
 	return ar.getImageFromMap(baseImagesMap, true)
 }
 
 // getImageFromMap returns an image from the provided map based on the runtime name and version.
-// If no image is found and isEnriched is true, a warning is logged before returning an empty string.
-func (ar *AbstractRuntime) getImageFromMap(imagesMap map[string]string, isEnriched bool) string {
+// If no image is found and warnOnFail is true, a warning is logged before returning an empty string.
+func (ar *AbstractRuntime) getImageFromMap(imagesMap map[string]string, warnOnFail bool) string {
 	runtimeName, runtimeVersion := common.GetRuntimeNameAndVersion(ar.FunctionConfig.Spec.Runtime)
 
 	// supports both values per runtimeName and per runtimeName + runtimeVersion
@@ -194,8 +195,7 @@ func (ar *AbstractRuntime) getImageFromMap(imagesMap map[string]string, isEnrich
 		return image
 	}
 
-	// if the map was enriched before, we expected to find a matching image for this runtime
-	if isEnriched {
+	if warnOnFail {
 		ar.Logger.WarnWith("Failed to find base image for runtime",
 			"runtime name", runtimeName,
 			"runtime version", runtimeVersion,

--- a/pkg/processor/build/runtime/runtime_test.go
+++ b/pkg/processor/build/runtime/runtime_test.go
@@ -21,7 +21,9 @@ package runtime
 import (
 	"testing"
 
+	"github.com/nuclio/nuclio/pkg/common/testutils/mocks"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
@@ -94,6 +96,105 @@ func (suite *AbstractRuntimeTestSuite) TestGetBaseImageFromMap() {
 			result := testAbstractRuntime.GetBaseImageFromMap(testCase.baseImages)
 
 			suite.Require().Equal(testCase.expectedBaseImage, result)
+		})
+	}
+}
+
+func (suite *AbstractRuntimeTestSuite) TestGetBaseImageFromMapWithMockLogger() {
+	testCases := []struct {
+		name               string
+		baseImages         map[string]string
+		runtime            string
+		expectedBaseImage  string
+		expectWarnWithCall bool
+	}{
+		{
+			name: "Base image found - no warning logged",
+			baseImages: map[string]string{
+				"python:3.12": "custom-python:3.12",
+			},
+			runtime:            "python:3.12",
+			expectedBaseImage:  "custom-python:3.12",
+			expectWarnWithCall: false,
+		},
+		{
+			name: "Base image not found - warning logged",
+			baseImages: map[string]string{
+				"golang": "custom-golang:latest",
+			},
+			runtime:            "python:3.12",
+			expectedBaseImage:  "",
+			expectWarnWithCall: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		suite.Run(testCase.name, func() {
+			mockLogger := new(mocks.MockLogger)
+
+			if testCase.expectWarnWithCall {
+				mockLogger.On("WarnWith", "Failed to find base image for runtime", mock.Anything).Once()
+			}
+
+			functionConfig := &functionconfig.Config{
+				Spec: functionconfig.Spec{
+					Runtime: testCase.runtime,
+				},
+			}
+
+			testAbstractRuntime := &AbstractRuntime{
+				Logger:         mockLogger,
+				FunctionConfig: functionConfig,
+			}
+
+			result := testAbstractRuntime.GetBaseImageFromMap(testCase.baseImages)
+
+			suite.Require().Equal(testCase.expectedBaseImage, result)
+			mockLogger.AssertExpectations(suite.T())
+		})
+	}
+}
+
+func (suite *AbstractRuntimeTestSuite) TestGetOverrideImageRegistryFromMapWithMockLogger() {
+	testCases := []struct {
+		name                  string
+		imageRegistries       map[string]string
+		runtime               string
+		expectedImageRegistry string
+	}{
+		{
+			name: "Override image registry found - no warning logged",
+			imageRegistries: map[string]string{
+				"python:3.12": "custom-registry.io",
+			},
+			runtime:               "python:3.12",
+			expectedImageRegistry: "custom-registry.io",
+		},
+		{
+			name: "Override image registry not found - no warning logged",
+			imageRegistries: map[string]string{},
+			runtime:               "python:3.12",
+			expectedImageRegistry: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		suite.Run(testCase.name, func() {
+			mockLogger := new(mocks.MockLogger)
+			functionConfig := &functionconfig.Config{
+				Spec: functionconfig.Spec{
+					Runtime: testCase.runtime,
+				},
+			}
+			testAbstractRuntime := &AbstractRuntime{
+				Logger:         mockLogger,
+				FunctionConfig: functionConfig,
+			}
+
+			result := testAbstractRuntime.GetOverrideImageRegistryFromMap(testCase.imageRegistries)
+
+			suite.Require().Equal(testCase.expectedImageRegistry, result)
+			mockLogger.AssertExpectations(suite.T())
 		})
 	}
 }

--- a/pkg/processor/build/runtime/runtime_test.go
+++ b/pkg/processor/build/runtime/runtime_test.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/common/testutils/mocks"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
-	"github.com/stretchr/testify/mock"
 
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -171,8 +171,8 @@ func (suite *AbstractRuntimeTestSuite) TestGetOverrideImageRegistryFromMapWithMo
 			expectedImageRegistry: "custom-registry.io",
 		},
 		{
-			name: "Override image registry not found - no warning logged",
-			imageRegistries: map[string]string{},
+			name:                  "Override image registry not found - no warning logged",
+			imageRegistries:       map[string]string{},
 			runtime:               "python:3.12",
 			expectedImageRegistry: "",
 		},


### PR DESCRIPTION
### 📝 Description
Improve runtime image resolution observability and testability by enriching image lookup helpers with runtime context and adding explicit warnings when expected base images are missing.

---

### 🛠️ Changes Made
- Refactored `getImageFromMap` to return runtime name and version alongside the resolved image.
- Updated base image lookup to log a warning when enrichment results in an empty base image.
- Added a reusable mock logger for unit tests.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Dev test
  - Removed relevant configurations from `nuclio-platform-config`
  - Deployed a function and validated that there are no warnings
<img width="1294" height="285" alt="image" src="https://github.com/user-attachments/assets/0fd8248a-6c65-4565-aac6-12feeef24422" />

- Added unit tests validating warning behavior and image resolution logic using the mock logger.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-725
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->