### PR TITLE
[Python] Respond 500 to events discarded during drain

### DIFF
--- a/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
@@ -167,6 +167,10 @@ class AsyncWrapper(AbstractWrapper):
                 else:
                     self._logger.debug("Event discarded")
 
+                    # respond with an error so the processor does not block forever waiting for
+                    # a response to the discarded event (its default event timeout is infinite)
+                    await self._write_response_error('Event discarded: worker draining', sock)
+
                 # Release event reference
                 del event
 

--- a/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
@@ -169,7 +169,7 @@ class AsyncWrapper(AbstractWrapper):
 
                     # respond with an error so the processor does not block forever waiting for
                     # a response to the discarded event (its default event timeout is infinite)
-                    await self._write_response_error('Event discarded: worker draining', sock)
+                    await self._write_response_error('Event discarded: worker drained', sock)
 
                 # Release event reference
                 del event

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -103,6 +103,10 @@ class Wrapper(AbstractWrapper):
                 else:
                     self._logger.debug_with('Event has been discarded', event=event)
 
+                    # respond with an error so the processor does not block forever waiting for
+                    # a response to the discarded event (its default event timeout is infinite)
+                    await self._write_response_error('Event discarded: worker draining', self._event_sock)
+
                 # allow event to be garbage collected by deleting the reference
                 del event
 

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -105,7 +105,7 @@ class Wrapper(AbstractWrapper):
 
                     # respond with an error so the processor does not block forever waiting for
                     # a response to the discarded event (its default event timeout is infinite)
-                    await self._write_response_error('Event discarded: worker draining', self._event_sock)
+                    await self._write_response_error('Event discarded: worker drained', self._event_sock)
 
                 # allow event to be garbage collected by deleting the reference
                 del event

--- a/pkg/processor/runtime/python/py/test_server_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_server_wrapper.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import json
 import logging
 import operator
 import socket
@@ -20,6 +21,7 @@ import sys
 import tempfile
 import random
 import unittest
+import unittest.mock
 import os
 
 import msgpack
@@ -176,6 +178,44 @@ class TestSubmitEvents(BaseTestSubmitEvents):
             minimum_messages_length=3,
             messages=self._unix_stream_server._messages,
         )
+
+    def test_discarded_event_returns_error_response(self):
+        # ML-12573: an event the processor already handed off when draining started must be
+        # answered with an error response, not silently dropped - the processor waits for the
+        # response with no timeout by default, so a silent drop wedges the worker (and its
+        # partition) forever.
+        self._wrapper._entrypoint = unittest.mock.MagicMock()
+        self._wrapper._discard_events = True
+
+        async def send_event_and_read_response():
+            client_socket = self._create_client_socket()
+            try:
+                event = self._event_to_dict(nuclio_sdk.Event(_id=0, body='discard-me'))
+                body = msgpack.Packer().pack(event)
+                await self._loop.sock_sendall(client_socket, struct.pack(">I", len(body)))
+                await self._loop.sock_sendall(client_socket, body)
+
+                # read until a response ('r') message arrives; fail rather than hang if the
+                # discarded event is never answered
+                data = bytearray()
+                while True:
+                    chunk = await asyncio.wait_for(self._loop.sock_recv(client_socket, 128), timeout=10)
+                    if not chunk:
+                        raise AssertionError('Connection closed before receiving a response')
+                    data.extend(chunk)
+                    for message in data.split(b'\n')[:-1]:
+                        if message.startswith(b'r'):
+                            return json.loads(message[1:])
+            finally:
+                client_socket.close()
+
+        response = self._loop.run_until_complete(send_event_and_read_response())
+
+        # the discarded event must not reach the handler
+        self._wrapper._entrypoint.assert_not_called()
+
+        self.assertEqual(500, response['status_code'])
+        self.assertIn('discarded', response['body'])
 
     async def _send_events(self, events, single_connection=True):
         data = []

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -528,6 +528,31 @@ class TestSubmitEvents(BaseTestSubmitEvents):
 
         self._wrapper._send_drain_complete_control_message.assert_not_called()
 
+    def test_discarded_event_returns_error_response(self):
+        # ML-12573: an event the processor already handed off when draining started must be
+        # answered with an error response, not silently dropped - the processor waits for the
+        # response with no timeout by default, so a silent drop wedges the worker (and its
+        # partition) forever.
+        self._wrapper._entrypoint = unittest.mock.MagicMock()
+        self._wrapper._discard_events = True
+
+        self._send_events([nuclio_sdk.Event(_id=0, body='discard-me')])
+        self._wrapper._event_sock.setblocking(False)
+        self._loop.run_until_complete(self._wrapper.serve_requests(num_requests=1))
+
+        # the discarded event must not reach the handler
+        self._wrapper._entrypoint.assert_not_called()
+
+        # the processor must still get a response ('s' start packet from setUp + 'r' error)
+        self._wait_until_received_messages(2, self._unix_stream_server._messages)
+        responses = [
+            message for message in self._unix_stream_server._messages
+            if message['type'] == PacketType.SINGLE_RESPONSE
+        ]
+        self.assertEqual(1, len(responses))
+        self.assertEqual(500, responses[0]['body']['status_code'])
+        self.assertIn('discarded', responses[0]['body']['body'])
+
     async def _collect_packets_async(self, entrypoint_output):
         return [
             (prefix, payload)


### PR DESCRIPTION
### 📝 Description

On a Kafka rebalance the processor signals the Python wrapper to drain (SIGUSR2) and the wrapper starts discarding events. An event the processor had already handed off was discarded **silently**, while the processor waits for its response with no timeout by default — so the worker was never freed and its partition stayed wedged after the rebalance (consumer lag, missing events).

The wrapper now replies to a discarded in-flight event with a 500 error response (`Event discarded: worker draining`), unblocking the processor and freeing the worker. The response travels the same path as a handler exception, so no Go-side changes are needed.

---

### 🛠️ Changes Made

- Reply with a 500 error response for events discarded while draining, in both the sync wrapper (`_nuclio_wrapper.py`) and the async wrapper (`_nuclio_async_wrapper.py`)
- Add regression tests for both wrappers

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

- New unit tests `test_discarded_event_returns_error_response` in `test_wrapper.py` and `test_server_wrapper.py`: with `_discard_events` set, an event must not reach the handler and must be answered with a status-500 `r` packet. Both fail without the fix (no response ever arrives) and pass with it.
- Full Python wrapper suites pass (38 tests, Python 3.12).

---

### 🔗 References
- Ticket link: ML-12573

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No
