### PR TITLE
[Kafka] Optimize worker restart logic during rebalance drain timeout

### DIFF
--- a/cmd/processor/app/processor_test.go
+++ b/cmd/processor/app/processor_test.go
@@ -233,9 +233,9 @@ func (t *testTrigger) GetProjectName() string {
 	return ""
 }
 
-func (t *testTrigger) Drain(ctx context.Context) error {
+func (t *testTrigger) Drain(ctx context.Context) (map[string]struct{}, error) {
 	t.Called(ctx)
-	return nil
+	return nil, nil
 }
 
 func (t *testTrigger) SignalWorkersToTerminate() error {

--- a/pkg/processor/statistics/gatherer/mock.go
+++ b/pkg/processor/statistics/gatherer/mock.go
@@ -83,8 +83,8 @@ func (mt *mockTrigger) Stop(force bool) (functionconfig.Checkpoint, error) {
 	return nil, nil
 }
 
-func (mt *mockTrigger) Drain(ctx context.Context) error {
-	return nil
+func (mt *mockTrigger) Drain(ctx context.Context) (map[string]struct{}, error) {
+	return nil, nil
 }
 
 func (mt *mockTrigger) SignalWorkersToContinue() error {

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
@@ -57,6 +59,7 @@ type kafka struct {
 	stopConsumptionChan      chan struct{}
 	partitionWorkerAllocator partitionworker.Allocator
 	ctx                      context.Context
+	restartWorkersOnCleanup  atomic.Bool
 }
 
 func newTrigger(parentLogger logger.Logger,
@@ -124,6 +127,9 @@ func (k *kafka) Start(checkpoint functionconfig.Checkpoint) error {
 	}
 
 	k.shutdownSignal = make(chan struct{}, 1)
+
+	// set restartWorkersOnCleanup to false at the start of each session, to prevent unnecessary worker restarts during normal rebalances
+	k.restartWorkersOnCleanup.Store(false)
 
 	// sendSignalCounter is a counter to track how many times a processor attempted to send a SIGCONT to the wrapper
 	// If the counter exceeds 3, we panic and restart the function to prevent entering a zombie state
@@ -199,6 +205,44 @@ func (k *kafka) Cleanup(session sarama.ConsumerGroupSession) error {
 	if err := k.partitionWorkerAllocator.Stop(); err != nil {
 		return errors.Wrap(err, "Failed to stop partition worker allocator")
 	}
+
+	if k.restartWorkersOnCleanup.Load() {
+		k.Logger.WarnWith("Workers were marked for restart during cleanup, " +
+			"restarting workers to prevent potential zombie state")
+
+		var successfullyDrained map[string]struct{}
+		var err error
+
+		// we set a timeout for the drain operation during cleanup to prevent potential hanging during shutdown in case the workers are taking too long to drain
+		// this is a safety mechanism to prevent the function from hanging indefinitely during shutdown, which would lead to a zombie state
+		ctx, cancel := context.WithTimeout(k.ctx, 1*time.Second)
+		defer cancel()
+
+		// we attempt to drain them again just to avoid unnecessary restarts - if the drain is successful, we will get draining done immediately
+		// if not - we proceed with the restart
+		if successfullyDrained, err = k.Drain(ctx); err != nil {
+			k.Logger.WarnWith("Failed to drain workers during cleanup",
+				"err", err.Error())
+		}
+		for _, worker := range k.WorkerAllocator.GetObjects() {
+			workerID := strconv.Itoa(worker.GetIndex())
+			if _, ok := successfullyDrained[workerID]; ok {
+				k.Logger.DebugWith("Worker successfully drained, no need to restart",
+					"workerIndex", worker.GetIndex())
+				continue
+			}
+
+			k.Logger.DebugWith("Worker was not drained, restarting",
+				"workerIndex", worker.GetIndex())
+			if err := worker.Restart(); err != nil {
+				k.Logger.WarnWith("Failed to restart worker during cleanup",
+					"workerIndex", worker.GetIndex(),
+					"err", err.Error())
+			}
+		}
+	}
+	// reset the flag to prevent unnecessary worker restarts during normal rebalances
+	k.restartWorkersOnCleanup.Store(false)
 
 	k.Logger.InfoWith("Ending consumer session",
 		"claims", session.Claims(),
@@ -372,7 +416,7 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 			// this needs to occur once. the reason is that this specific function (ConsumeClaim)
 			// runs in parallel for each partition, and we want to make sure that we only
 			// drain the workers once.
-			if err := k.Drain(drainingContext); err != nil {
+			if _, err := k.Drain(drainingContext); err != nil {
 				k.Logger.DebugWith("Failed to signal worker draining",
 					"err", err.Error(),
 					"partition", claim.Partition())
@@ -413,13 +457,8 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 		// the rebalance timeout occurred while we waited for the handler,
 		// which means that the handler is taking too long to process events or to drain
 		// we want to cancel event handling to unblock the rebalance and prevent a potential zombie state
-		if err := k.cancelEventHandling(workerInstance, claim); err != nil {
-			k.Logger.DebugWith("Failed to cancel event handling",
-				"err", err.Error(),
-				"partition", claim.Partition())
-
-			panic("Failed to cancel event handling")
-		}
+		// in order to do that, we mark the worker for restart
+		k.restartWorkersOnCleanup.Store(true)
 	}
 }
 
@@ -469,18 +508,6 @@ func (k *kafka) eventSubmitter(claim sarama.ConsumerGroupClaim, submittedEventCh
 	k.Logger.InfoWith("Event submitter stopped",
 		"topic", claim.Topic(),
 		"partition", claim.Partition())
-}
-
-func (k *kafka) cancelEventHandling(workerInstance eventprocessor.EventProcessor,
-	claim sarama.ConsumerGroupClaim) error {
-	if workerInstance.SupportsRestart() {
-		k.Logger.WarnWith("Cancelling event handling",
-			"topic", claim.Topic(),
-			"partition", claim.Partition())
-		return workerInstance.Restart()
-	}
-
-	return errors.New("Worker doesn't support restart")
 }
 
 func (k *kafka) newKafkaConfig() (*sarama.Config, error) {

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -210,36 +210,21 @@ func (k *kafka) Cleanup(session sarama.ConsumerGroupSession) error {
 		k.Logger.WarnWith("Workers were marked for restart during cleanup, " +
 			"restarting workers to prevent potential zombie state")
 
-		var successfullyDrained map[string]struct{}
-		var err error
-
-		// we set a timeout for the drain operation during cleanup to prevent potential hanging during shutdown in case the workers are taking too long to drain
-		// this is a safety mechanism to prevent the function from hanging indefinitely during shutdown, which would lead to a zombie state
+		// we set a timeout for the drain operation during cleanup to prevent potential hanging
+		// in case the workers are taking too long to drain, which would lead to a zombie state
 		ctx, cancel := context.WithTimeout(k.ctx, 1*time.Second)
 		defer cancel()
 
-		// we attempt to drain them again just to avoid unnecessary restarts - if the drain is successful, we will get draining done immediately
-		// if not - we proceed with the restart
-		if successfullyDrained, err = k.Drain(ctx); err != nil {
-			k.Logger.WarnWith("Failed to drain workers during cleanup",
-				"err", err.Error())
+		// attempt to drain again to avoid unnecessary restarts — if workers already drained,
+		// they will respond immediately and won't appear in the not-drained list
+		notDrainedWorkerIds, err := k.Drain(ctx)
+		if err != nil {
+			k.Logger.WarnWith("Failed to drain all workers during cleanup",
+				"err", err.Error(),
+				"notDrainedWorkerIds", notDrainedWorkerIds)
 		}
-		for _, worker := range k.WorkerAllocator.GetObjects() {
-			workerID := strconv.Itoa(worker.GetIndex())
-			if _, ok := successfullyDrained[workerID]; ok {
-				k.Logger.DebugWith("Worker successfully drained, no need to restart",
-					"workerIndex", worker.GetIndex())
-				continue
-			}
 
-			k.Logger.DebugWith("Worker was not drained, restarting",
-				"workerIndex", worker.GetIndex())
-			if err := worker.Restart(); err != nil {
-				k.Logger.WarnWith("Failed to restart worker during cleanup",
-					"workerIndex", worker.GetIndex(),
-					"err", err.Error())
-			}
-		}
+		k.restartWorkersByIds(notDrainedWorkerIds)
 	}
 	// reset the flag to prevent unnecessary worker restarts during normal rebalances
 	k.restartWorkersOnCleanup.Store(false)
@@ -416,9 +401,11 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 			// this needs to occur once. the reason is that this specific function (ConsumeClaim)
 			// runs in parallel for each partition, and we want to make sure that we only
 			// drain the workers once.
-			if _, err := k.Drain(drainingContext); err != nil {
-				k.Logger.DebugWith("Failed to signal worker draining",
+			notDrainedWorkers, err := k.Drain(drainingContext)
+			if err != nil {
+				k.Logger.DebugWith("Failed to drain all workers during rebalance",
 					"err", err.Error(),
+					"notDrainedWorkers", len(notDrainedWorkers),
 					"partition", claim.Partition())
 			}
 		})
@@ -508,6 +495,23 @@ func (k *kafka) eventSubmitter(claim sarama.ConsumerGroupClaim, submittedEventCh
 	k.Logger.InfoWith("Event submitter stopped",
 		"topic", claim.Topic(),
 		"partition", claim.Partition())
+}
+
+func (k *kafka) restartWorkersByIds(workerIds map[string]struct{}) {
+	for _, worker := range k.WorkerAllocator.GetObjects() {
+		workerID := strconv.Itoa(worker.GetIndex())
+		if _, shouldRestart := workerIds[workerID]; !shouldRestart {
+			continue
+		}
+
+		k.Logger.WarnWith("Restarting worker that was not drained",
+			"workerIndex", worker.GetIndex())
+		if err := worker.Restart(); err != nil {
+			k.Logger.WarnWith("Failed to restart worker during cleanup",
+				"workerIndex", worker.GetIndex(),
+				"err", err.Error())
+		}
+	}
 }
 
 func (k *kafka) newKafkaConfig() (*sarama.Config, error) {

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -401,11 +401,11 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 			// this needs to occur once. the reason is that this specific function (ConsumeClaim)
 			// runs in parallel for each partition, and we want to make sure that we only
 			// drain the workers once.
-			notDrainedWorkers, err := k.Drain(drainingContext)
+			notDrainedWorkerIds, err := k.Drain(drainingContext)
 			if err != nil {
 				k.Logger.DebugWith("Failed to drain all workers during rebalance",
 					"err", err.Error(),
-					"notDrainedWorkers", len(notDrainedWorkers),
+					"notDrainedWorkerIds", notDrainedWorkerIds,
 					"partition", claim.Partition())
 			}
 		})

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -19,6 +19,7 @@ package trigger
 import (
 	"context"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"time"
 
@@ -83,8 +84,9 @@ type Trigger interface {
 	// GetProjectName returns project name
 	GetProjectName() string
 
-	// Drain drains all workers and returns the unique IDs of workers that completed draining.
-	// On context cancellation/timeout, still returns the IDs of workers that drained so far alongside the error.
+	// Drain signals all workers to drain and waits for completion.
+	// Returns the IDs of workers that did NOT complete draining within the context deadline.
+	// On success (all drained), returns nil, nil.
 	Drain(ctx context.Context) (map[string]struct{}, error)
 
 	// SignalWorkersToContinue signal all workers to continue processing
@@ -388,7 +390,8 @@ func (at *AbstractTrigger) UnsubscribeFromControlMessageKind(kind controlcommuni
 }
 
 // Drain sends a signal to all workers and waits for them to finish draining their events.
-// Returns the unique IDs of workers that completed draining.
+// Returns the IDs of workers that did NOT complete draining within the context deadline.
+// On success (all drained), returns nil, nil.
 func (at *AbstractTrigger) Drain(ctx context.Context) (map[string]struct{}, error) {
 	drainingDoneControlMessageChan := make(chan *controlcommunication.ControlMessage)
 
@@ -407,10 +410,10 @@ func (at *AbstractTrigger) Drain(ctx context.Context) (map[string]struct{}, erro
 
 	workers := at.WorkerAllocator.GetObjects()
 	if err := at.WorkerAllocator.SignalDraining(); err != nil {
-		return nil, errors.Wrap(err, "Failed to signal all workers to drain events")
+		return at.resolveAllWorkerIds(workers), errors.Wrap(err, "Failed to signal all workers to drain events")
 	}
 
-	uniqueWorkerIds := make(map[string]struct{})
+	drainedWorkerIds := make(map[string]struct{})
 
 	for {
 		select {
@@ -420,15 +423,20 @@ func (at *AbstractTrigger) Drain(ctx context.Context) (map[string]struct{}, erro
 				at.Logger.WarnWith("Failed decoding control message attributes", "err", err.Error())
 				continue
 			}
-			uniqueWorkerIds[drainAttributes.WorkerId] = struct{}{}
-			if len(uniqueWorkerIds) == len(workers) {
+			drainedWorkerIds[drainAttributes.WorkerId] = struct{}{}
+			if len(drainedWorkerIds) == len(workers) {
 				at.Logger.DebugWith("All workers finished draining",
 					"numWorkers", len(workers))
-				return uniqueWorkerIds, nil
+				return nil, nil
 			}
 		case <-ctx.Done():
+			notDrainedWorkerIds := at.resolveNotDrainedWorkerIds(workers, drainedWorkerIds)
+			at.Logger.WarnWith("Drain timed out, not all workers finished draining",
+				"drainedWorkers", len(drainedWorkerIds),
+				"notDrainedWorkerIds", notDrainedWorkerIds,
+				"totalWorkers", len(workers))
 
-			return uniqueWorkerIds, errors.Wrap(ctx.Err(), "Failed waiting for all workers to drain")
+			return notDrainedWorkerIds, errors.Wrap(ctx.Err(), "Failed waiting for all workers to drain")
 		}
 	}
 }
@@ -475,6 +483,27 @@ func (at *AbstractTrigger) IsBusy() bool {
 	}
 
 	return false
+}
+
+func (at *AbstractTrigger) resolveAllWorkerIds(workers []eventprocessor.EventProcessor) map[string]struct{} {
+	workerIds := make(map[string]struct{}, len(workers))
+	for _, worker := range workers {
+		workerIds[strconv.Itoa(worker.GetIndex())] = struct{}{}
+	}
+	return workerIds
+}
+
+func (at *AbstractTrigger) resolveNotDrainedWorkerIds(workers []eventprocessor.EventProcessor,
+	drainedWorkerIds map[string]struct{}) map[string]struct{} {
+
+	notDrainedWorkerIds := make(map[string]struct{})
+	for _, worker := range workers {
+		workerID := strconv.Itoa(worker.GetIndex())
+		if _, drained := drainedWorkerIds[workerID]; !drained {
+			notDrainedWorkerIds[workerID] = struct{}{}
+		}
+	}
+	return notDrainedWorkerIds
 }
 
 func (at *AbstractTrigger) prepareEvent(event nuclio.Event, workerInstance eventprocessor.EventProcessor) (nuclio.Event, error) {

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -83,8 +83,9 @@ type Trigger interface {
 	// GetProjectName returns project name
 	GetProjectName() string
 
-	// Drain drains all workers
-	Drain(ctx context.Context) error
+	// Drain drains all workers and returns the unique IDs of workers that completed draining.
+	// On context cancellation/timeout, still returns the IDs of workers that drained so far alongside the error.
+	Drain(ctx context.Context) (map[string]struct{}, error)
 
 	// SignalWorkersToContinue signal all workers to continue processing
 	SignalWorkersToContinue() error
@@ -386,13 +387,14 @@ func (at *AbstractTrigger) UnsubscribeFromControlMessageKind(kind controlcommuni
 	return nil
 }
 
-// Drain sends a signal to all workers and waits for them to finish draining their events
-func (at *AbstractTrigger) Drain(ctx context.Context) error {
+// Drain sends a signal to all workers and waits for them to finish draining their events.
+// Returns the unique IDs of workers that completed draining.
+func (at *AbstractTrigger) Drain(ctx context.Context) (map[string]struct{}, error) {
 	drainingDoneControlMessageChan := make(chan *controlcommunication.ControlMessage)
 
 	// subscribe to worker draining complete control messages to know when workers are done draining and we can proceed with rebalance
 	if err := at.SubscribeToControlMessageKind(controlcommunication.DrainMessageKind, drainingDoneControlMessageChan); err != nil {
-		return errors.Wrap(err, "Failed to subscribe to drain control messages")
+		return nil, errors.Wrap(err, "Failed to subscribe to drain control messages")
 	}
 
 	// make sure to unsubscribe and close channel
@@ -405,7 +407,7 @@ func (at *AbstractTrigger) Drain(ctx context.Context) error {
 
 	workers := at.WorkerAllocator.GetObjects()
 	if err := at.WorkerAllocator.SignalDraining(); err != nil {
-		return errors.Wrap(err, "Failed to signal all workers to drain events")
+		return nil, errors.Wrap(err, "Failed to signal all workers to drain events")
 	}
 
 	uniqueWorkerIds := make(map[string]struct{})
@@ -422,10 +424,11 @@ func (at *AbstractTrigger) Drain(ctx context.Context) error {
 			if len(uniqueWorkerIds) == len(workers) {
 				at.Logger.DebugWith("All workers finished draining",
 					"numWorkers", len(workers))
-				return nil
+				return uniqueWorkerIds, nil
 			}
 		case <-ctx.Done():
-			return errors.New("Context cancelled while waiting for workers to drain")
+
+			return uniqueWorkerIds, errors.Wrap(ctx.Err(), "Failed waiting for all workers to drain")
 		}
 	}
 }


### PR DESCRIPTION
### 📝 Description
During a Kafka consumer rebalance, `drainOnRebalance` waits for in-flight event handlers and worker draining to complete within `maxWaitHandlerDuringRebalance`. If the timeout fires, the previous code called `cancelEventHandling` which directly restarted the worker inline. This had two problems:

1. **Nil pointer panic**: when the session closed while no message was being processed, `workerInstance` was nil, causing a SIGSEGV in `cancelEventHandling`
2. **Redundant restarts**: since `ConsumeClaim` runs in parallel (one goroutine per partition), multiple partitions timing out simultaneously would each call `cancelEventHandling` → `worker.Restart()` — potentially restarting the same worker multiple times concurrently

This change replaces the inline restart with a **deferred restart strategy**: on timeout, the worker is *marked* for restart via an atomic flag, and the actual restart is performed later in `Cleanup` (after all `ConsumeClaim` goroutines have returned). This is safer because `Cleanup` runs in a single goroutine with no race conditions, each worker is restarted at most once, and it can check which workers already drained successfully — avoiding unnecessary restarts entirely.

---

### 🛠️ Changes Made

**`pkg/processor/trigger/kafka/trigger.go`**
- Added `restartWorkersOnCleanup atomic.Bool` field to the `kafka` struct
- `drainOnRebalance` timeout path: replaced `cancelEventHandling` (which panicked on nil `workerInstance`) with `k.restartWorkersOnCleanup.Store(true)` — deferring the restart to `Cleanup`
- Removed `cancelEventHandling` method entirely (no longer needed)
- `Cleanup`: when `restartWorkersOnCleanup` is set, attempts a short (1s) drain to give already-drained workers a chance to report, then restarts only the workers that didn't drain successfully
- `Start`: resets `restartWorkersOnCleanup` to false at session start

**`pkg/processor/trigger/trigger.go`**
- Changed `Drain` return type from `error` to `(map[string]struct{}, error)` — returns the set of unique worker IDs that completed draining
- On context timeout, returns the partial set of drained worker IDs alongside the error (callers can still use the partial result)
- Error wraps `ctx.Err()` instead of a static string, so timeout vs cancellation is distinguishable

**`cmd/processor/app/processor_test.go`, `pkg/processor/statistics/gatherer/mock.go`**
- Updated `Drain` mock/test implementations to match the new signature

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
- The original panic (nil pointer dereference in `cancelEventHandling`) is no longer possible — the method is removed and workers are only restarted in `Cleanup` where all state is valid
- `Cleanup` restart loop: workers that successfully drained are skipped; only timed-out workers are restarted

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-764
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

**Why deferred restart instead of inline restart?**
`ConsumeClaim` runs in parallel goroutines (one per partition). The old `cancelEventHandling` ran inline in `drainOnRebalance`, which meant: (a) it could be called with a nil worker when no message was in-flight, causing a panic; (b) multiple partitions timing out simultaneously would restart the same worker multiple times concurrently; (c) it raced with the event submitter goroutine. Moving the restart to `Cleanup` — which sarama calls after all `ConsumeClaim` goroutines have returned — eliminates all three issues and ensures each worker is restarted at most once.

**Why re-drain in Cleanup?**
Between `drainOnRebalance` timing out and `Cleanup` running, some workers may have finished draining. The short re-drain in `Cleanup` captures these workers so they are not unnecessarily restarted. Workers that already reported draining-done will respond immediately, so the 1s timeout is sufficient.
