### PR TITLE
[Security] Fix cron trigger shell injection

### DIFF
--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1751,7 +1751,6 @@ func (lc *lazyClient) createOrUpdateCronJob(ctx context.Context,
 
 	// Prepare the new cron job object
 
-	// prepare cron job meta
 	cronJobMeta := metav1.ObjectMeta{
 		Name:      kube.CronJobName(),
 		Namespace: function.Namespace,
@@ -2143,54 +2142,54 @@ func (lc *lazyClient) generateCronTriggerCronJobSpec(ctx context.Context,
 		}
 	}
 
-	// generate a string containing all the headers with --header flag as prefix, to be used by curl later
-	headersAsCurlArg := ""
-	for headerKey := range attributes.Event.Headers {
-		headerValue := attributes.Event.GetHeaderString(headerKey)
-		headersAsCurlArg = fmt.Sprintf("%s --header \"%s: %s\"", headersAsCurlArg, headerKey, headerValue)
-	}
-
-	// add default headers
-	headersAsCurlArg = fmt.Sprintf("%s --header \"%s: %s\" --header \"%s: %s\"",
-		headersAsCurlArg,
-		headers.InvokeTrigger,
-		"cron",
-		headers.TargetName,
-		function.Name,
-	)
-
 	functionAddress, err := lc.getCronTriggerInvocationURL(resources, function.Namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get cron trigger invocation URL")
 	}
 
-	// generate the curl command to be run by the CronJob to invoke the function
-	// invoke the function (retry for 10 seconds)
-	curlCommand := fmt.Sprintf("curl --silent %s %s --retry 10 --retry-delay 1 --retry-max-time 10 --retry-connrefused",
-		headersAsCurlArg,
-		functionAddress)
+	// Build curl args using exec form so the CronJob container invokes curl directly,
+	// without a shell. This prevents user-supplied header keys/values or event body
+	// from being interpreted as shell syntax (see GHSA-v5px-423j-pf7p).
+	curlArgs := []string{"--silent"}
 
+	// user-supplied headers, sorted for deterministic ordering across reconciles
+	userHeaderKeys := make([]string, 0, len(attributes.Event.Headers))
+	for headerKey := range attributes.Event.Headers {
+		userHeaderKeys = append(userHeaderKeys, headerKey)
+	}
+	sort.Strings(userHeaderKeys)
+	for _, headerKey := range userHeaderKeys {
+		curlArgs = append(curlArgs,
+			"--header", fmt.Sprintf("%s: %s", headerKey, attributes.Event.GetHeaderString(headerKey)))
+	}
+
+	// default headers
+	curlArgs = append(curlArgs,
+		"--header", fmt.Sprintf("%s: %s", headers.InvokeTrigger, "cron"),
+		"--header", fmt.Sprintf("%s: %s", headers.TargetName, function.Name),
+	)
+
+	// event body, compacted as JSON when valid (for size/readability, not for safety)
 	if attributes.Event.Body != "" {
 		eventBody := attributes.Event.Body
-
-		// if a body exists - dump it into a file, and pass this file as argument (done to support JSON body)
-		eventBodyFilePath := "/tmp/eventbody.out"
-		eventBodyCurlArg := fmt.Sprintf("--data '@%s'", eventBodyFilePath)
-
-		// try compact as JSON (will fail if it's not a valid JSON)
 		eventBodyAsCompactedJSON := bytes.NewBuffer([]byte{})
 		if err := json.Compact(eventBodyAsCompactedJSON, []byte(eventBody)); err == nil {
-
-			// set the compacted JSON as event body
 			eventBody = eventBodyAsCompactedJSON.String()
 		}
-
-		curlCommand = fmt.Sprintf("echo %s > %s && %s %s",
-			strconv.Quote(eventBody),
-			eventBodyFilePath,
-			curlCommand,
-			eventBodyCurlArg)
+		// use --data-raw, not --data: --data treats a leading '@' as "load file"
+		// (and '@-' as "read stdin"), which would let a function spec author exfiltrate
+		// a file from the CronJob pod via a body of e.g. "@/etc/passwd".
+		curlArgs = append(curlArgs, "--data-raw", eventBody)
 	}
+
+	// retry settings and target URL (kept last so curl sees them after all flags)
+	curlArgs = append(curlArgs,
+		"--retry", "10",
+		"--retry-delay", "1",
+		"--retry-max-time", "10",
+		"--retry-connrefused",
+		functionAddress,
+	)
 
 	// get cron job retries until failing a job (default=2)
 	jobBackoffLimit := attributes.JobBackoffLimit
@@ -2209,7 +2208,8 @@ func (lc *lazyClient) generateCronTriggerCronJobSpec(ctx context.Context,
 							Image: common.GetEnvOrDefaultString(
 								"NUCLIO_CONTROLLER_CRON_TRIGGER_CRON_JOB_IMAGE_NAME",
 								"gcr.io/iguazio/curlimages/curl:7.81.0"),
-							Args:            []string{"/bin/sh", "-c", curlCommand},
+							Command:         []string{"curl"},
+							Args:            curlArgs,
 							ImagePullPolicy: v1.PullPolicy(common.GetEnvOrDefaultString("NUCLIO_CONTROLLER_CRON_TRIGGER_CRON_JOB_IMAGE_PULL_POLICY", "IfNotPresent")),
 						},
 					},

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -21,6 +21,7 @@ package functionres
 import (
 	"context"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -40,6 +41,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
 	autosv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
@@ -968,6 +970,190 @@ func (suite *lazyTestSuite) TestResolveAutoScaleMetricSpec() {
 			suite.Require().True(metricSpec.Pods.Target.AverageValue.Equal(podTargetValue))
 		}
 	}
+}
+
+// TestCronTriggerExecFormNoShellInjection is the regression test for GHSA-v5px-423j-pf7p.
+// It exercises the cron-trigger CronJob spec generation and asserts that the resulting
+// container runs `curl` directly (exec form) with user-supplied header keys/values and
+// event body passed as discrete argv entries — never as parts of a shell command.
+func (suite *lazyTestSuite) TestCronTriggerExecFormNoShellInjection() {
+	for _, testCase := range []struct {
+		name             string
+		headers          map[string]interface{}
+		body             string
+		assertions       func(args []string)
+		assertNoDataFlag bool
+	}{
+		{
+			name: "header_key_with_quote_does_not_break_shell",
+
+			// the advisory's Path-A payload: a header key containing `"` and shell
+			// metacharacters. In exec form, this entire string is one argv entry of
+			// curl after `--header`; the shell never sees it.
+			headers: map[string]interface{}{
+				`X-Inject"; echo PWNED; echo "`: "marker",
+			},
+			assertions: func(args []string) {
+				suite.Require().Contains(args,
+					`X-Inject"; echo PWNED; echo "`+`: marker`,
+					"header key+value should appear as a single literal argv entry")
+			},
+		},
+		{
+			name: "body_with_command_substitution_is_literal",
+
+			// the advisory's Path-B payload: `$()` survived strconv.Quote and was
+			// expanded by /bin/sh. In exec form, no shell sees it.
+			body: "$(id)",
+			assertions: func(args []string) {
+				suite.Require().Contains(args, "$(id)",
+					"body should appear as a literal argv entry")
+				suite.Require().Contains(args, "--data-raw",
+					"body should be passed via --data-raw, not --data")
+				suite.Require().NotContains(args, "--data",
+					"--data interprets leading '@' as file-load; must use --data-raw")
+			},
+		},
+		{
+			name: "body_starting_with_at_is_not_file_load",
+
+			// curl `--data` treats a body starting with `@` as "load from file" —
+			// using `--data-raw` removes that primitive.
+			body: "@/etc/passwd",
+			assertions: func(args []string) {
+				suite.Require().Contains(args, "@/etc/passwd",
+					"body should appear literally; --data-raw must prevent file load")
+				suite.Require().Contains(args, "--data-raw")
+				suite.Require().NotContains(args, "--data")
+			},
+		},
+		{
+			name:             "empty_body_omits_data_flag",
+			body:             "",
+			assertNoDataFlag: true,
+			assertions: func(args []string) {
+				suite.Require().NotContains(args, "--data-raw")
+				suite.Require().NotContains(args, "--data")
+			},
+		},
+		{
+			name: "json_body_is_compacted",
+			body: "{\n  \"a\": 1,\n  \"b\": 2\n}",
+			assertions: func(args []string) {
+				suite.Require().Contains(args, `{"a":1,"b":2}`,
+					"valid JSON body should be compacted before being passed to curl")
+			},
+		},
+		{
+			name: "non_json_body_passed_through_unchanged",
+			body: "not json",
+			assertions: func(args []string) {
+				suite.Require().Contains(args, "not json",
+					"non-JSON body should be passed through unchanged")
+			},
+		},
+		{
+			name: "headers_sorted_for_deterministic_order",
+
+			// use a custom prefix so the default X-Nuclio-* headers don't sneak into
+			// the order assertion
+			headers: map[string]interface{}{
+				"Q-Zeta":  "z",
+				"Q-Alpha": "a",
+				"Q-Mu":    "m",
+			},
+			assertions: func(args []string) {
+				userHeaderArgs := suite.collectHeaderArgs(args, "Q-")
+				suite.Require().Equal([]string{
+					"Q-Alpha: a",
+					"Q-Mu: m",
+					"Q-Zeta: z",
+				}, userHeaderArgs, "user-supplied headers must be sorted by key")
+			},
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.setKubeCronTriggerMode()
+
+			triggerAttributes := map[string]interface{}{
+				"schedule": "*/1 * * * *",
+				"event": map[string]interface{}{
+					"headers": testCase.headers,
+					"body":    testCase.body,
+				},
+			}
+			cronJob := suite.deployFunctionWithCronTrigger("test-func", triggerAttributes)
+
+			container := cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+
+			// the exec-form invariant: no shell anywhere.
+			suite.Require().Equal([]string{"curl"}, container.Command,
+				"container must invoke curl directly, never /bin/sh")
+			suite.Require().NotContains(container.Args, "/bin/sh",
+				"args must not contain /bin/sh — that's the vulnerability")
+			suite.Require().NotContains(container.Args, "-c",
+				"args must not contain -c — that's the shell-evaluation flag")
+
+			// default headers always emitted
+			suite.Require().Contains(container.Args, "X-Nuclio-Invoke-Trigger: cron")
+			suite.Require().Contains(container.Args, "X-Nuclio-Target: test-func")
+
+			testCase.assertions(container.Args)
+		})
+	}
+}
+
+// setKubeCronTriggerMode swaps the suite's platform configuration to one that creates
+// cron triggers as k8s CronJobs (the path the security fix lives in).
+func (suite *lazyTestSuite) setKubeCronTriggerMode() {
+	platformConfiguration, err := platformconfig.NewPlatformConfig("")
+	suite.Require().NoError(err)
+	platformConfiguration.CronTriggerCreationMode = platformconfig.KubeCronTriggerCreationMode
+	suite.client.SetPlatformConfigurationProvider(&mockedPlatformConfigurationProvider{
+		platformConfiguration: platformConfiguration,
+	})
+}
+
+// deployFunctionWithCronTrigger creates a NuclioFunction with a single cron trigger,
+// runs the reconciliation path, and returns the resulting k8s CronJob.
+func (suite *lazyTestSuite) deployFunctionWithCronTrigger(
+	functionName string,
+	triggerAttributes map[string]interface{}) *batchv1.CronJob {
+
+	functionInstance := suite.getFunctionInstanceWithDefaultProbes(functionName)
+
+	functionInstance.Spec.Triggers = map[string]functionconfig.Trigger{
+		"cron-trigger": {
+			Kind:       "cron",
+			Name:       "cron-trigger",
+			Attributes: triggerAttributes,
+		},
+	}
+
+	resources, err := suite.client.CreateOrUpdate(suite.ctx, functionInstance, "")
+	suite.Require().NoError(err)
+
+	cronJobs, err := resources.CronJobs()
+	suite.Require().NoError(err)
+	suite.Require().Len(cronJobs, 1,
+		"expected exactly one CronJob from a single cron trigger")
+
+	return cronJobs[0]
+}
+
+// collectHeaderArgs returns the values of all `--header <K: V>` pairs in args whose
+// key starts with the given prefix, in encounter order.
+func (suite *lazyTestSuite) collectHeaderArgs(args []string, keyPrefix string) []string {
+	var headerValues []string
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] != "--header" {
+			continue
+		}
+		if strings.HasPrefix(args[i+1], keyPrefix) {
+			headerValues = append(headerValues, args[i+1])
+		}
+	}
+	return headerValues
 }
 
 func (suite *lazyTestSuite) generateFunctionWithIngress(functionName, host string, annotations map[string]string) nuclioio.NuclioFunction {


### PR DESCRIPTION
### 📝 Description

Fixes the shell command injection in cron-trigger CronJob generation reported in [GHSA-v5px-423j-pf7p](https://github.com/nuclio/nuclio/security/advisories/GHSA-v5px-423j-pf7p). The controller built a `/bin/sh -c <curl …>` string by concatenating user-supplied header keys and event body, with two confirmed injection paths:

- header key containing `"` broke out of the double-quoted `--header` arg (`lazy.go:2150`);
- event body containing `$(…)` survived `strconv.Quote` and was expanded by the shell (`lazy.go:2188`).

---

### 🛠️ Changes Made

- Rewrote `generateCronTriggerCronJobSpec` to build curl args as a `[]string` and invoke curl directly via `Command: [\"curl\"], Args: curlArgs`. No `/bin/sh -c`, no string concatenation, no quoting — user input is never interpreted as shell syntax.
- Pass the event body via `--data-raw` (not `--data`), so a body beginning with `@` is not interpreted as \"load from file\" — closes a second-order file-exfiltration primitive surfaced during review.
- Iterate user-supplied headers in sorted order so the resulting CronJob spec is deterministic across reconciles (avoids spurious update churn from Go map iteration order).
- Drop the `echo body > /tmp/eventbody.out && curl ... --data @file` shell workaround; with exec form, `--data-raw <body>` is sufficient. JSON compaction is retained for size/readability.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

No documentation changes — the cron trigger user-facing surface (`event.headers`, `event.body`, `schedule`) is unchanged.

---

### 🧪 Testing

Added unit tests in `pkg/platform/kube/functionres/lazy_test.go` covering both injection paths:

| Test | Asserts |
|------|---------|
| `header_key_with_quote_does_not_break_shell` | advisory Path-A payload → literal argv entry |
| `body_with_command_substitution_is_literal` | advisory Path-B `$(id)` → literal argv entry |
| `body_starting_with_at_is_not_file_load` | `@/etc/passwd` → literal, `--data-raw` used |
| `empty_body_omits_data_flag` | no body → no `--data*` flag emitted |
| `json_body_is_compacted` | whitespace JSON → compacted |
| `non_json_body_passed_through_unchanged` | non-JSON → passed as-is |
| `headers_sorted_for_deterministic_order` | user headers sorted by key |

Every sub-test also asserts `Container.Command == [\"curl\"]` and that `Args` contains neither `/bin/sh` nor `-c`.

Local runs:
- `go test -race -tags=test_unit ./pkg/platform/kube/functionres/...` — green.
- `make test-unit` — 1251 tests, 5 skipped, 1 unrelated failure in `pkg/platform/local` (`TestKubePlatformTestSuite/TestVeryBigFunction` — needs the local `nuclio-local-storage-reader` docker container, which doesn't exist on the dev machine; no code path from this PR to that test).

---

### 🔗 References
- Ticket link: https://github.com/nuclio/nuclio/security/advisories/GHSA-v5px-423j-pf7p
- Design docs links: n/a (security fix)
- External links: [curl manual on `--data-raw`](https://curl.se/docs/manpage.html#--data-raw)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

Behavior-visible-to-users is unchanged: the same HTTP request lands at the function on the same schedule with the same headers and body. Internal entrypoint contract for the CronJob container changed from `Args: [\"/bin/sh\", \"-c\", \"...\"]` to `Command: [\"curl\"], Args: [...]` — operators who override `NUCLIO_CONTROLLER_CRON_TRIGGER_CRON_JOB_IMAGE_NAME` to an image without `curl` on PATH will need to switch back to a `curl`-bearing image. The default image (`gcr.io/iguazio/curlimages/curl:7.81.0`) is unaffected.

---

### 🔍️ Additional Notes

Suggested follow-up (out of scope for this PR): validate cron trigger header keys/values at admission to reject CR/LF. With the shell removed, the remaining low-severity vector is HTTP header smuggling into the function ingress via a header value containing `\r\n` — not exploitable beyond what an authenticated function-spec author can already do, but worth tightening.
