### PR TITLE
[ExplicitAck] Send draining done from worker 

### DIFF
--- a/cmd/processor/app/processor_test.go
+++ b/cmd/processor/app/processor_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -232,8 +233,8 @@ func (t *testTrigger) GetProjectName() string {
 	return ""
 }
 
-func (t *testTrigger) SignalWorkersToDrain() error {
-	t.Called()
+func (t *testTrigger) Drain(ctx context.Context) error {
+	t.Called(ctx)
 	return nil
 }
 

--- a/pkg/processor/controlcommunication/types.go
+++ b/pkg/processor/controlcommunication/types.go
@@ -28,6 +28,7 @@ type ControlMessageKind string
 const (
 	StreamMessageAckKind ControlMessageKind = "streamMessageAck"
 	LogMessageKind       ControlMessageKind = "log"
+	DrainMessageKind     ControlMessageKind = "drain"
 )
 
 // TODO: move to nuclio-sdk-go
@@ -40,6 +41,10 @@ type ControlMessageAttributesExplicitAck struct {
 	Topic     string `json:"topic"`
 	Partition int32  `json:"partition"`
 	Offset    int64  `json:"offset"`
+}
+
+type ControlMessageAttributesDrain struct {
+	WorkerId string `json:"workerId"`
 }
 
 type ControlConsumer struct {

--- a/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
@@ -196,6 +196,7 @@ class AsyncWrapper(AbstractWrapper):
                 result = self._call_drain_handler()
                 if asyncio.iscoroutine(result):
                     await result
+                await self._send_drain_complete_control_message()
 
             if self._is_termination_needed:
                 result = self._call_termination_handler()

--- a/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
@@ -193,15 +193,10 @@ class AsyncWrapper(AbstractWrapper):
             await self._on_serving_error(exc, sock)
         finally:
             if self._is_drain_needed:
-                result = self._call_drain_handler()
-                if asyncio.iscoroutine(result):
-                    await result
-                await self._send_drain_complete_control_message()
+                await self._call_drain_handler()
 
             if self._is_termination_needed:
-                result = self._call_termination_handler()
-                if asyncio.iscoroutine(result):
-                    await result
+                await self._call_termination_handler()
             self._cleanup_connection(sock, cancel_task=False)
 
     def _cleanup_connection(self, sock, cancel_task=True):

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -127,15 +127,10 @@ class Wrapper(AbstractWrapper):
 
             finally:
                 if self._is_drain_needed:
-                    result = self._call_drain_handler()
-                    if asyncio.iscoroutine(result):
-                        await result
-                    await self._send_drain_complete_control_message()
+                    await self._call_drain_handler()
 
                 if self._is_termination_needed:
-                    result = self._call_termination_handler()
-                    if asyncio.iscoroutine(result):
-                        await result
+                    await self._call_termination_handler()
 
             # for testing, we can ask wrapper to only read a set number of requests
             if num_requests is not None:

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -130,6 +130,7 @@ class Wrapper(AbstractWrapper):
                     result = self._call_drain_handler()
                     if asyncio.iscoroutine(result):
                         await result
+                    await self._send_drain_complete_control_message()
 
                 if self._is_termination_needed:
                     result = self._call_termination_handler()

--- a/pkg/processor/runtime/python/py/wrapper_common.py
+++ b/pkg/processor/runtime/python/py/wrapper_common.py
@@ -434,6 +434,7 @@ class AbstractWrapper(object):
         # do not perform draining if discarding events
         if self._discard_events:
             self._logger.debug('Draining signal is received, but it will be ignored as the worker is already drained')
+            self._send_drain_complete_control_message()
             return
 
         self._logger.debug_with('Received signal', signal=signal_name)

--- a/pkg/processor/runtime/python/py/wrapper_common.py
+++ b/pkg/processor/runtime/python/py/wrapper_common.py
@@ -104,6 +104,7 @@ class AbstractWrapper(object):
         self._platform = nuclio_sdk.Platform(platform_kind,
                                              namespace=namespace,
                                              on_control_callback=self._send_data_on_control_socket)
+        self._worker_id = worker_id
         self._decode_event_strings = decode_event_strings
 
         # 1gb
@@ -468,6 +469,13 @@ class AbstractWrapper(object):
         # set the flag to False so the drain handler will not be called more than once
         self._is_drain_needed = False
         return self._platform._on_signal(callback_type="drain")
+
+    async def _send_drain_complete_control_message(self):
+        self._logger.debug_with('Sending drain complete control message', worker_id=self._worker_id)
+        await self._send_data_on_control_socket({
+            'kind': 'drain',
+            'attributes': {'workerId': self._worker_id}
+        })
 
     def _call_termination_handler(self):
         self._logger.debug('Calling platform termination handler')

--- a/pkg/processor/runtime/python/py/wrapper_common.py
+++ b/pkg/processor/runtime/python/py/wrapper_common.py
@@ -166,7 +166,6 @@ class AbstractWrapper(object):
         self._is_drain_needed = False
         self._is_termination_needed = False
         self._discard_events = False
-
         self._drained = False
 
         self._event_message_length_task = None

--- a/pkg/processor/runtime/python/py/wrapper_common.py
+++ b/pkg/processor/runtime/python/py/wrapper_common.py
@@ -148,10 +148,26 @@ class AbstractWrapper(object):
                                            nuclio_sdk.TriggerInfo(trigger_kind, trigger_name),
                                            logger_per_async_task=logger_per_async_task)
 
-        # initialize flags
+        # Signal-driven lifecycle flags.
+        #
+        # _is_drain_needed / _is_termination_needed: set True by the respective signal handler,
+        # consumed (set back to False) in the finally block of the serving loop after
+        # executing the drain/termination handler.
+        #
+        # _discard_events: guards against processing events that arrive between a drain/termination
+        # signal and the completion of the handler. In the async wrapper, multiple coroutines may
+        # be serving connections concurrently; one coroutine could receive a new event while another
+        # is still executing the drain handler. This flag ensures those in-flight events are dropped.
+        # It is cleared by the SIGCONT (continue) signal when the processor is ready to resume.
+        #
+        # _drained: tracks whether the drain handler has already been called for the current
+        # drain cycle. When a second SIGUSR2 arrives while already drained (before SIGCONT),
+        # we skip the drain handler and immediately send the drain-complete control message.
         self._is_drain_needed = False
         self._is_termination_needed = False
         self._discard_events = False
+
+        self._drained = False
 
         self._event_message_length_task = None
 
@@ -433,8 +449,10 @@ class AbstractWrapper(object):
     def _on_drain_signal(self, signal_name):
         # do not perform draining if discarding events
         if self._discard_events:
-            self._logger.debug('Draining signal is received, but it will be ignored as the worker is already drained')
-            self._send_drain_complete_control_message()
+            if self._drained:
+                self._logger.debug('Draining signal is received, but it will be ignored as the worker is already drained')
+                self._send_drain_complete_control_message()
+            self._logger.debug('Draining signal is received, but it will be ignored as the worker is already being drained')
             return
 
         self._logger.debug_with('Received signal', signal=signal_name)
@@ -464,12 +482,20 @@ class AbstractWrapper(object):
         # set this flag to False, so continue normal event processing flow
         self._discard_events = False
 
-    def _call_drain_handler(self):
+        # reset drained flag to allow future drain signals to be handled properly
+        self._drained = True
+
+    async def _call_drain_handler(self):
         self._logger.debug('Calling platform drain handler')
 
         # set the flag to False so the drain handler will not be called more than once
         self._is_drain_needed = False
-        return self._platform._on_signal(callback_type="drain")
+        draining_result = self._platform._on_signal(callback_type="drain")
+        if asyncio.iscoroutine(draining_result):
+            await draining_result
+        self._drained = True
+
+        await self._send_drain_complete_control_message()
 
     async def _send_drain_complete_control_message(self):
         self._logger.debug_with('Sending drain complete control message', worker_id=self._worker_id)
@@ -478,16 +504,17 @@ class AbstractWrapper(object):
             'attributes': {'workerId': self._worker_id}
         })
 
-    def _call_termination_handler(self):
+    async def _call_termination_handler(self):
         self._logger.debug('Calling platform termination handler')
 
         # set the flag to False so the termination handler will not be called more than once
         self._is_termination_needed = False
 
-        # call termination handler
         # TODO: send a control message to the processor after this line,
         # to indicate that the termination handler has finished, and the processor can exit early
-        return self._platform._on_signal(callback_type="termination")
+        termination_result = self._platform._on_signal(callback_type="termination")
+        if asyncio.iscoroutine(termination_result):
+            await termination_result
 
     def _shutdown(self, error_code=0):
         self._logger.info("Shutting down...")

--- a/pkg/processor/runtime/python/runtime.go
+++ b/pkg/processor/runtime/python/runtime.go
@@ -145,10 +145,6 @@ func (py *python) Drain() error {
 		return errors.Wrap(err, "Failed to signal wrapper process to drain")
 	}
 
-	// wait for process to finish event handling or timeout
-	// TODO: replace the following function with one that waits for a control communication message or timeout
-	py.WaitForProcessTermination(py.configuration.WorkerTerminationTimeout)
-
 	return nil
 }
 

--- a/pkg/processor/statistics/gatherer/mock.go
+++ b/pkg/processor/statistics/gatherer/mock.go
@@ -19,6 +19,8 @@ limitations under the License.
 package gatherer
 
 import (
+	"context"
+
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
@@ -81,7 +83,7 @@ func (mt *mockTrigger) Stop(force bool) (functionconfig.Checkpoint, error) {
 	return nil, nil
 }
 
-func (mt *mockTrigger) SignalWorkersToDrain() error {
+func (mt *mockTrigger) Drain(ctx context.Context) error {
 	return nil
 }
 

--- a/pkg/processor/trigger/kafka/test/kafka_test.go
+++ b/pkg/processor/trigger/kafka/test/kafka_test.go
@@ -486,8 +486,6 @@ func (suite *testSuite) TestDrainHook() {
 		},
 	}
 
-	var rebalanceStartedTime time.Time
-
 	// deploy function
 	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
 		suite.Require().NotNil(deployResult, "Unexpected empty deploy results")
@@ -509,7 +507,6 @@ func (suite *testSuite) TestDrainHook() {
 
 		suite.DeployFunction(newCreateFunctionOptions, func(newDeployResult *platform.CreateFunctionResult) bool {
 			suite.Require().NotNil(newDeployResult, "Unexpected empty second deploy results")
-			rebalanceStartedTime = time.Now()
 
 			suite.Logger.DebugWith("Created second function, producing messages to topic",
 				"topic", topic)
@@ -523,28 +520,28 @@ func (suite *testSuite) TestDrainHook() {
 				suite.Require().NoError(err, "Failed to publish message")
 			}
 
-			// wait for at least the kafka trigger's WorkerTerminationTimeout to pass from first invocation,
-			// to allow the function to run its termination hook before we delete the function
-			<-time.After(time.Until(rebalanceStartedTime.Add(40 * time.Second)))
+			// verify drain hook files are written promptly after rebalance (via drain-complete control message),
+			// rather than waiting the full workerTerminationTimeout (40s).
+			// the drain callback only writes a file, so it should complete well within this window.
+			maxDrainWait := 8 * time.Second
+			err := common.RetryUntilSuccessful(maxDrainWait, 1*time.Second, func() bool {
+				for workerID := 0; workerID < 4; workerID++ {
+					filePath := path.Join(tempDir, fmt.Sprintf("drain-hook-%d.txt", workerID))
+					fileBytes, readErr := os.ReadFile(filePath)
+					if readErr != nil || len(fileBytes) == 0 {
+						return false
+					}
+				}
+				return true
+			})
+			suite.Require().NoError(err,
+				"Drain hook files were not written within %s - drain-complete control message may not be working", maxDrainWait)
 
 			return true
 		})
 
 		return true
 	})
-
-	// check that the function's drain hook was called by reading the file it should have written to
-	// 1 file per worker -> 4 files
-	for workerID := 0; workerID < 4; workerID++ {
-		filePath := path.Join(tempDir, fmt.Sprintf("drain-hook-%d.txt", workerID))
-		suite.Logger.DebugWith("Reading drain hook file", "filePath", filePath)
-		fileBytes, err := os.ReadFile(filePath)
-		suite.Require().NoError(err, "Failed to read drain hook file")
-
-		// check that the file is not empty
-		suite.Logger.DebugWith("Checking drain hook file is not empty", "fileContent", string(fileBytes))
-		suite.Require().NotEmpty(fileBytes, "Drain hook file is empty")
-	}
 }
 
 // TestFeatureCombinations tests different combinations of the following features:

--- a/pkg/processor/trigger/kafka/test/kafka_test.go
+++ b/pkg/processor/trigger/kafka/test/kafka_test.go
@@ -505,6 +505,11 @@ func (suite *testSuite) TestDrainHook() {
 
 		suite.Logger.Debug("Creating second function, to trigger rebalance")
 
+		// measure how long deploying the second function takes (triggers rebalance + drain on the first function).
+		// if drain-complete control message works, this should finish well under the 40s workerTerminationTimeout.
+		maxSecondFunctionDeployDuration := 25 * time.Second
+		secondFunctionDeployStart := time.Now()
+
 		suite.DeployFunction(newCreateFunctionOptions, func(newDeployResult *platform.CreateFunctionResult) bool {
 			suite.Require().NotNil(newDeployResult, "Unexpected empty second deploy results")
 
@@ -539,6 +544,11 @@ func (suite *testSuite) TestDrainHook() {
 
 			return true
 		})
+
+		secondFunctionDeployDuration := time.Since(secondFunctionDeployStart)
+		suite.Require().Less(secondFunctionDeployDuration, maxSecondFunctionDeployDuration,
+			"Second function deploy took %s, expected less than %s - drain-complete may not be shortcutting the workerTerminationTimeout",
+			secondFunctionDeployDuration, maxSecondFunctionDeployDuration)
 
 		return true
 	})

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -339,6 +339,9 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 	readyForRebalanceChan := make(chan bool)
 	defer close(readyForRebalanceChan)
 
+	drainingContext, cancel := context.WithTimeout(k.ctx, k.configuration.maxWaitHandlerDuringRebalance)
+	defer cancel()
+
 	go func() {
 		defer common.CatchAndLogPanicWithOptions(k.ctx, // nolint: errcheck
 			k.Logger,
@@ -349,8 +352,7 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 			})
 		var wg sync.WaitGroup
 		if waitForHandler {
-			wg.Add(2)
-			go func() {
+			wg.Go(func() {
 				err := <-submittedEventInstance.done
 
 				// we successfully submitted the message to the handler. mark it
@@ -363,23 +365,19 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 					)
 				}
 				k.Logger.DebugWith("Handler done", "partition", claim.Partition())
-				wg.Done()
-			}()
-		} else {
-			wg.Add(1)
+			})
 		}
 
-		go func() {
+		wg.Go(func() {
 			// this needs to occur once. the reason is that this specific function (ConsumeClaim)
 			// runs in parallel for each partition, and we want to make sure that we only
 			// drain the workers once.
-			if err := k.SignalWorkersToDrain(); err != nil {
+			if err := k.Drain(drainingContext); err != nil {
 				k.Logger.DebugWith("Failed to signal worker draining",
 					"err", err.Error(),
 					"partition", claim.Partition())
 			}
-			wg.Done()
-		}()
+		})
 
 		wg.Wait()
 		readyForRebalanceChan <- true
@@ -388,6 +386,9 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 	// wait a for rebalance readiness or max timeout
 	select {
 	case <-readyForRebalanceChan:
+		if waitForHandler {
+			k.UpdateStatistics(true, 1)
+		}
 		if functionconfig.ExplicitAckEnabled(k.configuration.ExplicitAckMode) {
 			// if we are in explicitAck it means that runtime code sends control messages to processor
 			// sometimes draining happens too fast, so we don't have enough time to process ack control message
@@ -401,22 +402,23 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 		k.Logger.DebugWith("Handler done, rebalancing will commence",
 			"partition", claim.Partition())
 
-	case <-time.After(k.configuration.maxWaitHandlerDuringRebalance):
+	case <-drainingContext.Done():
 		k.Logger.WarnWith("Timed out waiting for handler to complete",
 			"partition", claim.Partition())
 
-		// mark this as a failure, metric-wise
-		k.UpdateStatistics(false, 1)
-
 		if waitForHandler {
-			// the rebalance timeout occurred while we waited for the handler, cancel it and restart the worker
-			if err := k.cancelEventHandling(workerInstance, claim); err != nil {
-				k.Logger.DebugWith("Failed to cancel event handling",
-					"err", err.Error(),
-					"partition", claim.Partition())
+			// mark this as a failure, metric-wise
+			k.UpdateStatistics(false, 1)
+		}
+		// the rebalance timeout occurred while we waited for the handler,
+		// which means that the handler is taking too long to process events or to drain
+		// we want to cancel event handling to unblock the rebalance and prevent a potential zombie state
+		if err := k.cancelEventHandling(workerInstance, claim); err != nil {
+			k.Logger.DebugWith("Failed to cancel event handling",
+				"err", err.Error(),
+				"partition", claim.Partition())
 
-				panic("Failed to cancel event handling")
-			}
+			panic("Failed to cancel event handling")
 		}
 	}
 }

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
@@ -82,8 +83,8 @@ type Trigger interface {
 	// GetProjectName returns project name
 	GetProjectName() string
 
-	// SignalWorkersToDrain drains all workers
-	SignalWorkersToDrain() error
+	// Drain drains all workers
+	Drain(ctx context.Context) error
 
 	// SignalWorkersToContinue signal all workers to continue processing
 	SignalWorkersToContinue() error
@@ -385,13 +386,40 @@ func (at *AbstractTrigger) UnsubscribeFromControlMessageKind(kind controlcommuni
 	return nil
 }
 
-// SignalWorkersToDrain sends a signal to all workers, telling them to drop or ack events
-// that are currently being processed
-func (at *AbstractTrigger) SignalWorkersToDrain() error {
+// Drain sends a signal to all workers and waits for them to finish draining their events
+func (at *AbstractTrigger) Drain(ctx context.Context) error {
+	DrainingDoneControlMessageChan := make(chan *controlcommunication.ControlMessage)
+
+	//subscribe to worker draining complete control messages to know when workers are done draining and we can proceed with rebalance
+	if err := at.SubscribeToControlMessageKind(controlcommunication.DrainMessageKind, DrainingDoneControlMessageChan); err != nil {
+		return errors.Wrap(err, "Failed to subscribe to explicit ack control messages")
+	}
+
+	workers := at.WorkerAllocator.GetObjects()
 	if err := at.WorkerAllocator.SignalDraining(); err != nil {
 		return errors.Wrap(err, "Failed to signal all workers to drain events")
 	}
-	return nil
+
+	uniqueWorkerIds := make(map[string]struct{})
+
+	for {
+		select {
+		case controlMessage := <-DrainingDoneControlMessageChan:
+			drainAttributes := &controlcommunication.ControlMessageAttributesDrain{}
+			if err := mapstructure.Decode(controlMessage.Attributes, drainAttributes); err != nil {
+				at.Logger.WarnWith("Failed decoding control message attributes", "err", err.Error())
+				continue
+			}
+			uniqueWorkerIds[drainAttributes.WorkerId] = struct{}{}
+			if len(uniqueWorkerIds) == len(workers) {
+				at.Logger.DebugWith("All workers finished draining",
+					"numWorkers", len(workers))
+				return nil
+			}
+		case <-ctx.Done():
+			return errors.New("Context cancelled while waiting for workers to drain")
+		}
+	}
 }
 
 // SignalWorkersToContinue sends a signal to all workers, telling them to continue event processing

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -390,15 +390,15 @@ func (at *AbstractTrigger) UnsubscribeFromControlMessageKind(kind controlcommuni
 func (at *AbstractTrigger) Drain(ctx context.Context) error {
 	drainingDoneControlMessageChan := make(chan *controlcommunication.ControlMessage)
 
-	//subscribe to worker draining complete control messages to know when workers are done draining and we can proceed with rebalance
+	// subscribe to worker draining complete control messages to know when workers are done draining and we can proceed with rebalance
 	if err := at.SubscribeToControlMessageKind(controlcommunication.DrainMessageKind, drainingDoneControlMessageChan); err != nil {
-		return errors.Wrap(err, "Failed to subscribe to explicit ack control messages")
+		return errors.Wrap(err, "Failed to subscribe to drain control messages")
 	}
 
 	// make sure to unsubscribe and close channel
 	defer func() {
 		if err := at.UnsubscribeFromControlMessageKind(controlcommunication.DrainMessageKind, drainingDoneControlMessageChan); err != nil {
-			at.Logger.WarnWith("Failed to unsubscribe from explicit ack control messages", "err", err.Error())
+			at.Logger.WarnWith("Failed to unsubscribe from drain control messages", "err", err.Error())
 		}
 		close(drainingDoneControlMessageChan)
 	}()

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -388,12 +388,20 @@ func (at *AbstractTrigger) UnsubscribeFromControlMessageKind(kind controlcommuni
 
 // Drain sends a signal to all workers and waits for them to finish draining their events
 func (at *AbstractTrigger) Drain(ctx context.Context) error {
-	DrainingDoneControlMessageChan := make(chan *controlcommunication.ControlMessage)
+	drainingDoneControlMessageChan := make(chan *controlcommunication.ControlMessage)
 
 	//subscribe to worker draining complete control messages to know when workers are done draining and we can proceed with rebalance
-	if err := at.SubscribeToControlMessageKind(controlcommunication.DrainMessageKind, DrainingDoneControlMessageChan); err != nil {
+	if err := at.SubscribeToControlMessageKind(controlcommunication.DrainMessageKind, drainingDoneControlMessageChan); err != nil {
 		return errors.Wrap(err, "Failed to subscribe to explicit ack control messages")
 	}
+
+	// make sure to unsubscribe and close channel
+	defer func() {
+		if err := at.UnsubscribeFromControlMessageKind(controlcommunication.DrainMessageKind, drainingDoneControlMessageChan); err != nil {
+			at.Logger.WarnWith("Failed to unsubscribe from explicit ack control messages", "err", err.Error())
+		}
+		close(drainingDoneControlMessageChan)
+	}()
 
 	workers := at.WorkerAllocator.GetObjects()
 	if err := at.WorkerAllocator.SignalDraining(); err != nil {
@@ -404,7 +412,7 @@ func (at *AbstractTrigger) Drain(ctx context.Context) error {
 
 	for {
 		select {
-		case controlMessage := <-DrainingDoneControlMessageChan:
+		case controlMessage := <-drainingDoneControlMessageChan:
 			drainAttributes := &controlcommunication.ControlMessageAttributesDrain{}
 			if err := mapstructure.Decode(controlMessage.Attributes, drainAttributes); err != nil {
 				at.Logger.WarnWith("Failed decoding control message attributes", "err", err.Error())

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mitchellh/mapstructure"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
@@ -30,6 +29,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 
 	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

Replaces the fire-and-forget worker draining mechanism with an acknowledged draining protocol during Kafka rebalances.

Previously, `SignalWorkersToDrain()` sent SIGUSR2 to all workers and returned immediately. The Python runtime then blocked on `WaitForProcessTermination()` with a hard timeout — meaning the trigger had no way to know when draining actually completed. This caused unnecessary delays (always waiting the full timeout) or premature rebalances (timeout too short for the drain callback to finish).

The new `Drain(ctx context.Context)` method signals all workers, then blocks until each worker sends a `drain` control message back over the control socket confirming that its drain callback has finished. This allows the Kafka trigger to proceed with rebalance as soon as all workers are done, rather than relying on a fixed timeout.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

**Go side — acknowledged draining protocol**
- Renamed `SignalWorkersToDrain()` → `Drain(ctx context.Context)` in the `Trigger` interface and `AbstractTrigger`
- `Drain()` now subscribes to `DrainMessageKind` control messages, signals all workers, then waits for each worker to acknowledge completion (deduplicated by `WorkerId`)
- Removed `WaitForProcessTermination()` call from Python runtime's `Drain()` — waiting now happens at the trigger level via control messages
- Added `DrainMessageKind` and `ControlMessageAttributesDrain` to control communication types

**Go side — Kafka trigger improvements**
- `drainOnRebalance` now uses `context.WithTimeout` instead of raw `time.After` for unified timeout across handler wait and drain wait
- `cancelEventHandling` is now always called on timeout (not conditionally on `waitForHandler`), preventing potential zombie worker states
- Statistics are updated correctly: success metric only when handler completes, failure only when handler was in progress and timed out
- Replaced `wg.Add()`/`go func()`/`wg.Done()` with `wg.Go()`

**Python wrapper — drain-complete control message**
- Stored `worker_id` on `AbstractWrapper` for use in the control message
- Added `_send_drain_complete_control_message()` method that sends `{'kind': 'drain', 'attributes': {'workerId': ...}}` over the control socket
- Both sync (`_nuclio_wrapper.py`) and async (`_nuclio_async_wrapper.py`) wrappers send this message after the user's drain callback completes

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Integration tests `TestDrainHook` and `TestFeatureCombinations` validate end-to-end drain behavior with real Kafka rebalances

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-756
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

The `Trigger` interface method was renamed from `SignalWorkersToDrain()` to `Drain(ctx context.Context)`. All in-tree implementations and mocks have been updated. External trigger implementations (if any) would need to update their method signature.

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->

- The drain-complete message follows the same control socket protocol as existing `streamMessageAck` and `wrapperInitialized` messages (JSON + newline over Unix socket).
- If a worker receives a second drain signal while already drained (`_discard_events` is true), it silently ignores it. The trigger's `Drain()` deduplicates by `WorkerId`, so duplicate messages from repeated signals are harmless.
- A similar pattern could be applied to the termination handler (see existing TODO in `wrapper_common.py` line 490).
- Only the Python runtime sends the drain-complete control message. Go and Java runtimes would need equivalent changes if they support drain callbacks.