### PR TITLE
[Kaniko] Allow extra pod labels on build Job (IG4-2646)

### DIFF
--- a/docs/setup/k8s/running-in-production-k8s.md
+++ b/docs/setup/k8s/running-in-production-k8s.md
@@ -237,3 +237,33 @@ helm install nuclio \
     --set registry.pushPullUrl=<your registry URL> \
     nuclio/nuclio
 ```
+
+### Using Kaniko with cloud workload identity (Azure WI, GKE WI, AWS IRSA)
+
+On managed Kubernetes you can authenticate Kaniko to your container registry via a cloud workload identity bound to the build pod's ServiceAccount, instead of mounting a static docker-config secret.
+This is the standard pattern on AKS with Azure Workload Identity for ACR, on GKE with Workload Identity for Artifact Registry / GCR, and on EKS with IRSA for ECR.
+
+Because Kaniko jobs are created by the Nuclio dashboard at run time (rather than rendered by the chart), the chart exposes `dashboard.kaniko.podLabels`, a map of labels that the dashboard applies to every build pod template it creates.
+On clusters where workload identity is opt-in via a pod label (e.g. AKS requires `azure.workload.identity/use: "true"`), set those labels here.
+You also need to set `dashboard.kaniko.defaultServiceAccount` (or the per-function `BuilderServiceAccount`) to a ServiceAccount that is bound to the cloud identity with push permissions on the target registry.
+
+Example for AKS with Azure Workload Identity:
+
+```sh
+helm upgrade --install --reuse-values nuclio \
+    --set registry.pushPullUrl=<your-acr>.azurecr.io \
+    --set dashboard.containerBuilderKind=kaniko \
+    --set dashboard.kaniko.defaultServiceAccount=<sa-bound-to-acrpush-identity> \
+    --set-json 'dashboard.kaniko.podLabels={"azure.workload.identity/use":"true"}' \
+    nuclio/nuclio
+```
+
+#### Precedence when both are configured
+
+It's a valid configuration to set **both** `registry.secretName` (or `registry.credentials`) **and** `dashboard.kaniko.podLabels` + a workload-identity-bound `defaultServiceAccount`.
+Kaniko's auth resolution is the standard go-containerregistry chain, so when a docker-config secret is mounted at `/kaniko/.docker/config.json`, **those static credentials take precedence** over the federated token that workload identity would otherwise provide.
+The federated token is only consulted if the mounted config has no matching entry for the target registry.
+
+This means the workload-identity setup is effectively shadowed when `registry.secretName` / `registry.credentials` is also set.
+If you intend to authenticate to the registry via workload identity, do **not** also set `registry.secretName` (or only set one whose docker config does not match the target registry).
+It is the responsibility of whoever configures Nuclio to choose one auth path or the other; the chart does not enforce this.

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -166,6 +166,10 @@ spec:
         - name: NUCLIO_KANIKO_DEFAULT_SERVICE_ACCOUNT
           value: {{ .Values.dashboard.kaniko.defaultServiceAccount }}
         {{- end }}
+        {{- if .Values.dashboard.kaniko.podLabels }}
+        - name: NUCLIO_KANIKO_POD_LABELS
+          value: {{ .Values.dashboard.kaniko.podLabels | toJson | quote }}
+        {{- end }}
         {{- if .Values.registry.runRegistryURL }}
         - name: NUCLIO_DASHBOARD_RUN_REGISTRY_URL
           value: {{ .Values.registry.runRegistryURL }}

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -212,6 +212,12 @@ dashboard:
     # runtime (so they can't be set on the chart-rendered manifests).
     # Example use: { "azure.workload.identity/use": "true" } to activate
     # Azure Workload Identity token injection for ACR push on AKS.
+    #
+    # Note: if `registry.secretName` / `registry.credentials` is also set,
+    # the resulting docker-config secret is mounted at /kaniko/.docker
+    # and takes precedence over any federated token a workload identity
+    # would provide. See "Using Kaniko with cloud workload identity" in
+    # docs/setup/k8s/running-in-production-k8s.md.
     podLabels: {}
 
   # use to configure node port

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -207,6 +207,13 @@ dashboard:
     # the default service account to use for kaniko pod, if not specified otherwise
     defaultServiceAccount: ""
 
+    # Additional labels added to the kaniko build pod template.metadata.labels.
+    # The dashboard passes these through to the kaniko Job it creates at
+    # runtime (so they can't be set on the chart-rendered manifests).
+    # Example use: { "azure.workload.identity/use": "true" } to activate
+    # Azure Workload Identity token injection for ACR push on AKS.
+    podLabels: {}
+
   # use to configure node port
   nodePort:
 

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -316,6 +316,7 @@ func (k *Kaniko) compileJobSpec(ctx context.Context,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      jobName,
 					Namespace: namespace,
+					Labels:    k.resolveKanikoPodLabels(),
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
@@ -847,4 +848,19 @@ func (k *Kaniko) enrichServiceAccountFromBuilderConfiguration(buildOptions *Buil
 		return k.builderConfiguration.DefaultServiceAccount
 	}
 	return buildOptions.FunctionServiceAccount
+}
+
+// resolveKanikoPodLabels returns the labels to set on the kaniko Job pod
+// template. Returns nil when no labels are configured so the rendered pod
+// metadata is unchanged for installs that don't need this (e.g. on-prem,
+// credential-based cloud).
+func (k *Kaniko) resolveKanikoPodLabels() map[string]string {
+	if len(k.builderConfiguration.KanikoPodLabels) == 0 {
+		return nil
+	}
+	labels := make(map[string]string, len(k.builderConfiguration.KanikoPodLabels))
+	for key, value := range k.builderConfiguration.KanikoPodLabels {
+		labels[key] = value
+	}
+	return labels
 }

--- a/pkg/containerimagebuilderpusher/kaniko_test.go
+++ b/pkg/containerimagebuilderpusher/kaniko_test.go
@@ -24,7 +24,12 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestNewContainerBuilderConfigurationParsesKanikoPodLabels(t *testing.T) {
+type KanikoTestSuite struct {
+	suite.Suite
+	kaniko *Kaniko
+}
+
+func (suite *KanikoTestSuite) TestNewContainerBuilderConfigurationParsesKanikoPodLabels() {
 	for _, testCase := range []struct {
 		name      string
 		envValue  string
@@ -52,35 +57,23 @@ func TestNewContainerBuilderConfigurationParsesKanikoPodLabels(t *testing.T) {
 			expectErr: true,
 		},
 	} {
-		t.Run(testCase.name, func(t *testing.T) {
+		suite.Run(testCase.name, func() {
 			if testCase.envValue != "" {
-				t.Setenv("NUCLIO_KANIKO_POD_LABELS", testCase.envValue)
+				suite.T().Setenv("NUCLIO_KANIKO_POD_LABELS", testCase.envValue)
 			}
 
 			config, err := NewContainerBuilderConfiguration()
 			if testCase.expectErr {
-				if err == nil {
-					t.Fatalf("expected an error, got nil; config: %#v", config)
-				}
+				suite.Require().Error(err)
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if len(config.KanikoPodLabels) != len(testCase.expected) {
-				t.Fatalf("expected %d labels, got %d (%#v)",
-					len(testCase.expected), len(config.KanikoPodLabels), config.KanikoPodLabels)
-			}
-			for key, expectedValue := range testCase.expected {
-				if actual, ok := config.KanikoPodLabels[key]; !ok || actual != expectedValue {
-					t.Fatalf("label %q: expected %q, got %q (present=%v)", key, expectedValue, actual, ok)
-				}
-			}
+			suite.Require().NoError(err)
+			suite.Equal(testCase.expected, config.KanikoPodLabels)
 		})
 	}
 }
 
-func TestResolveKanikoPodLabelsCopiesAndIsolatesFromConfig(t *testing.T) {
+func (suite *KanikoTestSuite) TestResolveKanikoPodLabelsCopiesAndIsolatesFromConfig() {
 	configLabels := map[string]string{"azure.workload.identity/use": "true"}
 	k := &Kaniko{
 		builderConfiguration: &ContainerBuilderConfiguration{
@@ -89,27 +82,17 @@ func TestResolveKanikoPodLabelsCopiesAndIsolatesFromConfig(t *testing.T) {
 	}
 
 	resolved := k.resolveKanikoPodLabels()
-	if got := resolved["azure.workload.identity/use"]; got != "true" {
-		t.Fatalf("expected workload-identity label to be propagated, got %q", got)
-	}
+	suite.Equal("true", resolved["azure.workload.identity/use"])
 
 	// Mutating the returned map must not leak back into the shared config map.
 	resolved["mutated"] = "yes"
-	if _, leaked := configLabels["mutated"]; leaked {
-		t.Fatalf("resolveKanikoPodLabels must return a copy; mutation leaked into builderConfiguration")
-	}
+	_, leaked := configLabels["mutated"]
+	suite.False(leaked, "resolveKanikoPodLabels must return a copy; mutation leaked into builderConfiguration")
 }
 
-func TestResolveKanikoPodLabelsReturnsNilWhenNoLabelsConfigured(t *testing.T) {
+func (suite *KanikoTestSuite) TestResolveKanikoPodLabelsReturnsNilWhenNoLabelsConfigured() {
 	k := &Kaniko{builderConfiguration: &ContainerBuilderConfiguration{}}
-	if got := k.resolveKanikoPodLabels(); got != nil {
-		t.Fatalf("expected nil when no labels are configured, got %#v", got)
-	}
-}
-
-type KanikoTestSuite struct {
-	suite.Suite
-	kaniko *Kaniko
+	suite.Nil(k.resolveKanikoPodLabels())
 }
 
 func (suite *KanikoTestSuite) SetupTest() {

--- a/pkg/containerimagebuilderpusher/kaniko_test.go
+++ b/pkg/containerimagebuilderpusher/kaniko_test.go
@@ -24,6 +24,89 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+func TestNewContainerBuilderConfigurationParsesKanikoPodLabels(t *testing.T) {
+	for _, testCase := range []struct {
+		name      string
+		envValue  string
+		expected  map[string]string
+		expectErr bool
+	}{
+		{
+			name:     "Unset",
+			envValue: "",
+			expected: nil,
+		},
+		{
+			name:     "SingleLabel",
+			envValue: `{"azure.workload.identity/use":"true"}`,
+			expected: map[string]string{"azure.workload.identity/use": "true"},
+		},
+		{
+			name:     "MultipleLabels",
+			envValue: `{"a":"1","b":"2"}`,
+			expected: map[string]string{"a": "1", "b": "2"},
+		},
+		{
+			name:      "InvalidJSON",
+			envValue:  "not-json",
+			expectErr: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.envValue != "" {
+				t.Setenv("NUCLIO_KANIKO_POD_LABELS", testCase.envValue)
+			}
+
+			config, err := NewContainerBuilderConfiguration()
+			if testCase.expectErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil; config: %#v", config)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(config.KanikoPodLabels) != len(testCase.expected) {
+				t.Fatalf("expected %d labels, got %d (%#v)",
+					len(testCase.expected), len(config.KanikoPodLabels), config.KanikoPodLabels)
+			}
+			for key, expectedValue := range testCase.expected {
+				if actual, ok := config.KanikoPodLabels[key]; !ok || actual != expectedValue {
+					t.Fatalf("label %q: expected %q, got %q (present=%v)", key, expectedValue, actual, ok)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveKanikoPodLabelsCopiesAndIsolatesFromConfig(t *testing.T) {
+	configLabels := map[string]string{"azure.workload.identity/use": "true"}
+	k := &Kaniko{
+		builderConfiguration: &ContainerBuilderConfiguration{
+			KanikoPodLabels: configLabels,
+		},
+	}
+
+	resolved := k.resolveKanikoPodLabels()
+	if got := resolved["azure.workload.identity/use"]; got != "true" {
+		t.Fatalf("expected workload-identity label to be propagated, got %q", got)
+	}
+
+	// Mutating the returned map must not leak back into the shared config map.
+	resolved["mutated"] = "yes"
+	if _, leaked := configLabels["mutated"]; leaked {
+		t.Fatalf("resolveKanikoPodLabels must return a copy; mutation leaked into builderConfiguration")
+	}
+}
+
+func TestResolveKanikoPodLabelsReturnsNilWhenNoLabelsConfigured(t *testing.T) {
+	k := &Kaniko{builderConfiguration: &ContainerBuilderConfiguration{}}
+	if got := k.resolveKanikoPodLabels(); got != nil {
+		t.Fatalf("expected nil when no labels are configured, got %#v", got)
+	}
+}
+
 type KanikoTestSuite struct {
 	suite.Suite
 	kaniko *Kaniko

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package containerimagebuilderpusher
 
 import (
+	"encoding/json"
 	"strconv"
 	"time"
 
@@ -84,6 +85,13 @@ type ContainerBuilderConfiguration struct {
 	InsecurePullRegistry                 bool
 	PushImagesRetries                    int
 	ImageFSExtractionRetries             int
+
+	// KanikoPodLabels are labels to set on the metadata of the kaniko build
+	// pod template. Used, for example, to opt the pod into the Azure
+	// Workload Identity webhook (azure.workload.identity/use: "true") so
+	// kaniko can authenticate to ACR via federated tokens on identity-based
+	// installs.
+	KanikoPodLabels map[string]string
 }
 
 func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) {
@@ -164,6 +172,12 @@ func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) 
 
 	containerBuilderConfiguration.DefaultServiceAccount = common.GetEnvOrDefaultString("NUCLIO_KANIKO_DEFAULT_SERVICE_ACCOUNT",
 		"")
+
+	if rawPodLabels := common.GetEnvOrDefaultString("NUCLIO_KANIKO_POD_LABELS", ""); rawPodLabels != "" {
+		if err := json.Unmarshal([]byte(rawPodLabels), &containerBuilderConfiguration.KanikoPodLabels); err != nil {
+			return nil, errors.Wrap(err, "Failed to parse NUCLIO_KANIKO_POD_LABELS as JSON object")
+		}
+	}
 
 	return &containerBuilderConfiguration, nil
 }


### PR DESCRIPTION
### 📝 Description

Surface a new `dashboard.kaniko.podLabels` chart value (env `NUCLIO_KANIKO_POD_LABELS`, JSON object) that the dashboard applies to every kaniko Job pod template it creates at runtime.

The motivating use case is Azure AKS **identity-based** installs (Azure Workload Identity, no static ACR creds). The Azure WI webhook injects the federated token + `AZURE_*` env vars only when the pod carries `azure.workload.identity/use: \"true\"`. Today the kaniko Job pod template carries no labels at all, so the webhook skips it and the push to ACR fails with `UNAUTHORIZED`. With this change, the platform can opt the kaniko pod into the webhook (or set any other labels it needs) without touching nuclio source.

The label set is platform-wide (env-driven). RBAC grants on the SA the pod runs under are out of scope for this PR — see IG4-2646 for the full RCA and the decision to keep the builder running as the user SA with `AcrPush` granted to it operator-side.

---

### 🛠️ Changes Made

- `pkg/containerimagebuilderpusher/types.go` — new `KanikoPodLabels map[string]string` on `ContainerBuilderConfiguration`, populated from `NUCLIO_KANIKO_POD_LABELS` env (JSON, optional).
- `pkg/containerimagebuilderpusher/kaniko.go` — pod template now carries those labels via `resolveKanikoPodLabels()`. Returns `nil` when unset (no-op for on-prem/credential installs); returns a defensive copy when set.
- `pkg/containerimagebuilderpusher/kaniko_test.go` — new unit tests for env parsing (unset / single / multiple / invalid JSON) and resolver behaviour (propagation, copy-isolation, nil when unset).
- `hack/k8s/helm/nuclio/values.yaml` — new `dashboard.kaniko.podLabels: {}` with a comment pointing at the AKS-WI use case.
- `hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml` — emit `NUCLIO_KANIKO_POD_LABELS` (JSON-quoted) only when the map is non-empty.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable) — inline comment in \`values.yaml\` + Go doc on the new field
- [x] I have tested the changes in this PR

---

### 🧪 Testing

- \`go test -tags=test_unit ./pkg/containerimagebuilderpusher/...\` → PASS (3 new tests + existing suite).
- \`go vet ./pkg/containerimagebuilderpusher/...\` clean.
- \`helm lint hack/k8s/helm/nuclio\` clean.
- \`helm template\` with no override → no \`NUCLIO_KANIKO_POD_LABELS\` env (no-op).
- \`helm template --set-json 'dashboard.kaniko.podLabels={\"azure.workload.identity/use\":\"true\"}'\` →

  \`\`\`yaml
  - name: NUCLIO_KANIKO_POD_LABELS
    value: \"{\\\"azure.workload.identity/use\\\":\\\"true\\\"}\"
  \`\`\`

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/IG4-2646
- Companion: ML-12670 (mlrun side), DEVOPS-1918 (operator-side ACR grant on the user-jobs SA)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

Defaults to empty; render is unchanged for any install that doesn't opt in.

---

### 🔍️ Additional Notes

The fix is only operational once the platform (mlefi) actually sets the value on identity installs — there's a companion mlefi PR that wires \`dashboard.kaniko.podLabels = workload_identity_pod_labels()\`. The chart-only piece can land independently; it's backwards compatible.