### PR TITLE
[RabbitMQ] Fix integration tests failing with transient non-exclusive queue error on RabbitMQ 4

### DIFF
--- a/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
+++ b/pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go
@@ -452,7 +452,7 @@ func (suite *testSuite) createBrokerResources(topics []string) {
 
 		suite.brokerQueue, err = suite.brokerChannel.QueueDeclare(
 			suite.brokerQueueName,
-			false,
+			true, // durable — required by RabbitMQ 4+ (transient non-exclusive queues removed)
 			false,
 			false,
 			false,

--- a/pkg/processor/trigger/rabbitmq/trigger.go
+++ b/pkg/processor/trigger/rabbitmq/trigger.go
@@ -275,7 +275,7 @@ func (rmq *rabbitMq) createTopics() error {
 
 	rmq.brokerQueue, err = rmq.brokerChannel.QueueDeclare(
 		rmq.configuration.QueueName,    // queue name (account  + function name)
-		rmq.configuration.DurableQueue, // durable  TBD: change to true if/when we bind to persistent storage
+		rmq.configuration.DurableQueue, // durable
 		false,                          // delete when unused
 		false,                          // exclusive
 		false,                          // no-wait

--- a/pkg/processor/trigger/rabbitmq/types.go
+++ b/pkg/processor/trigger/rabbitmq/types.go
@@ -54,7 +54,11 @@ func NewConfiguration(id string,
 	triggerConfiguration *functionconfig.Trigger,
 	runtimeConfiguration *runtime.Configuration) (*Configuration, error) {
 	var err error
-	newConfiguration := Configuration{}
+	newConfiguration := Configuration{
+		// default to durable queue, as newer versions of RabbitMQ require durable queues
+		// Can be overridden by the user by setting the durableQueue attribute to false
+		DurableQueue: true,
+	}
 
 	// create base
 	baseConfiguration, err := trigger.NewConfiguration(id, triggerConfiguration, runtimeConfiguration)


### PR DESCRIPTION
### 📝 Description

RabbitMQ 4.x removed support for `transient non-exclusive queues` — queues that are both non-durable (`durable=false`) and non-exclusive (`exclusive=false`). Attempting to declare such a queue raises:
```
Exception (541) Reason: "INTERNAL_ERROR - Feature transient_nonexcl_queues is deprecated"
```
This caused all RabbitMQ integration tests to fail on CI, which uses `rabbitmq:4-management`.

This PR fixes the issue by defaulting to durable queues, which are required by RabbitMQ 4.x.

---

### 🛠️  Changes Made

- **`pkg/processor/trigger/rabbitmq/types.go`**: Default `DurableQueue` to `true` in `NewConfiguration`. The field can still be explicitly overridden to `false` via the `durableQueue` trigger attribute (e.g. for exclusive queues). Removed the stale `TBD` comment in `trigger.go` that anticipated this change.
- **`pkg/processor/trigger/rabbitmq/test/rabbitmq_test.go`**: Changed the test-side `QueueDeclare` call from `durable=false` to `durable=true` to match RabbitMQ 4 requirements.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

- All RabbitMQ integration tests (`TestIntegrationSuite`) previously failed on CI with the `transient_nonexcl_queues` error; this fix resolves them by declaring durable queues.
- No unit tests changed — the fix is entirely in configuration defaults and the test broker setup.

---

### 🔗 References
- Failing CI tests: https://github.com/nuclio/nuclio/actions/runs/24944447757/job/73043330114
- [RabbitMQ – List of Deprecated Features (`transient_nonexcl_queues`)](https://www.rabbitmq.com/release-information/deprecated-features-list)          
- [RabbitMQ 4.0 Deprecation Announcements](https://www.rabbitmq.com/blog/2021/08/21/4.0-deprecation-announcements) 

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

> Existing deployments that never set `durableQueue: false` in their trigger config will
> silently switch to durable queues on upgrade. This is the correct behaviour on RabbitMQ 4
> and is safe on earlier versions. Users who explicitly set `durableQueue: false` are
> unaffected.

---

### 🔍️ Additional Notes

The `transient_nonexcl_queues` feature was deprecated in RabbitMQ 3.x and fully removed in RabbitMQ 4.x. The trigger code already had a comment marking `DurableQueue` as `TBD: change to true` - this PR acts on that note.
