### PR TITLE
[Helm] Add shared imagePullSecrets support for service deployments

### DIFF
--- a/hack/k8s/helm/nuclio/templates/_helpers.tpl
+++ b/hack/k8s/helm/nuclio/templates/_helpers.tpl
@@ -108,6 +108,20 @@ NOTE: make sure to not quote here, because an empty string is false, but a quote
 {{- end -}}
 {{- end -}}
 
+{{/*
+Resolve image pull secrets for Nuclio service deployments.
+Priority:
+1. .Values.global.imagePullSecrets (subchart-friendly)
+2. .Values.imagePullSecrets (chart-local convenience)
+*/}}
+{{- define "nuclio.imagePullSecrets" -}}
+{{- $imagePullSecrets := .Values.global.imagePullSecrets | default .Values.imagePullSecrets | default list -}}
+{{- if gt (len $imagePullSecrets) 0 -}}
+imagePullSecrets:
+{{- toYaml $imagePullSecrets | nindent 2 }}
+{{- end }}
+{{- end -}}
+
 
 {{- define "nuclio.externalIPAddresses" -}}
 {{- if .Values.global.externalHostAddress -}}

--- a/hack/k8s/helm/nuclio/templates/deployment/autoscaler.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/autoscaler.yaml
@@ -42,6 +42,7 @@ spec:
         checksum/configmap-platform: {{ include (print $.Template.BasePath "/configmap/platform.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "nuclio.serviceAccountName" . }}
+      {{- include "nuclio.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- toYaml .Values.autoscaler.securityContext | nindent 8 }}
       containers:

--- a/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
@@ -42,6 +42,7 @@ spec:
         checksum/configmap-platform: {{ include (print $.Template.BasePath "/configmap/platform.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "nuclio.serviceAccountName" . }}
+      {{- include "nuclio.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- toYaml .Values.controller.securityContext | nindent 8 }}
       containers:

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -44,6 +44,7 @@ spec:
         checksum/configmap-platform: {{ include (print $.Template.BasePath "/configmap/platform.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "nuclio.serviceAccountName" . }}
+      {{- include "nuclio.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- toYaml .Values.dashboard.securityContext | nindent 8 }}
       containers:

--- a/hack/k8s/helm/nuclio/templates/deployment/dlx.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dlx.yaml
@@ -42,6 +42,7 @@ spec:
         checksum/configmap-platform: {{ include (print $.Template.BasePath "/configmap/platform.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "nuclio.serviceAccountName" . }}
+      {{- include "nuclio.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- toYaml .Values.dlx.securityContext | nindent 8 }}
       containers:

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -19,6 +19,12 @@
 # if true, all components assume no internet connectivity
 offline: false
 
+# shared image pull secrets for Nuclio service deployments (dashboard/controller/dlx/autoscaler)
+# chart-local fallback (prefer global.imagePullSecrets, especially when used as a subchart)
+# imagePullSecrets:
+#   - name: my-registry-secret
+imagePullSecrets: []
+
 # Controller settings
 controller:
   enabled: true
@@ -550,6 +556,10 @@ platform: {}
 # global is a stanza that is used if this is used as a subchart. Ignore otherwise
 global:
   externalHostAddress:
+  # image pull secrets shared by Nuclio service deployments (dashboard/controller/dlx/autoscaler)
+  # imagePullSecrets:
+  #   - name: my-registry-secret
+  imagePullSecrets: []
   registry:
     url:
     secretName:


### PR DESCRIPTION
### 📝 Description

This PR adds chart-level support for Kubernetes `imagePullSecrets` across Nuclio service deployments to prevent image pull failures in clusters where node-level auth is not automatically configured.  
It introduces a single shared configuration path so operators can set one secret list for all Nuclio services, with global values taking precedence for subchart compatibility.

---

### 🛠️ Changes Made

- Added a reusable Helm helper in `hack/k8s/helm/nuclio/templates/_helpers.tpl` to render `imagePullSecrets` once and reuse it across services.
- Implemented value resolution priority:
  - `global.imagePullSecrets` (preferred / subchart-friendly)
  - `imagePullSecrets` (chart-local fallback)
- Wired helper into pod specs for:
  - `dashboard`
  - `controller`
  - `dlx`
  - `autoscaler`
- Updated `hack/k8s/helm/nuclio/values.yaml` with documented defaults/examples for both local and global configuration.
- No breaking API/schema changes to existing component-specific values.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Render sanity:
  - `helm template nuclio hack/k8s/helm/nuclio`
- Debug render with **local** shared value:
  - `helm template nuclio hack/k8s/helm/nuclio --debug --set dlx.enabled=true --set autoscaler.enabled=true --set-json imagePullSecrets='[{"name":"local-pull-secret"}]'`
  - Verified rendered deployments (`dashboard`, `controller`, `dlx`, `autoscaler`) include `imagePullSecrets: [{name: local-pull-secret}]`
- Debug render with **global** shared value:
  - `helm template nuclio hack/k8s/helm/nuclio --debug --set dlx.enabled=true --set autoscaler.enabled=true --set-json global.imagePullSecrets='[{"name":"global-pull-secret"}]'`
  - Verified rendered deployments include `imagePullSecrets: [{name: global-pull-secret}]`

---

### 🔗 References
- Ticket link: N/A
- Design docs links: N/A
- External links: N/A

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- This change is intentionally centralized to avoid per-component duplication and keep future maintenance simple.