### PR TITLE
[Security] Prevent path traversal in spec.handler source-code write

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -87,6 +87,31 @@ func SanitizePath(path string) (string, error) {
 	return absPath, nil
 }
 
+// IsPathWithinDir reports whether targetPath resolves to a location strictly inside dir.
+// Both arguments are resolved to absolute paths first, so the check is robust against
+// "../" traversal sequences in targetPath. A path equal to dir is not considered within it.
+// Use this to prevent path traversal (CWE-22) before writing to a user-influenced path.
+func IsPathWithinDir(targetPath, dir string) (bool, error) {
+	absTargetPath, err := filepath.Abs(targetPath)
+	if err != nil {
+		return false, errors.Wrap(err, "Failed to resolve target path")
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return false, errors.Wrap(err, "Failed to resolve dir")
+	}
+
+	relPath, err := filepath.Rel(absDir, absTargetPath)
+	if err != nil {
+		// the paths share no common base (e.g. different Windows volumes) - not within
+		return false, nil
+	}
+
+	return relPath != "." &&
+		relPath != ".." &&
+		!strings.HasPrefix(relPath, ".."+string(os.PathSeparator)), nil
+}
+
 // FileExists returns true if the file @ path exists
 func FileExists(path string) bool {
 	_, err := os.Stat(path)

--- a/pkg/common/helper_test.go
+++ b/pkg/common/helper_test.go
@@ -704,6 +704,54 @@ func (suite *MiscTestSuite) TestImageHasRegistry() {
 	}
 }
 
+type IsPathWithinDirTestSuite struct {
+	suite.Suite
+}
+
+func (suite *IsPathWithinDirTestSuite) TestIsPathWithinDir() {
+	const dir = "/tmp/nuclio-build-123/source"
+	for _, testCase := range []struct {
+		name       string
+		targetPath string
+		expected   bool
+	}{
+		{
+			name:       "childWithinDir",
+			targetPath: "/tmp/nuclio-build-123/source/main.go",
+			expected:   true,
+		},
+		{
+			name:       "dirItself",
+			targetPath: "/tmp/nuclio-build-123/source",
+			expected:   false,
+		},
+		{
+			name:       "exactlyParentDir",
+			targetPath: "/tmp/nuclio-build-123",
+			expected:   false,
+		},
+		{
+			// the advisory reproducer: "../" sequences escaping the build dir
+			name:       "parentEscape",
+			targetPath: "/tmp/nuclio-build-123/source/../../../../tmp/evil.txt",
+			expected:   false,
+		},
+		{
+			// guards against a naive HasPrefix(path, dir) check, which would wrongly
+			// accept a sibling dir sharing the prefix ("source-evil" vs "source")
+			name:       "siblingWithSharedPrefix",
+			targetPath: "/tmp/nuclio-build-123/source-evil/x.txt",
+			expected:   false,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			within, err := IsPathWithinDir(testCase.targetPath, dir)
+			suite.Require().NoError(err)
+			suite.Require().Equal(testCase.expected, within)
+		})
+	}
+}
+
 func TestHelperTestSuite(t *testing.T) {
 	suite.Run(t, new(RetryUntilSuccessfulTestSuite))
 	suite.Run(t, new(RetryUntilSuccessfulOnErrorPatternsTestSuite))
@@ -714,4 +762,5 @@ func TestHelperTestSuite(t *testing.T) {
 	suite.Run(t, new(StripPrefixesTestSuite))
 	suite.Run(t, new(LabelsMapMatcherTestSuite))
 	suite.Run(t, new(MiscTestSuite))
+	suite.Run(t, new(IsPathWithinDirTestSuite))
 }

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -653,6 +653,17 @@ func (b *Builder) writeFunctionSourceCodeToTempFile(functionSourceCode string) (
 
 	sourceFilePath := path.Join(tempDir, moduleFileName)
 
+	// Guard against path traversal (CWE-22): moduleFileName is derived from the
+	// attacker-controlled spec.handler. path.Join strips leading separators and cleans
+	// the result, but "../" sequences can still resolve the file outside tempDir.
+	withinTempDir, err := common.IsPathWithinDir(sourceFilePath, tempDir)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to validate source file path")
+	}
+	if !withinTempDir {
+		return "", errors.Errorf("Handler module name resolves outside the build directory: %s", moduleFileName)
+	}
+
 	b.logger.DebugWith("Writing function source code to temporary file", "functionPath", sourceFilePath)
 	if err := os.WriteFile(sourceFilePath, decodedFunctionSourceCode, os.FileMode(0644)); err != nil {
 		return "", errors.Wrapf(err, "Failed to write given source code to file %s", sourceFilePath)

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -206,6 +206,31 @@ func (suite *testSuite) TestWriteFunctionSourceCodeToTempFileFailsOnUnknownExten
 	suite.Assert().Error(err)
 }
 
+// TestWriteFunctionSourceCodeToTempFileRejectsPathTraversal verifies that a malicious
+// spec.handler whose module name escapes the build temp dir is rejected before any write
+// happens, closing the path-traversal vulnerability (GHSA-wpcj-rmv4-86qg, CWE-22).
+// The traversal-detection logic itself is exhaustively unit-tested in common.IsPathWithinDir;
+// this asserts it is actually wired into the source-code write path. Before the fix this
+// handler caused os.WriteFile to write attacker bytes outside tempDir.
+func (suite *testSuite) TestWriteFunctionSourceCodeToTempFileRejectsPathTraversal() {
+	suite.builder.options.FunctionConfig.Spec.Runtime = "shell"
+	// exact reproducer from the advisory
+	suite.builder.options.FunctionConfig.Spec.Handler = "../../../../tmp/evil.txt:handler"
+
+	err := suite.builder.createTempDir()
+	suite.Require().NoError(err)
+	defer suite.builder.cleanupTempDir() // nolint: errcheck
+
+	encodedSourceCode := base64.StdEncoding.EncodeToString([]byte("echo pwned"))
+	suite.builder.options.FunctionConfig.Spec.Build.FunctionSourceCode = encodedSourceCode
+
+	tempPath, err := suite.builder.writeFunctionSourceCodeToTempFile(encodedSourceCode)
+	suite.Require().Error(err)
+	suite.Require().Contains(err.Error(), "outside the build directory")
+	// no path is returned and, since the guard runs before os.WriteFile, nothing is written
+	suite.Require().Empty(tempPath)
+}
+
 func (suite *testSuite) TestGetImage() {
 
 	// user specified


### PR DESCRIPTION
### 📝 Description

The Nuclio Dashboard serves `POST /api/functions` unauthenticated under the default NOP auth mode. The `spec.handler` field (`module:entrypoint`) is parsed by `ParseHandler` with no validation of the module portion, and during a source-code build `writeFunctionSourceCodeToTempFile` feeds that module name into `path.Join(tempDir, moduleFileName)`. Because `path.Join` cleans `../` sequences, a handler such as `"../../../../tmp/x:handler"` resolves outside `tempDir`, and `os.WriteFile` then writes attacker-controlled bytes to that path as the root Dashboard process — arbitrary file write across the container filesystem (CWE-22).

This adds a containment guard at the write sink so the handler-derived path can no longer escape the build directory.

---

### 🛠️ Changes Made
- `pkg/common/helper.go`: add `IsPathWithinDir(targetPath, dir)`, which resolves both arguments to absolute paths and uses `filepath.Rel` to report whether `targetPath` is strictly inside `dir` (robust against `../` and against the naive `HasPrefix` sibling-prefix footgun).
- `pkg/processor/build/builder.go`: in `writeFunctionSourceCodeToTempFile`, reject — before any write — a source path that resolves to or outside the build directory.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- `pkg/common`: table-driven unit tests for `IsPathWithinDir` (child within dir, dir itself, exact parent, `../` escape reproducer, sibling-with-shared-prefix) — runs under `make test-unit`.
- `pkg/processor/build`: a regression test asserting the guard is wired into the source-code write path and rejects the advisory reproducer; the pre-existing happy-path write test confirms legitimate handlers are unaffected.
- `gofmt` and `go vet` clean.

---

### 🔗 References
- External links: GHSA-wpcj-rmv4-86qg (CVSS 3.1 7.5 High, CWE-22)
- Ticket - https://ecliptos.atlassian.net/browse/NUC-804

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

Legitimate flat handlers (e.g. `main:handler`) resolve directly under `tempDir` and are unaffected. Only malformed/malicious module names that previously escaped `tempDir` now error.

---

### 🔍️ Additional Notes
- The fix is intentionally scoped to the write sink. `ParseHandler` is left unchanged because it is shared by the golang/shell processor runtimes at function runtime; tightening it there risks regressions and is the wrong layer for this sink.
- Possible follow-up (out of scope here): defense-in-depth validation rejecting path separators in `spec.handler` at API request-validation time.