### PR TITLE
[ControlCommunication] Drain in-flight deliveries on subscription Close

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -32,6 +32,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
 	"unicode/utf8"
@@ -734,4 +735,20 @@ func ImageHasRegistry(image string) bool {
 	}
 	firstSegment := image[:slashIndex]
 	return strings.Contains(firstSegment, ".") || strings.Contains(firstSegment, ":")
+}
+
+// WaitGroupWithTimeout waits for wg to complete, returning true if it finished
+// before the timeout elapsed or false otherwise.
+func WaitGroupWithTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
 }

--- a/pkg/processor/controlcommunication/controlcommunication_test.go
+++ b/pkg/processor/controlcommunication/controlcommunication_test.go
@@ -526,6 +526,38 @@ func (s *MergedSubscriptionTestSuite) TestConcurrentCloseAndSends() {
 	senders.Wait()
 }
 
+// TestCloseDrainsInflightToReader — a message the broker already dispatched must
+// be drained to a still-present reader on Close, not dropped. This is the
+// explicit-ack-on-rebalance guarantee: the reader (explicitAckHandler) is still
+// ranging C() while Close runs, so in-flight acks must reach it and be marked.
+// The reader here begins consuming only after Close has started, so a Close that
+// dropped in-flight deliveries (the pre-fix behaviour) would lose the message.
+func (s *MergedSubscriptionTestSuite) TestCloseDrainsInflightToReader() {
+	broker := NewControlMessageBrokerBase()
+	merged := MergeSubscriptions([]Subscription{mustSubscribe(s.T(), broker), mustSubscribe(s.T(), broker)})
+
+	msg := &ControlMessage{Kind: StreamMessageAckKind, Attributes: map[string]interface{}{"n": 1}}
+	s.Require().NoError(broker.SendToConsumers(msg))
+
+	got := make(chan *ControlMessage, 8)
+	go func() {
+		// begin reading only after Close has begun its drain
+		time.Sleep(50 * time.Millisecond)
+		for m := range merged.C() {
+			got <- m
+		}
+	}()
+
+	merged.Close()
+
+	select {
+	case m := <-got:
+		s.Require().EqualValues(1, m.Attributes["n"], "in-flight message must be drained to the reader, not dropped")
+	case <-time.After(regressionTimeout):
+		s.Fail("merged Close dropped the in-flight message instead of draining it")
+	}
+}
+
 func mustSubscribe(t *testing.T, broker *ControlMessageBrokerBase) Subscription {
 	t.Helper()
 	sub, err := broker.Subscribe(StreamMessageAckKind)

--- a/pkg/processor/controlcommunication/merged_subscription.go
+++ b/pkg/processor/controlcommunication/merged_subscription.go
@@ -18,6 +18,8 @@ package controlcommunication
 
 import (
 	"sync"
+
+	"github.com/nuclio/nuclio/pkg/common"
 )
 
 // MergeSubscriptions returns a single Subscription whose channel delivers
@@ -72,19 +74,28 @@ func (m *mergedSubscription) C() <-chan *ControlMessage {
 func (m *mergedSubscription) Close() {
 	m.closeOnce.Do(func() {
 
-		// signal forwarders to stop pushing to the merged channel; they may
-		// also exit via their underlying subscription's channel closing below
-		close(m.done)
-
-		// close underlying subscriptions: this both unblocks any forwarder
-		// reading sub.C() (closed channel returns ok=false) and releases the
-		// per-worker broker resources
+		// Close the underlying subscriptions concurrently. Each drains its in-flight
+		// deliveries to our forwarders, which flush them to the merged channel for
+		// the holder. Closing them concurrently (and waiting on the forwarders below,
+		// not here) overlaps the two drains so the whole close stays bounded by a
+		// single drainOnCloseTimeout.
+		var subClosers sync.WaitGroup
 		for _, sub := range m.subs {
-			sub.Close()
+			subClosers.Go(func() {
+				sub.Close()
+			})
 		}
 
-		// wait until every forwarder has exited so it's safe to close `merged`
+		// If the holder has stopped reading, the drain times out and we signal `done`
+		// so forwarders parked on `merged <- msg` drop instead of hanging Close;
+		// otherwise they exit as the underlying channels close. Either way every
+		// forwarder must exit before we close `merged` - on the timeout path `done` is
+		// already closed, so this returns promptly rather than waiting again.
+		if !common.WaitGroupWithTimeout(&m.forwarder, drainOnCloseTimeout) {
+			close(m.done)
+		}
 		m.forwarder.Wait()
+		subClosers.Wait()
 
 		close(m.merged)
 	})

--- a/pkg/processor/controlcommunication/subscription.go
+++ b/pkg/processor/controlcommunication/subscription.go
@@ -18,7 +18,13 @@ package controlcommunication
 
 import (
 	"sync"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/common"
 )
+
+// drainOnCloseTimeout bounds the drain attempt in Close (see Close for details).
+const drainOnCloseTimeout = 1 * time.Second
 
 // subscription is the broker-owned Subscription implementation.
 //
@@ -66,15 +72,20 @@ func (s *subscription) Close() {
 		// SendToConsumers call won't even see this subscription
 		s.broker.removeSubscription(s)
 
-		// unblock any delivery goroutines that are stuck on `messages <- msg`
-		// (no reader on the other end after Close)
-		close(s.done)
+		// Drain in-flight deliveries to the reader so messages the broker already
+		// dispatched are not dropped. While the holder is still ranging C() (e.g.
+		// explicitAckHandler during a rebalance) this completes immediately. If the
+		// reader has stopped, the drain times out and we signal `done` so the parked
+		// deliveries drop instead of hanging Close (the NUC-765 deadlock backstop).
+		if !common.WaitGroupWithTimeout(&s.inFlight, drainOnCloseTimeout) {
+			close(s.done)
+		}
 
-		// wait for every in-flight delivery to observe `done` and exit before
-		// we close `messages` — otherwise the goroutine could race and write
-		// to a closed channel
+		// Every delivery goroutine must exit before we close `messages` (a parked
+		// `messages <- msg` would panic on a closed channel). On the timeout path
+		// `done` is already closed, so the parked deliveries drop and this returns
+		// promptly rather than waiting again.
 		s.inFlight.Wait()
-
 		close(s.messages)
 	})
 }


### PR DESCRIPTION
### 📝 Description

Fixes a regression where **explicit-ack offsets are silently dropped on a consumer-group rebalance**, so the offsets the runtime acked are never committed.

After #4121 inverted the control-message broker to be non-blocking (fixing the NUC-765 deadlock), `SendToConsumers` dispatches each message in its own goroutine and returns immediately, and `subscription.Close()` signals `done` so any delivery still parked on `messages <- msg` exits via the `<-s.done` arm — i.e. it is **dropped**.

On a kafka rebalance, `ConsumeClaim` calls `Close()` on the explicit-ack subscription. Any ack control message that is still in flight (read off the socket and dispatched by the broker, but not yet handed to `explicitAckHandler`) is dropped, so `MarkOffset` is never called for it and the offset is never committed.

This breaks the happens-before that acknowledged draining (#4047 / #4162) depends on:

- **Before #4121** delivery was synchronous and in socket order — the reader processed each control message fully before the next, so by the time the worker's drain-complete signal reached `Drain()`, every preceding explicit ack had already been delivered and `MarkOffset`-ed.
- **After #4121** delivery is concurrent and unordered, so drain-complete can reach `Drain()` *before* the preceding acks reach `explicitAckHandler`. `Drain()` returns, `ConsumeClaim` calls `Close()`, and the still-in-flight acks are dropped.

---

### 🛠️ Changes Made

- `subscription.Close()` now lets in-flight deliveries reach the (still-ranging) reader before forcing the channel closed, falling back to the `done` drop only after a bounded grace. While a holder is still ranging `C()` (e.g. `explicitAckHandler` during a rebalance) this drains immediately; only a stopped/absent reader hits the timeout, so `Close()` can never hang — the NUC-765 deadlock fix is preserved.
- `mergedSubscription.Close()` closes its underlying subscriptions concurrently and waits for the forwarders to flush to the holder before its own `done` backstop, so the underlying drain and the forwarder drain overlap and the whole close stays bounded by a single timeout.
- Added `common.WaitGroupWithTimeout(wg, timeout)` helper.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

- New unit test `TestCloseDrainsInflightToReader` reproduces the bug: it **fails without the fix** (in-flight message dropped on `Close`) and **passes with it**.
- Full `pkg/processor/controlcommunication` suite passes with `-race`, including the existing NUC-765 deadlock-regression tests (`TestCloseUnblocksSendWithoutReader`, `TestConcurrentCloseAndSends`, etc.).

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links: regression introduced by #4121 (prep for the explicit-ack work in #4047 / #4162)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

Scope: this addresses the **ack-drop-on-rebalance** correctness regression so the committed offset reflects what the runtime acked.

It is **not** a complete fix for `kafka ExplicitOnly-64` flakiness on its own. Under heavy load that stress test can still fail because messages produced during its rapid add/remove-consumer churn aren't re-delivered within the test's window (un-acked messages awaiting redelivery under `initialOffset: latest`, plus a separate cold-start join-timing flake). Those are redelivery/test-timing concerns, tracked separately, not message loss — and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
