### PR TITLE
[Dependencies] Bump Alpine images to 3.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,17 +94,17 @@ endif
 
 # alpine is commonly used by controller / dlx / autoscaler
 ifeq ($(NUCLIO_ARCH), armhf)
-	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/arm32v7/alpine:3.20
+	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/arm32v7/alpine:3.23
 	NUCLIO_BASE_IMAGE_NAME 			?= gcr.io/iguazio/arm32v7/golang
 	NUCLIO_DOCKER_JAVA_OPENJDK		?= gcr.io/iguazio/openjdk:11-jdk-slim-bullseye
 	NODE_IMAGE_NAME 				?= gcr.io/iguazio/arm32v7/node:20
 else ifeq ($(NUCLIO_ARCH), arm64)
-	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/arm64v8/alpine:3.20
+	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/arm64v8/alpine:3.23
 	NUCLIO_BASE_IMAGE_NAME 			?= gcr.io/iguazio/arm64v8/golang
 	NUCLIO_DOCKER_JAVA_OPENJDK 		?= gcr.io/iguazio/arm64v8/openjdk:11-jdk-slim-bullseye
 	NODE_IMAGE_NAME 				?= gcr.io/iguazio/arm64v8/node:20
 else
-	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/alpine:3.20
+	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/alpine:3.23
 	NUCLIO_BASE_IMAGE_NAME 			?= gcr.io/iguazio/golang
 	NUCLIO_DOCKER_JAVA_OPENJDK		?= gcr.io/iguazio/openjdk:11-jdk-slim-bullseye
 	NODE_IMAGE_NAME 				?= gcr.io/iguazio/node:20

--- a/docs/reference/runtimes/golang/golang-reference.md
+++ b/docs/reference/runtimes/golang/golang-reference.md
@@ -30,7 +30,7 @@ See [Deploying Functions from a Dockerfile](../../../tasks/deploy-functions-from
 ```
 ARG NUCLIO_LABEL=0.5.6
 ARG NUCLIO_ARCH=amd64
-ARG NUCLIO_BASE_IMAGE=alpine:3.20
+ARG NUCLIO_BASE_IMAGE=alpine:3.23
 ARG NUCLIO_ONBUILD_IMAGE=nuclio/handler-builder-golang-onbuild:${NUCLIO_LABEL}-${NUCLIO_ARCH}-alpine
 
 # Supplies processor uhttpc, used for healthcheck

--- a/docs/tasks/configuring-a-platform.md
+++ b/docs/tasks/configuring-a-platform.md
@@ -335,7 +335,7 @@ runtimeBaseImages:
 
 In this example:
 - All Node.js functions will use `custom-registry.io/node:20` by default 
-- All Golang functions will use the default Nuclio Go base image (`gcr.io/iguazio/alpine:3.20`), since no image is explicitly specified
+- All Golang functions will use the default Nuclio Go base image (`gcr.io/iguazio/alpine:3.23`), since no image is explicitly specified
 - Python 3.11 functions will specifically use `custom-registry.io/python:3.11`
 - Python 3.12 functions will specifically use `custom-registry.io/python:3.12`
 - Other python functions (without a version-specific match) will use `custom-registry.io/python:3.12`, since `3.12` is the current default Python version

--- a/docs/tasks/deploy-functions-from-dockerfile.md
+++ b/docs/tasks/deploy-functions-from-dockerfile.md
@@ -39,7 +39,7 @@ The Dockerfile will look something like this:
 ```
 ARG NUCLIO_LABEL=latest
 ARG NUCLIO_ARCH=amd64
-ARG NUCLIO_BASE_IMAGE=alpine:3.20
+ARG NUCLIO_BASE_IMAGE=alpine:3.23
 ARG NUCLIO_ONBUILD_IMAGE=nuclio/handler-builder-golang-onbuild:${NUCLIO_LABEL}-${NUCLIO_ARCH}-alpine
 
 # Supplies processor uhttpc, used for healthcheck
@@ -66,7 +66,7 @@ CMD [ "processor" ]
 This multi-stage Dockerfile uses three `FROM` directives:
 
 1. `FROM nuclio/uhttpc:0.0.3-amd64` - used for providing an [open-source health-check related binary](https://github.com/nuclio/uhttpc) (basically, a self contained curl). This is used for the "local" platform. You don't need this or the `HEALTHCHECK` platform if you plan on running only on Kubernetes.
-2. `FROM alpine:3.20` - the base image on which the final processor image will run.
+2. `FROM alpine:3.23` - the base image on which the final processor image will run.
 3. `FROM nuclio/handler-builder-golang-onbuild` - this is where it gets interesting: while every runtime needs the processor binary, each runtime must also provide a unique set of artifacts. Interpreter-based runtimes, like Python and NodeJS, simply need to provide the shim layer and the user's code. However, compiled runtimes (Go, Java, .NET Core) must compile the user's code into a binary. This is done with a set of `ONBUILD` directives in the `onbuild` image. You provide the source, and the base image will do everything that is required to provide you with the artifact at the expected location. In this tutorial, by simply using `FROM nuclio/handler-builder-golang-onbuild` and providing Go source code, you will build a Go plugin that will reside at `/opt/nuclio/handler.so`. All you have to do is copy the plugin to the proper location in you final processor image.
 
 It is up to you to customize this Dockerfile, if you so choose (for example, by adding `RUN` directives that add dependencies), but all provided Dockerfiles are ready to go. Go ahead and build the function; you only need the **Dockerfile** and **helloworld.go**:

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -110,11 +110,11 @@ func NewPlatform(ctx context.Context,
 
 	switch runtime.GOARCH {
 	case "arm64":
-		newPlatform.storeImageName = "gcr.io/iguazio/arm64v8/alpine:3.20"
+		newPlatform.storeImageName = "gcr.io/iguazio/arm64v8/alpine:3.23"
 	case "arm":
-		newPlatform.storeImageName = "gcr.io/iguazio/arm32v7/alpine:3.20"
+		newPlatform.storeImageName = "gcr.io/iguazio/arm32v7/alpine:3.23"
 	default:
-		newPlatform.storeImageName = "gcr.io/iguazio/alpine:3.20"
+		newPlatform.storeImageName = "gcr.io/iguazio/alpine:3.23"
 	}
 
 	if newPlatform.ContainerBuilder, err = containerimagebuilderpusher.NewDocker(newPlatform.Logger,

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -567,8 +567,8 @@ func (c *Config) enrichElasticSearchConfig() {
 // getDefaultRuntimeBaseImages returns the default runtime base images
 func (c *Config) getDefaultRuntimeBaseImages() map[string]string {
 	return map[string]string{
-		common.RuntimeShell:      "gcr.io/iguazio/alpine:3.20",
-		common.RuntimeGolang:     "gcr.io/iguazio/alpine:3.20",
+		common.RuntimeShell:      "gcr.io/iguazio/alpine:3.23",
+		common.RuntimeGolang:     "gcr.io/iguazio/alpine:3.23",
 		common.RuntimePython310:  "gcr.io/iguazio/python:3.10",
 		common.RuntimePython311:  "gcr.io/iguazio/python:3.11",
 		common.RuntimePython312:  "gcr.io/iguazio/python:3.12",


### PR DESCRIPTION
### 📝 Description

Bump Nuclio's default Alpine base images from **3.20** to **3.23** across build defaults, platform config, local platform storage, and user-facing docs to get the latest security fixes. 
Alpine is used for controller, DLX, autoscaler, shell/golang runtime base images, and Dockerfile examples.

---

### 🛠️ Changes Made

**Alpine 3.23 (primary)**
- `Makefile` — `NUCLIO_DOCKER_ALPINE_IMAGE` for amd64, arm64, and armhf (`3.20` → `3.23`)
- `pkg/platformconfig/platformconfig.go` — default runtime base images for shell and golang
- `pkg/platform/local/platform.go` — local platform store image per architecture
- Docs — `golang-reference.md`, `configuring-a-platform.md`, `deploy-functions-from-dockerfile.md`

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing

**Alpine bump**
- Version-string updates only; no logic changes. Verify image builds pull `*:3.23` from `gcr.io/iguazio` (and arch-specific registries).

---

### 🔗 References

IG4-2329

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

Existing deployments keep running; new builds use Alpine 3.23 by default. Custom `runtimeBaseImages` overrides are unchanged.

---

### 🔍️ Additional Notes
