### PR TITLE
[Processor] Add reply support to NATS trigger

### DIFF
--- a/docs/reference/triggers/nats.md
+++ b/docs/reference/triggers/nats.md
@@ -20,7 +20,20 @@ The queue name may be a Go template, which may include any of the following fiel
 | :--- | :--- | :--- |
 | topic | string | The topic on which to listen. |
 | queueName | string | The name of a shared worker queue to join; (default: an auto-generated name per trigger). |
-| reply | bool | When set to true, publish the handler response body to the incoming message reply subject (`msg.Reply`) if present. |
+| reply | bool | When set to true, publish the handler response body to the incoming message reply subject (`msg.Reply`) if present. See [Reply encoding](#reply-encoding) for details. |
+
+### Reply encoding
+
+When `reply` is enabled, the trigger publishes the handler's return value to the
+NATS reply subject using the following rules:
+
+| **Response body type** | **Behavior** |
+| :--- | :--- |
+| `[]byte` | Published as-is. |
+| `string` | Converted to bytes and published. |
+| Any other type | JSON-serialized before publishing. |
+| `nil` | An empty message (no payload) is published. |
+| *(no reply subject)* | If the incoming NATS message has no reply subject (i.e. it was sent with `Publish` rather than `Request`), no reply is published regardless of this setting. |
 
 ### Example
 

--- a/docs/reference/triggers/nats.md
+++ b/docs/reference/triggers/nats.md
@@ -20,6 +20,7 @@ The queue name may be a Go template, which may include any of the following fiel
 | :--- | :--- | :--- |
 | topic | string | The topic on which to listen. |
 | queueName | string | The name of a shared worker queue to join; (default: an auto-generated name per trigger). |
+| reply | bool | When set to true, publish the handler response body to the incoming message reply subject (`msg.Reply`) if present. |
 
 ### Example
 
@@ -31,4 +32,5 @@ triggers:
     attributes:
       "topic": "my.topic"
       "queueName": "{{ .Namespace }}.{{ .Name }}.{{ .Id }}"
+      "reply": true
 ```

--- a/pkg/processor/trigger/nats/core/test/nats_test.go
+++ b/pkg/processor/trigger/nats/core/test/nats_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package test
 
 import (
+	"encoding/base64"
 	"fmt"
 	"testing"
 	"time"
@@ -27,7 +28,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
-	"github.com/nuclio/nuclio/pkg/processor/trigger/test"
+	triggertest "github.com/nuclio/nuclio/pkg/processor/trigger/test"
 
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/suite"
@@ -88,6 +89,73 @@ func (suite *testSuite) getDeployOptions() *platform.CreateFunctionOptions {
 			"topic": suite.topicName,
 		},
 		NumWorkers: 3,
+	}
+
+	return createFunctionOptions
+}
+
+func (suite *testSuite) TestReply() {
+	err := suite.createNatsConnection()
+	suite.Require().NoError(err, "Failed to create NATS connection")
+
+	createFunctionOptions := suite.getDeployOptionsForEcho(true)
+	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+		suite.Require().NotNil(deployResult, "Unexpected empty deploy results")
+
+		messageBody := "echo-this-back"
+
+		// retry — the NATS subscription in the processor may take a moment
+		// to become active after the function container starts
+		var replyMessage *nats.Msg
+		err := common.RetryUntilSuccessful(30*time.Second, 2*time.Second, func() bool {
+			var reqErr error
+			replyMessage, reqErr = suite.natsConn.Request(suite.topicName, []byte(messageBody), 5*time.Second)
+			return reqErr == nil
+		})
+		suite.Require().NoError(err, "Failed to receive NATS reply")
+		suite.Require().Equal(messageBody, string(replyMessage.Data))
+
+		return true
+	})
+}
+
+func (suite *testSuite) TestReplyDisabled() {
+	err := suite.createNatsConnection()
+	suite.Require().NoError(err, "Failed to create NATS connection")
+
+	createFunctionOptions := suite.getDeployOptionsForEcho(false)
+	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+		suite.Require().NotNil(deployResult, "Unexpected empty deploy results")
+
+		// with reply disabled the function should NOT publish a response,
+		// so nats.Request will time out
+		_, err := suite.natsConn.Request(suite.topicName, []byte("no-reply-body"), 3*time.Second)
+		suite.Require().ErrorIs(err, nats.ErrTimeout, "Expected timeout but got a reply")
+
+		return true
+	})
+}
+
+func (suite *testSuite) getDeployOptionsForEcho(reply bool) *platform.CreateFunctionOptions {
+	echoHandlerSourceCode := base64.StdEncoding.EncodeToString([]byte(`def handler(context, event):
+    return event.body
+`))
+
+	createFunctionOptions := suite.GetDeployOptions("echo_handler", "")
+	createFunctionOptions.FunctionConfig.Spec.Runtime = "python"
+	createFunctionOptions.FunctionConfig.Meta.Name = fmt.Sprintf("nats-reply-test-%v", reply)
+	createFunctionOptions.FunctionConfig.Spec.Handler = "echo_handler:handler"
+	createFunctionOptions.FunctionConfig.Spec.Build.Path = ""
+	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = echoHandlerSourceCode
+	createFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{}
+	createFunctionOptions.FunctionConfig.Spec.Triggers["nats"] = functionconfig.Trigger{
+		Kind: "nats",
+		URL:  fmt.Sprintf("nats://172.17.0.1:%d", suite.natsPort),
+		Attributes: map[string]interface{}{
+			"topic": suite.topicName,
+			"reply": reply,
+		},
+		NumWorkers: 1,
 	}
 
 	return createFunctionOptions

--- a/pkg/processor/trigger/nats/core/trigger.go
+++ b/pkg/processor/trigger/nats/core/trigger.go
@@ -118,6 +118,12 @@ func (n *nats) Start(checkpoint functionconfig.Checkpoint) error {
 		return errors.Wrapf(err, "Can't connect to NATS server %s", n.configuration.URL)
 	}
 	n.natsConnection = natsConnection
+	defer func() {
+		if err != nil {
+			natsConnection.Close()
+			n.natsConnection = nil
+		}
+	}()
 
 	messageChan := make(chan *natsio.Msg, 64)
 	n.natsSubscription, err = natsConnection.ChanQueueSubscribe(n.configuration.Topic, n.configuration.QueueName, messageChan)
@@ -135,9 +141,11 @@ func (n *nats) Stop(force bool) (functionconfig.Checkpoint, error) {
 		return nil, err
 	}
 
+	// Close the connection but don't nil the pointer — concurrent goroutines in
+	// publishReply may still hold a reference. After Close(), any Publish call
+	// will safely return nats.ErrConnectionClosed.
 	if n.natsConnection != nil {
 		n.natsConnection.Close()
-		n.natsConnection = nil
 	}
 
 	return nil, nil

--- a/pkg/processor/trigger/nats/core/trigger.go
+++ b/pkg/processor/trigger/nats/core/trigger.go
@@ -23,15 +23,15 @@ import (
 	"text/template"
 	"time"
 
+	natsio "github.com/nats-io/nats.go"
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
+
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
-
-	natsio "github.com/nats-io/nats.go"
-	"github.com/nuclio/errors"
-	"github.com/nuclio/logger"
 )
 
 type nats struct {

--- a/pkg/processor/trigger/nats/core/trigger.go
+++ b/pkg/processor/trigger/nats/core/trigger.go
@@ -23,15 +23,15 @@ import (
 	"text/template"
 	"time"
 
-	natsio "github.com/nats-io/nats.go"
-	"github.com/nuclio/errors"
-	"github.com/nuclio/logger"
-	"github.com/nuclio/nuclio-sdk-go"
-
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
+
+	natsio "github.com/nats-io/nats.go"
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+	"github.com/nuclio/nuclio-sdk-go"
 )
 
 type nats struct {

--- a/pkg/processor/trigger/nats/core/trigger.go
+++ b/pkg/processor/trigger/nats/core/trigger.go
@@ -18,10 +18,12 @@ package nats
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/url"
 	"text/template"
 	"time"
 
+	"github.com/nuclio/nuclio-sdk-go"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
@@ -36,6 +38,7 @@ type nats struct {
 	trigger.AbstractTrigger
 	configuration    *Configuration
 	stop             chan bool
+	natsConnection   *natsio.Conn
 	natsSubscription *natsio.Subscription
 }
 
@@ -114,6 +117,7 @@ func (n *nats) Start(checkpoint functionconfig.Checkpoint) error {
 	if err != nil {
 		return errors.Wrapf(err, "Can't connect to NATS server %s", n.configuration.URL)
 	}
+	n.natsConnection = natsConnection
 
 	messageChan := make(chan *natsio.Msg, 64)
 	n.natsSubscription, err = natsConnection.ChanQueueSubscribe(n.configuration.Topic, n.configuration.QueueName, messageChan)
@@ -126,7 +130,17 @@ func (n *nats) Start(checkpoint functionconfig.Checkpoint) error {
 
 func (n *nats) Stop(force bool) (functionconfig.Checkpoint, error) {
 	n.stop <- true
-	return nil, n.natsSubscription.Unsubscribe()
+
+	if err := n.natsSubscription.Unsubscribe(); err != nil {
+		return nil, err
+	}
+
+	if n.natsConnection != nil {
+		n.natsConnection.Close()
+		n.natsConnection = nil
+	}
+
+	return nil, nil
 }
 
 func (n *nats) listenForMessages(messageChan chan *natsio.Msg) {
@@ -149,10 +163,14 @@ func (n *nats) listenForMessages(messageChan chan *natsio.Msg) {
 					return
 				}
 
-				// submit the event to the worker, don't really do anything with response
-				_, processErr := n.SubmitEventToWorker(nil, workerInstance, event)
+				// submit the event to the worker and optionally publish the response as a NATS reply
+				response, processErr := n.SubmitEventToWorker(nil, workerInstance, event)
 				if processErr != nil {
 					n.Logger.ErrorWith("Can't process event", "error", processErr)
+				} else if n.configuration.Reply {
+					if err := n.publishReply(natsMessage, response); err != nil {
+						n.Logger.WarnWith("Failed to publish NATS reply", "error", err)
+					}
 				}
 
 				// release the worker
@@ -167,4 +185,36 @@ func (n *nats) listenForMessages(messageChan chan *natsio.Msg) {
 
 func (n *nats) GetConfig() map[string]interface{} {
 	return common.StructureToMap(n.configuration)
+}
+
+func (n *nats) publishReply(natsMessage *natsio.Msg, response nuclio.ProcessingResult) error {
+	if natsMessage.Reply == "" {
+		return nil
+	}
+
+	if n.natsConnection == nil {
+		return errors.New("NATS connection is not initialized")
+	}
+
+	responseBody := response.GetBody()
+	if responseBody == nil {
+		return n.natsConnection.Publish(natsMessage.Reply, nil)
+	}
+
+	var payload []byte
+
+	switch typedResponseBody := responseBody.(type) {
+	case []byte:
+		payload = typedResponseBody
+	case string:
+		payload = []byte(typedResponseBody)
+	default:
+		payloadJSON, err := json.Marshal(typedResponseBody)
+		if err != nil {
+			return errors.Wrap(err, "Failed to marshal response body")
+		}
+		payload = payloadJSON
+	}
+
+	return n.natsConnection.Publish(natsMessage.Reply, payload)
 }

--- a/pkg/processor/trigger/nats/core/types.go
+++ b/pkg/processor/trigger/nats/core/types.go
@@ -29,6 +29,7 @@ type Configuration struct {
 	trigger.Configuration
 	Topic     string
 	QueueName string
+	Reply     bool
 }
 
 func NewConfiguration(id string,


### PR DESCRIPTION
### 📝 Description
This PR adds support for the NATS request-reply pattern. When a trigger is configured with reply: true, the processor publishes the function's response back to the message's reply subject, enabling synchronous request-reply communication over NATS.

---

### 🛠️ Changes Made
- Added `publishReply()` method; after successful event processing, publishes the function response to the NATS message's reply subject
- Added `Reply` bool field to the NATS trigger Configuration struct (parsed via mapstructure from trigger attributes)

---

### ✅ Checklist
- [X] I updated the documentation (if applicable)
- [X] I have tested the changes in this PR

---

### 🧪 Testing
- Built processor and Python onbuild image
- Deployed Nuclio controller on a local k3d cluster
- Deployed a Python function with NATS trigger configured with `reply: true` against an external NATS server
- Verified using `nats req` function received the message and replied with the response body on the reply subject

---

### 🔗 References
- Ticket link: closes #4031
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [X] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->