### PR TITLE
[Trigger] Restore acknowledged worker draining

### DIFF
--- a/cmd/processor/app/processor_test.go
+++ b/cmd/processor/app/processor_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -235,6 +236,11 @@ func (t *testTrigger) GetProjectName() string {
 func (t *testTrigger) SignalWorkersToDrain() error {
 	t.Called()
 	return nil
+}
+
+func (t *testTrigger) Drain(ctx context.Context) (map[string]struct{}, error) {
+	t.Called()
+	return map[string]struct{}{}, nil
 }
 
 func (t *testTrigger) SignalWorkersToTerminate() error {

--- a/pkg/processor/controlcommunication/types.go
+++ b/pkg/processor/controlcommunication/types.go
@@ -25,6 +25,7 @@ type ControlMessageKind string
 const (
 	StreamMessageAckKind ControlMessageKind = "streamMessageAck"
 	LogMessageKind       ControlMessageKind = "log"
+	DrainMessageKind     ControlMessageKind = "drain"
 )
 
 // TODO: move to nuclio-sdk-go
@@ -37,6 +38,10 @@ type ControlMessageAttributesExplicitAck struct {
 	Topic     string `json:"topic"`
 	Partition int32  `json:"partition"`
 	Offset    int64  `json:"offset"`
+}
+
+type ControlMessageAttributesDrain struct {
+	WorkerId string `json:"workerId"`
 }
 
 // Subscription is a handle to a control-message subscription.

--- a/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
@@ -193,9 +193,7 @@ class AsyncWrapper(AbstractWrapper):
             await self._on_serving_error(exc, sock)
         finally:
             if self._is_drain_needed:
-                result = self._call_drain_handler()
-                if asyncio.iscoroutine(result):
-                    await result
+                await self._call_drain_handler()
 
             if self._is_termination_needed:
                 result = self._call_termination_handler()

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -127,9 +127,7 @@ class Wrapper(AbstractWrapper):
 
             finally:
                 if self._is_drain_needed:
-                    result = self._call_drain_handler()
-                    if asyncio.iscoroutine(result):
-                        await result
+                    await self._call_drain_handler()
 
                 if self._is_termination_needed:
                     result = self._call_termination_handler()

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -478,6 +478,56 @@ class TestSubmitEvents(BaseTestSubmitEvents):
     #         profiled_serve_requests_func(num_requests=num_of_events)
     #     self.assertEqual(num_of_events, self._wrapper._entrypoint.call_count, 'Received unexpected number of events')
 
+    def test_call_drain_handler_sends_drain_complete(self):
+        # NUC-756: after the user's drain callback runs, the wrapper must acknowledge completion to
+        # the processor over the control socket (kind='drain', carrying its worker id) so the
+        # trigger can proceed with the rebalance instead of waiting for a fixed timeout.
+        self._wrapper._worker_id = '3'
+        self._wrapper._send_data_on_control_socket = unittest.mock.AsyncMock()
+        self._wrapper._platform._on_signal = unittest.mock.MagicMock(return_value=None)
+
+        self._loop.run_until_complete(self._wrapper._call_drain_handler())
+
+        self._wrapper._platform._on_signal.assert_called_once_with(callback_type='drain')
+        self._wrapper._send_data_on_control_socket.assert_awaited_once_with({
+            'kind': 'drain',
+            'attributes': {'workerId': '3'},
+        })
+        self.assertTrue(self._wrapper._drained)
+
+    def test_on_drain_signal_resends_ack_when_already_drained(self):
+        # NUC-166: a second drain signal arriving while the worker is already drained (before
+        # SIGCONT resumes it) must re-send the acknowledgement rather than re-run the handler or be
+        # silently dropped, so the processor is not left waiting on a lost message.
+        self._wrapper._discard_events = True
+        self._wrapper._drained = True
+        self._wrapper._send_drain_complete_control_message = unittest.mock.AsyncMock()
+
+        async def trigger_signal():
+            self._wrapper._on_drain_signal('SIGUSR2')
+
+            # let the task scheduled via ensure_future run to completion
+            await asyncio.sleep(0)
+
+        self._loop.run_until_complete(trigger_signal())
+
+        self._wrapper._send_drain_complete_control_message.assert_called_once()
+
+    def test_on_drain_signal_ignored_while_still_draining(self):
+        # A drain signal arriving while a drain is in progress but not yet complete must be ignored
+        # outright - no re-run, and no premature acknowledgement before the handler finishes.
+        self._wrapper._discard_events = True
+        self._wrapper._drained = False
+        self._wrapper._send_drain_complete_control_message = unittest.mock.AsyncMock()
+
+        async def trigger_signal():
+            self._wrapper._on_drain_signal('SIGUSR2')
+            await asyncio.sleep(0)
+
+        self._loop.run_until_complete(trigger_signal())
+
+        self._wrapper._send_drain_complete_control_message.assert_not_called()
+
     async def _collect_packets_async(self, entrypoint_output):
         return [
             (prefix, payload)

--- a/pkg/processor/runtime/python/py/wrapper_common.py
+++ b/pkg/processor/runtime/python/py/wrapper_common.py
@@ -104,6 +104,7 @@ class AbstractWrapper(object):
         self._platform = nuclio_sdk.Platform(platform_kind,
                                              namespace=namespace,
                                              on_control_callback=self._send_data_on_control_socket)
+        self._worker_id = worker_id
         self._decode_event_strings = decode_event_strings
 
         # 1gb
@@ -148,9 +149,15 @@ class AbstractWrapper(object):
                                            logger_per_async_task=logger_per_async_task)
 
         # initialize flags
+        #
+        # _drained tracks whether the drain handler has already run for the current drain cycle.
+        # A second SIGUSR2 arriving while still discarding events (before SIGCONT resumes the
+        # worker) must not re-run the handler; if the handler already completed we re-send the
+        # drain-complete acknowledgement so the processor isn't left waiting on a lost message.
         self._is_drain_needed = False
         self._is_termination_needed = False
         self._discard_events = False
+        self._drained = False
 
         self._event_message_length_task = None
 
@@ -430,9 +437,16 @@ class AbstractWrapper(object):
         asyncio.get_running_loop().add_signal_handler(Constants.continue_signal, on_continue_signal)
 
     def _on_drain_signal(self, signal_name):
-        # do not perform draining if discarding events
+        # a drain is already in progress or finished for this cycle
         if self._discard_events:
-            self._logger.debug('Draining signal is received, but it will be ignored as the worker is already drained')
+            if self._drained:
+                # the handler already completed; the processor likely missed the original
+                # acknowledgement (e.g. its wait timed out and it re-signalled), so re-send it.
+                # this handler runs inside the event loop, so schedule the async send as a task.
+                self._logger.debug('Draining signal received while already drained, re-sending drain-complete')
+                asyncio.ensure_future(self._send_drain_complete_control_message())
+            else:
+                self._logger.debug('Draining signal received, ignoring as the worker is already being drained')
             return
 
         self._logger.debug_with('Received signal', signal=signal_name)
@@ -440,6 +454,9 @@ class AbstractWrapper(object):
 
         # set the flag to True to stop processing events which are received after draining
         self._discard_events = True
+
+        # starting a fresh drain cycle - the handler has not run yet for this cycle
+        self._drained = False
 
         # if serving loop is waiting for an event, unblock this operation to allow the drain callback to be called
         if self._event_message_length_task:
@@ -462,12 +479,30 @@ class AbstractWrapper(object):
         # set this flag to False, so continue normal event processing flow
         self._discard_events = False
 
-    def _call_drain_handler(self):
+    async def _call_drain_handler(self):
         self._logger.debug('Calling platform drain handler')
 
         # set the flag to False so the drain handler will not be called more than once
         self._is_drain_needed = False
-        return self._platform._on_signal(callback_type="drain")
+
+        draining_result = self._platform._on_signal(callback_type="drain")
+        if asyncio.iscoroutine(draining_result):
+            await draining_result
+
+        # mark the cycle as drained so a duplicate drain signal re-acknowledges instead of
+        # re-running the user's drain handler
+        self._drained = True
+
+        # acknowledge completion to the processor over the control socket so the trigger can
+        # proceed with the rebalance immediately rather than waiting for a fixed timeout
+        await self._send_drain_complete_control_message()
+
+    async def _send_drain_complete_control_message(self):
+        self._logger.debug_with('Sending drain complete control message', worker_id=self._worker_id)
+        await self._send_data_on_control_socket({
+            'kind': 'drain',
+            'attributes': {'workerId': self._worker_id},
+        })
 
     def _call_termination_handler(self):
         self._logger.debug('Calling platform termination handler')

--- a/pkg/processor/runtime/python/runtime.go
+++ b/pkg/processor/runtime/python/runtime.go
@@ -145,9 +145,10 @@ func (py *python) Drain() error {
 		return errors.Wrap(err, "Failed to signal wrapper process to drain")
 	}
 
-	// wait for process to finish event handling or timeout
-	// TODO: replace the following function with one that waits for a control communication message or timeout
-	py.WaitForProcessTermination(py.configuration.WorkerTerminationTimeout)
+	// note: we deliberately do NOT block on WaitForProcessTermination here. The wrapper sends a
+	// drain-complete control message once its drain callback finishes, and the trigger's Drain()
+	// waits for that acknowledgement (with its own timeout). Blocking here as well would
+	// re-introduce the fixed-timeout wait this acknowledged-drain mechanism replaced.
 
 	return nil
 }

--- a/pkg/processor/statistics/gatherer/mock.go
+++ b/pkg/processor/statistics/gatherer/mock.go
@@ -19,6 +19,8 @@ limitations under the License.
 package gatherer
 
 import (
+	"context"
+
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
@@ -83,6 +85,10 @@ func (mt *mockTrigger) Stop(force bool) (functionconfig.Checkpoint, error) {
 
 func (mt *mockTrigger) SignalWorkersToDrain() error {
 	return nil
+}
+
+func (mt *mockTrigger) Drain(ctx context.Context) (map[string]struct{}, error) {
+	return map[string]struct{}{}, nil
 }
 
 func (mt *mockTrigger) SignalWorkersToContinue() error {

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
@@ -57,6 +59,13 @@ type kafka struct {
 	stopConsumptionChan      chan struct{}
 	partitionWorkerAllocator partitionworker.Allocator
 	ctx                      context.Context
+
+	// restartWorkersOnCleanup is set when a rebalance drain times out. The per-partition
+	// ConsumeClaim goroutines cannot safely restart workers themselves (a worker is shared
+	// across claims, and on the waitForHandler=false path there is no worker handle), so the
+	// timeout path only flags intent. Cleanup runs once per session and performs the actual
+	// recovery, restarting any worker that did not acknowledge draining.
+	restartWorkersOnCleanup atomic.Bool
 }
 
 func newTrigger(parentLogger logger.Logger,
@@ -124,6 +133,10 @@ func (k *kafka) Start(checkpoint functionconfig.Checkpoint) error {
 	}
 
 	k.shutdownSignal = make(chan struct{}, 1)
+
+	// reset the restart-on-cleanup flag so a drain timeout from a previous session does not
+	// leak into this one and cause an unnecessary worker restart on the next rebalance
+	k.restartWorkersOnCleanup.Store(false)
 
 	// sendSignalCounter is a counter to track how many times a processor attempted to send a SIGCONT to the wrapper
 	// If the counter exceeds 3, we panic and restart the function to prevent entering a zombie state
@@ -199,6 +212,46 @@ func (k *kafka) Cleanup(session sarama.ConsumerGroupSession) error {
 	if err := k.partitionWorkerAllocator.Stop(); err != nil {
 		return errors.Wrap(err, "Failed to stop partition worker allocator")
 	}
+
+	if k.restartWorkersOnCleanup.Load() {
+		k.Logger.WarnWith("Workers were marked for restart during cleanup, " +
+			"restarting workers to prevent potential zombie state")
+
+		var successfullyDrained map[string]struct{}
+		var err error
+
+		// bound the drain attempt during cleanup so a worker stuck in its drain callback can't
+		// hang shutdown indefinitely (which would itself produce the zombie state we're recovering from)
+		ctx, cancel := context.WithTimeout(k.ctx, 1*time.Second)
+		defer cancel()
+
+		// try to drain once more: any worker that acknowledges here is healthy and need not be
+		// restarted; the rest are assumed stuck and are restarted below
+		if successfullyDrained, err = k.Drain(ctx); err != nil {
+			k.Logger.WarnWith("Failed to drain workers during cleanup",
+				"err", err.Error())
+		}
+
+		for _, worker := range k.WorkerAllocator.GetObjects() {
+			workerID := strconv.Itoa(worker.GetIndex())
+			if _, ok := successfullyDrained[workerID]; ok {
+				k.Logger.DebugWith("Worker successfully drained, no need to restart",
+					"workerIndex", worker.GetIndex())
+				continue
+			}
+
+			k.Logger.DebugWith("Worker was not drained, restarting",
+				"workerIndex", worker.GetIndex())
+			if err := worker.Restart(); err != nil {
+				k.Logger.WarnWith("Failed to restart worker during cleanup",
+					"workerIndex", worker.GetIndex(),
+					"err", err.Error())
+			}
+		}
+	}
+
+	// reset the flag to prevent unnecessary worker restarts during subsequent normal rebalances
+	k.restartWorkersOnCleanup.Store(false)
 
 	k.Logger.InfoWith("Ending consumer session",
 		"claims", session.Claims(),
@@ -295,7 +348,7 @@ consumptionLoop:
 				// waitForHandler value is true here because we catch session closure during waiting for event submitting
 				// which means that we start processing msg on this iteration, so during session closure we have to wait for
 				// event to be successfully submitted
-				k.drainOnRebalance(session, claim, workerInstance, &submittedEventInstance, message, true)
+				k.drainOnRebalance(session, claim, &submittedEventInstance, message, true)
 				if err := k.partitionWorkerAllocator.ReleaseWorker(cookie, workerInstance); err != nil {
 					return errors.Wrap(err, "Failed to release worker")
 				}
@@ -309,7 +362,7 @@ consumptionLoop:
 				"waitForHandler", false,
 			)
 			// waitForHandler value is false here because we didn't start msg processing on this iteration
-			k.drainOnRebalance(session, claim, nil, nil, nil, false)
+			k.drainOnRebalance(session, claim, nil, nil, false)
 			break consumptionLoop
 		}
 	}
@@ -332,13 +385,18 @@ consumptionLoop:
 
 func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 	claim sarama.ConsumerGroupClaim,
-	workerInstance eventprocessor.EventProcessor,
 	submittedEventInstance *submittedEvent,
 	message *sarama.ConsumerMessage,
 	waitForHandler bool) {
 
 	readyForRebalanceChan := make(chan bool)
 	defer close(readyForRebalanceChan)
+
+	// unified deadline for both waiting on the in-flight handler and waiting on drain
+	// acknowledgements: Drain respects this context and the select below uses the same timeout,
+	// so a single expiry covers "handler too slow" and "drain callback too slow"
+	drainingContext, cancel := context.WithTimeout(k.ctx, k.configuration.maxWaitHandlerDuringRebalance)
+	defer cancel()
 
 	go func() {
 		defer common.CatchAndLogPanicWithOptions(k.ctx, // nolint: errcheck
@@ -371,11 +429,14 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 		}
 
 		go func() {
-			// this needs to occur once. the reason is that this specific function (ConsumeClaim)
-			// runs in parallel for each partition, and we want to make sure that we only
-			// drain the workers once.
-			if err := k.SignalWorkersToDrain(); err != nil {
-				k.Logger.DebugWith("Failed to signal worker draining",
+			// ConsumeClaim runs in parallel for each partition, so this fires once per claim on a
+			// rebalance. That is safe: Drain is idempotent - the broker fans the drain signal out
+			// to every worker, the Python wrapper coalesces duplicate signals, and the trigger
+			// dedupes acknowledgements by worker ID. Drain returns as soon as every worker has
+			// acknowledged over the control socket (or the context times out) rather than blocking
+			// for a fixed timeout.
+			if _, err := k.Drain(drainingContext); err != nil {
+				k.Logger.DebugWith("Failed to drain workers",
 					"err", err.Error(),
 					"partition", claim.Partition())
 			}
@@ -402,23 +463,21 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 		k.Logger.DebugWith("Handler done, rebalancing will commence",
 			"partition", claim.Partition())
 
-	case <-time.After(k.configuration.maxWaitHandlerDuringRebalance):
+	case <-drainingContext.Done():
 		k.Logger.WarnWith("Timed out waiting for handler to complete",
 			"partition", claim.Partition())
 
 		// mark this as a failure, metric-wise
 		k.UpdateStatistics(false, 1)
 
-		if waitForHandler {
-			// the rebalance timeout occurred while we waited for the handler, cancel it and restart the worker
-			if err := k.cancelEventHandling(workerInstance, claim); err != nil {
-				k.Logger.DebugWith("Failed to cancel event handling",
-					"err", err.Error(),
-					"partition", claim.Partition())
-
-				panic("Failed to cancel event handling")
-			}
-		}
+		// the rebalance timeout expired while waiting for the handler to finish processing or for
+		// the worker to finish draining. We can't safely restart the worker from here (it is shared
+		// across partition claims, and on the waitForHandler=false path we hold no worker handle),
+		// so we flag the session: Cleanup runs once and restarts any worker that did not drain.
+		// This covers BOTH the waitForHandler=true path and the waitForHandler=false path - the
+		// latter previously had no recovery at all, permanently stalling the function (NUC-778),
+		// and the old per-claim restart could deref a nil worker on the false path (NUC-764).
+		k.restartWorkersOnCleanup.Store(true)
 	}
 }
 
@@ -468,18 +527,6 @@ func (k *kafka) eventSubmitter(claim sarama.ConsumerGroupClaim, submittedEventCh
 	k.Logger.InfoWith("Event submitter stopped",
 		"topic", claim.Topic(),
 		"partition", claim.Partition())
-}
-
-func (k *kafka) cancelEventHandling(workerInstance eventprocessor.EventProcessor,
-	claim sarama.ConsumerGroupClaim) error {
-	if workerInstance.SupportsRestart() {
-		k.Logger.WarnWith("Cancelling event handling",
-			"topic", claim.Topic(),
-			"partition", claim.Partition())
-		return workerInstance.Restart()
-	}
-
-	return errors.New("Worker doesn't support restart")
 }
 
 func (k *kafka) newKafkaConfig() (*sarama.Config, error) {

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -213,7 +213,7 @@ func (k *kafka) Cleanup(session sarama.ConsumerGroupSession) error {
 		return errors.Wrap(err, "Failed to stop partition worker allocator")
 	}
 
-	if k.restartWorkersOnCleanup.Load() {
+	if k.restartWorkersOnCleanup.Swap(false) {
 		k.Logger.WarnWith("Workers were marked for restart during cleanup, " +
 			"restarting workers to prevent potential zombie state")
 
@@ -250,8 +250,6 @@ func (k *kafka) Cleanup(session sarama.ConsumerGroupSession) error {
 		}
 	}
 
-	// reset the flag to prevent unnecessary worker restarts during subsequent normal rebalances
-	k.restartWorkersOnCleanup.Store(false)
 
 	k.Logger.InfoWith("Ending consumer session",
 		"claims", session.Claims(),

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -250,7 +250,6 @@ func (k *kafka) Cleanup(session sarama.ConsumerGroupSession) error {
 		}
 	}
 
-
 	k.Logger.InfoWith("Ending consumer session",
 		"claims", session.Claims(),
 		"memberID", session.MemberID(),

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -29,6 +29,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
 
 	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
@@ -84,6 +85,12 @@ type Trigger interface {
 
 	// SignalWorkersToDrain drains all workers
 	SignalWorkersToDrain() error
+
+	// Drain signals all workers to drain and waits for each to acknowledge completion
+	// over the control socket. It returns the set of worker IDs that finished draining.
+	// On context cancellation/timeout it still returns the IDs that drained so far,
+	// alongside the error, so callers can decide what to do with the rest.
+	Drain(ctx context.Context) (map[string]struct{}, error)
 
 	// SignalWorkersToContinue signal all workers to continue processing
 	SignalWorkersToContinue() error
@@ -387,6 +394,71 @@ func (at *AbstractTrigger) SignalWorkersToDrain() error {
 		return errors.Wrap(err, "Failed to signal all workers to drain events")
 	}
 	return nil
+}
+
+// Drain signals all workers to drain and waits for each to acknowledge completion over the
+// control socket. Each Python worker sends a DrainMessageKind control message carrying its
+// worker ID once its drain callback finishes; we deduplicate by worker ID and return once
+// every worker has acknowledged. On context cancellation/timeout we return the set of workers
+// that drained so far alongside the error, leaving the caller to recover the rest.
+//
+// The drain subscription is owned by this call: the broker is the sole writer/closer, so
+// Close() (deferred) drains any in-flight delivery and closes the channel without racing a
+// late acknowledgement. This is what makes the acknowledged-drain protocol deadlock-free on
+// top of the channel-ownership broker.
+func (at *AbstractTrigger) Drain(ctx context.Context) (map[string]struct{}, error) {
+	drainedWorkerIds := map[string]struct{}{}
+
+	// subscribe to worker drain-complete control messages so we know when each worker is
+	// done draining and the trigger may proceed with the rebalance
+	subscription, err := at.SubscribeToControlMessageKind(controlcommunication.DrainMessageKind)
+	if err != nil {
+		return drainedWorkerIds, errors.Wrap(err, "Failed to subscribe to drain control messages")
+	}
+
+	// Close() unsubscribes every per-worker subscription, drains in-flight deliveries and
+	// closes the merged channel exactly once - safe even if an acknowledgement is still in flight
+	defer subscription.Close()
+
+	workers := at.WorkerAllocator.GetObjects()
+	if err := at.SignalWorkersToDrain(); err != nil {
+		return drainedWorkerIds, errors.Wrap(err, "Failed to signal all workers to drain events")
+	}
+
+	for {
+		select {
+		case controlMessage, ok := <-subscription.C():
+			if !ok {
+				// the subscription channel was closed by the broker - there is nothing left to
+				// wait for. This happens when there are no workers to drain (MergeSubscriptions
+				// returns an already-closed subscription), in which case the drained set is empty
+				// and correct.
+				return drainedWorkerIds, nil
+			}
+
+			drainAttributes := &controlcommunication.ControlMessageAttributesDrain{}
+			if err := mapstructure.Decode(controlMessage.Attributes, drainAttributes); err != nil {
+				at.Logger.WarnWith("Failed decoding drain control message attributes", "err", err.Error())
+				continue
+			}
+
+			drainedWorkerIds[drainAttributes.WorkerId] = struct{}{}
+			at.Logger.DebugWith("Worker acknowledged draining",
+				"workerId", drainAttributes.WorkerId,
+				"drained", len(drainedWorkerIds),
+				"total", len(workers))
+
+			if len(drainedWorkerIds) == len(workers) {
+				return drainedWorkerIds, nil
+			}
+
+		case <-ctx.Done():
+			at.Logger.DebugWith("Context cancelled while waiting for workers to drain",
+				"drained", len(drainedWorkerIds),
+				"total", len(workers))
+			return drainedWorkerIds, errors.Wrap(ctx.Err(), "Context cancelled while waiting for workers to drain")
+		}
+	}
 }
 
 // SignalWorkersToContinue sends a signal to all workers, telling them to continue event processing

--- a/pkg/processor/trigger/trigger_test.go
+++ b/pkg/processor/trigger/trigger_test.go
@@ -1,0 +1,210 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trigger
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
+	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
+
+	"github.com/nuclio/logger"
+	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+// drainTestWorker is a minimal EventProcessor whose Subscribe is backed by a real control-message
+// broker, so the test delivers drain acknowledgements exactly as the RPC reader would in
+// production. It embeds MockEventProcessor only to satisfy the rest of the interface; Drain's code
+// path touches only GetIndex and Subscribe.
+//
+// ackTimes controls how many drain-complete messages the worker emits on SignalDraining: 0 models
+// a wrapper stuck in its drain callback, 1 is the normal case, and >1 models duplicate
+// acknowledgements (the processor may re-signal; the wrapper re-acks when already drained).
+type drainTestWorker struct {
+	*eventprocessor.MockEventProcessor
+	index    int
+	broker   *controlcommunication.ControlMessageBrokerBase
+	ackTimes int
+}
+
+func (w *drainTestWorker) GetIndex() int {
+	return w.index
+}
+
+func (w *drainTestWorker) Subscribe(kind controlcommunication.ControlMessageKind) (controlcommunication.Subscription, error) {
+	return w.broker.Subscribe(kind)
+}
+
+// acknowledgeDrain simulates the Python wrapper sending its drain-complete control message.
+func (w *drainTestWorker) acknowledgeDrain() error {
+	return w.broker.SendToConsumers(&controlcommunication.ControlMessage{
+		Kind: controlcommunication.DrainMessageKind,
+		Attributes: map[string]interface{}{
+			"workerId": strconv.Itoa(w.index),
+		},
+	})
+}
+
+// drainTestAllocator is a fake Allocator that, on SignalDraining, delivers each worker's
+// acknowledgements. SignalDraining runs synchronously inside Drain after the subscription is in
+// place, so deliveries are never lost to a race.
+type drainTestAllocator struct {
+	workers []*drainTestWorker
+}
+
+func (a *drainTestAllocator) SignalDraining() error {
+	for _, worker := range a.workers {
+		for i := 0; i < worker.ackTimes; i++ {
+			if err := worker.acknowledgeDrain(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (a *drainTestAllocator) GetObjects() []eventprocessor.EventProcessor {
+	objects := make([]eventprocessor.EventProcessor, 0, len(a.workers))
+	for _, worker := range a.workers {
+		objects = append(objects, worker)
+	}
+	return objects
+}
+
+func (a *drainTestAllocator) Allocate(timeout time.Duration) (eventprocessor.EventProcessor, error) {
+	return nil, nil
+}
+func (a *drainTestAllocator) Release(eventprocessor.EventProcessor)            {}
+func (a *drainTestAllocator) SetObjects([]eventprocessor.EventProcessor) error { return nil }
+func (a *drainTestAllocator) GetNumObjectsAvailable() int                      { return len(a.workers) }
+func (a *drainTestAllocator) GetStatistics() *statistics.AllocatorStatistics   { return nil }
+func (a *drainTestAllocator) SignalContinue() error                            { return nil }
+func (a *drainTestAllocator) SignalTermination() error                         { return nil }
+func (a *drainTestAllocator) Stop() error                                      { return nil }
+func (a *drainTestAllocator) IsTerminated() bool                               { return false }
+
+type DrainTestSuite struct {
+	suite.Suite
+	logger logger.Logger
+}
+
+func (suite *DrainTestSuite) SetupTest() {
+	suite.logger, _ = nucliozap.NewNuclioZapTest("test")
+}
+
+// newTrigger builds an AbstractTrigger whose workers each emit ackTimes[i] drain acknowledgements.
+func (suite *DrainTestSuite) newTrigger(ackTimes []int) *AbstractTrigger {
+	allocator := &drainTestAllocator{}
+	for i, times := range ackTimes {
+		allocator.workers = append(allocator.workers, &drainTestWorker{
+			MockEventProcessor: &eventprocessor.MockEventProcessor{},
+			index:              i,
+			broker:             controlcommunication.NewControlMessageBrokerBase(),
+			ackTimes:           times,
+		})
+	}
+	return &AbstractTrigger{Logger: suite.logger, WorkerAllocator: allocator}
+}
+
+// TestDrainReturnsWhenAllWorkersAcknowledge asserts the happy path: once every worker sends its
+// drain-complete message, Drain returns the full set of worker IDs with no error and without
+// waiting for any timeout. This is the acknowledged-drain behaviour NUC-756 restores.
+func (suite *DrainTestSuite) TestDrainReturnsWhenAllWorkersAcknowledge() {
+	abstractTrigger := suite.newTrigger([]int{1, 1, 1})
+
+	// generous deadline: the test must pass by acknowledgement, never by timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	drained, err := abstractTrigger.Drain(ctx)
+
+	suite.Require().NoError(err)
+	suite.Require().Len(drained, 3)
+	for i := 0; i < 3; i++ {
+		suite.Require().Contains(drained, strconv.Itoa(i))
+	}
+}
+
+// TestDrainReturnsPartialSetOnTimeout asserts that when a worker never acknowledges (its drain
+// callback is stuck), Drain does not hang: it returns once the context expires, reporting only the
+// workers that drained. The caller (kafka Cleanup) uses exactly this set to decide which workers to
+// restart - the recovery that fixes NUC-778 / NUC-766 on the waitForHandler=false path.
+func (suite *DrainTestSuite) TestDrainReturnsPartialSetOnTimeout() {
+	// worker 0 acknowledges, worker 1 stays silent
+	abstractTrigger := suite.newTrigger([]int{1, 0})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	drained, err := abstractTrigger.Drain(ctx)
+	elapsed := time.Since(start)
+
+	suite.Require().Error(err)
+	suite.Require().Len(drained, 1)
+	suite.Require().Contains(drained, "0")
+	suite.Require().NotContains(drained, "1")
+
+	// returned because the context expired, not because it hung indefinitely
+	suite.Require().Less(elapsed, 3*time.Second)
+}
+
+// TestDrainDeduplicatesRepeatedAcknowledgements asserts that duplicate drain-complete messages from
+// the same worker are collapsed by worker ID: worker 0 acks twice and worker 1 once, and Drain
+// returns exactly {"0","1"} - the duplicate neither inflates the count nor causes an early return
+// before the other worker is accounted for.
+func (suite *DrainTestSuite) TestDrainDeduplicatesRepeatedAcknowledgements() {
+	abstractTrigger := suite.newTrigger([]int{2, 1})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	drained, err := abstractTrigger.Drain(ctx)
+
+	suite.Require().NoError(err)
+	suite.Require().Len(drained, 2)
+	suite.Require().Contains(drained, "0")
+	suite.Require().Contains(drained, "1")
+}
+
+// TestDrainWithNoWorkersReturnsEmpty asserts Drain does not block or panic when there are no
+// workers to drain: MergeSubscriptions returns an already-closed subscription, and Drain must
+// return an empty set with no error rather than nil-dereferencing a closed-channel read.
+func (suite *DrainTestSuite) TestDrainWithNoWorkersReturnsEmpty() {
+	abstractTrigger := suite.newTrigger([]int{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	drained, err := abstractTrigger.Drain(ctx)
+
+	suite.Require().NoError(err)
+	suite.Require().Empty(drained)
+	suite.Require().Less(time.Since(start), 3*time.Second)
+}
+
+func TestDrainTestSuite(t *testing.T) {
+	suite.Run(t, new(DrainTestSuite))
+}


### PR DESCRIPTION
### 📝 Description

Restores the acknowledged worker-draining mechanism (NUC-756, previously shipped as #4047 and reverted) on top of the channel-ownership control-message broker (#4121).

Rebalance draining was fire-and-forget: the processor sent SIGUSR2 to each worker and blocked on a fixed `WaitForProcessTermination` timeout, so it never knew when draining actually finished — causing either unnecessary delay or premature rebalance. This replaces it with an acknowledged protocol: the Python wrapper sends a `drain` control message carrying its worker id once its drain callback completes, and the trigger's new `Drain(ctx) (map[string]struct{}, error)` waits for every worker to acknowledge (or the context to expire), returning the set of workers that drained.

The original was reverted because the broker could deadlock; that broker has since been reworked to be the sole writer/closer of subscription channels (#4121), so the feature is now safe to restore.

---

### 🛠️ Changes Made

- **Control types**: add `DrainMessageKind` and `ControlMessageAttributesDrain{WorkerId}`.
- **`AbstractTrigger.Drain(ctx)`**: subscribe to drain messages via the `Subscription` API, signal workers, collect acknowledgements deduplicated by worker id, and return the drained set. Returns the partial set + error on context timeout; handles a closed subscription channel (no workers) without blocking.
- **Kafka trigger**: `drainOnRebalance` waits via `Drain` under a unified `context.WithTimeout`. On timeout it flags the session (`restartWorkersOnCleanup`) rather than restarting per-claim; `Cleanup` runs a short final `Drain` and restarts only the workers that did not acknowledge. Removes the nil-prone `cancelEventHandling` and adds recovery on the `waitForHandler=false` path, which previously had none.
- **Python runtime/wrapper**: `runtime.Drain()` no longer blocks on `WaitForProcessTermination`; the wrapper stores its worker id, tracks a `_drained` flag, sends the drain-complete control message after the callback, and re-sends it when a drain signal arrives while already drained.
- **Mocks**: `Trigger` implementers in `statistics/gatherer` and `cmd/processor/app` updated for the new method.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

- New Go unit tests (`pkg/processor/trigger/trigger_test.go`, `-race`): `Drain` returns the full set when all workers ack; returns the partial set + error on context timeout (no hang); deduplicates repeated acks; returns empty for zero workers.
- New Python wrapper tests (`test_wrapper.py`, 32/32 pass): drain-complete sent after the callback; re-sent when already drained; ignored while still draining.
- `make fmt lint` → 0 issues. Existing kafka / controlcommunication / gatherer / processor suites pass with `-race`.
- Not run locally (require Docker + Kafka): integration suites `TestDrainHook`, `TestFeatureCombinations`, and the Jenkins kafka-rebalance scenarios.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-756
- Related bugs: NUC-764, NUC-778, NUC-166 (fixed); NUC-766 (pending integration confirmation)
- Restores: #4047 (reverted by #4061); builds on broker rework #4121

---

### 🚨 Breaking Changes?

- [x] No

The `Trigger` interface gains a `Drain(ctx context.Context) (map[string]struct{}, error)` method; all in-tree implementers and mocks are updated. External trigger implementations would need to add it.

---

### 🔍️ Additional Notes

- Only the Python runtime emits the drain-complete acknowledgement; Go/Java runtimes fall back to the context timeout in `Drain`.
- `drainOnRebalance` fires once per partition claim on a rebalance; this is safe because `Drain` is idempotent (broker fan-out + wrapper signal coalescing + ack dedup by worker id).