### PR TITLE
[Security] Fix CVE-2026-29042 - OS Command Injection in shell runtime

### DIFF
--- a/pkg/processor/runtime/shell/runtime.go
+++ b/pkg/processor/runtime/shell/runtime.go
@@ -295,6 +295,10 @@ func (s *shell) getCommandArguments(event nuclio.Event) []string {
 		arguments = s.configuration.Arguments
 	}
 
+	if arguments == "" {
+		return nil
+	}
+
 	return strings.Split(arguments, " ")
 }
 

--- a/pkg/processor/runtime/shell/runtime.go
+++ b/pkg/processor/runtime/shell/runtime.go
@@ -203,8 +203,10 @@ func (s *shell) processEvent(context context.Context,
 
 	if s.commandInPath {
 
-		// if the command is an executable, run it as a command with sh -c.
-		cmd = exec.CommandContext(context, "sh", "-c", strings.Join(command, " "))
+		// Run the command directly without sh -c to prevent shell metacharacter
+		// interpretation in user-supplied arguments (CVE-2026-29042).
+		// Go's exec resolves the command via LookPath internally.
+		cmd = exec.CommandContext(context, command[0], command[1:]...)
 	} else {
 
 		// if the command is a shell script run it with sh(without -c). this will make sh

--- a/pkg/processor/runtime/shell/runtime_test.go
+++ b/pkg/processor/runtime/shell/runtime_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package shell
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"path"
@@ -26,6 +27,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/common/headers"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/processor"
@@ -43,6 +45,33 @@ type TestTriggerInfoProvider struct{}
 func (ti *TestTriggerInfoProvider) GetClass() string { return "test class" }
 func (ti *TestTriggerInfoProvider) GetKind() string  { return "test kind" }
 func (ti *TestTriggerInfoProvider) GetName() string  { return "test name" }
+
+// testEventWithHeaders extends MemoryEvent with working GetHeaderByteSlice and
+// GetHeaderString implementations. MemoryEvent.GetHeader reads from the Headers
+// map, but the AbstractEvent base's GetHeaderByteSlice always returns empty,
+// so GetHeaderString (which calls GetHeaderByteSlice) never sees the map values.
+type testEventWithHeaders struct {
+	nuclio.MemoryEvent
+}
+
+func (event *testEventWithHeaders) GetHeaderByteSlice(key string) []byte {
+	header := event.GetHeader(key)
+	if header == nil {
+		return nil
+	}
+	switch typedValue := header.(type) {
+	case string:
+		return []byte(typedValue)
+	case []byte:
+		return typedValue
+	default:
+		return nil
+	}
+}
+
+func (event *testEventWithHeaders) GetHeaderString(key string) string {
+	return string(event.GetHeaderByteSlice(key))
+}
 
 type ShellRuntimeSuite struct {
 	suite.Suite
@@ -134,4 +163,149 @@ func TestShellRuntimeSuite(t *testing.T) {
 		return
 	}
 	suite.Run(t, new(ShellRuntimeSuite))
+}
+
+// CommandInjectionTestSuite demonstrates CVE-2026-29042 (OS Command Injection) in the shell
+// runtime's X-Nuclio-Arguments header processing. When the handler resolves to a
+// command in PATH, the runtime uses `sh -c` to execute it,  joining
+// the command and user-supplied arguments into a single string without sanitization
+// This allows shell metacharacters in the header value to break
+// out of the intended command and execute arbitrary commands with the container's
+// privileges.
+type CommandInjectionTestSuite struct {
+	suite.Suite
+	runtimeInstance       runtime.Runtime
+	logger                logger.Logger
+	tempRuntimeHandlerDir string
+}
+
+func (suite *CommandInjectionTestSuite) SetupSuite() {
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
+	configuration, err := NewConfiguration(suite.resolveRuntimeConfiguration())
+	suite.Require().NoError(err, "Failed to create configuration")
+
+	// Point handler dir to a directory where 'true' does not exist as a file,
+	// so the runtime resolves it via PATH and sets commandInPath=true.
+	// 'true' is ideal because it produces no output and ignores all arguments,
+	// so any injected command output (e.g. "INJECTED") can only appear if
+	// shell metacharacters were actually interpreted.
+	suite.tempRuntimeHandlerDir = os.Getenv("NUCLIO_SHELL_HANDLER_DIR")
+	err = os.Setenv("NUCLIO_SHELL_HANDLER_DIR", os.TempDir())
+	suite.Require().NoError(err, "Failed to set NUCLIO_SHELL_HANDLER_DIR")
+
+	configuration.Spec.Handler = "true:main"
+
+	suite.runtimeInstance, err = NewRuntime(suite.logger, configuration)
+	suite.Require().NoError(err, "Failed to create shell runtime")
+}
+
+func (suite *CommandInjectionTestSuite) TearDownSuite() {
+	suite.Require().NoError(os.Setenv("NUCLIO_SHELL_HANDLER_DIR", suite.tempRuntimeHandlerDir))
+}
+
+func (suite *CommandInjectionTestSuite) TestShellMetacharactersAreNotInterpreted() {
+	testCases := []struct {
+		name                string
+		argumentsPayload    string
+		forbiddenInResponse string
+	}{
+		{
+			name:                "semicolon must not break out of command",
+			argumentsPayload:    "; echo INJECTED ;",
+			forbiddenInResponse: "INJECTED",
+		},
+		{
+			name:                "backticks must not perform command substitution",
+			argumentsPayload:    "`echo INJECTED`",
+			forbiddenInResponse: "INJECTED",
+		},
+		{
+			name:                "dollar-paren must not perform command substitution",
+			argumentsPayload:    "$(echo INJECTED)",
+			forbiddenInResponse: "INJECTED",
+		},
+		{
+			name:                "pipe must not redirect to another command",
+			argumentsPayload:    "| echo INJECTED",
+			forbiddenInResponse: "INJECTED",
+		},
+		{
+			name:                "double-ampersand must not chain commands",
+			argumentsPayload:    "&& echo INJECTED",
+			forbiddenInResponse: "INJECTED",
+		},
+		{
+			name:                "semicolon must not allow reading sensitive files",
+			argumentsPayload:    "; cat /etc/passwd ;",
+			forbiddenInResponse: "root:",
+		},
+	}
+
+	for _, testCase := range testCases {
+		suite.Run(testCase.name, func() {
+			responseBody := suite.getResponseBodyForArguments(testCase.argumentsPayload)
+			suite.Require().NotContains(responseBody, testCase.forbiddenInResponse)
+		})
+	}
+}
+
+func (suite *CommandInjectionTestSuite) TestServiceAccountTokenCannotBeExfiltratedViaInjection() {
+
+	// Simulates the attack described in the vulnerability report: reading a
+	// Kubernetes ServiceAccount token from the filesystem via command injection.
+	// A temp file stands in for /var/run/secrets/kubernetes.io/serviceaccount/token.
+	fakeTokenContent := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.fake-sa-token"
+	tempFile, err := os.CreateTemp("", "fake-sa-token-*")
+	suite.Require().NoError(err)
+	defer os.Remove(tempFile.Name())
+
+	_, err = tempFile.WriteString(fakeTokenContent)
+	suite.Require().NoError(err)
+	suite.Require().NoError(tempFile.Close())
+
+	responseBody := suite.getResponseBodyForArguments(fmt.Sprintf("; cat %s ;", tempFile.Name()))
+	suite.Require().NotContains(responseBody, fakeTokenContent,
+		"Command injection must not allow reading ServiceAccount tokens from the filesystem")
+}
+
+// getResponseBodyForArguments sends an event with the given X-Nuclio-Arguments header
+// and returns the response body as a string. Returns empty string if the runtime
+// returns an error or nil response, since either outcome means no injection occurred.
+func (suite *CommandInjectionTestSuite) getResponseBodyForArguments(arguments string) string {
+	event := &testEventWithHeaders{
+		MemoryEvent: nuclio.MemoryEvent{
+			Body: []byte("test"),
+			Headers: map[string]interface{}{
+				headers.Arguments: arguments,
+			},
+		},
+	}
+	event.SetTriggerInfoProvider(&TestTriggerInfoProvider{})
+
+	response, err := suite.runtimeInstance.ProcessEvent(event, suite.logger)
+	if err != nil || response == nil {
+		return ""
+	}
+
+	return string(response.(nuclio.Response).Body)
+}
+
+func (suite *CommandInjectionTestSuite) resolveRuntimeConfiguration() *runtime.Configuration {
+	return &runtime.Configuration{
+		FunctionLogger: suite.logger,
+		Configuration: &processor.Configuration{
+			Config: functionconfig.Config{
+				Meta: functionconfig.Meta{},
+				Spec: functionconfig.Spec{},
+			},
+			PlatformConfig: &platformconfig.Config{},
+		},
+	}
+}
+
+func TestCommandInjectionTestSuite(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+	suite.Run(t, new(CommandInjectionTestSuite))
 }

--- a/pkg/processor/runtime/shell/test/shell_test.go
+++ b/pkg/processor/runtime/shell/test/shell_test.go
@@ -123,6 +123,88 @@ func (suite *TestSuite) TestStress() {
 	suite.BlastHTTP(blastConfiguration)
 }
 
+// TestCommandInjectionIsBlocked verifies that shell metacharacters in the
+// X-Nuclio-Arguments header are not interpreted when the handler is a PATH
+// command (commandInPath=true). Uses 'true' which produces no output and
+// ignores all arguments, so any injected command output can only appear if
+// shell metacharacters were actually interpreted (CVE-2026-29042).
+func (suite *TestSuite) TestCommandInjectionIsBlocked() {
+	statusOK := http.StatusOK
+
+	// Deploy 'true' as a PATH-based handler (no source code needed).
+	createFunctionOptions := suite.GetDeployOptions("cmd-injection-test", "/dev/null")
+	createFunctionOptions.FunctionConfig.Spec.Handler = "true"
+
+	suite.DeployFunctionAndRequests(createFunctionOptions, []*httpsuite.Request{
+		{
+			Name:        "semicolon must not break out of command",
+			RequestBody: "test",
+			RequestHeaders: map[string]interface{}{
+				headers.Arguments: "; echo INJECTED ;",
+			},
+			ExpectedResponseStatusCode: &statusOK,
+			ExpectedResponseBody: func(body []byte) {
+				suite.Require().NotContains(string(body), "INJECTED")
+			},
+		},
+		{
+			Name:        "backticks must not perform command substitution",
+			RequestBody: "test",
+			RequestHeaders: map[string]interface{}{
+				headers.Arguments: "`echo INJECTED`",
+			},
+			ExpectedResponseStatusCode: &statusOK,
+			ExpectedResponseBody: func(body []byte) {
+				suite.Require().NotContains(string(body), "INJECTED")
+			},
+		},
+		{
+			Name:        "dollar-paren must not perform command substitution",
+			RequestBody: "test",
+			RequestHeaders: map[string]interface{}{
+				headers.Arguments: "$(echo INJECTED)",
+			},
+			ExpectedResponseStatusCode: &statusOK,
+			ExpectedResponseBody: func(body []byte) {
+				suite.Require().NotContains(string(body), "INJECTED")
+			},
+		},
+		{
+			Name:        "pipe must not redirect to another command",
+			RequestBody: "test",
+			RequestHeaders: map[string]interface{}{
+				headers.Arguments: "| echo INJECTED",
+			},
+			ExpectedResponseStatusCode: &statusOK,
+			ExpectedResponseBody: func(body []byte) {
+				suite.Require().NotContains(string(body), "INJECTED")
+			},
+		},
+		{
+			Name:        "double-ampersand must not chain commands",
+			RequestBody: "test",
+			RequestHeaders: map[string]interface{}{
+				headers.Arguments: "&& echo INJECTED",
+			},
+			ExpectedResponseStatusCode: &statusOK,
+			ExpectedResponseBody: func(body []byte) {
+				suite.Require().NotContains(string(body), "INJECTED")
+			},
+		},
+		{
+			Name:        "semicolon must not allow reading sensitive files",
+			RequestBody: "test",
+			RequestHeaders: map[string]interface{}{
+				headers.Arguments: "; cat /etc/passwd ;",
+			},
+			ExpectedResponseStatusCode: &statusOK,
+			ExpectedResponseBody: func(body []byte) {
+				suite.Require().NotContains(string(body), "root:")
+			},
+		},
+	})
+}
+
 func TestIntegrationSuite(t *testing.T) {
 	if testing.Short() {
 		return


### PR DESCRIPTION
### 📝 Description

Fix CVE-2026-29042 (CWE-78: OS Command Injection) in the shell runtime. When a function handler resolved to a command in PATH, the runtime concatenated user-supplied `X-Nuclio-Arguments` header values into a `sh -c` command string without sanitization, allowing attackers to inject arbitrary OS commands via shell metacharacters (`;`, `` ` ``, `$()`, `|`, `&&`). This could be exploited to execute code with root privileges, read ServiceAccount tokens, and gain cluster-admin access.

---

### 🛠️ Changes Made

- **`pkg/processor/runtime/shell/runtime.go`**: Replace `sh -c strings.Join(command, " ")` with direct `exec.CommandContext(command[0], command[1:]...)` for PATH-based handlers. Go's `exec` resolves commands via `LookPath` internally, and arguments are passed as separate OS-level process args — shell metacharacters are never interpreted. The script path (`commandInPath == false`) was already safe and is unchanged.
- **`pkg/processor/runtime/shell/runtime_test.go`**: Add `CommandInjectionTestSuite` with unit-level tests covering 6 injection vectors (`;`, `` ` ``, `$()`, `|`, `&&`, sensitive file read) and a ServiceAccount token exfiltration simulation.
- **`pkg/processor/runtime/shell/test/shell_test.go`**: Add `TestCommandInjectionIsBlocked` e2e test that deploys a real shell function with a PATH-based handler and sends malicious HTTP requests with crafted `X-Nuclio-Arguments` headers.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

unit, integ (followed TDD approach, where firstly implemented the tests which failed and then created a fix)

---

### 🔗 References
- Ticket link: [CVE-2026-29042](https://iguazio.atlassian.net/browse/NUC-749)
- Design docs links:
- External links: https://cwe.mitre.org/data/definitions/78.html

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

**Root cause:** `getCommandArguments()` reads `X-Nuclio-Arguments` and splits by spaces without validation. When `commandInPath == true`, `processEvent()` joined the resulting slice into a single string and passed it to `sh -c`, which interpreted shell metacharacters.

**Why not input validation (regex allowlist)?** A regex like `^[a-zA-Z0-9_\-=., ]+$` would break documented use cases (e.g., ImageMagick's `"- -resize 50% fd:1"` contains `%`). Any allowlist is fragile — too narrow breaks users, too broad allows bypass — and doesn't address the root cause.

**Scope:** Only the `commandInPath == true` execution path was vulnerable. The script path (`sh script.sh args...`) passes arguments as positional parameters without shell interpretation and was already safe.