### PR TITLE
[Helm] Make OPA container extra args configurable and bump OPA to 1.17

### DIFF
--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -242,7 +242,9 @@ spec:
           - "--log-level={{ .Values.dashboard.opa.logLevel }}"
           - "--log-format={{ .Values.dashboard.opa.logFormat }}"
           - "--ignore=.*"
-          - "--disable-telemetry"
+          {{- range .Values.dashboard.opa.extraArgs }}
+          - {{ . | quote }}
+          {{- end }}
         volumeMounts:
           - readOnly: true
             mountPath: /config

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -306,9 +306,12 @@ dashboard:
     logLevel: info
     logFormat: json
 
+    extraArgs:
+      - "--skip-version-check"
+
     image:
       repository: openpolicyagent/opa
-      tag: 0.30.1
+      tag: 1.17.0
       pullPolicy: IfNotPresent
       pullSecrets: []
     resources: {}


### PR DESCRIPTION
### 📝 Description
Make the OPA dashboard sidecar's extra args configurable and bump OPA to 1.17. The hardcoded `--disable-telemetry` flag is replaced with a configurable `dashboard.opa.extraArgs` list so operators can append flags (e.g. `--skip-version-check`) per deployment without editing the template.

OPA deprecated `--disable-telemetry` in favor of `--skip-version-check`. `--skip-version-check` is accepted by OPA 1.16.x as well, making the swap forward- and backward-compatible.

---

### 🛠️ Changes Made
- `hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml`: drop the hardcoded `--disable-telemetry` arg; iterate `dashboard.opa.extraArgs` after the fixed args.
- `hack/k8s/helm/nuclio/values.yaml`: add `dashboard.opa.extraArgs` default (`["--skip-version-check"]`); bump OPA image tag `0.30.1 → 1.17.0`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Rendered the chart locally with `helm template` and confirmed the OPA container `args` end with the templated `extraArgs` entries (`--skip-version-check`) after the fixed flags.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links: github.com/McK-Private/mlefi/pull/574

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
- Default `openpolicyagent/opa` was bumped from `0.30.1` to `1.17.0`