### PR TITLE
[Platform] Support Elasticsearch API key authentication for the log DB

### DIFF
--- a/pkg/platform/kube/logProxy/elastic/elasticsearch.go
+++ b/pkg/platform/kube/logProxy/elastic/elasticsearch.go
@@ -57,14 +57,16 @@ func NewElasticSearchLogProxy(config *platformconfig.ElasticSearchConfig) (*Elas
 		// Set to true to skip TLS verification if SSLVerificationMode is "none"
 		InsecureSkipVerify: config.SSLVerificationMode == "none",
 	}
-	if esClient.client, err = elasticsearch.NewTypedClient(elasticsearch.Config{
+	esConfig := elasticsearch.Config{
 		Addresses: []string{config.URL},
-		Password:  config.Password,
 		Username:  config.Username,
+		Password:  config.Password,
+		APIKey:    config.APIKey,
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		},
-	}); err != nil {
+	}
+	if esClient.client, err = elasticsearch.NewTypedClient(esConfig); err != nil {
 		return nil, errors.Wrap(err, "Failed to create elasticsearch client")
 	}
 	return esClient, err

--- a/pkg/platform/kube/logProxy/elastic/factory.go
+++ b/pkg/platform/kube/logProxy/elastic/factory.go
@@ -109,7 +109,12 @@ func getVersionFromSearchEngine(client *http.Client, config *platformconfig.Elas
 		return nil, errors.Wrap(err, "Failed to create request")
 	}
 
-	if config.Username != "" && config.Password != "" {
+	// Auto-detection uses the Elasticsearch "ApiKey" scheme for the probe. For an
+	// OpenSearch cluster secured with an API key, set kind: opensearch explicitly
+	// so this probe is skipped (OpenSearch authenticates API keys with Bearer).
+	if config.APIKey != "" {
+		req.Header.Set("Authorization", "ApiKey "+config.APIKey)
+	} else if config.Username != "" && config.Password != "" {
 		req.SetBasicAuth(config.Username, config.Password)
 	}
 

--- a/pkg/platform/kube/logProxy/elastic/opensearch.go
+++ b/pkg/platform/kube/logProxy/elastic/opensearch.go
@@ -53,14 +53,24 @@ func NewOpenSearchLogProxy(config *platformconfig.ElasticSearchConfig) (*OpenSea
 		// Set to true to skip TLS verification if SSLVerificationMode is "none"
 		InsecureSkipVerify: config.SSLVerificationMode == "none",
 	}
-	if openSearchClient.client, err = opensearchapi.NewClient(opensearchapi.Config{Client: opensearch.Config{
+	openSearchConfig := opensearch.Config{
 		Addresses: []string{config.URL},
-		Password:  config.Password,
 		Username:  config.Username,
+		Password:  config.Password,
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		},
-	}}); err != nil {
+	}
+
+	// The opensearch-go client has no native API-key field, so pass the key as an
+	// Authorization header. OpenSearch's Security plugin (3.0+) authenticates API
+	// keys with the Bearer scheme — NOT Elasticsearch's "ApiKey <base64(id:key)>".
+	// Mutual exclusivity with basic auth is enforced by ElasticSearchConfig.Validate.
+	if config.APIKey != "" {
+		openSearchConfig.Header = http.Header{"Authorization": []string{"Bearer " + config.APIKey}}
+	}
+
+	if openSearchClient.client, err = opensearchapi.NewClient(opensearchapi.Config{Client: openSearchConfig}); err != nil {
 		return nil, errors.Wrap(err, "Failed to create opensearch client")
 	}
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -411,6 +411,10 @@ func (c *Config) ValidatePlatformConfig() error {
 			*c.scaleToZeroReadinessPollInterval)
 	}
 
+	if err := c.Kube.ElasticSearchConfig.Validate(); err != nil {
+		return errors.Wrap(err, "Failed to validate Elasticsearch config")
+	}
+
 	return nil
 }
 
@@ -591,6 +595,21 @@ func (c *Config) enrichElasticSearchConfig() {
 	if envPassword := os.Getenv("NUCLIO_ELASTIC_SEARCH_PASSWORD"); envPassword != "" {
 		c.Kube.ElasticSearchConfig.Password = envPassword
 	}
+	if envAPIKey := os.Getenv("NUCLIO_ELASTIC_SEARCH_API_KEY"); envAPIKey != "" {
+		c.Kube.ElasticSearchConfig.APIKey = envAPIKey
+	}
+}
+
+func (c *ElasticSearchConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+	passwordConfigured := c.Password != "" || common.GetEnvOrDefaultString("NUCLIO_ELASTIC_SEARCH_PASSWORD", "") != ""
+	apiKeyConfigured := c.APIKey != "" || common.GetEnvOrDefaultString("NUCLIO_ELASTIC_SEARCH_API_KEY", "") != ""
+	if passwordConfigured && apiKeyConfigured {
+		return errors.New("Elasticsearch authentication misconfiguration: basic auth (password) and API key auth are mutually exclusive — please configure only one")
+	}
+	return nil
 }
 
 // getDefaultRuntimeBaseImages returns the default runtime base images

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -947,6 +947,146 @@ func (suite *PlatformConfigTestSuite) getTestProbe(probeValue int32) *corev1.Pro
 	}
 }
 
+func (suite *PlatformConfigTestSuite) TestEnrichElasticSearchConfigAPIKey() {
+	testCases := []struct {
+		name           string
+		configYAML     string
+		envAPIKey      string
+		expectedAPIKey string
+	}{
+		{
+			name: "apiKeyFromConfig",
+			configYAML: `
+kube:
+  elasticSearchConfig:
+    apiKey: "config-api-key"
+`,
+			envAPIKey:      "",
+			expectedAPIKey: "config-api-key",
+		},
+		{
+			name: "apiKeyFromEnv",
+			configYAML: `
+kube:
+  elasticSearchConfig:
+    apiKey: ""
+`,
+			envAPIKey:      "env-api-key",
+			expectedAPIKey: "env-api-key",
+		},
+		{
+			name: "apiKeyEnvOverridesConfig",
+			configYAML: `
+kube:
+  elasticSearchConfig:
+    apiKey: "config-api-key"
+`,
+			envAPIKey:      "env-api-key",
+			expectedAPIKey: "env-api-key",
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			if tc.envAPIKey != "" {
+				os.Setenv("NUCLIO_ELASTIC_SEARCH_API_KEY", tc.envAPIKey)
+				defer os.Unsetenv("NUCLIO_ELASTIC_SEARCH_API_KEY")
+			}
+
+			var readConfiguration Config
+			err := suite.reader.Read(bytes.NewBufferString(tc.configYAML), "yaml", &readConfiguration)
+			suite.Require().NoError(err)
+
+			readConfiguration.enrichElasticSearchConfig()
+			suite.Equal(tc.expectedAPIKey, readConfiguration.Kube.ElasticSearchConfig.APIKey)
+		})
+	}
+}
+
+func (suite *PlatformConfigTestSuite) TestElasticSearchConfigValidateMutualExclusivity() {
+	testCases := []struct {
+		name        string
+		config      *ElasticSearchConfig
+		envPassword string
+		envAPIKey   string
+		expectError bool
+	}{
+		{
+			name:        "neitherConfigured",
+			config:      &ElasticSearchConfig{},
+			expectError: false,
+		},
+		{
+			name:        "onlyPasswordInConfig",
+			config:      &ElasticSearchConfig{Password: "secret"},
+			expectError: false,
+		},
+		{
+			name:        "onlyAPIKeyInConfig",
+			config:      &ElasticSearchConfig{APIKey: "my-api-key"},
+			expectError: false,
+		},
+		{
+			name:        "bothInConfig",
+			config:      &ElasticSearchConfig{Password: "secret", APIKey: "my-api-key"},
+			expectError: true,
+		},
+		{
+			name:        "passwordInConfigAPIKeyInEnv",
+			config:      &ElasticSearchConfig{Password: "secret"},
+			envAPIKey:   "env-api-key",
+			expectError: true,
+		},
+		{
+			name:        "apiKeyInConfigPasswordInEnv",
+			config:      &ElasticSearchConfig{APIKey: "my-api-key"},
+			envPassword: "env-password",
+			expectError: true,
+		},
+		{
+			name:        "nilConfig",
+			config:      nil,
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			if tc.envPassword != "" {
+				os.Setenv("NUCLIO_ELASTIC_SEARCH_PASSWORD", tc.envPassword)
+				defer os.Unsetenv("NUCLIO_ELASTIC_SEARCH_PASSWORD")
+			}
+			if tc.envAPIKey != "" {
+				os.Setenv("NUCLIO_ELASTIC_SEARCH_API_KEY", tc.envAPIKey)
+				defer os.Unsetenv("NUCLIO_ELASTIC_SEARCH_API_KEY")
+			}
+
+			err := tc.config.Validate()
+			if tc.expectError {
+				suite.Require().Error(err)
+				suite.Contains(err.Error(), "mutually exclusive")
+			} else {
+				suite.Require().NoError(err)
+			}
+		})
+	}
+}
+
+func (suite *PlatformConfigTestSuite) TestValidatePlatformConfigElasticSearchMutualExclusivity() {
+	config := &Config{
+		RuntimeBaseImages: map[string]string{"test-runtime": "test-image"},
+		Kube: PlatformKubeConfig{
+			ElasticSearchConfig: &ElasticSearchConfig{
+				Password: "secret",
+				APIKey:   "my-api-key",
+			},
+		},
+	}
+	err := config.ValidatePlatformConfig()
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "Elasticsearch config")
+}
+
 func TestPlatformConfigTestSuite(t *testing.T) {
 	suite.Run(t, new(PlatformConfigTestSuite))
 }

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -378,6 +378,7 @@ type ElasticSearchConfig struct {
 	SSLVerificationMode  string `json:"sslVerificationMode,omitempty"`
 	Username             string `json:"username,omitempty"`
 	Password             string `json:"password,omitempty"`
+	APIKey               string `json:"apiKey,omitempty" yaml:"apiKey,omitempty"`
 	Index                string `json:"index,omitempty"`
 	CustomQueryParameter string `json:"customQueryParameter,omitempty"`
 


### PR DESCRIPTION
### 📝 Description
Nuclio's Elasticsearch/OpenSearch log-DB client only supported basic auth (username/password). This adds API key authentication as an alternative, selected via config or the `NUCLIO_ELASTIC_SEARCH_API_KEY` environment variable — mirroring the existing `NUCLIO_ELASTIC_SEARCH_PASSWORD` handling — for both backends (nuclio serves them behind one `ElasticSearchConfig`, auto-detected).

---

### 🛠️ Changes Made
- `ElasticSearchConfig` gains an `APIKey` field (`apiKey` in json/yaml).
- `enrichElasticSearchConfig` reads `NUCLIO_ELASTIC_SEARCH_API_KEY` into it, alongside the existing password enrichment.
- **Elasticsearch backend:** the client is constructed with the native `APIKey` field (`Authorization: ApiKey …`).
- **OpenSearch backend:** the opensearch-go client has no native API-key field, so the key is sent as an `Authorization: Bearer <key>` header — the scheme OpenSearch's Security plugin (3.0+) uses for API keys.
- `ElasticSearchConfig.Validate` rejects configuring both password and API key auth (mutually exclusive), wired into `Config.ValidatePlatformConfig` so a misconfiguration fails fast at startup.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Table-driven unit tests (`test_unit`) covering API-key enrichment (config / env / env-overrides-config), the mutual-exclusivity validation (config-only, env-only, mixed, nil), and the top-level `ValidatePlatformConfig` path. All pass. `go build` / `go vet` cover the ES + OpenSearch client construction.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- The backend auto-detection probe uses the Elasticsearch `ApiKey` scheme. For an **OpenSearch** cluster secured with an API key, set `kind: opensearch` explicitly so the probe is skipped and the Bearer client is used directly.
- Pairs with the Helm chart change (#4184) that injects `NUCLIO_ELASTIC_SEARCH_API_KEY` into the dashboard pod.
