### PR TITLE
Revert "[ExplicitAck] Send draining done from worker "

### DIFF
--- a/cmd/processor/app/processor_test.go
+++ b/cmd/processor/app/processor_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package app
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -233,8 +232,8 @@ func (t *testTrigger) GetProjectName() string {
 	return ""
 }
 
-func (t *testTrigger) Drain(ctx context.Context) error {
-	t.Called(ctx)
+func (t *testTrigger) SignalWorkersToDrain() error {
+	t.Called()
 	return nil
 }
 

--- a/pkg/processor/controlcommunication/types.go
+++ b/pkg/processor/controlcommunication/types.go
@@ -28,7 +28,6 @@ type ControlMessageKind string
 const (
 	StreamMessageAckKind ControlMessageKind = "streamMessageAck"
 	LogMessageKind       ControlMessageKind = "log"
-	DrainMessageKind     ControlMessageKind = "drain"
 )
 
 // TODO: move to nuclio-sdk-go
@@ -41,10 +40,6 @@ type ControlMessageAttributesExplicitAck struct {
 	Topic     string `json:"topic"`
 	Partition int32  `json:"partition"`
 	Offset    int64  `json:"offset"`
-}
-
-type ControlMessageAttributesDrain struct {
-	WorkerId string `json:"workerId"`
 }
 
 type ControlConsumer struct {

--- a/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
@@ -193,10 +193,14 @@ class AsyncWrapper(AbstractWrapper):
             await self._on_serving_error(exc, sock)
         finally:
             if self._is_drain_needed:
-                await self._call_drain_handler()
+                result = self._call_drain_handler()
+                if asyncio.iscoroutine(result):
+                    await result
 
             if self._is_termination_needed:
-                await self._call_termination_handler()
+                result = self._call_termination_handler()
+                if asyncio.iscoroutine(result):
+                    await result
             self._cleanup_connection(sock, cancel_task=False)
 
     def _cleanup_connection(self, sock, cancel_task=True):

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -127,10 +127,14 @@ class Wrapper(AbstractWrapper):
 
             finally:
                 if self._is_drain_needed:
-                    await self._call_drain_handler()
+                    result = self._call_drain_handler()
+                    if asyncio.iscoroutine(result):
+                        await result
 
                 if self._is_termination_needed:
-                    await self._call_termination_handler()
+                    result = self._call_termination_handler()
+                    if asyncio.iscoroutine(result):
+                        await result
 
             # for testing, we can ask wrapper to only read a set number of requests
             if num_requests is not None:

--- a/pkg/processor/runtime/python/py/wrapper_common.py
+++ b/pkg/processor/runtime/python/py/wrapper_common.py
@@ -104,7 +104,6 @@ class AbstractWrapper(object):
         self._platform = nuclio_sdk.Platform(platform_kind,
                                              namespace=namespace,
                                              on_control_callback=self._send_data_on_control_socket)
-        self._worker_id = worker_id
         self._decode_event_strings = decode_event_strings
 
         # 1gb
@@ -148,25 +147,10 @@ class AbstractWrapper(object):
                                            nuclio_sdk.TriggerInfo(trigger_kind, trigger_name),
                                            logger_per_async_task=logger_per_async_task)
 
-        # Signal-driven lifecycle flags.
-        #
-        # _is_drain_needed / _is_termination_needed: set True by the respective signal handler,
-        # consumed (set back to False) in the finally block of the serving loop after
-        # executing the drain/termination handler.
-        #
-        # _discard_events: guards against processing events that arrive between a drain/termination
-        # signal and the completion of the handler. In the async wrapper, multiple coroutines may
-        # be serving connections concurrently; one coroutine could receive a new event while another
-        # is still executing the drain handler. This flag ensures those in-flight events are dropped.
-        # It is cleared by the SIGCONT (continue) signal when the processor is ready to resume.
-        #
-        # _drained: tracks whether the drain handler has already been called for the current
-        # drain cycle. When a second SIGUSR2 arrives while already drained (before SIGCONT),
-        # we skip the drain handler and immediately send the drain-complete control message.
+        # initialize flags
         self._is_drain_needed = False
         self._is_termination_needed = False
         self._discard_events = False
-        self._drained = False
 
         self._event_message_length_task = None
 
@@ -448,10 +432,7 @@ class AbstractWrapper(object):
     def _on_drain_signal(self, signal_name):
         # do not perform draining if discarding events
         if self._discard_events:
-            if self._drained:
-                self._logger.debug('Draining signal is received, but it will be ignored as the worker is already drained')
-                self._send_drain_complete_control_message()
-            self._logger.debug('Draining signal is received, but it will be ignored as the worker is already being drained')
+            self._logger.debug('Draining signal is received, but it will be ignored as the worker is already drained')
             return
 
         self._logger.debug_with('Received signal', signal=signal_name)
@@ -481,39 +462,23 @@ class AbstractWrapper(object):
         # set this flag to False, so continue normal event processing flow
         self._discard_events = False
 
-        # reset drained flag to allow future drain signals to be handled properly
-        self._drained = True
-
-    async def _call_drain_handler(self):
+    def _call_drain_handler(self):
         self._logger.debug('Calling platform drain handler')
 
         # set the flag to False so the drain handler will not be called more than once
         self._is_drain_needed = False
-        draining_result = self._platform._on_signal(callback_type="drain")
-        if asyncio.iscoroutine(draining_result):
-            await draining_result
-        self._drained = True
+        return self._platform._on_signal(callback_type="drain")
 
-        await self._send_drain_complete_control_message()
-
-    async def _send_drain_complete_control_message(self):
-        self._logger.debug_with('Sending drain complete control message', worker_id=self._worker_id)
-        await self._send_data_on_control_socket({
-            'kind': 'drain',
-            'attributes': {'workerId': self._worker_id}
-        })
-
-    async def _call_termination_handler(self):
+    def _call_termination_handler(self):
         self._logger.debug('Calling platform termination handler')
 
         # set the flag to False so the termination handler will not be called more than once
         self._is_termination_needed = False
 
+        # call termination handler
         # TODO: send a control message to the processor after this line,
         # to indicate that the termination handler has finished, and the processor can exit early
-        termination_result = self._platform._on_signal(callback_type="termination")
-        if asyncio.iscoroutine(termination_result):
-            await termination_result
+        return self._platform._on_signal(callback_type="termination")
 
     def _shutdown(self, error_code=0):
         self._logger.info("Shutting down...")

--- a/pkg/processor/runtime/python/runtime.go
+++ b/pkg/processor/runtime/python/runtime.go
@@ -145,6 +145,10 @@ func (py *python) Drain() error {
 		return errors.Wrap(err, "Failed to signal wrapper process to drain")
 	}
 
+	// wait for process to finish event handling or timeout
+	// TODO: replace the following function with one that waits for a control communication message or timeout
+	py.WaitForProcessTermination(py.configuration.WorkerTerminationTimeout)
+
 	return nil
 }
 

--- a/pkg/processor/statistics/gatherer/mock.go
+++ b/pkg/processor/statistics/gatherer/mock.go
@@ -19,8 +19,6 @@ limitations under the License.
 package gatherer
 
 import (
-	"context"
-
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
@@ -83,7 +81,7 @@ func (mt *mockTrigger) Stop(force bool) (functionconfig.Checkpoint, error) {
 	return nil, nil
 }
 
-func (mt *mockTrigger) Drain(ctx context.Context) error {
+func (mt *mockTrigger) SignalWorkersToDrain() error {
 	return nil
 }
 

--- a/pkg/processor/trigger/kafka/test/kafka_test.go
+++ b/pkg/processor/trigger/kafka/test/kafka_test.go
@@ -486,6 +486,8 @@ func (suite *testSuite) TestDrainHook() {
 		},
 	}
 
+	var rebalanceStartedTime time.Time
+
 	// deploy function
 	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
 		suite.Require().NotNil(deployResult, "Unexpected empty deploy results")
@@ -505,13 +507,9 @@ func (suite *testSuite) TestDrainHook() {
 
 		suite.Logger.Debug("Creating second function, to trigger rebalance")
 
-		// measure how long deploying the second function takes (triggers rebalance + drain on the first function).
-		// if drain-complete control message works, this should finish well under the 40s workerTerminationTimeout.
-		maxSecondFunctionDeployDuration := 25 * time.Second
-		secondFunctionDeployStart := time.Now()
-
 		suite.DeployFunction(newCreateFunctionOptions, func(newDeployResult *platform.CreateFunctionResult) bool {
 			suite.Require().NotNil(newDeployResult, "Unexpected empty second deploy results")
+			rebalanceStartedTime = time.Now()
 
 			suite.Logger.DebugWith("Created second function, producing messages to topic",
 				"topic", topic)
@@ -525,33 +523,28 @@ func (suite *testSuite) TestDrainHook() {
 				suite.Require().NoError(err, "Failed to publish message")
 			}
 
-			// verify drain hook files are written promptly after rebalance (via drain-complete control message),
-			// rather than waiting the full workerTerminationTimeout (40s).
-			// the drain callback only writes a file, so it should complete well within this window.
-			maxDrainWait := 8 * time.Second
-			err := common.RetryUntilSuccessful(maxDrainWait, 1*time.Second, func() bool {
-				for workerID := 0; workerID < 4; workerID++ {
-					filePath := path.Join(tempDir, fmt.Sprintf("drain-hook-%d.txt", workerID))
-					fileBytes, readErr := os.ReadFile(filePath)
-					if readErr != nil || len(fileBytes) == 0 {
-						return false
-					}
-				}
-				return true
-			})
-			suite.Require().NoError(err,
-				"Drain hook files were not written within %s - drain-complete control message may not be working", maxDrainWait)
+			// wait for at least the kafka trigger's WorkerTerminationTimeout to pass from first invocation,
+			// to allow the function to run its termination hook before we delete the function
+			<-time.After(time.Until(rebalanceStartedTime.Add(40 * time.Second)))
 
 			return true
 		})
 
-		secondFunctionDeployDuration := time.Since(secondFunctionDeployStart)
-		suite.Require().Less(secondFunctionDeployDuration, maxSecondFunctionDeployDuration,
-			"Second function deploy took %s, expected less than %s - drain-complete may not be shortcutting the workerTerminationTimeout",
-			secondFunctionDeployDuration, maxSecondFunctionDeployDuration)
-
 		return true
 	})
+
+	// check that the function's drain hook was called by reading the file it should have written to
+	// 1 file per worker -> 4 files
+	for workerID := 0; workerID < 4; workerID++ {
+		filePath := path.Join(tempDir, fmt.Sprintf("drain-hook-%d.txt", workerID))
+		suite.Logger.DebugWith("Reading drain hook file", "filePath", filePath)
+		fileBytes, err := os.ReadFile(filePath)
+		suite.Require().NoError(err, "Failed to read drain hook file")
+
+		// check that the file is not empty
+		suite.Logger.DebugWith("Checking drain hook file is not empty", "fileContent", string(fileBytes))
+		suite.Require().NotEmpty(fileBytes, "Drain hook file is empty")
+	}
 }
 
 // TestFeatureCombinations tests different combinations of the following features:

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -339,9 +339,6 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 	readyForRebalanceChan := make(chan bool)
 	defer close(readyForRebalanceChan)
 
-	drainingContext, cancel := context.WithTimeout(k.ctx, k.configuration.maxWaitHandlerDuringRebalance)
-	defer cancel()
-
 	go func() {
 		defer common.CatchAndLogPanicWithOptions(k.ctx, // nolint: errcheck
 			k.Logger,
@@ -352,7 +349,8 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 			})
 		var wg sync.WaitGroup
 		if waitForHandler {
-			wg.Go(func() {
+			wg.Add(2)
+			go func() {
 				err := <-submittedEventInstance.done
 
 				// we successfully submitted the message to the handler. mark it
@@ -365,19 +363,23 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 					)
 				}
 				k.Logger.DebugWith("Handler done", "partition", claim.Partition())
-			})
+				wg.Done()
+			}()
+		} else {
+			wg.Add(1)
 		}
 
-		wg.Go(func() {
+		go func() {
 			// this needs to occur once. the reason is that this specific function (ConsumeClaim)
 			// runs in parallel for each partition, and we want to make sure that we only
 			// drain the workers once.
-			if err := k.Drain(drainingContext); err != nil {
+			if err := k.SignalWorkersToDrain(); err != nil {
 				k.Logger.DebugWith("Failed to signal worker draining",
 					"err", err.Error(),
 					"partition", claim.Partition())
 			}
-		})
+			wg.Done()
+		}()
 
 		wg.Wait()
 		readyForRebalanceChan <- true
@@ -386,9 +388,6 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 	// wait a for rebalance readiness or max timeout
 	select {
 	case <-readyForRebalanceChan:
-		if waitForHandler {
-			k.UpdateStatistics(true, 1)
-		}
 		if functionconfig.ExplicitAckEnabled(k.configuration.ExplicitAckMode) {
 			// if we are in explicitAck it means that runtime code sends control messages to processor
 			// sometimes draining happens too fast, so we don't have enough time to process ack control message
@@ -402,23 +401,22 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 		k.Logger.DebugWith("Handler done, rebalancing will commence",
 			"partition", claim.Partition())
 
-	case <-drainingContext.Done():
+	case <-time.After(k.configuration.maxWaitHandlerDuringRebalance):
 		k.Logger.WarnWith("Timed out waiting for handler to complete",
 			"partition", claim.Partition())
 
-		if waitForHandler {
-			// mark this as a failure, metric-wise
-			k.UpdateStatistics(false, 1)
-		}
-		// the rebalance timeout occurred while we waited for the handler,
-		// which means that the handler is taking too long to process events or to drain
-		// we want to cancel event handling to unblock the rebalance and prevent a potential zombie state
-		if err := k.cancelEventHandling(workerInstance, claim); err != nil {
-			k.Logger.DebugWith("Failed to cancel event handling",
-				"err", err.Error(),
-				"partition", claim.Partition())
+		// mark this as a failure, metric-wise
+		k.UpdateStatistics(false, 1)
 
-			panic("Failed to cancel event handling")
+		if waitForHandler {
+			// the rebalance timeout occurred while we waited for the handler, cancel it and restart the worker
+			if err := k.cancelEventHandling(workerInstance, claim); err != nil {
+				k.Logger.DebugWith("Failed to cancel event handling",
+					"err", err.Error(),
+					"partition", claim.Partition())
+
+				panic("Failed to cancel event handling")
+			}
 		}
 	}
 }

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -29,7 +29,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 
 	"github.com/google/uuid"
-	"github.com/mitchellh/mapstructure"
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
@@ -83,8 +82,8 @@ type Trigger interface {
 	// GetProjectName returns project name
 	GetProjectName() string
 
-	// Drain drains all workers
-	Drain(ctx context.Context) error
+	// SignalWorkersToDrain drains all workers
+	SignalWorkersToDrain() error
 
 	// SignalWorkersToContinue signal all workers to continue processing
 	SignalWorkersToContinue() error
@@ -386,48 +385,13 @@ func (at *AbstractTrigger) UnsubscribeFromControlMessageKind(kind controlcommuni
 	return nil
 }
 
-// Drain sends a signal to all workers and waits for them to finish draining their events
-func (at *AbstractTrigger) Drain(ctx context.Context) error {
-	drainingDoneControlMessageChan := make(chan *controlcommunication.ControlMessage)
-
-	// subscribe to worker draining complete control messages to know when workers are done draining and we can proceed with rebalance
-	if err := at.SubscribeToControlMessageKind(controlcommunication.DrainMessageKind, drainingDoneControlMessageChan); err != nil {
-		return errors.Wrap(err, "Failed to subscribe to drain control messages")
-	}
-
-	// make sure to unsubscribe and close channel
-	defer func() {
-		if err := at.UnsubscribeFromControlMessageKind(controlcommunication.DrainMessageKind, drainingDoneControlMessageChan); err != nil {
-			at.Logger.WarnWith("Failed to unsubscribe from drain control messages", "err", err.Error())
-		}
-		close(drainingDoneControlMessageChan)
-	}()
-
-	workers := at.WorkerAllocator.GetObjects()
+// SignalWorkersToDrain sends a signal to all workers, telling them to drop or ack events
+// that are currently being processed
+func (at *AbstractTrigger) SignalWorkersToDrain() error {
 	if err := at.WorkerAllocator.SignalDraining(); err != nil {
 		return errors.Wrap(err, "Failed to signal all workers to drain events")
 	}
-
-	uniqueWorkerIds := make(map[string]struct{})
-
-	for {
-		select {
-		case controlMessage := <-drainingDoneControlMessageChan:
-			drainAttributes := &controlcommunication.ControlMessageAttributesDrain{}
-			if err := mapstructure.Decode(controlMessage.Attributes, drainAttributes); err != nil {
-				at.Logger.WarnWith("Failed decoding control message attributes", "err", err.Error())
-				continue
-			}
-			uniqueWorkerIds[drainAttributes.WorkerId] = struct{}{}
-			if len(uniqueWorkerIds) == len(workers) {
-				at.Logger.DebugWith("All workers finished draining",
-					"numWorkers", len(workers))
-				return nil
-			}
-		case <-ctx.Done():
-			return errors.New("Context cancelled while waiting for workers to drain")
-		}
-	}
+	return nil
 }
 
 // SignalWorkersToContinue sends a signal to all workers, telling them to continue event processing


### PR DESCRIPTION
Reverts nuclio/nuclio#4047

This changes found some problems with broker mechanism, so we decided to avoid the risks and revert it for now. Will get back to it in 1.16.x