### PR TITLE
[Security] Fix command injection via spec.build.tempDir in Kaniko builder (GHSA-x44h-qmrv-mh72)

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -96,6 +96,13 @@ func ContainsPathTraversal(path string) bool {
 	return strings.Contains(path, "..")
 }
 
+// ContainsShellMetacharacters reports whether the given string contains characters that
+// have special meaning to a POSIX shell (/bin/sh -c). Such characters must never appear
+// in values that are interpolated into a shell command string.
+func ContainsShellMetacharacters(s string) bool {
+	return strings.ContainsAny(s, ";|&$`(){}\\\"' \t\n*?[]<>~!")
+}
+
 // IsPathWithinDir reports whether targetPath resolves to a location strictly inside dir.
 // Both arguments are resolved to absolute paths first, so the check is robust against
 // "../" traversal sequences in targetPath. A path equal to dir is not considered within it.

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -18,10 +18,12 @@ package containerimagebuilderpusher
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path"
 	"regexp"
 	"strings"
@@ -222,10 +224,12 @@ func (k *Kaniko) createContainerBuildBundle(ctx context.Context,
 	tarFile.Close() // nolint: errcheck
 
 	k.logger.DebugWithCtx(ctx, "Compressing build bundle", "tarFilePath", tarFile.Name())
-	if _, err := k.cmdRunner.Run(&cmdrunner.RunOptions{
-		WorkingDir: &buildContainerBundleDir,
-	}, "tar -zcvf %s %s", path.Base(tarFile.Name()), contextDir); err != nil {
-		return "", "", errors.Wrapf(err, "Failed to compress build bundle")
+	tarCmd := exec.CommandContext(ctx, "tar", "-zcvf", path.Base(tarFile.Name()), contextDir)
+	tarCmd.Dir = buildContainerBundleDir
+	var tarStderr bytes.Buffer
+	tarCmd.Stderr = &tarStderr
+	if err := tarCmd.Run(); err != nil {
+		return "", "", errors.Wrapf(err, "Failed to compress build bundle: %s", tarStderr.String())
 	}
 
 	buildDir := "/tmp/kaniko-builds"

--- a/pkg/containerimagebuilderpusher/kaniko_test.go
+++ b/pkg/containerimagebuilderpusher/kaniko_test.go
@@ -19,14 +19,64 @@ limitations under the License.
 package containerimagebuilderpusher
 
 import (
+	"context"
+	"fmt"
+	"os"
 	"testing"
+	"time"
 
+	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
 )
 
 type KanikoTestSuite struct {
 	suite.Suite
 	kaniko *Kaniko
+}
+
+func (suite *KanikoTestSuite) TestCreateContainerBuildBundleSuccess() {
+	tempDir := suite.T().TempDir()
+	contextDir := suite.T().TempDir()
+
+	testFile := fmt.Sprintf("%s/test.txt", contextDir)
+	suite.Require().NoError(os.WriteFile(testFile, []byte("test"), 0644))
+
+	logger, err := nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+
+	k := &Kaniko{
+		logger:               logger,
+		builderConfiguration: &ContainerBuilderConfiguration{},
+	}
+
+	bundleFilename, assetPath, err := k.createContainerBuildBundle(context.Background(), "test/image:latest", contextDir, tempDir)
+	suite.Require().NoError(err)
+	suite.Require().NotEmpty(bundleFilename)
+	suite.Require().FileExists(assetPath)
+	defer os.Remove(assetPath) // nolint: errcheck
+}
+
+func (suite *KanikoTestSuite) TestCreateContainerBuildBundleSafeFromShellInjection() {
+	tempDir := suite.T().TempDir()
+
+	// contextDir with a semicolon-injected shell command
+	markerFile := fmt.Sprintf("%s/kaniko-injection-marker-%d", os.TempDir(), time.Now().UnixNano())
+	injectionPayload := fmt.Sprintf("/nonexistent-dir; touch %s", markerFile)
+
+	logger, err := nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+
+	k := &Kaniko{
+		logger:               logger,
+		builderConfiguration: &ContainerBuilderConfiguration{},
+	}
+
+	_, _, err = k.createContainerBuildBundle(context.Background(), "test/image:latest", injectionPayload, tempDir)
+	suite.Require().Error(err, "Expected tar to fail on non-existent contextDir")
+
+	_, statErr := os.Stat(markerFile)
+	suite.Require().True(os.IsNotExist(statErr),
+		"Shell injection marker was created — injection succeeded via shell execution")
 }
 
 func (suite *KanikoTestSuite) TestNewContainerBuilderConfigurationParsesKanikoPodLabels() {

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -948,6 +948,11 @@ func (b *Builder) createTempDir() error {
 			return errors.New("Invalid temporary directory path: contains '..'")
 		}
 
+		// Reject shell metacharacters — the path reaches a shell-executed tar command in the Kaniko builder
+		if common.ContainsShellMetacharacters(b.options.FunctionConfig.Spec.Build.TempDir) {
+			return errors.New("Invalid temporary directory path: contains shell metacharacters")
+		}
+
 		// if the user-provided temp directory is not under `/tmp` or `/var/folders/` (depends on OS), create it under it
 		if !strings.HasPrefix(b.options.FunctionConfig.Spec.Build.TempDir, os.TempDir()) {
 			b.tempDir = filepath.Join(os.TempDir(), b.options.FunctionConfig.Spec.Build.TempDir)

--- a/pkg/processor/build/builder_test.go
+++ b/pkg/processor/build/builder_test.go
@@ -1090,6 +1090,31 @@ func (suite *testSuite) TestCreateTempDir() {
 			tempDir:     "",
 			expectError: false,
 		},
+		{
+			name:        "Shell metacharacter semicolon injection",
+			tempDir:     "/tmp/evil;id",
+			expectError: true,
+		},
+		{
+			name:        "Shell metacharacter pipe injection",
+			tempDir:     "/tmp/evil|cat /etc/passwd",
+			expectError: true,
+		},
+		{
+			name:        "Shell metacharacter subshell injection",
+			tempDir:     "/tmp/evil$(id)",
+			expectError: true,
+		},
+		{
+			name:        "Shell metacharacter backtick injection",
+			tempDir:     "/tmp/evil`id`",
+			expectError: true,
+		},
+		{
+			name:        "Shell metacharacter ampersand injection",
+			tempDir:     "/tmp/evil&id",
+			expectError: true,
+		},
 	}
 
 	for _, testCase := range tests {


### PR DESCRIPTION
### 📝 Description

Fixes a command injection vulnerability (GHSA-x44h-qmrv-mh72, CWE-77) where an authenticated user with function-create permission could inject shell metacharacters into `spec.build.tempDir`, achieving arbitrary command execution inside the Dashboard container when the Kaniko builder is enabled.

The vulnerability existed because `spec.build.tempDir` was only validated against `..` (path traversal) but not shell metacharacters. The value flowed into `createContainerBuildBundle` where it was interpolated unquoted into `"tar -zcvf %s %s"` and executed via `/bin/sh -c`.

---

### 🛠️ Changes Made

- **Primary fix** (`pkg/containerimagebuilderpusher/kaniko.go`): Replace `ShellRunner.Run(... "tar -zcvf %s %s" ...)` with a direct `exec.CommandContext(ctx, "tar", "-zcvf", tarName, contextDir)`. Arguments are passed as discrete strings — no shell is involved, so metacharacters in `contextDir` cannot be interpreted as shell syntax.

- **Defense-in-depth** (`pkg/processor/build/builder.go` + `pkg/common/helper.go`): Add `ContainsShellMetacharacters` validator; `createTempDir()` now rejects any `spec.build.tempDir` value containing POSIX shell-special characters (`;|&$\`(){}\\\"' \t\n*?[]<>~!`) before the path is created on disk.

- **Tests** (`pkg/containerimagebuilderpusher/kaniko_test.go`, `pkg/processor/build/builder_test.go`):
  - `TestCreateContainerBuildBundleSuccess` — happy-path regression test for `createContainerBuildBundle`
  - `TestCreateContainerBuildBundleSafeFromShellInjection` — security regression test: passes a semicolon-injected `contextDir` and asserts the shell injection marker file is **not** created
  - `TestCreateTempDir` extended with 5 new table-driven cases covering `;`, `|`, `$()`, backtick, and `&` injection payloads

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

- Unit tests (`go test -tags=test_unit -race ./pkg/containerimagebuilderpusher/... ./pkg/common/...`): all pass including new security regression tests
- Manual verification: patched dashboard deployed to vmdev223ig4/oris (`dev-snapshot.artifactory.iguazeng.com/tomers/dashboard:1.17.1-amd64`), function deployment happy flow confirmed working, fix string present in running binary

---

### 🔗 References
- Ticket link: https://github.com/nuclio/nuclio/security/advisories/GHSA-x44h-qmrv-mh72
- External links: CWE-77 (Improper Neutralization of Special Elements used in a Command)

---

### 🚨 Breaking Changes?

- [x] No

The new `ContainsShellMetacharacters` validation in `createTempDir()` will reject `spec.build.tempDir` values containing shell metacharacters. Any legitimate use case with such characters in a temp directory name is not expected; the field exists for CI/testing overrides only.

---

### 🔍️ Additional Notes

Only the **Kaniko builder** is affected. The Docker builder passes its build context through structured Docker SDK APIs and never reaches the shell `tar` command. The primary fix (eliminating the shell) is the structural remedy; the input validation is a secondary hardening layer.