### PR TITLE
[Kaniko] Add support for ACR

### DIFF
--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -383,35 +383,38 @@ func (k *Kaniko) compileJobSpec(ctx context.Context,
 }
 
 func (k *Kaniko) configureSecretVolumeMount(buildOptions *BuildOptions, kanikoJobSpec *batchv1.Job) {
-	if k.matchECRUrl(buildOptions.RegistryURL) {
+	switch {
+	case k.matchECRUrl(buildOptions.RegistryURL):
 		k.configureECRInitContainerAndMount(buildOptions, kanikoJobSpec)
+	case k.matchACRUrl(buildOptions.RegistryURL):
+		k.configureACRCredentialsMount(buildOptions, kanikoJobSpec)
+	case len(buildOptions.SecretName) > 0:
+		k.configureDockerRegistrySecretMount(buildOptions, kanikoJobSpec)
+	}
+}
 
-		// if SecretName is defined - configure mount with docker credentials
-	} else if len(buildOptions.SecretName) > 0 {
+func (k *Kaniko) configureDockerRegistrySecretMount(buildOptions *BuildOptions, kanikoJobSpec *batchv1.Job) {
+	kanikoJobSpec.Spec.Template.Spec.Containers[0].VolumeMounts =
+		append(kanikoJobSpec.Spec.Template.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
+			Name:      "docker-config",
+			MountPath: "/kaniko/.docker",
+			ReadOnly:  true,
+		})
 
-		// configure mount with docker credentials
-		kanikoJobSpec.Spec.Template.Spec.Containers[0].VolumeMounts =
-			append(kanikoJobSpec.Spec.Template.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
-				Name:      "docker-config",
-				MountPath: "/kaniko/.docker",
-				ReadOnly:  true,
-			})
-
-		kanikoJobSpec.Spec.Template.Spec.Volumes = append(kanikoJobSpec.Spec.Template.Spec.Volumes, v1.Volume{
-			Name: "docker-config",
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
-					SecretName: buildOptions.SecretName,
-					Items: []v1.KeyToPath{
-						{
-							Key:  ".dockerconfigjson",
-							Path: "config.json",
-						},
+	kanikoJobSpec.Spec.Template.Spec.Volumes = append(kanikoJobSpec.Spec.Template.Spec.Volumes, v1.Volume{
+		Name: "docker-config",
+		VolumeSource: v1.VolumeSource{
+			Secret: &v1.SecretVolumeSource{
+				SecretName: buildOptions.SecretName,
+				Items: []v1.KeyToPath{
+					{
+						Key:  ".dockerconfigjson",
+						Path: "config.json",
 					},
 				},
 			},
-		})
-	}
+		},
+	})
 }
 
 func (k *Kaniko) configureECRInitContainerAndMount(buildOptions *BuildOptions, kanikoJobSpec *batchv1.Job) {
@@ -815,6 +818,72 @@ func (k *Kaniko) resolveAWSRegionFromECR(registryURL string) string {
 // Example: "123456789012.dkr.ecr.us-east-1.amazonaws.com" -> "123456789012"
 func (k *Kaniko) resolveAWSRegistryId(registryURL string) string {
 	return strings.Split(registryURL, ".")[0]
+}
+
+func (k *Kaniko) matchACRUrl(registryURL string) bool {
+	return strings.Contains(registryURL, ".azurecr.io")
+}
+
+// configureACRCredentialsMount sets up Azure Container Registry authentication for kaniko.
+// It uses the kaniko-native "acr-env" credential helper, which requires:
+// 1. A docker config.json with credHelpers mapping the ACR hostname to "acr-env"
+// 2. Azure credentials (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID) as environment variables
+//
+// The docker config is written by an init container to a shared emptyDir volume mounted at /kaniko/.docker,
+// rather than using a separate ConfigMap resource. This keeps the configuration self-contained within the pod
+// and avoids lifecycle management (creation before the job, cleanup after) and orphaned resources.
+// This follows the same init container pattern used by fetch-bundle and extract-bundle.
+// When RegistryProviderSecretName is set, the secret is mounted via envFrom to provide Azure credentials.
+// When no secret is provided, managed identity (e.g., Azure Workload Identity) is assumed.
+func (k *Kaniko) configureACRCredentialsMount(buildOptions *BuildOptions, kanikoJobSpec *batchv1.Job) {
+	dockerConfigVolumeName := "docker-config"
+	dockerConfigMountPath := "/kaniko/.docker"
+	dockerConfigJSON := fmt.Sprintf(`{"credHelpers":{"%s":"acr-env"}}`, buildOptions.RegistryURL)
+
+	dockerConfigVolumeMount := v1.VolumeMount{
+		Name:      dockerConfigVolumeName,
+		MountPath: dockerConfigMountPath,
+	}
+
+	kanikoJobSpec.Spec.Template.Spec.Volumes = append(kanikoJobSpec.Spec.Template.Spec.Volumes, v1.Volume{
+		Name: dockerConfigVolumeName,
+		VolumeSource: v1.VolumeSource{
+			EmptyDir: &v1.EmptyDirVolumeSource{},
+		},
+	})
+
+	kanikoJobSpec.Spec.Template.Spec.Containers[0].VolumeMounts = append(
+		kanikoJobSpec.Spec.Template.Spec.Containers[0].VolumeMounts,
+		dockerConfigVolumeMount,
+	)
+
+	writeConfigInitContainer := v1.Container{
+		Name:            "setup-acr-config",
+		Image:           k.builderConfiguration.BusyBoxImage,
+		ImagePullPolicy: v1.PullPolicy(k.builderConfiguration.KanikoImagePullPolicy),
+		Command:         []string{"/bin/sh"},
+		Args: []string{
+			"-c",
+			fmt.Sprintf("echo '%s' > %s/config.json", dockerConfigJSON, dockerConfigMountPath),
+		},
+		VolumeMounts: []v1.VolumeMount{dockerConfigVolumeMount},
+		Resources:    buildOptions.Resources,
+	}
+	kanikoJobSpec.Spec.Template.Spec.InitContainers = append(
+		kanikoJobSpec.Spec.Template.Spec.InitContainers, writeConfigInitContainer)
+
+	if k.builderConfiguration.RegistryProviderSecretName != "" {
+		kanikoJobSpec.Spec.Template.Spec.Containers[0].EnvFrom = append(
+			kanikoJobSpec.Spec.Template.Spec.Containers[0].EnvFrom,
+			v1.EnvFromSource{
+				SecretRef: &v1.SecretEnvSource{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: k.builderConfiguration.RegistryProviderSecretName,
+					},
+				},
+			},
+		)
+	}
 }
 
 func (k *Kaniko) enrichAndValidateServiceAccount(ctx context.Context, buildOptions *BuildOptions, namespace string) (string, error) {

--- a/pkg/containerimagebuilderpusher/kaniko_test.go
+++ b/pkg/containerimagebuilderpusher/kaniko_test.go
@@ -22,6 +22,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type KanikoTestSuite struct {
@@ -30,7 +33,12 @@ type KanikoTestSuite struct {
 }
 
 func (suite *KanikoTestSuite) SetupTest() {
-	suite.kaniko = &Kaniko{}
+	suite.kaniko = &Kaniko{
+		builderConfiguration: &ContainerBuilderConfiguration{
+			BusyBoxImage:          "busybox:stable",
+			KanikoImagePullPolicy: "IfNotPresent",
+		},
+	}
 }
 
 func (suite *KanikoTestSuite) TestResolveAWSRegistryId() {
@@ -88,6 +96,147 @@ func (suite *KanikoTestSuite) TestResolveAWSRegionFromECR() {
 			result := suite.kaniko.resolveAWSRegionFromECR(testCase.registryURL)
 			suite.Require().Equal(testCase.expected, result)
 		})
+	}
+}
+
+func (suite *KanikoTestSuite) TestConfigureSecretVolumeMount() {
+	for _, testCase := range []struct {
+		name                       string
+		registryURL                string
+		secretName                 string
+		registryProviderSecretName string
+		expectedInitContainerCount int
+		expectedVolumeCount        int
+		expectedVolumeMountCount   int
+		verifyFunc                 func(podSpec v1.PodSpec)
+	}{
+		{
+			name:                       "ACRWithSecret",
+			registryURL:                "myregistry.azurecr.io",
+			registryProviderSecretName: "acr-credentials",
+			expectedInitContainerCount: 3,
+			expectedVolumeCount:        2,
+			expectedVolumeMountCount:   2,
+			verifyFunc: func(podSpec v1.PodSpec) {
+				// Verify emptyDir volume for docker config
+				suite.Require().Equal("docker-config", podSpec.Volumes[1].Name)
+				suite.Require().NotNil(podSpec.Volumes[1].EmptyDir)
+
+				// Verify setup-acr-config init container with credHelpers
+				acrInitContainer := podSpec.InitContainers[2]
+				suite.Require().Equal("setup-acr-config", acrInitContainer.Name)
+				suite.Require().Contains(acrInitContainer.Args[1], `{"credHelpers":{"myregistry.azurecr.io":"acr-env"}}`)
+				suite.Require().Equal("/kaniko/.docker", acrInitContainer.VolumeMounts[0].MountPath)
+
+				// Verify docker config mount on kaniko executor
+				suite.Require().Equal("/kaniko/.docker", podSpec.Containers[0].VolumeMounts[1].MountPath)
+
+				// Verify envFrom with secret reference
+				suite.Require().Len(podSpec.Containers[0].EnvFrom, 1)
+				suite.Require().Equal("acr-credentials", podSpec.Containers[0].EnvFrom[0].SecretRef.Name)
+			},
+		},
+		{
+			name:                       "ACRWithoutSecret",
+			registryURL:                "myregistry.azurecr.io",
+			registryProviderSecretName: "",
+			expectedInitContainerCount: 3,
+			expectedVolumeCount:        2,
+			expectedVolumeMountCount:   2,
+			verifyFunc: func(podSpec v1.PodSpec) {
+				// Verify init container and volume are still created
+				suite.Require().Equal("setup-acr-config", podSpec.InitContainers[2].Name)
+				suite.Require().Contains(podSpec.InitContainers[2].Args[1], `"acr-env"`)
+
+				// Verify no envFrom (managed identity fallback)
+				suite.Require().Empty(podSpec.Containers[0].EnvFrom)
+			},
+		},
+		{
+			name:                       "DockerRegistrySecret",
+			registryURL:                "docker.io",
+			secretName:                 "my-docker-creds",
+			registryProviderSecretName: "",
+			expectedInitContainerCount: 2,
+			expectedVolumeCount:        2,
+			expectedVolumeMountCount:   2,
+			verifyFunc: func(podSpec v1.PodSpec) {
+				// Verify secret volume with dockerconfigjson mapping
+				suite.Require().NotNil(podSpec.Volumes[1].Secret)
+				suite.Require().Equal("my-docker-creds", podSpec.Volumes[1].Secret.SecretName)
+				suite.Require().Equal(".dockerconfigjson", podSpec.Volumes[1].VolumeSource.Secret.Items[0].Key)
+				suite.Require().Equal("config.json", podSpec.Volumes[1].VolumeSource.Secret.Items[0].Path)
+
+				// Verify read-only mount
+				suite.Require().True(podSpec.Containers[0].VolumeMounts[1].ReadOnly)
+			},
+		},
+		{
+			name:                       "NoRegistrySecret",
+			registryURL:                "docker.io",
+			secretName:                 "",
+			registryProviderSecretName: "",
+			expectedInitContainerCount: 2,
+			expectedVolumeCount:        1,
+			expectedVolumeMountCount:   1,
+			verifyFunc:                 nil,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.kaniko.builderConfiguration.RegistryProviderSecretName = testCase.registryProviderSecretName
+			buildOptions := &BuildOptions{
+				RegistryURL: testCase.registryURL,
+				SecretName:  testCase.secretName,
+			}
+			jobSpec := suite.createBaseJobSpec()
+
+			suite.kaniko.configureSecretVolumeMount(buildOptions, jobSpec)
+
+			podSpec := jobSpec.Spec.Template.Spec
+			suite.Require().Len(podSpec.InitContainers, testCase.expectedInitContainerCount)
+			suite.Require().Len(podSpec.Volumes, testCase.expectedVolumeCount)
+			suite.Require().Len(podSpec.Containers[0].VolumeMounts, testCase.expectedVolumeMountCount)
+
+			if testCase.verifyFunc != nil {
+				testCase.verifyFunc(podSpec)
+			}
+		})
+	}
+}
+
+func (suite *KanikoTestSuite) createBaseJobSpec() *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "test-ns",
+		},
+		Spec: batchv1.JobSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "kaniko-executor",
+							Image: "gcr.io/kaniko-project/executor:latest",
+							VolumeMounts: []v1.VolumeMount{
+								{Name: "tmp", MountPath: "/tmp"},
+							},
+						},
+					},
+					InitContainers: []v1.Container{
+						{Name: "fetch-bundle", Image: "busybox:stable"},
+						{Name: "extract-bundle", Image: "busybox:stable"},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: "tmp",
+							VolumeSource: v1.VolumeSource{
+								EmptyDir: &v1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
### 📝 Description

Add native Azure Container Registry (ACR) authentication support for Kaniko builds, using kaniko's built-in `acr-env` credential helper. This eliminates the need for pre-generated Docker login tokens when pushing images to ACR, analogous to the existing ECR support for AWS.

---

### 🛠️ Changes Made

- Added ACR URL detection via `matchACRUrl` (checks for `.azurecr.io`), following the same pattern as `matchECRUrl`
- Added `configureACRCredentialsMount` which:
  - Writes a `config.json` with `{"credHelpers":{"<registry>":"acr-env"}}` via a BusyBox init container to an emptyDir volume mounted at `/kaniko/.docker`
  - Mounts the Azure credentials secret (`AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`) via `envFrom` on the kaniko executor, using the existing `RegistryProviderSecretName` config field
  - Falls back to managed identity (e.g., Azure Workload Identity) when no secret is specified
- Refactored `configureSecretVolumeMount` from an if-else chain to a switch statement (linter requirement) and extracted the default docker registry secret logic into `configureDockerRegistrySecretMount`

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing

unit for now, real system TBD
---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/IG4-1360
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes


