### PR TITLE
[Platform] Introduce functionAuthenticationEnabled feature flag in platformConfig

### DIFF
--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -100,6 +100,7 @@ func (fsr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restfu
 			"autoScaleMetrics":                autoScaleMetrics,
 			"disableDefaultHttpTrigger":       fsr.getPlatform().GetDisableDefaultHttpTrigger(),
 			"defaultProxyLogsSource":          fsr.getPlatform().GetDefaultProxyLogsSource(),
+			"functionAuthenticationEnabled":   fsr.getPlatform().IsFunctionAuthenticationEnabled(),
 		},
 	}
 

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -98,9 +98,11 @@ func (fsr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restfu
 			"validFunctionPriorityClassNames": validFunctionPriorityClassNames,
 			"defaultFunctionPodResources":     defaultFunctionPodResources,
 			"autoScaleMetrics":                autoScaleMetrics,
-			"disableDefaultHttpTrigger":       fsr.getPlatform().GetDisableDefaultHttpTrigger(),
-			"defaultProxyLogsSource":          fsr.getPlatform().GetDefaultProxyLogsSource(),
-			"functionAuthenticationEnabled":   fsr.getPlatform().IsFunctionAuthenticationEnabled(),
+			"disableDefaultHttpTrigger": fsr.getPlatform().GetDisableDefaultHttpTrigger(),
+			"defaultProxyLogsSource":    fsr.getPlatform().GetDefaultProxyLogsSource(),
+			"featureFlags": map[string]interface{}{
+				"functionAuthenticationEnabled": fsr.getPlatform().IsFunctionAuthenticationEnabled(),
+			},
 		},
 	}
 

--- a/pkg/dashboard/resource/frontendspec.go
+++ b/pkg/dashboard/resource/frontendspec.go
@@ -98,11 +98,9 @@ func (fsr *frontendSpecResource) getFrontendSpec(request *http.Request) (*restfu
 			"validFunctionPriorityClassNames": validFunctionPriorityClassNames,
 			"defaultFunctionPodResources":     defaultFunctionPodResources,
 			"autoScaleMetrics":                autoScaleMetrics,
-			"disableDefaultHttpTrigger": fsr.getPlatform().GetDisableDefaultHttpTrigger(),
-			"defaultProxyLogsSource":    fsr.getPlatform().GetDefaultProxyLogsSource(),
-			"featureFlags": map[string]interface{}{
-				"functionAuthenticationEnabled": fsr.getPlatform().IsFunctionAuthenticationEnabled(),
-			},
+			"disableDefaultHttpTrigger":       fsr.getPlatform().GetDisableDefaultHttpTrigger(),
+			"defaultProxyLogsSource":          fsr.getPlatform().GetDefaultProxyLogsSource(),
+			"functionAuthenticationEnabled":   fsr.getPlatform().IsFunctionAuthenticationEnabled(),
 		},
 	}
 

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -3658,6 +3658,11 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
 		Once()
 
 	suite.mockPlatform.
+		On("IsFunctionAuthenticationEnabled").
+		Return(false).
+		Once()
+
+	suite.mockPlatform.
 		On("GetDefaultProxyLogsSource").
 		Return(platform.ProxyLogsSourceK8s).
 		Once()
@@ -3710,6 +3715,7 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
     },
     "defaultHTTPIngressHostTemplate": "{{ .FunctionName }}.{{ .ProjectName }}.{{ .Namespace }}.test.com",
 	"disableDefaultHttpTrigger": false,
+    "functionAuthenticationEnabled": false,
     "defaultFunctionPodResources": {
         "requests": {},
         "limits": {}

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -3715,9 +3715,7 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
     },
     "defaultHTTPIngressHostTemplate": "{{ .FunctionName }}.{{ .ProjectName }}.{{ .Namespace }}.test.com",
 	"disableDefaultHttpTrigger": false,
-	"featureFlags": {
-		"functionAuthenticationEnabled": false
-	},
+    "functionAuthenticationEnabled": false,
     "defaultFunctionPodResources": {
         "requests": {},
         "limits": {}

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -3715,7 +3715,9 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
     },
     "defaultHTTPIngressHostTemplate": "{{ .FunctionName }}.{{ .ProjectName }}.{{ .Namespace }}.test.com",
 	"disableDefaultHttpTrigger": false,
-    "functionAuthenticationEnabled": false,
+	"featureFlags": {
+		"functionAuthenticationEnabled": false
+	},
     "defaultFunctionPodResources": {
         "requests": {},
         "limits": {}

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1069,7 +1069,7 @@ func (ap *Platform) GetDisableDefaultHttpTrigger() bool {
 }
 
 func (ap *Platform) IsFunctionAuthenticationEnabled() bool {
-	return ap.Config.FeatureFlags.FunctionAuthenticationEnabled
+	return ap.Config.Authentication.FunctionAuthenticationEnabled
 }
 
 // GetAllowedAuthenticationModes returns allowed authentication modes

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1069,7 +1069,7 @@ func (ap *Platform) GetDisableDefaultHttpTrigger() bool {
 }
 
 func (ap *Platform) IsFunctionAuthenticationEnabled() bool {
-	return ap.Config.FunctionAuthenticationEnabled
+	return ap.Config.FeatureFlags.FunctionAuthenticationEnabled
 }
 
 // GetAllowedAuthenticationModes returns allowed authentication modes

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1068,6 +1068,10 @@ func (ap *Platform) GetDisableDefaultHttpTrigger() bool {
 	return ap.Config.DisableDefaultHTTPTrigger
 }
 
+func (ap *Platform) IsFunctionAuthenticationEnabled() bool {
+	return ap.Config.FunctionAuthenticationEnabled
+}
+
 // GetAllowedAuthenticationModes returns allowed authentication modes
 func (ap *Platform) GetAllowedAuthenticationModes() []string {
 	return nil

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1069,6 +1069,9 @@ func (ap *Platform) GetDisableDefaultHttpTrigger() bool {
 }
 
 func (ap *Platform) IsFunctionAuthenticationEnabled() bool {
+	if ap.Config.Authentication == nil {
+		return false
+	}
 	return ap.Config.Authentication.FunctionAuthenticationEnabled
 }
 

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -322,6 +322,11 @@ func (mp *Platform) GetDisableDefaultHttpTrigger() bool {
 	return args.Get(0).(bool)
 }
 
+func (mp *Platform) IsFunctionAuthenticationEnabled() bool {
+	args := mp.Called()
+	return args.Get(0).(bool)
+}
+
 func (mp *Platform) GetAllowedAuthenticationModes() []string {
 	args := mp.Called()
 	return args.Get(0).([]string)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -184,6 +184,9 @@ type Platform interface {
 	// GetDisableDefaultHttpTrigger returns if creation of default http trigger is disabled
 	GetDisableDefaultHttpTrigger() bool
 
+	// IsFunctionAuthenticationEnabled returns whether behind-Service function authentication is enabled
+	IsFunctionAuthenticationEnabled() bool
+
 	// GetAllowedAuthenticationModes returns allowed authentication modes
 	GetAllowedAuthenticationModes() []string
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -67,6 +67,10 @@ type Config struct {
 	DisableDefaultHTTPTrigger bool                             `json:"disableDefaultHTTPTrigger,omitempty"`
 	ServiceAccountConfig      ServiceAccountConfig             `json:"serviceAccount,omitempty"`
 
+	// FunctionAuthenticationEnabled gates behind-Service function-level authentication.
+	// When false (default) functions keep today's ingress-level authentication.
+	FunctionAuthenticationEnabled bool `json:"functionAuthenticationEnabled,omitempty"`
+
 	ContainerBuilderConfiguration *containerimagebuilderpusher.ContainerBuilderConfiguration `json:"containerBuilderConfiguration,omitempty"`
 
 	// stores the encoded FunctionReadinessTimeout as time.Duration

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -66,7 +66,7 @@ type Config struct {
 	SensitiveFields           SensitiveFieldsConfig            `json:"sensitiveFields,omitempty"`
 	DisableDefaultHTTPTrigger bool                             `json:"disableDefaultHTTPTrigger,omitempty"`
 	ServiceAccountConfig      ServiceAccountConfig             `json:"serviceAccount,omitempty"`
-	Authentication            Authentication                   `json:"authentication,omitempty"`
+	Authentication            *Authentication                  `json:"authentication,omitempty"`
 
 	ContainerBuilderConfiguration *containerimagebuilderpusher.ContainerBuilderConfiguration `json:"containerBuilderConfiguration,omitempty"`
 
@@ -113,6 +113,9 @@ func NewPlatformConfig(configurationPath string) (*Config, error) {
 
 func (c *Config) EnrichPlatformConfig() error {
 	defaultPlatformConfiguration := GetDefaultPlatformConfiguration()
+
+	// enrich authentication configuration
+	c.enrichAuthentication()
 
 	// enrich opa configuration
 	c.enrichOpaConfig()
@@ -555,6 +558,18 @@ func (c *Config) enrichLocalPlatform() {
 
 	if c.Local.FunctionContainersGracefulTerminationTimeout == 0 {
 		c.Local.FunctionContainersGracefulTerminationTimeout = time.Second * 10
+	}
+}
+
+func (c *Config) enrichAuthentication() {
+	if c.Authentication != nil {
+		return
+	}
+
+	// backward compatibility: populate from IngressConfig when Authentication is not explicitly set
+	c.Authentication = &Authentication{
+		AuthURL:   c.IngressConfig.IguazioAuthURL,
+		SignInURL: c.IngressConfig.IguazioSignInURL,
 	}
 }
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -215,7 +215,6 @@ func (c *Config) EnrichPlatformConfig() error {
 	c.enrichElasticSearchConfig()
 	c.enrichRuntimeBaseImages()
 	c.enrichProjectsLeaderConfig()
-	c.enrichFeatureFlags()
 
 	return nil
 }
@@ -640,12 +639,6 @@ func (c *Config) enrichRuntimeBaseImages() {
 		if _, exists := c.RuntimeBaseImages[runtimeName]; !exists {
 			c.RuntimeBaseImages[runtimeName] = defaultBaseImage
 		}
-	}
-}
-
-func (c *Config) enrichFeatureFlags() {
-	if c.FeatureFlags == nil {
-		c.FeatureFlags = FeatureFlags{}
 	}
 }
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -66,7 +66,7 @@ type Config struct {
 	SensitiveFields           SensitiveFieldsConfig            `json:"sensitiveFields,omitempty"`
 	DisableDefaultHTTPTrigger bool                             `json:"disableDefaultHTTPTrigger,omitempty"`
 	ServiceAccountConfig      ServiceAccountConfig             `json:"serviceAccount,omitempty"`
-	FeatureFlags              FeatureFlags                     `json:"featureFlags,omitempty"`
+	Authentication            Authentication                   `json:"authentication,omitempty"`
 
 	ContainerBuilderConfiguration *containerimagebuilderpusher.ContainerBuilderConfiguration `json:"containerBuilderConfiguration,omitempty"`
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -562,14 +562,8 @@ func (c *Config) enrichLocalPlatform() {
 }
 
 func (c *Config) enrichAuthentication() {
-	if c.Authentication != nil {
-		return
-	}
-
-	// backward compatibility: populate from IngressConfig when Authentication is not explicitly set
-	c.Authentication = &Authentication{
-		AuthURL:   c.IngressConfig.IguazioAuthURL,
-		SignInURL: c.IngressConfig.IguazioSignInURL,
+	if c.Authentication == nil {
+		c.Authentication = &Authentication{}
 	}
 }
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -66,10 +66,7 @@ type Config struct {
 	SensitiveFields           SensitiveFieldsConfig            `json:"sensitiveFields,omitempty"`
 	DisableDefaultHTTPTrigger bool                             `json:"disableDefaultHTTPTrigger,omitempty"`
 	ServiceAccountConfig      ServiceAccountConfig             `json:"serviceAccount,omitempty"`
-
-	// FunctionAuthenticationEnabled gates behind-Service function-level authentication.
-	// When false (default) functions keep today's ingress-level authentication.
-	FunctionAuthenticationEnabled bool `json:"functionAuthenticationEnabled,omitempty"`
+	FeatureFlags              FeatureFlags                     `json:"featureFlags,omitempty"`
 
 	ContainerBuilderConfiguration *containerimagebuilderpusher.ContainerBuilderConfiguration `json:"containerBuilderConfiguration,omitempty"`
 
@@ -218,6 +215,7 @@ func (c *Config) EnrichPlatformConfig() error {
 	c.enrichElasticSearchConfig()
 	c.enrichRuntimeBaseImages()
 	c.enrichProjectsLeaderConfig()
+	c.enrichFeatureFlags()
 
 	return nil
 }
@@ -642,6 +640,12 @@ func (c *Config) enrichRuntimeBaseImages() {
 		if _, exists := c.RuntimeBaseImages[runtimeName]; !exists {
 			c.RuntimeBaseImages[runtimeName] = defaultBaseImage
 		}
+	}
+}
+
+func (c *Config) enrichFeatureFlags() {
+	if c.FeatureFlags == nil {
+		c.FeatureFlags = FeatureFlags{}
 	}
 }
 

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -482,10 +482,16 @@ func (sfc *SensitiveFieldsConfig) CompileSensitiveFieldsRegex() []*regexp.Regexp
 	return sfc.SensitiveFieldsRegex
 }
 
-// FeatureFlags holds feature flags that can be toggled via platform configuration.
-type FeatureFlags struct {
+// Authentication holds authentication-related platform configuration.
+type Authentication struct {
 
 	// FunctionAuthenticationEnabled gates behind-Service function-level authentication.
 	// When false (default) functions keep ingress-level authentication.
 	FunctionAuthenticationEnabled bool `json:"functionAuthenticationEnabled,omitempty"`
+
+	// AuthURL is the back-end auth-check endpoint URL.
+	AuthURL string `json:"authURL,omitempty"`
+
+	// AuthSignin is the sign-in redirect URL.
+	AuthSignin string `json:"authSignin,omitempty"`
 }

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -481,3 +481,11 @@ func (sfc *SensitiveFieldsConfig) CompileSensitiveFieldsRegex() []*regexp.Regexp
 	}
 	return sfc.SensitiveFieldsRegex
 }
+
+// FeatureFlags holds feature flags that can be toggled via platform configuration.
+type FeatureFlags struct {
+
+	// FunctionAuthenticationEnabled gates behind-Service function-level authentication.
+	// When false (default) functions keep ingress-level authentication.
+	FunctionAuthenticationEnabled bool `json:"functionAuthenticationEnabled,omitempty"`
+}

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -492,6 +492,6 @@ type Authentication struct {
 	// AuthURL is the back-end auth-check endpoint URL.
 	AuthURL string `json:"authURL,omitempty"`
 
-	// AuthSignin is the sign-in redirect URL.
-	AuthSignin string `json:"authSignin,omitempty"`
+	// SignInURL is the sign-in redirect URL.
+	SignInURL string `json:"signInURL,omitempty"`
 }


### PR DESCRIPTION
### 📝 Description
Add the `functionAuthenticationEnabled` boolean feature flag to the nuclio platform configuration so components can gate behind-Service function-level authentication on it, and expose it to the UI via the existing `/api/frontend_spec` endpoint.

---

### 🛠️ Changes Made
- Added `FunctionAuthenticationEnabled bool` field to `platformconfig.Config` (`json:"functionAuthenticationEnabled,omitempty"`). Default `false` preserves today's ingress-level auth behavior when unset.
- Declared `IsFunctionAuthenticationEnabled() bool` on the `platform.Platform` interface and implemented it in `abstract.Platform` (inherited by both kube and local platforms).
- Exposed the flag via the existing `/api/frontend_spec` endpoint (`pkg/dashboard/resource/frontendspec.go`), same mechanism as `disableDefaultHttpTrigger` / `allowedAuthenticationModes`.
- Added mock method (`pkg/platform/mock/platform.go`) and updated `TestGetFrontendSpec` with the new expectation and JSON key.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Unit tests: `go test -tags=test_unit -race -short ./pkg/dashboard/... ./pkg/platformconfig/... ./pkg/platform/...` — all pass

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-831
- Design docs links: https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/594641703/HLD+BE+Nuclio+Function-level+Authentication
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Setting the flag value / mlefi Helm defaults is out of scope here