### PR TITLE
[Chart] Add rbac.createServiceAccount toggle

### DIFF
--- a/hack/k8s/helm/nuclio/templates/serviceaccount/service-account.yaml
+++ b/hack/k8s/helm/nuclio/templates/serviceaccount/service-account.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.rbac.createServiceAccount }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -495,6 +495,13 @@ rbac:
   # If true, creates the necessary roles and role bindings for nuclio's service account
   create: true
 
+  # If true (and rbac.create is true), creates the service account used by nuclio's
+  # components. Set to false when the service account is managed externally (e.g. to
+  # attach workload identity annotations) but the chart should still create the
+  # roles and role bindings that bind to it. When false, set `rbac.serviceAccountName`
+  # to the name of the existing service account.
+  createServiceAccount: true
+
   # serviceAccountName: service-account-name
 
   # Allow / deny cluster-wide resource access. values: "cluster", "namespaced".


### PR DESCRIPTION
### 📝 Description

Decouples ServiceAccount creation from Role/RoleBinding creation in the Helm chart. Setups that pre-create the SA externally (e.g. cloud installs that attach workload-identity annotations) previously had to set `rbac.create=false`, which also suppressed the Roles and RoleBindings — leaving Nuclio unable to act on its own CRDs.

With this change such installs can set:

\`\`\`yaml
rbac:
  create: true
  createServiceAccount: false
  serviceAccountName: <pre-existing-sa>
\`\`\`

and the chart will create the Roles + RoleBindings bound to the pre-existing SA. Backwards-compatible: the new value defaults to true.

---

### 🛠️ Changes Made

- Add new value \`rbac.createServiceAccount\` (default \`true\`) in \`hack/k8s/helm/nuclio/values.yaml\`.
- Gate \`templates/serviceaccount/service-account.yaml\` on \`and .Values.rbac.create .Values.rbac.createServiceAccount\` so the SA can be skipped while Roles + RoleBindings are still rendered.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable) — inline comment in \`values.yaml\`
- [x] I have tested the changes in this PR

---

### 🧪 Testing

Rendered the chart locally with \`helm template\` in three scenarios and confirmed expected output:

| Scenario | rbac.create | rbac.createServiceAccount | SA | Role | RoleBinding |
|---|---|---|---|---|---|
| Default (on-prem) | true | true (default) | ✅ | ✅ | ✅ |
| Cloud (SA pre-created) | true | false | ❌ | ✅ | ✅ |
| Legacy disable-all | false | (any) | ❌ | ❌ | ❌ |

\`helm lint hack/k8s/helm/nuclio\` passes.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/IG4-2640
- Companion PR in mlefi to consume the new toggle: McK-Private/mlefi (\`ig4-2640-rbac-granular-sa-toggle\`)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

The new value defaults to \`true\`, preserving the prior behavior for all existing installs (\`rbac.create=true\` still creates SA + Roles + RoleBindings; \`rbac.create=false\` still creates nothing).

---

### 🔍️ Additional Notes

No \`Chart.yaml\` version bump — CI handles that.