### PR TITLE
[Projects] Skip OPA project authorization for Iguazio auth kind

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1380,6 +1380,14 @@ func (ap *Platform) QueryOPAMultipleResources(ctx context.Context,
 	return ap.queryOPAPermissionsMultiResources(ctx, resources, action, permissionOptions)
 }
 
+func (ap *Platform) IsAuthKindIguazioV4() bool {
+	return ap.IsAuthKind(auth.KindIguazioV4)
+}
+
+func (ap *Platform) IsAuthKind(kind auth.Kind) bool {
+	return ap.Config.Opa.AuthKind == kind
+}
+
 func (ap *Platform) functionBuildRequired(functionConfig *functionconfig.Config) (bool, error) {
 
 	// if neverBuild was passed explicitly don't build
@@ -2254,14 +2262,14 @@ func (ap *Platform) queryOPAPermissions(ctx context.Context,
 }
 
 func (ap *Platform) getOPAResourcesPrefix() string {
-	if ap.Config.Opa.AuthKind == auth.KindIguazioV4 {
+	if ap.IsAuthKindIguazioV4() {
 		return opa.IguazioV4ResourcePrefix
 	}
 	return ""
 }
 
 func (ap *Platform) getOPAManagementPrefix() string { // nolint: unused
-	if ap.Config.Opa.AuthKind == auth.KindIguazioV4 {
+	if ap.IsAuthKindIguazioV4() {
 		return opa.IguazioV4ManagementPrefix
 	}
 	return ""

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -737,10 +737,9 @@ func (p *Platform) CreateProject(ctx context.Context, createProjectOptions *plat
 		return errors.Wrap(err, "Failed to enrich a project configuration")
 	}
 
-	// check OPA permissions
 	permissionOptions := createProjectOptions.PermissionOptions
 	permissionOptions.RaiseForbidden = true
-	if _, err := p.QueryOPAProjectPermissions(ctx,
+	if err := p.checkProjectAuthorization(ctx,
 		"",
 		opaclient.ActionCreate,
 		&permissionOptions); err != nil {
@@ -788,8 +787,7 @@ func (p *Platform) CreateProject(ctx context.Context, createProjectOptions *plat
 // UpdateProject updates an existing project
 func (p *Platform) UpdateProject(ctx context.Context, updateProjectOptions *platform.UpdateProjectOptions) error {
 
-	// check OPA permissions
-	if _, err := p.QueryOPAProjectPermissions(ctx,
+	if err := p.checkProjectAuthorization(ctx,
 		updateProjectOptions.ProjectConfig.Meta.Name,
 		opaclient.ActionUpdate,
 		&updateProjectOptions.PermissionOptions); err != nil {
@@ -815,8 +813,7 @@ func (p *Platform) DeleteProject(ctx context.Context, deleteProjectOptions *plat
 		deleteProjectOptions.AuthSession = &nop.Session{}
 	}
 
-	// check OPA permissions
-	if _, err := p.QueryOPAProjectPermissions(ctx,
+	if err := p.checkProjectAuthorization(ctx,
 		deleteProjectOptions.Meta.Name,
 		opaclient.ActionDelete,
 		&deleteProjectOptions.PermissionOptions); err != nil {
@@ -2557,4 +2554,18 @@ func (p *Platform) validateAPIGatewayAuthentication(apiGatewayConfig *platform.A
 	default:
 	}
 	return nil
+}
+
+func (p *Platform) checkProjectAuthorization(ctx context.Context,
+	projectName string,
+	action opaclient.Action,
+	permissionOptions *opaclient.PermissionOptions) error {
+
+	// in Iguazio 3.x, the project leader is the source of truth for authorization
+	if !p.IsAuthKindIguazioV4() {
+		return nil
+	}
+
+	_, err := p.QueryOPAProjectPermissions(ctx, projectName, action, permissionOptions)
+	return err
 }

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -165,11 +165,21 @@ func (suite *KubePlatformTestSuite) ResetCRDMocks() {
 	suite.platform.apiGatewayScrubber = platform.NewAPIGatewayScrubber(suite.Logger, platform.GetAPIGatewaySensitiveField(), suite.platform.consumer.KubeClientSet)
 }
 
+func (suite *KubePlatformTestSuite) withAuthKind(kind auth.Kind) {
+	previous := suite.abstractPlatform.Config.Opa.AuthKind
+	suite.abstractPlatform.Config.Opa.AuthKind = kind
+	suite.T().Cleanup(func() {
+		suite.abstractPlatform.Config.Opa.AuthKind = previous
+	})
+}
+
 type ProjectKubePlatformTestSuite struct {
 	KubePlatformTestSuite
 }
 
 func (suite *ProjectKubePlatformTestSuite) TestGetProjectsCache() {
+	suite.withAuthKind(auth.KindIguazioV4)
+
 	suite.nuclioProjectInterfaceMock.On("Create",
 		suite.ctx,
 		mock.Anything,
@@ -181,7 +191,7 @@ func (suite *ProjectKubePlatformTestSuite) TestGetProjectsCache() {
 	// allow project create via OPA
 	suite.mockedOpaClient.
 		On("QueryPermissions",
-			"/projects",
+			"/resources/projects",
 			opaclient.ActionCreate,
 			mock.AnythingOfType("*opaclient.PermissionOptions")).
 		Return(true, nil).
@@ -208,8 +218,8 @@ func (suite *ProjectKubePlatformTestSuite) TestGetProjectsCache() {
 		On("QueryPermissionsMultiResources",
 			suite.ctx,
 			[]string{
-				fmt.Sprintf("/projects/%s", "some-name"),
-				fmt.Sprintf("/projects/%s", "other-name"),
+				fmt.Sprintf("/resources/projects/%s", "some-name"),
+				fmt.Sprintf("/resources/projects/%s", "other-name"),
 			},
 			opaclient.ActionRead,
 			mock.Anything).
@@ -265,7 +275,7 @@ func (suite *ProjectKubePlatformTestSuite) TestGetProjectsCache() {
 	// allow project delete via OPA
 	suite.mockedOpaClient.
 		On("QueryPermissions",
-			fmt.Sprintf("/projects/%s", "some-name"),
+			fmt.Sprintf("/resources/projects/%s", "some-name"),
 			opaclient.ActionDelete,
 			mock.AnythingOfType("*opaclient.PermissionOptions")).
 		Return(true, nil).
@@ -282,6 +292,78 @@ func (suite *ProjectKubePlatformTestSuite) TestGetProjectsCache() {
 	suite.Require().Equal(suite.platform.projectsCache.Len(),
 		0,
 		"project was not removed from cache")
+}
+
+func (suite *ProjectKubePlatformTestSuite) TestCheckProjectAuthorizationSkippedForNonIguazioV4() {
+	for _, kind := range []auth.Kind{auth.KindNop, auth.KindIguazio} {
+		suite.Run(string(kind), func() {
+			suite.withAuthKind(kind)
+
+			// no OPA mocks registered - any OPA call would panic the mock
+			for _, action := range []opaclient.Action{
+				opaclient.ActionCreate,
+				opaclient.ActionUpdate,
+				opaclient.ActionDelete,
+			} {
+				err := suite.platform.checkProjectAuthorization(suite.ctx,
+					"some-project",
+					action,
+					&opaclient.PermissionOptions{
+						MemberIds:      []string{"id1"},
+						RaiseForbidden: true,
+					})
+				suite.Require().NoError(err)
+			}
+		})
+	}
+}
+
+func (suite *ProjectKubePlatformTestSuite) TestCheckProjectAuthorizationInvokedForIguazioV4() {
+	for _, tc := range []struct {
+		name       string
+		opaAllowed bool
+		expectErr  bool
+	}{
+		{
+			name:       "Allowed",
+			opaAllowed: true,
+			expectErr:  false,
+		},
+		{
+			name:       "Forbidden",
+			opaAllowed: false,
+			expectErr:  true,
+		},
+	} {
+		suite.Run(tc.name, func() {
+			defer suite.ResetCRDMocks()
+			suite.withAuthKind(auth.KindIguazioV4)
+
+			projectName := "some-project"
+			suite.mockedOpaClient.
+				On("QueryPermissions",
+					fmt.Sprintf("/resources/projects/%s", projectName),
+					opaclient.ActionUpdate,
+					mock.AnythingOfType("*opaclient.PermissionOptions")).
+				Return(tc.opaAllowed, nil).
+				Once()
+			defer suite.mockedOpaClient.AssertExpectations(suite.T())
+
+			err := suite.platform.checkProjectAuthorization(suite.ctx,
+				projectName,
+				opaclient.ActionUpdate,
+				&opaclient.PermissionOptions{
+					MemberIds:      []string{"id1"},
+					RaiseForbidden: true,
+				})
+
+			if tc.expectErr {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+			}
+		})
+	}
 }
 
 type FunctionKubePlatformTestSuite struct {


### PR DESCRIPTION
### 📝 Description

In Iguazio 3.x deployments (auth kind `iguazio`, not `iguazio-v4`), the project leader is the authoritative source for project authorization. 
Previously, `CreateProject`, `UpdateProject`, and `DeleteProject` on the kube platform would always call OPA to authorize the action on the project resource - which is wrong for 3.x where that check should be left entirely to the project leader.

This PR introduces `checkProjectAuthorization` which short-circuits the OPA call for the `iguazio` auth kind, and adds `IsAuthKindIguazioV4` / `IsAuthKind` helpers on the abstract platform to make the check reusable and testable.

---

### 🛠️ Changes Made

- **`pkg/platform/kube/platform.go`**: Replaced direct `QueryOPAProjectPermissions` calls in `CreateProject`, `UpdateProject`, and `DeleteProject` with a new `checkProjectAuthorization` helper that is a no-op for Iguazio auth kinds.
- **`pkg/platform/abstract/platform.go`**: Added `IsAuthKind(kind)` and `IsAuthKindIguazioV4()` helper methods on the abstract platform; refactored `getOPAResourcesPrefix` and `getOPAManagementPrefix` to use them.
- **`pkg/platform/kube/platform_test.go`**:
  - Added `withAuthKind` test helper on `KubePlatformTestSuite` that overrides `Opa.AuthKind` for the duration of a test and restores it via `t.Cleanup`.
  - Updated `TestGetProjectsCache` to use `auth.KindIguazioV4` and fixed OPA resource paths to `/resources/projects/...` (the correct IguazioV4 prefix).
  - Added `TestCheckProjectAuthorizationSkippedForNonIguazioV4`: verifies no OPA call is made for `KindNop` and `KindIguazio`.
  - Added `TestCheckProjectAuthorizationInvokedForIguazioV4`: verifies OPA is called under `KindIguazioV4` and that denied responses surface as errors.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

- All existing unit tests in `pkg/platform/kube` and `pkg/platform/abstract` pass.
- Two new focused unit tests cover the skip-on-non-IguazioV4 behavior and the OPA-enforced path under IguazioV4 (allow + deny cases).
- Tested on vmdev16

---

### 🔗 References
- Ticket link: NUC-800
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes
- [x] No

---

### 🔍️ Additional Notes

The behavior change only affects deployments where `Opa.AuthKind` is `iguazio` (i.e., vanilla Iguazio 3.x ). IguazioV4 deployments are unaffected — they continue to have project create/update/delete gated by OPA exactly as before.