### PR TITLE
[Controller] Upgrade ingresses on new version

### DIFF
--- a/pkg/common/consts.go
+++ b/pkg/common/consts.go
@@ -49,7 +49,7 @@ const NuclioLabelKeyFunctionCronJobPod = "nuclio.io/function-cron-job-pod"
 
 // Nuclio Annotations
 
-const NuclioAnnotationKeyControllerVersion = "nuclio.io/controller-version"
+const NuclioAnnotationKeyVersion = "nuclio.io/version"
 
 // KubernetesDomainLevelMaxLength DNS domain level limitation is 63 chars
 // https://en.wikipedia.org/wiki/Subdomain#Overview

--- a/pkg/common/consts.go
+++ b/pkg/common/consts.go
@@ -47,6 +47,10 @@ const NuclioLabelKeyComponent = "nuclio.io/component"
 const NuclioLabelKeyFunctionCronTriggerName = "nuclio.io/function-cron-trigger-name"
 const NuclioLabelKeyFunctionCronJobPod = "nuclio.io/function-cron-job-pod"
 
+// Nuclio Annotations
+
+const NuclioAnnotationKeyControllerVersion = "nuclio.io/controller-version"
+
 // KubernetesDomainLevelMaxLength DNS domain level limitation is 63 chars
 // https://en.wikipedia.org/wiki/Subdomain#Overview
 const KubernetesDomainLevelMaxLength = 63

--- a/pkg/common/version.go
+++ b/pkg/common/version.go
@@ -31,8 +31,8 @@ func GetNuclioVersion() string {
 	return "unknown"
 }
 
-// IsControllerVersionStale reports whether stampedVersion is older than the running controller's
-func IsControllerVersionStale(stampedVersion string) bool {
+// IsNuclioVersionStale reports whether stampedVersion is older than the running Nuclio version
+func IsNuclioVersionStale(stampedVersion string) bool {
 	currentVersion := GetNuclioVersion()
 
 	if stampedVersion == currentVersion {

--- a/pkg/common/version.go
+++ b/pkg/common/version.go
@@ -23,8 +23,8 @@ import (
 	"github.com/v3io/version-go"
 )
 
-// GetControllerVersion returns the build version label, or "unknown" for dev builds.
-func GetControllerVersion() string {
+// GetNuclioVersion returns the build version label, or "unknown" for dev builds.
+func GetNuclioVersion() string {
 	if label := version.Get().Label; label != "" {
 		return label
 	}
@@ -33,7 +33,8 @@ func GetControllerVersion() string {
 
 // IsControllerVersionStale reports whether stampedVersion is older than the running controller's
 func IsControllerVersionStale(stampedVersion string) bool {
-	currentVersion := GetControllerVersion()
+	currentVersion := GetNuclioVersion()
+
 	if stampedVersion == currentVersion {
 		return false
 	}

--- a/pkg/common/version.go
+++ b/pkg/common/version.go
@@ -19,8 +19,32 @@ package common
 import (
 	"runtime"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/v3io/version-go"
 )
+
+// GetControllerVersion returns the build version label, or "unknown" for dev builds.
+func GetControllerVersion() string {
+	if label := version.Get().Label; label != "" {
+		return label
+	}
+	return "unknown"
+}
+
+// IsControllerVersionStale reports whether stampedVersion is older than the running controller's
+func IsControllerVersionStale(stampedVersion string) bool {
+	currentVersion := GetControllerVersion()
+	if stampedVersion == currentVersion {
+		return false
+	}
+	stamped, stampedErr := semver.NewVersion(stampedVersion)
+	current, currentErr := semver.NewVersion(currentVersion)
+	if stampedErr != nil || currentErr != nil {
+		// if version differs, and they are not semver, consider it stale
+		return true
+	}
+	return stamped.LessThan(*current)
+}
 
 // SetVersionFromEnv is being used by tests to override linker injected values
 func SetVersionFromEnv() {

--- a/pkg/common/version_test.go
+++ b/pkg/common/version_test.go
@@ -1,0 +1,65 @@
+//go:build test_unit
+
+/*
+Copyright 2023 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/v3io/version-go"
+)
+
+type VersionTestSuite struct {
+	suite.Suite
+	originalVersion *version.Info
+}
+
+func (suite *VersionTestSuite) SetupSuite() {
+	suite.originalVersion = version.Get()
+}
+
+func (suite *VersionTestSuite) TearDownSuite() {
+	version.Set(suite.originalVersion)
+}
+
+func (suite *VersionTestSuite) TestIsControllerVersionStale() {
+	for _, tc := range []struct {
+		name    string
+		current string
+		stamped string
+		stale   bool
+	}{
+		{name: "equal semver", current: "1.16.5", stamped: "1.16.5", stale: false},
+		{name: "older semver", current: "1.16.5", stamped: "1.16.4", stale: true},
+		{name: "older minor", current: "1.16.5", stamped: "1.15.27", stale: true},
+		{name: "newer semver", current: "1.16.5", stamped: "1.16.6", stale: false},
+		{name: "equal non-semver", current: "latest", stamped: "latest", stale: false},
+		{name: "different non-semver falls back to inequality", current: "latest", stamped: "1.16.4", stale: true},
+		{name: "empty stamp", current: "1.16.5", stamped: "", stale: true},
+	} {
+		suite.Run(tc.name, func() {
+			version.Set(&version.Info{Label: tc.current})
+			suite.Equal(tc.stale, IsControllerVersionStale(tc.stamped))
+		})
+	}
+}
+
+func TestVersionTestSuite(t *testing.T) {
+	suite.Run(t, new(VersionTestSuite))
+}

--- a/pkg/common/version_test.go
+++ b/pkg/common/version_test.go
@@ -38,7 +38,7 @@ func (suite *VersionTestSuite) TearDownSuite() {
 	version.Set(suite.originalVersion)
 }
 
-func (suite *VersionTestSuite) TestIsControllerVersionStale() {
+func (suite *VersionTestSuite) TestIsNuclioVersionStale() {
 	for _, tc := range []struct {
 		name    string
 		current string
@@ -55,7 +55,7 @@ func (suite *VersionTestSuite) TestIsControllerVersionStale() {
 	} {
 		suite.Run(tc.name, func() {
 			version.Set(&version.Info{Label: tc.current})
-			suite.Equal(tc.stale, IsControllerVersionStale(tc.stamped))
+			suite.Equal(tc.stale, IsNuclioVersionStale(tc.stamped))
 		})
 	}
 }

--- a/pkg/platform/kube/controller/apigateway.go
+++ b/pkg/platform/kube/controller/apigateway.go
@@ -84,7 +84,7 @@ func (ago *apiGatewayOperator) CreateOrUpdate(ctx context.Context, object runtim
 	}
 
 	// validate the state is inside states to respond to, or upgrade ones created by an older controller version
-	needsUpgrade := common.IsControllerVersionStale(apiGateway.Annotations[common.NuclioAnnotationKeyVersion])
+	needsUpgrade := common.IsNuclioVersionStale(apiGateway.Annotations[common.NuclioAnnotationKeyVersion])
 	if !ago.shouldRespondToState(apiGateway.Status.State) && !needsUpgrade {
 		ago.logger.DebugWithCtx(ctx, "Api gateway state is not waiting for creation/update, skipping create/update",
 			"name", apiGateway.Spec.Name,

--- a/pkg/platform/kube/controller/apigateway.go
+++ b/pkg/platform/kube/controller/apigateway.go
@@ -84,7 +84,7 @@ func (ago *apiGatewayOperator) CreateOrUpdate(ctx context.Context, object runtim
 	}
 
 	// validate the state is inside states to respond to, or upgrade ones created by an older controller version
-	needsUpgrade := common.IsControllerVersionStale(apiGateway.Annotations[common.NuclioAnnotationKeyControllerVersion])
+	needsUpgrade := common.IsControllerVersionStale(apiGateway.Annotations[common.NuclioAnnotationKeyVersion])
 	if !ago.shouldRespondToState(apiGateway.Status.State) && !needsUpgrade {
 		ago.logger.DebugWithCtx(ctx, "Api gateway state is not waiting for creation/update, skipping create/update",
 			"name", apiGateway.Spec.Name,
@@ -135,7 +135,7 @@ func (ago *apiGatewayOperator) CreateOrUpdate(ctx context.Context, object runtim
 	if apiGateway.Annotations == nil {
 		apiGateway.Annotations = map[string]string{}
 	}
-	apiGateway.Annotations[common.NuclioAnnotationKeyControllerVersion] = common.GetNuclioVersion()
+	apiGateway.Annotations[common.NuclioAnnotationKeyVersion] = common.GetNuclioVersion()
 
 	// set state to ready
 	if err := ago.setAPIGatewayState(ctx, apiGateway, platform.APIGatewayStateReady, nil); err != nil {

--- a/pkg/platform/kube/controller/apigateway.go
+++ b/pkg/platform/kube/controller/apigateway.go
@@ -135,7 +135,7 @@ func (ago *apiGatewayOperator) CreateOrUpdate(ctx context.Context, object runtim
 	if apiGateway.Annotations == nil {
 		apiGateway.Annotations = map[string]string{}
 	}
-	apiGateway.Annotations[common.NuclioAnnotationKeyControllerVersion] = common.GetControllerVersion()
+	apiGateway.Annotations[common.NuclioAnnotationKeyControllerVersion] = common.GetNuclioVersion()
 
 	// set state to ready
 	if err := ago.setAPIGatewayState(ctx, apiGateway, platform.APIGatewayStateReady, nil); err != nil {

--- a/pkg/platform/kube/controller/apigateway.go
+++ b/pkg/platform/kube/controller/apigateway.go
@@ -83,8 +83,9 @@ func (ago *apiGatewayOperator) CreateOrUpdate(ctx context.Context, object runtim
 		return errors.New("Received unexpected object, expected api gateway")
 	}
 
-	// validate the state is inside states to respond to
-	if !ago.shouldRespondToState(apiGateway.Status.State) {
+	// validate the state is inside states to respond to, or upgrade ones created by an older controller version
+	needsUpgrade := common.IsControllerVersionStale(apiGateway.Annotations[common.NuclioAnnotationKeyControllerVersion])
+	if !ago.shouldRespondToState(apiGateway.Status.State) && !needsUpgrade {
 		ago.logger.DebugWithCtx(ctx, "Api gateway state is not waiting for creation/update, skipping create/update",
 			"name", apiGateway.Spec.Name,
 			"state", apiGateway.Status.State)
@@ -129,6 +130,12 @@ func (ago *apiGatewayOperator) CreateOrUpdate(ctx context.Context, object runtim
 
 	// wait for api gateway to become available
 	ago.controller.apigatewayresClient.WaitAvailable(ctx, apiGateway.Namespace, apiGateway.Name)
+
+	// stamp current controller version
+	if apiGateway.Annotations == nil {
+		apiGateway.Annotations = map[string]string{}
+	}
+	apiGateway.Annotations[common.NuclioAnnotationKeyControllerVersion] = common.GetControllerVersion()
 
 	// set state to ready
 	if err := ago.setAPIGatewayState(ctx, apiGateway, platform.APIGatewayStateReady, nil); err != nil {

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1897,7 +1897,7 @@ func (lc *lazyClient) getDeploymentAnnotations(function *nuclioio.NuclioFunction
 	}
 
 	annotations["nuclio.io/function-config"] = serializedFunctionConfigJSON
-	annotations[common.NuclioAnnotationKeyControllerVersion] = common.GetControllerVersion()
+	annotations[common.NuclioAnnotationKeyControllerVersion] = common.GetNuclioVersion()
 
 	// add function annotations
 	for annotationKey, annotationValue := range function.Annotations {
@@ -2311,7 +2311,7 @@ func (lc *lazyClient) populateIngressConfig(ctx context.Context,
 	}
 
 	// stamp current version for upgrade-reconcile detection
-	meta.Annotations[common.NuclioAnnotationKeyControllerVersion] = common.GetControllerVersion()
+	meta.Annotations[common.NuclioAnnotationKeyControllerVersion] = common.GetNuclioVersion()
 
 	// clear out existing so that we don't keep adding rules
 	spec.Rules = []networkingv1.IngressRule{}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1655,7 +1655,7 @@ func (lc *lazyClient) createOrUpdateIngress(ctx context.Context,
 		ingressRulesExist := len(ingress.Spec.Rules) > 0
 
 		// older controller version: clear all managed fields
-		if common.IsControllerVersionStale(ingress.Annotations[common.NuclioAnnotationKeyControllerVersion]) {
+		if common.IsControllerVersionStale(ingress.Annotations[common.NuclioAnnotationKeyVersion]) {
 			ingress.Labels = functionLabels
 			ingress.Spec = networkingv1.IngressSpec{}
 		}
@@ -1897,7 +1897,7 @@ func (lc *lazyClient) getDeploymentAnnotations(function *nuclioio.NuclioFunction
 	}
 
 	annotations["nuclio.io/function-config"] = serializedFunctionConfigJSON
-	annotations[common.NuclioAnnotationKeyControllerVersion] = common.GetNuclioVersion()
+	annotations[common.NuclioAnnotationKeyVersion] = common.GetNuclioVersion()
 
 	// add function annotations
 	for annotationKey, annotationValue := range function.Annotations {
@@ -2311,7 +2311,7 @@ func (lc *lazyClient) populateIngressConfig(ctx context.Context,
 	}
 
 	// stamp current version for upgrade-reconcile detection
-	meta.Annotations[common.NuclioAnnotationKeyControllerVersion] = common.GetNuclioVersion()
+	meta.Annotations[common.NuclioAnnotationKeyVersion] = common.GetNuclioVersion()
 
 	// clear out existing so that we don't keep adding rules
 	spec.Rules = []networkingv1.IngressRule{}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1655,7 +1655,7 @@ func (lc *lazyClient) createOrUpdateIngress(ctx context.Context,
 		ingressRulesExist := len(ingress.Spec.Rules) > 0
 
 		// older controller version: clear all managed fields
-		if common.IsControllerVersionStale(ingress.Annotations[common.NuclioAnnotationKeyVersion]) {
+		if common.IsNuclioVersionStale(ingress.Annotations[common.NuclioAnnotationKeyVersion]) {
 			ingress.Labels = functionLabels
 			ingress.Spec = networkingv1.IngressSpec{}
 		}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -50,7 +50,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
-	"github.com/v3io/version-go"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1655,6 +1654,12 @@ func (lc *lazyClient) createOrUpdateIngress(ctx context.Context,
 		// save to bool if there are current rules
 		ingressRulesExist := len(ingress.Spec.Rules) > 0
 
+		// older controller version: clear all managed fields
+		if common.IsControllerVersionStale(ingress.Annotations[common.NuclioAnnotationKeyControllerVersion]) {
+			ingress.Labels = functionLabels
+			ingress.Spec = networkingv1.IngressSpec{}
+		}
+
 		if err := lc.populateIngressConfig(ctx, functionLabels, function, &ingress.ObjectMeta, &ingress.Spec); err != nil {
 			return nil, errors.Wrap(err, "Failed to populate ingress spec")
 		}
@@ -1891,15 +1896,8 @@ func (lc *lazyClient) getDeploymentAnnotations(function *nuclioio.NuclioFunction
 		return nil, errors.Wrap(err, "Failed to get function as JSON")
 	}
 
-	var nuclioVersion string
-
-	// get version
-	nuclioVersion = version.Get().Label
-	if nuclioVersion == "" {
-		nuclioVersion = "unknown"
-	}
 	annotations["nuclio.io/function-config"] = serializedFunctionConfigJSON
-	annotations["nuclio.io/controller-version"] = nuclioVersion
+	annotations[common.NuclioAnnotationKeyControllerVersion] = common.GetControllerVersion()
 
 	// add function annotations
 	for annotationKey, annotationValue := range function.Annotations {
@@ -2311,6 +2309,9 @@ func (lc *lazyClient) populateIngressConfig(ctx context.Context,
 		platformConfig.IngressConfig.EnableSSLRedirect {
 		meta.Annotations[annotations.NginxSSLRedirect] = "true"
 	}
+
+	// stamp current version for upgrade-reconcile detection
+	meta.Annotations[common.NuclioAnnotationKeyControllerVersion] = common.GetControllerVersion()
 
 	// clear out existing so that we don't keep adding rules
 	spec.Rules = []networkingv1.IngressRule{}

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -180,7 +180,7 @@ func (suite *lazyTestSuite) TestEnrichIngressWithDefaultAnnotations() {
 			},
 			expectedFunctionIngressAnnotations: map[string]string{
 				"a": "c",
-				common.NuclioAnnotationKeyControllerVersion: common.GetControllerVersion(),
+				common.NuclioAnnotationKeyControllerVersion: common.GetNuclioVersion(),
 			},
 		},
 		{
@@ -190,7 +190,7 @@ func (suite *lazyTestSuite) TestEnrichIngressWithDefaultAnnotations() {
 			},
 			expectedFunctionIngressAnnotations: map[string]string{
 				"a": "",
-				common.NuclioAnnotationKeyControllerVersion: common.GetControllerVersion(),
+				common.NuclioAnnotationKeyControllerVersion: common.GetNuclioVersion(),
 			},
 		},
 		{
@@ -204,7 +204,7 @@ func (suite *lazyTestSuite) TestEnrichIngressWithDefaultAnnotations() {
 				}
 				err := mergo.Merge(&ingressAnnotations, &defaultIngressAnnotations)
 				suite.Require().NoError(err)
-				ingressAnnotations[common.NuclioAnnotationKeyControllerVersion] = common.GetControllerVersion()
+				ingressAnnotations[common.NuclioAnnotationKeyControllerVersion] = common.GetNuclioVersion()
 				return ingressAnnotations
 			}(),
 		},

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -180,6 +180,7 @@ func (suite *lazyTestSuite) TestEnrichIngressWithDefaultAnnotations() {
 			},
 			expectedFunctionIngressAnnotations: map[string]string{
 				"a": "c",
+				common.NuclioAnnotationKeyControllerVersion: common.GetControllerVersion(),
 			},
 		},
 		{
@@ -189,6 +190,7 @@ func (suite *lazyTestSuite) TestEnrichIngressWithDefaultAnnotations() {
 			},
 			expectedFunctionIngressAnnotations: map[string]string{
 				"a": "",
+				common.NuclioAnnotationKeyControllerVersion: common.GetControllerVersion(),
 			},
 		},
 		{
@@ -202,6 +204,7 @@ func (suite *lazyTestSuite) TestEnrichIngressWithDefaultAnnotations() {
 				}
 				err := mergo.Merge(&ingressAnnotations, &defaultIngressAnnotations)
 				suite.Require().NoError(err)
+				ingressAnnotations[common.NuclioAnnotationKeyControllerVersion] = common.GetControllerVersion()
 				return ingressAnnotations
 			}(),
 		},

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -179,8 +179,8 @@ func (suite *lazyTestSuite) TestEnrichIngressWithDefaultAnnotations() {
 				"a": "c",
 			},
 			expectedFunctionIngressAnnotations: map[string]string{
-				"a": "c",
-				common.NuclioAnnotationKeyControllerVersion: common.GetNuclioVersion(),
+				"a":                               "c",
+				common.NuclioAnnotationKeyVersion: common.GetNuclioVersion(),
 			},
 		},
 		{
@@ -189,8 +189,8 @@ func (suite *lazyTestSuite) TestEnrichIngressWithDefaultAnnotations() {
 				"a": "",
 			},
 			expectedFunctionIngressAnnotations: map[string]string{
-				"a": "",
-				common.NuclioAnnotationKeyControllerVersion: common.GetNuclioVersion(),
+				"a":                               "",
+				common.NuclioAnnotationKeyVersion: common.GetNuclioVersion(),
 			},
 		},
 		{
@@ -204,7 +204,7 @@ func (suite *lazyTestSuite) TestEnrichIngressWithDefaultAnnotations() {
 				}
 				err := mergo.Merge(&ingressAnnotations, &defaultIngressAnnotations)
 				suite.Require().NoError(err)
-				ingressAnnotations[common.NuclioAnnotationKeyControllerVersion] = common.GetNuclioVersion()
+				ingressAnnotations[common.NuclioAnnotationKeyVersion] = common.GetNuclioVersion()
 				return ingressAnnotations
 			}(),
 		},

--- a/pkg/platform/kube/test/apigateway/api_gateway_test.go
+++ b/pkg/platform/kube/test/apigateway/api_gateway_test.go
@@ -277,7 +277,15 @@ func (suite *DeployAPIGatewayTestSuite) TestUpdate() {
 		suite.Require().Equal(afterUpdateHostValue, ingressInstance.Spec.Rules[0].Host)
 
 		apiGateway := suite.GetAPIGateway(getAPIGatewayOptions)
-		suite.Require().Equal(testAnnotations, apiGateway.GetConfig().Meta.Annotations)
+
+		// the controller stamps its version on the gateway, so expect it alongside the user annotations
+		expectedAnnotations := map[string]string{
+			common.NuclioAnnotationKeyControllerVersion: common.GetNuclioVersion(),
+		}
+		for key, value := range testAnnotations {
+			expectedAnnotations[key] = value
+		}
+		suite.Require().Equal(expectedAnnotations, apiGateway.GetConfig().Meta.Annotations)
 		return true
 	})
 }

--- a/pkg/platform/kube/test/apigateway/api_gateway_test.go
+++ b/pkg/platform/kube/test/apigateway/api_gateway_test.go
@@ -280,7 +280,7 @@ func (suite *DeployAPIGatewayTestSuite) TestUpdate() {
 
 		// the controller stamps its version on the gateway, so expect it alongside the user annotations
 		expectedAnnotations := map[string]string{
-			common.NuclioAnnotationKeyControllerVersion: common.GetNuclioVersion(),
+			common.NuclioAnnotationKeyVersion: common.GetNuclioVersion(),
 		}
 		for key, value := range testAnnotations {
 			expectedAnnotations[key] = value


### PR DESCRIPTION
### 📝 Description
After a Nuclio controller upgrade, existing API gateways and function ingresses were not re-reconciled with the new controller’s configuration.

This PR introduces a controller-version annotation (`nuclio.io/controller-version`) on managed resources and reconciles them when the version is older than the running controller, so upgrades converge existing workloads once at startup.

---

### 🛠️ Changes Made
- Added `NuclioAnnotationKeyControllerVersion` and shared helpers `GetControllerVersion()` / `IsControllerVersionStale()` (semver `<` comparison; non-semver labels fall back to inequality)
- **API gateway operator**: reconcile settled gateways when their CR carries a old version; stamp the current controller version on the gateway CR after a successful reconcile
- **Function resources**: stamp controller version on ingresses; on ingress update, clear managed fields (`Labels`, `Spec`) when the version is old

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- **Unit**: Added a versioning check unit test
- **Manual**: tested locally that a new version triggers both the function trigger http and API GW re-creation

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->
The existing resources without version annotation will be re-created once with the new controller version after upgrading.

---

### 🔍️ Additional Notes
- Version check uses **strictly older** (`<`), not `!=`, so during a rolling controller upgrade the terminating old pod does not fight the new one over stamps.
- API gateway stamp on the **CR** (cheap on resync); function ingress stamp on the **ingress** (needed for in-place field reset). Deployments already used this annotation pattern; ingress stamping is new.

<!-- ### 📸 Screenshots / Logs -->
