### PR TITLE
[ECR] Add --registry-id support for cross-account access

### DIFF
--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -420,7 +420,7 @@ func (k *Kaniko) configureECRInitContainerAndMount(buildOptions *BuildOptions, k
 	// fail silently in order to ignore "repository already exists" errors
 	// if any other error occurs - kaniko will fail similarly
 	region := k.resolveAWSRegionFromECR(buildOptions.RegistryURL)
-	registryID := strings.Split(buildOptions.RegistryURL, ".")[0]
+	registryID := k.resolveAWSRegistryId(buildOptions.RegistryURL)
 	createRepoTemplate := "aws ecr create-repository --repository-name %s --region %s --registry-id %s || true"
 	createMainRepo := fmt.Sprintf(createRepoTemplate, buildOptions.RepoName, region, registryID)
 	createCacheRepo := fmt.Sprintf(createRepoTemplate,
@@ -809,6 +809,12 @@ func (k *Kaniko) matchECRUrl(registryURL string) bool {
 
 func (k *Kaniko) resolveAWSRegionFromECR(registryURL string) string {
 	return strings.Split(registryURL, ".")[3]
+}
+
+// resolveAWSRegistryId extracts the AWS account ID (registry ID) from an ECR registry URL
+// Example: "123456789012.dkr.ecr.us-east-1.amazonaws.com" -> "123456789012"
+func (k *Kaniko) resolveAWSRegistryId(registryURL string) string {
+	return strings.Split(registryURL, ".")[0]
 }
 
 func (k *Kaniko) enrichAndValidateServiceAccount(ctx context.Context, buildOptions *BuildOptions, namespace string) (string, error) {

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -420,11 +420,13 @@ func (k *Kaniko) configureECRInitContainerAndMount(buildOptions *BuildOptions, k
 	// fail silently in order to ignore "repository already exists" errors
 	// if any other error occurs - kaniko will fail similarly
 	region := k.resolveAWSRegionFromECR(buildOptions.RegistryURL)
-	createRepoTemplate := "aws ecr create-repository --repository-name %s --region %s || true"
-	createMainRepo := fmt.Sprintf(createRepoTemplate, buildOptions.RepoName, region)
+	registryID := strings.Split(buildOptions.RegistryURL, ".")[0]
+	createRepoTemplate := "aws ecr create-repository --repository-name %s --region %s --registry-id %s || true"
+	createMainRepo := fmt.Sprintf(createRepoTemplate, buildOptions.RepoName, region, registryID)
 	createCacheRepo := fmt.Sprintf(createRepoTemplate,
 		fmt.Sprintf("%s/cache", buildOptions.RepoName),
-		region)
+		region,
+		registryID)
 	createReposCommand := fmt.Sprintf("%s && %s",
 		createMainRepo,
 		createCacheRepo)

--- a/pkg/containerimagebuilderpusher/kaniko_test.go
+++ b/pkg/containerimagebuilderpusher/kaniko_test.go
@@ -1,0 +1,96 @@
+//go:build test_unit
+
+/*
+Copyright 2023 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package containerimagebuilderpusher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type KanikoTestSuite struct {
+	suite.Suite
+	kaniko *Kaniko
+}
+
+func (suite *KanikoTestSuite) SetupTest() {
+	suite.kaniko = &Kaniko{}
+}
+
+func (suite *KanikoTestSuite) TestResolveAWSRegistryId() {
+	for _, testCase := range []struct {
+		name        string
+		registryURL string
+		expected    string
+	}{
+		{
+			name:        "StandardECRURL",
+			registryURL: "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+			expected:    "123456789012",
+		},
+		{
+			name:        "DifferentRegion",
+			registryURL: "987654321098.dkr.ecr.eu-west-1.amazonaws.com",
+			expected:    "987654321098",
+		},
+		{
+			name:        "APRegion",
+			registryURL: "111222333444.dkr.ecr.ap-southeast-1.amazonaws.com",
+			expected:    "111222333444",
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			result := suite.kaniko.resolveAWSRegistryId(testCase.registryURL)
+			suite.Require().Equal(testCase.expected, result)
+		})
+	}
+}
+
+func (suite *KanikoTestSuite) TestResolveAWSRegionFromECR() {
+	for _, testCase := range []struct {
+		name        string
+		registryURL string
+		expected    string
+	}{
+		{
+			name:        "USEast1",
+			registryURL: "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+			expected:    "us-east-1",
+		},
+		{
+			name:        "EUWest1",
+			registryURL: "987654321098.dkr.ecr.eu-west-1.amazonaws.com",
+			expected:    "eu-west-1",
+		},
+		{
+			name:        "APSoutheast1",
+			registryURL: "111222333444.dkr.ecr.ap-southeast-1.amazonaws.com",
+			expected:    "ap-southeast-1",
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			result := suite.kaniko.resolveAWSRegionFromECR(testCase.registryURL)
+			suite.Require().Equal(testCase.expected, result)
+		})
+	}
+}
+
+func TestKanikoTestSuite(t *testing.T) {
+	suite.Run(t, new(KanikoTestSuite))
+}


### PR DESCRIPTION
  This commit adds support for creating ECR repositories in a specific AWS account when using cross-account ECR access. Previously, aws ecr create-repository was creating repositories in the IAM user's home account instead of the target registry account.

  Changes:
  - Extract registry ID (AWS account) from RegistryURL
  - Add --registry-id parameter to aws ecr create-repository commands
  - Apply fix to both main repository and cache repository creation

  This enables cross-account ECR scenarios where IAM user is in account A (Security account) and ECR repositories are in account B (Platform account) with permissions via resource policies.

  Fixes #4034

  ---

  ### Description

  This PR enables Nuclio to create ECR repositories in a specified AWS account when using cross-account ECR setups. The fix extracts the AWS account ID (registry ID) from the `RegistryURL` and passes it to the `aws ecr create-repository` command via the `--registry-id`
  parameter.

  **Problem Scenario:**
  - IAM user in Account A (e.g., 09xxxxxxxxxx - Security account)
  - Target ECR registry in Account B (e.g., 42xxxxxxxxxx - Platform account)
  - IAM user has cross-account permissions via ECR resource policies
  - **Current behavior:** Repositories created in Account A (wrong) ❌
  - **Fixed behavior:** Repositories created in Account B (correct) ✅

  ---

  ### 🛠️ Changes Made

  **File:** `pkg/containerimagebuilderpusher/kaniko.go` (lines 419-432)

  1. **Extract registry ID:** Added `registryID := strings.Split(buildOptions.RegistryURL, ".")[0]` to extract AWS account ID from ECR URL
  2. **Update template:** Changed `createRepoTemplate` to include `--registry-id %s` parameter
  3. **Apply to both repos:** Updated both main repository and cache repository creation commands

  **Example:**
  - Input: `42xxxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com`
  - Extracted Registry ID: `42xxxxxxxxxx`
  - Command: `aws ecr create-repository --repository-name myrepo --region us-east-1 --registry-id 42xxxxxxxxxx || true`

  ---

  ### ✅ Checklist

  - [x] I updated the documentation (if applicable) - N/A, code is self-documenting
  - [x] I have tested the changes in this PR

  ---

  ### 🧪 Testing

  **Compilation Test:** ✅ PASSED
  ```bash
  go build ./pkg/containerimagebuilderpusher/
  # Successfully compiled with no errors

  Logic Verification Test: ✅ ALL PASSED
  Tested registry ID extraction with multiple ECR URL formats:
  - Cross-account ECR: 42xxxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com → Registry ID: 42xxxxxxxxxx ✅
  - IAM home account: 09xxxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com → Registry ID: 09xxxxxxxxxx ✅
  - Alternative region: 19xxxxxxxxxx.dkr.ecr.eu-west-1.amazonaws.com → Registry ID: 19xxxxxxxxxx ✅

  Generated commands verified to include correct --registry-id parameter for all test cases.

  Note: This fix has been tested for compilation and logic correctness. Real-world testing with actual ECR cross-account deployments would be valuable for maintainers to verify before merge.

  ---
  🔗 References

  - Issue: #4034
  - Related Discussion: Community request for cross-account ECR support in enterprise environments
  - AWS Documentation: https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policy-examples.html#IAM_within_account

  ---
  🚨 Breaking Changes?

  - No

  This is a backward-compatible enhancement. Existing single-account ECR setups continue to work exactly as before, as the registry ID is extracted from the existing RegistryURL parameter.

  ---
  🔍️ Additional Notes

  Implementation Notes:
  - The fix is minimal (5 lines changed) and follows the existing code pattern
  - Uses the same URL parsing approach as the existing resolveAWSRegionFromECR() function
  - The || true ensures failure tolerance (repository already exists errors are ignored)
  - No configuration changes required - registry ID is automatically derived from RegistryURL

  Enterprise Use Case:
  This fix is critical for organizations using AWS Organizations with centralized security/IAM accounts and separate application accounts. It enables proper separation of IAM credentials (Security account) from application resources (Platform account).

  Testing in Production:
  While I've tested compilation and logic, maintainers may want to verify with actual AWS ECR cross-account scenarios or add integration tests if available.