### PR TITLE
[Build] Fix arm64 handler-builder-python-onbuild downloading x86_64 wheels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ else
 	NODE_IMAGE_NAME 				?= gcr.io/iguazio/node:20
 endif
 
-NUCLIO_PYTHON_BASE_IMAGE_NAME ?= gcr.io/iguazio/python
+NUCLIO_PYTHON_BASE_IMAGE_NAME ?= python
 
 NUCLIO_BASE_IMAGE_TAG ?= 1.25
 NUCLIO_BASE_ALPINE_IMAGE_TAG ?= 1.25-alpine
@@ -471,6 +471,7 @@ PIP_REQUIRE_VIRTUALENV=false
 .PHONY: handler-builder-python-onbuild
 handler-builder-python-onbuild: processor
 	docker build \
+		--platform $(NUCLIO_OS)/$(NUCLIO_ARCH) \
 		--build-arg NUCLIO_DOCKER_IMAGE_TAG=$(NUCLIO_DOCKER_IMAGE_TAG) \
 		--build-arg NUCLIO_DOCKER_REPO=$(NUCLIO_DOCKER_REPO) \
 		--build-arg NUCLIO_PYTHON_BASE_IMAGE_NAME=$(NUCLIO_PYTHON_BASE_IMAGE_NAME) \


### PR DESCRIPTION
## Problem

When CI is building `handler-builder-python-onbuild` for `arm64` on an amd64 CI runner with QEMU, the resulting image contains **x86_64 wheels** instead of aarch64 wheels. This causes function builds to fail on native arm64 nodes with:

```
ERROR: No matching distribution found for msgpack==1.1.0
```

## Root cause — two independent bugs:

**1. Missing `--platform` in the Makefile `docker build` call**

`handler-builder-python-onbuild` is the only image target that did not pass `--platform` to `docker build` (every other
target, e.g. `processor`, does). Without it, Docker reads `DOCKER_DEFAULT_PLATFORM` from the environment, but if the base image has no arm64 manifest, Docker silently falls back to the amd64 image.

**2. `gcr.io/iguazio/python` has no arm64 manifest**

The default `NUCLIO_PYTHON_BASE_IMAGE_NAME` points to an iguazio-internal image (`gcr.io/iguazio/python`) that only publishes amd64 images. When Docker pulls it "for arm64" (with QEMU), it gets the amd64 variant, so `pip download` runs
inside an **amd64** Python interpreter and fetches `manylinux_x86_64` wheels — even though the target platform is arm64.

## Fix

- **Switch `NUCLIO_PYTHON_BASE_IMAGE_NAME` default to `python`** — the official Docker Hub image with a proper multi-arch  manifest (`linux/amd64`, `linux/arm64`, etc.). The builder stage only needs a standard CPython to run `pip download` - seems that no iguazio-specific image is required.
- **Add `--platform $(NUCLIO_OS)/$(NUCLIO_ARCH)`** to the `handler-builder-python-onbuild` docker build command,
consistent with every other image target in the Makefile.

## Test
- Build only the python311-builder stage with the fix applied
```
  docker build \
    --platform linux/arm64 \
    --build-arg NUCLIO_PYTHON_BASE_IMAGE_NAME=python \
    --target python311-builder \
    --file pkg/processor/build/runtime/python/docker/onbuild/Dockerfile \
    --tag test-py311-arm64 \
    .
```
- Check what wheels were downloaded
```
  docker run --rm --platform linux/arm64 test-py311-arm64 ls /whl/
```
  Expected after fix — all wheel filenames should contain aarch64, not x86_64:
```
  msgpack-1.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
```