### PR TITLE
[RabbitMQ] Add async processing support

### DIFF
--- a/docs/reference/triggers/rabbitmq.md
+++ b/docs/reference/triggers/rabbitmq.md
@@ -106,3 +106,29 @@ During the enrichment stage, if credentials are provided within the URL, they ar
 The URL is then sanitized (i.e., credentials are removed) to prevent sensitive data from being exposed in logs or configurations.
 
 > Note: If both the URL and the trigger configuration specify credentials, the credentials from the URL take precedence and will override any existing username or password values in the trigger specification.
+
+## Asynchronous Mode
+
+The RabbitMQ trigger supports asynchronous processing mode with the Python runtime. In async mode, messages are dispatched concurrently, allowing a single worker to process multiple messages in parallel via multiple socket connections. This is especially beneficial for I/O-bound handlers.
+
+To enable async mode, set `mode: async` on the trigger configuration. You can optionally configure the number of connections per worker via `async.maxConnectionsNumber` (default: 1000).
+
+> **Note:** Async mode processes messages concurrently, so completion order is not guaranteed. If your function depends on strict message ordering, use the default sync mode. The `prefetchCount` attribute controls how many unacked messages RabbitMQ delivers at once, which naturally limits concurrency in async mode.
+
+For more details on async mode configuration and behavior, see [Asynchronous Mode](../../tasks/async-mode.md).
+
+### Async Mode Example
+
+```yaml
+triggers:
+  myRabbit:
+    kind: "rabbit-mq"
+    url: "amqp://user:pass@10.0.0.1:5672"
+    mode: async
+    async:
+      maxConnectionsNumber: 500
+    attributes:
+      exchangeName: "myExchangeName"
+      queueName: "myQueueName"
+      prefetchCount: 100
+```

--- a/docs/tasks/async-mode.md
+++ b/docs/tasks/async-mode.md
@@ -6,7 +6,7 @@
 
 Nuclio now supports asynchronous function invocation within a single worker process.
 This feature enhances performance and resource utilization, particularly in use cases where functions handle multiple concurrent requests. It is especially beneficial for I/O-bound operations.
-Currently, asynchronous mode is available only for HTTP triggers and the Python runtime.
+Currently, asynchronous mode is available for HTTP and RabbitMQ triggers with the Python runtime.
 
 ## Enabling Async Mode
 

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -188,6 +188,7 @@ var runtimesSupportBatching = []string{
 
 var triggerKindsSupportAsync = []string{
 	"http",
+	"rabbit-mq",
 }
 var runtimesSupportAsync = []string{
 	"python",

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -2588,6 +2588,26 @@ func (suite *AbstractPlatformTestSuite) TestValidateProcessingMode() {
 			},
 			expectedError: "failed to parse connection availability timeout",
 		},
+		{
+			name: "rabbit-mq async trigger with valid config -> no error",
+			functionConfig: &functionconfig.Config{
+				Spec: functionconfig.Spec{
+					Runtime: "python",
+					Triggers: map[string]functionconfig.Trigger{
+						"test-trigger": {
+							Name: "test-trigger",
+							Kind: "rabbit-mq",
+							Mode: functionconfig.AsyncTriggerWorkMode,
+							AsyncConfig: &functionconfig.AsyncConfig{
+								MaxConnectionsNumber: 10,
+								MinConnectionsNumber: 5,
+							},
+						},
+					},
+				},
+			},
+			expectedError: "",
+		},
 	}
 	for _, testCase := range testCases {
 		suite.Run(testCase.name, func() {

--- a/pkg/processor/trigger/rabbitmq/factory.go
+++ b/pkg/processor/trigger/rabbitmq/factory.go
@@ -50,8 +50,16 @@ func (f *factory) Create(parentLogger logger.Logger,
 	workerAllocator, err := f.GetWorkerAllocator(triggerConfiguration.WorkerAllocatorName,
 		namedWorkerAllocators,
 		func() (eventprocessor.Allocator, error) {
-			return worker.WorkerFactorySingleton.CreateFixedPoolWorkerAllocator(triggerLogger, configuration.NumWorkers,
-				runtimeConfiguration)
+			switch triggerConfiguration.Mode {
+			case functionconfig.AsyncTriggerWorkMode:
+				return worker.WorkerFactorySingleton.CreateNonBlockingWorkerAllocator(triggerLogger,
+					configuration.NumWorkers,
+					runtimeConfiguration)
+			default:
+				return worker.WorkerFactorySingleton.CreateFixedPoolWorkerAllocator(triggerLogger,
+					configuration.NumWorkers,
+					runtimeConfiguration)
+			}
 		})
 
 	if err != nil {

--- a/pkg/processor/trigger/rabbitmq/rabbitmq_test.go
+++ b/pkg/processor/trigger/rabbitmq/rabbitmq_test.go
@@ -21,8 +21,10 @@ package rabbitmq
 import (
 	"testing"
 
+	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/trigger"
 
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
@@ -83,6 +85,40 @@ func (suite *TestSuite) TestSetEmptyParametersMakesNoChange() {
 	suite.trigger.setEmptyParameters()
 
 	suite.EqualValues(suite.trigger.configuration.Topics, []string{})
+}
+
+func (suite *TestSuite) TestIsAsyncModeReturnsFalseByDefault() {
+	suite.trigger.configuration = &Configuration{
+		Configuration: trigger.Configuration{
+			Trigger: &functionconfig.Trigger{},
+		},
+	}
+
+	suite.Require().False(suite.trigger.isAsyncMode())
+}
+
+func (suite *TestSuite) TestIsAsyncModeReturnsFalseForSyncMode() {
+	suite.trigger.configuration = &Configuration{
+		Configuration: trigger.Configuration{
+			Trigger: &functionconfig.Trigger{
+				Mode: functionconfig.SyncTriggerWorkMode,
+			},
+		},
+	}
+
+	suite.Require().False(suite.trigger.isAsyncMode())
+}
+
+func (suite *TestSuite) TestIsAsyncModeReturnsTrueForAsyncMode() {
+	suite.trigger.configuration = &Configuration{
+		Configuration: trigger.Configuration{
+			Trigger: &functionconfig.Trigger{
+				Mode: functionconfig.AsyncTriggerWorkMode,
+			},
+		},
+	}
+
+	suite.Require().True(suite.trigger.isAsyncMode())
 }
 
 func TestRabbitMQSuite(t *testing.T) {

--- a/pkg/processor/trigger/rabbitmq/trigger.go
+++ b/pkg/processor/trigger/rabbitmq/trigger.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
@@ -43,6 +44,8 @@ type rabbitMq struct {
 	brokerInputMessagesChannel <-chan amqp.Delivery
 	stopChan                   chan struct{}
 	connectionErrorChan        chan *amqp.Error
+	inFlightMessages           sync.WaitGroup
+	handlerDone                chan struct{}
 }
 
 func newTrigger(parentLogger logger.Logger,
@@ -78,6 +81,14 @@ func (rmq *rabbitMq) Initialize() error {
 	}
 
 	rmq.setEmptyParameters()
+
+	// warn if async mode is used without a prefetch count, as this can lead to unbounded goroutine creation
+	if rmq.isAsyncMode() && rmq.configuration.PrefetchCount == 0 {
+		rmq.Logger.Warn("Async mode is enabled without a prefetchCount limit. " +
+			"This may cause unbounded goroutine creation under high throughput. " +
+			"Consider setting prefetchCount to limit concurrency")
+	}
+
 	return nil
 }
 
@@ -87,6 +98,7 @@ func (rmq *rabbitMq) Start(checkpoint functionconfig.Checkpoint) error {
 		"brokerUrl", rmq.configuration.URL)
 
 	rmq.stopChan = make(chan struct{})
+	rmq.handlerDone = make(chan struct{})
 
 	if err := rmq.createBrokerResources(); err != nil {
 		return errors.Wrap(err, "Failed to create broker resources")
@@ -102,6 +114,13 @@ func (rmq *rabbitMq) Stop(force bool) (functionconfig.Checkpoint, error) {
 
 	// stop listening for messages
 	close(rmq.stopChan)
+
+	// wait for the message handler loop to exit, so no new goroutines can be spawned
+	<-rmq.handlerDone
+
+	// now wait for any in-flight async message goroutines to complete
+	// before closing the broker channel, so they can properly ack/nack their messages
+	rmq.inFlightMessages.Wait()
 
 	// close broker
 	if err := rmq.brokerChannel.Close(); err != nil {
@@ -179,6 +198,8 @@ func (rmq *rabbitMq) getConnectionConfig() *amqp.Config {
 }
 
 func (rmq *rabbitMq) handleBrokerMessages() {
+	defer close(rmq.handlerDone)
+
 	for {
 		select {
 		case err := <-rmq.connectionErrorChan:
@@ -193,7 +214,17 @@ func (rmq *rabbitMq) handleBrokerMessages() {
 			rmq.Logger.DebugWith("Stopping consumption from queue", "queueName", rmq.configuration.QueueName)
 			return
 		case message := <-rmq.brokerInputMessagesChannel:
-			rmq.processMessage(&message)
+
+			// in async mode, dispatch each message in its own goroutine to allow concurrent processing
+			if rmq.isAsyncMode() {
+				rmq.inFlightMessages.Add(1)
+				go func() {
+					defer rmq.inFlightMessages.Done()
+					rmq.processMessage(&message)
+				}()
+			} else {
+				rmq.processMessage(&message)
+			}
 		}
 	}
 }
@@ -451,4 +482,8 @@ func (rmq *rabbitMq) getConsumerName() (string, error) {
 
 	// empty to let the client generate a random name
 	return consumerName, nil
+}
+
+func (rmq *rabbitMq) isAsyncMode() bool {
+	return rmq.configuration.Mode == functionconfig.AsyncTriggerWorkMode
 }


### PR DESCRIPTION
### 📝 Description

Add support for asynchronous processing mode on RabbitMQ triggers (Python runtime only). Previously, async mode was restricted to HTTP triggers. This change enables RabbitMQ triggers to process messages concurrently when configured with `mode: async`, while preserving the existing serial processing behavior for sync (default) mode.

---

### 🛠️ Changes Made

- **`pkg/functionconfig/types.go`**: Added `"rabbit-mq"` to the `triggerKindsSupportAsync` allowlist, enabling async mode at the platform validation layer.
- **`pkg/processor/trigger/rabbitmq/factory.go`**: Worker allocator creation now switches on trigger mode: `NonBlockingWorkerAllocator` for async, `FixedPoolWorkerAllocator` for sync/default. This mirrors the existing HTTP factory pattern.
- **`pkg/processor/trigger/rabbitmq/trigger.go`**:
  - In `handleBrokerMessages()`, async mode dispatches `processMessage` in its own goroutine for concurrent processing. Sync mode continues to process messages serially.
  - Added `sync.WaitGroup` (`inFlightMessages`) to track in-flight async goroutines and drain them gracefully in `Stop()` before closing the broker channel.
  - Added a warning log in `Initialize()` when async mode is used without a `prefetchCount` limit.
  - Added `isAsyncMode()` helper.
- **`pkg/processor/trigger/rabbitmq/rabbitmq_test.go`**: Three new unit tests verifying `isAsyncMode()` returns correct values for default/empty, explicit sync, and async modes.
- **`pkg/platform/abstract/platform_test.go`**: New test case confirming `rabbit-mq` with `AsyncTriggerWorkMode` passes platform validation.
- **`docs/tasks/async-mode.md`**: Updated supported triggers list to include RabbitMQ alongside HTTP.
- **`docs/reference/triggers/rabbitmq.md`**: Added "Asynchronous Mode" section with configuration details, ordering caveats, and an example.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

- **Unit tests** (`go test -tags test_unit`):
  - `pkg/processor/trigger/rabbitmq/...` – 10/10 passing (6 existing + 3 new `isAsyncMode` tests + 1 existing config test)
  - `pkg/platform/abstract` – `TestValidateProcessingMode` – 9/9 passing (8 existing + 1 new `rabbit-mq async trigger with valid config`)
- Sync (default) mode behavior is completely unchanged – the `if rmq.isAsyncMode()` branch only activates when the trigger is explicitly configured with `mode: async`.

---

### 🔗 References
- Ticket link: N/A
- Design docs links: N/A
- External links: N/A

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- **Runtime restriction**: Async mode only works with the Python runtime. The existing `runtimesSupportAsync` allowlist (Python only) enforces this, so no changes needed.
- **Message ordering**: Async mode processes messages concurrently, so completion order is not guaranteed. Users who depend on strict ordering should continue using the default sync mode.
- **Backpressure**: The default `prefetchCount` is 0 (unlimited). In async mode, each message spawns a goroutine, so running without a prefetch limit can cause unbounded goroutine creation. The trigger logs a warning at startup if async mode is enabled without a `prefetchCount`. Users should set it explicitly.
- **Graceful shutdown**: `Stop()` first waits for the message handler loop to exit via a `handlerDone` channel (preventing new goroutines from being spawned), then waits on a `sync.WaitGroup` to drain in-flight async goroutines, and only then closes the broker channel. This ensures all messages are properly ACKed/NACKed before teardown.
- **ACK/NACK semantics**: Each `processMessage` goroutine independently blocks until the worker returns, then ACKs/NACKs. The `amqp091-go` library supports concurrent ACK/NACK on the same channel.
