### PR TITLE
[Security] Sanitize Java runtimeAttributes.repositories to prevent build-time RCE

### DIFF
--- a/docs/reference/runtimes/java/java-reference.md
+++ b/docs/reference/runtimes/java/java-reference.md
@@ -101,6 +101,8 @@ repositories {
 }
 ```
 
+Each `repositories` value is validated before it is written to the **build.gradle** script: only the characters `A-Z`, `a-z`, `0-9`, `_`, `.`, `:`, `/`, `(`, `)` and `-` are permitted (for example `mavenCentral()` or `jcenter()`). A value containing any other character — such as whitespace, quotes, braces or newlines — is rejected and the function build fails. This prevents arbitrary Groovy from being injected into the generated build script. To use a fully custom repository configuration (for example a private `maven { ... }` repository), provide your own **build.gradle** file as described below.
+
 ### Custom Gradle script
 
 Providing a **build.gradle** file inside the function directory or archive overrides the script generation.

--- a/docs/reference/runtimes/java/java-reference.md
+++ b/docs/reference/runtimes/java/java-reference.md
@@ -101,7 +101,7 @@ repositories {
 }
 ```
 
-Each `repositories` value is validated before it is written to the **build.gradle** script: only the characters `A-Z`, `a-z`, `0-9`, `_`, `.`, `:`, `/`, `(`, `)` and `-` are permitted (for example `mavenCentral()` or `jcenter()`). A value containing any other character — such as whitespace, quotes, braces or newlines — is rejected and the function build fails. This prevents arbitrary Groovy from being injected into the generated build script. To use a fully custom repository configuration (for example a private `maven { ... }` repository), provide your own **build.gradle** file as described below.
+Each `repositories` value is validated before it is written to the **build.gradle** script: a value must be a no-argument repository declaration of the form `name()` — for example `mavenCentral()`, `jcenter()`, `google()`, `mavenLocal()` or `gradlePluginPortal()`. Any other value — anything containing arguments, method chains, quotes, braces or whitespace — is rejected and the function build fails. This prevents arbitrary Groovy from being executed during the build. To use a custom repository configuration (for example a private `maven { ... }` repository), provide your own **build.gradle** file as described below.
 
 ### Custom Gradle script
 

--- a/pkg/processor/build/runtime/java/types.go
+++ b/pkg/processor/build/runtime/java/types.go
@@ -26,16 +26,15 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// repositoryPattern enumerates the characters permitted in a user-supplied Gradle
-// repository declaration (e.g. "mavenCentral()"). Repository values are rendered verbatim
-// into the generated build.gradle, so any unescaped Groovy metacharacter is a code
-// injection vector: an attacker can embed "}" to break out of the `repositories { }` block
-// and append arbitrary top-level statements that Gradle executes during its configuration
-// phase (GHSA-3v79-m2cg-89ww). This allowlist accepts every documented repository form
-// while rejecting the metacharacters that enable the exploit - braces, quotes, internal
-// whitespace, newlines, ";", "$" and backslash - so no string literal can be constructed
-// and no statement boundary crossed. Surrounding whitespace is trimmed before matching.
-var repositoryPattern = regexp.MustCompile(`^[A-Za-z0-9_.:/()-]+$`)
+// repositoryPattern matches a single no-argument Gradle repository declaration of the form
+// "name()" (e.g. "mavenCentral()"). Repository values are rendered verbatim into the
+// generated build.gradle, so the value must not be able to express arbitrary Groovy that
+// Gradle would execute during its configuration phase (GHSA-3v79-m2cg-89ww). Permitting only
+// a bare "name()" call - no ".", no arguments, no string-delimiter characters - means no
+// method chain, command string or block break-out can be formed, while every documented
+// repository shortcut (mavenCentral(), jcenter(), google(), mavenLocal(),
+// gradlePluginPortal()) is accepted. Surrounding whitespace is trimmed before matching.
+var repositoryPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*\(\)$`)
 
 type dependency struct {
 	Group   string `json:"group,omitempty"`
@@ -81,8 +80,8 @@ func newBuildAttributes(encodedBuildAttributes map[string]interface{}) (*buildAt
 		trimmedRepository := strings.TrimSpace(repository)
 		if !repositoryPattern.MatchString(trimmedRepository) {
 			return nil, errors.Errorf(
-				"Invalid repository value %q: only the characters A-Z a-z 0-9 _ . : / ( ) - are allowed",
-				repository)
+				"Invalid repository value %q: must be a no-argument repository declaration such as mavenCentral()",
+				trimmedRepository)
 		}
 		newBuildAttributes.Repositories[i] = trimmedRepository
 	}

--- a/pkg/processor/build/runtime/java/types.go
+++ b/pkg/processor/build/runtime/java/types.go
@@ -18,11 +18,24 @@ package java
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/nuclio/errors"
 	"sigs.k8s.io/yaml"
 )
+
+// repositoryPattern enumerates the characters permitted in a user-supplied Gradle
+// repository declaration (e.g. "mavenCentral()"). Repository values are rendered verbatim
+// into the generated build.gradle, so any unescaped Groovy metacharacter is a code
+// injection vector: an attacker can embed "}" to break out of the `repositories { }` block
+// and append arbitrary top-level statements that Gradle executes during its configuration
+// phase (GHSA-3v79-m2cg-89ww). This allowlist accepts every documented repository form
+// while rejecting the metacharacters that enable the exploit - braces, quotes, internal
+// whitespace, newlines, ";", "$" and backslash - so no string literal can be constructed
+// and no statement boundary crossed. Surrounding whitespace is trimmed before matching.
+var repositoryPattern = regexp.MustCompile(`^[A-Za-z0-9_.:/()-]+$`)
 
 type dependency struct {
 	Group   string `json:"group,omitempty"`
@@ -59,6 +72,19 @@ func newBuildAttributes(encodedBuildAttributes map[string]interface{}) (*buildAt
 		newBuildAttributes.Repositories = []string{
 			"mavenCentral()",
 		}
+		return &newBuildAttributes, nil
+	}
+
+	// validate every user-supplied repository value before it is rendered into build.gradle,
+	// to prevent Groovy/Gradle code injection during the build (GHSA-3v79-m2cg-89ww)
+	for i, repository := range newBuildAttributes.Repositories {
+		trimmedRepository := strings.TrimSpace(repository)
+		if !repositoryPattern.MatchString(trimmedRepository) {
+			return nil, errors.Errorf(
+				"Invalid repository value %q: only the characters A-Z a-z 0-9 _ . : / ( ) - are allowed",
+				repository)
+		}
+		newBuildAttributes.Repositories[i] = trimmedRepository
 	}
 
 	return &newBuildAttributes, nil

--- a/pkg/processor/build/runtime/java/types_test.go
+++ b/pkg/processor/build/runtime/java/types_test.go
@@ -96,6 +96,34 @@ func (suite *testSuite) TestNewBuildAttributesRepositoryValidation() {
 			repositories: []string{"maven { url 'https://evil' }"},
 			expectError:  true,
 		},
+		// the following payloads execute code inside the repositories {} block without
+		// any block-breakout metacharacters (no brace, newline or quote); the structural
+		// "name()" rule must still reject them (GHSA-3v79-m2cg-89ww)
+		{
+			name:         "method call with argument rejected",
+			repositories: []string{"System.exit(0)"},
+			expectError:  true,
+		},
+		{
+			name:         "runtime exec rejected",
+			repositories: []string{"Runtime.getRuntime().exec(/usr/bin/id/)"},
+			expectError:  true,
+		},
+		{
+			name:         "slashy-string execute rejected",
+			repositories: []string{"/id/.execute()"},
+			expectError:  true,
+		},
+		{
+			name:         "char-cast string construction rejected",
+			repositories: []string{"((char)105).toString().concat(((char)100).toString()).execute()"},
+			expectError:  true,
+		},
+		{
+			name:         "method chain rejected",
+			repositories: []string{"mavenCentral().toString()"},
+			expectError:  true,
+		},
 		{
 			name:         "empty string element rejected",
 			repositories: []string{""},

--- a/pkg/processor/build/runtime/java/types_test.go
+++ b/pkg/processor/build/runtime/java/types_test.go
@@ -38,6 +38,96 @@ func (suite *testSuite) TestSuccessfulParseDependencies() {
 	suite.Require().Equal("0.2.1", dep.Version)
 }
 
+// TestNewBuildAttributesDefaultsToMavenCentral verifies that an absent or empty
+// repositories attribute falls back to mavenCentral(), preserving prior behaviour.
+func (suite *testSuite) TestNewBuildAttributesDefaultsToMavenCentral() {
+	for _, encoded := range []map[string]interface{}{
+		nil,
+		{},
+		{"repositories": []string{}},
+	} {
+		buildAttributes, err := newBuildAttributes(encoded)
+		suite.Require().NoError(err)
+		suite.Require().Equal([]string{"mavenCentral()"}, buildAttributes.Repositories)
+	}
+}
+
+// TestNewBuildAttributesRepositoryValidation covers the repository allowlist that
+// guards against Groovy/Gradle code injection into the generated build.gradle
+// (GHSA-3v79-m2cg-89ww).
+func (suite *testSuite) TestNewBuildAttributesRepositoryValidation() {
+	// the exact payload from the advisory: close the repositories block, run a
+	// command, re-open the block
+	injectionPayload := "mavenCentral()\n}\nprintln('[RCE-PROOF] ' + ['sh', '-c', 'id'].execute().text)\nrepositories {"
+
+	for _, testCase := range []struct {
+		name         string
+		repositories []string
+		expectError  bool
+		expected     []string
+	}{
+		{
+			name:         "built-in repositories accepted",
+			repositories: []string{"mavenCentral()", "jcenter()", "google()", "mavenLocal()", "gradlePluginPortal()"},
+			expected:     []string{"mavenCentral()", "jcenter()", "google()", "mavenLocal()", "gradlePluginPortal()"},
+		},
+		{
+			name:         "surrounding whitespace trimmed",
+			repositories: []string{"  mavenCentral()  "},
+			expected:     []string{"mavenCentral()"},
+		},
+		{
+			name:         "advisory injection payload rejected",
+			repositories: []string{injectionPayload},
+			expectError:  true,
+		},
+		{
+			name:         "closing brace rejected",
+			repositories: []string{"mavenCentral()}"},
+			expectError:  true,
+		},
+		{
+			name:         "newline rejected",
+			repositories: []string{"mavenCentral()\nmavenLocal()"},
+			expectError:  true,
+		},
+		{
+			name:         "quote rejected",
+			repositories: []string{"maven { url 'https://evil' }"},
+			expectError:  true,
+		},
+		{
+			name:         "empty string element rejected",
+			repositories: []string{""},
+			expectError:  true,
+		},
+		{
+			name:         "whitespace-only element rejected",
+			repositories: []string{"   "},
+			expectError:  true,
+		},
+		{
+			name:         "one invalid among valid rejects whole list",
+			repositories: []string{"mavenCentral()", injectionPayload},
+			expectError:  true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			buildAttributes, err := newBuildAttributes(map[string]interface{}{
+				"repositories": testCase.repositories,
+			})
+
+			if testCase.expectError {
+				suite.Require().Error(err)
+				return
+			}
+
+			suite.Require().NoError(err)
+			suite.Require().Equal(testCase.expected, buildAttributes.Repositories)
+		})
+	}
+}
+
 func TestBuilderSuite(t *testing.T) {
 	suite.Run(t, new(testSuite))
 }


### PR DESCRIPTION
### 📝 Description

The Java runtime generates the function `build.gradle` by rendering user-supplied `spec.build.runtimeAttributes.repositories[]` values verbatim into a Groovy DSL via Go's `text/template` (`{{ . }}`, no escaping). A crafted value can execute arbitrary Groovy during Gradle's configuration phase — an unauthenticated build-time RCE as root in the builder container (GHSA-3v79-m2cg-89ww, CVSS 10.0, CWE-94). Either by breaking out of the `repositories { }` block with `}`, or without any such metacharacter at all (e.g. `/id/.execute()` using a Groovy slashy string, or a string assembled from `char` casts).

This PR validates each repository value at its source (`newBuildAttributes`) before it is ever rendered, failing the build fast with a descriptive error.

---

### 🛠️ Changes Made
- `pkg/processor/build/runtime/java/types.go`: validate each repository value against the **structural** pattern `^[A-Za-z][A-Za-z0-9_]*\(\)$` — a single no-argument method call (e.g. `mavenCentral()`). A character allowlist is not sufficient for this sink: `mavenCentral()` and an exploit such as `/id/.execute()` or `((char)105).toString().concat(...).execute()` are built from the same characters, so any charset permissive enough to accept the former accepts the latter. Permitting only a bare `name()` call — no `.`, no arguments, no string-delimiter characters — means no method chain, command string or block break-out can be formed, while every documented repository shortcut (`mavenCentral()`, `jcenter()`, `google()`, `mavenLocal()`, `gradlePluginPortal()`) is accepted. The empty-list → `mavenCentral()` default is preserved; surrounding whitespace is trimmed.
- `pkg/processor/build/runtime/java/types_test.go`: table-driven unit tests covering the default, the accepted built-ins, and rejection of both block-breakout payloads (`}`, newline, quote) and metacharacter-free execution payloads (`System.exit(0)`, `Runtime.getRuntime().exec(/usr/bin/id/)`, `/id/.execute()`, char-cast string construction, method chains).
- `docs/reference/runtimes/java/java-reference.md`: documented that a repository value must be a no-argument `name()` declaration and that custom repositories (e.g. a private `maven { … }`) require a user-provided `build.gradle`.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- `go test -race -tags=test_unit ./pkg/processor/build/runtime/java/` — pass, including 14 repository-validation cases (accepted built-ins, block-breakout payloads, and metacharacter-free execution payloads such as `/id/.execute()` and the char-cast construction).
- `go vet` and `gofmt -l` clean.
- `golangci-lint` was not run locally (the available binary is built with go1.25, below this module's go1.26.3) — relying on CI for the lint gate.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-805
- Advisory: GHSA-3v79-m2cg-89ww
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

Only repository values that are not a no-argument `name()` declaration are now rejected (these were not valid method-call repository entries). A custom repository configuration (e.g. a private `maven { … }` block) should be supplied via a user-provided `build.gradle`, which already overrides script generation.

---

### 🔍️ Additional Notes
- Follow-up (intentionally out of scope here): the `dependencies` field (`group`/`name`/`version`) is rendered into single-quoted Groovy in the same template and is injectable by the same mechanism (a `'` breaks out of the string). It should receive equivalent validation in a separate change.
