### PR TITLE
[Security] Guard event-handler parser against path traversal

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -87,6 +87,14 @@ func SanitizePath(path string) (string, error) {
 	return absPath, nil
 }
 
+// ContainsPathTraversal reports whether the given path contains a directory-traversal
+// sequence ("..") and therefore must not be trusted for filesystem access. Note that
+// stripping "../" is not a safe alternative, since inputs such as "....//" would still
+// resolve to "../"; reject the input outright instead.
+func ContainsPathTraversal(path string) bool {
+	return strings.Contains(path, "..")
+}
+
 // IsPathWithinDir reports whether targetPath resolves to a location strictly inside dir.
 // Both arguments are resolved to absolute paths first, so the check is robust against
 // "../" traversal sequences in targetPath. A path equal to dir is not considered within it.

--- a/pkg/common/helper_test.go
+++ b/pkg/common/helper_test.go
@@ -752,6 +752,54 @@ func (suite *IsPathWithinDirTestSuite) TestIsPathWithinDir() {
 	}
 }
 
+type ContainsPathTraversalTestSuite struct {
+	suite.Suite
+}
+
+func (suite *ContainsPathTraversalTestSuite) TestContainsPathTraversal() {
+	for _, testCase := range []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "cleanAbsolutePath",
+			path:     "/tmp/nuclio-build-123/source",
+			expected: false,
+		},
+		{
+			name:     "cleanRelativePath",
+			path:     "handler/main.go",
+			expected: false,
+		},
+		{
+			name:     "emptyPath",
+			path:     "",
+			expected: false,
+		},
+		{
+			name:     "leadingTraversal",
+			path:     "../../etc/passwd",
+			expected: true,
+		},
+		{
+			name:     "embeddedTraversal",
+			path:     "/tmp/nuclio-build-123/source/../../../../etc/passwd",
+			expected: true,
+		},
+		{
+			// removing "../" alone would leave "../", so the whole input must be rejected
+			name:     "obfuscatedTraversal",
+			path:     "....//etc/passwd",
+			expected: true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Require().Equal(testCase.expected, ContainsPathTraversal(testCase.path))
+		})
+	}
+}
+
 func TestHelperTestSuite(t *testing.T) {
 	suite.Run(t, new(RetryUntilSuccessfulTestSuite))
 	suite.Run(t, new(RetryUntilSuccessfulOnErrorPatternsTestSuite))
@@ -763,4 +811,5 @@ func TestHelperTestSuite(t *testing.T) {
 	suite.Run(t, new(LabelsMapMatcherTestSuite))
 	suite.Run(t, new(MiscTestSuite))
 	suite.Run(t, new(IsPathWithinDirTestSuite))
+	suite.Run(t, new(ContainsPathTraversalTestSuite))
 }

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -944,7 +944,7 @@ func (b *Builder) createTempDir() error {
 	if b.options.FunctionConfig.Spec.Build.TempDir != "" {
 
 		// Validate the user-provided temporary directory to ensure it does not contain directory traversal sequences
-		if strings.Contains(b.options.FunctionConfig.Spec.Build.TempDir, "..") {
+		if common.ContainsPathTraversal(b.options.FunctionConfig.Spec.Build.TempDir) {
 			return errors.New("Invalid temporary directory path: contains '..'")
 		}
 

--- a/pkg/processor/build/runtime/golang/eventhandlerparser/parse.go
+++ b/pkg/processor/build/runtime/golang/eventhandlerparser/parse.go
@@ -24,6 +24,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/nuclio/nuclio/pkg/common"
+
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 )
@@ -40,6 +42,13 @@ func NewEventHandlerParser(logger logger.Logger) *EventHandlerParser {
 
 // ParseEventHandlers return list of packages and handler names in path
 func (ehp *EventHandlerParser) ParseEventHandlers(eventHandlerPath string) ([]string, []string, error) {
+
+	// eventHandlerPath derives from user-controlled function config (Spec.Build.Path);
+	// reject directory-traversal sequences before filesystem access.
+	if common.ContainsPathTraversal(eventHandlerPath) {
+		return nil, nil, errors.New("Invalid event handler path: contains '..'")
+	}
+
 	pathInfo, err := os.Stat(eventHandlerPath)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "Failed to get path information")

--- a/pkg/processor/build/runtime/golang/eventhandlerparser/parse_test.go
+++ b/pkg/processor/build/runtime/golang/eventhandlerparser/parse_test.go
@@ -101,6 +101,23 @@ func (suite *ParseSuite) TestBadCode() {
 	suite.Require().Error(err, "No error on bad code")
 }
 
+func (suite *ParseSuite) TestRejectsPathTraversal() {
+
+	// a valid handler directory exists, but the path used to reach it contains a
+	// traversal sequence - the parser must reject it before touching the file system
+	handlerDir, err := os.MkdirTemp("", "parse-test")
+	suite.Require().NoError(err, "Can't create temporary directory")
+	suite.createHandler(handlerDir, 0)
+
+	// build the path by hand (not filepath.Join, which would clean away the "..") so the
+	// traversal sequence reaches the parser verbatim, even though it resolves to a real dir
+	traversalPath := handlerDir + "/../" + filepath.Base(handlerDir)
+
+	_, _, err = suite.parser.ParseEventHandlers(traversalPath)
+	suite.Require().Error(err, "Expected error for path containing '..'")
+	suite.Require().Contains(err.Error(), "..", "Error should reference the rejected traversal sequence")
+}
+
 func (suite *ParseSuite) TestFindHandlersInDirectory() {
 	handlerDir, err := os.MkdirTemp("", "parse-test")
 	suite.Require().NoError(err, "Can't create temporary directory")


### PR DESCRIPTION
### 📝 Description

The golang event-handler parser (`ParseEventHandlers`) reads a directory and parses its `.go` files using a path derived from user-controlled function configuration (`spec.build.path`, submitted via the Dashboard HTTP API). The path reaches the parser with no validation of its own, and `filepath.Clean`/`Abs` upstream is not recognised as a barrier — so CodeQL flags an unmitigated `go/path-injection` flow (CWE-22) at `pkg/processor/build/runtime/golang/eventhandlerparser/parse.go` (alert #823, sinks: `os.Stat`, `os.ReadDir`, `parser.ParseFile`).

This adds a directory-traversal guard at the parser's own boundary, before any filesystem access. It follows the same family as #4143 — the `..` predicate lands next to that PR's `IsPathWithinDir` in `pkg/common`.

---

### 🛠️ Changes Made
- `pkg/common/helper.go`: add `ContainsPathTraversal(path)`, a small shared predicate that reports whether a path contains a `".."` sequence (documents why stripping `../` is unsafe — `"....//"` would survive).
- `pkg/processor/build/runtime/golang/eventhandlerparser/parse.go`: reject a traversal path at the top of `ParseEventHandlers`, before `os.Stat` — one guard covers all three sinks since the others derive from the same variable.
- `pkg/processor/build/builder.go`: refactor the existing inline `spec.build.tempDir` `".."` check in `createTempDir` to use the shared helper (DRY; no behaviour change).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- `pkg/common`: table-driven unit tests for `ContainsPathTraversal` (clean absolute/relative paths, empty, leading `../`, embedded `../`, and the obfuscated `....//` case).
- `pkg/processor/.../eventhandlerparser`: `TestRejectsPathTraversal` — a real handler dir reached via a verbatim `..` path is rejected before parsing; existing happy-path suite still passes (5/5).
- `gofmt` and `go vet` clean on all changed files. CodeQL not run locally; the guard matches CodeQL's documented `..`-reject barrier, so alert #823 is expected to auto-close on the next scan of the merge.

---

### 🔗 References
- CodeQL alert: https://github.com/nuclio/nuclio/security/code-scanning/823
- Related: #4143 (`IsPathWithinDir`, same CWE-22 cleanup, same `pkg/common/helper.go`)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- The guard is defence-in-depth for the production flow (the path is already `..`-free by the time it reaches the parser via `builder.go`), but hardens the otherwise-unvalidated public `ParseEventHandlers` boundary.
- Follow-up (out of scope here): an authenticated Dashboard user can still point `spec.build.path` at an arbitrary **absolute** server path — that is an authorization/allowlisting question, not pure traversal, and a base-dir containment fix there risks breaking nuctl local-path builds and kube volume-mounted code paths.