### PR TITLE
[Projects] Fix create permission check race against OPA bundle propagation

### DIFF
--- a/pkg/opa/opa.go
+++ b/pkg/opa/opa.go
@@ -62,7 +62,11 @@ func GetUserAndGroupIdsFromHeaders(request *http.Request) []string {
 }
 
 func GenerateProjectResourceString(projectName, prefix string) string {
-	return fmt.Sprintf("%s/projects/%s", prefix, projectName)
+	resource := fmt.Sprintf("%s/projects", prefix)
+	if projectName != "" {
+		resource = fmt.Sprintf("%s/%s", resource, projectName)
+	}
+	return resource
 }
 
 func GenerateFunctionResourceString(projectName, functionName, prefix string) string {

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -741,7 +741,7 @@ func (p *Platform) CreateProject(ctx context.Context, createProjectOptions *plat
 	permissionOptions := createProjectOptions.PermissionOptions
 	permissionOptions.RaiseForbidden = true
 	if _, err := p.QueryOPAProjectPermissions(ctx,
-		createProjectOptions.ProjectConfig.Meta.Name,
+		"",
 		opaclient.ActionCreate,
 		&permissionOptions); err != nil {
 		return errors.Wrap(err, "Failed to authorize project creation")

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -181,7 +181,7 @@ func (suite *ProjectKubePlatformTestSuite) TestGetProjectsCache() {
 	// allow project create via OPA
 	suite.mockedOpaClient.
 		On("QueryPermissions",
-			fmt.Sprintf("/projects/%s", "some-name"),
+			"/projects",
 			opaclient.ActionCreate,
 			mock.AnythingOfType("*opaclient.PermissionOptions")).
 		Return(true, nil).


### PR DESCRIPTION
### 📝 Description

#4107 added a hard OPA `create` check at the top of `Platform.CreateProject` to close the NUC-795 bypass. 
The check uses the per-project resource path `/resources/projects/<name>`, instead of checking if the caller is allowed to create projects in general `/resources/projects/<name>`.
This almost always caused 403 issues, as the project does not yet exist.

---

### 🛠️ Changes Made

- `pkg/platform/kube/platform.go` — `CreateProject` passes `""` instead of the project name to `QueryOPAProjectPermissions` so the OPA query targets the projects collection rather than the not-yet-grantable per-project resource.
- `pkg/opa/opa.go` — `GenerateProjectResourceString` returns `<prefix>/projects` (no trailing slash) when the project name is empty, matching the collection resource exactly.
- `pkg/platform/kube/platform_test.go` — update the mock expectation in `TestGetProjectsCache` to the new collection path.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

Manual verification on vmdev223ig4 (IG4, mlrun as projects leader) with admin
user via the mlrun SDK (`db.create_project`):

- Before the fix: ~1/10 creates succeed; remainder fail with the
  `/resources/projects/<name>` 403 traced to `platform.go:747`.
- After the fix: **5/5 creates succeed consecutively.** No 403s observed.

Updated `TestGetProjectsCache` mock asserts the OPA call uses the new
collection path; existing unit tests still pass.

---

### 🔗 References
- Ticket link: NUC-799
- Related ticket (regression test): REG-2358
- Originating fix that introduced the race: #4107 (NUC-795)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- The IG3 `overrideHeaderValue` short-circuit (opa-client) is unaffected by this change. IG3 leader-origin creates continue to bypass OPA at the client layer; IG4 leader-origin creates now succeed via the collection-level check.