### PR TITLE
[Platform] Propagate EnvFrom when enriching container spec for init and sidecar container

### DIFF
--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -36,6 +36,36 @@ func RemoveEnvFromSlice(env v1.EnvVar, slice []v1.EnvVar) []v1.EnvVar {
 	return slice
 }
 
+// MergeEnvFromSlices merges two lists of EnvFromSource, giving priority to entries from the primary list.
+// Deduplication is based on source type, name, and prefix.
+func MergeEnvFromSlices(primaryEnvFrom []v1.EnvFromSource, secondaryEnvFrom []v1.EnvFromSource) []v1.EnvFromSource {
+	existing := make(map[string]bool)
+	for _, envSource := range primaryEnvFrom {
+		existing[envFromSourceKey(envSource)] = true
+	}
+	merged := append([]v1.EnvFromSource{}, primaryEnvFrom...)
+	for _, envSource := range secondaryEnvFrom {
+		if !existing[envFromSourceKey(envSource)] {
+			merged = append(merged, envSource)
+		}
+	}
+	return merged
+}
+
+// envFromSourceKey returns a unique string key for an EnvFromSource based on its source type (secret or configmap),
+// name, and optional prefix. Two entries with the same secret/configmap name but different prefixes are
+// considered distinct, as they inject different env var names into the container.
+func envFromSourceKey(envSource v1.EnvFromSource) string {
+	prefix := envSource.Prefix
+	if envSource.SecretRef != nil {
+		return "secret:" + prefix + ":" + envSource.SecretRef.Name
+	}
+	if envSource.ConfigMapRef != nil {
+		return "configmap:" + prefix + ":" + envSource.ConfigMapRef.Name
+	}
+	return ""
+}
+
 // MergeEnvSlices merges two lists of environment variables, giving priority to variables from the primary list
 func MergeEnvSlices(primaryEnv []v1.EnvVar, secondaryEnv []v1.EnvVar) []v1.EnvVar {
 	envMap := make(map[string]v1.EnvVar)

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1717,10 +1717,36 @@ func (p *Platform) enrichContainerSpec(container *v1.Container, functionConfig *
 	}
 	container.Env = common.MergeEnvSlices(container.Env, functionConfig.Spec.Env)
 
+	// enrich envFrom - propagate function-level bulk secret/configmap mounts to the container,
+	// skipping entries already present to avoid duplicates.
+	// This ensures init containers and sidecars receive the same envFrom sources as the main processor container
+	existingEnvFrom := make(map[string]bool)
+	for _, e := range container.EnvFrom {
+		existingEnvFrom[envFromKey(e)] = true
+	}
+	for _, e := range functionConfig.Spec.EnvFrom {
+		if !existingEnvFrom[envFromKey(e)] {
+			container.EnvFrom = append(container.EnvFrom, e)
+		}
+	}
+
 	// image pull policy
 	if container.ImagePullPolicy == "" {
 		container.ImagePullPolicy = functionConfig.Spec.ImagePullPolicy
 	}
+}
+
+// envFromKey returns a unique string key for an EnvFromSource based on its source type (secret or configmap),
+// name, and optional prefix.
+func envFromKey(e v1.EnvFromSource) string {
+	prefix := e.Prefix
+	if e.SecretRef != nil {
+		return "secret:" + prefix + ":" + e.SecretRef.Name
+	}
+	if e.ConfigMapRef != nil {
+		return "configmap:" + prefix + ":" + e.ConfigMapRef.Name
+	}
+	return ""
 }
 
 func (p *Platform) clearCallStack(message string) string {

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1720,33 +1720,12 @@ func (p *Platform) enrichContainerSpec(container *v1.Container, functionConfig *
 	// enrich envFrom - propagate function-level bulk secret/configmap mounts to the container,
 	// skipping entries already present to avoid duplicates.
 	// This ensures init containers and sidecars receive the same envFrom sources as the main processor container
-	existingEnvFrom := make(map[string]bool)
-	for _, e := range container.EnvFrom {
-		existingEnvFrom[envFromKey(e)] = true
-	}
-	for _, e := range functionConfig.Spec.EnvFrom {
-		if !existingEnvFrom[envFromKey(e)] {
-			container.EnvFrom = append(container.EnvFrom, e)
-		}
-	}
+	container.EnvFrom = common.MergeEnvFromSlices(container.EnvFrom, functionConfig.Spec.EnvFrom)
 
 	// image pull policy
 	if container.ImagePullPolicy == "" {
 		container.ImagePullPolicy = functionConfig.Spec.ImagePullPolicy
 	}
-}
-
-// envFromKey returns a unique string key for an EnvFromSource based on its source type (secret or configmap),
-// name, and optional prefix.
-func envFromKey(e v1.EnvFromSource) string {
-	prefix := e.Prefix
-	if e.SecretRef != nil {
-		return "secret:" + prefix + ":" + e.SecretRef.Name
-	}
-	if e.ConfigMapRef != nil {
-		return "configmap:" + prefix + ":" + e.ConfigMapRef.Name
-	}
-	return ""
 }
 
 func (p *Platform) clearCallStack(message string) string {

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -627,6 +627,94 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateSidecarContainers() {
 	}
 }
 
+func (suite *FunctionKubePlatformTestSuite) TestEnrichContainerSpecEnvFrom() {
+	s3Secret := v1.EnvFromSource{
+		SecretRef: &v1.SecretEnvSource{
+			LocalObjectReference: v1.LocalObjectReference{Name: "s3-credentials"},
+		},
+	}
+	otherSecret := v1.EnvFromSource{
+		SecretRef: &v1.SecretEnvSource{
+			LocalObjectReference: v1.LocalObjectReference{Name: "other-secret"},
+		},
+	}
+
+	for _, testCase := range []struct {
+		name             string
+		containerEnvFrom []v1.EnvFromSource
+		functionEnvFrom  []v1.EnvFromSource
+		expectedEnvFrom  []v1.EnvFromSource
+	}{
+		{
+			name:             "function-envFrom-propagated-to-empty-container",
+			containerEnvFrom: nil,
+			functionEnvFrom:  []v1.EnvFromSource{s3Secret},
+			expectedEnvFrom:  []v1.EnvFromSource{s3Secret},
+		},
+		{
+			name:             "function-envFrom-appended-to-existing-container-envFrom",
+			containerEnvFrom: []v1.EnvFromSource{otherSecret},
+			functionEnvFrom:  []v1.EnvFromSource{s3Secret},
+			expectedEnvFrom:  []v1.EnvFromSource{otherSecret, s3Secret},
+		},
+		{
+			name:             "duplicate-envFrom-not-added",
+			containerEnvFrom: []v1.EnvFromSource{s3Secret},
+			functionEnvFrom:  []v1.EnvFromSource{s3Secret},
+			expectedEnvFrom:  []v1.EnvFromSource{s3Secret},
+		},
+		{
+			name:             "no-function-envFrom-container-unchanged",
+			containerEnvFrom: []v1.EnvFromSource{otherSecret},
+			functionEnvFrom:  nil,
+			expectedEnvFrom:  []v1.EnvFromSource{otherSecret},
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			functionConfig := &functionconfig.Config{
+				Spec: functionconfig.Spec{
+					EnvFrom: testCase.functionEnvFrom,
+				},
+			}
+			container := &v1.Container{
+				EnvFrom: testCase.containerEnvFrom,
+			}
+
+			suite.platform.enrichContainerSpec(container, functionConfig)
+
+			suite.Require().Equal(testCase.expectedEnvFrom, container.EnvFrom)
+		})
+	}
+}
+
+func (suite *FunctionKubePlatformTestSuite) TestEnrichInitContainersAndSidecarsEnvFrom() {
+	s3Secret := v1.EnvFromSource{
+		SecretRef: &v1.SecretEnvSource{
+			LocalObjectReference: v1.LocalObjectReference{Name: "s3-credentials"},
+		},
+	}
+
+	functionConfig := &functionconfig.Config{
+		Spec: functionconfig.Spec{
+			EnvFrom: []v1.EnvFromSource{s3Secret},
+			InitContainers: []*v1.Container{
+				{Name: "mlrun-source-loader"},
+			},
+			Sidecars: []*v1.Container{
+				{Name: "app-sidecar"},
+			},
+		},
+	}
+
+	suite.platform.enrichInitContainersSpec(functionConfig)
+	suite.platform.enrichSidecarsSpec(functionConfig)
+
+	suite.Require().Equal([]v1.EnvFromSource{s3Secret}, functionConfig.Spec.InitContainers[0].EnvFrom,
+		"init container should receive envFrom from function spec")
+	suite.Require().Equal([]v1.EnvFromSource{s3Secret}, functionConfig.Spec.Sidecars[0].EnvFrom,
+		"sidecar should receive envFrom from function spec")
+}
+
 func (suite *FunctionKubePlatformTestSuite) TestValidateProbesSpec() {
 	for _, testCase := range []struct {
 		name                 string


### PR DESCRIPTION
### 📝 Description
`enrichContainerSpec` in Nuclio's kube platform propagates function-level `Spec.Env` to init containers and sidecars, but was not propagating `Spec.EnvFrom`. 
This caused init containers (specifically `mlrun-source-loader`) and sidecars to miss bulk secret mounts set via `EnvFrom`, resulting in AccessDenied errors when trying to access S3 storage.
                                                                                                                                                                              
---

### 🛠️ Changes Made
- Extended `enrichContainerSpec` to also merge `Spec.EnvFrom` entries into the container, in addition to the existing `Spec.Env` merging

- Added `envFromKey` helper for deduplication — identifies an `EnvFromSource` by source type (secret/configmap), name, and prefix to avoid duplicate entries

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
 - Added unit tests in platform_test.go:
`TestEnrichContainerSpecEnvFrom` — covers propagation to an empty container, appending to existing EnvFrom, deduplication of already-present entries, and no-op when function has no `EnvFrom`
`TestEnrichInitContainersAndSidecarsEnvFrom` — end-to-end regression test verifying that both `mlrun-source-loader` init container and app sidecar receive `EnvFrom` from the function spec

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-768
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->