### PR TITLE
[Security] Fix unauthenticated OS command injection in dashboard (GHSA-jx7q-cpg6-669g)

### DIFF
--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -72,6 +72,11 @@ func (fr *functionResource) GetAll(request *http.Request) (map[string]restful.At
 	}
 
 	functionName := request.Header.Get(headers.FunctionName)
+	if functionName != "" {
+		if err := fr.validateFunctionName(functionName); err != nil {
+			return nil, errors.Wrap(err, "Failed to validate function name")
+		}
+	}
 	getFunctionOptions := fr.resolveGetFunctionOptionsFromRequest(request, functionName, false)
 	functions, err := fr.getPlatform().GetFunctions(ctx, getFunctionOptions)
 	if err != nil {
@@ -100,6 +105,11 @@ func (fr *functionResource) GetByID(request *http.Request, id string) (restful.A
 	namespace := fr.getNamespaceFromRequest(request)
 	if namespace == "" {
 		return nil, nuclio.NewErrBadRequest("Namespace must exist")
+	}
+
+	// validate function name from URL path
+	if err := fr.validateFunctionName(id); err != nil {
+		return nil, errors.Wrap(err, "Failed to validate function name")
 	}
 
 	// get function
@@ -360,6 +370,9 @@ func (fr *functionResource) getFunctionLogs(request *http.Request) (*restful.Cus
 	if functionName == "" {
 		return nil, errors.New("Function name must not be empty")
 	}
+	if err := fr.validateFunctionName(functionName); err != nil {
+		return nil, err
+	}
 
 	// ensure replica name
 	functionReplicaName := fr.GetRouterURLParam(request, "replicaName")
@@ -408,6 +421,9 @@ func (fr *functionResource) proxyFunctionLogs(request *http.Request) (*restful.C
 	functionName := fr.GetRouterURLParam(request, "id")
 	if functionName == "" {
 		return nil, errors.New("Function name must not be empty")
+	}
+	if err := fr.validateFunctionName(functionName); err != nil {
+		return nil, err
 	}
 
 	// ensure access
@@ -912,6 +928,14 @@ func (fr *functionResource) getCreationStateUpdatedTimeout(request *http.Request
 		}
 	}
 	return timeoutDuration
+}
+
+func (fr *functionResource) validateFunctionName(functionName string) error {
+	if errorMessages := validation.IsQualifiedName(functionName); len(errorMessages) != 0 {
+		return nuclio.NewErrBadRequest("Function name doesn't conform to k8s naming convention. Errors: " +
+			strings.Join(errorMessages, ", "))
+	}
+	return nil
 }
 
 // register the resource

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -371,7 +371,7 @@ func (fr *functionResource) getFunctionLogs(request *http.Request) (*restful.Cus
 		return nil, errors.New("Function name must not be empty")
 	}
 	if err := fr.validateFunctionName(functionName); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to validate function name")
 	}
 
 	// ensure replica name
@@ -423,7 +423,7 @@ func (fr *functionResource) proxyFunctionLogs(request *http.Request) (*restful.C
 		return nil, errors.New("Function name must not be empty")
 	}
 	if err := fr.validateFunctionName(functionName); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to validate function name")
 	}
 
 	// ensure access

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -191,6 +191,40 @@ type functionTestSuite struct {
 	dashboardTestSuite
 }
 
+func (suite *functionTestSuite) TestGetAllRejectsMaliciousFunctionName() {
+	// Malicious name from advisory PoC - contains shell injection payload.
+	// Validation should reject before reaching the platform (no mock.On needed).
+	expectedStatusCode := http.StatusBadRequest
+
+	suite.sendRequest(
+		"GET",
+		"/api/functions",
+		map[string]string{
+			headers.FunctionNamespace: "test-namespace",
+			headers.FunctionName:      `x";sleep 5;"`,
+		},
+		nil,
+		&expectedStatusCode,
+		nil,
+	)
+}
+
+func (suite *functionTestSuite) TestGetByIDRejectsMaliciousFunctionName() {
+	// Same payload injected via URL path segment.
+	expectedStatusCode := http.StatusBadRequest
+
+	suite.sendRequest(
+		"GET",
+		`/api/functions/x%22%3Bsleep%205%3B%22`, // URL-encoded: x";sleep 5;"
+		map[string]string{
+			headers.FunctionNamespace: "test-namespace",
+		},
+		nil,
+		&expectedStatusCode,
+		nil,
+	)
+}
+
 func (suite *functionTestSuite) TestCreateDeploymentError() {
 
 	// mock a failure before the function is updated (e.g. during project fetching)

--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -330,15 +330,18 @@ func (s *Store) getResources(resourceDir string,
 	rowHandler func([]byte) error) error {
 
 	var commandStdout, resourcePath string
+	var err error
 
 	// if the request is for a single resource, get that file
 	if resourceName != "" {
 		resourcePath = s.getResourcePath(resourceDir, resourceNamespace, resourceName)
+		// Quote the path to prevent shell metacharacter injection.
+		commandStdout, _, err = s.runCommand(nil, "/bin/cat %s", common.Quote(resourcePath))
 	} else {
 		resourcePath = path.Join(s.getResourceNamespaceDir(resourceDir, resourceNamespace), "*")
+		// Wildcard: keep shell wrapper for glob expansion; wildcard is hardcoded, not user-supplied.
+		commandStdout, _, err = s.runCommand(nil, `/bin/sh -c "/bin/cat %s"`, resourcePath)
 	}
-
-	commandStdout, _, err := s.runCommand(nil, `/bin/sh -c "/bin/cat %s"`, resourcePath)
 	if err != nil {
 
 		// if the error indicates that there's no such file that means nothing was created yet
@@ -495,12 +498,12 @@ func (s *Store) deleteResource(resourceDir string, resourceNamespace string, res
 	resourcePath := s.getResourcePath(resourceDir, resourceNamespace, resourceName)
 
 	// stat the file
-	if _, _, err := s.runCommand(nil, "/bin/stat %s", resourcePath); err != nil {
+	if _, _, err := s.runCommand(nil, "/bin/stat %s", common.Quote(resourcePath)); err != nil {
 		return nuclio.ErrNotFound
 	}
 
 	// remove the file
-	_, _, err := s.runCommand(nil, "/bin/rm %s", resourcePath)
+	_, _, err := s.runCommand(nil, "/bin/rm %s", common.Quote(resourcePath))
 
 	// if the error indicates that there's no such file - that means nothing was created yet
 	if cause := errors.Cause(err); cause != nil && strings.Contains(cause.Error(), "No such file") {

--- a/pkg/platform/local/client/store_test.go
+++ b/pkg/platform/local/client/store_test.go
@@ -1,0 +1,47 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/common"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetResourcesNamedPathIsQuoted verifies that a resource path derived from
+// a malicious function name is shell-quoted before being used in a command,
+// so that shell metacharacters are treated as literals.
+func TestGetResourcesNamedPathIsQuoted(t *testing.T) {
+	s := &Store{}
+	// Use a name with shell metacharacters but no spaces (getResourcePath truncates at spaces,
+	// so a space-bearing name would never reach runCommand intact).
+	maliciousName := `x";cat+/etc/passwd;"`
+	resourcePath := s.getResourcePath(functionsDir, "default", maliciousName)
+
+	// getResourcePath produces a path containing the raw name characters.
+	assert.Contains(t, resourcePath, maliciousName)
+
+	// common.Quote must wrap the result in single quotes when it contains
+	// shell metacharacters, neutralising them.
+	quoted := common.Quote(resourcePath)
+	assert.True(t, strings.HasPrefix(quoted, "'"), "expected path to be single-quoted, got: %s", quoted)
+}


### PR DESCRIPTION
### 📝 Description

Fixes an unauthenticated OS command injection vulnerability (GHSA-jx7q-cpg6-669g, CVSS 10.0) in the nuclio dashboard on the local (Docker) platform.

The function name supplied to the function read/list API (`GET /api/functions`, `GET /api/functions/{id}`, and the log-streaming endpoints) was never validated before reaching a shell command in the local store (`getResources`). An anonymous attacker able to reach the dashboard HTTP port could inject shell metacharacters via the `X-Nuclio-Function-Name` header or URL path segment to execute arbitrary commands as root inside the dashboard container. Because that container has access to the Docker socket, this translates to full host compromise.

The Kubernetes platform is **not affected** — it uses a CRD-based backend that does not pass function names to shell commands.

---

### 🛠️ Changes Made

- **`pkg/dashboard/resource/function.go`** — Added `validateFunctionName` helper (uses `validation.IsQualifiedName`). Called in `GetAll`, `GetByID`, `getFunctionLogs`, and `proxyFunctionLogs` — all four URL entry points that accept a function name. Invalid names are rejected with HTTP 400 before reaching the platform layer, matching the validation already applied on the create/update/delete path (`processFunctionInfo`).

- **`pkg/platform/local/client/store.go`** — Defense-in-depth: `getResources` (named-resource case) and `deleteResource` now call `common.Quote(resourcePath)` before interpolating the path into shell commands. This neutralises any shell metacharacters in the path even if a name somehow bypasses the HTTP-layer validation.

- **`pkg/dashboard/test/server_test.go`** — Two new unit tests (`TestGetAllRejectsMaliciousFunctionName`, `TestGetByIDRejectsMaliciousFunctionName`) sending the PoC payload from the advisory and asserting HTTP 400.

- **`pkg/platform/local/client/store_test.go`** — New unit test verifying that `common.Quote` single-quotes paths containing shell metacharacters.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

- Unit tests: `go test -tags=test_unit -race ./pkg/dashboard/test/... ./pkg/platform/local/client/...` — all pass.
- Two new tests directly exercise the PoC payloads from the advisory (`x";sleep 5;"`) on both the header and URL path attack vectors.
- Lint: `make lint` — clean.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links: https://github.com/nuclio/nuclio/security/advisories/GHSA-jx7q-cpg6-669g

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- Function names that are valid Kubernetes qualified names (alphanumeric, `-`, `_`, `.`, max 63 chars) continue to work unchanged.
- The wildcard path in `getResources` (list-all case) still embeds the namespace unquoted in the shell command — that is a pre-existing condition and a separate concern outside the scope of this fix.