### PR TITLE
[CI] Default bump-patch in release trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ on:
         type: string
       bump_version_mode:
         description: 'Version bump mode'
-        default: 'bump-minor'
+        default: 'bump-patch'
         type: choice
         options: ['bump-minor', 'bump-major', 'bump-patch']
       helm_chart_target_version:


### PR DESCRIPTION
### 📝 Description

Change the default `bump_version_mode` for the manual release workflow dispatch from `bump-minor` to `bump-patch`.

Previously, triggering a release manually without specifying a version bump mode would default to a minor bump (e.g. `1.16.x → 1.17.0`). This changes the default to a patch bump (`1.16.1 → 1.16.2`), which better reflects the most common release cadence where patch releases are far more frequent than minor ones.

---

### 🛠️ Changes Made

- `.github/workflows/release.yaml`: Changed `default: 'bump-minor'` → `default: 'bump-patch'` for the `bump_version_mode` workflow dispatch input.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

No code changes — workflow input default value only. Verified by inspecting the `release.yaml` workflow definition.

---

### 🔗 References

- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [x] No

---

### 🔍️ Additional Notes

The full list of options remains unchanged (`bump-minor`, `bump-major`, `bump-patch`). This only affects the pre-selected default when triggering the workflow via the GitHub UI.