### PR TITLE
[Dashboard] Fix container stop signal handling

### DIFF
--- a/cmd/dashboard/docker/Dockerfile
+++ b/cmd/dashboard/docker/Dockerfile
@@ -100,4 +100,7 @@ RUN apk --update --no-cache add \
 
 HEALTHCHECK --interval=1s --timeout=3s CMD /usr/local/bin/uhttpc --url http://127.0.0.1:8082/ready || exit 1
 
+# Override nginx base image's STOPSIGNAL (SIGQUIT) with SIGTERM for faster container shutdown
+STOPSIGNAL SIGTERM
+
 CMD ["sh",  "-c", "./runner.sh"]

--- a/cmd/dashboard/docker/runner.sh
+++ b/cmd/dashboard/docker/runner.sh
@@ -21,6 +21,7 @@ _term() {
 
 trap _term TERM
 trap _term INT
+trap _term QUIT
 
 echo "Running in parallel"
 


### PR DESCRIPTION
### 📝 Description

Fixes slow dashboard container shutdown in Docker by aligning the image stop signal with the runner’s signal handling.
The dashboard image inherited `SIGQUIT` from the nginx base image, but `runner.sh` did not handle it, so `docker stop` waited for Docker’s 10-second timeout before force killing the container.

---

### 🛠️ Changes Made

- Added `STOPSIGNAL SIGTERM` to `cmd/dashboard/docker/Dockerfile` to override nginx’s inherited `SIGQUIT`
- Added `trap _term QUIT` to `cmd/dashboard/docker/runner.sh` for robust signal handling
- Preserved existing `TERM` and `INT` shutdown behavior

---

### ✅ Checklist

- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

- Manual tests:
  - Build dashboard image
  - Run dashboard container
  - Execute `time docker stop <container>`
  - Verify shutdown completes quickly (target: ~1s, not ~10s)

```bash
$ docker run --name testnuclio --rm -d -v /var/run/docker.sock:/var/run/docker.sock quay.io/nuclio/dashboard:latest-amd64
$ time docker stop testnuclio
0.01s user 0.01s system 2% cpu 1.212 total
```

---

### 🔗 References

- Ticket link: Closes #4057

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- This is a targeted runtime behavior fix in container signal handling.
- No API, CRD, or Helm schema changes are included.