### PR TITLE
[LogProxy] Respect SSL verification mode during search engine auto-detection

### DIFF
--- a/pkg/platform/kube/logProxy/elastic/factory.go
+++ b/pkg/platform/kube/logProxy/elastic/factory.go
@@ -17,6 +17,7 @@ limitations under the License.
 package elastic
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -86,7 +87,14 @@ func getVersionFromSearchEngineWithRetries(
 	retryInterval time.Duration,
 	timeout time.Duration,
 ) (*versionInfo, error) {
-	client := &http.Client{Timeout: timeout}
+	client := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: config.SSLVerificationMode == "none",
+			},
+		},
+	}
 	var versionInfoInstance *versionInfo
 	var err error
 

--- a/pkg/platform/kube/logProxy/elastic/factory_test.go
+++ b/pkg/platform/kube/logProxy/elastic/factory_test.go
@@ -1,0 +1,81 @@
+//go:build test_unit
+
+/*
+Copyright 2025 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package elastic
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type FactoryTestSuite struct {
+	suite.Suite
+	server *httptest.Server
+}
+
+// SetupTest starts a fresh TLS test server (self-signed cert) that mimics the
+// search engine's version endpoint for every test.
+func (suite *FactoryTestSuite) SetupTest() {
+	suite.server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":{"number":"8.11.0"}}`))
+	}))
+}
+
+func (suite *FactoryTestSuite) TearDownTest() {
+	suite.server.Close()
+}
+
+// TestSSLVerificationModeNoneSkipsCertVerification asserts that setting
+// SSLVerificationMode to "none" allows the auto-detection probe to succeed
+// against a server presenting a self-signed/untrusted certificate.
+func (suite *FactoryTestSuite) TestSSLVerificationModeNoneSkipsCertVerification() {
+	config := &platformconfig.ElasticSearchConfig{
+		URL:                 suite.server.URL,
+		SSLVerificationMode: "none",
+	}
+
+	versionInfoInstance, err := getVersionFromSearchEngineWithRetries(config, 1, time.Millisecond, 5*time.Second)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(versionInfoInstance)
+	suite.Equal("8.11.0", versionInfoInstance.Version.Number)
+}
+
+// TestDefaultSSLVerificationModeRejectsUntrustedCert asserts that, without
+// explicitly disabling SSL verification, the auto-detection probe still
+// performs full certificate verification and fails against a self-signed cert.
+func (suite *FactoryTestSuite) TestDefaultSSLVerificationModeRejectsUntrustedCert() {
+	config := &platformconfig.ElasticSearchConfig{
+		URL: suite.server.URL,
+	}
+
+	versionInfoInstance, err := getVersionFromSearchEngineWithRetries(config, 1, time.Millisecond, 5*time.Second)
+	suite.Require().Error(err)
+	suite.Require().Nil(versionInfoInstance)
+	suite.Contains(err.Error(), "Failed to connect to search engine endpoint")
+}
+
+func TestFactoryTestSuite(t *testing.T) {
+	suite.Run(t, new(FactoryTestSuite))
+}


### PR DESCRIPTION
### 📝 Description

When `kind` is not explicitly set in the Elasticsearch/OpenSearch log proxy config, `CreateLogProxy` auto-detects the backend by probing the search engine's version endpoint. That probe built its own `http.Client` with no TLS configuration, so it always performed full certificate verification regardless of `sslVerificationMode`. 
This caused the dashboard to fail to start against search engines using self-signed or private-CA certificates, even though `sslVerificationMode: none` is already honored by the real Elasticsearch/OpenSearch clients created later on.

```
Error - Get "https://kibana-es-rocky9.iguaz.io:9200": tls: failed to verify certificate: x509: certificate signed by unknown authority
    .../pkg/platform/kube/logProxy/elastic/factory.go:118
```

---

### 🛠️ Changes Made
- `getVersionFromSearchEngineWithRetries` now builds its `http.Client`'s `Transport`/`tls.Config` from `config.SSLVerificationMode`, matching the behavior already used by `NewElasticSearchLogProxy` and `NewOpenSearchLogProxy`.
- Added `factory_test.go` covering both the fixed insecure-skip-verify path and the default (still-verifying) path against a self-signed TLS test server.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Added unit tests using `httptest.NewTLSServer` with a self-signed certificate:
  - `TestSSLVerificationModeNoneSkipsCertVerification` — confirms the auto-detection probe succeeds when `sslVerificationMode: none` is set.
  - `TestDefaultSSLVerificationModeRejectsUntrustedCert` — confirms the probe still rejects untrusted certs by default (no regression to security).
- Ran `go test -tags=test_unit -race -run TestFactoryTestSuite ./pkg/platform/kube/logProxy/elastic/...` — both pass.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-867
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
None.

Made with [Cursor](https://cursor.com)