### PR TITLE
[Infra] Add auth-proxy sidecar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,7 @@ DOCKER_IMAGES_RULES ?= \
 	processor \
 	autoscaler \
 	dlx \
+	auth-proxy \
 	handler-builder-golang-onbuild \
 	handler-builder-java-onbuild \
 	handler-builder-ruby-onbuild \
@@ -454,6 +455,30 @@ dlx: build-builder
 ifneq ($(filter dlx,$(DOCKER_IMAGES_RULES)),)
 $(eval IMAGES_TO_PUSH += $(NUCLIO_DOCKER_DLX_IMAGE_NAME))
 $(eval DOCKER_IMAGES_CACHE += $(NUCLIO_DOCKER_DLX_IMAGE_NAME_CACHE))
+endif
+
+# Auth-proxy
+NUCLIO_DOCKER_AUTH_PROXY_IMAGE_NAME=$(NUCLIO_DOCKER_REPO)/auth-proxy:$(NUCLIO_DOCKER_IMAGE_TAG)
+NUCLIO_DOCKER_AUTH_PROXY_IMAGE_NAME_CACHE=$(NUCLIO_CACHE_REPO)/auth-proxy:$(NUCLIO_DOCKER_IMAGE_CACHE_TAG)
+
+.PHONY: auth-proxy
+auth-proxy: build-builder
+	docker build \
+		--build-arg ALPINE_IMAGE=$(NUCLIO_DOCKER_ALPINE_IMAGE) \
+		--build-arg NUCLIO_GO_LINK_FLAGS_INJECT_VERSION="$(GO_LINK_FLAGS_INJECT_VERSION)" \
+		--build-arg NUCLIO_DOCKER_IMAGE_TAG=$(NUCLIO_DOCKER_IMAGE_TAG) \
+		--build-arg NUCLIO_DOCKER_REPO=$(NUCLIO_DOCKER_REPO) \
+		--build-arg BUILDKIT_INLINE_CACHE=1 \
+		--cache-from $(NUCLIO_DOCKER_AUTH_PROXY_IMAGE_NAME_CACHE) \
+		--file cmd/authproxy/Dockerfile \
+		--tag $(NUCLIO_DOCKER_AUTH_PROXY_IMAGE_NAME) \
+		--tag $(NUCLIO_DOCKER_AUTH_PROXY_IMAGE_NAME_CACHE) \
+		--platform $(NUCLIO_OS)/$(NUCLIO_ARCH) \
+		$(NUCLIO_DOCKER_LABELS) .
+
+ifneq ($(filter auth-proxy,$(DOCKER_IMAGES_RULES)),)
+$(eval IMAGES_TO_PUSH += $(NUCLIO_DOCKER_AUTH_PROXY_IMAGE_NAME))
+$(eval DOCKER_IMAGES_CACHE += $(NUCLIO_DOCKER_AUTH_PROXY_IMAGE_NAME_CACHE))
 endif
 
 #

--- a/cmd/authproxy/Dockerfile
+++ b/cmd/authproxy/Dockerfile
@@ -1,0 +1,40 @@
+# Copyright 2026 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Build stage: builds the auth-proxy binary
+#
+
+ARG ALPINE_IMAGE
+ARG NUCLIO_DOCKER_REPO
+ARG NUCLIO_DOCKER_IMAGE_TAG
+
+FROM $NUCLIO_DOCKER_REPO/nuclio-builder:$NUCLIO_DOCKER_IMAGE_TAG as build-auth-proxy
+
+ARG NUCLIO_GO_LINK_FLAGS_INJECT_VERSION
+
+# build auth-proxy
+RUN go build \
+    -ldflags="${NUCLIO_GO_LINK_FLAGS_INJECT_VERSION}" \
+    -o auth-proxy cmd/authproxy/main.go
+
+FROM $ALPINE_IMAGE
+
+RUN apk upgrade --no-cache \
+    && apk add --no-cache ca-certificates
+
+# copy auth-proxy binary from build stage
+COPY --from=build-auth-proxy /nuclio/auth-proxy /usr/local/bin
+
+CMD [ "auth-proxy" ]

--- a/cmd/authproxy/app/authproxy.go
+++ b/cmd/authproxy/app/authproxy.go
@@ -17,15 +17,11 @@ limitations under the License.
 package app
 
 import (
-	"fmt"
-	"net/http"
-
 	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/loggersink"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
 	"github.com/nuclio/errors"
-	"github.com/nuclio/logger"
 
 	// register logger sinks (stdout, appinsights) into the loggersink registry via init()
 	_ "github.com/nuclio/nuclio/pkg/sinks"
@@ -60,87 +56,6 @@ func Run(mode auth.ProxyMode,
 		return errors.Wrap(err, "Failed to start auth-proxy server")
 	}
 	select {}
-}
-
-// server fronts a function or the DLX.
-type server struct {
-	logger      logger.Logger
-	httpServer  *http.Server
-	upstreamURL string
-	authURL     string
-	signinURL   string
-}
-
-// newServer builds the auth-proxy for the given mode. The mode decides only where it listens and what it
-// serves: reverseProxy is exposed to the cluster on a configurable port and forwards to the processor;
-// authOnly is reachable only from within the pod (loopback) and serves the DLX /auth endpoint.
-func newServer(parentLogger logger.Logger,
-	mode auth.ProxyMode,
-	listenPort int,
-	upstreamURL string,
-	authURL string,
-	signinURL string) (*server, error) {
-
-	var listenAddress string
-	var handler http.Handler
-	authLogger := parentLogger.GetChild("authproxy")
-
-	switch mode {
-	case auth.ProxyModeReverseProxy:
-		listenAddress = fmt.Sprintf(":%d", listenPort)
-		handler = newReverseProxyHandler(authLogger)
-	case auth.ProxyModeAuthOnly:
-		listenAddress = fmt.Sprintf("127.0.0.1:%d", listenPort)
-		handler = newAuthOnlyHandler(authLogger)
-	default:
-		return nil, errors.Errorf("Unknown auth-proxy mode: %s", mode)
-	}
-
-	return &server{
-		logger: authLogger,
-		httpServer: &http.Server{
-			Addr:    listenAddress,
-			Handler: handler,
-		},
-		upstreamURL: upstreamURL,
-		authURL:     authURL,
-		signinURL:   signinURL,
-	}, nil
-}
-
-func (s *server) start() error {
-	s.logger.InfoWith("Starting auth-proxy",
-		"listenAddress", s.httpServer.Addr,
-		"upstreamURL", s.upstreamURL,
-		"authURL", s.authURL,
-		"signinURL", s.signinURL)
-
-	if err := s.httpServer.ListenAndServe(); err != nil {
-		return errors.Wrap(err, "Auth-proxy server failed to start")
-	}
-
-	return nil
-}
-
-// newReverseProxyHandler serves the running-function topology. It does not forward requests upstream yet:
-// authenticating and proxying to the processor over loopback is implemented in NUC-828 / NUC-837.
-func newReverseProxyHandler(logger logger.Logger) http.Handler {
-	return http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
-		logger.Warn("reverseProxy forwarding is not yet implemented")
-		responseWriter.WriteHeader(http.StatusNotImplemented)
-	})
-}
-
-// newAuthOnlyHandler serves the DLX /auth decision endpoint. Only /auth is routed; any other path
-// returns 404, pinning the endpoint surface now so the NUC-837 decision logic slots into /auth.
-func newAuthOnlyHandler(logger logger.Logger) http.Handler {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/auth", func(responseWriter http.ResponseWriter, _ *http.Request) {
-		//TODO: implement authOnly decision as part of NUC-837
-		logger.Warn("authOnly mode was requested but is not yet implemented")
-		responseWriter.WriteHeader(http.StatusNotImplemented)
-	})
-	return mux
 }
 
 func validateConfiguration(listenPort int, upstreamURL string, authURL string, signinURL string) error {

--- a/cmd/authproxy/app/authproxy.go
+++ b/cmd/authproxy/app/authproxy.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/loggersink"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+
+	// register logger sinks (stdout, appinsights) into the loggersink registry via init()
+	_ "github.com/nuclio/nuclio/pkg/sinks"
+)
+
+// server fronts a function or the DLX.
+type server struct {
+	logger      logger.Logger
+	httpServer  *http.Server
+	upstreamURL string
+	authURL     string
+	redirectURL string
+}
+
+// Run creates and starts the auth-proxy server for the given mode.
+func Run(mode auth.ProxyMode,
+	listenPort int,
+	upstreamURL string,
+	authURL string,
+	redirectURL string,
+	platformConfigurationPath string) error {
+	if err := validateConfiguration(listenPort, upstreamURL, authURL, redirectURL); err != nil {
+		return errors.Wrap(err, "Invalid auth-proxy configuration")
+	}
+
+	platformConfiguration, err := platformconfig.NewPlatformConfig(platformConfigurationPath)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get platform configuration")
+	}
+
+	rootLogger, err := loggersink.CreateSystemLogger("auth-proxy", platformConfiguration)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create logger")
+	}
+
+	server, err := newServer(rootLogger, mode, listenPort, upstreamURL, authURL, redirectURL)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create auth-proxy server")
+	}
+	if err := server.start(); err != nil {
+		return errors.Wrap(err, "Failed to start auth-proxy server")
+	}
+	select {}
+}
+
+// newServer builds the auth-proxy for the given mode. The mode decides only where it listens and what it
+// serves: reverse-proxy is exposed to the cluster on a configurable port and forwards to the processor;
+// auth-only is reachable only from within the pod (loopback) and serves the DLX /auth endpoint.
+func newServer(parentLogger logger.Logger,
+	mode auth.ProxyMode,
+	listenPort int,
+	upstreamURL string,
+	authURL string,
+	redirectURL string) (*server, error) {
+
+	var listenAddress string
+	var handler http.Handler
+	logger := parentLogger.GetChild("authproxy")
+
+	switch mode {
+	case auth.ProxyModeReverseProxy:
+		listenAddress = fmt.Sprintf(":%d", listenPort)
+		handler = newReverseProxyHandler(logger)
+	case auth.ProxyModeAuthOnly:
+		listenAddress = fmt.Sprintf("127.0.0.1:%d", listenPort)
+		handler = newAuthOnlyHandler(logger)
+	default:
+		return nil, errors.Errorf("Unknown auth-proxy mode: %s", mode)
+	}
+
+	return &server{
+		logger: logger,
+		httpServer: &http.Server{
+			Addr:    listenAddress,
+			Handler: handler,
+		},
+		upstreamURL: upstreamURL,
+		authURL:     authURL,
+		redirectURL: redirectURL,
+	}, nil
+}
+
+func (s *server) start() error {
+	s.logger.InfoWith("Starting auth-proxy",
+		"listenAddress", s.httpServer.Addr,
+		"upstreamURL", s.upstreamURL,
+		"authURL", s.authURL,
+		"redirectURL", s.redirectURL)
+
+	go func() {
+		if err := s.httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			s.logger.ErrorWith("Auth-proxy server stopped", "error", err)
+		}
+	}()
+
+	return nil
+}
+
+// newReverseProxyHandler serves the running-function topology. It does not forward requests upstream yet:
+// authenticating and proxying to the processor over loopback is implemented in NUC-828 / NUC-837.
+func newReverseProxyHandler(logger logger.Logger) http.Handler {
+	return http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
+		logger.Warn("reverse-proxy forwarding is not yet implemented")
+		responseWriter.WriteHeader(http.StatusNotImplemented)
+	})
+}
+
+// newAuthOnlyHandler serves the DLX /auth decision endpoint. Only /auth is routed; any other path
+// returns 404, pinning the endpoint surface now so the NUC-837 decision logic slots into /auth.
+func newAuthOnlyHandler(logger logger.Logger) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth", func(responseWriter http.ResponseWriter, _ *http.Request) {
+		//TODO - implement auth-only decision as part of NUC-837
+		logger.Warn("auth-only mode was requested but is not yet implemented")
+		responseWriter.WriteHeader(http.StatusNotImplemented)
+	})
+	return mux
+}
+
+func validateConfiguration(listenPort int, upstreamURL string, authURL string, redirectURL string) error {
+	if listenPort == 0 {
+		return errors.Errorf("Invalid listen port: %d", listenPort)
+	}
+
+	if upstreamURL == "" {
+		return errors.New("Upstream URL must be provided")
+	}
+
+	if authURL == "" {
+		return errors.New("Auth URL must be provided")
+	}
+
+	if redirectURL == "" {
+		return errors.New("Redirect URL must be provided")
+	}
+
+	return nil
+}

--- a/cmd/authproxy/app/authproxy.go
+++ b/cmd/authproxy/app/authproxy.go
@@ -31,23 +31,14 @@ import (
 	_ "github.com/nuclio/nuclio/pkg/sinks"
 )
 
-// server fronts a function or the DLX.
-type server struct {
-	logger      logger.Logger
-	httpServer  *http.Server
-	upstreamURL string
-	authURL     string
-	redirectURL string
-}
-
 // Run creates and starts the auth-proxy server for the given mode.
 func Run(mode auth.ProxyMode,
 	listenPort int,
 	upstreamURL string,
 	authURL string,
-	redirectURL string,
+	signinURL string,
 	platformConfigurationPath string) error {
-	if err := validateConfiguration(listenPort, upstreamURL, authURL, redirectURL); err != nil {
+	if err := validateConfiguration(listenPort, upstreamURL, authURL, signinURL); err != nil {
 		return errors.Wrap(err, "Invalid auth-proxy configuration")
 	}
 
@@ -61,7 +52,7 @@ func Run(mode auth.ProxyMode,
 		return errors.Wrap(err, "Failed to create logger")
 	}
 
-	server, err := newServer(rootLogger, mode, listenPort, upstreamURL, authURL, redirectURL)
+	server, err := newServer(rootLogger, mode, listenPort, upstreamURL, authURL, signinURL)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create auth-proxy server")
 	}
@@ -71,15 +62,24 @@ func Run(mode auth.ProxyMode,
 	select {}
 }
 
+// server fronts a function or the DLX.
+type server struct {
+	logger      logger.Logger
+	httpServer  *http.Server
+	upstreamURL string
+	authURL     string
+	signinURL   string
+}
+
 // newServer builds the auth-proxy for the given mode. The mode decides only where it listens and what it
-// serves: reverse-proxy is exposed to the cluster on a configurable port and forwards to the processor;
-// auth-only is reachable only from within the pod (loopback) and serves the DLX /auth endpoint.
+// serves: reverseProxy is exposed to the cluster on a configurable port and forwards to the processor;
+// authOnly is reachable only from within the pod (loopback) and serves the DLX /auth endpoint.
 func newServer(parentLogger logger.Logger,
 	mode auth.ProxyMode,
 	listenPort int,
 	upstreamURL string,
 	authURL string,
-	redirectURL string) (*server, error) {
+	signinURL string) (*server, error) {
 
 	var listenAddress string
 	var handler http.Handler
@@ -104,7 +104,7 @@ func newServer(parentLogger logger.Logger,
 		},
 		upstreamURL: upstreamURL,
 		authURL:     authURL,
-		redirectURL: redirectURL,
+		signinURL:   signinURL,
 	}, nil
 }
 
@@ -113,13 +113,11 @@ func (s *server) start() error {
 		"listenAddress", s.httpServer.Addr,
 		"upstreamURL", s.upstreamURL,
 		"authURL", s.authURL,
-		"redirectURL", s.redirectURL)
+		"signinURL", s.signinURL)
 
-	go func() {
-		if err := s.httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			s.logger.ErrorWith("Auth-proxy server stopped", "error", err)
-		}
-	}()
+	if err := s.httpServer.ListenAndServe(); err != nil {
+		return errors.Wrap(err, "Auth-proxy server failed to start")
+	}
 
 	return nil
 }
@@ -128,7 +126,7 @@ func (s *server) start() error {
 // authenticating and proxying to the processor over loopback is implemented in NUC-828 / NUC-837.
 func newReverseProxyHandler(logger logger.Logger) http.Handler {
 	return http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
-		logger.Warn("reverse-proxy forwarding is not yet implemented")
+		logger.Warn("reverseProxy forwarding is not yet implemented")
 		responseWriter.WriteHeader(http.StatusNotImplemented)
 	})
 }
@@ -138,14 +136,14 @@ func newReverseProxyHandler(logger logger.Logger) http.Handler {
 func newAuthOnlyHandler(logger logger.Logger) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/auth", func(responseWriter http.ResponseWriter, _ *http.Request) {
-		//TODO - implement auth-only decision as part of NUC-837
-		logger.Warn("auth-only mode was requested but is not yet implemented")
+		//TODO - implement authOnly decision as part of NUC-837
+		logger.Warn("authOnly mode was requested but is not yet implemented")
 		responseWriter.WriteHeader(http.StatusNotImplemented)
 	})
 	return mux
 }
 
-func validateConfiguration(listenPort int, upstreamURL string, authURL string, redirectURL string) error {
+func validateConfiguration(listenPort int, upstreamURL string, authURL string, signinURL string) error {
 	if listenPort == 0 {
 		return errors.Errorf("Invalid listen port: %d", listenPort)
 	}
@@ -158,7 +156,7 @@ func validateConfiguration(listenPort int, upstreamURL string, authURL string, r
 		return errors.New("Auth URL must be provided")
 	}
 
-	if redirectURL == "" {
+	if signinURL == "" {
 		return errors.New("Redirect URL must be provided")
 	}
 

--- a/cmd/authproxy/app/authproxy.go
+++ b/cmd/authproxy/app/authproxy.go
@@ -83,21 +83,21 @@ func newServer(parentLogger logger.Logger,
 
 	var listenAddress string
 	var handler http.Handler
-	logger := parentLogger.GetChild("authproxy")
+	authLogger := parentLogger.GetChild("authproxy")
 
 	switch mode {
 	case auth.ProxyModeReverseProxy:
 		listenAddress = fmt.Sprintf(":%d", listenPort)
-		handler = newReverseProxyHandler(logger)
+		handler = newReverseProxyHandler(authLogger)
 	case auth.ProxyModeAuthOnly:
 		listenAddress = fmt.Sprintf("127.0.0.1:%d", listenPort)
-		handler = newAuthOnlyHandler(logger)
+		handler = newAuthOnlyHandler(authLogger)
 	default:
 		return nil, errors.Errorf("Unknown auth-proxy mode: %s", mode)
 	}
 
 	return &server{
-		logger: logger,
+		logger: authLogger,
 		httpServer: &http.Server{
 			Addr:    listenAddress,
 			Handler: handler,
@@ -136,7 +136,7 @@ func newReverseProxyHandler(logger logger.Logger) http.Handler {
 func newAuthOnlyHandler(logger logger.Logger) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/auth", func(responseWriter http.ResponseWriter, _ *http.Request) {
-		//TODO - implement authOnly decision as part of NUC-837
+		//TODO: implement authOnly decision as part of NUC-837
 		logger.Warn("authOnly mode was requested but is not yet implemented")
 		responseWriter.WriteHeader(http.StatusNotImplemented)
 	})
@@ -144,7 +144,8 @@ func newAuthOnlyHandler(logger logger.Logger) http.Handler {
 }
 
 func validateConfiguration(listenPort int, upstreamURL string, authURL string, signinURL string) error {
-	if listenPort == 0 {
+	// TCP ports are 16-bit unsigned integers, so the valid range is 1-65535 (0 is reserved)
+	if listenPort < 1 || listenPort > 65535 {
 		return errors.Errorf("Invalid listen port: %d", listenPort)
 	}
 

--- a/cmd/authproxy/app/authproxy_test.go
+++ b/cmd/authproxy/app/authproxy_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package app
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -53,7 +54,7 @@ func (suite *AuthProxyTestSuite) TestModeListenAddress() {
 		{name: "authOnly is loopback", mode: auth.ProxyModeAuthOnly, expectedListenAddress: "127.0.0.1:8080"},
 	} {
 		suite.Run(testCase.name, func() {
-			server, err := newServer(suite.logger, testCase.mode, 8080, "http://127.0.0.1:6080", "", "")
+			server, err := newServer(suite.logger, testCase.mode, 8080, "http://127.0.0.1:8080", "", "")
 			suite.Require().NoError(err)
 			suite.Require().Equal(testCase.expectedListenAddress, server.httpServer.Addr)
 		})
@@ -77,7 +78,11 @@ func (suite *AuthProxyTestSuite) TestAuthOnlyHandlerRouting() {
 		suite.Run(testCase.name, func() {
 			response, err := http.Get(handlerServer.URL + testCase.path)
 			suite.Require().NoError(err)
-			defer response.Body.Close()
+			defer func(Body io.ReadCloser) {
+				if err := Body.Close(); err != nil {
+					suite.logger.WarnWith("Failed to close response body", "err", err)
+				}
+			}(response.Body)
 
 			suite.Require().Equal(testCase.expectedStatusCode, response.StatusCode)
 		})

--- a/cmd/authproxy/app/authproxy_test.go
+++ b/cmd/authproxy/app/authproxy_test.go
@@ -1,0 +1,95 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/auth"
+
+	"github.com/nuclio/logger"
+	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type AuthProxyTestSuite struct {
+	suite.Suite
+	logger logger.Logger
+}
+
+func (suite *AuthProxyTestSuite) SetupTest() {
+	var err error
+	suite.logger, err = nucliozap.NewNuclioZapTest("auth-proxy-test")
+	suite.Require().NoError(err)
+}
+
+// TestModeListenAddress verifies the only difference between the modes: reverse-proxy is exposed on the
+// configurable port, auth-only is bound to loopback (reachable only from within the pod).
+func (suite *AuthProxyTestSuite) TestModeListenAddress() {
+	for _, testCase := range []struct {
+		name                  string
+		mode                  auth.ProxyMode
+		expectedListenAddress string
+	}{
+		{name: "reverse-proxy is exposed", mode: auth.ProxyModeReverseProxy, expectedListenAddress: ":8080"},
+		{name: "auth-only is loopback", mode: auth.ProxyModeAuthOnly, expectedListenAddress: "127.0.0.1:8080"},
+	} {
+		suite.Run(testCase.name, func() {
+			server, err := newServer(suite.logger, testCase.mode, 8080, "http://127.0.0.1:6080", "", "")
+			suite.Require().NoError(err)
+			suite.Require().Equal(testCase.expectedListenAddress, server.httpServer.Addr)
+		})
+	}
+}
+
+// TestAuthOnlyHandlerRouting verifies only /auth is served (reserved for NUC-837); any other path 404s.
+func (suite *AuthProxyTestSuite) TestAuthOnlyHandlerRouting() {
+	handlerServer := httptest.NewServer(newAuthOnlyHandler(suite.logger))
+	defer handlerServer.Close()
+
+	for _, testCase := range []struct {
+		name               string
+		path               string
+		expectedStatusCode int
+	}{
+		{name: "auth endpoint reserved for NUC-837", path: "/auth", expectedStatusCode: http.StatusNotImplemented},
+		{name: "root not routed", path: "/", expectedStatusCode: http.StatusNotFound},
+		{name: "arbitrary path not routed", path: "/invoke", expectedStatusCode: http.StatusNotFound},
+	} {
+		suite.Run(testCase.name, func() {
+			response, err := http.Get(handlerServer.URL + testCase.path)
+			suite.Require().NoError(err)
+			defer response.Body.Close()
+
+			suite.Require().Equal(testCase.expectedStatusCode, response.StatusCode)
+		})
+	}
+}
+
+func (suite *AuthProxyTestSuite) TestUnknownModeRejected() {
+	_, err := newServer(suite.logger, "unknown-mode", 8080, "http://127.0.0.1:6080", "", "")
+	suite.Require().Error(err)
+	suite.Require().Contains(err.Error(), "Unknown auth-proxy mode")
+}
+
+func TestAuthProxyTestSuite(t *testing.T) {
+	suite.Run(t, new(AuthProxyTestSuite))
+}

--- a/cmd/authproxy/app/authproxy_test.go
+++ b/cmd/authproxy/app/authproxy_test.go
@@ -41,16 +41,16 @@ func (suite *AuthProxyTestSuite) SetupTest() {
 	suite.Require().NoError(err)
 }
 
-// TestModeListenAddress verifies the only difference between the modes: reverse-proxy is exposed on the
-// configurable port, auth-only is bound to loopback (reachable only from within the pod).
+// TestModeListenAddress verifies the only difference between the modes: reverseProxy is exposed on the
+// configurable port, authOnly is bound to loopback (reachable only from within the pod).
 func (suite *AuthProxyTestSuite) TestModeListenAddress() {
 	for _, testCase := range []struct {
 		name                  string
 		mode                  auth.ProxyMode
 		expectedListenAddress string
 	}{
-		{name: "reverse-proxy is exposed", mode: auth.ProxyModeReverseProxy, expectedListenAddress: ":8080"},
-		{name: "auth-only is loopback", mode: auth.ProxyModeAuthOnly, expectedListenAddress: "127.0.0.1:8080"},
+		{name: "reverseProxy is exposed", mode: auth.ProxyModeReverseProxy, expectedListenAddress: ":8080"},
+		{name: "authOnly is loopback", mode: auth.ProxyModeAuthOnly, expectedListenAddress: "127.0.0.1:8080"},
 	} {
 		suite.Run(testCase.name, func() {
 			server, err := newServer(suite.logger, testCase.mode, 8080, "http://127.0.0.1:6080", "", "")

--- a/cmd/authproxy/app/server.go
+++ b/cmd/authproxy/app/server.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/nuclio/nuclio/pkg/auth"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+)
+
+// server fronts a function or the DLX.
+type server struct {
+	logger      logger.Logger
+	httpServer  *http.Server
+	upstreamURL string
+	authURL     string
+	signinURL   string
+}
+
+// newServer builds the auth-proxy for the given mode. The mode decides only where it listens and what it
+// serves: reverseProxy is exposed to the cluster on a configurable port and forwards to the processor;
+// authOnly is reachable only from within the pod (loopback) and serves the DLX /auth endpoint.
+func newServer(parentLogger logger.Logger,
+	mode auth.ProxyMode,
+	listenPort int,
+	upstreamURL string,
+	authURL string,
+	signinURL string) (*server, error) {
+
+	var listenAddress string
+	var handler http.Handler
+
+	switch mode {
+	case auth.ProxyModeReverseProxy:
+		listenAddress = fmt.Sprintf(":%d", listenPort)
+		handler = newReverseProxyHandler(parentLogger)
+	case auth.ProxyModeAuthOnly:
+		listenAddress = fmt.Sprintf("127.0.0.1:%d", listenPort)
+		handler = newAuthOnlyHandler(parentLogger)
+	default:
+		return nil, errors.Errorf("Unknown auth-proxy mode: %s", mode)
+	}
+
+	return &server{
+		logger: parentLogger,
+		httpServer: &http.Server{
+			Addr:    listenAddress,
+			Handler: handler,
+		},
+		upstreamURL: upstreamURL,
+		authURL:     authURL,
+		signinURL:   signinURL,
+	}, nil
+}
+
+func (s *server) start() error {
+	s.logger.InfoWith("Starting auth-proxy",
+		"listenAddress", s.httpServer.Addr,
+		"upstreamURL", s.upstreamURL,
+		"authURL", s.authURL,
+		"signinURL", s.signinURL)
+
+	if err := s.httpServer.ListenAndServe(); err != nil {
+		return errors.Wrap(err, "Auth-proxy server failed to start")
+	}
+
+	return nil
+}
+
+// newReverseProxyHandler serves the running-function topology. It does not forward requests upstream yet:
+// authenticating and proxying to the processor over loopback is implemented in NUC-828 / NUC-837.
+func newReverseProxyHandler(logger logger.Logger) http.Handler {
+	return http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
+		logger.Warn("reverseProxy forwarding is not yet implemented")
+		responseWriter.WriteHeader(http.StatusNotImplemented)
+	})
+}
+
+// newAuthOnlyHandler serves the DLX /auth decision endpoint. Only /auth is routed; any other path
+// returns 404, pinning the endpoint surface now so the NUC-837 decision logic slots into /auth.
+func newAuthOnlyHandler(logger logger.Logger) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth", func(responseWriter http.ResponseWriter, _ *http.Request) {
+		//TODO: implement authOnly decision as part of NUC-837
+		logger.Warn("authOnly mode was requested but is not yet implemented")
+		responseWriter.WriteHeader(http.StatusNotImplemented)
+	})
+	return mux
+}

--- a/cmd/authproxy/app/server_test.go
+++ b/cmd/authproxy/app/server_test.go
@@ -31,12 +31,12 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type AuthProxyTestSuite struct {
+type ServerTestSuite struct {
 	suite.Suite
 	logger logger.Logger
 }
 
-func (suite *AuthProxyTestSuite) SetupTest() {
+func (suite *ServerTestSuite) SetupTest() {
 	var err error
 	suite.logger, err = nucliozap.NewNuclioZapTest("auth-proxy-test")
 	suite.Require().NoError(err)
@@ -44,7 +44,7 @@ func (suite *AuthProxyTestSuite) SetupTest() {
 
 // TestModeListenAddress verifies the only difference between the modes: reverseProxy is exposed on the
 // configurable port, authOnly is bound to loopback (reachable only from within the pod).
-func (suite *AuthProxyTestSuite) TestModeListenAddress() {
+func (suite *ServerTestSuite) TestModeListenAddress() {
 	for _, testCase := range []struct {
 		name                  string
 		mode                  auth.ProxyMode
@@ -62,7 +62,7 @@ func (suite *AuthProxyTestSuite) TestModeListenAddress() {
 }
 
 // TestAuthOnlyHandlerRouting verifies only /auth is served (reserved for NUC-837); any other path 404s.
-func (suite *AuthProxyTestSuite) TestAuthOnlyHandlerRouting() {
+func (suite *ServerTestSuite) TestAuthOnlyHandlerRouting() {
 	handlerServer := httptest.NewServer(newAuthOnlyHandler(suite.logger))
 	defer handlerServer.Close()
 
@@ -89,12 +89,12 @@ func (suite *AuthProxyTestSuite) TestAuthOnlyHandlerRouting() {
 	}
 }
 
-func (suite *AuthProxyTestSuite) TestUnknownModeRejected() {
+func (suite *ServerTestSuite) TestUnknownModeRejected() {
 	_, err := newServer(suite.logger, "unknown-mode", 8080, "http://127.0.0.1:6080", "", "")
 	suite.Require().Error(err)
 	suite.Require().Contains(err.Error(), "Unknown auth-proxy mode")
 }
 
-func TestAuthProxyTestSuite(t *testing.T) {
-	suite.Run(t, new(AuthProxyTestSuite))
+func TestServerTestSuite(t *testing.T) {
+	suite.Run(t, new(ServerTestSuite))
 }

--- a/cmd/authproxy/main.go
+++ b/cmd/authproxy/main.go
@@ -28,11 +28,11 @@ import (
 )
 
 func main() {
-	mode := flag.String("mode", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_MODE", string(auth.ProxyModeReverseProxy)), "Auth-proxy mode: reverse-proxy or auth-only")
+	mode := flag.String("mode", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_MODE", string(auth.ProxyModeReverseProxy)), "Auth-proxy mode: reverseProxy or authOnly")
 	listenPort := flag.Int("listen-port", common.GetEnvOrDefaultInt("NUCLIO_AUTHPROXY_LISTEN_PORT", 8080), "Port the auth-proxy listens on")
 	upstreamURL := flag.String("upstream-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_UPSTREAM_URL", "http://127.0.0.1:6080"), "URL of the upstream service (processor) to forward requests to")
-	authURL := flag.String("auth-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_AUTH_URL", ""), "URL of the authentication endpoint (Orca GetSelf)")
-	redirectURL := flag.String("redirect-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_REDIRECT_URL", ""), "URL unauthenticated browser requests are redirected to (oauth2-proxy /oauth2/start)")
+	authURL := flag.String("auth-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_AUTH_URL", ""), "URL of the authentication endpoint")
+	signinURL := flag.String("signin-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_SIGNIN_URL", ""), "URL unauthenticated browser requests are redirected to sign-in")
 	platformConfigurationPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
 	flag.Parse()
 
@@ -40,7 +40,7 @@ func main() {
 		*listenPort,
 		*upstreamURL,
 		*authURL,
-		*redirectURL,
+		*signinURL,
 		*platformConfigurationPath); err != nil {
 		errors.PrintErrorStack(os.Stderr, err, 5)
 		os.Exit(1)

--- a/cmd/authproxy/main.go
+++ b/cmd/authproxy/main.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/nuclio/nuclio/cmd/authproxy/app"
+	"github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/common"
+
+	"github.com/nuclio/errors"
+)
+
+func main() {
+	mode := flag.String("mode", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_MODE", string(auth.ProxyModeReverseProxy)), "Auth-proxy mode: reverse-proxy or auth-only")
+	listenPort := flag.Int("listen-port", common.GetEnvOrDefaultInt("NUCLIO_AUTHPROXY_LISTEN_PORT", 8080), "Port the auth-proxy listens on")
+	upstreamURL := flag.String("upstream-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_UPSTREAM_URL", "http://127.0.0.1:6080"), "URL of the upstream service (processor) to forward requests to")
+	authURL := flag.String("auth-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_AUTH_URL", ""), "URL of the authentication endpoint (Orca GetSelf)")
+	redirectURL := flag.String("redirect-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_REDIRECT_URL", ""), "URL unauthenticated browser requests are redirected to (oauth2-proxy /oauth2/start)")
+	platformConfigurationPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
+	flag.Parse()
+
+	if err := app.Run(auth.ProxyMode(*mode),
+		*listenPort,
+		*upstreamURL,
+		*authURL,
+		*redirectURL,
+		*platformConfigurationPath); err != nil {
+		errors.PrintErrorStack(os.Stderr, err, 5)
+		os.Exit(1)
+	}
+}

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -29,6 +29,17 @@ const (
 	KindIguazioV4 = "iguazio-v4"
 )
 
+// ProxyMode selects how the auth-proxy operates.
+type ProxyMode string
+
+const (
+	// ProxyModeReverseProxy fronts a function: authenticates each request, forwards allowed ones to the processor.
+	ProxyModeReverseProxy ProxyMode = "reverse-proxy"
+
+	// ProxyModeAuthOnly serves only the /auth endpoint (called by the DLX); does no forwarding.
+	ProxyModeAuthOnly ProxyMode = "auth-only"
+)
+
 type SessionContextKey string
 
 const (

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -34,10 +34,10 @@ type ProxyMode string
 
 const (
 	// ProxyModeReverseProxy fronts a function: authenticates each request, forwards allowed ones to the processor.
-	ProxyModeReverseProxy ProxyMode = "reverse-proxy"
+	ProxyModeReverseProxy ProxyMode = "reverseProxy"
 
 	// ProxyModeAuthOnly serves only the /auth endpoint (called by the DLX); does no forwarding.
-	ProxyModeAuthOnly ProxyMode = "auth-only"
+	ProxyModeAuthOnly ProxyMode = "authOnly"
 )
 
 type SessionContextKey string

--- a/pkg/platform/kube/resourcescaler/test/resourcescaler_test.go
+++ b/pkg/platform/kube/resourcescaler/test/resourcescaler_test.go
@@ -250,7 +250,7 @@ func (suite *ResourceScalerTestSuite) TestSanity() {
 
 		// add target header, expect it to wake up the function
 		// for this specific test case, the response status code is 502
-		// reason dlx tries to reverse-proxy the request to the function by its service
+		// reason dlx tries to reverseProxy the request to the function by its service
 		// and since the dlx component is running as a process (and not as a POD)
 		// it fails to resolve the internal (kubernetes) function host
 		// Background: make DLX work in "test" mode, where it invoke the function from within the k8s cluster
@@ -348,7 +348,7 @@ func (suite *ResourceScalerTestSuite) TestMultiTargetScaleFromZero() {
 
 				// add target header, expect it to wake up both functions
 				// for this specific test case, the response status code is 502
-				// reason dlx tries to reverse-proxy the request to the function by its service
+				// reason dlx tries to reverseProxy the request to the function by its service
 				// and since the dlx component is running as a process (and not as a POD)
 				// it fails to resolve the internal (kubernetes) function host
 				// Background: make DLX work in "test" mode, where it invoke the function from within the k8s cluster


### PR DESCRIPTION
### 📝 Description

Stands up the new **auth-proxy** service image and its build/release wiring. This is the image-infrastructure slice of the Nuclio function-level auth feature: it delivers a deployable, releasable image and the mode scaffolding, but **no auth logic yet** — both request handlers are stubs.

The image is built and released through the **same mechanism as the existing `dlx` image** (no custom build path). A single image supports two topologies selected by a `--mode` flag / `NUCLIO_AUTHPROXY_MODE` env var:
- **reverse-proxy** — fronts a running function, exposed on a configurable port (`:<port>`).
- **auth-only** — serves the DLX `/auth` decision endpoint, bound to loopback (`127.0.0.1:<port>`) so it is reachable only from within the pod.

---

### 🛠️ Changes Made
- **`pkg/auth/types.go`** — new `ProxyMode` type with `ProxyModeReverseProxy` and `ProxyModeAuthOnly` constants.
- **`cmd/authproxy/main.go`** — entrypoint: flags/env for mode, listen port, upstream/auth/redirect URLs, and platform-config path.
- **`cmd/authproxy/app/authproxy.go`** — server that binds per mode (reverse-proxy → `:<port>`; auth-only → `127.0.0.1:<port>`), config validation, and two stub handlers returning `501 Not Implemented`. Auth-only routes only `/auth` (any other path → `404`), pinning the endpoint surface for NUC-837.
- **`cmd/authproxy/Dockerfile`** — two-stage build (nuclio-builder → alpine) producing the `auth-proxy` binary.
- **`Makefile`** — `auth-proxy` added to `DOCKER_IMAGES_RULES` plus its build/push/cache rules, mirroring `dlx`.
- **`cmd/authproxy/app/authproxy_test.go`** — unit tests.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

**Manual (deployed as a sidecar on a lab, both modes):**

_auth-only mode_ — bound to loopback (`127.0.0.1:9080`), `/auth` handled by the stub:
```
$ kubectl -n oris exec -it nuclio-test1-7f5698b999-vhnxn -- curl 127.0.0.1:9080
404 page not found
$ kubectl -n oris exec -it nuclio-test1-7f5698b999-vhnxn -- curl 127.0.0.1:9080/v1/something
404 page not found

$ kubectl -n oris exec -it nuclio-test1-7f5698b999-vhnxn -- curl 127.0.0.1:9080/auth
$ kubectl -n oris exec -it nuclio-test1-7f5698b999-vhnxn -- curl 127.0.0.1:9080/auth
$ kubectl -n oris logs nuclio-test1-7f5698b999-vhnxn -c auth-proxy
26.07.09 15:33:35.404 (I) auth-proxy.authproxy Starting auth-proxy {"listenAddress": "127.0.0.1:9080", "upstreamURL": "http://127.0.0.1:8080", "authURL": "http://127.0.0.1:9999/placeholder", "redirectURL": "http://127.0.0.1:9999/placeholder22"}
26.07.09 15:36:45.161 (W) auth-proxy.authproxy auth-only mode was requested but is not yet implemented
26.07.09 15:37:08.601 (W) auth-proxy.authproxy auth-only mode was requested but is not yet implemented
```

_reverse-proxy mode_ — exposed on `:9080`, request hits the stub:
```
$ kubectl -n oris exec -it nuclio-test1-55db8c758d-jcfvw -- curl 127.0.0.1:9080

$ kubectl -n oris logs nuclio-test1-55db8c758d-jcfvw -c auth-proxy
26.07.09 16:22:31.818 (I) auth-proxy.authproxy Starting auth-proxy {"listenAddress": ":9080", "upstreamURL": "http://127.0.0.1:8080", "authURL": "http://127.0.0.1:9999/placeholder", "redirectURL": "http://127.0.0.1:9999/placeholder22"}
26.07.09 16:23:11.211 (W) auth-proxy.authproxy reverse-proxy forwarding is not yet implemented
26.07.09 16:23:26.223 (W) auth-proxy.authproxy reverse-proxy forwarding is not yet implemented
```

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-827
- Design docs links: [HLD | BE | Nuclio Function-level Authentication — §2.6 Building the auth-proxy sidecar image](https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/594641703/HLD+BE+Nuclio+Function-level+Authentication#2.6-Building-the-auth-proxy-sidecar-image)
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Ships **infrastructure and mode scaffolding only** — both handlers return `501 Not Implemented`.
