### PR TITLE
[Clients] Add retry wrapper for Nuclio CRD client

### DIFF
--- a/pkg/platform/abstract/project/internalc/kube/kube.go
+++ b/pkg/platform/abstract/project/internalc/kube/kube.go
@@ -63,9 +63,9 @@ func (c *Client) Get(ctx context.Context, getProjectsOptions *platform.GetProjec
 	if getProjectsOptions.Meta.Name != "" {
 
 		// get specific NuclioProject CR
-		projectInstance, err := c.consumer.NuclioClientSet.NuclioV1beta1().
-			NuclioProjects(getProjectsOptions.Meta.Namespace).
-			Get(ctx, getProjectsOptions.Meta.Name, metav1.GetOptions{})
+		projectInstance, err := c.consumer.NuclioClientSet.GetNuclioProject(ctx,
+			getProjectsOptions.Meta.Namespace,
+			getProjectsOptions.Meta.Name)
 
 		if err != nil {
 
@@ -81,9 +81,9 @@ func (c *Client) Get(ctx context.Context, getProjectsOptions *platform.GetProjec
 
 	} else {
 
-		projectInstanceList, err := c.consumer.NuclioClientSet.NuclioV1beta1().
-			NuclioProjects(getProjectsOptions.Meta.Namespace).
-			List(ctx, metav1.ListOptions{LabelSelector: ""})
+		projectInstanceList, err := c.consumer.NuclioClientSet.ListNuclioProjects(ctx,
+			getProjectsOptions.Meta.Namespace,
+			metav1.ListOptions{})
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to list projects")
 		}
@@ -111,9 +111,7 @@ func (c *Client) Create(ctx context.Context, createProjectOptions *platform.Crea
 	newProject := nuclioio.NuclioProject{}
 	c.platformProjectToProject(createProjectOptions.ProjectConfig, &newProject)
 
-	nuclioProject, err := c.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioProjects(newProject.Namespace).
-		Create(ctx, &newProject, metav1.CreateOptions{})
+	nuclioProject, err := c.consumer.NuclioClientSet.CreateNuclioProject(ctx, newProject.Namespace, &newProject)
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			return nil, nuclio.WrapErrConflict(err)
@@ -125,9 +123,9 @@ func (c *Client) Create(ctx context.Context, createProjectOptions *platform.Crea
 }
 
 func (c *Client) Update(ctx context.Context, updateProjectOptions *platform.UpdateProjectOptions) (platform.Project, error) {
-	projectInstance, err := c.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioProjects(updateProjectOptions.ProjectConfig.Meta.Namespace).
-		Get(ctx, updateProjectOptions.ProjectConfig.Meta.Name, metav1.GetOptions{})
+	projectInstance, err := c.consumer.NuclioClientSet.GetNuclioProject(ctx,
+		updateProjectOptions.ProjectConfig.Meta.Namespace,
+		updateProjectOptions.ProjectConfig.Meta.Name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nuclio.WrapErrNotFound(err)
@@ -144,9 +142,7 @@ func (c *Client) Update(ctx context.Context, updateProjectOptions *platform.Upda
 	now := time.Now()
 	projectInstance.Status.UpdatedAt = &now
 
-	nuclioProject, err := c.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioProjects(projectInstance.Namespace).
-		Update(ctx, projectInstance, metav1.UpdateOptions{})
+	nuclioProject, err := c.consumer.NuclioClientSet.UpdateNuclioProject(ctx, projectInstance.Namespace, projectInstance)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to update nuclio project")
 	}
@@ -155,9 +151,10 @@ func (c *Client) Update(ctx context.Context, updateProjectOptions *platform.Upda
 }
 
 func (c *Client) Delete(ctx context.Context, deleteProjectOptions *platform.DeleteProjectOptions) error {
-	if err := c.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioProjects(deleteProjectOptions.Meta.Namespace).
-		Delete(ctx, deleteProjectOptions.Meta.Name, metav1.DeleteOptions{}); err != nil {
+	if err := c.consumer.NuclioClientSet.DeleteNuclioProject(ctx,
+		deleteProjectOptions.Meta.Namespace,
+		deleteProjectOptions.Meta.Name,
+		metav1.DeleteOptions{}); err != nil {
 
 		if apierrors.IsNotFound(err) {
 			return nuclio.NewErrNotFound(fmt.Sprintf("Project %s not found", deleteProjectOptions.Meta.Name))

--- a/pkg/platform/kube/clients/nuclio/client.go
+++ b/pkg/platform/kube/clients/nuclio/client.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2025 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nuclio
+
+import (
+	"context"
+	"time"
+
+	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+	"github.com/nuclio/nuclio/pkg/platform/kube/clients"
+	nuclioioclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio/clientset/versioned"
+
+	"github.com/nuclio/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+type clientWithRetry struct {
+	nuclioioclient.Interface
+	retries int
+	delay   time.Duration
+}
+
+func NewClientWithRetryFromConfig(config *rest.Config) (Client, error) {
+	nuclioClient, err := nuclioioclient.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create Nuclio client")
+	}
+	return &clientWithRetry{
+		Interface: nuclioClient,
+		retries:   clients.MaxRetries,
+		delay:     clients.Delay,
+	}, nil
+}
+
+func NewClientWithRetryFromClient(nuclioClient nuclioioclient.Interface) Client {
+	return &clientWithRetry{
+		Interface: nuclioClient,
+		retries:   clients.MaxRetries,
+		delay:     clients.Delay,
+	}
+}
+
+// --- NuclioFunction methods ---
+
+func (c *clientWithRetry) GetNuclioFunction(ctx context.Context, namespace, name string) (*nuclioio.NuclioFunction, error) {
+	return clients.RequestWithRetry[*nuclioio.NuclioFunction](func() (*nuclioio.NuclioFunction, error) {
+		return c.NuclioV1beta1().NuclioFunctions(namespace).Get(ctx, name, metav1.GetOptions{})
+	}, c.retries, c.delay)
+}
+
+func (c *clientWithRetry) ListNuclioFunctions(ctx context.Context, namespace string, opts metav1.ListOptions) (*nuclioio.NuclioFunctionList, error) {
+	return clients.RequestWithRetry[*nuclioio.NuclioFunctionList](func() (*nuclioio.NuclioFunctionList, error) {
+		return c.NuclioV1beta1().NuclioFunctions(namespace).List(ctx, opts)
+	}, c.retries, c.delay)
+}
+
+func (c *clientWithRetry) CreateNuclioFunction(ctx context.Context, namespace string, function *nuclioio.NuclioFunction) (*nuclioio.NuclioFunction, error) {
+	return clients.RequestWithRetry[*nuclioio.NuclioFunction](func() (*nuclioio.NuclioFunction, error) {
+		return c.NuclioV1beta1().NuclioFunctions(namespace).Create(ctx, function, metav1.CreateOptions{})
+	}, c.retries, c.delay)
+}
+
+func (c *clientWithRetry) UpdateNuclioFunction(ctx context.Context, namespace string, function *nuclioio.NuclioFunction) (*nuclioio.NuclioFunction, error) {
+	return clients.RequestWithRetry[*nuclioio.NuclioFunction](func() (*nuclioio.NuclioFunction, error) {
+		return c.NuclioV1beta1().NuclioFunctions(namespace).Update(ctx, function, metav1.UpdateOptions{})
+	}, c.retries, c.delay)
+}
+
+func (c *clientWithRetry) DeleteNuclioFunction(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) (err error) {
+	_, err = clients.RequestWithRetry(func() (any, error) {
+		return nil, c.NuclioV1beta1().NuclioFunctions(namespace).Delete(ctx, name, opts)
+	}, c.retries, c.delay)
+	return
+}
+
+// --- NuclioProject methods ---
+
+func (c *clientWithRetry) GetNuclioProject(ctx context.Context, namespace, name string) (*nuclioio.NuclioProject, error) {
+	return clients.RequestWithRetry[*nuclioio.NuclioProject](func() (*nuclioio.NuclioProject, error) {
+		return c.NuclioV1beta1().NuclioProjects(namespace).Get(ctx, name, metav1.GetOptions{})
+	}, c.retries, c.delay)
+}
+
+func (c *clientWithRetry) ListNuclioProjects(ctx context.Context, namespace string, opts metav1.ListOptions) (*nuclioio.NuclioProjectList, error) {
+	return clients.RequestWithRetry[*nuclioio.NuclioProjectList](func() (*nuclioio.NuclioProjectList, error) {
+		return c.NuclioV1beta1().NuclioProjects(namespace).List(ctx, opts)
+	}, c.retries, c.delay)
+}
+
+func (c *clientWithRetry) CreateNuclioProject(ctx context.Context, namespace string, project *nuclioio.NuclioProject) (*nuclioio.NuclioProject, error) {
+	return clients.RequestWithRetry[*nuclioio.NuclioProject](func() (*nuclioio.NuclioProject, error) {
+		return c.NuclioV1beta1().NuclioProjects(namespace).Create(ctx, project, metav1.CreateOptions{})
+	}, c.retries, c.delay)
+}
+
+func (c *clientWithRetry) UpdateNuclioProject(ctx context.Context, namespace string, project *nuclioio.NuclioProject) (*nuclioio.NuclioProject, error) {
+	return clients.RequestWithRetry[*nuclioio.NuclioProject](func() (*nuclioio.NuclioProject, error) {
+		return c.NuclioV1beta1().NuclioProjects(namespace).Update(ctx, project, metav1.UpdateOptions{})
+	}, c.retries, c.delay)
+}
+
+func (c *clientWithRetry) DeleteNuclioProject(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) (err error) {
+	_, err = clients.RequestWithRetry(func() (any, error) {
+		return nil, c.NuclioV1beta1().NuclioProjects(namespace).Delete(ctx, name, opts)
+	}, c.retries, c.delay)
+	return
+}
+
+// --- NuclioAPIGateway methods ---
+
+func (c *clientWithRetry) GetNuclioAPIGateway(ctx context.Context, namespace, name string) (*nuclioio.NuclioAPIGateway, error) {
+	return clients.RequestWithRetry[*nuclioio.NuclioAPIGateway](func() (*nuclioio.NuclioAPIGateway, error) {
+		return c.NuclioV1beta1().NuclioAPIGateways(namespace).Get(ctx, name, metav1.GetOptions{})
+	}, c.retries, c.delay)
+}
+
+func (c *clientWithRetry) ListNuclioAPIGateways(ctx context.Context, namespace string, opts metav1.ListOptions) (*nuclioio.NuclioAPIGatewayList, error) {
+	return clients.RequestWithRetry[*nuclioio.NuclioAPIGatewayList](func() (*nuclioio.NuclioAPIGatewayList, error) {
+		return c.NuclioV1beta1().NuclioAPIGateways(namespace).List(ctx, opts)
+	}, c.retries, c.delay)
+}
+
+func (c *clientWithRetry) CreateNuclioAPIGateway(ctx context.Context, namespace string, apiGateway *nuclioio.NuclioAPIGateway) (*nuclioio.NuclioAPIGateway, error) {
+	return clients.RequestWithRetry[*nuclioio.NuclioAPIGateway](func() (*nuclioio.NuclioAPIGateway, error) {
+		return c.NuclioV1beta1().NuclioAPIGateways(namespace).Create(ctx, apiGateway, metav1.CreateOptions{})
+	}, c.retries, c.delay)
+}
+
+func (c *clientWithRetry) UpdateNuclioAPIGateway(ctx context.Context, namespace string, apiGateway *nuclioio.NuclioAPIGateway) (*nuclioio.NuclioAPIGateway, error) {
+	return clients.RequestWithRetry[*nuclioio.NuclioAPIGateway](func() (*nuclioio.NuclioAPIGateway, error) {
+		return c.NuclioV1beta1().NuclioAPIGateways(namespace).Update(ctx, apiGateway, metav1.UpdateOptions{})
+	}, c.retries, c.delay)
+}
+
+func (c *clientWithRetry) DeleteNuclioAPIGateway(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) (err error) {
+	_, err = clients.RequestWithRetry(func() (any, error) {
+		return nil, c.NuclioV1beta1().NuclioAPIGateways(namespace).Delete(ctx, name, opts)
+	}, c.retries, c.delay)
+	return
+}
+
+// --- NuclioFunctionEvent methods ---
+
+func (c *clientWithRetry) GetNuclioFunctionEvent(ctx context.Context, namespace, name string) (*nuclioio.NuclioFunctionEvent, error) {
+	return clients.RequestWithRetry[*nuclioio.NuclioFunctionEvent](func() (*nuclioio.NuclioFunctionEvent, error) {
+		return c.NuclioV1beta1().NuclioFunctionEvents(namespace).Get(ctx, name, metav1.GetOptions{})
+	}, c.retries, c.delay)
+}
+
+func (c *clientWithRetry) ListNuclioFunctionEvents(ctx context.Context, namespace string, opts metav1.ListOptions) (*nuclioio.NuclioFunctionEventList, error) {
+	return clients.RequestWithRetry[*nuclioio.NuclioFunctionEventList](func() (*nuclioio.NuclioFunctionEventList, error) {
+		return c.NuclioV1beta1().NuclioFunctionEvents(namespace).List(ctx, opts)
+	}, c.retries, c.delay)
+}
+
+func (c *clientWithRetry) CreateNuclioFunctionEvent(ctx context.Context, namespace string, functionEvent *nuclioio.NuclioFunctionEvent) (*nuclioio.NuclioFunctionEvent, error) {
+	return clients.RequestWithRetry[*nuclioio.NuclioFunctionEvent](func() (*nuclioio.NuclioFunctionEvent, error) {
+		return c.NuclioV1beta1().NuclioFunctionEvents(namespace).Create(ctx, functionEvent, metav1.CreateOptions{})
+	}, c.retries, c.delay)
+}
+
+func (c *clientWithRetry) UpdateNuclioFunctionEvent(ctx context.Context, namespace string, functionEvent *nuclioio.NuclioFunctionEvent) (*nuclioio.NuclioFunctionEvent, error) {
+	return clients.RequestWithRetry[*nuclioio.NuclioFunctionEvent](func() (*nuclioio.NuclioFunctionEvent, error) {
+		return c.NuclioV1beta1().NuclioFunctionEvents(namespace).Update(ctx, functionEvent, metav1.UpdateOptions{})
+	}, c.retries, c.delay)
+}
+
+func (c *clientWithRetry) DeleteNuclioFunctionEvent(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) (err error) {
+	_, err = clients.RequestWithRetry(func() (any, error) {
+		return nil, c.NuclioV1beta1().NuclioFunctionEvents(namespace).Delete(ctx, name, opts)
+	}, c.retries, c.delay)
+	return
+}

--- a/pkg/platform/kube/clients/nuclio/consumer.go
+++ b/pkg/platform/kube/clients/nuclio/consumer.go
@@ -23,7 +23,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
-	nuclioioclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio/clientset/versioned"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -33,7 +32,7 @@ import (
 )
 
 type Consumer struct {
-	NuclioClientSet nuclioioclient.Interface
+	NuclioClientSet Client
 	KubeClientSet   kube.Client
 	KubeHost        string
 	kubeconfigPath  string
@@ -67,8 +66,8 @@ func NewConsumer(ctx context.Context, logger logger.Logger, kubeconfigPath strin
 		return nil, errors.Wrap(err, "Failed to create client set")
 	}
 
-	// create a client for function custom resources
-	newConsumer.NuclioClientSet, err = nuclioioclient.NewForConfig(restConfig)
+	// create a retry-wrapped client for function custom resources
+	newConsumer.NuclioClientSet, err = NewClientWithRetryFromConfig(restConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create function custom resource client")
 	}
@@ -76,7 +75,7 @@ func NewConsumer(ctx context.Context, logger logger.Logger, kubeconfigPath strin
 	return &newConsumer, nil
 }
 
-func (c *Consumer) getNuclioClientSet(authConfig *platform.AuthConfig) (nuclioioclient.Interface, error) {
+func (c *Consumer) getNuclioClientSet(authConfig *platform.AuthConfig) (Client, error) {
 
 	// if no authentication was passed, can use the generic client. otherwise must create
 	if authConfig == nil {
@@ -92,5 +91,5 @@ func (c *Consumer) getNuclioClientSet(authConfig *platform.AuthConfig) (nuclioio
 	// set the auth provider config
 	restConfig.BearerToken = authConfig.Token
 
-	return nuclioioclient.NewForConfig(restConfig)
+	return NewClientWithRetryFromConfig(restConfig)
 }

--- a/pkg/platform/kube/clients/nuclio/deleter.go
+++ b/pkg/platform/kube/clients/nuclio/deleter.go
@@ -63,13 +63,11 @@ func (d *Deleter) Delete(ctx context.Context, consumer *Consumer, deleteFunction
 		}
 	}
 
-	// get specific function CR
-	if err := nuclioClientSet.
-		NuclioV1beta1().
-		NuclioFunctions(deleteFunctionOptions.FunctionConfig.Meta.Namespace).
-		Delete(ctx, resourceName, metav1.DeleteOptions{
-			Preconditions: deletePreconditions,
-		}); err != nil && !apierrors.IsNotFound(err) {
+	// delete the specific function CR
+	if err := nuclioClientSet.DeleteNuclioFunction(ctx,
+		deleteFunctionOptions.FunctionConfig.Meta.Namespace,
+		resourceName,
+		metav1.DeleteOptions{Preconditions: deletePreconditions}); err != nil && !apierrors.IsNotFound(err) {
 		return errors.Wrap(err, "Failed to delete function CR")
 	}
 

--- a/pkg/platform/kube/clients/nuclio/deployer.go
+++ b/pkg/platform/kube/clients/nuclio/deployer.go
@@ -116,13 +116,9 @@ func (d *Deployer) CreateOrUpdateFunction(ctx context.Context,
 
 	// if function didn't exist, create. otherwise update
 	if !functionExists {
-		functionInstance, err = nuclioClientSet.NuclioV1beta1().
-			NuclioFunctions(functionInstance.Namespace).
-			Create(ctx, functionInstance, metav1.CreateOptions{})
+		functionInstance, err = nuclioClientSet.CreateNuclioFunction(ctx, functionInstance.Namespace, functionInstance)
 	} else {
-		functionInstance, err = nuclioClientSet.NuclioV1beta1().
-			NuclioFunctions(functionInstance.Namespace).
-			Update(ctx, functionInstance, metav1.UpdateOptions{})
+		functionInstance, err = nuclioClientSet.UpdateNuclioFunction(ctx, functionInstance.Namespace, functionInstance)
 	}
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create/update function")
@@ -317,9 +313,7 @@ func waitForFunctionReadiness(ctx context.Context,
 	conditionFunc := func(conditionCtx context.Context) (bool, error) {
 
 		// get the appropriate function CR
-		function, err = consumer.NuclioClientSet.NuclioV1beta1().
-			NuclioFunctions(namespace).
-			Get(conditionCtx, name, metav1.GetOptions{})
+		function, err = consumer.NuclioClientSet.GetNuclioFunction(conditionCtx, namespace, name)
 		if err != nil {
 			return true, err
 		}

--- a/pkg/platform/kube/clients/nuclio/getter.go
+++ b/pkg/platform/kube/clients/nuclio/getter.go
@@ -52,10 +52,7 @@ func (g *Getter) Get(ctx context.Context,
 	if getFunctionsOptions.Name != "" {
 
 		// Get specific function CR
-		function, err := consumer.NuclioClientSet.
-			NuclioV1beta1().
-			NuclioFunctions(getFunctionsOptions.Namespace).
-			Get(ctx, getFunctionsOptions.Name, metav1.GetOptions{})
+		function, err := consumer.NuclioClientSet.GetNuclioFunction(ctx, getFunctionsOptions.Namespace, getFunctionsOptions.Name)
 		if err != nil {
 
 			// if we didn't find the function, return an empty slice
@@ -71,9 +68,11 @@ func (g *Getter) Get(ctx context.Context,
 	} else {
 
 		functionInstanceList, err := consumer.NuclioClientSet.
-			NuclioV1beta1().
-			NuclioFunctions(getFunctionsOptions.Namespace).
-			List(ctx, metav1.ListOptions{LabelSelector: getFunctionsOptions.Labels})
+			ListNuclioFunctions(ctx,
+				getFunctionsOptions.Namespace,
+				metav1.ListOptions{
+					LabelSelector: getFunctionsOptions.Labels,
+				})
 
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to list functions")

--- a/pkg/platform/kube/clients/nuclio/types.go
+++ b/pkg/platform/kube/clients/nuclio/types.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2025 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nuclio
+
+import (
+	"context"
+
+	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Client provides resilient methods to interact with Nuclio CRDs
+type Client interface {
+
+	// --- NuclioFunctions ---
+
+	// GetNuclioFunction fetches a specific NuclioFunction by name from a given namespace.
+	GetNuclioFunction(ctx context.Context, namespace, name string) (*nuclioio.NuclioFunction, error)
+
+	// ListNuclioFunctions retrieves the list of NuclioFunctions in a given namespace.
+	ListNuclioFunctions(ctx context.Context, namespace string, opts metav1.ListOptions) (*nuclioio.NuclioFunctionList, error)
+
+	// CreateNuclioFunction creates a new NuclioFunction in the specified namespace.
+	CreateNuclioFunction(ctx context.Context, namespace string, function *nuclioio.NuclioFunction) (*nuclioio.NuclioFunction, error)
+
+	// UpdateNuclioFunction updates an existing NuclioFunction in the specified namespace.
+	UpdateNuclioFunction(ctx context.Context, namespace string, function *nuclioio.NuclioFunction) (*nuclioio.NuclioFunction, error)
+
+	// DeleteNuclioFunction removes a NuclioFunction from the specified namespace.
+	DeleteNuclioFunction(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
+
+	// --- NuclioProjects ---
+
+	// GetNuclioProject fetches a specific NuclioProject by name from a given namespace.
+	GetNuclioProject(ctx context.Context, namespace, name string) (*nuclioio.NuclioProject, error)
+
+	// ListNuclioProjects retrieves the list of NuclioProjects in a given namespace.
+	ListNuclioProjects(ctx context.Context, namespace string, opts metav1.ListOptions) (*nuclioio.NuclioProjectList, error)
+
+	// CreateNuclioProject creates a new NuclioProject in the specified namespace.
+	CreateNuclioProject(ctx context.Context, namespace string, project *nuclioio.NuclioProject) (*nuclioio.NuclioProject, error)
+
+	// UpdateNuclioProject updates an existing NuclioProject in the specified namespace.
+	UpdateNuclioProject(ctx context.Context, namespace string, project *nuclioio.NuclioProject) (*nuclioio.NuclioProject, error)
+
+	// DeleteNuclioProject removes a NuclioProject from the specified namespace.
+	DeleteNuclioProject(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
+
+	// --- NuclioAPIGateways ---
+
+	// GetNuclioAPIGateway fetches a specific NuclioAPIGateway by name from a given namespace.
+	GetNuclioAPIGateway(ctx context.Context, namespace, name string) (*nuclioio.NuclioAPIGateway, error)
+
+	// ListNuclioAPIGateways retrieves the list of NuclioAPIGateways in a given namespace.
+	ListNuclioAPIGateways(ctx context.Context, namespace string, opts metav1.ListOptions) (*nuclioio.NuclioAPIGatewayList, error)
+
+	// CreateNuclioAPIGateway creates a new NuclioAPIGateway in the specified namespace.
+	CreateNuclioAPIGateway(ctx context.Context, namespace string, apiGateway *nuclioio.NuclioAPIGateway) (*nuclioio.NuclioAPIGateway, error)
+
+	// UpdateNuclioAPIGateway updates an existing NuclioAPIGateway in the specified namespace.
+	UpdateNuclioAPIGateway(ctx context.Context, namespace string, apiGateway *nuclioio.NuclioAPIGateway) (*nuclioio.NuclioAPIGateway, error)
+
+	// DeleteNuclioAPIGateway removes a NuclioAPIGateway from the specified namespace.
+	DeleteNuclioAPIGateway(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
+
+	// --- NuclioFunctionEvents ---
+
+	// GetNuclioFunctionEvent fetches a specific NuclioFunctionEvent by name from a given namespace.
+	GetNuclioFunctionEvent(ctx context.Context, namespace, name string) (*nuclioio.NuclioFunctionEvent, error)
+
+	// ListNuclioFunctionEvents retrieves the list of NuclioFunctionEvents in a given namespace.
+	ListNuclioFunctionEvents(ctx context.Context, namespace string, opts metav1.ListOptions) (*nuclioio.NuclioFunctionEventList, error)
+
+	// CreateNuclioFunctionEvent creates a new NuclioFunctionEvent in the specified namespace.
+	CreateNuclioFunctionEvent(ctx context.Context, namespace string, functionEvent *nuclioio.NuclioFunctionEvent) (*nuclioio.NuclioFunctionEvent, error)
+
+	// UpdateNuclioFunctionEvent updates an existing NuclioFunctionEvent in the specified namespace.
+	UpdateNuclioFunctionEvent(ctx context.Context, namespace string, functionEvent *nuclioio.NuclioFunctionEvent) (*nuclioio.NuclioFunctionEvent, error)
+
+	// DeleteNuclioFunctionEvent removes a NuclioFunctionEvent from the specified namespace.
+	DeleteNuclioFunctionEvent(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error
+}

--- a/pkg/platform/kube/clients/nuclio/updater.go
+++ b/pkg/platform/kube/clients/nuclio/updater.go
@@ -28,7 +28,6 @@ import (
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/opa-client"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type Updater struct {
@@ -51,11 +50,9 @@ func (u *Updater) Update(ctx context.Context, updateFunctionOptions *platform.Up
 	u.logger.InfoWithCtx(ctx, "Updating function", "name", updateFunctionOptions.FunctionMeta.Name)
 
 	// get specific function CR
-	function, err := u.consumer.
-		NuclioClientSet.
-		NuclioV1beta1().
-		NuclioFunctions(updateFunctionOptions.FunctionMeta.Namespace).
-		Get(ctx, updateFunctionOptions.FunctionMeta.Name, metav1.GetOptions{})
+	function, err := u.consumer.NuclioClientSet.GetNuclioFunction(ctx,
+		updateFunctionOptions.FunctionMeta.Namespace,
+		updateFunctionOptions.FunctionMeta.Name)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get function")
 	}
@@ -97,10 +94,9 @@ func (u *Updater) Update(ctx context.Context, updateFunctionOptions *platform.Up
 	}
 
 	// trigger an update
-	updatedFunction, err := nuclioClientSet.
-		NuclioV1beta1().
-		NuclioFunctions(updateFunctionOptions.FunctionMeta.Namespace).
-		Update(ctx, function, metav1.UpdateOptions{})
+	updatedFunction, err := nuclioClientSet.UpdateNuclioFunction(ctx,
+		updateFunctionOptions.FunctionMeta.Namespace,
+		function)
 	if err != nil {
 		return errors.Wrap(err, "Failed to update function CR")
 	}
@@ -132,10 +128,7 @@ func (u *Updater) UpdateState(ctx context.Context, functionName, namespace strin
 	}
 
 	// get specific function CR
-	function, err := nuclioClientSet.
-		NuclioV1beta1().
-		NuclioFunctions(namespace).
-		Get(ctx, functionName, metav1.GetOptions{})
+	function, err := nuclioClientSet.GetNuclioFunction(ctx, namespace, functionName)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get function")
 	}
@@ -156,10 +149,7 @@ func (u *Updater) UpdateState(ctx context.Context, functionName, namespace strin
 	delete(function.Annotations, functionconfig.FunctionAnnotationSkipBuild)
 
 	// trigger an update
-	updatedFunction, err := nuclioClientSet.
-		NuclioV1beta1().
-		NuclioFunctions(namespace).
-		Update(ctx, function, metav1.UpdateOptions{})
+	updatedFunction, err := nuclioClientSet.UpdateNuclioFunction(ctx, namespace, function)
 	if err != nil {
 		return errors.Wrap(err, "Failed to update function CR")
 	}

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -932,9 +932,7 @@ func (p *Platform) CreateAPIGateway(ctx context.Context,
 	newAPIGateway.Status.State = platform.APIGatewayStateWaitingForProvisioning
 
 	// create
-	if _, err := p.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioAPIGateways(newAPIGateway.Namespace).
-		Create(ctx, newAPIGateway, metav1.CreateOptions{}); err != nil {
+	if _, err := p.consumer.NuclioClientSet.CreateNuclioAPIGateway(ctx, newAPIGateway.Namespace, newAPIGateway); err != nil {
 		return errors.Wrap(err, "Failed to create an API gateway")
 	}
 
@@ -944,9 +942,9 @@ func (p *Platform) CreateAPIGateway(ctx context.Context,
 // UpdateAPIGateway will update a previously existing api gateway
 func (p *Platform) UpdateAPIGateway(ctx context.Context, updateAPIGatewayOptions *platform.UpdateAPIGatewayOptions) error {
 	// get existing api gateway
-	apiGateway, err := p.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioAPIGateways(updateAPIGatewayOptions.APIGatewayConfig.Meta.Namespace).
-		Get(ctx, updateAPIGatewayOptions.APIGatewayConfig.Meta.Name, metav1.GetOptions{})
+	apiGateway, err := p.consumer.NuclioClientSet.GetNuclioAPIGateway(ctx,
+		updateAPIGatewayOptions.APIGatewayConfig.Meta.Namespace,
+		updateAPIGatewayOptions.APIGatewayConfig.Meta.Name)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get api gateway to update")
 	}
@@ -1012,9 +1010,9 @@ func (p *Platform) UpdateAPIGateway(ctx context.Context, updateAPIGatewayOptions
 	apiGateway.Status.State = platform.APIGatewayStateWaitingForProvisioning
 
 	// update
-	if _, err := p.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioAPIGateways(updateAPIGatewayOptions.APIGatewayConfig.Meta.Namespace).
-		Update(ctx, apiGateway, metav1.UpdateOptions{}); err != nil {
+	if _, err := p.consumer.NuclioClientSet.UpdateNuclioAPIGateway(ctx,
+		updateAPIGatewayOptions.APIGatewayConfig.Meta.Namespace,
+		apiGateway); err != nil {
 		return errors.Wrap(err, "Failed to update an api gateway")
 	}
 
@@ -1030,9 +1028,9 @@ func (p *Platform) DeleteAPIGateway(ctx context.Context, deleteAPIGatewayOptions
 	}
 
 	// get existing api gateway to resolve project name for OPA check
-	apiGatewayToDelete, err := p.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioAPIGateways(deleteAPIGatewayOptions.Meta.Namespace).
-		Get(ctx, deleteAPIGatewayOptions.Meta.Name, metav1.GetOptions{})
+	apiGatewayToDelete, err := p.consumer.NuclioClientSet.GetNuclioAPIGateway(ctx,
+		deleteAPIGatewayOptions.Meta.Namespace,
+		deleteAPIGatewayOptions.Meta.Name)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get API gateway to delete")
 	}
@@ -1052,9 +1050,10 @@ func (p *Platform) DeleteAPIGateway(ctx context.Context, deleteAPIGatewayOptions
 	p.Logger.DebugWithCtx(ctx, "Deleting api gateway", "name", deleteAPIGatewayOptions.Meta.Name)
 
 	// delete
-	if err := p.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioAPIGateways(deleteAPIGatewayOptions.Meta.Namespace).
-		Delete(ctx, deleteAPIGatewayOptions.Meta.Name, metav1.DeleteOptions{}); err != nil {
+	if err := p.consumer.NuclioClientSet.DeleteNuclioAPIGateway(ctx,
+		deleteAPIGatewayOptions.Meta.Namespace,
+		deleteAPIGatewayOptions.Meta.Name,
+		metav1.DeleteOptions{}); err != nil {
 
 		return errors.Wrapf(err,
 			"Failed to delete API gateway %s from namespace %s",
@@ -1075,9 +1074,9 @@ func (p *Platform) GetAPIGateways(ctx context.Context, getAPIGatewaysOptions *pl
 	if getAPIGatewaysOptions.Name != "" {
 
 		// get specific NuclioAPIGateway CR
-		apiGateway, err := p.consumer.NuclioClientSet.NuclioV1beta1().
-			NuclioAPIGateways(getAPIGatewaysOptions.Namespace).
-			Get(ctx, getAPIGatewaysOptions.Name, metav1.GetOptions{})
+		apiGateway, err := p.consumer.NuclioClientSet.GetNuclioAPIGateway(ctx,
+			getAPIGatewaysOptions.Namespace,
+			getAPIGatewaysOptions.Name)
 		if err != nil {
 
 			// if we didn't find the NuclioAPIGateway, return an empty slice
@@ -1152,9 +1151,9 @@ func (p *Platform) CreateFunctionEvent(ctx context.Context, createFunctionEventO
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
-	if _, err := p.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioFunctionEvents(createFunctionEventOptions.FunctionEventConfig.Meta.Namespace).
-		Create(ctx, &newFunctionEvent, metav1.CreateOptions{}); err != nil {
+	if _, err := p.consumer.NuclioClientSet.CreateNuclioFunctionEvent(ctx,
+		createFunctionEventOptions.FunctionEventConfig.Meta.Namespace,
+		&newFunctionEvent); err != nil {
 		return errors.Wrap(err, "Failed to create a function event")
 	}
 	return nil
@@ -1165,9 +1164,9 @@ func (p *Platform) UpdateFunctionEvent(ctx context.Context, updateFunctionEventO
 	updatedFunctionEvent := nuclioio.NuclioFunctionEvent{}
 	p.platformFunctionEventToFunctionEvent(&updateFunctionEventOptions.FunctionEventConfig, &updatedFunctionEvent)
 
-	functionEvent, err := p.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioFunctionEvents(updateFunctionEventOptions.FunctionEventConfig.Meta.Namespace).
-		Get(ctx, updateFunctionEventOptions.FunctionEventConfig.Meta.Name, metav1.GetOptions{})
+	functionEvent, err := p.consumer.NuclioClientSet.GetNuclioFunctionEvent(ctx,
+		updateFunctionEventOptions.FunctionEventConfig.Meta.Namespace,
+		updateFunctionEventOptions.FunctionEventConfig.Meta.Name)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get a function event")
 	}
@@ -1195,9 +1194,9 @@ func (p *Platform) UpdateFunctionEvent(ctx context.Context, updateFunctionEventO
 	functionEvent.Annotations = updatedFunctionEvent.Annotations
 	functionEvent.Labels = updatedFunctionEvent.Labels
 
-	if _, err := p.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioFunctionEvents(updateFunctionEventOptions.FunctionEventConfig.Meta.Namespace).
-		Update(ctx, functionEvent, metav1.UpdateOptions{}); err != nil {
+	if _, err := p.consumer.NuclioClientSet.UpdateNuclioFunctionEvent(ctx,
+		updateFunctionEventOptions.FunctionEventConfig.Meta.Namespace,
+		functionEvent); err != nil {
 		return errors.Wrap(err, "Failed to update a function event")
 	}
 
@@ -1206,9 +1205,9 @@ func (p *Platform) UpdateFunctionEvent(ctx context.Context, updateFunctionEventO
 
 // DeleteFunctionEvent will delete a previously existing function event
 func (p *Platform) DeleteFunctionEvent(ctx context.Context, deleteFunctionEventOptions *platform.DeleteFunctionEventOptions) error {
-	functionEventToDelete, err := p.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioFunctionEvents(deleteFunctionEventOptions.Meta.Namespace).
-		Get(ctx, deleteFunctionEventOptions.Meta.Name, metav1.GetOptions{})
+	functionEventToDelete, err := p.consumer.NuclioClientSet.GetNuclioFunctionEvent(ctx,
+		deleteFunctionEventOptions.Meta.Namespace,
+		deleteFunctionEventOptions.Meta.Name)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get a function event")
 	}
@@ -1228,9 +1227,10 @@ func (p *Platform) DeleteFunctionEvent(ctx context.Context, deleteFunctionEventO
 		return errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
 
-	if err := p.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioFunctionEvents(deleteFunctionEventOptions.Meta.Namespace).
-		Delete(ctx, deleteFunctionEventOptions.Meta.Name, metav1.DeleteOptions{}); err != nil {
+	if err := p.consumer.NuclioClientSet.DeleteNuclioFunctionEvent(ctx,
+		deleteFunctionEventOptions.Meta.Namespace,
+		deleteFunctionEventOptions.Meta.Name,
+		metav1.DeleteOptions{}); err != nil {
 		return errors.Wrapf(err,
 			"Failed to delete function event %s from namespace %s",
 			deleteFunctionEventOptions.Meta.Name,
@@ -1249,9 +1249,9 @@ func (p *Platform) GetFunctionEvents(ctx context.Context, getFunctionEventsOptio
 	if getFunctionEventsOptions.Meta.Name != "" {
 
 		// get specific function event CR
-		functionEvent, err := p.consumer.NuclioClientSet.NuclioV1beta1().
-			NuclioFunctionEvents(getFunctionEventsOptions.Meta.Namespace).
-			Get(ctx, getFunctionEventsOptions.Meta.Name, metav1.GetOptions{})
+		functionEvent, err := p.consumer.NuclioClientSet.GetNuclioFunctionEvent(ctx,
+			getFunctionEventsOptions.Meta.Namespace,
+			getFunctionEventsOptions.Meta.Name)
 
 		if err != nil {
 
@@ -1279,9 +1279,9 @@ func (p *Platform) GetFunctionEvents(ctx context.Context, getFunctionEventsOptio
 				encodedFunctionNames)
 		}
 
-		functionEventInstanceList, err := p.consumer.NuclioClientSet.NuclioV1beta1().
-			NuclioFunctionEvents(getFunctionEventsOptions.Meta.Namespace).
-			List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		functionEventInstanceList, err := p.consumer.NuclioClientSet.ListNuclioFunctionEvents(ctx,
+			getFunctionEventsOptions.Meta.Namespace,
+			metav1.ListOptions{LabelSelector: labelSelector})
 
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to list function events")
@@ -1515,9 +1515,7 @@ func (p *Platform) generateFunctionToAPIGatewaysMapping(ctx context.Context, nam
 	functionToAPIGateways := map[string][]string{}
 
 	// get all api gateways in the namespace
-	apiGateways, err := p.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioAPIGateways(namespace).
-		List(ctx, metav1.ListOptions{})
+	apiGateways, err := p.consumer.NuclioClientSet.ListNuclioAPIGateways(ctx, namespace, metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to list API gateways")
 	}
@@ -1539,9 +1537,9 @@ func (p *Platform) generateFunctionToAPIGatewaysMapping(ctx context.Context, nam
 
 func (p *Platform) getApiGateways(ctx context.Context, getAPIGatewaysOptions *platform.GetAPIGatewaysOptions) ([]nuclioio.NuclioAPIGateway, error) {
 
-	apiGateways, err := p.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioAPIGateways(getAPIGatewaysOptions.Namespace).
-		List(ctx, metav1.ListOptions{LabelSelector: getAPIGatewaysOptions.Labels})
+	apiGateways, err := p.consumer.NuclioClientSet.ListNuclioAPIGateways(ctx,
+		getAPIGatewaysOptions.Namespace,
+		metav1.ListOptions{LabelSelector: getAPIGatewaysOptions.Labels})
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to list API gateways")
 	}
@@ -1803,13 +1801,9 @@ func (p *Platform) getFunction(ctx context.Context,
 		"name", getFunctionOptions.Name)
 
 	// get specific function CR
-	function, err := p.consumer.NuclioClientSet.NuclioV1beta1().
-		NuclioFunctions(getFunctionOptions.Namespace).
-		Get(ctx,
-			getFunctionOptions.Name,
-			metav1.GetOptions{
-				ResourceVersion: getFunctionOptions.ResourceVersion,
-			})
+	function, err := p.consumer.NuclioClientSet.GetNuclioFunction(ctx,
+		getFunctionOptions.Namespace,
+		getFunctionOptions.Name)
 	if err != nil {
 
 		// if we didn't find the function, return nothing

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -153,7 +153,7 @@ func (suite *KubePlatformTestSuite) ResetCRDMocks() {
 		Platform: suite.abstractPlatform,
 		getter:   getter,
 		consumer: &nuclio.Consumer{
-			NuclioClientSet: suite.nuclioioInterfaceMock,
+			NuclioClientSet: nuclio.NewClientWithRetryFromClient(suite.nuclioioInterfaceMock),
 			KubeClientSet:   kube.NewClientWithRetryFromClient(&suite.kubeClientSet),
 		},
 		projectsCache: cache.NewExpiring(),


### PR DESCRIPTION
### 📝 Description                                            

Functions could get stuck forever in `Deploying` state when the Kubernetes API server's etcd experienced transient timeouts (etcdserver: request timed out), or on any other transient k8s API error.

**The root cause:** `waitForFunctionReadiness` and `CreateOrUpdateFunction` both called the `NuclioClientSet` (the client for Nuclio CRDs) directly without any retry logic. 
When an etcd timeout hits, two things would fail in sequence:
1. The Get in `waitForFunctionReadiness` would fail → triggering the error-handling path
2. The Update in `reportCreationError` that was supposed to set the function state to Error would also fail (etcd still down) → function CR is never updated and stays in `Deploying` forever
                                                                                                                                                        
The fix follows the same pattern already used for `KubeClientSet`: wrap the Nuclio CRD client in a `clientWithRetry` that uses `clients.RequestWithRetry` (up to 5 retries with 1s delay) for all operations, automatically handling `etcdserver:` and other transient k8s API errors.

---
### 🛠️  Changes Made

- New Client interface (`pkg/platform/kube/clients/nuclio/types.go`): flat CRUD methods for all 4 Nuclio CRD types — `NuclioFunction`, `NuclioProject`, `NuclioAPIGateway`, `NuclioFunctionEvent`
- New clientWithRetry implementation (`pkg/platform/kube/clients/nuclio/client.go`): wraps nuclioioclient.Interface and delegates every method through `clients.RequestWithRetry`; constructors `NewClientWithRetryFromConfig` and `NewClientWithRetryFromClient` mirror the kube client pattern
- `consumer.go`: `NuclioClientSet` field type changed from `nuclioioclient.Interface` to `Client`; both `NewConsumer` and `getNuclioClientSet` now use `NewClientWithRetryFromConfig`
- All consumer callers migrated to flat method calls: `deployer.go`, `getter.go`, `deleter.go`, `updater.go`, `platform.go` (APIGateways + FunctionEvents), `project/internalc/kube/kube.go` (Projects)
- `platform_test.go`: wraps the existing `nuclioioclient.Interface` mock with `NewClientWithRetryFromClient` so the layered mock chain continues to work without modification
  
---                                                                                                                                                     
### ✅ Checklist                                              

- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---
### 🧪 Testing

- Existing unit tests pass: go test -tags test_unit ./pkg/platform/kube/ ✅
- The test mock (`nuclioioInterfaceMock`) is wrapped with `NewClientWithRetryFromClient`, so `clientWithRetry` internally calls through to the existing mock chain — no mock expectations needed to change

---
### 🔗 References

- Ticket link: https://iguazio.atlassian.net/browse/NUC-779

---
### 🚨 Breaking Changes?

- [ ] Yes
- [x] No

---
### 🔍️ Additional Notes

The controller's own `nuclioClientSet` field (in `pkg/platform/kube/controller/`) is a separate instance typed as `nuclioioclient.Interface` and is out of scope — it handles Watch/informer traffic where retry is managed by the informer framework itself.