### PR TITLE
[OPA] Make authz resource/management namespace prefixes configurable

### DIFF
--- a/pkg/opa/types.go
+++ b/pkg/opa/types.go
@@ -26,12 +26,15 @@ const (
 	DefaultRequestTimeout       = 10
 	DefaultPermissionQueryPath  = "/v1/data/iguazio/authz/allow"
 	DefaultPermissionFilterPath = "/v1/data/iguazio/authz/filter_allowed"
-
-	IguazioV4ResourcePrefix   = "/resources"
-	IguazioV4ManagementPrefix = "/mgmt"
 )
 
 type Config struct {
 	*opaclient.Config
-	AuthKind auth.Kind `json:"authKind,omitempty"`
+	AuthKind                auth.Kind              `json:"authKind,omitempty"`
+	AuthorizationNamespaces AuthorizationNamespace `json:"authorizationNamespaces"`
+}
+
+type AuthorizationNamespace struct {
+	Resources  string `json:"resources,omitempty"`
+	Management string `json:"management,omitempty"`
 }

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -2315,15 +2315,15 @@ func (ap *Platform) queryOPAPermissions(ctx context.Context,
 }
 
 func (ap *Platform) getOPAResourcesPrefix() string {
-	if ap.IsAuthKindIguazioV4() {
-		return opa.IguazioV4ResourcePrefix
+	if ap.Config.Opa.AuthorizationNamespaces.Resources != "" {
+		return fmt.Sprintf("/%s", ap.Config.Opa.AuthorizationNamespaces.Resources)
 	}
 	return ""
 }
 
 func (ap *Platform) getOPAManagementPrefix() string { // nolint: unused
-	if ap.IsAuthKindIguazioV4() {
-		return opa.IguazioV4ManagementPrefix
+	if ap.Config.Opa.AuthorizationNamespaces.Management != "" {
+		return fmt.Sprintf("/%s", ap.Config.Opa.AuthorizationNamespaces.Management)
 	}
 	return ""
 }

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -168,8 +168,12 @@ func (suite *KubePlatformTestSuite) ResetCRDMocks() {
 func (suite *KubePlatformTestSuite) withAuthKind(kind auth.Kind) {
 	previous := suite.abstractPlatform.Config.Opa.AuthKind
 	suite.abstractPlatform.Config.Opa.AuthKind = kind
+	suite.abstractPlatform.Config.Opa.AuthorizationNamespaces.Resources = "resources"
+	suite.abstractPlatform.Config.Opa.AuthorizationNamespaces.Management = "mgmt"
 	suite.T().Cleanup(func() {
 		suite.abstractPlatform.Config.Opa.AuthKind = previous
+		suite.abstractPlatform.Config.Opa.AuthorizationNamespaces.Resources = ""
+		suite.abstractPlatform.Config.Opa.AuthorizationNamespaces.Management = ""
 	})
 }
 


### PR DESCRIPTION
### 📝 Description
Decouples the OPA authorization resource/management path-prefix namespaces from `AuthKind`. Previously `/resources` and `/mgmt` were hardcoded constants (`IguazioV4ResourcePrefix`, `IguazioV4ManagementPrefix`) applied only when `AuthKind == IguazioV4`. They're now configurable via `Config.Opa.AuthorizationNamespaces`.

---

### 🛠️ Changes Made
- `pkg/opa/types.go`: removed the hardcoded `IguazioV4ResourcePrefix`/`IguazioV4ManagementPrefix` constants; added `AuthorizationNamespace{Resources, Management}` struct and a new `AuthorizationNamespaces` field on `Config`.
- `pkg/platform/abstract/platform.go`: `getOPAResourcesPrefix`/`getOPAManagementPrefix` now derive the prefix from `Config.Opa.AuthorizationNamespaces` instead of gating on `IsAuthKindIguazioV4()`.
- `pkg/platform/kube/platform_test.go`: test helper `withAuthKind` now also sets/resets the new namespace fields.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Updated unit tests in `pkg/platform/kube/platform_test.go` to set the new namespace config alongside auth kind.

---

### 🔗 References
- Ticket link: NUC-868

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
None.