### PR TITLE
[Dashboard] Cleanup zombie functions on startup

### DIFF
--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/auth"
@@ -40,6 +41,7 @@ import (
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/opa-client"
+	"golang.org/x/sync/semaphore"
 )
 
 type PlatformAuthorizationMode string
@@ -47,6 +49,8 @@ type PlatformAuthorizationMode string
 const (
 	PlatformAuthorizationModeServiceAccount          PlatformAuthorizationMode = "service-account"
 	PlatformAuthorizationModeAuthorizationHeaderOIDC PlatformAuthorizationMode = "authorization-header-oidc"
+	// maximum number of stale-function updates to run concurrently
+	staleFunctionUpdateConcurrency = 5
 )
 
 type Server struct {
@@ -186,15 +190,13 @@ func NewServer(parentLogger logger.Logger,
 	return newServer, nil
 }
 
-// Start runs the base server, then marks any zombie functions (stuck in a pre-build/build state
-// from a previous deployment) as error so they are visible and redeployable.
+// Start Starts the server and launches background job to mark stale functions as errored
 func (s *Server) Start() error {
 	if err := s.AbstractServer.Start(); err != nil {
 		return errors.Wrap(err, "Failed to start server")
 	}
 
-	// Start() has no ctx in the restful.Server interface, so the sweep uses its own context
-	s.markZombieFunctionsAsError(context.Background())
+	go s.markStaleFunctionsAsError(context.Background())
 
 	return nil
 }
@@ -301,65 +303,76 @@ func (s *Server) getRegistryURL() string {
 	return registryURL
 }
 
-// markZombieFunctionsAsError flips functions that are stuck in a pre-build/build state to error.
-func (s *Server) markZombieFunctionsAsError(ctx context.Context) {
+// markStaleFunctionsAsError flips functions that are stuck in a pre-build/build state to error.
+func (s *Server) markStaleFunctionsAsError(ctx context.Context) {
 	functions, err := s.Platform.GetFunctions(ctx, &platform.GetFunctionsOptions{
 		Namespace: s.GetDefaultNamespace(),
 	})
 	if err != nil {
 		// non-fatal: a transient list failure shouldn't block the dashboard from starting
-		s.Logger.WarnWithCtx(ctx, "Failed to get functions while sweeping for zombie functions; skipping sweep",
+		s.Logger.WarnWithCtx(ctx, "Failed to get functions while sweeping for stale functions; skipping sweep",
 			"err", err.Error())
 		return
 	}
 
 	// states from which no process can advance the function after a dashboard restart
-	zombieStates := map[functionconfig.FunctionState]struct{}{
+	staleStates := map[functionconfig.FunctionState]struct{}{
 		functionconfig.FunctionStateWaitingForBuild: {},
 		functionconfig.FunctionStateBuilding:        {},
 	}
 
+	// update stale functions concurrently, bounded by a semaphore
+	var wg sync.WaitGroup
+	sem := semaphore.NewWeighted(staleFunctionUpdateConcurrency)
+
 	for _, function := range functions {
 		functionStatus := function.GetStatus()
-		if _, isZombie := zombieStates[functionStatus.State]; !isZombie {
+		if _, isStale := staleStates[functionStatus.State]; !isStale {
 			continue
 		}
 
 		functionConfig := function.GetConfig()
-		s.Logger.DebugWithCtx(ctx, "Found zombie function on startup, setting its state to error",
+		s.Logger.DebugWithCtx(ctx, "Found stale function on startup, setting its state to error",
 			"functionName", functionConfig.Meta.Name,
 			"functionState", functionStatus.State)
 
-		functionStatus.State = functionconfig.FunctionStateError
-		functionStatus.Message = "Function deployment was interrupted and could not be completed. Please redeploy the function."
+		_ = sem.Acquire(ctx, 1)
+		wg.Go(func() {
+			defer sem.Release(1)
 
-		if err := s.Platform.UpdateFunction(ctx, &platform.UpdateFunctionOptions{
-			FunctionMeta:   &functionConfig.Meta,
-			FunctionSpec:   &functionConfig.Spec,
-			FunctionStatus: functionStatus,
+			functionStatus.State = functionconfig.FunctionStateError
+			functionStatus.Message = "Function deployment was interrupted and could not be completed. Please redeploy the function."
 
-			// the sweep runs at startup with no user session; mark it as a system call so it
-			// bypasses OPA authorization (the configured override value is matched by the OPA client)
-			PermissionOptions: opaclient.PermissionOptions{
-				OverrideHeaderValue: s.platformConfiguration.Opa.OverrideHeaderValue,
-			},
-		}); err != nil {
+			if err := s.Platform.UpdateFunction(ctx, &platform.UpdateFunctionOptions{
+				FunctionMeta:   &functionConfig.Meta,
+				FunctionSpec:   &functionConfig.Spec,
+				FunctionStatus: functionStatus,
 
-			// the kube platform's UpdateFunction persists the status and then waits for function
-			// readiness, which returns an error for the "error" state we just set. that wait error is
-			// expected here and means the update actually succeeded.
-			if strings.Contains(errors.RootCause(err).Error(), "in error state") {
-				s.Logger.DebugWithCtx(ctx, "Zombie function state set to error",
-					"functionName", functionConfig.Meta.Name)
-				continue
+				// the sweep runs at startup with no user session; mark it as a system call so it
+				// bypasses OPA authorization (the configured override value is matched by the OPA client)
+				PermissionOptions: opaclient.PermissionOptions{
+					OverrideHeaderValue: s.platformConfiguration.Opa.OverrideHeaderValue,
+				},
+			}); err != nil {
+
+				// the kube platform's UpdateFunction persists the status and then waits for function
+				// readiness, which returns an error for the "error" state we just set. that wait error is
+				// expected here and means the update actually succeeded.
+				if strings.Contains(errors.RootCause(err).Error(), "in error state") {
+					s.Logger.DebugWithCtx(ctx, "Stale function state set to error",
+						"functionName", functionConfig.Meta.Name)
+					return
+				}
+
+				// non-fatal: keep sweeping the remaining functions
+				s.Logger.WarnWithCtx(ctx, "Failed to set stale function state to error",
+					"functionName", functionConfig.Meta.Name,
+					"err", err.Error())
 			}
-
-			// non-fatal: keep sweeping the remaining functions
-			s.Logger.WarnWithCtx(ctx, "Failed to set zombie function state to error",
-				"functionName", functionConfig.Meta.Name,
-				"err", err.Error())
-		}
+		})
 	}
+
+	wg.Wait()
 }
 
 func (s *Server) resolveDockerCredentialsRegistryURL(credentials dockercreds.Credentials) string {

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -310,7 +310,7 @@ func (s *Server) markStaleFunctionsAsError(ctx context.Context) {
 	})
 	if err != nil {
 		// non-fatal: a transient list failure shouldn't block the dashboard from starting
-		s.Logger.WarnWithCtx(ctx, "Failed to get functions while sweeping for stale functions; skipping sweep",
+		s.Logger.WarnWithCtx(ctx, "Failed to list functions for stale-function sweep; skipping",
 			"err", err.Error())
 		return
 	}
@@ -368,11 +368,16 @@ func (s *Server) markStaleFunctionsAsError(ctx context.Context) {
 				s.Logger.WarnWithCtx(ctx, "Failed to set stale function state to error",
 					"functionName", functionConfig.Meta.Name,
 					"err", err.Error())
+				return
 			}
+
+			s.Logger.DebugWithCtx(ctx, "Marked stale function as error",
+				"functionName", functionConfig.Meta.Name)
 		})
 	}
 
 	wg.Wait()
+	s.Logger.DebugWithCtx(ctx, "Finished marking stale functions as error")
 }
 
 func (s *Server) resolveDockerCredentialsRegistryURL(credentials dockercreds.Credentials) string {

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dashboard
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -29,6 +30,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/dashboard/functiontemplates"
 	"github.com/nuclio/nuclio/pkg/dockerclient"
 	"github.com/nuclio/nuclio/pkg/dockercreds"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/restful"
@@ -37,6 +39,7 @@ import (
 	"github.com/go-chi/cors"
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
+	"github.com/nuclio/opa-client"
 )
 
 type PlatformAuthorizationMode string
@@ -183,6 +186,19 @@ func NewServer(parentLogger logger.Logger,
 	return newServer, nil
 }
 
+// Start runs the base server, then marks any zombie functions (stuck in a pre-build/build state
+// from a previous deployment) as error so they are visible and redeployable.
+func (s *Server) Start() error {
+	if err := s.AbstractServer.Start(); err != nil {
+		return errors.Wrap(err, "Failed to start server")
+	}
+
+	// Start() has no ctx in the restful.Server interface, so the sweep uses its own context
+	s.markZombieFunctionsAsError(context.Background())
+
+	return nil
+}
+
 func (s *Server) GetRegistryURL() string {
 	return s.defaultRegistryURL
 }
@@ -283,6 +299,67 @@ func (s *Server) getRegistryURL() string {
 	}
 
 	return registryURL
+}
+
+// markZombieFunctionsAsError flips functions that are stuck in a pre-build/build state to error.
+func (s *Server) markZombieFunctionsAsError(ctx context.Context) {
+	functions, err := s.Platform.GetFunctions(ctx, &platform.GetFunctionsOptions{
+		Namespace: s.GetDefaultNamespace(),
+	})
+	if err != nil {
+		// non-fatal: a transient list failure shouldn't block the dashboard from starting
+		s.Logger.WarnWithCtx(ctx, "Failed to get functions while sweeping for zombie functions; skipping sweep",
+			"err", err.Error())
+		return
+	}
+
+	// states from which no process can advance the function after a dashboard restart
+	zombieStates := map[functionconfig.FunctionState]struct{}{
+		functionconfig.FunctionStateWaitingForBuild: {},
+		functionconfig.FunctionStateBuilding:        {},
+	}
+
+	for _, function := range functions {
+		functionStatus := function.GetStatus()
+		if _, isZombie := zombieStates[functionStatus.State]; !isZombie {
+			continue
+		}
+
+		functionConfig := function.GetConfig()
+		s.Logger.DebugWithCtx(ctx, "Found zombie function on startup, setting its state to error",
+			"functionName", functionConfig.Meta.Name,
+			"functionState", functionStatus.State)
+
+		functionStatus.State = functionconfig.FunctionStateError
+		functionStatus.Message = "Function deployment was interrupted and could not be completed. Please redeploy the function."
+
+		if err := s.Platform.UpdateFunction(ctx, &platform.UpdateFunctionOptions{
+			FunctionMeta:   &functionConfig.Meta,
+			FunctionSpec:   &functionConfig.Spec,
+			FunctionStatus: functionStatus,
+
+			// the sweep runs at startup with no user session; mark it as a system call so it
+			// bypasses OPA authorization (the configured override value is matched by the OPA client)
+			PermissionOptions: opaclient.PermissionOptions{
+				OverrideHeaderValue: s.platformConfiguration.Opa.OverrideHeaderValue,
+			},
+		}); err != nil {
+
+			// the kube platform's UpdateFunction persists the status and then waits for function
+			// readiness, which returns an error for the "error" state we just set. that wait error is
+			// expected here and means the update actually succeeded.
+			if strings.Contains(errors.RootCause(err).Error(), "in error state") {
+				s.Logger.DebugWithCtx(ctx, "Zombie function state set to error",
+					"functionName", functionConfig.Meta.Name)
+				continue
+			}
+
+			// non-fatal: keep sweeping the remaining functions
+			s.Logger.WarnWithCtx(ctx, "Failed to set zombie function state to error",
+				"functionName", functionConfig.Meta.Name,
+				"err", err.Error())
+		}
+	}
 }
 
 func (s *Server) resolveDockerCredentialsRegistryURL(credentials dockercreds.Credentials) string {

--- a/pkg/dashboard/server_test.go
+++ b/pkg/dashboard/server_test.go
@@ -30,10 +30,10 @@ import (
 	mockplatform "github.com/nuclio/nuclio/pkg/platform/mock"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/restful"
-	opaclient "github.com/nuclio/opa-client"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
+	opaclient "github.com/nuclio/opa-client"
 	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"

--- a/pkg/dashboard/server_test.go
+++ b/pkg/dashboard/server_test.go
@@ -55,7 +55,6 @@ func (suite *DashboardServerTestSuite) SetupTest() {
 	suite.mockPlatform = &mockplatform.Platform{}
 	suite.Platform = suite.mockPlatform
 	suite.defaultNamespace = "default-namespace"
-	// the zombie sweep reads the OPA override value to authorize its update as a system call
 	suite.platformConfiguration = &platformconfig.Config{
 		Opa: &opa.Config{
 			Config: &opaclient.Config{OverrideHeaderValue: "iguazio"},
@@ -102,9 +101,9 @@ func (suite *DashboardServerTestSuite) TestResolveRegistryURLFromDockerCredentia
 	}
 }
 
-// TestMarkZombieFunctionsAsError verifies that functions in pre-build/build states are flipped to
+// TestMarkStaleFunctionsAsError verifies that functions in pre-build/build states are flipped to
 // error while functions in other states are left untouched.
-func (suite *DashboardServerTestSuite) TestMarkZombieFunctionsAsError() {
+func (suite *DashboardServerTestSuite) TestMarkStaleFunctionsAsError() {
 	buildingFunction := suite.newFunction("f-building", functionconfig.FunctionStateBuilding)
 	waitingForBuildFunction := suite.newFunction("f-waiting", functionconfig.FunctionStateWaitingForBuild)
 	readyFunction := suite.newFunction("f-ready", functionconfig.FunctionStateReady)
@@ -137,7 +136,7 @@ func (suite *DashboardServerTestSuite) TestMarkZombieFunctionsAsError() {
 		Return(nil).
 		Twice()
 
-	suite.markZombieFunctionsAsError(context.Background())
+	suite.markStaleFunctionsAsError(context.Background())
 
 	suite.mockPlatform.AssertExpectations(suite.T())
 	for name, flipped := range expectedFlipped {
@@ -145,10 +144,10 @@ func (suite *DashboardServerTestSuite) TestMarkZombieFunctionsAsError() {
 	}
 }
 
-// TestMarkZombieFunctionsAsErrorSuppressesReadinessError verifies that the expected
+// TestMarkStaleFunctionsAsErrorSuppressesReadinessError verifies that the expected
 // "in error state" readiness-wait error returned by the kube platform's UpdateFunction (after the
 // status was already persisted) is treated as success and does not abort the sweep.
-func (suite *DashboardServerTestSuite) TestMarkZombieFunctionsAsErrorSuppressesReadinessError() {
+func (suite *DashboardServerTestSuite) TestMarkStaleFunctionsAsErrorSuppressesReadinessError() {
 	buildingFunction := suite.newFunction("f-building", functionconfig.FunctionStateBuilding)
 
 	suite.mockPlatform.
@@ -165,21 +164,21 @@ func (suite *DashboardServerTestSuite) TestMarkZombieFunctionsAsErrorSuppressesR
 		Return(readinessErr).
 		Once()
 
-	suite.markZombieFunctionsAsError(context.Background())
+	suite.markStaleFunctionsAsError(context.Background())
 
 	suite.mockPlatform.AssertExpectations(suite.T())
 }
 
-// TestMarkZombieFunctionsAsErrorGetFunctionsError verifies that a failure to list functions is
+// TestMarkStaleFunctionsAsErrorGetFunctionsError verifies that a failure to list functions is
 // non-fatal: the sweep returns without panicking and never attempts to update any function.
-func (suite *DashboardServerTestSuite) TestMarkZombieFunctionsAsErrorGetFunctionsError() {
+func (suite *DashboardServerTestSuite) TestMarkStaleFunctionsAsErrorGetFunctionsError() {
 	suite.mockPlatform.
 		On("GetFunctions", mock.Anything, mock.Anything).
 		Return([]platform.Function{}, errors.New("failed to list functions")).
 		Once()
 
 	suite.Require().NotPanics(func() {
-		suite.markZombieFunctionsAsError(context.Background())
+		suite.markStaleFunctionsAsError(context.Background())
 	})
 
 	suite.mockPlatform.AssertExpectations(suite.T())

--- a/pkg/dashboard/server_test.go
+++ b/pkg/dashboard/server_test.go
@@ -19,26 +19,51 @@ limitations under the License.
 package dashboard
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/dockercreds"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/opa"
+	"github.com/nuclio/nuclio/pkg/platform"
+	mockplatform "github.com/nuclio/nuclio/pkg/platform/mock"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+	"github.com/nuclio/nuclio/pkg/restful"
+	opaclient "github.com/nuclio/opa-client"
 
+	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
 type DashboardServerTestSuite struct {
 	suite.Suite
 	Server
-	Logger logger.Logger
+	mockPlatform *mockplatform.Platform
+	Logger       logger.Logger
 }
 
 func (suite *DashboardServerTestSuite) SetupTest() {
 	var err error
+
 	suite.Logger, err = nucliozap.NewNuclioZapTest("test")
 	suite.Require().NoError(err)
+
+	suite.mockPlatform = &mockplatform.Platform{}
+	suite.Platform = suite.mockPlatform
+	suite.defaultNamespace = "default-namespace"
+	// the zombie sweep reads the OPA override value to authorize its update as a system call
+	suite.platformConfiguration = &platformconfig.Config{
+		Opa: &opa.Config{
+			Config: &opaclient.Config{OverrideHeaderValue: "iguazio"},
+		},
+	}
+
+	// the sweep logs via the embedded AbstractServer's logger, so it must be wired in the test
+	suite.AbstractServer = &restful.AbstractServer{Logger: suite.Logger}
 }
 
 func (suite *DashboardServerTestSuite) TestResolveRegistryURLFromDockerCredentials() {
@@ -75,6 +100,99 @@ func (suite *DashboardServerTestSuite) TestResolveRegistryURLFromDockerCredentia
 	} {
 		suite.Require().Equal(testCase.expectedRegistryURL, suite.resolveDockerCredentialsRegistryURL(testCase.credentials))
 	}
+}
+
+// TestMarkZombieFunctionsAsError verifies that functions in pre-build/build states are flipped to
+// error while functions in other states are left untouched.
+func (suite *DashboardServerTestSuite) TestMarkZombieFunctionsAsError() {
+	buildingFunction := suite.newFunction("f-building", functionconfig.FunctionStateBuilding)
+	waitingForBuildFunction := suite.newFunction("f-waiting", functionconfig.FunctionStateWaitingForBuild)
+	readyFunction := suite.newFunction("f-ready", functionconfig.FunctionStateReady)
+
+	verifyGetFunctions := func(getFunctionsOptions *platform.GetFunctionsOptions) bool {
+		return getFunctionsOptions.Namespace == "default-namespace"
+	}
+
+	// names of functions we expect to be flipped to error
+	expectedFlipped := map[string]bool{
+		"f-building": false,
+		"f-waiting":  false,
+	}
+	verifyUpdateFunction := func(updateFunctionOptions *platform.UpdateFunctionOptions) bool {
+		name := updateFunctionOptions.FunctionMeta.Name
+		_, expected := expectedFlipped[name]
+		suite.Require().True(expected, "unexpected function flipped to error: %s", name)
+		suite.Require().Equal(functionconfig.FunctionStateError, updateFunctionOptions.FunctionStatus.State)
+		suite.Require().NotEmpty(updateFunctionOptions.FunctionStatus.Message)
+		expectedFlipped[name] = true
+		return true
+	}
+
+	suite.mockPlatform.
+		On("GetFunctions", mock.Anything, mock.MatchedBy(verifyGetFunctions)).
+		Return([]platform.Function{buildingFunction, waitingForBuildFunction, readyFunction}, nil).
+		Once()
+	suite.mockPlatform.
+		On("UpdateFunction", mock.Anything, mock.MatchedBy(verifyUpdateFunction)).
+		Return(nil).
+		Twice()
+
+	suite.markZombieFunctionsAsError(context.Background())
+
+	suite.mockPlatform.AssertExpectations(suite.T())
+	for name, flipped := range expectedFlipped {
+		suite.Require().True(flipped, "expected function to be flipped to error: %s", name)
+	}
+}
+
+// TestMarkZombieFunctionsAsErrorSuppressesReadinessError verifies that the expected
+// "in error state" readiness-wait error returned by the kube platform's UpdateFunction (after the
+// status was already persisted) is treated as success and does not abort the sweep.
+func (suite *DashboardServerTestSuite) TestMarkZombieFunctionsAsErrorSuppressesReadinessError() {
+	buildingFunction := suite.newFunction("f-building", functionconfig.FunctionStateBuilding)
+
+	suite.mockPlatform.
+		On("GetFunctions", mock.Anything, mock.Anything).
+		Return([]platform.Function{buildingFunction}, nil).
+		Once()
+
+	// mimic kube updater: status is persisted, then waitForFunctionReadiness returns this error
+	readinessErr := errors.Wrap(
+		errors.New("NuclioFunction in error state:\nFunction deployment was interrupted"),
+		"Failed to wait for function readiness")
+	suite.mockPlatform.
+		On("UpdateFunction", mock.Anything, mock.Anything).
+		Return(readinessErr).
+		Once()
+
+	suite.markZombieFunctionsAsError(context.Background())
+
+	suite.mockPlatform.AssertExpectations(suite.T())
+}
+
+// TestMarkZombieFunctionsAsErrorGetFunctionsError verifies that a failure to list functions is
+// non-fatal: the sweep returns without panicking and never attempts to update any function.
+func (suite *DashboardServerTestSuite) TestMarkZombieFunctionsAsErrorGetFunctionsError() {
+	suite.mockPlatform.
+		On("GetFunctions", mock.Anything, mock.Anything).
+		Return([]platform.Function{}, errors.New("failed to list functions")).
+		Once()
+
+	suite.Require().NotPanics(func() {
+		suite.markZombieFunctionsAsError(context.Background())
+	})
+
+	suite.mockPlatform.AssertExpectations(suite.T())
+	suite.mockPlatform.AssertNotCalled(suite.T(), "UpdateFunction", mock.Anything, mock.Anything)
+}
+
+func (suite *DashboardServerTestSuite) newFunction(name string,
+	state functionconfig.FunctionState) *platform.AbstractFunction {
+	function := &platform.AbstractFunction{}
+	function.Config.Meta.Name = name
+	function.Config.Meta.Namespace = "default-namespace"
+	function.Status.State = state
+	return function
 }
 
 func TestDashboardServerTestSuite(t *testing.T) {


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
When the nuclio dashboard restarts while a function is mid-deployment, the function is left stuck in a pre-build/build state (e.g. `building`) forever — the process that was building it is gone and nothing advances it (the controller's function monitor intentionally skips provisioning states). This adds a startup sweep in the dashboard that marks such "zombie" functions as `error`, so they become visible to the user and can be redeployed.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
- Added a `Start()` override on the dashboard `Server` that runs the base server and then sweeps for zombie functions.
- Added `markZombieFunctionsAsError`, which lists functions in the dashboard's namespace and flips those in a pre-build/build state (`waitingForBuild`, `building`) to `error` with an explanatory message.
- The sweep runs as a system call (passes the configured OPA `overrideHeaderValue`) so the startup update is authorized without a user session.
- Best-effort by design: list/update failures are logged and never fail dashboard startup; the expected kube readiness-wait "in error state" error is treated as a successful update.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
- Unit tests (`pkg/dashboard/server_test.go`): zombie states flipped to `error` while other states are untouched; the expected readiness-wait "in error state" error is suppressed; a `GetFunctions` failure is non-fatal and triggers no updates.
- Manual: deployed the dashboard to a live cluster with functions stuck in `building` and confirmed they were flipped to `error` on startup.
  - <img width="1879" height="636" alt="image" src="https://github.com/user-attachments/assets/9e3164bf-b620-47d5-a2a2-8c15b7873469" />
  - [After restart the dashboard]
     <img width="1175" height="329" alt="image" src="https://github.com/user-attachments/assets/d729bef0-949b-4cc0-b7f4-6e2d46618dc6" />




---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-7
- Design docs links:
- External links: https://github.com/nuclio/nuclio/pull/1910 (previous closed PR, used as inspiration)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
- Known limitation: the sweep marks all pre-build/build functions as `error` on startup. If a separate live deployer (e.g. `nuctl`, or another dashboard replica) is actively building a function in the same namespace when the dashboard restarts, that in-flight function will be flipped to `error` and will need to be redeployed.
- Post-build states (`waitingForResourceConfiguration` onward) are intentionally out of scope — they are reconciled by the controller and self-heal.
