### PR TITLE
[API GW] Fix OAuth2 Redirect Loop For Iguazio-Auth API Gateways

### DIFF
--- a/pkg/platform/kube/ingress/ingress.go
+++ b/pkg/platform/kube/ingress/ingress.go
@@ -504,6 +504,14 @@ func (m *Manager) compileIguazioAuthAnnotations() (map[string]string, error) {
 		return nil, errors.New("Iguazio login URL is not configured")
 	}
 
+	// Append the rd parameter to force an HTTPS post-callback redirect.
+	// Without this, nginx uses the original request scheme in the rd URL. If the
+	// browser navigated over HTTP, oauth2-proxy redirects back to http://$host after
+	// login. The _oauth2_proxy cookie has Secure set, so the browser omits it on HTTP
+	// requests, causing the auth check to fail and the OAuth2 flow to loop indefinitely.
+	// This matches the pattern already used by compileDexAuthAnnotations.
+	signinURL = fmt.Sprintf("%s?rd=https://$host$escaped_request_uri", signinURL)
+
 	iguazioAnnotations := annotations.GetIguazioAuthenticationModeAnnotations()
 	iguazioAnnotations[annotations.NginxAuthSignIn] = signinURL
 	iguazioAnnotations[annotations.NginxAuthURL] = authURL

--- a/pkg/platform/kube/ingress/ingress.go
+++ b/pkg/platform/kube/ingress/ingress.go
@@ -510,7 +510,11 @@ func (m *Manager) compileIguazioAuthAnnotations() (map[string]string, error) {
 	// login. The _oauth2_proxy cookie has Secure set, so the browser omits it on HTTP
 	// requests, causing the auth check to fail and the OAuth2 flow to loop indefinitely.
 	// This matches the pattern already used by compileDexAuthAnnotations.
-	signinURL = fmt.Sprintf("%s?rd=https://$host$escaped_request_uri", signinURL)
+	separator := "?"
+	if strings.Contains(signinURL, "?") {
+		separator = "&"
+	}
+	signinURL = fmt.Sprintf("%s%srd=https://$host$escaped_request_uri", signinURL, separator)
 
 	iguazioAnnotations := annotations.GetIguazioAuthenticationModeAnnotations()
 	iguazioAnnotations[annotations.NginxAuthSignIn] = signinURL

--- a/pkg/platform/kube/ingress/ingress_test.go
+++ b/pkg/platform/kube/ingress/ingress_test.go
@@ -57,7 +57,7 @@ func (suite *IngressTestSuite) TestCompileIguazioAuthAnnotations() {
 			},
 			expectedAnnotations: map[string]string{
 				annotations.NginxAuthURL:    "test-auth-url",
-				annotations.NginxAuthSignIn: "test-sign-in-url",
+				annotations.NginxAuthSignIn: "test-sign-in-url?rd=https://$host$escaped_request_uri",
 			},
 		},
 		{

--- a/pkg/platform/kube/ingress/ingress_test.go
+++ b/pkg/platform/kube/ingress/ingress_test.go
@@ -61,6 +61,19 @@ func (suite *IngressTestSuite) TestCompileIguazioAuthAnnotations() {
 			},
 		},
 		{
+			name: "Sign-in URL already has a query param",
+			platformConfiguration: &platformconfig.Config{
+				IngressConfig: platformconfig.IngressConfig{
+					IguazioAuthURL:   "test-auth-url",
+					IguazioSignInURL: "test-sign-in-url?foo=bar",
+				},
+			},
+			expectedAnnotations: map[string]string{
+				annotations.NginxAuthURL:    "test-auth-url",
+				annotations.NginxAuthSignIn: "test-sign-in-url?foo=bar&rd=https://$host$escaped_request_uri",
+			},
+		},
+		{
 			name: "missing AuthURL in conf",
 			platformConfiguration: &platformconfig.Config{
 				IngressConfig: platformconfig.IngressConfig{

--- a/pkg/platform/kube/test/apigateway/api_gateway_test.go
+++ b/pkg/platform/kube/test/apigateway/api_gateway_test.go
@@ -151,18 +151,21 @@ def handler(context, event):
 	})
 }
 
+// compareAnnotations verifies that the ingress annotations contain the expected Iguazio auth values.
+// The sign-in annotation is expected to have ?rd=https://$host$escaped_request_uri appended.
 func (suite *DeployAPIGatewayTestSuite) compareAnnotations(
 	ingressAnnotations, iguazioAuthAnnotations map[string]string,
 	testSignInUrl, testAuthUrl string,
 ) {
+	expectedSignInAnnotation := testSignInUrl + "?rd=https://$host$escaped_request_uri"
 	for key, value := range iguazioAuthAnnotations {
 		switch key {
 		case annotations.NginxAuthSignIn:
-			suite.Require().Equal(ingressAnnotations[key], testSignInUrl)
+			suite.Require().Equal(expectedSignInAnnotation, ingressAnnotations[key])
 		case annotations.NginxAuthURL:
-			suite.Require().Equal(ingressAnnotations[key], testAuthUrl)
+			suite.Require().Equal(testAuthUrl, ingressAnnotations[key])
 		default:
-			suite.Require().Equal(ingressAnnotations[key], value)
+			suite.Require().Equal(value, ingressAnnotations[key])
 		}
 	}
 }


### PR DESCRIPTION
### 📝 Description

When a Nuclio API Gateway is configured with Iguazio authentication and a user navigates to its URL over HTTP, nginx appends the original (HTTP) request URL as the `rd` parameter when redirecting to `oauth2-proxy/oauth2/start`. After a successful Keycloak login, oauth2-proxy redirects the browser back to that `http://` URL. Because the `_oauth2_proxy` session cookie has the `Secure` flag set, the browser does not attach it to HTTP requests. nginx then calls igz-api as the `auth-url`, igz-api finds no cookie and returns 401, nginx redirects to `oauth2/start` again — producing an infinite redirect loop that terminates with a CSRF 403 from oauth2-proxy after several iterations.

The fix appends `?rd=https://$host$escaped_request_uri` to the `auth-signin` annotation generated by `compileIguazioAuthAnnotations()`, forcing the post-callback redirect to always use HTTPS regardless of the original request scheme. This is the same pattern already used by `compileDexAuthAnnotations()` in the same file.

---

### 🛠️ Changes Made

- `pkg/platform/kube/ingress/ingress.go`: In `compileIguazioAuthAnnotations()`, append `?rd=https://$host$escaped_request_uri` to `signinURL` before setting the `NginxAuthSignIn` annotation.
- `pkg/platform/kube/ingress/ingress_test.go`: Update the expected `NginxAuthSignIn` annotation value in `TestCompileIguazioAuthAnnotations` to include the `rd` parameter.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

- Unit Tests
- Manual Testing by Patching system with modified nuclio, creating a new API GW and using it in the browser.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/IG4-1873
- External links:
  - [ingress-nginx OAuth external auth example](https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/)
  - [oauth2-proxy nginx integration](https://oauth2-proxy.github.io/oauth2-proxy/configuration/integrations/nginx/)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- The `compileDexAuthAnnotations()` function in the same file already applies this pattern correctly; `compileIguazioAuthAnnotations()` was simply missing it.
- `ssl-redirect: "true"` is already set on Iguazio-auth API GW ingresses via `GetIguazioAuthenticationModeAnnotations()`, but ssl-redirect alone does not prevent the loop: nginx executes the auth sub-request before returning the ssl-redirect 301, so the cookieless HTTP request reaches igz-api and fails before the browser ever upgrades to HTTPS.
