### PR TITLE
[Controller] Delete function replicaset explicitely on project deletion

### DIFF
--- a/pkg/platform/kube/clients/kube/client.go
+++ b/pkg/platform/kube/clients/kube/client.go
@@ -230,6 +230,15 @@ func (r *clientWithRetry) DeleteDeployment(ctx context.Context, namespace string
 	return
 }
 
+func (r *clientWithRetry) DeleteCollectionReplicaSets(ctx context.Context, namespace string, deleteOptions metav1.DeleteOptions, listOptions metav1.ListOptions) (err error) {
+	_, err = clients.RequestWithRetry(func() (any, error) {
+		return nil, r.AppsV1().
+			ReplicaSets(namespace).
+			DeleteCollection(ctx, deleteOptions, listOptions)
+	}, r.retries, r.delay)
+	return
+}
+
 func (r *clientWithRetry) ListPods(ctx context.Context, namespace string, listOptions metav1.ListOptions) (*corev1.PodList, error) {
 	return clients.RequestWithRetry[*corev1.PodList](func() (*corev1.PodList, error) {
 		return r.CoreV1().Pods(namespace).List(ctx, listOptions)

--- a/pkg/platform/kube/clients/kube/types.go
+++ b/pkg/platform/kube/clients/kube/types.go
@@ -103,6 +103,11 @@ type Client interface {
 	// DeleteDeployment deletes a Deployment.
 	DeleteDeployment(ctx context.Context, namespace string, name string, deleteOptions metav1.DeleteOptions) error
 
+	// --- ReplicaSets ---
+
+	// DeleteCollectionReplicaSets deletes a collection of ReplicaSets in a namespace.
+	DeleteCollectionReplicaSets(ctx context.Context, namespace string, deleteOptions metav1.DeleteOptions, listOptions metav1.ListOptions) error
+
 	// --- Pods ---
 
 	// ListPods lists Pods in a namespace.

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -533,10 +533,14 @@ func (lc *lazyClient) Delete(ctx context.Context, namespace string, name string,
 			"deploymentName", deploymentName)
 	}
 
-	// When a custom grace period is set (e.g. project deletion), delete pods explicitly
-	// so the overridden GracePeriodSeconds applies to actual pod termination.
-	// Deployment cascade does not propagate GracePeriodSeconds to pods.
+	// When a custom grace period is set (e.g. project deletion), delete ReplicaSets and pods
+	// explicitly so the overridden GracePeriodSeconds applies to actual pod termination.
+	// Deployment cascade does not propagate GracePeriodSeconds to pods, and the ReplicaSet
+	// must be removed first to prevent it from recreating pods we delete.
 	if deleteOptions.GracePeriodSeconds != nil {
+		if err := lc.deleteFunctionReplicaSets(ctx, name, namespace); err != nil {
+			return errors.Wrap(err, "Failed to delete function replica sets")
+		}
 		if err := lc.deleteFunctionPods(ctx, name, namespace, deleteOptions); err != nil {
 			return errors.Wrap(err, "Failed to delete function pods")
 		}
@@ -2791,6 +2795,19 @@ func (lc *lazyClient) getFunctionSecrets(ctx context.Context, function *nuclioio
 }
 
 // deleteFunctionSecrets deletes the function's secrets
+func (lc *lazyClient) deleteFunctionReplicaSets(ctx context.Context, functionName, namespace string) error {
+	lc.logger.DebugWithCtx(ctx, "Deleting function replica sets", "functionName", functionName)
+	if err := lc.kubeClientSet.DeleteCollectionReplicaSets(ctx,
+		namespace,
+		metav1.DeleteOptions{},
+		metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", common.NuclioResourceLabelKeyFunctionName, functionName),
+		}); err != nil {
+		return errors.Wrapf(err, "Failed to delete replica sets for function %s", functionName)
+	}
+	return nil
+}
+
 func (lc *lazyClient) deleteFunctionPods(ctx context.Context, functionName, namespace string, deleteOptions metav1.DeleteOptions) error {
 	lc.logger.DebugWithCtx(ctx, "Deleting function pods",
 		"functionName", functionName,


### PR DESCRIPTION
### 📝 Description
Delete function replicaset explicitely on project deletion before deleting pods. To avoid pods being recreated and then removed with default gracePeriod of 30s instead of the required 10s.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
integ test
---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-758
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->