### PR TITLE
[Helm] Add Elasticsearch API key auth to the dashboard chart

### DIFF
--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -131,13 +131,19 @@ spec:
           value: {{ .Values.dashboard.kaniko.image.pullPolicy }}
         - name: NUCLIO_KANIKO_JOB_DELETION_TIMEOUT
           value: {{ .Values.dashboard.kaniko.jobDeletionTimeout | quote }}
-        {{- if and .Values.dashboard.elasticSearchPassword.secretName .Values.dashboard.elasticSearchPassword.secretKey }}
+        {{- if and .Values.dashboard.elasticSearchApiKey.secretName .Values.dashboard.elasticSearchApiKey.secretKey }}
+        - name: NUCLIO_ELASTIC_SEARCH_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.dashboard.elasticSearchApiKey.secretName }}
+              key: {{ .Values.dashboard.elasticSearchApiKey.secretKey }}
+        {{- else if and .Values.dashboard.elasticSearchPassword.secretName .Values.dashboard.elasticSearchPassword.secretKey }}
         - name: NUCLIO_ELASTIC_SEARCH_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ .Values.dashboard.elasticSearchPassword.secretName }}
               key: {{ .Values.dashboard.elasticSearchPassword.secretKey }}
-         {{- end }}
+        {{- end }}
         {{- if .Values.dashboard.kaniko.insecurePushRegistry }}
         - name: NUCLIO_KANIKO_INSECURE_PUSH_REGISTRY
           value: "true"

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -344,7 +344,15 @@ dashboard:
       periodSeconds: 15
       failureThreshold: 4
 
+  # Elasticsearch basic auth password secret.
+  # Used only when elasticSearchApiKey is not set — the API key takes precedence.
   elasticSearchPassword:
+    secretName: ""
+    secretKey: ""
+
+  # Elasticsearch API key secret.
+  # Takes precedence over elasticSearchPassword when both are set.
+  elasticSearchApiKey:
     secretName: ""
     secretKey: ""
 


### PR DESCRIPTION
### 📝 Description
The dashboard chart could inject Elasticsearch basic-auth credentials (`elasticSearchPassword`) but had no way to supply an API key. This adds an `elasticSearchApiKey` secret reference and injects it into the dashboard as `NUCLIO_ELASTIC_SEARCH_API_KEY` — the env var the platform reads.

---

### 🛠️ Changes Made
- `values.yaml`: new `dashboard.elasticSearchApiKey` stanza (`secretName` / `secretKey`), documented as taking precedence over `elasticSearchPassword`.
- `dashboard.yaml`: inject the API key from its secret as `NUCLIO_ELASTIC_SEARCH_API_KEY`; when both the API key and password secrets are set, only the API key is emitted (rendered as an `if / else`).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- `helm lint` passes; `helm template` renders the API-key env var when the secret is set and falls back to the password env var otherwise.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-847
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No

<!-- Purely additive: both secret refs default to empty, so existing installs are unchanged. -->

---

### 🔍️ Additional Notes
- Pairs with the platform-config change that reads `NUCLIO_ELASTIC_SEARCH_API_KEY`.