### PR TITLE
[Controller] Reduce function termination grace period on project deletion

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -52,7 +52,8 @@ func Run(kubeconfigPath string,
 	evictedPodsCleanupIntervalStr string,
 	functionEventOperatorNumWorkersStr string,
 	projectOperatorNumWorkersStr string,
-	apiGatewayOperatorNumWorkersStr string) error {
+	apiGatewayOperatorNumWorkersStr string,
+	functionDeletionGracePeriodOnProjectRemovalStr string) error {
 
 	newController, err := createController(kubeconfigPath,
 		namespace,
@@ -67,7 +68,8 @@ func Run(kubeconfigPath string,
 		evictedPodsCleanupIntervalStr,
 		functionEventOperatorNumWorkersStr,
 		projectOperatorNumWorkersStr,
-		apiGatewayOperatorNumWorkersStr)
+		apiGatewayOperatorNumWorkersStr,
+		functionDeletionGracePeriodOnProjectRemovalStr)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create controller")
 	}
@@ -94,7 +96,8 @@ func createController(kubeconfigPath string,
 	evictedPodsCleanupIntervalStr string,
 	functionEventOperatorNumWorkersStr string,
 	projectOperatorNumWorkersStr string,
-	apiGatewayOperatorNumWorkersStr string) (*controller.Controller, error) {
+	apiGatewayOperatorNumWorkersStr string,
+	functionDeletionGracePeriodOnProjectRemovalStr string) (*controller.Controller, error) {
 
 	functionOperatorNumWorkers, err := strconv.Atoi(functionOperatorNumWorkersStr)
 	if err != nil {
@@ -139,6 +142,11 @@ func createController(kubeconfigPath string,
 	apiGatewayOperatorNumWorkers, err := strconv.Atoi(apiGatewayOperatorNumWorkersStr)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to resolve number of workers for api gateway operator")
+	}
+
+	functionDeletionGracePeriodOnProjectRemoval, err := time.ParseDuration(functionDeletionGracePeriodOnProjectRemovalStr)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to parse function deletion grace period on project removal")
 	}
 
 	// get platform configuration
@@ -211,7 +219,8 @@ func createController(kubeconfigPath string,
 		functionOperatorNumWorkers,
 		functionEventOperatorNumWorkers,
 		projectOperatorNumWorkers,
-		apiGatewayOperatorNumWorkers)
+		apiGatewayOperatorNumWorkers,
+		functionDeletionGracePeriodOnProjectRemoval)
 
 	if err != nil {
 		return nil, err

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -51,6 +51,7 @@ func main() {
 	functionEventOperatorNumWorkersStr := flag.String("function-event-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_EVENT_OPERATOR_NUM_WORKERS", "2"), "Set number of workers for the function event operator (optional)")
 	projectOperatorNumWorkersStr := flag.String("project-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_PROJECT_OPERATOR_NUM_WORKERS", "2"), "Set number of workers for the project operator (optional)")
 	apiGatewayOperatorNumWorkersStr := flag.String("api-gateway-operator-num-workers", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_API_GATEWAY_OPERATOR_NUM_WORKERS", "2"), "Set number of workers for the api gateway operator (optional)")
+	functionDeletionGracePeriodOnProjectRemovalStr := flag.String("function-deletion-grace-period-on-project-removal", common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_FUNCTION_DELETION_GRACE_PERIOD_ON_PROJECT_REMOVAL", "10s"), "Set pod termination grace period for function deletion during project removal (optional)")
 
 	flag.Parse()
 
@@ -70,7 +71,8 @@ func main() {
 		*evictedPodsCleanupIntervalStr,
 		*functionEventOperatorNumWorkersStr,
 		*projectOperatorNumWorkersStr,
-		*apiGatewayOperatorNumWorkersStr); err != nil {
+		*apiGatewayOperatorNumWorkersStr,
+		*functionDeletionGracePeriodOnProjectRemovalStr); err != nil {
 		errors.PrintErrorStack(os.Stderr, err, 5)
 
 		os.Exit(1)

--- a/pkg/platform/kube/controller/controller.go
+++ b/pkg/platform/kube/controller/controller.go
@@ -53,6 +53,9 @@ type Controller struct {
 	apiGatewayOperator    *apiGatewayOperator
 	resyncInterval        time.Duration
 
+	// grace period for pod termination when deleting functions as part of project removal
+	functionDeletionGracePeriodOnProjectRemoval time.Duration
+
 	// monitors
 	cronJobMonitoring          *CronJobMonitoring
 	evictedPodsMonitoring      *EvictedPodsMonitoring
@@ -77,7 +80,8 @@ func NewController(parentLogger logger.Logger,
 	functionOperatorNumWorkers int,
 	functionEventOperatorNumWorkers int,
 	projectOperatorNumWorkers int,
-	apiGatewayOperatorNumWorkers int) (*Controller, error) {
+	apiGatewayOperatorNumWorkers int,
+	functionDeletionGracePeriodOnProjectRemoval time.Duration) (*Controller, error) {
 	var err error
 
 	// replace "*" with "", which is actually "all" in kube-speak
@@ -99,6 +103,7 @@ func NewController(parentLogger logger.Logger,
 		platformConfigurationName:  platformConfigurationName,
 		resyncInterval:             resyncInterval,
 		functionMonitoringInterval: functionMonitoringInterval,
+		functionDeletionGracePeriodOnProjectRemoval: functionDeletionGracePeriodOnProjectRemoval,
 	}
 
 	newController.logger.DebugWithCtx(ctx, "Read configuration",

--- a/pkg/platform/kube/controller/controller_test.go
+++ b/pkg/platform/kube/controller/controller_test.go
@@ -90,7 +90,8 @@ func (suite *ControllerTestSuite) SetupTest() {
 		defaultNumWorkers,
 		defaultNumWorkers,
 		defaultNumWorkers,
-		defaultNumWorkers)
+		defaultNumWorkers,
+		10*time.Second)
 	suite.Require().NoError(err)
 
 	suite.logger.Info("Starting test")

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -394,7 +394,7 @@ func (fo *functionOperator) resolveDeleteOptions(ctx context.Context, namespace 
 		fo.logger.WarnWithCtx(ctx, "Failed to check project existence, using default delete options",
 			"functionName", functionName,
 			"projectName", projectName,
-			"err", err)
+			"err", err.Error())
 		return deleteOptions
 	}
 

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform/abstract"
+	"github.com/nuclio/nuclio/pkg/platform/kube"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	"github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio"
 	"github.com/nuclio/nuclio/pkg/platform/kube/functionres"
@@ -35,6 +36,7 @@ import (
 	"github.com/nuclio/logger"
 	"github.com/v3io/scaler/pkg/scalertypes"
 	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -344,7 +346,59 @@ func (fo *functionOperator) Delete(ctx context.Context, namespace string, name s
 		"name", name,
 		"namespace", namespace)
 
-	return fo.functionresClient.Delete(ctx, namespace, name)
+	deleteOptions := fo.resolveDeleteOptions(ctx, namespace, name)
+
+	return fo.functionresClient.Delete(ctx, namespace, name, deleteOptions)
+}
+
+// resolveDeleteOptions builds delete options for function resource cleanup.
+// If the function's project no longer exists (project deletion scenario), sets a shorter grace
+// period to speed up resource cleanup while still honoring the draining/termination callback contract.
+// If the project exists (normal deletion or project was recreated), returns empty options to use defaults.
+func (fo *functionOperator) resolveDeleteOptions(ctx context.Context, namespace string, functionName string) metav1.DeleteOptions {
+	propagationPolicy := metav1.DeletePropagationForeground
+	deleteOptions := metav1.DeleteOptions{
+		PropagationPolicy: &propagationPolicy,
+	}
+
+	deploymentName := kube.DeploymentNameFromFunctionName(functionName)
+	deployment, err := fo.controller.kubeClientSet.GetDeployment(ctx, namespace, deploymentName)
+	if err != nil {
+		fo.logger.DebugWithCtx(ctx, "Could not get deployment to resolve project, using default delete options",
+			"functionName", functionName,
+			"err", err)
+		return deleteOptions
+	}
+
+	projectName, exists := deployment.Labels[common.NuclioResourceLabelKeyProjectName]
+	if !exists || projectName == "" {
+		fo.logger.DebugWithCtx(ctx, "Deployment has no project label, using default delete options",
+			"functionName", functionName)
+		return deleteOptions
+	}
+
+	_, err = fo.controller.nuclioClientSet.NuclioV1beta1().
+		NuclioProjects(namespace).
+		Get(ctx, projectName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			gracePeriod := int64(fo.controller.functionDeletionGracePeriodOnProjectRemoval.Seconds())
+			fo.logger.InfoWithCtx(ctx,
+				"Project not found, using reduced grace period for function deletion",
+				"functionName", functionName,
+				"projectName", projectName,
+				"gracePeriodSeconds", gracePeriod)
+			deleteOptions.GracePeriodSeconds = &gracePeriod
+			return deleteOptions
+		}
+		fo.logger.WarnWithCtx(ctx, "Failed to check project existence, using default delete options",
+			"functionName", functionName,
+			"projectName", projectName,
+			"err", err)
+		return deleteOptions
+	}
+
+	return deleteOptions
 }
 
 func (fo *functionOperator) setFunctionScaleToZeroStatus(ctx context.Context,

--- a/pkg/platform/kube/controller/nucliofunction_test.go
+++ b/pkg/platform/kube/controller/nucliofunction_test.go
@@ -100,7 +100,8 @@ func (suite *NuclioFunctionTestSuite) SetupTest() {
 		defaultNumWorkers,
 		defaultNumWorkers,
 		defaultNumWorkers,
-		defaultNumWorkers)
+		defaultNumWorkers,
+		10*time.Second)
 	suite.Require().NoError(err)
 }
 

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -533,6 +533,15 @@ func (lc *lazyClient) Delete(ctx context.Context, namespace string, name string,
 			"deploymentName", deploymentName)
 	}
 
+	// When a custom grace period is set (e.g. project deletion), delete pods explicitly
+	// so the overridden GracePeriodSeconds applies to actual pod termination.
+	// Deployment cascade does not propagate GracePeriodSeconds to pods.
+	if deleteOptions.GracePeriodSeconds != nil {
+		if err := lc.deleteFunctionPods(ctx, name, namespace, deleteOptions); err != nil {
+			return errors.Wrap(err, "Failed to delete function pods")
+		}
+	}
+
 	// Delete configMap if exists
 	configMapName := kube.ConfigMapNameFromFunctionName(name)
 	err = lc.kubeClientSet.DeleteConfigMap(ctx, namespace, configMapName, deleteOptions)
@@ -2782,6 +2791,21 @@ func (lc *lazyClient) getFunctionSecrets(ctx context.Context, function *nuclioio
 }
 
 // deleteFunctionSecrets deletes the function's secrets
+func (lc *lazyClient) deleteFunctionPods(ctx context.Context, functionName, namespace string, deleteOptions metav1.DeleteOptions) error {
+	lc.logger.DebugWithCtx(ctx, "Deleting function pods",
+		"functionName", functionName,
+		"gracePeriodSeconds", deleteOptions.GracePeriodSeconds)
+	if err := lc.kubeClientSet.DeleteCollectionPods(ctx,
+		namespace,
+		deleteOptions,
+		metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", common.NuclioResourceLabelKeyFunctionName, functionName),
+		}); err != nil {
+		return errors.Wrapf(err, "Failed to delete pods for function %s", functionName)
+	}
+	return nil
+}
+
 func (lc *lazyClient) deleteFunctionSecrets(ctx context.Context, functionName, namespace string) error {
 
 	// function can have multiple secrets, in case a flex volume exists

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -479,11 +479,7 @@ func (lc *lazyClient) WaitAvailable(ctx context.Context,
 	}
 }
 
-func (lc *lazyClient) Delete(ctx context.Context, namespace string, name string) error {
-	propagationPolicy := metav1.DeletePropagationForeground
-	deleteOptions := metav1.DeleteOptions{
-		PropagationPolicy: &propagationPolicy,
-	}
+func (lc *lazyClient) Delete(ctx context.Context, namespace string, name string, deleteOptions metav1.DeleteOptions) error {
 
 	// Delete ingress
 	ingressName := kube.IngressNameFromFunctionName(name)

--- a/pkg/platform/kube/functionres/types.go
+++ b/pkg/platform/kube/functionres/types.go
@@ -29,6 +29,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type PlatformConfigurationProvider interface {
@@ -55,7 +56,7 @@ type Client interface {
 	WaitAvailable(context.Context, *nuclioio.NuclioFunction, time.Time) (functionconfig.FunctionState, error)
 
 	// Delete deletes resources
-	Delete(context.Context, string, string) error
+	Delete(ctx context.Context, namespace string, name string, deleteOptions metav1.DeleteOptions) error
 
 	// SetPlatformConfigurationProvider sets the provider of the platform configuration for any future access
 	SetPlatformConfigurationProvider(PlatformConfigurationProvider)

--- a/pkg/platform/kube/test/project/project_test.go
+++ b/pkg/platform/kube/test/project/project_test.go
@@ -19,17 +19,23 @@ limitations under the License.
 package project
 
 import (
+	"encoding/base64"
 	"testing"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platform/kube"
 	kubesuite "github.com/nuclio/nuclio/pkg/platform/kube/test/suite"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ProjectTestSuite struct {
@@ -354,6 +360,102 @@ func (suite *ProjectTestSuite) TestDeleteCascading() {
 		suite.Require().NoError(err)
 		suite.Require().Len(functionEvents, 0, "Some function events were not removed")
 	}
+}
+
+func (suite *ProjectTestSuite) TestDeleteCascadingWithTerminationCallback() {
+	projectName := "project-with-termination-callback"
+	functionName := "func-with-long-termination"
+
+	projectConfig := platform.ProjectConfig{
+		Meta: platform.ProjectMeta{
+			Name:      projectName,
+			Namespace: suite.Namespace,
+		},
+	}
+	err := suite.Platform.CreateProject(suite.Ctx, &platform.CreateProjectOptions{
+		ProjectConfig: &projectConfig,
+	})
+	suite.Require().NoError(err, "Failed to create project")
+
+	createFunctionOptions := suite.CompileCreateFunctionOptions(functionName)
+	createFunctionOptions.FunctionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName] = projectName
+
+	// the termination callback sleeps for 30s, simulating a long-running drain;
+	// with the default 30s pod terminationGracePeriodSeconds, this would take the full 30s.
+	// our reduced grace period on project removal should cut this short.
+	createFunctionOptions.FunctionConfig.Spec.Build.FunctionSourceCode = base64.StdEncoding.EncodeToString([]byte(`
+def handler(context, event):
+    return "hello world"
+
+def termination_callback():
+    import time
+    time.sleep(30)
+
+def init_context(context):
+    context.platform.set_termination_callback(termination_callback)
+`))
+
+	// raise workerTerminationTimeout so the processor doesn't kill the wrapper before
+	// the 30s sleep; the pod-level grace period is what should terminate it early.
+	createFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{
+		"http": {
+			Kind:                     "http",
+			WorkerTerminationTimeout: "60s",
+		},
+	}
+
+	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+		suite.Require().NotEmpty(deployResult)
+
+		pods := suite.GetFunctionPods(functionName)
+		suite.Require().NotEmpty(pods, "Function pods should exist")
+		firstPod := pods[0]
+
+		err := suite.WaitMessageInPodLog(firstPod.Namespace, firstPod.Name,
+			"Processor started", &v1.PodLogOptions{}, 30*time.Second)
+		suite.Require().NoError(err, "Processor did not start in time")
+
+		// delete the project CR; this returns immediately
+		err = suite.Platform.DeleteProject(suite.Ctx, &platform.DeleteProjectOptions{
+			Meta: platform.ProjectMeta{
+				Name:      projectName,
+				Namespace: suite.Namespace,
+			},
+			Strategy: platform.DeleteProjectStrategyCascading,
+		})
+		suite.Require().NoError(err, "Failed to delete project")
+
+		deletionStart := time.Now()
+
+		deploymentName := kube.DeploymentNameFromFunctionName(functionName)
+		err = common.RetryUntilSuccessful(30*time.Second, 1*time.Second, func() bool {
+			_, getErr := suite.KubeClientSet.AppsV1().Deployments(suite.Namespace).Get(
+				suite.Ctx, deploymentName, metav1.GetOptions{})
+			return apierrors.IsNotFound(getErr)
+		})
+		suite.Require().NoError(err, "Function deployment was not removed in time")
+
+		deletionDuration := time.Since(deletionStart)
+		suite.Logger.InfoWith("Function deployment removed after project deletion",
+			"duration", deletionDuration.String())
+
+		suite.Require().Less(deletionDuration.Seconds(), float64(15),
+			"Function removal took longer than 15s; grace period override may not be working")
+
+		return true
+	})
+
+	// cleanup: ensure project and function are gone (in case test fails mid-way)
+	defer suite.Platform.DeleteProject(suite.Ctx, &platform.DeleteProjectOptions{ // nolint: errcheck
+		Meta: platform.ProjectMeta{
+			Name:      projectName,
+			Namespace: suite.Namespace,
+		},
+		Strategy: platform.DeleteProjectStrategyCascading,
+	})
+	defer suite.Platform.DeleteFunction(suite.Ctx, &platform.DeleteFunctionOptions{ // nolint: errcheck
+		FunctionConfig: createFunctionOptions.FunctionConfig,
+	})
 }
 
 func TestProjectTestSuite(t *testing.T) {

--- a/pkg/platform/kube/test/project/project_test.go
+++ b/pkg/platform/kube/test/project/project_test.go
@@ -426,9 +426,16 @@ def init_context(context):
 
 		err = common.RetryUntilSuccessful(30*time.Second, 1*time.Second, func() bool {
 			pods := suite.GetFunctionPods(functionName)
+			activePods := 0
+			for _, pod := range pods {
+				if pod.DeletionTimestamp == nil {
+					activePods++
+				}
+			}
 			suite.Logger.DebugWith("Waiting for function pods to be removed",
-				"remainingPods", len(pods))
-			return len(pods) == 0
+				"totalPods", len(pods),
+				"activePods", activePods)
+			return activePods == 0
 		})
 		suite.Require().NoError(err, "Function pods were not removed in time")
 
@@ -436,8 +443,8 @@ def init_context(context):
 		suite.Logger.InfoWith("Function pods removed after project deletion",
 			"duration", deletionDuration.String())
 
-		suite.Require().Less(deletionDuration.Seconds(), float64(15),
-			"Function pod removal took longer than 15s; grace period override may not be working")
+		suite.Require().Less(deletionDuration.Seconds(), float64(20),
+			"Function pod removal took longer than 20s; grace period override may not be working")
 
 		return true
 	})

--- a/pkg/platform/kube/test/project/project_test.go
+++ b/pkg/platform/kube/test/project/project_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
-	"github.com/nuclio/nuclio/pkg/platform/kube"
 	kubesuite "github.com/nuclio/nuclio/pkg/platform/kube/test/suite"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
@@ -34,8 +33,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ProjectTestSuite struct {
@@ -411,7 +408,7 @@ def init_context(context):
 		suite.Require().NotEmpty(pods, "Function pods should exist")
 		firstPod := pods[0]
 
-		err := suite.WaitMessageInPodLog(firstPod.Namespace, firstPod.Name,
+		err = suite.WaitMessageInPodLog(firstPod.Namespace, firstPod.Name,
 			"Processor started", &v1.PodLogOptions{}, 30*time.Second)
 		suite.Require().NoError(err, "Processor did not start in time")
 
@@ -427,22 +424,20 @@ def init_context(context):
 
 		deletionStart := time.Now()
 
-		deploymentName := kube.DeploymentNameFromFunctionName(functionName)
 		err = common.RetryUntilSuccessful(30*time.Second, 1*time.Second, func() bool {
-			_, getErr := suite.KubeClientSet.AppsV1().Deployments(suite.Namespace).Get(
-				suite.Ctx, deploymentName, metav1.GetOptions{})
-			return apierrors.IsNotFound(getErr)
+			pods := suite.GetFunctionPods(functionName)
+			suite.Logger.DebugWith("Waiting for function pods to be removed",
+				"remainingPods", len(pods))
+			return len(pods) == 0
 		})
-		suite.Require().NoError(err, "Function deployment was not removed in time")
+		suite.Require().NoError(err, "Function pods were not removed in time")
 
 		deletionDuration := time.Since(deletionStart)
-		suite.Logger.InfoWith("Function deployment removed after project deletion",
+		suite.Logger.InfoWith("Function pods removed after project deletion",
 			"duration", deletionDuration.String())
 
-		// usually it takes a bit more than 10s for the function to be removed after project deletion
-		// but it should be much less than the 30s sleep in the termination callback, which means the grace period override is working.
 		suite.Require().Less(deletionDuration.Seconds(), float64(20),
-			"Function removal took longer than 15s; grace period override may not be working")
+			"Function pod removal took longer than 15s; grace period override may not be working")
 
 		return true
 	})

--- a/pkg/platform/kube/test/project/project_test.go
+++ b/pkg/platform/kube/test/project/project_test.go
@@ -439,7 +439,9 @@ def init_context(context):
 		suite.Logger.InfoWith("Function deployment removed after project deletion",
 			"duration", deletionDuration.String())
 
-		suite.Require().Less(deletionDuration.Seconds(), float64(15),
+		// usually it takes a bit more than 10s for the function to be removed after project deletion
+		// but it should be much less than the 30s sleep in the termination callback, which means the grace period override is working.
+		suite.Require().Less(deletionDuration.Seconds(), float64(20),
 			"Function removal took longer than 15s; grace period override may not be working")
 
 		return true

--- a/pkg/platform/kube/test/project/project_test.go
+++ b/pkg/platform/kube/test/project/project_test.go
@@ -436,7 +436,7 @@ def init_context(context):
 		suite.Logger.InfoWith("Function pods removed after project deletion",
 			"duration", deletionDuration.String())
 
-		suite.Require().Less(deletionDuration.Seconds(), float64(20),
+		suite.Require().Less(deletionDuration.Seconds(), float64(15),
 			"Function pod removal took longer than 15s; grace period override may not be working")
 
 		return true

--- a/pkg/platform/kube/test/suite/suite.go
+++ b/pkg/platform/kube/test/suite/suite.go
@@ -704,7 +704,8 @@ func (suite *KubeTestSuite) createController() *controller.Controller {
 		1,
 		1,
 		1,
-		1)
+		1,
+		time.Second*10) // function deletion grace period on project removal
 	suite.Require().NoError(err)
 	return controllerInstance
 }


### PR DESCRIPTION
### 📝 Description
When deleting a project, all its functions are cleaned up via cascading delete. Previously, each function's pods would wait the full default termination grace period (30s), even though the entire project is being removed. This change allows the controller to detect a project deletion scenario and apply a shorter, configurable grace period (default 10s) to speed up resource cleanup while still honoring the draining/termination callback contract.

---

### 🛠️ Changes Made
- `functionres.Client.Delete` interface now accepts `metav1.DeleteOptions` instead of hardcoding propagation policy internally, giving callers control over deletion behavior
- `functionOperator.Delete` resolves delete options via `resolveDeleteOptions`, which checks whether the function's project still exists. If the project is gone (cascading delete), it sets a reduced `GracePeriodSeconds`; otherwise it uses defaults
- `DeletePropagationForeground` is now set in `resolveDeleteOptions` rather than inside `lazyClient.Delete`
- Added configurable flag `--function-deletion-grace-period-on-project-removal` / env var `NUCLIO_CONTROLLER_FUNCTION_DELETION_GRACE_PERIOD_ON_PROJECT_REMOVAL` (default `10s`)
- Added integration test `TestDeleteCascadingWithTerminationCallback`

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Integration test `TestDeleteCascadingWithTerminationCallback`: deploys a function with a 30s sleep termination callback, deletes its parent project with cascading strategy, and asserts the function's deployment is removed within 15s
- Existing `TestDeleteCascading` and `TestProcessorShutdown` should remain unaffected
- Normal (non-project) function deletion continues to use the default grace period

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-760
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [x] Yes (explain below)
- [ ] No

The `functionres.Client` interface's `Delete` method signature changed from `Delete(context.Context, string, string) error` to `Delete(ctx context.Context, namespace string, name string, deleteOptions metav1.DeleteOptions) error`. Any external implementations of this interface will need to be updated.

---

### 🔍️ Additional Notes
The grace period is configurable so operators can tune it per-cluster. Setting it to `0s` would force-kill pods immediately; the default `10s` gives functions a short window to run termination callbacks before being killed.

Tested on vmdev:
controller logs:
<img width="1745" height="179" alt="image" src="https://github.com/user-attachments/assets/2796a518-2bf2-47e8-96a1-f81f982d873c" />

function logs:
```
{"level":"warn","time":"2026-03-24T13:00:23.785Z","name":"processor","message":"Got system signal","more":{"signal":"terminated"}}
{"level":"debug","time":"2026-03-24T13:00:24.721Z","name":"processor.http","message":"Pre-handle validation failed because trigger is not ready","more":{"triggerKind":"http","triggerName":"default-http","triggerStatus":4}}
{"level":"debug","time":"2026-03-24T13:00:25.721Z","name":"processor.http","message":"Pre-handle validation failed because trigger is not ready","more":{"triggerKind":"http","triggerName":"default-http","triggerStatus":4}}
{"level":"debug","time":"2026-03-24T13:00:26.721Z","name":"processor.http","message":"Pre-handle validation failed because trigger is not ready","more":{"triggerKind":"http","triggerName":"default-http","triggerStatus":4}}
{"level":"debug","time":"2026-03-24T13:00:27.721Z","name":"processor.http","message":"Pre-handle validation failed because trigger is not ready","more":{"triggerKind":"http","triggerName":"default-http","triggerStatus":4}}
{"level":"debug","time":"2026-03-24T13:00:28.721Z","name":"processor.http","message":"Pre-handle validation failed because trigger is not ready","more":{"triggerKind":"http","triggerName":"default-http","triggerStatus":4}}
{"level":"debug","time":"2026-03-24T13:00:28.786Z","name":"processor.http.w0.python.logger","message":"Signaling wrapper process","more":{"pid":12,"signal":"user defined signal 1"}}
{"level":"debug","time":"2026-03-24T13:00:28.786Z","name":"processor.http.w0.python.logger","message":"Waiting for process termination","more":{"process":{"Pid":12},"timeout":"10s","wid":0}}
{"level":"debug","time":"2026-03-24T13:00:28.787Z","name":"processor.http.w0.python.logger.connection-manager.control","message":"Received signal","more":{"signal":"SIGUSR1","worker_id":"0"}}
{"level":"debug","time":"2026-03-24T13:00:28.787Z","name":"processor.http.w0.python.logger.connection-manager.control","message":"Waiting for event message was interrupted by a signal","more":{"worker_id":"0"}}
{"level":"debug","time":"2026-03-24T13:00:28.787Z","name":"processor.http.w0.python.logger.connection-manager.control","message":"Calling platform termination handler","more":{"worker_id":"0"}}
{"level":"debug","time":"2026-03-24T13:00:29.721Z","name":"processor.http","message":"Pre-handle validation failed because trigger is not ready","more":{"triggerKind":"http","triggerName":"default-http","triggerStatus":4}}
{"level":"debug","time":"2026-03-24T13:00:30.721Z","name":"processor.http","message":"Pre-handle validation failed because trigger is not ready","more":{"triggerKind":"http","triggerName":"default-http","triggerStatus":4}}
{"level":"debug","time":"2026-03-24T13:00:31.721Z","name":"processor.http","message":"Pre-handle validation failed because trigger is not ready","more":{"triggerKind":"http","triggerName":"default-http","triggerStatus":4}}
{"level":"debug","time":"2026-03-24T13:00:32.721Z","name":"processor.http","message":"Pre-handle validation failed because trigger is not ready","more":{"triggerKind":"http","triggerName":"default-http","triggerStatus":4}}
{"level":"debug","time":"2026-03-24T13:00:33.721Z","name":"processor.http","message":"Pre-handle validation failed because trigger is not ready","more":{"triggerKind":"http","triggerName":"default-http","triggerStatus":4}}
{"level":"debug","time":"2026-03-24T13:00:34.721Z","name":"processor.http","message":"Pre-handle validation failed because trigger is not ready","more":{"triggerKind":"http","triggerName":"default-http","triggerStatus":4}}
{"level":"debug","time":"2026-03-24T13:00:35.721Z","name":"processor.http","message":"Pre-handle validation failed because trigger is not ready","more":{"triggerKind":"http","triggerName":"default-http","triggerStatus":4}}
{"level":"debug","time":"2026-03-24T13:00:36.721Z","name":"processor.http","message":"Pre-handle validation failed because trigger is not ready","more":{"triggerKind":"http","triggerName":"default-http","triggerStatus":4}}
{"level":"debug","time":"2026-03-24T13:00:37.721Z","name":"processor.http","message":"Pre-handle validation failed because trigger is not ready","more":{"triggerKind":"http","triggerName":"default-http","triggerStatus":4}}
{"level":"debug","time":"2026-03-24T13:00:38.721Z","name":"processor.http","message":"Pre-handle validation failed because trigger is not ready","more":{"triggerKind":"http","triggerName":"default-http","triggerStatus":4}}
{"level":"debug","time":"2026-03-24T13:00:38.787Z","name":"processor.http.w0.python.logger","message":"Timeout waiting for process termination, assuming closed","more":{"process":{"Pid":12},"wid":0}}
{"level":"debug","time":"2026-03-24T13:00:38.787Z","name":"processor.http.w0","message":"Successfully terminated worker","more":{"workerIndex":0}}
{"level":"debug","time":"2026-03-24T13:00:38.787Z","name":"processor.http","message":"Stopping HTTP trigger"}
{"level":"info","time":"2026-03-24T13:00:38.787Z","name":"processor","message":"All triggers are terminated"}
{"level":"info","time":"2026-03-24T13:00:38.787Z","name":"processor","message":"Processor quitting"}
```
