### PR TITLE
[Platform] Retry function-create OPA authorization on deny

### DIFF
--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1292,6 +1292,59 @@ func (ap *Platform) EnsureProjectRead(ctx context.Context,
 	return nil
 }
 
+// OPAPermissionPropagationWindow / OPAPermissionPropagationInterval bound the wait for OPA to
+// reflect permissions granted by a just-created project/policy. The grants are committed at create
+// time, but the OPA permission manifest regenerates asynchronously, so an operation fired within the
+// window can authorize against a manifest that does not yet grant it. CreateProject waits this long
+// for the project-read grant (#3951) and EnsureFunctionCreateAuthorized for the function-create
+// grant; they share one value so the two propagation waits stay consistent.
+const (
+	OPAPermissionPropagationWindow   = 10 * time.Second
+	OPAPermissionPropagationInterval = 1 * time.Second
+)
+
+// EnsureFunctionCreateAuthorized authorizes function creation against OPA, retrying on a deny to
+// absorb the OPA manifest-propagation lag after a freshly-created project: a deploy fired
+// within ~1s of project creation can authorize against a manifest that does not yet grant
+// function-create. It re-queries until OPA grants the create or the window expires; on expiry it
+// surfaces OPA's own last error — the canonical Forbidden (403) on a genuine denial, or the
+// underlying error on a persistent OPA failure — rather than the retry primitive's generic timeout.
+// The happy path (already allowed) issues a single query and adds no latency; retry only fires on a
+// denial. Like the EnsureProjectRead wait CreateProject performs, the polling is not ctx-cancellable
+// between attempts.
+func (ap *Platform) EnsureFunctionCreateAuthorized(ctx context.Context,
+	projectName string,
+	functionName string,
+	permissionOptions *opaclient.PermissionOptions) error {
+
+	authzOptions := *permissionOptions
+	authzOptions.RaiseForbidden = true
+
+	var lastErr error
+	if err := common.RetryUntilSuccessful(OPAPermissionPropagationWindow,
+		OPAPermissionPropagationInterval,
+		func() bool {
+			_, lastErr = ap.QueryOPAFunctionPermissions(ctx,
+				projectName,
+				functionName,
+				opaclient.ActionCreate,
+				&authzOptions)
+			return lastErr == nil
+		}); err != nil {
+
+		// Window exhausted while OPA kept denying (or erroring). lastErr is the typed error from the
+		// final attempt — the canonical 403 on a genuine denial — which the caller surfaces in
+		// preference to the retry primitive's generic "timed out" error. Fall back to that timeout
+		// error if lastErr is somehow nil: this is an authorization gate, so an exhausted window must
+		// fail closed and never return nil (which would read as authorized).
+		if lastErr == nil {
+			lastErr = err
+		}
+		return lastErr
+	}
+	return nil
+}
+
 func (ap *Platform) QueryOPAProjectPermissions(ctx context.Context,
 	projectName string,
 	action opaclient.Action,

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -206,13 +206,13 @@ func (p *Platform) CreateFunction(ctx context.Context, createFunctionOptions *pl
 		return nil, errors.Wrap(err, "Failed to enrich and validate a function configuration")
 	}
 
-	// Check OPA permissions
+	// Check OPA permissions. Retry on a deny to absorb the OPA manifest-propagation lag after a
+	// freshly-created project: the function-create grant may not be live in OPA yet when a
+	// deploy is fired right after project creation. A genuine denial still 403s (after the window).
 	permissionOptions := createFunctionOptions.PermissionOptions
-	permissionOptions.RaiseForbidden = true
-	if _, err := p.QueryOPAFunctionPermissions(ctx,
+	if err := p.EnsureFunctionCreateAuthorized(ctx,
 		createFunctionOptions.FunctionConfig.Meta.Labels[common.NuclioResourceLabelKeyProjectName],
 		createFunctionOptions.FunctionConfig.Meta.Name,
-		opaclient.ActionCreate,
 		&permissionOptions); err != nil {
 		return nil, errors.Wrap(err, "Failed authorizing OPA permissions for resource")
 	}
@@ -761,8 +761,8 @@ func (p *Platform) CreateProject(ctx context.Context, createProjectOptions *plat
 	}
 
 	// ensure project permissions are populated in OPA
-	if err := common.RetryUntilSuccessful(time.Second*10,
-		time.Second*1,
+	if err := common.RetryUntilSuccessful(abstract.OPAPermissionPropagationWindow,
+		abstract.OPAPermissionPropagationInterval,
 		func() bool {
 			if err := p.EnsureProjectRead(ctx, createProjectOptions.ProjectConfig.Meta.Name, &createProjectOptions.PermissionOptions); err != nil {
 				return false


### PR DESCRIPTION
### 📝 Description

A Nuclio function deploy fired within ~1 s of creating a project intermittently returns `403`
from nuclio-dashboard (~14% hit rate; mlrun surfaces it as `400`). The owner policy granting
function-create is committed at project creation, but the OPA permission manifest regenerates
**asynchronously**, so a deploy fired in the propagation window authorizes against a manifest that
does not yet grant create — and the authorization turns the valid `200 {result:false}` into an
immediate hard `403` (the OPA client only retries transport errors, never a valid deny).

This makes the function-create authorization **wait out** the short propagation lag instead of
403-ing on the first deny — mirroring the `EnsureProjectRead` wait `CreateProject` already performs
for the project-read grant (#3951), applied to the function-create grant the deploy actually needs.
A genuine denial still `403`s, after at most the retry window.

---

### 🛠️ Changes Made

- `pkg/platform/abstract/platform.go` — add `EnsureFunctionCreateAuthorized`: re-query the
  function-create authorization inside `common.RetryUntilSuccessful` until OPA grants it. On window
  exhaustion it surfaces OPA's **own typed error** — the canonical `403` on a genuine denial, the
  underlying error on a persistent OPA outage — never the retry primitive's generic "timed out", and
  it **fails closed** (never returns `nil` on an exhausted window). The happy path (already allowed)
  issues a single query and adds no latency; retry fires only on a deny.
- `pkg/platform/abstract/platform.go` — extract the wait into shared
  `OPAPermissionPropagationWindow` / `OPAPermissionPropagationInterval` constants (**10 s / 1 s**).
- `pkg/platform/kube/platform.go` — `CreateFunction` calls the new helper in place of the
  single-shot OPA check; `CreateProject`'s existing project-read wait (#3951) now uses the shared
  constants instead of inline `time.Second*10, time.Second*1` (**no behavior change** — identical
  values, just de-duplicated so both propagation waits stay in lockstep).

---

### ✅ Checklist
- [x] I updated the documentation (if applicable) — n/a, no user-facing/API/behaviour change
- [ ] I have tested the changes in this PR — see Testing

---

### 🧪 Testing

No unit tests in this PR. Verification is end-to-end via the attached reproducer: patch this build
into an IG4 lab and run `repro_nuclio_deploy_race.py`, expecting the ~14% hit rate to drop to 0%.
**Not yet run** — pending the lab patch.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-808 (current Jira key: NUC-810 — re-keyed; same bug)
- Design docs links:
- External links: relates to orca PR #823 (the synchronous-manifest-regen alternative, **not taken** —
  per ticket discussion, making project-create's regen synchronous was deemed risky, so the agreed
  direction is to retry in nuclio). Mirrors the project-read wait added in #3951.

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- Window/interval (10 s / 1 s) deliberately match the project-read wait `CreateProject` performs
  (#3951), for consistency across the two propagation races. A genuinely-forbidden deploy now waits
  up to the window before its `403` — the same ceiling the project path already accepts.
- **Follow-up:** confirm on a lab via the repro that the real manifest-propagation lag sits within
  the window.
