### PR TITLE
[Controller] Recover functions stuck in Error after transient API timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ pkg/processor/runtime/python/py/whl
 
 vendor
 
+# Claude Code plan/scratch directories (not for source control)
+.claude/
+.claude-plans/
+
 # general
 *.class
 *.iml

--- a/pkg/platform/kube/clients/retry.go
+++ b/pkg/platform/kube/clients/retry.go
@@ -17,10 +17,13 @@ limitations under the License.
 package clients
 
 import (
+	"context"
+	stderrors "errors"
 	"strings"
 	"time"
 
 	"github.com/nuclio/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // default retry parameters
@@ -36,7 +39,7 @@ func RequestWithRetry[T any](fn func() (T, error), maxRetries int, delay time.Du
 		if err == nil {
 			return result, nil
 		}
-		if !isK8sRetryableErrors(err) {
+		if !IsK8sRetryableError(err) {
 			return result, err // Not retryable, fail fast
 		}
 
@@ -45,10 +48,32 @@ func RequestWithRetry[T any](fn func() (T, error), maxRetries int, delay time.Du
 	return result, errors.Wrapf(err, "Kubernetes call failed after %d retries", maxRetries)
 }
 
-func isK8sRetryableErrors(err error) bool {
+// IsK8sRetryableError reports whether err describes a transient Kubernetes API,
+// etcd, or network condition where the operation may have succeeded server-side
+// but the response never reached the client — i.e. it is safe to retry.
+//
+// It first tries typed apierror predicates and context.DeadlineExceeded, then
+// falls back to substring matching for cases where the error has been wrapped
+// (the project's errors library produces plain strings via Error(), so typed
+// checks against the wrapped value fail).
+func IsK8sRetryableError(err error) bool {
 	if err == nil {
 		return false
 	}
+
+	// Typed checks — preferred when the original apierror is still in the
+	// chain (e.g. fresh from the kubernetes client, before nuclio wrapping).
+	if apierrors.IsServerTimeout(err) ||
+		apierrors.IsTimeout(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsInternalError(err) ||
+		apierrors.IsServiceUnavailable(err) {
+		return true
+	}
+	if stderrors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
 	errStr := err.Error()
 	return strings.Contains(errStr, "Error: etcdserver: ") ||
 		strings.Contains(errStr, "etcdserver: leader changed") ||
@@ -56,5 +81,8 @@ func isK8sRetryableErrors(err error) bool {
 		strings.Contains(errStr, "Kubernetes cluster unreachable") ||
 		strings.Contains(errStr, "Unable to connect to the server") ||
 		strings.Contains(errStr, "Internal error occurred: resource quota evaluation timed out") ||
-		strings.Contains(errStr, ":443: i/o timeout")
+		strings.Contains(errStr, ":443: i/o timeout") ||
+		strings.Contains(errStr, "Timeout: request did not complete within") ||
+		strings.Contains(errStr, "the server was unable to return a response in the time allotted") ||
+		strings.Contains(errStr, "context deadline exceeded")
 }

--- a/pkg/platform/kube/clients/retry_test.go
+++ b/pkg/platform/kube/clients/retry_test.go
@@ -1,0 +1,200 @@
+//go:build test_unit
+
+/*
+Copyright 2025 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clients
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/nuclio/errors"
+	"github.com/stretchr/testify/suite"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type RetryTestSuite struct {
+	suite.Suite
+}
+
+func (s *RetryTestSuite) TestIsK8sRetryableErrorClassification() {
+	groupResource := schema.GroupResource{Group: "", Resource: "services"}
+
+	cases := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{
+			name:      "nil",
+			err:       nil,
+			retryable: false,
+		},
+		{
+			name:      "typed_server_timeout",
+			err:       apierrors.NewServerTimeout(groupResource, "update", 0),
+			retryable: true,
+		},
+		{
+			name:      "typed_timeout",
+			err:       apierrors.NewTimeoutError("request timed out", 0),
+			retryable: true,
+		},
+		{
+			name:      "typed_too_many_requests",
+			err:       apierrors.NewTooManyRequestsError("calm down"),
+			retryable: true,
+		},
+		{
+			name:      "typed_internal",
+			err:       apierrors.NewInternalError(fmt.Errorf("boom")),
+			retryable: true,
+		},
+		{
+			name:      "typed_service_unavailable",
+			err:       apierrors.NewServiceUnavailable("nope"),
+			retryable: true,
+		},
+		{
+			name:      "typed_wrapped_server_timeout",
+			err:       errors.Wrap(apierrors.NewServerTimeout(groupResource, "update", 0), "Failed to update resource"),
+			retryable: true,
+		},
+		{
+			name:      "context_deadline_exceeded",
+			err:       context.DeadlineExceeded,
+			retryable: true,
+		},
+		{
+			name:      "context_deadline_wrapped",
+			err:       errors.Wrap(context.DeadlineExceeded, "Failed to update resource"),
+			retryable: true,
+		},
+		{
+			name:      "string_apiserver_504",
+			err:       fmt.Errorf("Timeout: request did not complete within requested timeout - context deadline exceeded"),
+			retryable: true,
+		},
+		{
+			name:      "string_unable_to_return_response",
+			err:       fmt.Errorf("the server was unable to return a response in the time allotted, but may still be processing the request"),
+			retryable: true,
+		},
+		{
+			name:      "string_etcd_leader_changed",
+			err:       fmt.Errorf("etcdserver: leader changed"),
+			retryable: true,
+		},
+		{
+			name:      "string_rpc_error",
+			err:       fmt.Errorf("rpc error: code = Unavailable"),
+			retryable: true,
+		},
+		{
+			name:      "string_i_o_timeout",
+			err:       fmt.Errorf("dial tcp 10.0.0.1:443: i/o timeout"),
+			retryable: true,
+		},
+		{
+			name: "non_retryable_not_found",
+			err: apierrors.NewNotFound(groupResource,
+				"some-resource"),
+			retryable: false,
+		},
+		{
+			name:      "non_retryable_bad_request",
+			err:       apierrors.NewBadRequest("malformed"),
+			retryable: false,
+		},
+		{
+			name:      "non_retryable_conflict",
+			err:       apierrors.NewConflict(groupResource, "some-resource", fmt.Errorf("conflict")),
+			retryable: false,
+		},
+		{
+			name:      "non_retryable_generic",
+			err:       fmt.Errorf("something else broke"),
+			retryable: false,
+		},
+		{
+			name: "non_retryable_status_error_other_reason",
+			err: &apierrors.StatusError{
+				ErrStatus: metav1.Status{
+					Status:  metav1.StatusFailure,
+					Reason:  metav1.StatusReasonForbidden,
+					Message: "forbidden",
+				},
+			},
+			retryable: false,
+		},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			s.Assert().Equal(tc.retryable, IsK8sRetryableError(tc.err))
+		})
+	}
+}
+
+func (s *RetryTestSuite) TestRequestWithRetrySucceedsAfterTransientFailures() {
+	calls := 0
+	fn := func() (string, error) {
+		calls++
+		if calls < 3 {
+			return "", apierrors.NewServerTimeout(schema.GroupResource{Resource: "services"}, "update", 0)
+		}
+		return "ok", nil
+	}
+
+	result, err := RequestWithRetry[string](fn, 5, time.Millisecond)
+	s.Require().NoError(err)
+	s.Assert().Equal("ok", result)
+	s.Assert().Equal(3, calls)
+}
+
+func (s *RetryTestSuite) TestRequestWithRetryFailsFastOnNonRetryable() {
+	calls := 0
+	fn := func() (string, error) {
+		calls++
+		return "", apierrors.NewBadRequest("malformed")
+	}
+
+	_, err := RequestWithRetry[string](fn, 5, time.Millisecond)
+	s.Require().Error(err)
+	s.Assert().Equal(1, calls, "non-retryable error should not be retried")
+}
+
+func (s *RetryTestSuite) TestRequestWithRetryExhaustsThenWraps() {
+	calls := 0
+	fn := func() (string, error) {
+		calls++
+		return "", apierrors.NewServerTimeout(schema.GroupResource{Resource: "services"}, "update", 0)
+	}
+
+	_, err := RequestWithRetry[string](fn, 3, time.Millisecond)
+	s.Require().Error(err)
+	s.Assert().Equal(3, calls)
+	s.Assert().Contains(err.Error(), "Kubernetes call failed after 3 retries")
+}
+
+func TestRetryTestSuite(t *testing.T) {
+	suite.Run(t, new(RetryTestSuite))
+}

--- a/pkg/platform/kube/controller/nucliofunction.go
+++ b/pkg/platform/kube/controller/nucliofunction.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform/abstract"
 	"github.com/nuclio/nuclio/pkg/platform/kube"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+	"github.com/nuclio/nuclio/pkg/platform/kube/clients"
 	"github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio"
 	"github.com/nuclio/nuclio/pkg/platform/kube/functionres"
 	"github.com/nuclio/nuclio/pkg/platform/kube/operator"
@@ -248,17 +249,17 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 
 	// enrich node selectors with values from function, project and platform and save enriched value to function.status
 	if err := fo.enrichNodeSelector(ctx, function); err != nil {
-		return fo.setFunctionError(ctx, function, functionconfig.FunctionStateError, nil, errors.Wrap(err, "Failed to enrich node selectors when create/update function"))
+		return fo.recordReconcileError(ctx, function, nil, errors.Wrap(err, "Failed to enrich node selectors when create/update function"))
 	}
 
 	if err := fo.enrichAndValidateServiceAccount(ctx, function); err != nil {
-		return fo.setFunctionError(ctx, function, functionconfig.FunctionStateError, nil, errors.Wrap(err, "Failed to enrich or validate service account when create/update function"))
+		return fo.recordReconcileError(ctx, function, nil, errors.Wrap(err, "Failed to enrich or validate service account when create/update function"))
 	}
 
 	// ensure function resources (deployment, ingress, configmap, etc ...)
 	resources, err := fo.functionresClient.CreateOrUpdate(ctx, function, fo.imagePullSecrets)
 	if err != nil {
-		return fo.setFunctionError(ctx, function, functionconfig.FunctionStateError, nil, errors.Wrap(err, "Failed to create/update function"))
+		return fo.recordReconcileError(ctx, function, nil, errors.Wrap(err, "Failed to create/update function"))
 	}
 
 	// readinessTimeout would be zero when
@@ -286,10 +287,7 @@ func (fo *functionOperator) CreateOrUpdate(ctx context.Context, object runtime.O
 	}
 
 	if err = fo.updateFunctionSelectorIfRequired(ctx, function); err != nil {
-		return fo.setFunctionError(ctx,
-			function,
-			functionconfig.FunctionStateError,
-			nil,
+		return fo.recordReconcileError(ctx, function, nil,
 			errors.Wrap(err, "Failed to patch function service selector when scale from zero"))
 	}
 
@@ -432,6 +430,65 @@ func (fo *functionOperator) updateFunctionSelectorIfRequired(ctx context.Context
 		}
 	}
 	return nil
+}
+
+// recordReconcileError records a reconcile failure on the function CR. For
+// transient Kubernetes API errors (server timeout, context deadline, 5xx) the
+// function is set to FunctionStateUnhealthy so the function_monitor can flip
+// it back to Ready when the API recovers and the deployment reports as
+// available. Non-transient failures still go to the terminal FunctionStateError
+// sink. The (wrapped) error is returned unchanged so the operator's work queue
+// re-enqueues with backoff.
+func (fo *functionOperator) recordReconcileError(
+	ctx context.Context,
+	function *nuclioio.NuclioFunction,
+	resources functionres.Resources,
+	wrappedErr error) error {
+
+	if clients.IsK8sRetryableError(wrappedErr) {
+		return fo.markFunctionUnhealthy(ctx, function, wrappedErr)
+	}
+	return fo.setFunctionError(ctx, function, functionconfig.FunctionStateError, resources, wrappedErr)
+}
+
+// markFunctionUnhealthy transitions the function to FunctionStateUnhealthy
+// while preserving the rest of its status (invocation URLs, logs, scale-to-zero
+// state, etc.). Unlike setFunctionError, which rebuilds Status from scratch
+// and drops invocation URLs, this helper is used for recoverable conditions
+// where the function_monitor is expected to flip the state back to Ready as
+// soon as the underlying deployment becomes available again.
+//
+// The original error is returned so callers (and the operator work queue)
+// see the failure.
+func (fo *functionOperator) markFunctionUnhealthy(
+	ctx context.Context,
+	function *nuclioio.NuclioFunction,
+	err error) error {
+
+	// the calling context may already be deadline-cancelled (which is often
+	// how we get here) — detach so the CR status update still goes through.
+	detachedContext := context.WithoutCancel(ctx)
+
+	fo.logger.WarnWithCtx(detachedContext,
+		"Marking function as unhealthy (transient error); function_monitor will recover",
+		"functionName", function.Name,
+		"functionNamespace", function.Namespace,
+		"err", err)
+
+	function.Status.State = functionconfig.FunctionStateUnhealthy
+	function.Status.Message = errors.GetErrorStackString(err, 10)
+
+	if _, updateErr := fo.controller.nuclioClientSet.
+		NuclioV1beta1().
+		NuclioFunctions(function.Namespace).
+		Update(detachedContext, function, metav1.UpdateOptions{}); updateErr != nil {
+		fo.logger.WarnWithCtx(detachedContext,
+			"Failed to update function status to unhealthy",
+			"functionName", function.Name,
+			"updateErr", errors.Cause(updateErr))
+	}
+
+	return err
 }
 
 func (fo *functionOperator) setFunctionError(

--- a/pkg/platform/kube/controller/nucliofunction_test.go
+++ b/pkg/platform/kube/controller/nucliofunction_test.go
@@ -34,8 +34,10 @@ import (
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
@@ -154,6 +156,74 @@ func (suite *NuclioFunctionTestSuite) TestRecoverFromPanic() {
 
 	// function state must be change to error after panicking during its create/update
 	suite.Assert().Equal(functionconfig.FunctionStateError, functionInstance.Status.State)
+}
+
+// TestTransientApiErrorMarksFunctionUnhealthy reproduces NUC-797: a transient
+// Kubernetes API server timeout on resource create/update used to send the
+// function to terminal FunctionStateError. The controller's statesToRespond
+// excludes Error, so the function would never re-reconcile. The fix marks the
+// function as FunctionStateUnhealthy instead, which the function_monitor can
+// flip back to Ready once the API recovers and the deployment is available.
+func (suite *NuclioFunctionTestSuite) TestTransientApiErrorMarksFunctionUnhealthy() {
+	functionInstance := &nuclioio.NuclioFunction{}
+	functionInstance.Name = "transient-error-func"
+	functionInstance.Namespace = suite.namespace
+	functionInstance.Status.State = functionconfig.FunctionStateWaitingForResourceConfiguration
+	functionInstance.Status.InternalInvocationURLs = []string{"transient-error-func.svc.cluster.local:8080"}
+	functionInstance.Status.ExternalInvocationURLs = []string{"transient-error-func.example.com"}
+	functionInstance.Labels = map[string]string{
+		common.NuclioResourceLabelKeyProjectName: suite.projectName,
+	}
+
+	_, err := suite.functionClientSet.NuclioV1beta1().
+		NuclioFunctions(suite.namespace).
+		Create(suite.ctx, functionInstance, metav1.CreateOptions{})
+	suite.Require().NoError(err)
+
+	suite.k8sClientSet.PrependReactor("create",
+		"services",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewServerTimeout(schema.GroupResource{Resource: "services"}, "create", 0)
+		})
+
+	err = suite.controller.functionOperator.CreateOrUpdate(suite.ctx, functionInstance)
+	suite.Require().Error(err, "transient error should surface so the work queue retries")
+
+	suite.Assert().Equal(functionconfig.FunctionStateUnhealthy, functionInstance.Status.State,
+		"transient K8s API error must not strand the function in terminal FunctionStateError")
+	suite.Assert().Equal([]string{"transient-error-func.svc.cluster.local:8080"}, functionInstance.Status.InternalInvocationURLs,
+		"invocation URLs must be preserved on transient-error transition")
+	suite.Assert().Equal([]string{"transient-error-func.example.com"}, functionInstance.Status.ExternalInvocationURLs,
+		"invocation URLs must be preserved on transient-error transition")
+}
+
+// TestNonTransientApiErrorMarksFunctionError guards against regressions where
+// the new transient-error path accidentally swallows real failures.
+func (suite *NuclioFunctionTestSuite) TestNonTransientApiErrorMarksFunctionError() {
+	functionInstance := &nuclioio.NuclioFunction{}
+	functionInstance.Name = "real-error-func"
+	functionInstance.Namespace = suite.namespace
+	functionInstance.Status.State = functionconfig.FunctionStateWaitingForResourceConfiguration
+	functionInstance.Labels = map[string]string{
+		common.NuclioResourceLabelKeyProjectName: suite.projectName,
+	}
+
+	_, err := suite.functionClientSet.NuclioV1beta1().
+		NuclioFunctions(suite.namespace).
+		Create(suite.ctx, functionInstance, metav1.CreateOptions{})
+	suite.Require().NoError(err)
+
+	suite.k8sClientSet.PrependReactor("create",
+		"services",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewBadRequest("service spec is invalid")
+		})
+
+	err = suite.controller.functionOperator.CreateOrUpdate(suite.ctx, functionInstance)
+	suite.Require().Error(err)
+
+	suite.Assert().Equal(functionconfig.FunctionStateError, functionInstance.Status.State,
+		"non-transient errors must still go to terminal FunctionStateError")
 }
 
 func TestTestSuite(t *testing.T) {


### PR DESCRIPTION
### 📝 Description

A transient Kubernetes API-server timeout during a function reconcile (`Timeout: request did not complete within requested timeout - context deadline exceeded`, `server timeout`, 5xx) was being recorded on the function CR as terminal `FunctionStateError`. `statesToRespond` excludes `Error`, so the controller never re-reconciled the function even after the API server recovered — and `function_monitor` only ever flips between `Ready` ↔ `Unhealthy`, never out of `Error`. Net effect: a single API hiccup permanently stranded otherwise healthy functions in the UI as `Error` while the underlying pods/services kept running.

The fix:
1. Broaden `IsK8sRetryableError` (was unexported `isK8sRetryableErrors`) to classify K8s API timeouts, `context.DeadlineExceeded`, and 5xx as retryable. Typed `apierrors.Is*` checks first, string fallbacks for already-wrapped variants.
2. When `nucliofunction.CreateOrUpdate` (and the surrounding reconcile-path calls) hit a transient K8s error, route through a new `recordReconcileError` helper that picks between `FunctionStateUnhealthy` (recoverable — `function_monitor` will flip back to `Ready` once the deployment reports available) and `FunctionStateError` (terminal). Invocation URLs and the rest of `Status` are preserved on the transient path.

---

### 🛠️ Changes Made

- `pkg/platform/kube/clients/retry.go` — extend the retryable-error classifier with typed `apierrors.IsServerTimeout`/`IsTimeout`/`IsTooManyRequests`/`IsInternalError`/`IsServiceUnavailable`, `errors.Is(err, context.DeadlineExceeded)`, and three new string fallbacks for wrapped variants (`Timeout: request did not complete within`, `the server was unable to return a response in the time allotted`, `context deadline exceeded`). Rename `isK8sRetryableErrors` → exported `IsK8sRetryableError` so the controller can reuse it.
- `pkg/platform/kube/controller/nucliofunction.go` — new `recordReconcileError(ctx, function, resources, wrappedErr)` helper used by `enrichNodeSelector`, `enrichAndValidateServiceAccount`, `functionresClient.CreateOrUpdate`, and `updateFunctionSelectorIfRequired` reconcile-path call sites. Routes transient errors through new `markFunctionUnhealthy`, which preserves invocation URLs and the rest of `Status` (only `State` and `Message` mutate). Detached context for the CR update so deadline-cancelled callers can still persist the status.
- `pkg/platform/kube/clients/retry_test.go` — new table-driven test for `IsK8sRetryableError` (22 subtests across typed predicates, wrapped variants, string fallbacks, and non-retryable regressions) plus `RequestWithRetry` happy/fail-fast/exhaust tests.
- `pkg/platform/kube/controller/nucliofunction_test.go` — two new cases: `TestTransientApiErrorMarksFunctionUnhealthy` (regression test for NUC-797: server-timeout reactor on service create → function lands on `Unhealthy`, invocation URLs preserved) and `TestNonTransientApiErrorMarksFunctionError` (guard so the new branch doesn't swallow real failures).

---

### ✅ Checklist
- [x] I updated the documentation (if applicable) — no user-facing contract change
- [x] I have tested the changes in this PR

---

### 🧪 Testing

Local:
- `go test -tags=test_unit -race -count=1 ./pkg/platform/kube/clients/... ./pkg/platform/kube/controller/... ./pkg/platform/kube/functionres/... ./pkg/platform/kube/monitoring/...` — all green.
- `go build ./...` and `go vet ./pkg/platform/kube/clients/... ./pkg/platform/kube/controller/...` — clean.
- `golangci-lint` skipped locally (bundled binary targets Go 1.25 but the repo is on 1.26.3); CI will run it.

Lab repro: lab `vmdev48ig4` had functions in projects `mm-alerts-lrt0` / `mm-alerts-lrt1` stuck in `Error` with the exact stack from the ticket (`functionres/lazy.go:1049` → `lazy.go:211` → `nucliofunction.go:261`); the new tests cover that exact reproducer at the unit level (server-timeout reactor on `services.create`). End-to-end re-validation will happen via `/igz4-dev` patch after merge.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-797
- Design docs links: n/a — bugfix
- External links: n/a

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

`isK8sRetryableErrors` had one caller in the same package — the rename to exported `IsK8sRetryableError` only adds capability. No CRD schema, API, or platform-config surface change.

---

### 🔍️ Additional Notes

The fix relies on the existing `function_monitor` loop (Ready ↔ Unhealthy) to recover transient-error functions once the API server is responsive again. If the transient error happens during *initial* provisioning (deployment never created), the function stays in `Unhealthy` — same recoverability as today's `Error`, but with a less alarming state name; the user still re-deploys. This was a deliberate scope decision — adding `Unhealthy` to `statesToRespond` would broaden the controller's reconcile triggers and is a separate change.