### PR TITLE
[CI] Publish helm chart only after chart-bump PR is merged

### DIFF
--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -1,0 +1,87 @@
+# Copyright 2025 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Publish Helm Chart
+
+# Triggered by the merge of the `chart-bump-*` PR created by `release.yaml`.
+# Packages the bumped chart from the target branch and opens a PR to gh-pages.
+# Enforces that the chart-bump PR is merged before publishing.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  helm-publish:
+    name: Publish helm charts
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'chart-bump-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target branch (post-merge)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Resolve helm chart version
+        id: chart_version
+        run: |
+          HELM_VERSION=$(grep '^version:' hack/k8s/helm/nuclio/Chart.yaml | awk '{print $2}' | tr -d '"')
+          if [ -z "$HELM_VERSION" ]; then
+            echo "Failed to read helm chart version from Chart.yaml" >&2
+            exit 1
+          fi
+          echo "helm_version=${HELM_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          path: nuclio-helm
+
+      - name: Set up Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # 5.0.0
+
+      - name: Set up yq
+        run: |
+          wget https://github.com/mikefarah/yq/releases/download/v4.15.1/yq_linux_amd64 -O /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+
+      - name: Create package and update index
+        run: |
+          echo "Creating package and updating index"
+          helm package -d nuclio-helm/charts hack/k8s/helm/nuclio
+          cd nuclio-helm/charts
+          helm repo index . --url https://nuclio.github.io/nuclio/charts/ --merge index.yaml
+
+      - name: Create PR to gh-pages
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Releasing chart ${{ steps.chart_version.outputs.helm_version }}"
+          title: "Releasing chart ${{ steps.chart_version.outputs.helm_version }}"
+          body: |
+            This PR publishes the Helm chart for version `${{ steps.chart_version.outputs.helm_version }}`.
+
+            Triggered by the merge of #${{ github.event.pull_request.number }} (`${{ github.event.pull_request.title }}`) into `${{ github.event.pull_request.base.ref }}`.
+          branch: release/helm-chart-${{ steps.chart_version.outputs.helm_version }}
+          base: gh-pages
+          path: nuclio-helm
+          delete-branch: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -203,7 +203,10 @@ jobs:
           branch: chart-bump-${{ needs.prepare-inputs.outputs.version }}
           title: "[Chart] Bump to ${{ needs.prepare-inputs.outputs.version }}"
           base: ${{ github.event.inputs.branch }}
-          body: "This PR was automatically created by the release workflow to bump Helm chart version to ${{ needs.prepare-inputs.outputs.version }}."
+          body: |
+            This PR bumps the Helm chart version to `${{ needs.prepare-inputs.outputs.helm_version }}` as part of releasing nuclio `${{ needs.prepare-inputs.outputs.version }}`.
+
+            **This PR must be merged first.** Merging triggers the `Publish Helm Chart` workflow, which packages the chart from this branch and opens a follow-up PR against `gh-pages` to publish it to the Helm repo.
           delete-branch: true
 
   image_matrix_prep:
@@ -388,55 +391,7 @@ jobs:
           files: '/home/runner/go/bin/nuctl-*'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-  helm-publish:
-    name: Publish helm charts
-    if: github.event_name == 'workflow_dispatch' && (github.event.inputs.skip_bump_helm_charts != 'true' || github.event.inputs.bump_helm_charts_only == 'true')
-    needs: [ prepare-inputs, release-images ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-         ref: ${{ github.event.inputs.branch }}
-
-      - name: Checkout gh-pages branch
-        uses: actions/checkout@v6
-        with:
-          ref: gh-pages
-          path: nuclio-helm
-
-      - name: Set up Helm
-        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # 5.0.0
-
-      - name: Set up yq
-        run: |
-          wget https://github.com/mikefarah/yq/releases/download/v4.15.1/yq_linux_amd64 -O /usr/local/bin/yq
-          chmod +x /usr/local/bin/yq
-
-      - name: Set commit message
-        id: set_commit_message
-        run: |
-          HELM_PUBLISH_COMMIT_MESSAGE="Releasing chart ${{ needs.prepare-inputs.outputs.helm_version }}"
-          echo "HELM_PUBLISH_COMMIT_MESSAGE=$HELM_PUBLISH_COMMIT_MESSAGE" >> $GITHUB_ENV
-
-      - name: Create package and update index
-        run: |
-          echo "Creating package and updating index"
-          helm package -d nuclio-helm/charts hack/k8s/helm/nuclio
-          cd nuclio-helm/charts
-          helm repo index . --url https://nuclio.github.io/nuclio/charts/ --merge index.yaml
-
-      - name: Create PR to gh-pages
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "${{ env.HELM_PUBLISH_COMMIT_MESSAGE }}"
-          title: "${{ env.HELM_PUBLISH_COMMIT_MESSAGE }}"
-          body: |
-            This PR publishes the Helm chart for version `${{ needs.prepare-inputs.outputs.helm_version }}`.
-
-            ⚠️ Please ensure the branch `${{ github.event.inputs.branch }}` has been bumped before merging this PR.
-          branch: release/helm-chart-${{ needs.prepare-inputs.outputs.helm_version }}
-          base: gh-pages
-          path: nuclio-helm
-          delete-branch: true
+# NOTE: Publishing the helm chart to `gh-pages` has moved to `helm-publish.yaml`,
+# which is triggered by the merge of the `chart-bump-*` PR opened above.
+# This guarantees gh-pages is updated from the bumped chart on the target branch
+# rather than the pre-bump state.


### PR DESCRIPTION
### 📝 Description

The release workflow opens two PRs in parallel:

1. **Chart-bump PR** (`[Chart] Bump to X`) → target release branch — bumps `Chart.yaml`/`values.yaml`.
2. **Chart-publish PR** (`Releasing chart X`) → `gh-pages` — publishes the packaged helm chart.

Today both jobs run in the same workflow run, so `gh-pages` can be updated from the *pre-bump* source. The only safeguard was a ⚠️ note in the publish-PR body asking reviewers to merge in the right order by hand.

This PR makes the ordering structural: the publish job now runs in its own workflow that triggers on the merge of the chart-bump PR, so `gh-pages` can't be updated until the bump has actually landed.

---

### 🛠️ Changes Made

- Removed the `helm-publish` job from `release.yaml`.
- Added `.github/workflows/helm-publish.yaml`, triggered by `pull_request: closed` with `merged == true` and head ref `chart-bump-*`. It checks out the post-merge target branch, reads the helm version from `hack/k8s/helm/nuclio/Chart.yaml`, packages, and opens the PR to `gh-pages` (same logic as before, just relocated and re-sourced).
- Rewrote the chart-bump PR body to explain the new flow (merge this first → publish workflow fires).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

YAML diff reviewed locally. End-to-end will run on the next release dispatch. Note: GitHub's anti-recursion rule means PRs created via \`GITHUB_TOKEN\` don't fire downstream workflows for *open* events — but the *merge* event is initiated by a human reviewer, so \`pull_request: closed\` does fire. If chart-bump PRs are ever switched to auto-merge via \`GITHUB_TOKEN\`, this workflow would need to be re-triggered via a PAT.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

The publish step still runs and still produces the same PR against \`gh-pages\`; only the trigger boundary changed.

---

### 🔍️ Additional Notes

- The publish job no longer has an explicit \`needs: release-images\` dependency. By the time a human reviews and merges the chart-bump PR, image builds will normally already be complete; if they aren't, the publish PR can still be created safely (the chart references images by version tag).
- Branch base of the chart-bump PR is not restricted in the new workflow — same as today, the release workflow's configurable \`branch\` input is respected.