### PR TITLE
[Docs] Document Dashboard credential exposure controls

### DIFF
--- a/.github/styles/Nuclio/ignore.txt
+++ b/.github/styles/Nuclio/ignore.txt
@@ -80,3 +80,4 @@ requeue
 requeued
 hardcoded
 tcp
+plaintext

--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -9,6 +9,7 @@ This document describes advanced configuration options and best-practice guideli
 - [The preferred deployment method](#the-preferred-deployment-method)
 - [Freezing a qualified version](#freezing-a-qualified-version)
 - [Multi-Tenancy](#multi-tenancy)
+- [Securing the Dashboard](#securing-the-dashboard)
 - [Air-gapped deployment](#air-gapped-deployment)
 - [Using Kaniko as an image builder](#using-kaniko-as-an-image-builder)
 
@@ -69,6 +70,39 @@ Note:
   This means that the controller handles Nuclio resources (functions, function events, and projects) only within its own namespace.
   This is supported by using the `controller.namespace` and `rbac.crdAccessMode` [Helm values](https://github.com/nuclio/nuclio/tree/development/hack/k8s/helm/nuclio/values.yaml) configurations.
 - To provide ample separation at the level of the container registry, it's highly recommended that the Nuclio deployments of multiple tenants either don't share container registries, or that they don't share a tenant when using a multi-tenant registry (such as `registry.hub.docker.com` or `quay.io`).
+
+<a id="securing-the-dashboard"></a>
+## Securing the Dashboard
+
+> **Security note:** The Nuclio Dashboard exposes an HTTP API (`/api/...`) that reads and writes function configuration, including any credentials carried by event triggers — for example the top-level `password` and `secret` fields, and nested values inside `attributes` such as `attributes.sasl.password` and `attributes.accesskey` on Kafka triggers or `attributes.password` on `v3io-stream` triggers.
+> The default Helm deployment does **not** authenticate this API and does **not** mask trigger credentials at rest. Treat the Dashboard as a privileged control plane and harden it before exposing it on any network that is not fully trusted.
+
+The default chart values are tuned for a quick development setup and assume the Dashboard sits on a trusted network. Before running Nuclio in production, apply both controls below.
+
+### Authenticate the Dashboard API
+
+By default, `dashboard.authConfig.kind` is unset, which selects the "NOP" authenticator — every request is accepted without credentials. The built-in authenticator kinds are listed in [`pkg/auth/types.go`](https://github.com/nuclio/nuclio/blob/development/pkg/auth/types.go); the non-NOP options are tied to specific platforms. For deployments that do not run on one of those platforms, terminate authentication at the network layer instead — for example with an authenticating ingress controller, an OAuth2 / OIDC proxy, or a service-mesh authorization policy — and ensure the Dashboard service only accepts traffic from that proxy.
+
+Without an authenticator in front of the Dashboard, any client that can reach the Dashboard service (port 8070 by default) can read every function definition in the namespace — including the trigger credentials stored on those functions.
+
+### Mask sensitive fields at rest
+
+The Nuclio Kubernetes deployer can move sensitive trigger fields out of the `NuclioFunction` CRD and into Kubernetes Secrets, replacing the value in the CRD with a reference token. This feature is controlled by `platformConfig.sensitiveFields.maskSensitiveFields` and is **off by default** in the official Helm chart.
+
+When the feature is off, credentials supplied to triggers (Kafka `password` and `attributes.sasl.password`, RabbitMQ `password`, `v3io-stream` `attributes.password`, Kinesis `attributes.secretAccessKey`, and so on) are stored verbatim in the `NuclioFunction` CRD and returned in plaintext by `GET /api/functions` and `GET /api/functions/{name}`.
+
+Enable masking in your Helm values:
+
+```yaml
+# values.yaml
+platformConfig:
+  sensitiveFields:
+    maskSensitiveFields: true
+```
+
+See [Sensitive fields](../../tasks/configuring-a-platform.md#sensitive-fields) in the platform configuration guide for the default match list and how to extend it with `customSensitiveFields`.
+
+> **Note:** Masking applies on function deploy. Functions that already exist when you enable the feature need to be re-deployed for their credentials to migrate from the CRD into a Secret.
 
 ## Freezing a qualified version
 

--- a/docs/tasks/configuring-a-platform.md
+++ b/docs/tasks/configuring-a-platform.md
@@ -221,6 +221,8 @@ compared to function config values, which can be specified in the function confi
 Nuclio resources (currently function configuration and api gateway configuration) may contain sensitive information such as passwords, tokens, etc.
 When the 'masking sensitive fields' feature is enabled, these fields get obfuscated, and their raw values are stored separately (in a Kubernetes secret). They are then populated internally when needed, during function deployment or api gateway creation.
 
+> **Security note:** This feature is **disabled by default** in the official Helm chart (`platformConfig.sensitiveFields.maskSensitiveFields` is commented out, which resolves to `false`). When it is disabled, trigger credentials such as `password`, `secret`, and nested values like `attributes.sasl.password` are written verbatim into the `NuclioFunction` CRD and returned in plaintext by the Dashboard API (for example, `GET /api/functions`). Enable it for any deployment whose Dashboard or CRD store is reachable by clients that should not see those credentials — see [Securing the Dashboard](../setup/k8s/running-in-production-k8s.md#securing-the-dashboard) in the production guide for the full hardening checklist.
+
 In api gateway config only `password` field is masked if 'masking sensitive fields' is enabled.
 For function config there are some config fields that are [masked by default](https://github.com/nuclio/nuclio/blob/development/pkg/platformconfig/types.go#L303-L340). You can add custom sensitive fields to mask by specifying the regex to the path in the function configuration.
 The masked fields are replaced with references (`$ref`) in the function configuration.

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -584,6 +584,12 @@ platform: {}
 #    webapiURL: ""
 #    getStreamShardsConcurrentRequests: 64
 #
+#  # Security: maskSensitiveFields moves trigger credentials (password, secret, nested
+#  # attributes.sasl.password, etc.) out of the NuclioFunction CRD into Kubernetes Secrets
+#  # and replaces them with reference tokens. It is OFF by default. When off, credentials
+#  # are stored verbatim in the CRD and returned in plaintext by the Dashboard API
+#  # (GET /api/functions). Enable for production deployments. See
+#  # docs/setup/k8s/running-in-production-k8s.md#securing-the-dashboard.
 #  sensitiveFields:
 #    maskSensitiveFields: true
 #


### PR DESCRIPTION
### 📝 Description

Document the operator obligations that follow from the Dashboard's default configuration. By default the Dashboard API has no authenticator (NOP) and `platformConfig.sensitiveFields.maskSensitiveFields` is commented out in the official chart, so trigger credentials (`password`, `secret`, nested `attributes.sasl.password`, etc.) are stored verbatim in the `NuclioFunction` CRD and returned in cleartext by `GET /api/functions`. The behaviour is by design for the development setup, but the production guide did not state the controls operators must apply before the Dashboard becomes reachable from anything other than a trusted network.

This PR adds a `Securing the Dashboard` section to the production guide, tightens the existing `Sensitive fields` reference, and adds an inline warning above the commented-out `sensitiveFields` block in `values.yaml`.

---

### 🛠️ Changes Made

- `docs/setup/k8s/running-in-production-k8s.md`: new `Securing the Dashboard` section with two subsections — authenticate the Dashboard API (`dashboard.authConfig.kind`; valid values per `pkg/auth/types.go`) and enable `platformConfig.sensitiveFields.maskSensitiveFields`. TOC entry added.
- `docs/tasks/configuring-a-platform.md`: security-note blockquote on the existing `Sensitive fields` subsection stating the feature is off by default, what is exposed when off, and cross-linking the new production section.
- `hack/k8s/helm/nuclio/values.yaml`: inline comment above the commented-out `sensitiveFields:` block explaining the production implication and pointing at the production-guide anchor.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing

Doc-only change; no runtime tests. Validated by reading every cited Helm key, auth kind, and trigger field against the current code (`pkg/auth/types.go`, `pkg/platformconfig/types.go:440-453`, `hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml`); cross-file relative links and in-page anchors resolve. Sphinx render not executed locally.

---

### 🔗 References
- Ticket link: https://github.com/nuclio/nuclio/security/advisories/GHSA-cfvm-vr8m-mv24
- External links: https://cwe.mitre.org/data/definitions/200.html, https://cwe.mitre.org/data/definitions/312.html

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

Response to GHSA-cfvm-vr8m-mv24, which was closed with `submission.accepted: false` — the behaviour is documented as expected for the default development setup, but the production guide did not surface the operator-side controls. This PR closes that documentation gap; it does not change any runtime behaviour or chart defaults.