### PR TITLE
[Builder] Move onbuild commands to the code instead of keeping them in onbuild metadata

### DIFF
--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
@@ -209,7 +210,7 @@ func (d *Docker) gatherArtifactsForSingleStageDockerfile(ctx context.Context,
 			}
 		}
 
-		// build an image to trigger the onbuild stuff. then extract the artifacts
+		// build a temporary image to run stage commands and extract the compiled artifacts
 		if err := d.buildFromAndCopyObjectsFromContainer(ctx,
 			onbuildArtifact.Image,
 			buildOptions.ContextDir,
@@ -232,11 +233,10 @@ func (d *Docker) buildFromAndCopyObjectsFromContainer(ctx context.Context,
 
 	dockerfilePath := path.Join(contextDir, "Dockerfile.onbuild")
 
-	onbuildDockerfileContents := fmt.Sprintf(`FROM %s
-ARG NUCLIO_LABEL
-ARG NUCLIO_ARCH
-%s
-`, onbuildImage, stageCommands)
+	onbuildDockerfileContents := fmt.Sprintf("FROM %s\nARG NUCLIO_LABEL\nARG NUCLIO_ARCH\n", onbuildImage)
+	if strings.TrimSpace(stageCommands) != "" {
+		onbuildDockerfileContents += stageCommands + "\n"
+	}
 
 	// generate a simple Dockerfile from the onbuild image
 	if err := os.WriteFile(dockerfilePath, []byte(onbuildDockerfileContents), 0644); err != nil {

--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -214,7 +214,8 @@ func (d *Docker) gatherArtifactsForSingleStageDockerfile(ctx context.Context,
 			onbuildArtifact.Image,
 			buildOptions.ContextDir,
 			onbuildArtifactPaths,
-			buildOptions.BuildArgs); err != nil {
+			buildOptions.BuildArgs,
+			onbuildArtifact.StageCommands); err != nil {
 			return errors.Wrap(err, "Failed to copy objects from onbuild")
 		}
 	}
@@ -226,14 +227,16 @@ func (d *Docker) buildFromAndCopyObjectsFromContainer(ctx context.Context,
 	onbuildImage string,
 	contextDir string,
 	artifactPaths map[string]string,
-	buildArgs map[string]string) error {
+	buildArgs map[string]string,
+	stageCommands string) error {
 
 	dockerfilePath := path.Join(contextDir, "Dockerfile.onbuild")
 
 	onbuildDockerfileContents := fmt.Sprintf(`FROM %s
 ARG NUCLIO_LABEL
 ARG NUCLIO_ARCH
-`, onbuildImage)
+%s
+`, onbuildImage, stageCommands)
 
 	// generate a simple Dockerfile from the onbuild image
 	if err := os.WriteFile(dockerfilePath, []byte(onbuildDockerfileContents), 0644); err != nil {

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -148,11 +148,10 @@ func (k *Kaniko) GetOnbuildStages(onbuildArtifacts []runtime.Artifact) ([]string
 		}
 
 		baseImage := fmt.Sprintf("FROM %s AS %s", artifact.Image, artifact.Name)
-		onbuildDockerfileContents := fmt.Sprintf(`%s
-ARG NUCLIO_LABEL
-ARG NUCLIO_ARCH
-%s
-`, baseImage, artifact.StageCommands)
+		onbuildDockerfileContents := fmt.Sprintf("%s\nARG NUCLIO_LABEL\nARG NUCLIO_ARCH\n", baseImage)
+		if strings.TrimSpace(artifact.StageCommands) != "" {
+			onbuildDockerfileContents += artifact.StageCommands + "\n"
+		}
 
 		onbuildStages = append(onbuildStages, onbuildDockerfileContents)
 	}

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -151,7 +151,8 @@ func (k *Kaniko) GetOnbuildStages(onbuildArtifacts []runtime.Artifact) ([]string
 		onbuildDockerfileContents := fmt.Sprintf(`%s
 ARG NUCLIO_LABEL
 ARG NUCLIO_ARCH
-`, baseImage)
+%s
+`, baseImage, artifact.StageCommands)
 
 		onbuildStages = append(onbuildStages, onbuildDockerfileContents)
 	}

--- a/pkg/processor/build/runtime/dotnetcore/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/dotnetcore/docker/onbuild/Dockerfile
@@ -54,19 +54,3 @@ RUN cd /home/nuclio/src/wrapper \
 
 # Copy the proj
 COPY pkg/processor/build/runtime/dotnetcore/docker/onbuild/handler.csproj /home/nuclio/src/handler/handler.csproj
-
-# Specify the directory where the handler is kept. By default it is the context dir, but it is overridable
-ONBUILD ARG NUCLIO_BUILD_LOCAL_HANDLER_DIR=.
-
-# copy the user code files
-ONBUILD COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} /home/nuclio/src/handler
-
-ONBUILD RUN dotnet add /home/nuclio/src/handler package Microsoft.CSharp && \
-            dotnet add /home/nuclio/src/handler package System.Dynamic.Runtime && \
-            dotnet add /home/nuclio/src/handler package Newtonsoft.Json && \
-            dotnet add /home/nuclio/src/handler package Microsoft.Azure.EventHubs -v 2.2.1 && \
-            dotnet add /home/nuclio/src/handler reference /home/nuclio/src/nuclio-sdk-dotnetcore/nuclio-sdk-dotnetcore.csproj
-
-ONBUILD RUN cd /home/nuclio/src/handler \
-    && dotnet restore \
-    && dotnet publish -c Release -o /home/nuclio/bin/handler

--- a/pkg/processor/build/runtime/dotnetcore/runtime.go
+++ b/pkg/processor/build/runtime/dotnetcore/runtime.go
@@ -54,9 +54,21 @@ func (d *dotnetcore) GetProcessorDockerfileInfo(
 			"/home/nuclio/bin/handler":               "/opt/nuclio/handler",
 			"/home/nuclio/src/nuclio-sdk-dotnetcore": "/opt/nuclio/nuclio-sdk-dotnetcore",
 		},
+		StageCommands: d.getHandlerBuildStageCommands(),
 	}
 	processorDockerfileInfo.OnbuildArtifacts = []runtime.Artifact{artifact}
 
 	processorDockerfileInfo.BaseImage = baseImage
 	return &processorDockerfileInfo, nil
+}
+
+func (d *dotnetcore) getHandlerBuildStageCommands() string {
+	return `ARG NUCLIO_BUILD_LOCAL_HANDLER_DIR=.
+COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} /home/nuclio/src/handler
+RUN dotnet add /home/nuclio/src/handler package Microsoft.CSharp && \
+    dotnet add /home/nuclio/src/handler package System.Dynamic.Runtime && \
+    dotnet add /home/nuclio/src/handler package Newtonsoft.Json && \
+    dotnet add /home/nuclio/src/handler package Microsoft.Azure.EventHubs -v 2.2.1 && \
+    dotnet add /home/nuclio/src/handler reference /home/nuclio/src/nuclio-sdk-dotnetcore/nuclio-sdk-dotnetcore.csproj
+RUN cd /home/nuclio/src/handler && dotnet restore && dotnet publish -c Release -o /home/nuclio/bin/handler`
 }

--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile
@@ -54,21 +54,3 @@ WORKDIR /handler
 # Set go proxy env
 ARG NUCLIO_GO_PROXY=${NUCLIO_GO_PROXY}
 ENV GOPROXY $NUCLIO_GO_PROXY
-
-# Specify the directory where the handler is kept. By default it is the context dir, but it is overridable
-ONBUILD ARG NUCLIO_BUILD_LOCAL_HANDLER_DIR=.
-
-# Copy handler sources to container, build-handler will move it to the right place
-ONBUILD COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} ./
-
-# Specify an onbuild arg to specify offline
-ONBUILD ARG NUCLIO_BUILD_OFFLINE
-
-# Run moduler to ensure go modules exists and downloaded
-ONBUILD RUN mv /moduler.sh . && sync && ./moduler.sh
-
-# Compile handler as plugin
-ONBUILD RUN go build \
-    -mod=mod \
-    -buildmode=plugin \
-    -o /home/nuclio/bin/handler.so .

--- a/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile.alpine
+++ b/pkg/processor/build/runtime/golang/docker/onbuild/Dockerfile.alpine
@@ -64,21 +64,3 @@ WORKDIR /handler
 # Set go proxy env
 ARG NUCLIO_GO_PROXY=${NUCLIO_GO_PROXY}
 ENV GOPROXY $NUCLIO_GO_PROXY
-
-# Specify the directory where the handler is kept. By default it is the context dir, but it is overridable
-ONBUILD ARG NUCLIO_BUILD_LOCAL_HANDLER_DIR=.
-
-# Copy handler sources to container, build-handler will move it to the right place
-ONBUILD COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} ./
-
-# Specify an onbuild arg to specify offline
-ONBUILD ARG NUCLIO_BUILD_OFFLINE
-
-# Run moduler to ensure go modules exists and downloaded
-ONBUILD RUN mv /moduler.sh . && sync && ./moduler.sh
-
-# Compile handler as plugin
-ONBUILD RUN go build \
-    -mod=mod \
-    -buildmode=plugin \
-    -o /home/nuclio/bin/handler.so .

--- a/pkg/processor/build/runtime/golang/runtime.go
+++ b/pkg/processor/build/runtime/golang/runtime.go
@@ -91,8 +91,18 @@ func (g *golang) GetProcessorDockerfileInfo(
 			"/home/nuclio/bin/processor":  "/usr/local/bin/processor",
 			"/home/nuclio/bin/handler.so": "/opt/nuclio/handler.so",
 		},
+		StageCommands: g.getHandlerBuildStageCommands(),
 	}
 	processorDockerfileInfo.OnbuildArtifacts = []runtime.Artifact{artifact}
 
 	return &processorDockerfileInfo, nil
+}
+
+func (g *golang) getHandlerBuildStageCommands() string {
+	return `ARG NUCLIO_BUILD_LOCAL_HANDLER_DIR=.
+WORKDIR /handler
+COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} ./
+ARG NUCLIO_BUILD_OFFLINE
+RUN mv /moduler.sh . && sync && ./moduler.sh
+RUN go build -mod=mod -buildmode=plugin -o /home/nuclio/bin/handler.so .`
 }

--- a/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
@@ -58,29 +58,12 @@ RUN curl -LO https://repo1.maven.org/maven2/io/nuclio/nuclio-sdk-java/1.1.0/nucl
 # Copy the downloaded SDK Jar to the userHandler folder
 RUN cp nuclio-sdk-java-1.1.0.jar /home/gradle/src/userHandler/nuclio-sdk-java-1.1.0.jar
 
-# Copy the gradle build script and user sources to /home/gradle/src/userHandler
-ONBUILD COPY handler/build.gradle /home/gradle/src/userHandler
-
-# Specify the directory where the handler is kept. By default it is the context dir, but it is overridable
-ONBUILD ARG NUCLIO_BUILD_LOCAL_HANDLER_DIR=.
-
-# Copy the entire code to /home/gradle/src/userHandler, where gradle expects it to reside. Note that
-# this will also copy build.gradle... but we'll ignore it
-ONBUILD COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} /home/gradle/src/userHandler
-
-# Run the handle builder to create /home/gradle/src/userHandler/build/libs/user-handler.jar.
-ONBUILD RUN cd /home/gradle/src/userHandler \
-    && ./build-user-handler.sh
-
 #
 # Build wrapper
 #
 
 # Create wrapper directory
 RUN mkdir -p /home/gradle/src/wrapper
-
-# Copy user-handler generated earlier to wrapper
-ONBUILD RUN mv /home/gradle/src/userHandler/build/libs/user-handler.jar /home/gradle/src/wrapper/user-handler.jar
 
 # The directory will hold wrapper source, SDK jar, user-handler.jar and wrapper gradle build script
 COPY pkg/processor/runtime/java/build.gradle \
@@ -94,6 +77,3 @@ RUN cp nuclio-sdk-java-1.1.0.jar /home/gradle/src/wrapper/nuclio-sdk-java-1.1.0.
 # Download dependencies
 RUN cd /home/gradle/src/wrapper \
     && gradle --build-cache compileJava
-
-# Build nuclio-java-wrapper.jar
-ONBUILD RUN /home/gradle/src/wrapper/build-wrapped-handler.sh

--- a/pkg/processor/build/runtime/java/runtime.go
+++ b/pkg/processor/build/runtime/java/runtime.go
@@ -68,10 +68,20 @@ func (j *java) GetProcessorDockerfileInfo(
 			"/home/gradle/bin/processor":                                  "/usr/local/bin/processor",
 			"/home/gradle/src/wrapper/build/libs/nuclio-java-wrapper.jar": "/opt/nuclio/nuclio-java-wrapper.jar",
 		},
+		StageCommands: j.getHandlerBuildStageCommands(),
 	}
 	processorDockerfileInfo.OnbuildArtifacts = []runtime.Artifact{artifact}
 
 	return &processorDockerfileInfo, nil
+}
+
+func (j *java) getHandlerBuildStageCommands() string {
+	return `COPY handler/build.gradle /home/gradle/src/userHandler
+ARG NUCLIO_BUILD_LOCAL_HANDLER_DIR=.
+COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} /home/gradle/src/userHandler
+RUN cd /home/gradle/src/userHandler && ./build-user-handler.sh
+RUN mv /home/gradle/src/userHandler/build/libs/user-handler.jar /home/gradle/src/wrapper/user-handler.jar
+RUN /home/gradle/src/wrapper/build-wrapped-handler.sh`
 }
 
 func (j *java) createGradleBuildScript(stagingBuildDir string) error {

--- a/pkg/processor/build/runtime/runtime.go
+++ b/pkg/processor/build/runtime/runtime.go
@@ -47,6 +47,11 @@ type Artifact struct {
 	Image         string
 	Paths         map[string]string
 	ExternalImage bool
+
+	// StageCommands contains explicit Dockerfile instructions to build user code within the onbuild stage.
+	// For compiled runtimes (Go, Java, .NET Core), these commands copy handler source and compile it.
+	// This replaces the former ONBUILD trigger mechanism with explicit, visible build steps.
+	StageCommands string
 }
 
 type Runtime interface {


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

Previously, the Go, Java, and .NET Core onbuild images relied on Docker's `ONBUILD` trigger mechanism to compile user handler code. These triggers are stored as image metadata and execute automatically when the image is used as a base in a subsequent `FROM` instruction.

**The problem:** When images are mirrored through a `dir:` -> `oci:` transport (e.g., via skopeo in manifesto), the image config blob is converted from `application/vnd.docker.container.image.v1+json` to `application/vnd.oci.image.config.v1+json`. The OCI image spec intentionally excludes the `OnBuild` field -- it was deliberately left out because OCI considers it a Dockerfile build concern, not an image property. So skopeo drops it during the format conversion, and the resulting image silently loses all `ONBUILD` triggers. This causes Kaniko builds to fail with errors like:

```
lstat /kaniko/0/home/nuclio/bin/handler.so: no such file or directory
```

This PR moves the compilation instructions from `ONBUILD` metadata in Dockerfiles into explicit `StageCommands` defined in Go code, making the build process visible, debuggable, and resilient.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

**StageCommands (replacing ONBUILD)**
- Added `StageCommands` field to `runtime.Artifact` struct to hold explicit Dockerfile instructions for each build stage
- Populated `StageCommands` for Go, Java, and .NET Core runtimes with the compilation steps previously defined as `ONBUILD`
- Removed all `ONBUILD` instructions from:
  - `golang/docker/onbuild/Dockerfile`
  - `golang/docker/onbuild/Dockerfile.alpine`
  - `java/docker/onbuild/Dockerfile`
  - `dotnetcore/docker/onbuild/Dockerfile`
- Modified `Kaniko.GetOnbuildStages` and `Docker.buildFromAndCopyObjectsFromContainer` to inject `StageCommands` into the generated Dockerfiles

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
will run long ci

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/IG4-1579
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [x] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

Existing onbuild images of older versions still contain `ONBUILD` metadata. When used with this code, both the `ONBUILD` triggers and the explicit `StageCommands` will run, causing the `mv /moduler.sh .` step (Go) to fail because `ONBUILD` already moved the file. Ensure onbuild images are rebuilt from the updated Dockerfiles (without `ONBUILD`) before deploying this code.

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->

- Python, Ruby, and NodeJS runtimes are unaffected -- they don't have compilation steps in their `ONBUILD` instructions, so no `StageCommands` were needed.
