### PR TITLE
[Helm] Add container-level securityContext support for system pods

### DIFF
--- a/hack/k8s/helm/nuclio/templates/_helpers.tpl
+++ b/hack/k8s/helm/nuclio/templates/_helpers.tpl
@@ -226,3 +226,33 @@ imagePullSecrets:
 {{- define "nuclio.podTemplateLabels.controller" -}}{{- include "nuclio.podTemplateLabels" (merge (dict "component" "controller" "podLabels" .Values.controller.podLabels) .) -}}{{- end -}}
 {{- define "nuclio.podTemplateLabels.dlx" -}}{{- include "nuclio.podTemplateLabels" (merge (dict "component" "dlx" "podLabels" .Values.dlx.podLabels) .) -}}{{- end -}}
 {{- define "nuclio.podTemplateLabels.autoscaler" -}}{{- include "nuclio.podTemplateLabels" (merge (dict "component" "autoscaler" "podLabels" .Values.autoscaler.podLabels) .) -}}{{- end -}}
+
+{{/*
+  Container-level securityContext for a Nuclio service container.
+  Merges the shared .Values.global.containerSecurityContext default with the
+  per-component .Values.<component>.containerSecurityContext override, the
+  override winning on key collisions. Renders nothing when the effective
+  context is empty, so containers stay unchanged unless hardening is configured.
+  Usage: include "nuclio.containerSecurityContext.dashboard" .  (or .controller, .dlx, .autoscaler)
+*/}}
+{{- define "nuclio.containerSecurityContext" -}}
+{{- $global := dict -}}
+{{- if .Values.global -}}
+{{- $global = .Values.global.containerSecurityContext | default dict -}}
+{{- end -}}
+{{- $override := .componentSecurityContext | default dict -}}
+{{- $merged := mergeOverwrite (deepCopy $global) $override -}}
+{{- if $merged -}}
+{{- toYaml $merged -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+  Per-component shortcuts for nuclio.containerSecurityContext.
+  Pass the component's containerSecurityContext override through; the helper
+  merges it over the shared global default.
+*/}}
+{{- define "nuclio.containerSecurityContext.dashboard" -}}{{- include "nuclio.containerSecurityContext" (merge (dict "componentSecurityContext" .Values.dashboard.containerSecurityContext) .) -}}{{- end -}}
+{{- define "nuclio.containerSecurityContext.controller" -}}{{- include "nuclio.containerSecurityContext" (merge (dict "componentSecurityContext" .Values.controller.containerSecurityContext) .) -}}{{- end -}}
+{{- define "nuclio.containerSecurityContext.dlx" -}}{{- include "nuclio.containerSecurityContext" (merge (dict "componentSecurityContext" .Values.dlx.containerSecurityContext) .) -}}{{- end -}}
+{{- define "nuclio.containerSecurityContext.autoscaler" -}}{{- include "nuclio.containerSecurityContext" (merge (dict "componentSecurityContext" .Values.autoscaler.containerSecurityContext) .) -}}{{- end -}}

--- a/hack/k8s/helm/nuclio/templates/deployment/autoscaler.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/autoscaler.yaml
@@ -44,6 +44,10 @@ spec:
       - name: {{ template "nuclio.scalerName" . }}
         image: {{ .Values.autoscaler.image.repository }}:{{ .Values.autoscaler.image.tag }}
         imagePullPolicy: {{ .Values.autoscaler.image.pullPolicy }}
+        {{- with (include "nuclio.containerSecurityContext.autoscaler" .) }}
+        securityContext:
+          {{- . | nindent 10 }}
+        {{- end }}
         {{- if .Values.autoscaler.resources }}
         resources:
           {{ toYaml .Values.autoscaler.resources | nindent 11 }}

--- a/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
@@ -44,6 +44,10 @@ spec:
       - name: {{ template "nuclio.controllerName" . }}
         image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+        {{- with (include "nuclio.containerSecurityContext.controller" .) }}
+        securityContext:
+          {{- . | nindent 10 }}
+        {{- end }}
         {{- if .Values.controller.resources }}
         resources:
           {{ toYaml .Values.controller.resources | nindent 11 }}

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -46,6 +46,10 @@ spec:
       - name: {{ template "nuclio.dashboardName" . }}
         image: {{ .Values.dashboard.image.repository }}:{{ .Values.dashboard.image.tag }}
         imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}
+        {{- with (include "nuclio.containerSecurityContext.dashboard" .) }}
+        securityContext:
+          {{- . | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 8070
         - name: liveness-port
@@ -70,6 +74,13 @@ spec:
           failureThreshold: 4
           periodSeconds: 15
         volumeMounts:
+        {{- if .Values.dashboard.writableTmpVolume }}
+        # Writable scratch space for the embedded builder (build temp dirs,
+        # /tmp/kaniko-builds bundles, fetched function templates). Required
+        # when readOnlyRootFilesystem is enabled on the dashboard container.
+        - name: tmp
+          mountPath: /tmp
+        {{- end }}
         {{- if .Values.dashboard.pipCACertSecretName }}
         - mountPath: /etc/ssl/certs/nuclio
           name: pip-ca-cert
@@ -257,6 +268,10 @@ spec:
             name: opa-config
       {{- end }}
       volumes:
+      {{- if .Values.dashboard.writableTmpVolume }}
+      - name: tmp
+        emptyDir: {}
+      {{- end }}
       {{- if .Values.dashboard.pipCACertSecretName }}
       - name: pip-ca-cert
         secret:

--- a/hack/k8s/helm/nuclio/templates/deployment/dlx.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dlx.yaml
@@ -44,6 +44,10 @@ spec:
       - name: {{ template "nuclio.dlxName" . }}
         image: {{ .Values.dlx.image.repository }}:{{ .Values.dlx.image.tag }}
         imagePullPolicy: {{ .Values.dlx.image.pullPolicy }}
+        {{- with (include "nuclio.containerSecurityContext.dlx" .) }}
+        securityContext:
+          {{- . | nindent 10 }}
+        {{- end }}
         {{- if .Values.dlx.resources }}
         resources:
           {{ toYaml .Values.dlx.resources | nindent 11 }}

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -53,10 +53,16 @@ controller:
   ##
   nodeSelector: {}
 
-  ## Deployment security context
+  ## Pod-level security context
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
   securityContext: {}
+
+  ## Container-level security context for this component's main container.
+  ## Merged over the shared .Values.global.containerSecurityContext default,
+  ## with the values here winning on key collisions. Use it to override the
+  ## shared default per component (e.g. `readOnlyRootFilesystem: false`).
+  containerSecurityContext: {}
 
   ## List of node taints to tolerate (requires Kubernetes >= 1.6)
   tolerations: []
@@ -128,10 +134,16 @@ dashboard:
   ##
   nodeSelector: {}
 
-  ## Deployment security context
+  ## Pod-level security context
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
   securityContext: {}
+
+  ## Container-level security context for this component's main container.
+  ## Merged over the shared .Values.global.containerSecurityContext default,
+  ## with the values here winning on key collisions. Use it to override the
+  ## shared default per component (e.g. `readOnlyRootFilesystem: false`).
+  containerSecurityContext: {}
 
   ## List of node taints to tolerate (requires Kubernetes >= 1.6)
   tolerations: []
@@ -160,6 +172,12 @@ dashboard:
 
   # Supported container builders: "kaniko", "docker"
   containerBuilderKind: "docker"
+
+  # Mount an emptyDir at /tmp so the embedded builder can write build temp
+  # dirs, /tmp/kaniko-builds bundles and fetched function templates. Enable
+  # this whenever the dashboard container runs with readOnlyRootFilesystem: true
+  # (otherwise the dashboard writes directly to its rootfs /tmp).
+  writableTmpVolume: false
 
   # Monitor docker deamon connectivity, in conjunction with container builder kind "docker"
   monitorDockerDeamon:
@@ -380,10 +398,16 @@ autoscaler:
   ##
   nodeSelector: {}
 
-  ## Deployment security context
+  ## Pod-level security context
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
   securityContext: {}
+
+  ## Container-level security context for this component's main container.
+  ## Merged over the shared .Values.global.containerSecurityContext default,
+  ## with the values here winning on key collisions. Use it to override the
+  ## shared default per component (e.g. `readOnlyRootFilesystem: false`).
+  containerSecurityContext: {}
 
   ## List of node taints to tolerate (requires Kubernetes >= 1.6)
   tolerations: []
@@ -420,10 +444,16 @@ dlx:
   ##
   nodeSelector: {}
 
-  ## Deployment security context
+  ## Pod-level security context
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
   securityContext: {}
+
+  ## Container-level security context for this component's main container.
+  ## Merged over the shared .Values.global.containerSecurityContext default,
+  ## with the values here winning on key collisions. Use it to override the
+  ## shared default per component (e.g. `readOnlyRootFilesystem: false`).
+  containerSecurityContext: {}
 
   ## List of node taints to tolerate (requires Kubernetes >= 1.6)
   tolerations: []
@@ -637,6 +667,23 @@ platform: {}
 # global is a stanza that is used if this is used as a subchart. Ignore otherwise
 global:
   externalHostAddress:
+
+  # Shared container-level securityContext applied to every Nuclio service
+  # container (dashboard/controller/dlx/autoscaler). Set once here to harden
+  # all components; override per component via <component>.containerSecurityContext.
+  # Empty by default so the chart renders unchanged unless hardening is configured.
+  # Note: readOnlyRootFilesystem: true on the dashboard requires
+  # dashboard.writableTmpVolume: true (the embedded builder writes under /tmp).
+  # Example hardened set:
+  #   allowPrivilegeEscalation: false
+  #   capabilities:
+  #     drop:
+  #       - ALL
+  #   readOnlyRootFilesystem: true
+  #   runAsNonRoot: true
+  #   runAsUser: 1000
+  containerSecurityContext: {}
+
   # image pull secrets shared by Nuclio service deployments (dashboard/controller/dlx/autoscaler)
   # imagePullSecrets:
   #   - name: my-registry-secret


### PR DESCRIPTION
### 📝 Description

Aligns the four deployed Nuclio system components (dashboard, controller, dlx, autoscaler) with the security baseline in IG4-2306 (via IG4-3021). 
The chart previously exposed only a **pod-level** `securityContext`, which cannot carry the container-scoped fields the baseline requires (`allowPrivilegeEscalation`, `capabilities.drop`, `readOnlyRootFilesystem`). This adds an opt-in **container-level** `securityContext` hook — a shared default with per-component overrides — plus an optional writable `/tmp` volume for the dashboard so it can run under a read-only root filesystem.

Defaults are empty, so rendered manifests are unchanged unless hardening is explicitly configured.

---

### 🛠️ Changes Made
- `_helpers.tpl`: new `nuclio.containerSecurityContext` helper that merges `global.containerSecurityContext` with the per-component `<component>.containerSecurityContext` (the component override wins) and renders nothing when both are empty; plus per-component shortcut templates for dashboard/controller/dlx/autoscaler.
- Deployment templates (dashboard/controller/dlx/autoscaler): render a container-level `securityContext` on each main container via the helper. The existing pod-level `securityContext` is left untouched.
- Dashboard: new `dashboard.writableTmpVolume` flag that adds an `emptyDir` volume mounted at `/tmp`, so the embedded builder (build temp dirs, `/tmp/kaniko-builds`, fetched templates) keeps working when `readOnlyRootFilesystem: true`.
- `values.yaml`: add `global.containerSecurityContext` (empty, with a commented hardened example), a per-component `containerSecurityContext: {}` on all four components, and `dashboard.writableTmpVolume: false`. Also relabels the existing pod `securityContext` comment from "Deployment security context" to "Pod-level security context".

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
- `helm lint` passes.
- `helm template` with defaults renders unchanged — no container `securityContext`, no `/tmp` volume — confirming the change is non-breaking.
- `helm template` with a hardened `global.containerSecurityContext`, `dashboard.writableTmpVolume=true`, and a dashboard override `containerSecurityContext.readOnlyRootFilesystem=false`: all four containers get the full container context; the per-component override correctly wins for the dashboard (`readOnlyRootFilesystem: false` while the others inherit `true`); the `/tmp` `emptyDir` + mount render only when the flag is set; the existing docker-sock mount is unaffected.
- This chart has no automated unit tests.

---

### 🔗 References
- Ticket link: IG4-3021
- External links: Parent feature IG4-2306

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

All new values default to empty/`false`, so the rendered manifests are identical unless hardening is explicitly configured.

---

### 🔍️ Additional Notes
- This PR adds the chart capability only; enabling the hardening is left to the chart consumer setting `global.containerSecurityContext` and `dashboard.writableTmpVolume`.
- controller/dlx/autoscaler can run `readOnlyRootFilesystem: true` with no writable volume (they write nothing to disk at runtime); only the dashboard needs the `/tmp` `emptyDir`.