### PR TITLE
[CI] Bump Traefik to Stable v3.7.1

### DIFF
--- a/pkg/nuctl/test/apigagteway_test.go
+++ b/pkg/nuctl/test/apigagteway_test.go
@@ -276,6 +276,27 @@ func (suite *apiGatewayInvokeTestSuite) testInvoke(authenticationMode ingress.Au
 		return request
 	}
 
+	// when auth is enabled, wait until bad credentials are rejected before asserting the happy path
+	// the secret is created after the ingress, so we need to wait until it's applied
+	if authenticationMode != ingress.AuthenticationModeNone {
+		err = common.RetryUntilSuccessful(90*time.Second, 1*time.Second, func() bool {
+			request := createHTTPRequest()
+
+			// fill request with bad credentials
+			switch authenticationMode {
+			case ingress.AuthenticationModeBasicAuth:
+				request.SetBasicAuth(basicAuthUsername, "bad-credentials")
+			default:
+				suite.Require().Failf("Must implement a scenario where a test would fail for ingress %s",
+					string(authenticationMode))
+			}
+
+			_, statusCode, err := suite.invokeHTTPRequest(request)
+			return err == nil && statusCode == http.StatusUnauthorized
+		})
+		suite.Require().NoError(err, "Auth middleware was not enforced within timeout")
+	}
+
 	// invoke the api-gateway URL to make sure it works (we get the expected function response)
 	// we retry as it takes some time for apigw resource create function ingress
 	err = common.RetryUntilSuccessful(90*time.Second, 1*time.Second, func() bool {
@@ -287,29 +308,6 @@ func (suite *apiGatewayInvokeTestSuite) testInvoke(authenticationMode ingress.Au
 		return err == nil && statusCode == http.StatusOK && responseBody == expectedResponseBody
 	})
 	suite.Require().NoError(err)
-
-	// test scenarios where auth is given, but bad credentials were given
-	if authenticationMode != ingress.AuthenticationModeNone {
-
-		// create request
-		request := createHTTPRequest()
-
-		// fill request request with credentials correspondingly to its ingress auth mode
-		switch authenticationMode {
-		case ingress.AuthenticationModeBasicAuth:
-			request.SetBasicAuth(basicAuthUsername, "bad-credentials")
-		default:
-			suite.Require().Failf("Must implement a scenario where a test would fail for ingress %s",
-				string(authenticationMode))
-		}
-
-		// invoke http request with bad credentials
-		_, statusCode, err := suite.invokeHTTPRequest(request)
-		suite.Require().NoError(err)
-
-		// expect it to fail due to unauthorized request
-		suite.Require().Equal(statusCode, http.StatusUnauthorized)
-	}
 }
 
 func (suite *apiGatewayInvokeTestSuite) deployFunction() string {

--- a/pkg/nuctl/test/apigagteway_test.go
+++ b/pkg/nuctl/test/apigagteway_test.go
@@ -276,27 +276,6 @@ func (suite *apiGatewayInvokeTestSuite) testInvoke(authenticationMode ingress.Au
 		return request
 	}
 
-	// when auth is enabled, wait until bad credentials are rejected before asserting the happy path
-	// the secret is created after the ingress, so we need to wait until it's applied
-	if authenticationMode != ingress.AuthenticationModeNone {
-		err = common.RetryUntilSuccessful(90*time.Second, 1*time.Second, func() bool {
-			request := createHTTPRequest()
-
-			// fill request with bad credentials
-			switch authenticationMode {
-			case ingress.AuthenticationModeBasicAuth:
-				request.SetBasicAuth(basicAuthUsername, "bad-credentials")
-			default:
-				suite.Require().Failf("Must implement a scenario where a test would fail for ingress %s",
-					string(authenticationMode))
-			}
-
-			_, statusCode, err := suite.invokeHTTPRequest(request)
-			return err == nil && statusCode == http.StatusUnauthorized
-		})
-		suite.Require().NoError(err, "Auth middleware was not enforced within timeout")
-	}
-
 	// invoke the api-gateway URL to make sure it works (we get the expected function response)
 	// we retry as it takes some time for apigw resource create function ingress
 	err = common.RetryUntilSuccessful(90*time.Second, 1*time.Second, func() bool {
@@ -308,6 +287,29 @@ func (suite *apiGatewayInvokeTestSuite) testInvoke(authenticationMode ingress.Au
 		return err == nil && statusCode == http.StatusOK && responseBody == expectedResponseBody
 	})
 	suite.Require().NoError(err)
+
+	// test scenarios where auth is given, but bad credentials were given
+	if authenticationMode != ingress.AuthenticationModeNone {
+
+		// create request
+		request := createHTTPRequest()
+
+		// fill request request with credentials correspondingly to its ingress auth mode
+		switch authenticationMode {
+		case ingress.AuthenticationModeBasicAuth:
+			request.SetBasicAuth(basicAuthUsername, "bad-credentials")
+		default:
+			suite.Require().Failf("Must implement a scenario where a test would fail for ingress %s",
+				string(authenticationMode))
+		}
+
+		// invoke http request with bad credentials
+		_, statusCode, err := suite.invokeHTTPRequest(request)
+		suite.Require().NoError(err)
+
+		// expect it to fail due to unauthorized request
+		suite.Require().Equal(statusCode, http.StatusUnauthorized)
+	}
 }
 
 func (suite *apiGatewayInvokeTestSuite) deployFunction() string {

--- a/pkg/platform/kube/ingress/ingress.go
+++ b/pkg/platform/kube/ingress/ingress.go
@@ -160,31 +160,6 @@ func (m *Manager) CreateOrUpdateResources(ctx context.Context, resources *Resour
 
 	m.logger.InfoWithCtx(ctx, "Creating/Updating ingress resources", "ingressName", resources.Ingress.Name)
 
-	if appliedIngress, err = m.kubeClientSet.CreateIngress(
-		ctx,
-		resources.Ingress.Namespace,
-		resources.Ingress); err != nil {
-
-		if !apierrors.IsAlreadyExists(err) {
-			return nil, nil, errors.Wrap(err, "Failed to create ingress")
-		}
-
-		// if the ingress already exists - update it
-		m.logger.InfoWithCtx(ctx, "Ingress already exists. Updating it",
-			"ingressName", resources.Ingress.Name)
-		if appliedIngress, err = m.kubeClientSet.UpdateIngress(
-			ctx,
-			resources.Ingress.Namespace,
-			resources.Ingress); err != nil {
-
-			return nil, nil, errors.Wrap(err, "Failed to update ingress")
-		}
-		m.logger.InfoWithCtx(ctx, "Successfully updated ingress", "ingressName", resources.Ingress.Name)
-
-	} else {
-		m.logger.InfoWithCtx(ctx, "Successfully created ingress", "ingressName", resources.Ingress.Name)
-	}
-
 	// if there's a secret among the ingress resources - create/update it
 	if resources.BasicAuthSecret != nil {
 
@@ -217,6 +192,31 @@ func (m *Manager) CreateOrUpdateResources(ctx context.Context, resources *Resour
 			m.logger.InfoWithCtx(ctx, "Successfully created basic-auth secret",
 				"secretName", resources.BasicAuthSecret.Name)
 		}
+	}
+
+	if appliedIngress, err = m.kubeClientSet.CreateIngress(
+		ctx,
+		resources.Ingress.Namespace,
+		resources.Ingress); err != nil {
+
+		if !apierrors.IsAlreadyExists(err) {
+			return nil, nil, errors.Wrap(err, "Failed to create ingress")
+		}
+
+		// if the ingress already exists - update it
+		m.logger.InfoWithCtx(ctx, "Ingress already exists. Updating it",
+			"ingressName", resources.Ingress.Name)
+		if appliedIngress, err = m.kubeClientSet.UpdateIngress(
+			ctx,
+			resources.Ingress.Namespace,
+			resources.Ingress); err != nil {
+
+			return nil, nil, errors.Wrap(err, "Failed to update ingress")
+		}
+		m.logger.InfoWithCtx(ctx, "Successfully updated ingress", "ingressName", resources.Ingress.Name)
+
+	} else {
+		m.logger.InfoWithCtx(ctx, "Successfully created ingress", "ingressName", resources.Ingress.Name)
 	}
 
 	return appliedIngress, appliedBasicAuthSecret, nil

--- a/test/k8s/ci_assets/install_traefik.sh
+++ b/test/k8s/ci_assets/install_traefik.sh
@@ -32,7 +32,7 @@ helm install traefik traefik/traefik \
   --set providers.kubernetesGateway.enabled=true \
   --set gateway.enabled=false \
   --set gatewayClass.enabled=true \
-  --version 40.0.0-ea.3
+  --version 40.0.0
 
 # create nginx IngressClass standalone resource mapping to Traefik
 kubectl apply -f - <<EOF

--- a/test/k8s/ci_assets/install_traefik.sh
+++ b/test/k8s/ci_assets/install_traefik.sh
@@ -32,7 +32,7 @@ helm install traefik traefik/traefik \
   --set providers.kubernetesGateway.enabled=true \
   --set gateway.enabled=false \
   --set gatewayClass.enabled=true \
-  --version 40.0.0
+  --version 40.2.0
 
 # create nginx IngressClass standalone resource mapping to Traefik
 kubectl apply -f - <<EOF


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
Bump Traefik version installed during CI from v3.7.0 Early Access to Stable v3.7.1 (chart version [40.2.0](https://github.com/traefik/traefik-helm-chart/releases/tag/v40.2.0))

This also changes the order of creation between basic auth secret and ingress: now the basic auth secret is created before the ingress.

Before Traefik CI test sometimes failed because it could not find it:
`2026-05-14T14:02:04Z ERR github.com/traefik/traefik/v3/pkg/provider/kubernetes/ingress-nginx/build.go:418 > Cannot resolve auth secret, skipping auth middleware error="getting secret nuclio-agw-get-test-apigateway-d82tblqsep49hlt5b8l0-1-basic-auth: secret \"nuclio-agw-get-test-apigateway-d82tblqsep49hlt5b8l0-1-basic-auth\" not found" ingress="default/nuclio-agw-get-test-apigateway-d82tblqsep49hlt5b8l0-1 rule-0 path-0" namespace=default providerName=kubernetesingressnginx`

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
- Bump traefik version in CI install script
- Create Basic Auth secret before Ingress

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
- Integration Tests

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->