### PR TITLE
[Dashboard] Support custom S3 endpoint for source-archive fetch

### DIFF
--- a/docs/reference/function-configuration/code-entry-types.md
+++ b/docs/reference/function-configuration/code-entry-types.md
@@ -280,7 +280,8 @@ Set the [`spec.build.codeEntryType`](function-configuration-reference.md#functio
   - `s3AccessKeyId` (dashboard: **Access key ID**) (Optional) &mdash; an S3 access key ID for download authentication.
   - `s3SecretAccessKey` (dashboard: **Secret access key**) (Optional) &mdash; an S3 secret access key for download authentication.
   - `s3SessionToken` (dashboard: **Session token**) (Optional) &mdash; an S3 session token for download authentication.
-  - `s3Region` (dashboard: **Region**) (Optional) &mdash; the AWS Region of the configured bucket. When this parameter isn't provided, it's implicitly deduced.
+  - `s3Region` (dashboard: **Region**) (Optional) &mdash; the AWS Region of the configured bucket. When this parameter isn't provided, it's implicitly deduced (skipped if `s3Endpoint` is set).
+  - `s3Endpoint` (dashboard: **Endpoint**) (Optional) &mdash; a custom S3 endpoint URL for S3-compatible backends such as MinIO. When set, the fetch targets this endpoint, uses path-style addressing, and skips the bucket-region probe.
   - `workDir` (dashboard: **Work directory**) (Optional) &mdash; the relative path to the function-code directory within the extracted archive-file directory.
       The default work directory is the root of the extracted archive-file directory (`"/"`).
 
@@ -300,6 +301,7 @@ spec:
       s3SecretAccessKey: "my-53cr3t-@cce55-k3y"
       s3SessionToken: "my-s3ss10n-t0k3n"
       s3Region: "us-east-1"
+      s3Endpoint: "https://minio.example.com"
       workDir: "/go/myfunc"
 ```
 

--- a/pkg/common/aws.go
+++ b/pkg/common/aws.go
@@ -34,7 +34,7 @@ import (
 const DefaultRegion = "us-east-1"
 
 type S3Client interface {
-	Download(file *os.File, bucket, itemKey, region, accessKeyID, secretAccessKey, sessionToken string) error
+	Download(file *os.File, bucket, itemKey, region, accessKeyID, secretAccessKey, sessionToken, endpoint string) error
 	DownloadWithinEC2Instance(file *os.File, bucket, itemKey string) error
 }
 
@@ -48,28 +48,36 @@ func (asc *AbstractS3Client) Download(file *os.File,
 	region string,
 	accessKeyID string,
 	secretAccessKey string,
-	sessionToken string) error {
+	sessionToken string,
+	endpoint string) error {
 	bucketAndPath, item := asc.resolveBucketPathAndItem(bucket, itemKey)
 
 	// Create AWS config with credentials
-	cfg, err := config.LoadDefaultConfig(context.TODO(),
+	cfgOpts := []func(*config.LoadOptions) error{
 		config.WithRegion(DefaultRegion), // default region (some valid region must be mentioned)
 		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken)),
-	)
+	}
+	if endpoint != "" {
+		cfgOpts = append(cfgOpts, config.WithBaseEndpoint(endpoint))
+	}
+	cfg, err := config.LoadDefaultConfig(context.TODO(), cfgOpts...)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create AWS config")
 	}
 
-	// get the bucket's region in case it wasn't given
-	if region == "" {
-		region, err = asc.getBucketRegion(context.TODO(), cfg, bucketAndPath)
+	// Skip GetBucketLocation when a custom endpoint is set;
+	// not all S3-compatible backends implement it.
+	if region == "" && endpoint == "" {
+		region, err = asc.getBucketRegion(context.TODO(), cfg, bucketAndPath, endpoint)
 		if err != nil {
 			return errors.Wrap(err, "Failed to get bucket region")
 		}
 	}
-	cfg.Region = region
+	if region != "" {
+		cfg.Region = region
+	}
 
-	return asc.download(file, cfg, bucketAndPath, item)
+	return asc.download(file, cfg, bucketAndPath, item, endpoint)
 }
 
 func (asc *AbstractS3Client) DownloadWithinEC2Instance(file *os.File, bucket, itemKey string) error {
@@ -80,7 +88,7 @@ func (asc *AbstractS3Client) DownloadWithinEC2Instance(file *os.File, bucket, it
 	if err != nil {
 		return errors.Wrap(err, "Failed to create AWS config")
 	}
-	return asc.download(file, cfg, bucketAndPath, item)
+	return asc.download(file, cfg, bucketAndPath, item, "")
 }
 
 func (asc *AbstractS3Client) resolveBucketPathAndItem(bucket, itemKey string) (string, string) {
@@ -89,8 +97,19 @@ func (asc *AbstractS3Client) resolveBucketPathAndItem(bucket, itemKey string) (s
 	return bucketAndPath, item
 }
 
-func (asc *AbstractS3Client) getBucketRegion(ctx context.Context, cfg aws.Config, bucket string) (string, error) {
-	s3Client := s3.NewFromConfig(cfg)
+// newS3Client forces path-style addressing when a custom endpoint is set,
+// which most S3-compatible backends require for sigv4 to match.
+func newS3Client(cfg aws.Config, endpoint string) *s3.Client {
+	if endpoint == "" {
+		return s3.NewFromConfig(cfg)
+	}
+	return s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.UsePathStyle = true
+	})
+}
+
+func (asc *AbstractS3Client) getBucketRegion(ctx context.Context, cfg aws.Config, bucket, endpoint string) (string, error) {
+	s3Client := newS3Client(cfg, endpoint)
 	result, err := s3Client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
 		Bucket: aws.String(bucket),
 	})
@@ -105,8 +124,8 @@ func (asc *AbstractS3Client) getBucketRegion(ctx context.Context, cfg aws.Config
 	return string(result.LocationConstraint), nil
 }
 
-func (asc *AbstractS3Client) download(file *os.File, cfg aws.Config, bucketAndPath, item string) error {
-	s3Client := s3.NewFromConfig(cfg)
+func (asc *AbstractS3Client) download(file *os.File, cfg aws.Config, bucketAndPath, item, endpoint string) error {
+	s3Client := newS3Client(cfg, endpoint)
 	downloader := manager.NewDownloader(s3Client)
 
 	_, err := downloader.Download(context.TODO(), file, &s3.GetObjectInput{
@@ -124,12 +143,12 @@ type MockS3Client struct {
 	FilePath string
 }
 
-func (msc *MockS3Client) Download(file *os.File, bucket, itemKey, region, accessKeyID, secretAccessKey, sessionToken string) error {
+func (msc *MockS3Client) Download(file *os.File, bucket, itemKey, region, accessKeyID, secretAccessKey, sessionToken, endpoint string) error {
 	functionArchiveFileBytes, _ := os.ReadFile(msc.FilePath)
 
 	_ = os.WriteFile(file.Name(), functionArchiveFileBytes, os.FileMode(os.O_RDWR))
 
-	args := msc.Called(file, bucket, itemKey, region, accessKeyID, secretAccessKey, sessionToken)
+	args := msc.Called(file, bucket, itemKey, region, accessKeyID, secretAccessKey, sessionToken, endpoint)
 	return args.Error(0)
 }
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -740,7 +740,7 @@ func (b *Builder) validateAndParseS3Attributes(attributes map[string]interface{}
 	parsedAttributes := map[string]string{}
 
 	mandatoryFields := []string{"s3Bucket", "s3ItemKey"}
-	optionalFields := []string{"s3Region", "s3AccessKeyId", "s3SecretAccessKey", "s3SessionToken"}
+	optionalFields := []string{"s3Region", "s3AccessKeyId", "s3SecretAccessKey", "s3SessionToken", "s3Endpoint"}
 
 	for _, key := range append(mandatoryFields, optionalFields...) {
 		value, found := attributes[key]
@@ -1765,7 +1765,8 @@ func (b *Builder) downloadFunctionFromS3(tempFile *os.File) error {
 		s3Attributes["s3Region"],
 		s3Attributes["s3AccessKeyId"],
 		s3Attributes["s3SecretAccessKey"],
-		s3Attributes["s3SessionToken"]); err != nil {
+		s3Attributes["s3SessionToken"],
+		s3Attributes["s3Endpoint"]); err != nil {
 
 		// assume running on ec2 container, which resolves the authentication seamlessly
 		if downloadError := b.s3Client.DownloadWithinEC2Instance(tempFile,

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -519,6 +519,7 @@ func (suite *testSuite) TestValidateAndParseS3Attributes() {
 		"s3AccessKeyId":     "myaccesskeyid",
 		"s3SecretAccessKey": "mysecretaccesskey",
 		"s3SessionToken":    "mys3sessiontoken",
+		"s3Endpoint":        "https://minio.example.com",
 	}
 	expectedResult := map[string]string{
 		"s3Bucket":          "my-bucket",
@@ -527,6 +528,7 @@ func (suite *testSuite) TestValidateAndParseS3Attributes() {
 		"s3AccessKeyId":     "myaccesskeyid",
 		"s3SecretAccessKey": "mysecretaccesskey",
 		"s3SessionToken":    "mys3sessiontoken",
+		"s3Endpoint":        "https://minio.example.com",
 	}
 	res, err := suite.builder.validateAndParseS3Attributes(goodS3CodeEntryAttributes)
 	suite.Require().NoError(err)
@@ -600,7 +602,8 @@ func (suite *testSuite) TestResolveFunctionPathS3CodeEntry() {
 			mock.MatchedBy(common.GenerateStringMatchVerifier("my-s3-region")),
 			mock.MatchedBy(common.GenerateStringMatchVerifier("my-s3-access-key-id")),
 			mock.MatchedBy(common.GenerateStringMatchVerifier("my-s3-secret-access-key")),
-			mock.MatchedBy(common.GenerateStringMatchVerifier("my-s3-session-token"))).
+			mock.MatchedBy(common.GenerateStringMatchVerifier("my-s3-session-token")),
+			mock.MatchedBy(common.GenerateStringMatchVerifier("https://minio.example.com"))).
 		Return(nil).
 		Once()
 
@@ -614,6 +617,7 @@ func (suite *testSuite) TestResolveFunctionPathS3CodeEntry() {
 			"s3AccessKeyId":     "my-s3-access-key-id",
 			"s3SecretAccessKey": "my-s3-secret-access-key",
 			"s3SessionToken":    "my-s3-session-token",
+			"s3Endpoint":        "https://minio.example.com",
 			"workDir":           "/funcs/my-python-func",
 		},
 	}


### PR DESCRIPTION
### 📝 Description

When a function's source archive lives on an S3-compatible backend (e.g. MinIO) rather than real AWS S3, the dashboard can't fetch it. Credentials are read from `codeEntryAttributes`, but the endpoint and addressing style are read only from process env / SDK defaults, which target AWS. Result: requests either go to AWS instead of the configured backend, or fail with `SignatureDoesNotMatch` because the SDK uses virtual-hosted addressing while MinIO normalizes to path-style.

---

### 🛠️ Changes Made
- `validateAndParseS3Attributes` accepts a new optional `s3Endpoint`, passed to `S3Client.Download(...)`.
- `AbstractS3Client.Download`: when `endpoint` is set, apply it via `config.WithBaseEndpoint(...)`, skip the `GetBucketLocation` region lookup (not reliably implemented by S3-compatible backends), and build the s3 client with `UsePathStyle: true`.
- `docs/reference/function-configuration/code-entry-types.md` lists `s3Endpoint` alongside the other `codeEntryAttributes` and shows it in the example.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- `go test -tags "test_integration test_local" -run "TestBuilderSuite/TestValidateAndParseS3Attributes|TestBuilderSuite/TestResolveFunctionPathS3CodeEntry" ./pkg/processor/build/` — pass.
- For ML-12586: end-to-end on an IG4 lab with MinIO as the artifact store: nuclio function deploy with an `s3://` source archive succeeds after this patch plus a mlrun change that populates `codeEntryAttributes["s3Endpoint"]` from project secrets (https://github.com/mlrun/mlrun/pull/9721).

---

### 🔗 References
- Ticket link: NUC-296, ML-12586

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

The `S3Client.Download` signature gains an `endpoint` parameter. Only call site (`builder.go`) and the `MockS3Client` are updated in this PR; no external consumers in nuclio.