### PR TITLE
[ControlCommunication] Fix broker deadlock by inverting channel ownership

### DIFF
--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -377,7 +377,7 @@ func (p *Processor) getSecretsMap(scrubber *functionconfig.Scrubber) (map[string
 
 func (p *Processor) createTriggers(processorConfiguration *processor.Configuration) ([]trigger.Trigger, error) {
 	var triggers []trigger.Trigger
-	abstractControlMessageBroker := controlcommunication.NewAbstractControlMessageBroker()
+	abstractControlMessageBroker := controlcommunication.NewControlMessageBrokerBase()
 
 	// create error group
 	errGroup, _ := errgroup.WithContext(context.Background(), p.logger)

--- a/pkg/processor/controlcommunication/broker.go
+++ b/pkg/processor/controlcommunication/broker.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlcommunication
+
+import (
+	"bufio"
+	"sync"
+)
+
+// ControlMessageBrokerBase is the default ControlMessageBroker implementation.
+// Embed it in a struct to inherit fan-out and subscription management;
+// override WriteControlMessage and ReadControlMessage for transport-specific behaviour.
+type ControlMessageBrokerBase struct {
+	subscriptions []*subscription
+	lock          sync.Mutex
+}
+
+// NewControlMessageBrokerBase creates a new control message broker base
+func NewControlMessageBrokerBase() *ControlMessageBrokerBase {
+	return &ControlMessageBrokerBase{}
+}
+
+func (b *ControlMessageBrokerBase) WriteControlMessage(message *ControlMessage) error {
+	return nil
+}
+
+func (b *ControlMessageBrokerBase) ReadControlMessage(reader *bufio.Reader) (*ControlMessage, error) {
+	return nil, nil
+}
+
+func (b *ControlMessageBrokerBase) SendToConsumers(message *ControlMessage) error {
+
+	// snapshot matching subscriptions under the lock so we can release it before
+	// any blocking channel write. wg.Add must happen under the same lock that
+	// guards removal, otherwise a concurrent Close() could miss in-flight sends.
+	b.lock.Lock()
+	var targets []*subscription
+	for _, sub := range b.subscriptions {
+		if sub.kind == message.Kind {
+			sub.inFlight.Add(1)
+			targets = append(targets, sub)
+		}
+	}
+	b.lock.Unlock()
+
+	// deliver to each subscription concurrently — a slow subscriber must not
+	// block delivery to fast ones, and a Close()d subscription must not block
+	// the broker at all
+	for _, sub := range targets {
+		go sub.deliver(message)
+	}
+
+	return nil
+}
+
+func (b *ControlMessageBrokerBase) Subscribe(kind ControlMessageKind) (Subscription, error) {
+	sub := newSubscription(kind, b)
+
+	b.lock.Lock()
+	b.subscriptions = append(b.subscriptions, sub)
+	b.lock.Unlock()
+
+	return sub, nil
+}
+
+// removeSubscription removes sub from the broker's subscription list. Called by
+// subscription.Close() — never call directly from outside the package.
+func (b *ControlMessageBrokerBase) removeSubscription(target *subscription) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	for i, sub := range b.subscriptions {
+		if sub == target {
+			b.subscriptions = append(b.subscriptions[:i], b.subscriptions[i+1:]...)
+			return
+		}
+	}
+}

--- a/pkg/processor/controlcommunication/broker.go
+++ b/pkg/processor/controlcommunication/broker.go
@@ -21,9 +21,9 @@ import (
 	"sync"
 )
 
-// ControlMessageBrokerBase is the default ControlMessageBroker implementation.
-// Embed it in a struct to inherit fan-out and subscription management;
-// override WriteControlMessage and ReadControlMessage for transport-specific behaviour.
+// ControlMessageBrokerBase provides fan-out and subscription management for
+// embedding. Override WriteControlMessage and ReadControlMessage for
+// transport-specific behaviour.
 type ControlMessageBrokerBase struct {
 	subscriptions []*subscription
 	lock          sync.Mutex

--- a/pkg/processor/controlcommunication/controlcommunication_test.go
+++ b/pkg/processor/controlcommunication/controlcommunication_test.go
@@ -35,11 +35,11 @@ const regressionTimeout = 2 * time.Second
 
 type BrokerTestSuite struct {
 	suite.Suite
-	broker *AbstractControlMessageBroker
+	broker *ControlMessageBrokerBase
 }
 
 func (s *BrokerTestSuite) SetupTest() {
-	s.broker = NewAbstractControlMessageBroker()
+	s.broker = NewControlMessageBrokerBase()
 }
 
 // TestSubscribeReceive — the happy path. A subscriber receives every message
@@ -337,8 +337,8 @@ type MergedSubscriptionTestSuite struct {
 // TestMergeAggregatesFromAllSubs — every message sent through any underlying
 // subscription must arrive on the merged channel.
 func (s *MergedSubscriptionTestSuite) TestMergeAggregatesFromAllSubs() {
-	brokerA := NewAbstractControlMessageBroker()
-	brokerB := NewAbstractControlMessageBroker()
+	brokerA := NewControlMessageBrokerBase()
+	brokerB := NewControlMessageBrokerBase()
 
 	subA, err := brokerA.Subscribe(StreamMessageAckKind)
 	s.Require().NoError(err)
@@ -389,7 +389,7 @@ func (s *MergedSubscriptionTestSuite) TestMergeEmpty() {
 // TestSingleSubPassthrough — MergeSubscriptions([sub]) should just return the
 // sub itself to avoid an unnecessary forwarder goroutine.
 func (s *MergedSubscriptionTestSuite) TestSingleSubPassthrough() {
-	broker := NewAbstractControlMessageBroker()
+	broker := NewControlMessageBrokerBase()
 	sub, err := broker.Subscribe(StreamMessageAckKind)
 	s.Require().NoError(err)
 
@@ -401,7 +401,7 @@ func (s *MergedSubscriptionTestSuite) TestSingleSubPassthrough() {
 // TestCloseClosesAllUnderlying — closing the merged subscription must close
 // every underlying subscription too (no leaked channels or goroutines).
 func (s *MergedSubscriptionTestSuite) TestCloseClosesAllUnderlying() {
-	broker := NewAbstractControlMessageBroker()
+	broker := NewControlMessageBrokerBase()
 
 	const n = 4
 	subs := make([]Subscription, 0, n)
@@ -438,7 +438,7 @@ func (s *MergedSubscriptionTestSuite) TestCloseClosesAllUnderlying() {
 // reading from the merged channel (e.g. ctx.Done in Drain() just fired).
 // Close must drain the in-flight messages and not deadlock.
 func (s *MergedSubscriptionTestSuite) TestCloseUnblocksAggregatedSendWithoutReader() {
-	broker := NewAbstractControlMessageBroker()
+	broker := NewControlMessageBrokerBase()
 	sub, err := broker.Subscribe(StreamMessageAckKind)
 	s.Require().NoError(err)
 
@@ -465,7 +465,7 @@ func (s *MergedSubscriptionTestSuite) TestCloseUnblocksAggregatedSendWithoutRead
 // TestConcurrentCloseAndSends — race detector regression. Many concurrent
 // sends and a Close in the middle must not panic, deadlock, or trip -race.
 func (s *MergedSubscriptionTestSuite) TestConcurrentCloseAndSends() {
-	broker := NewAbstractControlMessageBroker()
+	broker := NewControlMessageBrokerBase()
 
 	const n = 4
 	subs := make([]Subscription, 0, n)
@@ -526,7 +526,7 @@ func (s *MergedSubscriptionTestSuite) TestConcurrentCloseAndSends() {
 	senders.Wait()
 }
 
-func mustSubscribe(t *testing.T, broker *AbstractControlMessageBroker) Subscription {
+func mustSubscribe(t *testing.T, broker *ControlMessageBrokerBase) Subscription {
 	t.Helper()
 	sub, err := broker.Subscribe(StreamMessageAckKind)
 	if err != nil {

--- a/pkg/processor/controlcommunication/controlcommunication_test.go
+++ b/pkg/processor/controlcommunication/controlcommunication_test.go
@@ -19,56 +19,526 @@ limitations under the License.
 package controlcommunication
 
 import (
-	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
-	"github.com/nuclio/logger"
-	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
 )
 
-type ControlCommunicationTestSuite struct {
+// regressionTimeout is the upper bound for any operation that we expect to
+// finish ~immediately under correct behaviour. If we hit this timeout, the
+// test fails — picking it long enough that load on CI doesn't false-positive
+// but short enough to keep the suite snappy.
+const regressionTimeout = 2 * time.Second
+
+type BrokerTestSuite struct {
 	suite.Suite
-	logger logger.Logger
-	ctx    context.Context
 	broker *AbstractControlMessageBroker
 }
 
-func (suite *ControlCommunicationTestSuite) SetupTest() {
-	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
-	suite.ctx = context.Background()
-	suite.broker = NewAbstractControlMessageBroker()
+func (s *BrokerTestSuite) SetupTest() {
+	s.broker = NewAbstractControlMessageBroker()
 }
 
-func (suite *ControlCommunicationTestSuite) TestSubscribeUnsubscribe() {
+// TestSubscribeReceive — the happy path. A subscriber receives every message
+// sent for its kind, in order, and other kinds are not delivered to it.
+func (s *BrokerTestSuite) TestSubscribeReceive() {
+	sub, err := s.broker.Subscribe(StreamMessageAckKind)
+	s.Require().NoError(err)
+	defer sub.Close()
 
-	// create 2 control message channels
-	controlMessageChannel1 := make(chan *ControlMessage)
-	controlMessageChannel2 := make(chan *ControlMessage)
+	want := &ControlMessage{Kind: StreamMessageAckKind, Attributes: map[string]interface{}{"i": 1}}
+	other := &ControlMessage{Kind: LogMessageKind, Attributes: map[string]interface{}{"i": 2}}
 
-	// subscribe the channels to an explicit ack control message kind
-	for _, controlMessageChannel := range []chan *ControlMessage{controlMessageChannel1, controlMessageChannel2} {
-		err := suite.broker.Subscribe(StreamMessageAckKind, controlMessageChannel)
-		suite.Require().NoError(err)
+	s.Require().NoError(s.broker.SendToConsumers(want))
+	s.Require().NoError(s.broker.SendToConsumers(other)) // must not be delivered
+
+	got := s.recvWithTimeout(sub)
+	s.Require().Equal(want, got)
+
+	// no second delivery — verify by checking the channel is empty after a short wait
+	select {
+	case msg := <-sub.C():
+		s.Failf("received unexpected message", "%v", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// TestMultipleSubscribersSameKind — both subscribers must receive every
+// matching message (broadcast).
+func (s *BrokerTestSuite) TestMultipleSubscribersSameKind() {
+	subA, err := s.broker.Subscribe(StreamMessageAckKind)
+	s.Require().NoError(err)
+	defer subA.Close()
+
+	subB, err := s.broker.Subscribe(StreamMessageAckKind)
+	s.Require().NoError(err)
+	defer subB.Close()
+
+	msg := &ControlMessage{Kind: StreamMessageAckKind}
+	s.Require().NoError(s.broker.SendToConsumers(msg))
+
+	s.Require().Equal(msg, s.recvWithTimeout(subA))
+	s.Require().Equal(msg, s.recvWithTimeout(subB))
+}
+
+// TestCloseUnblocksSendWithoutReader — the core NUC-765 regression test.
+//
+// Before the fix, a SendToConsumers call would hold the broker mutex while
+// writing to an unbuffered channel that had no reader, deadlocking every
+// subsequent Subscribe/Unsubscribe/Send. After the fix, Close must unblock the
+// in-flight send and the broker must remain usable.
+func (s *BrokerTestSuite) TestCloseUnblocksSendWithoutReader() {
+	sub, err := s.broker.Subscribe(StreamMessageAckKind)
+	s.Require().NoError(err)
+
+	// SendToConsumers schedules a delivery goroutine that will block on the
+	// unbuffered channel because no one is reading.
+	s.Require().NoError(s.broker.SendToConsumers(&ControlMessage{Kind: StreamMessageAckKind}))
+
+	// Close must return promptly even though the delivery goroutine is parked
+	// on `messages <-`.
+	done := make(chan struct{})
+	go func() {
+		sub.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(regressionTimeout):
+		s.Fail("Close() blocked — broker is still deadlocked (NUC-765 regression)")
 	}
 
-	// make sure the channel is subscribed
-	suite.Require().Len(suite.broker.Consumers, 1)
-	suite.Require().Len(suite.broker.Consumers[0].channels, 2)
-	suite.Require().Equal(suite.broker.Consumers[0].channels[0], controlMessageChannel1)
-	suite.Require().Equal(suite.broker.Consumers[0].channels[1], controlMessageChannel2)
+	// And the broker is still usable after Close — subscribe a fresh
+	// subscription, send, receive.
+	fresh, err := s.broker.Subscribe(StreamMessageAckKind)
+	s.Require().NoError(err)
+	defer fresh.Close()
 
-	// close the first channel, then unsubscribe it
-	close(controlMessageChannel1)
-	err := suite.broker.Unsubscribe(StreamMessageAckKind, controlMessageChannel1)
-	suite.Require().NoError(err)
-
-	// make sure the channel is unsubscribed
-	suite.Require().Len(suite.broker.Consumers, 1)
-	suite.Require().Len(suite.broker.Consumers[0].channels, 1)
-	suite.Require().Equal(suite.broker.Consumers[0].channels[0], controlMessageChannel2)
+	msg := &ControlMessage{Kind: StreamMessageAckKind, Attributes: map[string]interface{}{"post": "close"}}
+	s.Require().NoError(s.broker.SendToConsumers(msg))
+	s.Require().Equal(msg, s.recvWithTimeout(fresh))
 }
 
-func TestControlCommunicationTestSuite(t *testing.T) {
-	suite.Run(t, new(ControlCommunicationTestSuite))
+// TestSendAfterCloseIsSafe — once a subscription is closed, the broker must
+// not panic on a closed-channel write, and must not deliver any further
+// messages to the closed channel.
+func (s *BrokerTestSuite) TestSendAfterCloseIsSafe() {
+	sub, err := s.broker.Subscribe(StreamMessageAckKind)
+	s.Require().NoError(err)
+	sub.Close()
+
+	// post-close sends must succeed (no panic, no error) and must be no-ops
+	// for this subscription
+	for i := 0; i < 10; i++ {
+		s.Require().NoError(s.broker.SendToConsumers(&ControlMessage{Kind: StreamMessageAckKind}))
+	}
+
+	// channel was closed by Close() — receiving on a closed channel returns
+	// the zero value immediately with ok=false
+	msg, ok := <-sub.C()
+	s.Require().False(ok, "channel must be closed after Close()")
+	s.Require().Nil(msg)
+}
+
+// TestCloseIdempotent — Close must be safe to call multiple times.
+func (s *BrokerTestSuite) TestCloseIdempotent() {
+	sub, err := s.broker.Subscribe(StreamMessageAckKind)
+	s.Require().NoError(err)
+
+	sub.Close()
+	s.Require().NotPanics(func() { sub.Close() })
+	s.Require().NotPanics(func() { sub.Close() })
+}
+
+// TestCloseRaceWithSend — high-concurrency stress: many goroutines hammer
+// SendToConsumers while another closes the subscription. The race detector
+// is expected to be clean. No panics, no deadlocks.
+func (s *BrokerTestSuite) TestCloseRaceWithSend() {
+	sub, err := s.broker.Subscribe(StreamMessageAckKind)
+	s.Require().NoError(err)
+
+	var senders sync.WaitGroup
+	stop := make(chan struct{})
+
+	for i := 0; i < 8; i++ {
+		senders.Add(1)
+		go func() {
+			defer senders.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = s.broker.SendToConsumers(&ControlMessage{Kind: StreamMessageAckKind})
+				}
+			}
+		}()
+	}
+
+	// drain a few messages so the readers don't all park immediately, then
+	// close while sends are in flight
+	go func() {
+		for i := 0; i < 50; i++ {
+			select {
+			case <-sub.C():
+			case <-time.After(10 * time.Millisecond):
+				return
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond) // let some sends pile up
+	closed := make(chan struct{})
+	go func() {
+		sub.Close()
+		close(closed)
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(regressionTimeout):
+		s.Fail("Close raced with concurrent senders and deadlocked")
+	}
+
+	close(stop)
+	senders.Wait()
+}
+
+// TestSlowSubscriberDoesNotBlockOthers — if one subscription stops reading,
+// the broker must still deliver to other subscriptions of the same kind.
+// Before the fix, sub.Send held the broker lock and one slow channel froze
+// the whole broker.
+//
+// Delivery is concurrent (one goroutine per send per subscription), so we
+// assert the *set* of messages fast received, not the order.
+func (s *BrokerTestSuite) TestSlowSubscriberDoesNotBlockOthers() {
+	slow, err := s.broker.Subscribe(StreamMessageAckKind)
+	s.Require().NoError(err)
+	defer slow.Close()
+
+	fast, err := s.broker.Subscribe(StreamMessageAckKind)
+	s.Require().NoError(err)
+	defer fast.Close()
+
+	// slow has no reader. fast does.
+	for i := 0; i < 3; i++ {
+		s.Require().NoError(s.broker.SendToConsumers(&ControlMessage{
+			Kind:       StreamMessageAckKind,
+			Attributes: map[string]interface{}{"i": i},
+		}))
+	}
+
+	seen := map[int]bool{}
+	for i := 0; i < 3; i++ {
+		got := s.recvWithTimeout(fast)
+		seen[got.Attributes["i"].(int)] = true
+	}
+	s.Require().Equal(map[int]bool{0: true, 1: true, 2: true}, seen,
+		"fast subscriber should receive every send despite slow being stalled")
+}
+
+// TestSubscribeWhileSendInFlight — Subscribe and SendToConsumers must not
+// deadlock against each other (both acquire broker lock; lock holders must
+// never block on channel I/O while holding the lock).
+func (s *BrokerTestSuite) TestSubscribeWhileSendInFlight() {
+	stalled, err := s.broker.Subscribe(StreamMessageAckKind)
+	s.Require().NoError(err)
+	defer stalled.Close()
+
+	// stall a delivery on `stalled`
+	s.Require().NoError(s.broker.SendToConsumers(&ControlMessage{Kind: StreamMessageAckKind}))
+
+	done := make(chan struct{})
+	go func() {
+		// must not block on the stalled delivery
+		_, err := s.broker.Subscribe(StreamMessageAckKind)
+		s.Require().NoError(err)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(regressionTimeout):
+		s.Fail("Subscribe blocked on broker lock held by stalled SendToConsumers — NUC-765 regression")
+	}
+}
+
+// TestNoSubscribersIsNoop — SendToConsumers with no subscribers must succeed
+// and be a no-op.
+func (s *BrokerTestSuite) TestNoSubscribersIsNoop() {
+	s.Require().NoError(s.broker.SendToConsumers(&ControlMessage{Kind: StreamMessageAckKind}))
+}
+
+// TestCrossKindIsolation — the original NUC-765 deadlock froze every
+// Subscribe/Unsubscribe/SendToConsumers across *all* message kinds, because a
+// single mutex was held while broadcasting. After the fix, a stalled subscriber
+// on kind A must not block subscribe or send on kind B.
+func (s *BrokerTestSuite) TestCrossKindIsolation() {
+
+	// stuck reader on StreamMessageAckKind
+	stalled, err := s.broker.Subscribe(StreamMessageAckKind)
+	s.Require().NoError(err)
+	defer stalled.Close()
+
+	// fire a send that will park indefinitely waiting for a reader of `stalled`
+	s.Require().NoError(s.broker.SendToConsumers(&ControlMessage{Kind: StreamMessageAckKind}))
+
+	// while that send goroutine is parked, a different-kind subscribe must
+	// succeed promptly
+	done := make(chan struct {
+		sub Subscription
+		err error
+	})
+	go func() {
+		sub, err := s.broker.Subscribe(LogMessageKind)
+		done <- struct {
+			sub Subscription
+			err error
+		}{sub, err}
+	}()
+
+	var logSub Subscription
+	select {
+	case result := <-done:
+		s.Require().NoError(result.err)
+		logSub = result.sub
+	case <-time.After(regressionTimeout):
+		s.Fail("Subscribe(LogMessageKind) blocked while a StreamMessageAck delivery was parked — broker mutex held across kinds (NUC-765 regression)")
+	}
+	defer logSub.Close()
+
+	// and a send on the unrelated kind must reach its subscriber promptly
+	logMsg := &ControlMessage{Kind: LogMessageKind, Attributes: map[string]interface{}{"x": 1}}
+	s.Require().NoError(s.broker.SendToConsumers(logMsg))
+	s.Require().Equal(logMsg, s.recvWithTimeout(logSub))
+}
+
+// recvWithTimeout receives one message from the subscription or fails the test
+// after regressionTimeout.
+func (s *BrokerTestSuite) recvWithTimeout(sub Subscription) *ControlMessage {
+	s.T().Helper()
+	select {
+	case msg, ok := <-sub.C():
+		s.Require().True(ok, "subscription closed unexpectedly")
+		return msg
+	case <-time.After(regressionTimeout):
+		s.Fail("timed out waiting for message")
+		return nil
+	}
+}
+
+type MergedSubscriptionTestSuite struct {
+	suite.Suite
+}
+
+// TestMergeAggregatesFromAllSubs — every message sent through any underlying
+// subscription must arrive on the merged channel.
+func (s *MergedSubscriptionTestSuite) TestMergeAggregatesFromAllSubs() {
+	brokerA := NewAbstractControlMessageBroker()
+	brokerB := NewAbstractControlMessageBroker()
+
+	subA, err := brokerA.Subscribe(StreamMessageAckKind)
+	s.Require().NoError(err)
+	subB, err := brokerB.Subscribe(StreamMessageAckKind)
+	s.Require().NoError(err)
+
+	merged := MergeSubscriptions([]Subscription{subA, subB})
+	defer merged.Close()
+
+	msgA := &ControlMessage{Kind: StreamMessageAckKind, Attributes: map[string]interface{}{"from": "A"}}
+	msgB := &ControlMessage{Kind: StreamMessageAckKind, Attributes: map[string]interface{}{"from": "B"}}
+
+	s.Require().NoError(brokerA.SendToConsumers(msgA))
+	s.Require().NoError(brokerB.SendToConsumers(msgB))
+
+	seen := map[string]bool{}
+	for i := 0; i < 2; i++ {
+		select {
+		case got := <-merged.C():
+			seen[got.Attributes["from"].(string)] = true
+		case <-time.After(regressionTimeout):
+			s.Fail("timed out aggregating messages")
+		}
+	}
+	s.Require().True(seen["A"])
+	s.Require().True(seen["B"])
+}
+
+// TestMergeEmpty — MergeSubscriptions([]) must return an already-closed
+// Subscription so that range loops on C() exit immediately. The alternative —
+// an open never-delivering channel — would deadlock callers like
+// explicitAckHandler that do `for msg := range sub.C()`.
+func (s *MergedSubscriptionTestSuite) TestMergeEmpty() {
+	merged := MergeSubscriptions(nil)
+	s.Require().NotNil(merged)
+
+	select {
+	case _, ok := <-merged.C():
+		s.Require().False(ok, "empty merge must return a pre-closed channel")
+	case <-time.After(regressionTimeout):
+		s.Fail("empty merge returned a channel that never closes — callers would block forever")
+	}
+
+	// Close on an already-closed merge must be a no-op
+	s.Require().NotPanics(func() { merged.Close() })
+}
+
+// TestSingleSubPassthrough — MergeSubscriptions([sub]) should just return the
+// sub itself to avoid an unnecessary forwarder goroutine.
+func (s *MergedSubscriptionTestSuite) TestSingleSubPassthrough() {
+	broker := NewAbstractControlMessageBroker()
+	sub, err := broker.Subscribe(StreamMessageAckKind)
+	s.Require().NoError(err)
+
+	merged := MergeSubscriptions([]Subscription{sub})
+	s.Require().Same(sub, merged, "single-sub merge should be a passthrough")
+	merged.Close()
+}
+
+// TestCloseClosesAllUnderlying — closing the merged subscription must close
+// every underlying subscription too (no leaked channels or goroutines).
+func (s *MergedSubscriptionTestSuite) TestCloseClosesAllUnderlying() {
+	broker := NewAbstractControlMessageBroker()
+
+	const n = 4
+	subs := make([]Subscription, 0, n)
+	for i := 0; i < n; i++ {
+		sub, err := broker.Subscribe(StreamMessageAckKind)
+		s.Require().NoError(err)
+		subs = append(subs, sub)
+	}
+
+	merged := MergeSubscriptions(subs)
+	merged.Close()
+
+	// every underlying sub's channel is closed
+	for i, sub := range subs {
+		select {
+		case _, ok := <-sub.C():
+			s.Require().Falsef(ok, "underlying sub %d channel should be closed", i)
+		case <-time.After(regressionTimeout):
+			s.Failf("timed out", "underlying sub %d channel did not close", i)
+		}
+	}
+
+	// merged channel is closed too
+	select {
+	case _, ok := <-merged.C():
+		s.Require().False(ok)
+	case <-time.After(regressionTimeout):
+		s.Fail("merged channel did not close")
+	}
+}
+
+// TestCloseUnblocksAggregatedSendWithoutReader — the NUC-765 race at the
+// trigger layer: messages arrive at the underlying sub while no one is
+// reading from the merged channel (e.g. ctx.Done in Drain() just fired).
+// Close must drain the in-flight messages and not deadlock.
+func (s *MergedSubscriptionTestSuite) TestCloseUnblocksAggregatedSendWithoutReader() {
+	broker := NewAbstractControlMessageBroker()
+	sub, err := broker.Subscribe(StreamMessageAckKind)
+	s.Require().NoError(err)
+
+	merged := MergeSubscriptions([]Subscription{sub, mustSubscribe(s.T(), broker)})
+
+	// fire several messages while no one reads merged.C()
+	for i := 0; i < 5; i++ {
+		s.Require().NoError(broker.SendToConsumers(&ControlMessage{Kind: StreamMessageAckKind}))
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		merged.Close()
+		close(closed)
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(regressionTimeout):
+		s.Fail("merged Close() deadlocked when reader had stopped")
+	}
+}
+
+// TestConcurrentCloseAndSends — race detector regression. Many concurrent
+// sends and a Close in the middle must not panic, deadlock, or trip -race.
+func (s *MergedSubscriptionTestSuite) TestConcurrentCloseAndSends() {
+	broker := NewAbstractControlMessageBroker()
+
+	const n = 4
+	subs := make([]Subscription, 0, n)
+	for i := 0; i < n; i++ {
+		subs = append(subs, mustSubscribe(s.T(), broker))
+	}
+	merged := MergeSubscriptions(subs)
+
+	var senders sync.WaitGroup
+	stop := make(chan struct{})
+	var sent int64
+
+	for i := 0; i < 8; i++ {
+		senders.Add(1)
+		go func() {
+			defer senders.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = broker.SendToConsumers(&ControlMessage{Kind: StreamMessageAckKind})
+					atomic.AddInt64(&sent, 1)
+				}
+			}
+		}()
+	}
+
+	// reader that may stop at any point
+	go func() {
+		for {
+			select {
+			case _, ok := <-merged.C():
+				if !ok {
+					return
+				}
+			case <-time.After(100 * time.Millisecond):
+				return
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	closed := make(chan struct{})
+	go func() {
+		merged.Close()
+		close(closed)
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(regressionTimeout):
+		s.Fail("merged Close() deadlocked under concurrent senders")
+	}
+
+	close(stop)
+	senders.Wait()
+}
+
+func mustSubscribe(t *testing.T, broker *AbstractControlMessageBroker) Subscription {
+	t.Helper()
+	sub, err := broker.Subscribe(StreamMessageAckKind)
+	if err != nil {
+		t.Fatalf("Subscribe failed: %v", err)
+	}
+	return sub
+}
+
+func TestBrokerSuite(t *testing.T) {
+	suite.Run(t, new(BrokerTestSuite))
+}
+
+func TestMergedSubscriptionSuite(t *testing.T) {
+	suite.Run(t, new(MergedSubscriptionTestSuite))
 }

--- a/pkg/processor/controlcommunication/merged_subscription.go
+++ b/pkg/processor/controlcommunication/merged_subscription.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlcommunication
+
+import (
+	"sync"
+)
+
+// MergeSubscriptions returns a single Subscription whose channel delivers
+// messages from every provided subscription. Used by triggers to fan-in
+// per-worker subscriptions into one stream.
+//
+// Closing the returned Subscription closes every underlying subscription and
+// then closes the merged channel exactly once. Close is idempotent.
+//
+// If subs is empty, a non-nil already-closed Subscription is returned so that
+// callers ranging over C() exit immediately instead of blocking forever.
+func MergeSubscriptions(subs []Subscription) Subscription {
+	switch len(subs) {
+	case 0:
+		m := newMergedSubscription(nil)
+		m.Close()
+		return m
+	case 1:
+		return subs[0]
+	default:
+		return newMergedSubscription(subs)
+	}
+}
+
+type mergedSubscription struct {
+	subs      []Subscription
+	merged    chan *ControlMessage
+	done      chan struct{}
+	forwarder sync.WaitGroup
+	closeOnce sync.Once
+}
+
+func newMergedSubscription(subs []Subscription) *mergedSubscription {
+	merged := &mergedSubscription{
+		subs:   subs,
+		merged: make(chan *ControlMessage),
+		done:   make(chan struct{}),
+	}
+
+	merged.forwarder.Add(len(subs))
+	for _, sub := range subs {
+		go merged.forward(sub)
+	}
+
+	return merged
+}
+
+func (m *mergedSubscription) C() <-chan *ControlMessage {
+	return m.merged
+}
+
+func (m *mergedSubscription) Close() {
+	m.closeOnce.Do(func() {
+
+		// signal forwarders to stop pushing to the merged channel; they may
+		// also exit via their underlying subscription's channel closing below
+		close(m.done)
+
+		// close underlying subscriptions: this both unblocks any forwarder
+		// reading sub.C() (closed channel returns ok=false) and releases the
+		// per-worker broker resources
+		for _, sub := range m.subs {
+			sub.Close()
+		}
+
+		// wait until every forwarder has exited so it's safe to close `merged`
+		m.forwarder.Wait()
+
+		close(m.merged)
+	})
+}
+
+func (m *mergedSubscription) forward(sub Subscription) {
+	defer m.forwarder.Done()
+
+	for {
+		select {
+		case msg, ok := <-sub.C():
+			if !ok {
+				return
+			}
+			select {
+			case m.merged <- msg:
+			case <-m.done:
+				return
+			}
+		case <-m.done:
+			return
+		}
+	}
+}

--- a/pkg/processor/controlcommunication/subscription.go
+++ b/pkg/processor/controlcommunication/subscription.go
@@ -33,7 +33,7 @@ import (
 //     the `done` arm before close() runs.
 type subscription struct {
 	kind     ControlMessageKind
-	broker   *AbstractControlMessageBroker
+	broker   *ControlMessageBrokerBase
 	messages chan *ControlMessage
 	done     chan struct{}
 
@@ -46,7 +46,7 @@ type subscription struct {
 	closeOnce sync.Once
 }
 
-func newSubscription(kind ControlMessageKind, broker *AbstractControlMessageBroker) *subscription {
+func newSubscription(kind ControlMessageKind, broker *ControlMessageBrokerBase) *subscription {
 	return &subscription{
 		kind:     kind,
 		broker:   broker,

--- a/pkg/processor/controlcommunication/subscription.go
+++ b/pkg/processor/controlcommunication/subscription.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlcommunication
+
+import (
+	"sync"
+)
+
+// subscription is the broker-owned Subscription implementation.
+//
+// Lifecycle invariants:
+//   - The channel `messages` is closed exactly once, inside Close(), after all
+//     in-flight delivery goroutines have observed the close signal.
+//   - SendToConsumers increments `inFlight` while holding the broker lock and
+//     before starting a delivery goroutine; Close() removes the subscription
+//     from the broker (so no new increments can happen) and then waits on
+//     `inFlight`. This pairs Add/Wait correctly without races.
+//   - Delivery goroutines never panic on a closed channel because they exit via
+//     the `done` arm before close() runs.
+type subscription struct {
+	kind     ControlMessageKind
+	broker   *AbstractControlMessageBroker
+	messages chan *ControlMessage
+	done     chan struct{}
+
+	// inFlight counts delivery goroutines currently between SendToConsumers
+	// (which increments under the broker lock) and goroutine exit. Close()
+	// waits on this before closing `messages`.
+	inFlight sync.WaitGroup
+
+	// closeOnce guards Close() so it is idempotent and goroutine-safe.
+	closeOnce sync.Once
+}
+
+func newSubscription(kind ControlMessageKind, broker *AbstractControlMessageBroker) *subscription {
+	return &subscription{
+		kind:     kind,
+		broker:   broker,
+		messages: make(chan *ControlMessage),
+		done:     make(chan struct{}),
+	}
+}
+
+func (s *subscription) C() <-chan *ControlMessage {
+	return s.messages
+}
+
+func (s *subscription) Close() {
+	s.closeOnce.Do(func() {
+
+		// stop the broker from scheduling new deliveries; after this point any
+		// SendToConsumers call won't even see this subscription
+		s.broker.removeSubscription(s)
+
+		// unblock any delivery goroutines that are stuck on `messages <- msg`
+		// (no reader on the other end after Close)
+		close(s.done)
+
+		// wait for every in-flight delivery to observe `done` and exit before
+		// we close `messages` — otherwise the goroutine could race and write
+		// to a closed channel
+		s.inFlight.Wait()
+
+		close(s.messages)
+	})
+}
+
+// deliver attempts to send message to the subscription's reader. It exits when
+// the reader picks up the message or when Close() has signalled `done`,
+// whichever happens first. The caller must have called inFlight.Add(1) before
+// invoking deliver (this is done in SendToConsumers under the broker lock).
+func (s *subscription) deliver(message *ControlMessage) {
+	defer s.inFlight.Done()
+
+	select {
+	case s.messages <- message:
+	case <-s.done:
+	}
+}

--- a/pkg/processor/controlcommunication/types.go
+++ b/pkg/processor/controlcommunication/types.go
@@ -81,4 +81,3 @@ type ControlMessageBroker interface {
 	// Subscription.Close() to release resources.
 	Subscribe(kind ControlMessageKind) (Subscription, error)
 }
-

--- a/pkg/processor/controlcommunication/types.go
+++ b/pkg/processor/controlcommunication/types.go
@@ -19,8 +19,6 @@ package controlcommunication
 import (
 	"bufio"
 	"sync"
-
-	"github.com/nuclio/errors"
 )
 
 type ControlMessageKind string
@@ -42,56 +40,28 @@ type ControlMessageAttributesExplicitAck struct {
 	Offset    int64  `json:"offset"`
 }
 
-type ControlConsumer struct {
-	channels []chan *ControlMessage
-	kind     ControlMessageKind
+// Subscription is a handle to a control-message subscription.
+//
+// The broker owns the underlying channel: it is the sole writer and the sole closer.
+// Callers receive messages by ranging or selecting on C() and must invoke Close()
+// when they are no longer interested in messages. After Close() returns, the channel
+// is closed and no further sends to it will occur, so it is safe for the broker to
+// drop late messages without panicking on a closed-channel write.
+//
+// Close is idempotent and safe to call from multiple goroutines.
+type Subscription interface {
+
+	// C returns the receive-only channel for control messages of the subscribed kind.
+	// The channel is closed by the broker exactly once, after Close() returns.
+	C() <-chan *ControlMessage
+
+	// Close unsubscribes from the broker and closes the channel. Safe to call
+	// multiple times.
+	Close()
 }
 
-// NewControlConsumer creates a new control consumer
-func NewControlConsumer(kind ControlMessageKind) *ControlConsumer {
-
-	return &ControlConsumer{
-		channels: make([]chan *ControlMessage, 0),
-		kind:     kind,
-	}
-}
-
-// GetKind returns the kind of the consumer
-func (c *ControlConsumer) GetKind() ControlMessageKind {
-	return c.kind
-}
-
-// Send broadcasts a message to all subscribed channels
-func (c *ControlConsumer) Send(message *ControlMessage) error {
-
-	wg := sync.WaitGroup{}
-	wg.Add(len(c.channels))
-	for _, channel := range c.channels {
-
-		go func(channel chan *ControlMessage, message *ControlMessage) {
-			channel <- message
-			wg.Done()
-		}(channel, message)
-	}
-
-	wg.Wait()
-	return nil
-}
-
-func (c *ControlConsumer) addChannel(channel chan *ControlMessage) {
-	c.channels = append(c.channels, channel)
-}
-
-func (c *ControlConsumer) deleteChannel(channelToDelete chan *ControlMessage) {
-	// remove the channel from the consumer
-	for i, channel := range c.channels {
-		if channel == channelToDelete {
-			c.channels = append(c.channels[:i], c.channels[i+1:]...)
-			break
-		}
-	}
-}
-
+// ControlMessageBroker routes control messages received from a runtime wrapper to
+// subscribers interested in specific message kinds.
 type ControlMessageBroker interface {
 
 	// WriteControlMessage writes a control message to the control communication
@@ -100,27 +70,29 @@ type ControlMessageBroker interface {
 	// ReadControlMessage reads a control message from the control communication
 	ReadControlMessage(reader *bufio.Reader) (*ControlMessage, error)
 
-	// SendToConsumers sends a control message to all consumers
+	// SendToConsumers fans out a control message to all subscriptions whose kind matches.
+	// The call returns once delivery has been scheduled; per-subscription delivery
+	// happens asynchronously and is bounded by the subscription's lifetime — a
+	// subscription that is Close()d while a send is in flight drops the message
+	// instead of blocking the broker.
 	SendToConsumers(message *ControlMessage) error
 
-	// Subscribe subscribes channel to a control message kind
-	Subscribe(kind ControlMessageKind, channel chan *ControlMessage) error
-
-	// Unsubscribe unsubscribes channel from a control message kind
-	Unsubscribe(kind ControlMessageKind, channel chan *ControlMessage) error
+	// Subscribe creates a new subscription for the given control message kind.
+	// The returned Subscription owns its channel; the caller must invoke
+	// Subscription.Close() to release resources.
+	Subscribe(kind ControlMessageKind) (Subscription, error)
 }
 
+// AbstractControlMessageBroker is the default ControlMessageBroker implementation.
+// The zero value is not usable; construct with NewAbstractControlMessageBroker.
 type AbstractControlMessageBroker struct {
-	Consumers   []*ControlConsumer
-	channelLock sync.Mutex
+	subscriptions []*subscription
+	lock          sync.Mutex
 }
 
 // NewAbstractControlMessageBroker creates a new abstract control message broker
 func NewAbstractControlMessageBroker() *AbstractControlMessageBroker {
-	return &AbstractControlMessageBroker{
-		Consumers:   make([]*ControlConsumer, 0),
-		channelLock: sync.Mutex{},
-	}
+	return &AbstractControlMessageBroker{}
 }
 
 func (acmb *AbstractControlMessageBroker) WriteControlMessage(message *ControlMessage) error {
@@ -132,59 +104,49 @@ func (acmb *AbstractControlMessageBroker) ReadControlMessage(reader *bufio.Reade
 }
 
 func (acmb *AbstractControlMessageBroker) SendToConsumers(message *ControlMessage) error {
-	acmb.channelLock.Lock()
-	defer acmb.channelLock.Unlock()
 
-	for _, consumer := range acmb.Consumers {
-		if consumer.GetKind() == message.Kind {
-			if err := consumer.Send(message); err != nil {
-				return errors.Wrap(err, "Failed to send message to consumer")
-			}
+	// snapshot matching subscriptions under the lock so we can release it before
+	// any blocking channel write. wg.Add must happen under the same lock that
+	// guards removal, otherwise a concurrent Close() could miss in-flight sends.
+	acmb.lock.Lock()
+	var targets []*subscription
+	for _, sub := range acmb.subscriptions {
+		if sub.kind == message.Kind {
+			sub.inFlight.Add(1)
+			targets = append(targets, sub)
 		}
+	}
+	acmb.lock.Unlock()
+
+	// deliver to each subscription concurrently — a slow subscriber must not
+	// block delivery to fast ones, and a Close()d subscription must not block
+	// the broker at all
+	for _, sub := range targets {
+		go sub.deliver(message)
 	}
 
 	return nil
 }
 
-func (acmb *AbstractControlMessageBroker) Subscribe(kind ControlMessageKind, channel chan *ControlMessage) error {
+func (acmb *AbstractControlMessageBroker) Subscribe(kind ControlMessageKind) (Subscription, error) {
+	sub := newSubscription(kind, acmb)
 
-	// acquire lock to prevent concurrent access to the consumers and channels
-	acmb.channelLock.Lock()
-	defer acmb.channelLock.Unlock()
+	acmb.lock.Lock()
+	acmb.subscriptions = append(acmb.subscriptions, sub)
+	acmb.lock.Unlock()
 
-	// create consumers if they don't exist
-	if acmb.Consumers == nil {
-		acmb.Consumers = make([]*ControlConsumer, 0)
-	}
-
-	// Add the consumer to the list of the relevant kind
-	for _, consumer := range acmb.Consumers {
-		if consumer.GetKind() == kind {
-			consumer.addChannel(channel)
-			return nil
-		}
-	}
-
-	// consumer for the kind doesn't exist, create one
-	consumer := NewControlConsumer(kind)
-	consumer.addChannel(channel)
-	acmb.Consumers = append(acmb.Consumers, consumer)
-
-	return nil
+	return sub, nil
 }
 
-func (acmb *AbstractControlMessageBroker) Unsubscribe(kind ControlMessageKind, channel chan *ControlMessage) error {
-
-	// acquire lock to prevent concurrent access to the consumers and channels
-	acmb.channelLock.Lock()
-	defer acmb.channelLock.Unlock()
-
-	// Find the consumer with relevant kind
-	for _, consumer := range acmb.Consumers {
-		if consumer.GetKind() == kind {
-			consumer.deleteChannel(channel)
-			return nil
+// removeSubscription removes sub from the broker's subscription list. Called by
+// subscription.Close() — never call directly from outside the package.
+func (acmb *AbstractControlMessageBroker) removeSubscription(target *subscription) {
+	acmb.lock.Lock()
+	defer acmb.lock.Unlock()
+	for i, sub := range acmb.subscriptions {
+		if sub == target {
+			acmb.subscriptions = append(acmb.subscriptions[:i], acmb.subscriptions[i+1:]...)
+			return
 		}
 	}
-	return nil
 }

--- a/pkg/processor/controlcommunication/types.go
+++ b/pkg/processor/controlcommunication/types.go
@@ -18,7 +18,6 @@ package controlcommunication
 
 import (
 	"bufio"
-	"sync"
 )
 
 type ControlMessageKind string
@@ -83,70 +82,3 @@ type ControlMessageBroker interface {
 	Subscribe(kind ControlMessageKind) (Subscription, error)
 }
 
-// AbstractControlMessageBroker is the default ControlMessageBroker implementation.
-// The zero value is not usable; construct with NewAbstractControlMessageBroker.
-type AbstractControlMessageBroker struct {
-	subscriptions []*subscription
-	lock          sync.Mutex
-}
-
-// NewAbstractControlMessageBroker creates a new abstract control message broker
-func NewAbstractControlMessageBroker() *AbstractControlMessageBroker {
-	return &AbstractControlMessageBroker{}
-}
-
-func (acmb *AbstractControlMessageBroker) WriteControlMessage(message *ControlMessage) error {
-	return nil
-}
-
-func (acmb *AbstractControlMessageBroker) ReadControlMessage(reader *bufio.Reader) (*ControlMessage, error) {
-	return nil, nil
-}
-
-func (acmb *AbstractControlMessageBroker) SendToConsumers(message *ControlMessage) error {
-
-	// snapshot matching subscriptions under the lock so we can release it before
-	// any blocking channel write. wg.Add must happen under the same lock that
-	// guards removal, otherwise a concurrent Close() could miss in-flight sends.
-	acmb.lock.Lock()
-	var targets []*subscription
-	for _, sub := range acmb.subscriptions {
-		if sub.kind == message.Kind {
-			sub.inFlight.Add(1)
-			targets = append(targets, sub)
-		}
-	}
-	acmb.lock.Unlock()
-
-	// deliver to each subscription concurrently — a slow subscriber must not
-	// block delivery to fast ones, and a Close()d subscription must not block
-	// the broker at all
-	for _, sub := range targets {
-		go sub.deliver(message)
-	}
-
-	return nil
-}
-
-func (acmb *AbstractControlMessageBroker) Subscribe(kind ControlMessageKind) (Subscription, error) {
-	sub := newSubscription(kind, acmb)
-
-	acmb.lock.Lock()
-	acmb.subscriptions = append(acmb.subscriptions, sub)
-	acmb.lock.Unlock()
-
-	return sub, nil
-}
-
-// removeSubscription removes sub from the broker's subscription list. Called by
-// subscription.Close() — never call directly from outside the package.
-func (acmb *AbstractControlMessageBroker) removeSubscription(target *subscription) {
-	acmb.lock.Lock()
-	defer acmb.lock.Unlock()
-	for i, sub := range acmb.subscriptions {
-		if sub == target {
-			acmb.subscriptions = append(acmb.subscriptions[:i], acmb.subscriptions[i+1:]...)
-			return
-		}
-	}
-}

--- a/pkg/processor/eventprocessor/mock.go
+++ b/pkg/processor/eventprocessor/mock.go
@@ -113,12 +113,10 @@ func (m *MockEventProcessor) SupportsRestart() bool {
 	return m.Called().Bool(0)
 }
 
-func (m *MockEventProcessor) Subscribe(kind controlcommunication.ControlMessageKind, channel chan *controlcommunication.ControlMessage) error {
-	return m.Called(kind, channel).Error(0)
-}
-
-func (m *MockEventProcessor) Unsubscribe(kind controlcommunication.ControlMessageKind, channel chan *controlcommunication.ControlMessage) error {
-	return m.Called(kind, channel).Error(0)
+func (m *MockEventProcessor) Subscribe(kind controlcommunication.ControlMessageKind) (controlcommunication.Subscription, error) {
+	args := m.Called(kind)
+	sub, _ := args.Get(0).(controlcommunication.Subscription)
+	return sub, args.Error(1)
 }
 
 func (m *MockEventProcessor) WaitForStart(timeout time.Duration) error {

--- a/pkg/processor/eventprocessor/types.go
+++ b/pkg/processor/eventprocessor/types.go
@@ -128,11 +128,9 @@ type EventProcessor interface {
 	// SupportsRestart checks if the event processor supports restarting
 	SupportsRestart() bool
 
-	// Subscribe registers a channel to receive control messages of a specific kind
-	Subscribe(kind controlcommunication.ControlMessageKind, channel chan *controlcommunication.ControlMessage) error
-
-	// Unsubscribe removes a previously registered channel for control messages
-	Unsubscribe(kind controlcommunication.ControlMessageKind, channel chan *controlcommunication.ControlMessage) error
+	// Subscribe creates a control-message subscription owned by this processor's
+	// broker. The caller must Close() the returned Subscription to release it.
+	Subscribe(kind controlcommunication.ControlMessageKind) (controlcommunication.Subscription, error)
 
 	// WaitForStart blocks until the event processor has fully started
 	WaitForStart(timeout time.Duration) (err error)

--- a/pkg/processor/runtime/rpc/abstract_test.go
+++ b/pkg/processor/runtime/rpc/abstract_test.go
@@ -146,12 +146,10 @@ func (suite *RuntimeSuite) TestSubscribeToControlMessage() {
 
 	time.Sleep(1 * time.Second)
 
-	// create channel for consumer
-	controlMessageChannel := make(chan *controlcommunication.ControlMessage)
-
-	// subscribe to test message kind
-	err = suite.testRuntimeInstance.GetControlMessageBroker().Subscribe(messageKind, controlMessageChannel)
+	// subscribe to test message kind — the broker owns the channel
+	sub, err := suite.testRuntimeInstance.GetControlMessageBroker().Subscribe(messageKind)
 	suite.Require().NoError(err, "Can't subscribe to control message")
+	defer sub.Close()
 
 	// create control message
 	controlMessage := &controlcommunication.ControlMessage{
@@ -165,7 +163,7 @@ func (suite *RuntimeSuite) TestSubscribeToControlMessage() {
 
 	// wait for control message in a goroutine
 	go func() {
-		receivedControlMessage := <-controlMessageChannel
+		receivedControlMessage := <-sub.C()
 		suite.Require().Equal(controlMessage, receivedControlMessage, "Received control message doesn't match")
 		done <- true
 	}()

--- a/pkg/processor/runtime/rpc/abstract_test.go
+++ b/pkg/processor/runtime/rpc/abstract_test.go
@@ -65,7 +65,7 @@ func newTestRuntime(parentLogger logger.Logger, configuration *runtime.Configura
 		return nil, errors.Wrap(err, "Failed to create runtime")
 	}
 
-	newTestRuntime.configuration.ControlMessageBroker = controlmessagebroker.NewRpcControlMessageBroker(nil, parentLogger, nil).AbstractControlMessageBroker
+	newTestRuntime.configuration.ControlMessageBroker = controlmessagebroker.NewRpcControlMessageBroker(nil, parentLogger, nil).ControlMessageBrokerBase
 
 	return newTestRuntime, nil
 }
@@ -234,7 +234,7 @@ func (suite *RuntimeSuite) createLogger() logger.Logger {
 func (suite *RuntimeSuite) createConfig(loggerInstance logger.Logger) *runtime.Configuration {
 	return &runtime.Configuration{
 		FunctionLogger:       loggerInstance,
-		ControlMessageBroker: controlcommunication.NewAbstractControlMessageBroker(),
+		ControlMessageBroker: controlcommunication.NewControlMessageBrokerBase(),
 		Configuration: &processor.Configuration{
 			Config: functionconfig.Config{
 				Meta: functionconfig.Meta{

--- a/pkg/processor/runtime/rpc/connection/abstract.go
+++ b/pkg/processor/runtime/rpc/connection/abstract.go
@@ -819,7 +819,7 @@ func NewAbstractControlMessageConnection(parentLogger logger.Logger, broker cont
 	}
 }
 
-func (bc *AbstractControlMessageConnection) SetBroker(abstractBroker *controlcommunication.AbstractControlMessageBroker) {
+func (bc *AbstractControlMessageConnection) SetBroker(abstractBroker *controlcommunication.ControlMessageBrokerBase) {
 	bc.broker = controlmessagebroker.NewRpcControlMessageBroker(
 		bc.encoder,
 		bc.Logger,

--- a/pkg/processor/runtime/rpc/connection/abstract.go
+++ b/pkg/processor/runtime/rpc/connection/abstract.go
@@ -636,14 +636,10 @@ func (be *AbstractEventConnection) Continue() error {
 	return nuclio.ErrNotImplemented
 }
 
-// Subscribe subscribes to a control message kind
-func (be *AbstractEventConnection) Subscribe(kind controlcommunication.ControlMessageKind, channel chan *controlcommunication.ControlMessage) error {
-	return nuclio.ErrNotImplemented
-}
-
-// Unsubscribe unsubscribes from a control message kind
-func (be *AbstractEventConnection) Unsubscribe(kind controlcommunication.ControlMessageKind, channel chan *controlcommunication.ControlMessage) error {
-	return nuclio.ErrNotImplemented
+// Subscribe is not implemented at the event-connection level; control-message
+// subscriptions go through the runtime broker.
+func (be *AbstractEventConnection) Subscribe(kind controlcommunication.ControlMessageKind) (controlcommunication.Subscription, error) {
+	return nil, nuclio.ErrNotImplemented
 }
 
 func (be *AbstractEventConnection) processItem(item interface{}, functionLogger logger.Logger) (result.Result, error) {

--- a/pkg/processor/runtime/rpc/controlmessagebroker/controlmessagebroker.go
+++ b/pkg/processor/runtime/rpc/controlmessagebroker/controlmessagebroker.go
@@ -29,20 +29,20 @@ import (
 )
 
 type rpcControlMessageBroker struct {
-	*controlcommunication.AbstractControlMessageBroker
+	*controlcommunication.ControlMessageBrokerBase
 	ControlMessageEventEncoder encoder.EventEncoder
 	logger                     logger.Logger
 }
 
 // NewRpcControlMessageBroker creates a new RPC control message broker
-func NewRpcControlMessageBroker(encoder encoder.EventEncoder, logger logger.Logger, abstractControlMessageBroker *controlcommunication.AbstractControlMessageBroker) *rpcControlMessageBroker {
+func NewRpcControlMessageBroker(encoder encoder.EventEncoder, logger logger.Logger, abstractControlMessageBroker *controlcommunication.ControlMessageBrokerBase) *rpcControlMessageBroker {
 
 	if abstractControlMessageBroker == nil {
-		abstractControlMessageBroker = controlcommunication.NewAbstractControlMessageBroker()
+		abstractControlMessageBroker = controlcommunication.NewControlMessageBrokerBase()
 	}
 
 	return &rpcControlMessageBroker{
-		AbstractControlMessageBroker: abstractControlMessageBroker,
+		ControlMessageBrokerBase: abstractControlMessageBroker,
 		ControlMessageEventEncoder:   encoder,
 		logger:                       logger.GetChild("controlMessageBroker"),
 	}

--- a/pkg/processor/runtime/rpc/controlmessagebroker/controlmessagebroker.go
+++ b/pkg/processor/runtime/rpc/controlmessagebroker/controlmessagebroker.go
@@ -42,9 +42,9 @@ func NewRpcControlMessageBroker(encoder encoder.EventEncoder, logger logger.Logg
 	}
 
 	return &rpcControlMessageBroker{
-		ControlMessageBrokerBase: abstractControlMessageBroker,
-		ControlMessageEventEncoder:   encoder,
-		logger:                       logger.GetChild("controlMessageBroker"),
+		ControlMessageBrokerBase:   abstractControlMessageBroker,
+		ControlMessageEventEncoder: encoder,
+		logger:                     logger.GetChild("controlMessageBroker"),
 	}
 }
 

--- a/pkg/processor/runtime/types.go
+++ b/pkg/processor/runtime/types.go
@@ -56,7 +56,7 @@ type Configuration struct {
 	TriggerName              string
 	TriggerKind              string
 	WorkerTerminationTimeout time.Duration
-	ControlMessageBroker     *controlcommunication.AbstractControlMessageBroker
+	ControlMessageBroker     *controlcommunication.ControlMessageBrokerBase
 	Mode                     functionconfig.TriggerWorkMode
 	AsyncConfig              *functionconfig.AsyncConfig
 }

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -228,11 +228,11 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 	// channel and is closed in the deferred cleanup below.
 	var explicitAckSubscription controlcommunication.Subscription
 	if functionconfig.ExplicitAckEnabled(k.configuration.ExplicitAckMode) {
-		sub, err := k.SubscribeToControlMessageKind(controlcommunication.StreamMessageAckKind)
+		var err error
+		explicitAckSubscription, err = k.SubscribeToControlMessageKind(controlcommunication.StreamMessageAckKind)
 		if err != nil {
 			return errors.Wrap(err, "Failed to subscribe to explicit ack control messages")
 		}
-		explicitAckSubscription = sub
 
 		go k.explicitAckHandler(
 			session,

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -217,7 +217,6 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 
 	// initialize goroutine communication channels
 	submittedEventChan := make(chan *submittedEvent)
-	explicitAckControlMessageChan := make(chan *controlcommunication.ControlMessage)
 	workerDrainingCompleteChan := make(chan bool)
 
 	// submit the events in a goroutine so that we can unblock immediately
@@ -225,16 +224,19 @@ func (k *kafka) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.C
 
 	ackWindowSize := int64(k.configuration.ackWindowSize)
 
-	// listen for explicit ack messages if enabled
+	// listen for explicit ack messages if enabled. The subscription owns its
+	// channel and is closed in the deferred cleanup below.
+	var explicitAckSubscription controlcommunication.Subscription
 	if functionconfig.ExplicitAckEnabled(k.configuration.ExplicitAckMode) {
-
-		if err := k.SubscribeToControlMessageKind(controlcommunication.StreamMessageAckKind, explicitAckControlMessageChan); err != nil {
+		sub, err := k.SubscribeToControlMessageKind(controlcommunication.StreamMessageAckKind)
+		if err != nil {
 			return errors.Wrap(err, "Failed to subscribe to explicit ack control messages")
 		}
+		explicitAckSubscription = sub
 
 		go k.explicitAckHandler(
 			session,
-			explicitAckControlMessageChan,
+			explicitAckSubscription.C(),
 			claim.Partition(),
 			claim.Topic(),
 		)
@@ -314,16 +316,15 @@ consumptionLoop:
 
 	k.Logger.DebugWith("Claim consumption stopped", "partition", claim.Partition())
 
-	// unsubscribe channel from the streamAck control message kind before closing it
-	if functionconfig.ExplicitAckEnabled(k.configuration.ExplicitAckMode) {
-		if err := k.UnsubscribeFromControlMessageKind(controlcommunication.StreamMessageAckKind, explicitAckControlMessageChan); err != nil {
-			k.Logger.WarnWith("Failed to unsubscribe channel from control message kind", "err", err)
-		}
+	// Close the explicit-ack subscription before closing the event submitter:
+	// Close() drives the broker to drain in-flight deliveries and then close the
+	// subscription's channel, which terminates explicitAckHandler's range loop.
+	if explicitAckSubscription != nil {
+		explicitAckSubscription.Close()
 	}
 
 	// shut down goroutines and channels
 	close(submittedEventChan)
-	close(explicitAckControlMessageChan)
 	close(workerDrainingCompleteChan)
 
 	return submitError
@@ -660,10 +661,12 @@ func (k *kafka) resolveSCRAMClientGeneratorFunc(mechanism sarama.SASLMechanism) 
 }
 
 // explicitAckHandler reads offset data messages from the trigger's control channel, and marks the
-// offset accordingly
+// offset accordingly. The channel is owned by the broker; the handler exits
+// cleanly when the subscription is closed and the channel is therefore drained
+// and closed by the broker.
 func (k *kafka) explicitAckHandler(
 	session sarama.ConsumerGroupSession,
-	controlMessageChan chan *controlcommunication.ControlMessage,
+	controlMessageChan <-chan *controlcommunication.ControlMessage,
 	partitionNumber int32,
 	topic string) {
 

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -345,44 +345,39 @@ func (at *AbstractTrigger) Restart() error {
 	return nil
 }
 
-// SubscribeToControlMessageKind subscribes all workers to control message kind
-func (at *AbstractTrigger) SubscribeToControlMessageKind(kind controlcommunication.ControlMessageKind,
-	controlMessageChan chan *controlcommunication.ControlMessage) error {
+// SubscribeToControlMessageKind subscribes every worker's control-message broker
+// to the given kind and merges them into a single Subscription that delivers
+// messages from any worker over one channel.
+//
+// The caller owns the returned Subscription and must call Close() — typically
+// in a defer — to release the per-worker subscriptions and close the merged
+// channel. Because the broker is the sole writer/closer, Close() is safe to
+// invoke at any time without racing against in-flight deliveries.
+func (at *AbstractTrigger) SubscribeToControlMessageKind(kind controlcommunication.ControlMessageKind) (controlcommunication.Subscription, error) {
 
+	workers := at.WorkerAllocator.GetObjects()
 	at.Logger.DebugWith("Subscribing to control message kind",
 		"kind", kind,
-		"numWorkers", len(at.WorkerAllocator.GetObjects()))
+		"numWorkers", len(workers))
 
-	for _, workerInstance := range at.WorkerAllocator.GetObjects() {
-		if err := workerInstance.Subscribe(kind, controlMessageChan); err != nil {
-			return errors.Wrapf(err,
+	subs := make([]controlcommunication.Subscription, 0, len(workers))
+	for _, workerInstance := range workers {
+		sub, err := workerInstance.Subscribe(kind)
+		if err != nil {
+			// release any subscriptions we already created so we don't leak
+			// channels on the partial-failure path
+			for _, s := range subs {
+				s.Close()
+			}
+			return nil, errors.Wrapf(err,
 				"Failed to subscribe to control message kind %s in worker %d",
 				kind,
 				workerInstance.GetIndex())
 		}
+		subs = append(subs, sub)
 	}
 
-	return nil
-}
-
-// UnsubscribeFromControlMessageKind unsubscribes all workers from control message kind
-func (at *AbstractTrigger) UnsubscribeFromControlMessageKind(kind controlcommunication.ControlMessageKind,
-	controlMessageChan chan *controlcommunication.ControlMessage) error {
-
-	at.Logger.DebugWith("Unsubscribing channel from control message kind",
-		"kind", kind,
-		"numWorkers", len(at.WorkerAllocator.GetObjects()))
-
-	for _, workerInstance := range at.WorkerAllocator.GetObjects() {
-		if err := workerInstance.Unsubscribe(kind, controlMessageChan); err != nil {
-			return errors.Wrapf(err,
-				"Failed to unsubscribe channel from control message kind %s in worker %d",
-				kind,
-				workerInstance.GetIndex())
-		}
-	}
-
-	return nil
+	return controlcommunication.MergeSubscriptions(subs), nil
 }
 
 // SignalWorkersToDrain sends a signal to all workers, telling them to drop or ack events

--- a/pkg/processor/trigger/v3iostream/trigger.go
+++ b/pkg/processor/trigger/v3iostream/trigger.go
@@ -175,7 +175,6 @@ func (vs *v3iostream) ConsumeClaim(session streamconsumergroup.Session, claim st
 	}
 
 	submittedEventChan := make(chan *submittedEvent)
-	explicitAckControlMessageChan := make(chan *controlcommunication.ControlMessage)
 
 	// submit the events in a goroutine so that we can unblock immediately
 	go vs.eventSubmitter(claim, submittedEventChan)
@@ -186,14 +185,18 @@ func (vs *v3iostream) ConsumeClaim(session streamconsumergroup.Session, claim st
 
 	commitRecordFuncHandler := vs.resolveCommitRecordFuncHandler(session)
 
-	// listen for explicit ack messages if enabled
+	// listen for explicit ack messages if enabled. The subscription owns its
+	// channel and is closed in the deferred cleanup below.
+	var explicitAckSubscription controlcommunication.Subscription
 	if functionconfig.ExplicitAckEnabled(vs.configuration.ExplicitAckMode) {
-		if err := vs.SubscribeToControlMessageKind(controlcommunication.StreamMessageAckKind, explicitAckControlMessageChan); err != nil {
+		sub, err := vs.SubscribeToControlMessageKind(controlcommunication.StreamMessageAckKind)
+		if err != nil {
 			return errors.Wrap(err, "Failed to subscribe to explicit ack control messages")
 		}
+		explicitAckSubscription = sub
 
 		go vs.explicitAckHandler(
-			explicitAckControlMessageChan,
+			explicitAckSubscription.C(),
 			commitRecordFuncHandler,
 			claim.GetShardID(),
 			claim.GetStreamPath(),
@@ -237,16 +240,15 @@ func (vs *v3iostream) ConsumeClaim(session streamconsumergroup.Session, claim st
 
 	vs.Logger.DebugWith("Claim consumption stopped", "shardID", claim.GetShardID())
 
-	// unsubscribe channel from the streamAck control message kind before closing it
-	if functionconfig.ExplicitAckEnabled(vs.configuration.ExplicitAckMode) {
-		if err := vs.UnsubscribeFromControlMessageKind(controlcommunication.StreamMessageAckKind, explicitAckControlMessageChan); err != nil {
-			vs.Logger.WarnWith("Failed to unsubscribe channel from control message kind", "err", err)
-		}
+	// Close the explicit-ack subscription before closing the event submitter:
+	// Close() drives the broker to drain in-flight deliveries and then close the
+	// subscription's channel, which terminates explicitAckHandler's range loop.
+	if explicitAckSubscription != nil {
+		explicitAckSubscription.Close()
 	}
 
-	// shut down the event submitter and the explicit ack handler
+	// shut down the event submitter
 	close(submittedEventChan)
-	close(explicitAckControlMessageChan)
 
 	return submitError
 }
@@ -428,7 +430,7 @@ func (vs *v3iostream) resolveCommitRecordFuncHandler(session streamconsumergroup
 }
 
 func (vs *v3iostream) explicitAckHandler(
-	controlMessageChan chan *controlcommunication.ControlMessage,
+	controlMessageChan <-chan *controlcommunication.ControlMessage,
 	commitRecordFuncHandler func(*v3io.StreamRecord),
 	claimShardId int,
 	claimStreamPath string) {

--- a/pkg/processor/trigger/v3iostream/trigger.go
+++ b/pkg/processor/trigger/v3iostream/trigger.go
@@ -189,11 +189,11 @@ func (vs *v3iostream) ConsumeClaim(session streamconsumergroup.Session, claim st
 	// channel and is closed in the deferred cleanup below.
 	var explicitAckSubscription controlcommunication.Subscription
 	if functionconfig.ExplicitAckEnabled(vs.configuration.ExplicitAckMode) {
-		sub, err := vs.SubscribeToControlMessageKind(controlcommunication.StreamMessageAckKind)
+		var err error
+		explicitAckSubscription, err = vs.SubscribeToControlMessageKind(controlcommunication.StreamMessageAckKind)
 		if err != nil {
 			return errors.Wrap(err, "Failed to subscribe to explicit ack control messages")
 		}
-		explicitAckSubscription = sub
 
 		go vs.explicitAckHandler(
 			explicitAckSubscription.C(),

--- a/pkg/processor/worker/worker.go
+++ b/pkg/processor/worker/worker.go
@@ -172,14 +172,10 @@ func (w *Worker) Continue() error {
 	return nil
 }
 
-// Subscribe subscribes to a control message kind
-func (w *Worker) Subscribe(kind controlcommunication.ControlMessageKind, channel chan *controlcommunication.ControlMessage) error {
-	return w.runtime.GetControlMessageBroker().Subscribe(kind, channel)
-}
-
-// Unsubscribe unsubscribes from a control message kind
-func (w *Worker) Unsubscribe(kind controlcommunication.ControlMessageKind, channel chan *controlcommunication.ControlMessage) error {
-	return w.runtime.GetControlMessageBroker().Unsubscribe(kind, channel)
+// Subscribe creates a control-message subscription owned by this worker's
+// runtime broker. The caller must Close() the returned Subscription.
+func (w *Worker) Subscribe(kind controlcommunication.ControlMessageKind) (controlcommunication.Subscription, error) {
+	return w.runtime.GetControlMessageBroker().Subscribe(kind)
 }
 
 func (w *Worker) WaitForStart(time.Duration) error {


### PR DESCRIPTION
### 📝 Description
Prep for https://ecliptos.atlassian.net/browse/NUC-756
Fixes the NUC-765 deadlock in `AbstractControlMessageBroker`.

The broker held a single mutex (`channelLock`) for every state operation **and** kept it held while broadcasting over unbuffered subscriber channels. A single subscriber that stopped reading was enough to freeze every subsequent `Subscribe` / `Unsubscribe` / `SendToConsumers` across **all** message kinds and triggers sharing the broker — leading to the integration-test symptom where Kafka reported only 3 of 4 group members and the replica stayed a phantom for ~10 minutes until session timeout.

The root cause is that channels were written to by the broker but **closed** by callers, so the broker had to synchronise on `wg.Wait()` to know when it was safe to release the lock. This PR inverts that ownership: the broker is now the sole writer and sole closer of subscription channels. Callers receive a `Subscription` handle and call `Close()` to release it.


---

### 🛠️ Changes Made

**`pkg/processor/controlcommunication`**

- New `Subscription` interface: `C() <-chan *ControlMessage`, `Close()` (idempotent, goroutine-safe). The broker owns the channel.
- New `subscription` (`subscription.go`) — `Close()` removes the sub from the broker under the lock, unblocks any parked delivery goroutines via a `done` channel, waits for them to exit, then closes `messages` exactly once. Delivery goroutines exit via `<-done` so they can never write to a closed channel.
- New `MergeSubscriptions` / `mergedSubscription` (`merged_subscription.go`) — fans-in per-worker subscriptions into one channel; `Close()` propagates to every underlying sub. Single-sub case is passthrough; empty case returns a pre-closed Subscription so range loops exit immediately.
- `AbstractControlMessageBroker.SendToConsumers` snapshots matching subscriptions under the lock, then releases it before any channel write. `Unsubscribe()` is replaced by `Subscription.Close()`. Mutex is never held across channel I/O.
- Removed `ControlConsumer` and the per-kind grouping — each subscription stands on its own.

**Caller migration**

- `pkg/processor/trigger/trigger.go` — `SubscribeToControlMessageKind` now returns a merged `Subscription`. Removed `UnsubscribeFromControlMessageKind`.
- `pkg/processor/trigger/kafka/trigger.go` and `pkg/processor/trigger/v3iostream/trigger.go` — `explicitAckHandler` ranges over `sub.C()` and exits when the broker closes it; `ConsumeClaim` defers `sub.Close()` before tearing down the event submitter so the handler unwinds cleanly.
- `pkg/processor/worker/worker.go`, `pkg/processor/eventprocessor/{types,mock}.go`, `pkg/processor/runtime/rpc/connection/abstract.go` — `Subscribe(kind)` on the EventProcessor interface returns a `Subscription`.

---

### ✅ Checklist

- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

Unit tests in `pkg/processor/controlcommunication/controlcommunication_test.go` (build tag \`test_unit\`):

**\`BrokerTestSuite\`**

- \`TestSubscribeReceive\` — happy path; subscriber receives only its kind.
- \`TestMultipleSubscribersSameKind\` — broadcast to N subscribers of the same kind.
- \`TestCloseUnblocksSendWithoutReader\` — **core NUC-765 regression**: \`Close()\` returns promptly even though a delivery goroutine is parked on an unbuffered channel.
- \`TestSendAfterCloseIsSafe\` — post-close sends are no-ops, no \`send on closed channel\` panic.
- \`TestCloseIdempotent\` — \`Close()\` safe to call multiple times.
- \`TestCloseRaceWithSend\` — 8 concurrent senders + concurrent \`Close()\`; race detector clean.
- \`TestSlowSubscriberDoesNotBlockOthers\` — a stalled subscriber doesn't starve a fast one of the same kind.
- \`TestSubscribeWhileSendInFlight\` — \`Subscribe()\` doesn't block on a parked \`SendToConsumers\`.
- \`TestNoSubscribersIsNoop\` — send with zero subscribers succeeds.
- \`TestCrossKindIsolation\` — a parked send on kind A must not block subscribe/send on kind B (directly mirrors the original \"freeze across all kinds\" bug).

**\`MergedSubscriptionTestSuite\`**

- \`TestMergeAggregatesFromAllSubs\` — messages from any underlying broker reach the merged channel.
- \`TestSingleSubPassthrough\` — \`MergeSubscriptions([sub])\` returns the sub itself.
- \`TestMergeEmpty\` — \`MergeSubscriptions(nil)\` returns a pre-closed sub so callers don't deadlock on \`for range C()\`.
- \`TestCloseClosesAllUnderlying\` — closing the merge closes every underlying sub (no goroutine/channel leaks).
- \`TestCloseUnblocksAggregatedSendWithoutReader\` — trigger-layer race: messages arrive at underlying subs while no one reads the merged channel; \`Close()\` drains without deadlock.
- \`TestConcurrentCloseAndSends\` — race-detector stress test with concurrent senders and \`Close()\`.

Verified:

\`\`\`
go test -race -tags test_unit -count=50 ./pkg/processor/controlcommunication/...
ok  github.com/nuclio/nuclio/pkg/processor/controlcommunication  12.664s
\`\`\`

Also compiled-checked everything under \`test_unit\` and \`test_integration\` tags. Integration regression (4 replicas × 64 partitions sharing a consumer group) is not in this PR; that needs to land as Jenkins coverage.

---

### 🔗 References

- Ticket link: https://ecliptos.atlassian.net/browse/NUC-765
- Original (offending) PR: https://github.com/nuclio/nuclio/pull/4047 — \`[ExplicitAck] Send draining done from worker\` (reverted in development as \`fcc485a7c6\` and in 1.15.x as \`abf60eb135\`)
- Related ticket: [NUC-756](https://ecliptos.atlassian.net/browse/NUC-756) — \"Create a mechanism for worker to signal that draining is done\"

---

### 🚨 Breaking Changes?

- [x] Yes (explain below)
- [ ] No

\`controlcommunication.ControlMessageBroker\` API changes:

- \`Subscribe(kind) (Subscription, error)\` replaces \`SubscribeToControlMessageKind(kind, chan)\`.
- \`UnsubscribeFromControlMessageKind\` is removed — call \`Subscription.Close()\` instead.
- \`EventProcessor.Subscribe(kind)\` returns \`(Subscription, error)\` (was \`error\`-only).
- \`AbstractTrigger.SubscribeToControlMessageKind(kind)\` returns \`(Subscription, error)\` and no longer takes a channel.

In-tree callers (kafka trigger, v3iostream trigger, RPC runtime, worker, mocks, tests) are migrated in this PR. Downstream consumers of the broker API will need to switch from \"create channel → subscribe → unsubscribe → close channel\" to \"subscribe → use sub.C() → sub.Close()\".

---

### 🔍️ Additional Notes

- Does **not** re-land the NUC-756 \"draining done\" feature. The revert stays in place; the broker-level fix is a prerequisite.
- The 64×-amplification of \`SignalWorkersToDrain\` flagged in the ticket (Option E of the design doc) is **out of scope** for this PR — should be a follow-up once a draining-done protocol is reintroduced.
- Integration regression mirroring the failing Jenkins scenario (4 replicas × 64 partitions, two functions sharing a consumer group, asserting group membership) is also out of scope here.

[NUC-756]: https://iguazio.atlassian.net/browse/NUC-756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ