### PR TITLE
[Security] Fix serialize-javascript RCE vulnerability (CVE-2020-7660)

### DIFF
--- a/pkg/processor/runtime/nodejs/js/package-lock.json
+++ b/pkg/processor/runtime/nodejs/js/package-lock.json
@@ -2590,16 +2590,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -2967,27 +2957,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -3004,13 +2973,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
+      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/shebang-command": {
@@ -5053,7 +5022,7 @@
         "log-symbols": "^4.1.0",
         "minimatch": "^5.1.6",
         "ms": "^2.1.3",
-        "serialize-javascript": "^6.0.2",
+        "serialize-javascript": ">=7.0.3",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
         "workerpool": "^6.5.1",
@@ -5387,15 +5356,6 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -5657,12 +5617,6 @@
         }
       }
     },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
-    },
     "semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -5673,13 +5627,10 @@
       }
     },
     "serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
+      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "dev": true
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/pkg/processor/runtime/nodejs/js/package.json
+++ b/pkg/processor/runtime/nodejs/js/package.json
@@ -11,6 +11,9 @@
   "license": "MIT",
   "homepage": "https://github.com/nuclio/nuclio#readme",
   "dependencies": {},
+  "overrides": {
+    "serialize-javascript": ">=7.0.3"
+  },
   "devDependencies": {
     "eslint": "^7.12.1",
     "eslint-config-standard": "^16.0.1",


### PR DESCRIPTION
### 📝 Description
  Override `serialize-javascript` to v7.0.3+ to patch an RCE vulnerability (CVE-2020-7660).
  The vulnerable version (6.0.2) is pulled in transitively via `mocha@10.8.2` and cannot be updated by Dependabot due to mocha's pinned dependency range 
  (`^6.0.2`).

  ---
  ### 🛠️ Changes Made
  - Added `"overrides": { "serialize-javascript": ">=7.0.3" }` to `pkg/processor/runtime/nodejs/js/package.json`
  - Regenerated `package-lock.json` (resolves to `serialize-javascript@7.0.4`)
  ---
  ### ✅ Checklist
  - [ ] I updated the documentation (if applicable)
  - [x] I have tested the changes in this PR
  ---
  ### 🧪 Testing
  - All 8 existing mocha tests pass after the override
  - Verified via `npm ls serialize-javascript` that the resolved version is 7.0.4 (overridden)
  ---
  ### 🔗 References
  - Ticket link: [serialize-javascript RCE via RegExp.flags and Date.prototype.toISOString() #180](https://github.com/yahoo/serialize-javascript/issues/180)
  - Patch release: https://github.com/yahoo/serialize-javascript/releases/tag/v7.0.3
  - Upstream blocker: mocha v11 still pins `serialize-javascript` to `^6.0.2` — only mocha v12 (beta) bumps it
  ---
  ### 🚨 Breaking Changes?
  - [ ] Yes (explain below)
  - [x] No
  ---
  ### 🔍️ Additional Notes
  - `serialize-javascript` is a **dev-only transitive dependency** (mocha's test infrastructure), not shipped in the nuclio processor runtime. The real-world 
  attack surface is minimal, but the override is a clean fix that silences the alert with no risk.
  - Once mocha v12 is stable and bumps its own dep to `^7.0.2`, the override can be removed.

