### PR TITLE
[Docs] Fix ImageMagick broken link

### DIFF
--- a/docs/reference/runtimes/shell/shell-reference.md
+++ b/docs/reference/runtimes/shell/shell-reference.md
@@ -65,7 +65,7 @@ em-esrever
 
 ## Handle events with any executable binary
 
-Because the shell runtime simply forks a process, you can leverage it to run any executable binary in the container image. This means that you don't need to provide any code to the shell runtime, only a function configuration. In this example, you install the [ImageMagick](https://www.imagemagick.org/script/index.php) utility and call its `convert` executable on each event. You then send the function images and use `convert` to reduce the image by 50% in the response. You do this by invoking the `nuctl` CLI as follows:
+Because the shell runtime simply forks a process, you can leverage it to run any executable binary in the container image. This means that you don't need to provide any code to the shell runtime, only a function configuration. In this example, you install the [ImageMagick](https://imagemagick.org) utility and call its `convert` executable on each event. You then send the function images and use `convert` to reduce the image by 50% in the response. You do this by invoking the `nuctl` CLI as follows:
 
 ```sh
 nuctl deploy -p /dev/null convert \


### PR DESCRIPTION
### 📝 Description

Fix the `ImageMagick` link that doesn't exist anymore

---

### 🛠️ Changes Made

- `docs/reference/runtimes/shell/shell-reference.md` - replace the `ImageMagick` link to their homepage - https://imagemagick.org/

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- ran `make linkcheck`
---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->