### PR TITLE
[Kafka] Fix drainOnRebalance race: send on closed channel

### DIFF
--- a/pkg/processor/eventprocessor/mock.go
+++ b/pkg/processor/eventprocessor/mock.go
@@ -31,6 +31,24 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// ZeroAllocator is a no-op Allocator that owns zero workers. It is intended
+// for use in unit tests where Drain must return immediately: with no workers,
+// MergeSubscriptions returns an already-closed channel, so Drain returns as
+// soon as the loop reads the first (zero-value) message.
+type ZeroAllocator struct{}
+
+func (z *ZeroAllocator) Allocate(_ time.Duration) (EventProcessor, error) { return nil, nil }
+func (z *ZeroAllocator) Release(_ EventProcessor)                         {}
+func (z *ZeroAllocator) GetObjects() []EventProcessor                     { return nil }
+func (z *ZeroAllocator) SetObjects(_ []EventProcessor) error              { return nil }
+func (z *ZeroAllocator) GetNumObjectsAvailable() int                      { return 0 }
+func (z *ZeroAllocator) GetStatistics() *statistics.AllocatorStatistics   { return nil }
+func (z *ZeroAllocator) SignalDraining() error                            { return nil }
+func (z *ZeroAllocator) SignalContinue() error                            { return nil }
+func (z *ZeroAllocator) SignalTermination() error                         { return nil }
+func (z *ZeroAllocator) Stop() error                                      { return nil }
+func (z *ZeroAllocator) IsTerminated() bool                               { return false }
+
 type MockEventProcessor struct {
 	mock.Mock
 }

--- a/pkg/processor/trigger/kafka/kafka_test.go
+++ b/pkg/processor/trigger/kafka/kafka_test.go
@@ -19,7 +19,10 @@ limitations under the License.
 package kafka
 
 import (
+	"bytes"
+	"context"
 	"crypto/tls"
+	"sync"
 	"os"
 	"path"
 	"testing"
@@ -27,7 +30,9 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor"
+	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
+	"github.com/nuclio/nuclio/pkg/processor/statistics"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
 	"github.com/nuclio/nuclio/pkg/processor/util/partitionworker"
 
@@ -586,6 +591,117 @@ func (suite *TestSuite) TestMetadataAndAdminMaxRetryConfiguration() {
 		})
 	}
 }
+
+// TestDrainOnRebalanceTimeoutDoesNotPanic is a regression test for NUC-825.
+//
+// Without the fix, drainOnRebalance closed readyForRebalanceChan via a deferred
+// close when returning on the timeout path. The background goroutine could be
+// mid-wg.Wait() at that point; once wg.Wait() returned, the bare send
+// `readyForRebalanceChan <- true` panicked on the already-closed channel. The
+// caught panic corrupted the consumer group, causing an infinite retry loop and
+// preventing the HPA from scaling down.
+//
+// With the fix the deferred close is removed and the send is guarded:
+//
+//	select {
+//	case readyForRebalanceChan <- true:
+//	case <-drainingContext.Done():
+//	}
+//
+// so the goroutine takes the Done case and exits cleanly.
+func (suite *TestSuite) TestDrainOnRebalanceTimeoutDoesNotPanic() {
+	// syncWriter protects the shared buffer from concurrent writes by the logger
+	// goroutine and reads by the test goroutine.
+	var logBuf syncWriter
+	captureLogger, err := nucliozap.NewNuclioZap("test", "console", nil, &logBuf, &logBuf, nucliozap.DebugLevel)
+	suite.Require().NoError(err)
+
+	k := &kafka{
+		AbstractTrigger: trigger.AbstractTrigger{
+			Logger:          captureLogger,
+			WorkerAllocator: &zeroWorkerAllocator{},
+			Statistics:      &trigger.Statistics{},
+		},
+		configuration: &Configuration{},
+		ctx:           context.Background(),
+	}
+	k.configuration.maxWaitHandlerDuringRebalance = 30 * time.Millisecond
+
+	done := make(chan error)
+	se := &submittedEvent{done: done}
+
+	// drainOnRebalance blocks until the 30 ms timeout fires because the handler
+	// (goroutine A) is waiting for `done` and never completes.
+	k.drainOnRebalance(&noopSession{}, &noopClaim{}, se, &sarama.ConsumerMessage{}, true)
+
+	// drainOnRebalance returned via timeout. Signal goroutine A so it calls
+	// wg.Done() and the outer goroutine reaches the race-condition site.
+	done <- nil
+
+	// Give the goroutines a moment to run through the select and exit.
+	time.Sleep(100 * time.Millisecond)
+
+	suite.True(k.restartWorkersOnCleanup.Load(), "restartWorkersOnCleanup must be set on drain timeout")
+	suite.NotContains(logBuf.string(), "Panic caught while trying to write into channel",
+		"goroutine must exit cleanly via the drainingContext.Done case, not panic")
+}
+
+// syncWriter is a goroutine-safe io.Writer backed by a bytes.Buffer.
+type syncWriter struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (w *syncWriter) Write(p []byte) (n int, err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.b.Write(p)
+}
+
+func (w *syncWriter) string() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.b.String()
+}
+
+// zeroWorkerAllocator is a no-op Allocator with zero workers. Drain returns
+// immediately because MergeSubscriptions([]) yields an already-closed channel.
+type zeroWorkerAllocator struct{}
+
+func (z *zeroWorkerAllocator) Allocate(_ time.Duration) (eventprocessor.EventProcessor, error) {
+	return nil, nil
+}
+func (z *zeroWorkerAllocator) Release(_ eventprocessor.EventProcessor)             {}
+func (z *zeroWorkerAllocator) GetObjects() []eventprocessor.EventProcessor         { return nil }
+func (z *zeroWorkerAllocator) SetObjects(_ []eventprocessor.EventProcessor) error  { return nil }
+func (z *zeroWorkerAllocator) GetNumObjectsAvailable() int                         { return 0 }
+func (z *zeroWorkerAllocator) GetStatistics() *statistics.AllocatorStatistics      { return nil }
+func (z *zeroWorkerAllocator) SignalDraining() error                               { return nil }
+func (z *zeroWorkerAllocator) SignalContinue() error                               { return nil }
+func (z *zeroWorkerAllocator) SignalTermination() error                            { return nil }
+func (z *zeroWorkerAllocator) Stop() error                                         { return nil }
+func (z *zeroWorkerAllocator) IsTerminated() bool                                  { return false }
+
+// noopSession is a no-op sarama.ConsumerGroupSession.
+type noopSession struct{}
+
+func (n *noopSession) Claims() map[string][]int32                           { return nil }
+func (n *noopSession) MemberID() string                                    { return "" }
+func (n *noopSession) GenerationID() int32                                 { return 0 }
+func (n *noopSession) MarkOffset(_ string, _ int32, _ int64, _ string)    {}
+func (n *noopSession) Commit()                                             {}
+func (n *noopSession) ResetOffset(_ string, _ int32, _ int64, _ string)   {}
+func (n *noopSession) MarkMessage(_ *sarama.ConsumerMessage, _ string)    {}
+func (n *noopSession) Context() context.Context                            { return context.Background() }
+
+// noopClaim is a no-op sarama.ConsumerGroupClaim.
+type noopClaim struct{}
+
+func (n *noopClaim) Topic() string                                { return "" }
+func (n *noopClaim) Partition() int32                             { return 0 }
+func (n *noopClaim) InitialOffset() int64                         { return 0 }
+func (n *noopClaim) HighWaterMarkOffset() int64                   { return 0 }
+func (n *noopClaim) Messages() <-chan *sarama.ConsumerMessage     { return nil }
 
 func TestKafkaSuite(t *testing.T) {
 	suite.Run(t, new(TestSuite))

--- a/pkg/processor/trigger/kafka/kafka_test.go
+++ b/pkg/processor/trigger/kafka/kafka_test.go
@@ -22,9 +22,9 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"sync"
 	"os"
 	"path"
+	"sync"
 	"testing"
 	"time"
 

--- a/pkg/processor/trigger/kafka/kafka_test.go
+++ b/pkg/processor/trigger/kafka/kafka_test.go
@@ -652,23 +652,23 @@ func (w *syncWriter) string() string {
 // noopSession is a no-op sarama.ConsumerGroupSession.
 type noopSession struct{}
 
-func (n *noopSession) Claims() map[string][]int32                           { return nil }
-func (n *noopSession) MemberID() string                                    { return "" }
-func (n *noopSession) GenerationID() int32                                 { return 0 }
-func (n *noopSession) MarkOffset(_ string, _ int32, _ int64, _ string)    {}
-func (n *noopSession) Commit()                                             {}
-func (n *noopSession) ResetOffset(_ string, _ int32, _ int64, _ string)   {}
-func (n *noopSession) MarkMessage(_ *sarama.ConsumerMessage, _ string)    {}
-func (n *noopSession) Context() context.Context                            { return context.Background() }
+func (n *noopSession) Claims() map[string][]int32                       { return nil }
+func (n *noopSession) MemberID() string                                 { return "" }
+func (n *noopSession) GenerationID() int32                              { return 0 }
+func (n *noopSession) MarkOffset(_ string, _ int32, _ int64, _ string)  {}
+func (n *noopSession) Commit()                                          {}
+func (n *noopSession) ResetOffset(_ string, _ int32, _ int64, _ string) {}
+func (n *noopSession) MarkMessage(_ *sarama.ConsumerMessage, _ string)  {}
+func (n *noopSession) Context() context.Context                         { return context.Background() }
 
 // noopClaim is a no-op sarama.ConsumerGroupClaim.
 type noopClaim struct{}
 
-func (n *noopClaim) Topic() string                                { return "" }
-func (n *noopClaim) Partition() int32                             { return 0 }
-func (n *noopClaim) InitialOffset() int64                         { return 0 }
-func (n *noopClaim) HighWaterMarkOffset() int64                   { return 0 }
-func (n *noopClaim) Messages() <-chan *sarama.ConsumerMessage     { return nil }
+func (n *noopClaim) Topic() string                            { return "" }
+func (n *noopClaim) Partition() int32                         { return 0 }
+func (n *noopClaim) InitialOffset() int64                     { return 0 }
+func (n *noopClaim) HighWaterMarkOffset() int64               { return 0 }
+func (n *noopClaim) Messages() <-chan *sarama.ConsumerMessage { return nil }
 
 func TestKafkaSuite(t *testing.T) {
 	suite.Run(t, new(TestSuite))

--- a/pkg/processor/trigger/kafka/kafka_test.go
+++ b/pkg/processor/trigger/kafka/kafka_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/processor"
 	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
 	"github.com/nuclio/nuclio/pkg/processor/runtime"
-	"github.com/nuclio/nuclio/pkg/processor/statistics"
 	"github.com/nuclio/nuclio/pkg/processor/trigger"
 	"github.com/nuclio/nuclio/pkg/processor/util/partitionworker"
 
@@ -592,23 +591,9 @@ func (suite *TestSuite) TestMetadataAndAdminMaxRetryConfiguration() {
 	}
 }
 
-// TestDrainOnRebalanceTimeoutDoesNotPanic is a regression test for NUC-825.
-//
-// Without the fix, drainOnRebalance closed readyForRebalanceChan via a deferred
-// close when returning on the timeout path. The background goroutine could be
-// mid-wg.Wait() at that point; once wg.Wait() returned, the bare send
-// `readyForRebalanceChan <- true` panicked on the already-closed channel. The
-// caught panic corrupted the consumer group, causing an infinite retry loop and
-// preventing the HPA from scaling down.
-//
-// With the fix the deferred close is removed and the send is guarded:
-//
-//	select {
-//	case readyForRebalanceChan <- true:
-//	case <-drainingContext.Done():
-//	}
-//
-// so the goroutine takes the Done case and exits cleanly.
+// TestDrainOnRebalanceTimeoutDoesNotPanic verifies that when the rebalance
+// timeout fires while a handler is still in-flight the background goroutine
+// exits cleanly instead of panicking.
 func (suite *TestSuite) TestDrainOnRebalanceTimeoutDoesNotPanic() {
 	// syncWriter protects the shared buffer from concurrent writes by the logger
 	// goroutine and reads by the test goroutine.
@@ -619,7 +604,7 @@ func (suite *TestSuite) TestDrainOnRebalanceTimeoutDoesNotPanic() {
 	k := &kafka{
 		AbstractTrigger: trigger.AbstractTrigger{
 			Logger:          captureLogger,
-			WorkerAllocator: &zeroWorkerAllocator{},
+			WorkerAllocator: &eventprocessor.ZeroAllocator{},
 			Statistics:      &trigger.Statistics{},
 		},
 		configuration: &Configuration{},
@@ -663,24 +648,6 @@ func (w *syncWriter) string() string {
 	defer w.mu.Unlock()
 	return w.b.String()
 }
-
-// zeroWorkerAllocator is a no-op Allocator with zero workers. Drain returns
-// immediately because MergeSubscriptions([]) yields an already-closed channel.
-type zeroWorkerAllocator struct{}
-
-func (z *zeroWorkerAllocator) Allocate(_ time.Duration) (eventprocessor.EventProcessor, error) {
-	return nil, nil
-}
-func (z *zeroWorkerAllocator) Release(_ eventprocessor.EventProcessor)             {}
-func (z *zeroWorkerAllocator) GetObjects() []eventprocessor.EventProcessor         { return nil }
-func (z *zeroWorkerAllocator) SetObjects(_ []eventprocessor.EventProcessor) error  { return nil }
-func (z *zeroWorkerAllocator) GetNumObjectsAvailable() int                         { return 0 }
-func (z *zeroWorkerAllocator) GetStatistics() *statistics.AllocatorStatistics      { return nil }
-func (z *zeroWorkerAllocator) SignalDraining() error                               { return nil }
-func (z *zeroWorkerAllocator) SignalContinue() error                               { return nil }
-func (z *zeroWorkerAllocator) SignalTermination() error                            { return nil }
-func (z *zeroWorkerAllocator) Stop() error                                         { return nil }
-func (z *zeroWorkerAllocator) IsTerminated() bool                                  { return false }
 
 // noopSession is a no-op sarama.ConsumerGroupSession.
 type noopSession struct{}

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -442,9 +442,9 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 		wg.Wait()
 		// Guard the send so that if drainOnRebalance already returned via the timeout
 		// path the goroutine exits cleanly instead of sending on a closed channel and
-		// panicking (NUC-825). Without the guard, defer close(readyForRebalanceChan)
-		// fires on the timeout path while this goroutine is still in wg.Wait(); when
-		// wg.Wait() returns the send would race the close and panic.
+		// panicking. Without the guard, defer close(readyForRebalanceChan) fires on
+		// the timeout path while this goroutine is still in wg.Wait(); when wg.Wait()
+		// returns the send would race the close and panic.
 		select {
 		case readyForRebalanceChan <- true:
 		case <-drainingContext.Done():

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -387,7 +387,6 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 	waitForHandler bool) {
 
 	readyForRebalanceChan := make(chan bool)
-	defer close(readyForRebalanceChan)
 
 	// unified deadline for both waiting on the in-flight handler and waiting on drain
 	// acknowledgements: Drain respects this context and the select below uses the same timeout,
@@ -441,7 +440,15 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 		}()
 
 		wg.Wait()
-		readyForRebalanceChan <- true
+		// Guard the send so that if drainOnRebalance already returned via the timeout
+		// path the goroutine exits cleanly instead of sending on a closed channel and
+		// panicking (NUC-825). Without the guard, defer close(readyForRebalanceChan)
+		// fires on the timeout path while this goroutine is still in wg.Wait(); when
+		// wg.Wait() returns the send would race the close and panic.
+		select {
+		case readyForRebalanceChan <- true:
+		case <-drainingContext.Done():
+		}
 	}()
 
 	// wait a for rebalance readiness or max timeout


### PR DESCRIPTION
### 📝 Description

\`drainOnRebalance\` had a race condition that caused a "send on closed channel" panic when the \`maxWaitHandlerDuringRebalance\` timeout fired while a handler was still in-flight.

The function deferred \`close(readyForRebalanceChan)\`. On the timeout path (\`<-drainingContext.Done()\`), the function returned and the deferred close fired, while the background goroutine was still blocked in \`wg.Wait()\`. When \`wg.Wait()\` eventually returned, the bare \`readyForRebalanceChan <- true\` panicked.

The caught panic corrupted the consumer group state, causing an infinite \`"Failed to consume from group"\` retry loop that kept CPU elevated and prevented the HPA from scaling down the function replicas.

---

### 🛠️ Changes Made

**\`pkg/processor/trigger/kafka/trigger.go\`**
- Removed \`defer close(readyForRebalanceChan)\` — closing the channel from the caller while a background goroutine may still send to it was the source of the panic
- Replaced the bare \`readyForRebalanceChan <- true\` with a \`select\` guarded by \`drainingContext.Done()\`, so the goroutine exits cleanly via the Done case when the timeout has already fired

**\`pkg/processor/trigger/kafka/kafka_test.go\`**
- Added \`TestDrainOnRebalanceTimeoutDoesNotPanic\` regression test with supporting mock types (\`noopSession\`, \`noopClaim\`, \`zeroWorkerAllocator\`, \`syncWriter\`)

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing

- Unit regression test \`TestDrainOnRebalanceTimeoutDoesNotPanic\` (added in this PR): reproduces the race window by keeping the handler goroutine alive past the rebalance timeout, then asserts no "Panic caught" message is logged and \`restartWorkersOnCleanup\` is set
- Passes \`go test -race -tags test_unit ./pkg/processor/trigger/kafka/\`
- Validated against logs from the NUC-825 repro confirming the panic pattern

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-825
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

Not applicable.