### PR TITLE
[Buildah] Extract Kaniko Job Helpers

### DIFF
--- a/pkg/common/map.go
+++ b/pkg/common/map.go
@@ -141,6 +141,19 @@ func GetStringToStringMapOrEmpty(m map[string]string) map[string]string {
 	return m
 }
 
+// CopyStringMapOrNil returns a shallow copy of m, or nil if m is empty. The copy means mutating the
+// result never leaks back into m.
+func CopyStringMapOrNil(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(m))
+	for key, value := range m {
+		copied[key] = value
+	}
+	return copied
+}
+
 // GetAttributeRecursivelyFromMapStringInterface iterates over the attributes slice and recursively searches the map,
 // returning the last attribute in the slice
 func GetAttributeRecursivelyFromMapStringInterface(mapStringInterface map[string]interface{}, attributes []string) map[string]interface{} {

--- a/pkg/common/map_test.go
+++ b/pkg/common/map_test.go
@@ -58,6 +58,23 @@ func (ts *MapTestSuite) TestMapStringInterfaceGetOrDefault() {
 	ts.Require().Equal(true, vb)
 }
 
+func (ts *MapTestSuite) TestCopyStringMapOrNilCopiesAndIsolatesFromSource() {
+	source := map[string]string{"azure.workload.identity/use": "true"}
+
+	copied := CopyStringMapOrNil(source)
+	ts.Equal("true", copied["azure.workload.identity/use"])
+
+	// Mutating the returned map must not leak back into the source map.
+	copied["mutated"] = "yes"
+	_, leaked := source["mutated"]
+	ts.False(leaked, "CopyStringMapOrNil must return a copy; mutation leaked into the source map")
+}
+
+func (ts *MapTestSuite) TestCopyStringMapOrNilReturnsNilWhenEmpty() {
+	ts.Nil(CopyStringMapOrNil(nil))
+	ts.Nil(CopyStringMapOrNil(map[string]string{}))
+}
+
 func TestMapTestSuite(t *testing.T) {
 	suite.Run(t, new(MapTestSuite))
 }

--- a/pkg/containerimagebuilderpusher/jobrunner.go
+++ b/pkg/containerimagebuilderpusher/jobrunner.go
@@ -32,6 +32,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
 	"github.com/nuclio/nuclio/pkg/platform/kube/utils"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -72,16 +73,80 @@ func newJobRunner(builderName string,
 	}, nil
 }
 
-// resolvePodLabels returns a copy of labels, or nil if labels is empty.
-func resolvePodLabels(labels map[string]string) map[string]string {
-	if len(labels) == 0 {
-		return nil
+// GetKind returns the backend name this jobRunner was constructed for (e.g. "kaniko", "buildah").
+func (r *jobRunner) GetKind() string {
+	return r.builderName
+}
+
+// GetDefaultRegistryCredentialsSecretName returns the secret with credentials to push/pull from the
+// docker registry. Shared across backends: they all read the same builderConfiguration field.
+func (r *jobRunner) GetDefaultRegistryCredentialsSecretName() string {
+	return r.builderConfiguration.DefaultRegistryCredentialsSecretName
+}
+
+// GetBaseImageRegistry returns the base image registry.
+func (r *jobRunner) GetBaseImageRegistry(registry string) string {
+	return r.builderConfiguration.DefaultBaseRegistryURL
+}
+
+// GetRegistryKind returns the registry kind (onCluster, offCluster, or empty if not specified).
+func (r *jobRunner) GetRegistryKind() string {
+	return r.builderConfiguration.RegistryKind
+}
+
+// GetOnbuildImageRegistry returns the onbuild base registry.
+func (r *jobRunner) GetOnbuildImageRegistry(registry string) string {
+	return r.builderConfiguration.DefaultOnbuildRegistryURL
+}
+
+// GetOnbuildStages builds the multistage-build FROM directives for onbuildArtifacts. Pure function of
+// its argument, shared across backends.
+func (r *jobRunner) GetOnbuildStages(onbuildArtifacts []runtime.Artifact) ([]string, error) {
+	onbuildStages := make([]string, 0, len(onbuildArtifacts))
+	stage := 0
+
+	for _, artifact := range onbuildArtifacts {
+		if artifact.ExternalImage {
+			continue
+		}
+
+		stage++
+		if len(artifact.Name) == 0 {
+			artifact.Name = fmt.Sprintf("onbuildStage-%d", stage)
+		}
+
+		baseImage := fmt.Sprintf("FROM %s AS %s", artifact.Image, artifact.Name)
+		onbuildDockerfileContents := fmt.Sprintf("%s\nARG NUCLIO_LABEL\nARG NUCLIO_ARCH\n", baseImage)
+		if strings.TrimSpace(artifact.StageCommands) != "" {
+			onbuildDockerfileContents += artifact.StageCommands + "\n"
+		}
+
+		onbuildStages = append(onbuildStages, onbuildDockerfileContents)
 	}
-	resolved := make(map[string]string, len(labels))
-	for key, value := range labels {
-		resolved[key] = value
+
+	return onbuildStages, nil
+}
+
+// TransformOnbuildArtifactPaths changes onbuild artifact paths depending on the type of the builder
+// used. Pure function of its argument, shared across backends.
+func (r *jobRunner) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifact) (map[string]string, error) {
+	stagedArtifactPaths := make(map[string]string)
+	for _, artifact := range onbuildArtifacts {
+		for source, destination := range artifact.Paths {
+			var transformedSource string
+			if artifact.ExternalImage {
+
+				// External image as stage
+				transformedSource = fmt.Sprintf("--from=%s %s", artifact.Image, source)
+			} else {
+
+				// Previously built stage
+				transformedSource = fmt.Sprintf("--from=%s %s", artifact.Name, source)
+			}
+			stagedArtifactPaths[transformedSource] = destination
+		}
 	}
-	return resolved
+	return stagedArtifactPaths, nil
 }
 
 // createContainerBuildBundle tars contextDir and symlinks the result into

--- a/pkg/containerimagebuilderpusher/jobrunner.go
+++ b/pkg/containerimagebuilderpusher/jobrunner.go
@@ -1,0 +1,489 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package containerimagebuilderpusher
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
+	"github.com/nuclio/nuclio/pkg/platform/kube/utils"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// jobRunner holds the generic Kubernetes-Job-lifecycle machinery shared by every backend.
+type jobRunner struct {
+	builderName          string
+	kubeClientSet        kube.Client
+	logger               logger.Logger
+	builderConfiguration *ContainerBuilderConfiguration
+	jobNameRegex         *regexp.Regexp
+}
+
+// newJobRunner constructs a jobRunner for the backend named builderName (e.g. "kaniko", "buildah").
+func newJobRunner(builderName string,
+	parentLogger logger.Logger,
+	kubeClientSet kube.Client,
+	builderConfiguration *ContainerBuilderConfiguration) (*jobRunner, error) {
+
+	if builderConfiguration == nil {
+		return nil, errors.New("Missing builder configuration")
+	}
+
+	// Valid job name is composed of a DNS-1123 subdomains which in turn must contain only lower case
+	// alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com')
+	jobNameRegex := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
+
+	return &jobRunner{
+		builderName:          builderName,
+		logger:               parentLogger.GetChild(builderName),
+		kubeClientSet:        kubeClientSet,
+		builderConfiguration: builderConfiguration,
+		jobNameRegex:         jobNameRegex,
+	}, nil
+}
+
+// resolvePodLabels returns a copy of labels, or nil if labels is empty.
+func resolvePodLabels(labels map[string]string) map[string]string {
+	if len(labels) == 0 {
+		return nil
+	}
+	resolved := make(map[string]string, len(labels))
+	for key, value := range labels {
+		resolved[key] = value
+	}
+	return resolved
+}
+
+// createContainerBuildBundle tars contextDir and symlinks the result into
+// /tmp/<builderName>-builds (a directory served over HTTP by the dashboard),
+// so the build Job's fetch-bundle init container can retrieve it.
+func (r *jobRunner) createContainerBuildBundle(ctx context.Context,
+	image string,
+	contextDir string,
+	tempDir string) (string, string, error) {
+
+	buildDir := fmt.Sprintf("/tmp/%s-builds", r.builderName)
+
+	// Create temp directory to store compressed container build bundle
+	buildContainerBundleDir := path.Join(tempDir, "tar")
+	if err := os.Mkdir(buildContainerBundleDir, 0744); err != nil {
+		return "", "", errors.Wrapf(err, "Failed to create tar dir: %s", buildContainerBundleDir)
+	}
+	r.logger.DebugWithCtx(ctx, "Created tar dir", "dir", buildContainerBundleDir)
+
+	tarFilename := fmt.Sprintf("%s.tar.gz", strings.ReplaceAll(image, "/", "_"))
+	tarFilename = strings.ReplaceAll(tarFilename, ":", "_")
+	tarFile, err := os.CreateTemp(buildContainerBundleDir, fmt.Sprintf("*-%s", tarFilename))
+	if err != nil {
+		return "", "", errors.Wrap(err, "Failed to create tar bundle")
+	}
+
+	// allow read on group
+	tarFile.Chmod(0744) // nolint: errcheck
+
+	// we do not use its fd
+	tarFile.Close() // nolint: errcheck
+
+	r.logger.DebugWithCtx(ctx, "Compressing build bundle", "tarFilePath", tarFile.Name())
+	tarCmd := exec.CommandContext(ctx, "tar", "-zcvf", path.Base(tarFile.Name()), contextDir)
+	tarCmd.Dir = buildContainerBundleDir
+	var tarStderr bytes.Buffer
+	tarCmd.Stderr = &tarStderr
+	if err := tarCmd.Run(); err != nil {
+		return "", "", errors.Wrapf(err, "Failed to compress build bundle: %s", tarStderr.String())
+	}
+
+	// we need 755 permission to allow running nuclio function with non-root SecurityContext
+	if err := os.MkdirAll(buildDir, 0755); err != nil {
+		return "", "", errors.Wrapf(err, "Failed to ensure directory")
+	}
+
+	// Create symlink to bundle tar file in nginx serving directory
+	assetPath := path.Join(buildDir, path.Base(tarFile.Name()))
+	r.logger.DebugWithCtx(ctx,
+		"Creating symlink to bundle tar",
+		"tarFileName", tarFile.Name(),
+		"assetPath", assetPath)
+
+	if err := os.Link(tarFile.Name(), assetPath); err != nil {
+		return "", "", errors.Wrapf(err, "Failed to create symlink to build bundle")
+	}
+
+	return path.Base(tarFile.Name()), assetPath, nil
+}
+
+func (r *jobRunner) compileJobName(ctx context.Context, image string) string {
+
+	functionName := strings.ReplaceAll(image, "/", "")
+	functionName = strings.ReplaceAll(functionName, ":", "")
+	functionName = strings.ReplaceAll(functionName, "-", "")
+	randomSuffix := common.GenerateRandomString(10, common.SmallLettersAndNumbers)
+	nuclioPrefix := "nuclio-"
+
+	// Truncate function name so the job name won't exceed k8s limit of 63
+	functionNameLimit := 63 - (len(r.builderConfiguration.JobPrefix) + len(randomSuffix) + len(nuclioPrefix) + 2)
+	if len(functionName) > functionNameLimit {
+		functionName = functionName[0:functionNameLimit]
+	}
+
+	jobName := fmt.Sprintf("%s%s.%s.%s", nuclioPrefix, r.builderConfiguration.JobPrefix, functionName, randomSuffix)
+
+	// Fallback
+	if !r.jobNameRegex.MatchString(jobName) {
+		r.logger.DebugWithCtx(ctx,
+			"Job name does not match k8s regex. Won't use function name",
+			"jobName", jobName)
+		jobName = fmt.Sprintf("%s.%s", r.builderConfiguration.JobPrefix, randomSuffix)
+	}
+
+	return jobName
+}
+
+func (r *jobRunner) waitForJobCompletion(ctx context.Context,
+	namespace string,
+	jobName string,
+	buildTimeoutSeconds int64,
+	readinessTimoutSeconds int,
+	buildLogger logger.Logger) error {
+	r.logger.DebugWithCtx(ctx,
+		"Waiting for job completion",
+		"buildTimeoutSeconds", buildTimeoutSeconds,
+		"readinessTimeoutSeconds", readinessTimoutSeconds)
+	timeout := time.Now().Add(time.Duration(buildTimeoutSeconds) * time.Second)
+
+	if err := r.resolveFailFast(ctx, buildLogger, namespace, jobName, time.Duration(readinessTimoutSeconds)*time.Second); err != nil {
+		return errors.Wrap(err, "Job failed to run")
+	}
+
+	for time.Now().Before(timeout) {
+		runningJob, err := r.kubeClientSet.GetJob(ctx, namespace, jobName)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				r.logger.WarnWithCtx(ctx,
+					"Failed to pull job status",
+					"err", err.Error())
+			}
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
+		if runningJob.Status.Succeeded > 0 {
+			jobLogs, err := r.getJobPodLogs(ctx, jobName, namespace)
+			if err != nil {
+				r.logger.DebugWithCtx(ctx,
+					"Job was completed successfully but failed to retrieve job logs",
+					"err", err.Error())
+				return nil
+			}
+
+			r.logger.DebugWithCtx(ctx,
+				"Job was completed successfully",
+				"jobLogs", jobLogs)
+			return nil
+		}
+		if runningJob.Status.Failed > 0 {
+			jobPod, err := r.getJobPod(ctx, jobName, namespace, false)
+			if err != nil {
+				return errors.Wrap(err, "Failed to get job pod")
+			}
+			buildLogger.WarnWithCtx(ctx,
+				"Build container image job has failed",
+				"initContainerStatuses", jobPod.Status.InitContainerStatuses,
+				"containerStatuses", jobPod.Status.ContainerStatuses,
+				"conditions", jobPod.Status.Conditions,
+				"reason", jobPod.Status.Reason,
+				"message", jobPod.Status.Message,
+				"phase", jobPod.Status.Phase,
+				"jobName", jobName)
+
+			jobLogs, err := r.getPodLogs(ctx, jobPod)
+			if err != nil {
+				buildLogger.WarnWithCtx(ctx,
+					"Failed to get job logs", "err", err.Error())
+				return errors.Wrap(err, "Failed to retrieve job logs")
+			}
+			return errors.Errorf("Job failed. Job logs:\n%s", jobLogs)
+		}
+
+		r.logger.DebugWithCtx(ctx,
+			"Waiting for job completion",
+			"ttl", time.Until(timeout).String(),
+			"jobName", jobName)
+		time.Sleep(10 * time.Second)
+	}
+
+	jobPod, err := r.getJobPod(ctx, jobName, namespace, false)
+	if err != nil {
+		return errors.Wrap(err, "Job failed and was unable to get job pod")
+	}
+
+	r.logger.WarnWithCtx(ctx,
+		"Build container image job has timed out",
+		"initContainerStatuses", jobPod.Status.InitContainerStatuses,
+		"containerStatuses", jobPod.Status.ContainerStatuses,
+		"conditions", jobPod.Status.Conditions,
+		"reason", jobPod.Status.Reason,
+		"message", jobPod.Status.Message,
+		"phase", jobPod.Status.Phase,
+		"jobName", jobName)
+
+	jobLogs, err := r.getPodLogs(ctx, jobPod)
+	if err != nil {
+		return errors.Wrap(err, "Job failed and was unable to retrieve job logs")
+	}
+	return errors.Errorf("Job has timed out. Job logs:\n%s", jobLogs)
+}
+
+func (r *jobRunner) resolveFailFast(ctx context.Context,
+	buildLogger logger.Logger,
+	namespace,
+	jobName string,
+	readinessTimout time.Duration) error {
+
+	// fail fast timeout is max(readinessTimeout, 5 minutes)
+	if readinessTimout < 5*time.Minute {
+		readinessTimout = 5 * time.Minute
+	}
+	failFastTimeout := time.After(readinessTimout)
+	var lastError string
+
+	// fail fast if job pod stuck in Pending or Unknown state
+	for {
+		select {
+		case <-failFastTimeout:
+			buildLogger.WarnWithCtx(ctx,
+				"Job was not completed in time",
+				"jobName", jobName,
+				"failFastTimeoutDuration", readinessTimout.String())
+
+			if lastError != "" {
+				return errors.Errorf("Job was not completed in time, job name: %s. Error: %s ", jobName,
+					lastError)
+			} else {
+				return errors.Errorf("Job was not completed in time, job name: %s", jobName)
+			}
+		default:
+			jobPod, err := r.getJobPod(ctx, jobName, namespace, true)
+			if err != nil {
+				r.logger.WarnWithCtx(ctx,
+					"Failed to get job pod",
+					"jobName", jobName,
+					"err", err.Error())
+				time.Sleep(5 * time.Second)
+
+				// skip in case job hasn't started yet. it will fail on timeout if getJobPod keeps failing.
+				continue
+			}
+			if jobPod.Status.Phase == v1.PodPending || jobPod.Status.Phase == v1.PodUnknown {
+				if failure, failed := r.getLastPodWarningEvent(ctx, namespace, jobPod.Name); failed {
+					errorMessage := fmt.Sprintf("%s event for pod %s. Message: %s",
+						failure.Reason,
+						jobPod.Name,
+						failure.Message)
+
+					// if an error has changed, print it to the logs
+					if errorMessage != lastError {
+						buildLogger.WarnWithCtx(ctx,
+							"Build pod received a warning event",
+							"eventReason", failure.Reason,
+							"eventMessage", failure.Message,
+							"podName", jobPod.Name)
+						lastError = errorMessage
+					}
+				}
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			return nil
+		}
+	}
+}
+
+func (r *jobRunner) getJobPodLogs(ctx context.Context, jobName string, namespace string) (string, error) {
+	jobPod, err := r.getJobPod(ctx, jobName, namespace, false)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to get job pod")
+	}
+	return r.getPodLogs(ctx, jobPod)
+}
+
+func (r *jobRunner) getPodLogs(ctx context.Context, jobPod *v1.Pod) (string, error) {
+	r.logger.DebugWithCtx(ctx,
+		"Fetching pod logs",
+		"name", jobPod.Name,
+		"namespace", jobPod.Namespace)
+
+	restReadCloser, err := r.kubeClientSet.StreamPodLogs(ctx, jobPod.Namespace, jobPod.Name, &v1.PodLogOptions{})
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to get log read/closer")
+	}
+
+	defer restReadCloser.Close() // nolint: errcheck
+
+	logContents, err := io.ReadAll(restReadCloser)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to read logs")
+	}
+
+	formattedLogContents := r.prettifyLogContents(string(logContents))
+
+	return formattedLogContents, nil
+}
+
+// getLastPodWarningEvent returns the last k8s warning event for a given pod
+// if event found, then returns (event, true)
+// else returns nil, false
+func (r *jobRunner) getLastPodWarningEvent(ctx context.Context, namespace, podName string) (*v1.Event, bool) {
+	events := r.getPodEvents(ctx, namespace, podName)
+	if events == nil {
+		return nil, false
+	}
+	// Iterate over the events and look for warnings
+	for i := len(events.Items) - 1; i >= 0; i-- {
+		if events.Items[i].Type == v1.EventTypeWarning {
+			return &events.Items[i], true
+		}
+	}
+	return nil, false
+}
+
+func (r *jobRunner) getPodEvents(ctx context.Context, namespace, podName string) *v1.EventList {
+
+	events, err := r.kubeClientSet.ListEvents(ctx, namespace, metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("involvedObject.kind=Pod,involvedObject.name=%s", podName),
+	})
+
+	if err != nil {
+		r.logger.WarnWithCtx(ctx,
+			"Failed to list events for pod",
+			"podName", podName,
+			"err", err.Error())
+		return nil
+	}
+	return events
+}
+
+func (r *jobRunner) getJobPod(ctx context.Context, jobName, namespace string, quiet bool) (*v1.Pod, error) {
+	if !quiet {
+		r.logger.DebugWithCtx(ctx, "Getting job pods", "jobName", jobName)
+	}
+	jobPods, err := r.kubeClientSet.ListPods(ctx, namespace, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("job-name=%s", jobName),
+	})
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to list job's pods")
+	}
+	if len(jobPods.Items) == 0 {
+		return nil, errors.New("No pods found for job")
+	}
+	if len(jobPods.Items) > 1 {
+		return nil, errors.New("Got too many job pods")
+	}
+	return &jobPods.Items[0], nil
+}
+
+func (r *jobRunner) prettifyLogContents(logContents string) string {
+	scanner := bufio.NewScanner(strings.NewReader(logContents))
+
+	formattedLogLinesArray := &[]string{}
+
+	for scanner.Scan() {
+		logLine := scanner.Text()
+
+		prettifiedLogLine := r.prettifyLogLine(logLine)
+
+		*formattedLogLinesArray = append(*formattedLogLinesArray, prettifiedLogLine)
+	}
+
+	return strings.Join(*formattedLogLinesArray, "\n")
+}
+
+func (r *jobRunner) prettifyLogLine(logLine string) string {
+
+	// remove ansi color characters generated automatically by the build tool - so the log will be human-readable on the UI
+	logLine = common.RemoveANSIColorsFromString(logLine)
+
+	return logLine
+}
+
+func (r *jobRunner) deleteJob(ctx context.Context, namespace string, jobName string) error {
+	r.logger.DebugWithCtx(ctx, "Deleting job", "namespace", namespace, "job", jobName)
+
+	propagationPolicy := metav1.DeletePropagationBackground
+	if err := r.kubeClientSet.DeleteJob(ctx, namespace, jobName, metav1.DeleteOptions{
+		PropagationPolicy: &propagationPolicy,
+	}); err != nil {
+		r.logger.WarnWithCtx(ctx,
+			"Failed to delete job",
+			"namespace", namespace,
+			"job", jobName,
+			"error", err.Error(),
+		)
+		return errors.Wrap(err, "Failed to delete job")
+	}
+	r.logger.DebugWithCtx(ctx, "Successfully deleted job", "namespace", namespace, "job", jobName)
+	return nil
+}
+
+func (r *jobRunner) enrichAndValidateServiceAccount(ctx context.Context, buildOptions *BuildOptions, namespace string) (string, error) {
+	// try to enrich service account from builder configuration
+	enrichedServiceAccount := r.enrichServiceAccountFromBuilderConfiguration(buildOptions)
+
+	// enrich (from project/platform) and validate service account
+	return utils.EnrichAndValidateServiceAccount(ctx,
+		r.kubeClientSet,
+		buildOptions.DefaultPlatformServiceAccount,
+		buildOptions.ProjectSecretTemplate,
+		buildOptions.ProjectSecretDefaultServiceAccountKey,
+		buildOptions.ProjectSecretAllowedServiceAccountsKey,
+		buildOptions.ProjectSecretForbiddenServiceAccountsKey,
+		buildOptions.DefaultForbiddenServiceAccounts,
+		enrichedServiceAccount,
+		buildOptions.ProjectName,
+		namespace,
+		true,
+	)
+}
+
+func (r *jobRunner) enrichServiceAccountFromBuilderConfiguration(buildOptions *BuildOptions) string {
+	// if a builder service account is provided in build options, use it.
+	if buildOptions.BuilderServiceAccount != "" {
+		return buildOptions.BuilderServiceAccount
+	}
+	// otherwise, if default service account is provided in builder configuration, use it.
+	if r.builderConfiguration.DefaultServiceAccount != "" {
+		return r.builderConfiguration.DefaultServiceAccount
+	}
+	return buildOptions.FunctionServiceAccount
+}

--- a/pkg/containerimagebuilderpusher/jobrunner_test.go
+++ b/pkg/containerimagebuilderpusher/jobrunner_test.go
@@ -1,0 +1,101 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package containerimagebuilderpusher
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type JobRunnerTestSuite struct {
+	suite.Suite
+}
+
+func (suite *JobRunnerTestSuite) TestCreateContainerBuildBundleSuccess() {
+	tempDir := suite.T().TempDir()
+	contextDir := suite.T().TempDir()
+
+	testFile := fmt.Sprintf("%s/test.txt", contextDir)
+	suite.Require().NoError(os.WriteFile(testFile, []byte("test"), 0644))
+
+	logger, err := nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+
+	r := &jobRunner{
+		builderName:          "test",
+		logger:               logger,
+		builderConfiguration: &ContainerBuilderConfiguration{},
+	}
+
+	bundleFilename, assetPath, err := r.createContainerBuildBundle(context.Background(), "test/image:latest", contextDir, tempDir)
+	suite.Require().NoError(err)
+	suite.Require().NotEmpty(bundleFilename)
+	suite.Require().FileExists(assetPath)
+	defer os.Remove(assetPath) // nolint: errcheck
+}
+
+func (suite *JobRunnerTestSuite) TestCreateContainerBuildBundleSafeFromShellInjection() {
+	tempDir := suite.T().TempDir()
+
+	// contextDir with a semicolon-injected shell command
+	markerFile := fmt.Sprintf("%s/kaniko-injection-marker-%d", os.TempDir(), time.Now().UnixNano())
+	injectionPayload := fmt.Sprintf("/nonexistent-dir; touch %s", markerFile)
+
+	logger, err := nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+
+	r := &jobRunner{
+		builderName:          "test",
+		logger:               logger,
+		builderConfiguration: &ContainerBuilderConfiguration{},
+	}
+
+	_, _, err = r.createContainerBuildBundle(context.Background(), "test/image:latest", injectionPayload, tempDir)
+	suite.Require().Error(err, "Expected tar to fail on non-existent contextDir")
+
+	_, statErr := os.Stat(markerFile)
+	suite.Require().True(os.IsNotExist(statErr),
+		"Shell injection marker was created — injection succeeded via shell execution")
+}
+
+func (suite *JobRunnerTestSuite) TestResolvePodLabelsCopiesAndIsolatesFromConfig() {
+	configLabels := map[string]string{"azure.workload.identity/use": "true"}
+
+	resolved := resolvePodLabels(configLabels)
+	suite.Equal("true", resolved["azure.workload.identity/use"])
+
+	// Mutating the returned map must not leak back into the shared config map.
+	resolved["mutated"] = "yes"
+	_, leaked := configLabels["mutated"]
+	suite.False(leaked, "resolvePodLabels must return a copy; mutation leaked into the source map")
+}
+
+func (suite *JobRunnerTestSuite) TestResolvePodLabelsReturnsNilWhenNoLabelsConfigured() {
+	suite.Nil(resolvePodLabels(nil))
+}
+
+func TestJobRunnerTestSuite(t *testing.T) {
+	suite.Run(t, new(JobRunnerTestSuite))
+}

--- a/pkg/containerimagebuilderpusher/jobrunner_test.go
+++ b/pkg/containerimagebuilderpusher/jobrunner_test.go
@@ -80,22 +80,6 @@ func (suite *JobRunnerTestSuite) TestCreateContainerBuildBundleSafeFromShellInje
 		"Shell injection marker was created — injection succeeded via shell execution")
 }
 
-func (suite *JobRunnerTestSuite) TestResolvePodLabelsCopiesAndIsolatesFromConfig() {
-	configLabels := map[string]string{"azure.workload.identity/use": "true"}
-
-	resolved := resolvePodLabels(configLabels)
-	suite.Equal("true", resolved["azure.workload.identity/use"])
-
-	// Mutating the returned map must not leak back into the shared config map.
-	resolved["mutated"] = "yes"
-	_, leaked := configLabels["mutated"]
-	suite.False(leaked, "resolvePodLabels must return a copy; mutation leaked into the source map")
-}
-
-func (suite *JobRunnerTestSuite) TestResolvePodLabelsReturnsNilWhenNoLabelsConfigured() {
-	suite.Nil(resolvePodLabels(nil))
-}
-
 func TestJobRunnerTestSuite(t *testing.T) {
 	suite.Run(t, new(JobRunnerTestSuite))
 }

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -17,70 +17,43 @@ limitations under the License.
 package containerimagebuilderpusher
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
-	"os/exec"
-	"path"
-	"regexp"
 	"strings"
 	"time"
 
-	"github.com/nuclio/nuclio/pkg/cmdrunner"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
-	"github.com/nuclio/nuclio/pkg/platform/kube/utils"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const kanikoKind = "kaniko"
+
 type Kaniko struct {
-	kubeClientSet        kube.Client
-	logger               logger.Logger
-	builderConfiguration *ContainerBuilderConfiguration
-	jobNameRegex         *regexp.Regexp
-	cmdRunner            cmdrunner.CmdRunner
+	*jobRunner
 }
 
 func NewKaniko(logger logger.Logger,
 	kubeClientSet kube.Client,
 	builderConfiguration *ContainerBuilderConfiguration) (*Kaniko, error) {
 
-	if builderConfiguration == nil {
-		return nil, errors.New("Missing kaniko builder configuration")
-	}
-
-	// Valid job name is composed of a DNS-1123 subdomains which in turn must contain only lower case
-	// alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com')
-	jobNameRegex := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
-
-	shellRunner, err := cmdrunner.NewShellRunner(logger)
+	jr, err := newJobRunner(kanikoKind, logger, kubeClientSet, builderConfiguration)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create shell runner")
+		return nil, errors.Wrap(err, "Failed to create kaniko job runner")
 	}
 
-	kanikoBuilder := &Kaniko{
-		logger:               logger.GetChild("kaniko"),
-		kubeClientSet:        kubeClientSet,
-		builderConfiguration: builderConfiguration,
-		jobNameRegex:         jobNameRegex,
-		cmdRunner:            shellRunner,
-	}
-
-	return kanikoBuilder, nil
+	return &Kaniko{jobRunner: jr}, nil
 }
 
 func (k *Kaniko) GetKind() string {
-	return "kaniko"
+	return kanikoKind
 }
 
 func (k *Kaniko) BuildAndPushContainerImage(ctx context.Context,
@@ -198,60 +171,6 @@ func (k *Kaniko) GetOnbuildImageRegistry(registry string) string {
 	return k.builderConfiguration.DefaultOnbuildRegistryURL
 }
 
-func (k *Kaniko) createContainerBuildBundle(ctx context.Context,
-	image string,
-	contextDir string,
-	tempDir string) (string, string, error) {
-
-	// Create temp directory to store compressed container build bundle
-	buildContainerBundleDir := path.Join(tempDir, "tar")
-	if err := os.Mkdir(buildContainerBundleDir, 0744); err != nil {
-		return "", "", errors.Wrapf(err, "Failed to create tar dir: %s", buildContainerBundleDir)
-	}
-	k.logger.DebugWithCtx(ctx, "Created tar dir", "dir", buildContainerBundleDir)
-
-	tarFilename := fmt.Sprintf("%s.tar.gz", strings.ReplaceAll(image, "/", "_"))
-	tarFilename = strings.ReplaceAll(tarFilename, ":", "_")
-	tarFile, err := os.CreateTemp(buildContainerBundleDir, fmt.Sprintf("*-%s", tarFilename))
-	if err != nil {
-		return "", "", errors.Wrap(err, "Failed to create tar bundle")
-	}
-
-	// allow read on group
-	tarFile.Chmod(0744) // nolint: errcheck
-
-	// we do not use its fd
-	tarFile.Close() // nolint: errcheck
-
-	k.logger.DebugWithCtx(ctx, "Compressing build bundle", "tarFilePath", tarFile.Name())
-	tarCmd := exec.CommandContext(ctx, "tar", "-zcvf", path.Base(tarFile.Name()), contextDir)
-	tarCmd.Dir = buildContainerBundleDir
-	var tarStderr bytes.Buffer
-	tarCmd.Stderr = &tarStderr
-	if err := tarCmd.Run(); err != nil {
-		return "", "", errors.Wrapf(err, "Failed to compress build bundle: %s", tarStderr.String())
-	}
-
-	buildDir := "/tmp/kaniko-builds"
-	// we need 755 permission to allow running nuclio function with non-root SecurityContext
-	if err := os.MkdirAll(buildDir, 0755); err != nil {
-		return "", "", errors.Wrapf(err, "Failed to ensure directory")
-	}
-
-	// Create symlink to bundle tar file in nginx serving directory
-	assetPath := path.Join(buildDir, path.Base(tarFile.Name()))
-	k.logger.DebugWithCtx(ctx,
-		"Creating symlink to bundle tar",
-		"tarFileName", tarFile.Name(),
-		"assetPath", assetPath)
-
-	if err := os.Link(tarFile.Name(), assetPath); err != nil {
-		return "", "", errors.Wrapf(err, "Failed to create symlink to build bundle")
-	}
-
-	return path.Base(tarFile.Name()), assetPath, nil
-}
-
 func (k *Kaniko) compileJobSpec(ctx context.Context,
 	namespace string,
 	buildOptions *BuildOptions,
@@ -320,7 +239,7 @@ func (k *Kaniko) compileJobSpec(ctx context.Context,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      jobName,
 					Namespace: namespace,
-					Labels:    k.resolveKanikoPodLabels(),
+					Labels:    resolvePodLabels(k.builderConfiguration.KanikoPodLabels),
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
@@ -494,320 +413,6 @@ func (k *Kaniko) configureECRInitContainerAndMount(buildOptions *BuildOptions, k
 	kanikoJobSpec.Spec.Template.Spec.InitContainers = append(kanikoJobSpec.Spec.Template.Spec.InitContainers, initContainer)
 }
 
-func (k *Kaniko) compileJobName(ctx context.Context, image string) string {
-
-	functionName := strings.ReplaceAll(image, "/", "")
-	functionName = strings.ReplaceAll(functionName, ":", "")
-	functionName = strings.ReplaceAll(functionName, "-", "")
-	randomSuffix := common.GenerateRandomString(10, common.SmallLettersAndNumbers)
-	nuclioPrefix := "nuclio-"
-
-	// Truncate function name so the job name won't exceed k8s limit of 63
-	functionNameLimit := 63 - (len(k.builderConfiguration.JobPrefix) + len(randomSuffix) + len(nuclioPrefix) + 2)
-	if len(functionName) > functionNameLimit {
-		functionName = functionName[0:functionNameLimit]
-	}
-
-	jobName := fmt.Sprintf("%s%s.%s.%s", nuclioPrefix, k.builderConfiguration.JobPrefix, functionName, randomSuffix)
-
-	// Fallback
-	if !k.jobNameRegex.MatchString(jobName) {
-		k.logger.DebugWithCtx(ctx,
-			"Job name does not match k8s regex. Won't use function name",
-			"jobName", jobName)
-		jobName = fmt.Sprintf("%s.%s", k.builderConfiguration.JobPrefix, randomSuffix)
-	}
-
-	return jobName
-}
-
-func (k *Kaniko) waitForJobCompletion(ctx context.Context,
-	namespace string,
-	jobName string,
-	buildTimeoutSeconds int64,
-	readinessTimoutSeconds int,
-	buildLogger logger.Logger) error {
-	k.logger.DebugWithCtx(ctx,
-		"Waiting for job completion",
-		"buildTimeoutSeconds", buildTimeoutSeconds,
-		"readinessTimeoutSeconds", readinessTimoutSeconds)
-	timeout := time.Now().Add(time.Duration(buildTimeoutSeconds) * time.Second)
-
-	if err := k.resolveFailFast(ctx, buildLogger, namespace, jobName, time.Duration(readinessTimoutSeconds)*time.Second); err != nil {
-		return errors.Wrap(err, "Kaniko job failed to run")
-	}
-
-	for time.Now().Before(timeout) {
-		runningJob, err := k.kubeClientSet.GetJob(ctx, namespace, jobName)
-		if err != nil {
-			if !apierrors.IsNotFound(err) {
-				k.logger.WarnWithCtx(ctx,
-					"Failed to pull kaniko job status",
-					"err", err.Error())
-			}
-			time.Sleep(1 * time.Second)
-			continue
-		}
-
-		if runningJob.Status.Succeeded > 0 {
-			jobLogs, err := k.getJobPodLogs(ctx, jobName, namespace)
-			if err != nil {
-				k.logger.DebugWithCtx(ctx,
-					"Job was completed successfully but failed to retrieve job logs",
-					"err", err.Error())
-				return nil
-			}
-
-			k.logger.DebugWithCtx(ctx,
-				"Job was completed successfully",
-				"jobLogs", jobLogs)
-			return nil
-		}
-		if runningJob.Status.Failed > 0 {
-			jobPod, err := k.getJobPod(ctx, jobName, namespace, false)
-			if err != nil {
-				return errors.Wrap(err, "Failed to get job pod")
-			}
-			buildLogger.WarnWithCtx(ctx,
-				"Build container image job has failed",
-				"initContainerStatuses", jobPod.Status.InitContainerStatuses,
-				"containerStatuses", jobPod.Status.ContainerStatuses,
-				"conditions", jobPod.Status.Conditions,
-				"reason", jobPod.Status.Reason,
-				"message", jobPod.Status.Message,
-				"phase", jobPod.Status.Phase,
-				"jobName", jobName)
-
-			jobLogs, err := k.getPodLogs(ctx, jobPod)
-			if err != nil {
-				buildLogger.WarnWithCtx(ctx,
-					"Failed to get job logs", "err", err.Error())
-				return errors.Wrap(err, "Failed to retrieve kaniko job logs")
-			}
-			return errors.Errorf("Job failed. Job logs:\n%s", jobLogs)
-		}
-
-		k.logger.DebugWithCtx(ctx,
-			"Waiting for job completion",
-			"ttl", time.Until(timeout).String(),
-			"jobName", jobName)
-		time.Sleep(10 * time.Second)
-	}
-
-	jobPod, err := k.getJobPod(ctx, jobName, namespace, false)
-	if err != nil {
-		return errors.Wrap(err, "Job failed and was unable to get job pod")
-	}
-
-	k.logger.WarnWithCtx(ctx,
-		"Build container image job has timed out",
-		"initContainerStatuses", jobPod.Status.InitContainerStatuses,
-		"containerStatuses", jobPod.Status.ContainerStatuses,
-		"conditions", jobPod.Status.Conditions,
-		"reason", jobPod.Status.Reason,
-		"message", jobPod.Status.Message,
-		"phase", jobPod.Status.Phase,
-		"jobName", jobName)
-
-	jobLogs, err := k.getPodLogs(ctx, jobPod)
-	if err != nil {
-		return errors.Wrap(err, "Job failed and was unable to retrieve job logs")
-	}
-	return errors.Errorf("Job has timed out. Job logs:\n%s", jobLogs)
-}
-
-func (k *Kaniko) resolveFailFast(ctx context.Context,
-	buildLogger logger.Logger,
-	namespace,
-	jobName string,
-	readinessTimout time.Duration) error {
-
-	// fail fast timeout is max(readinessTimeout, 5 minutes)
-	if readinessTimout < 5*time.Minute {
-		readinessTimout = 5 * time.Minute
-	}
-	failFastTimeout := time.After(readinessTimout)
-	var lastError string
-
-	// fail fast if job pod stuck in Pending or Unknown state
-	for {
-		select {
-		case <-failFastTimeout:
-			buildLogger.WarnWithCtx(ctx,
-				"Kaniko job was not completed in time",
-				"jobName", jobName,
-				"failFastTimeoutDuration", readinessTimout.String())
-
-			if lastError != "" {
-				return errors.Errorf("Job was not completed in time, job name: %s. Error: %s ", jobName,
-					lastError)
-			} else {
-				return errors.Errorf("Job was not completed in time, job name: %s", jobName)
-			}
-		default:
-			jobPod, err := k.getJobPod(ctx, jobName, namespace, true)
-			if err != nil {
-				k.logger.WarnWithCtx(ctx,
-					"Failed to get kaniko job pod",
-					"jobName", jobName,
-					"err", err.Error())
-				time.Sleep(5 * time.Second)
-
-				// skip in case job hasn't started yet. it will fail on timeout if getJobPod keeps failing.
-				continue
-			}
-			if jobPod.Status.Phase == v1.PodPending || jobPod.Status.Phase == v1.PodUnknown {
-				if failure, failed := k.getLastPodWarningEvent(ctx, namespace, jobPod.Name); failed {
-					errorMessage := fmt.Sprintf("%s event for Kaniko pod %s. Message: %s",
-						failure.Reason,
-						jobPod.Name,
-						failure.Message)
-
-					// if an error has changed, print it to the logs
-					if errorMessage != lastError {
-						buildLogger.WarnWithCtx(ctx,
-							"Kaniko pod received a warning event",
-							"eventReason", failure.Reason,
-							"eventMessage", failure.Message,
-							"podName", jobPod.Name)
-						lastError = errorMessage
-					}
-				}
-				time.Sleep(5 * time.Second)
-				continue
-			}
-			return nil
-		}
-	}
-}
-
-func (k *Kaniko) getJobPodLogs(ctx context.Context, jobName string, namespace string) (string, error) {
-	jobPod, err := k.getJobPod(ctx, jobName, namespace, false)
-	if err != nil {
-		return "", errors.Wrap(err, "Failed to get job pod")
-	}
-	return k.getPodLogs(ctx, jobPod)
-}
-
-func (k *Kaniko) getPodLogs(ctx context.Context, jobPod *v1.Pod) (string, error) {
-	k.logger.DebugWithCtx(ctx,
-		"Fetching pod logs",
-		"name", jobPod.Name,
-		"namespace", jobPod.Namespace)
-
-	restReadCloser, err := k.kubeClientSet.StreamPodLogs(ctx, jobPod.Namespace, jobPod.Name, &v1.PodLogOptions{})
-	if err != nil {
-		return "", errors.Wrap(err, "Failed to get log read/closer")
-	}
-
-	defer restReadCloser.Close() // nolint: errcheck
-
-	logContents, err := io.ReadAll(restReadCloser)
-	if err != nil {
-		return "", errors.Wrap(err, "Failed to read logs")
-	}
-
-	formattedLogContents := k.prettifyLogContents(string(logContents))
-
-	return formattedLogContents, nil
-}
-
-// getLastPodWarningEvent returns the last k8s warning event for a given pod
-// if event found, then returns (event, true)
-// else returns nil, false
-func (k *Kaniko) getLastPodWarningEvent(ctx context.Context, namespace, podName string) (*v1.Event, bool) {
-	events := k.getPodEvents(ctx, namespace, podName)
-	if events == nil {
-		return nil, false
-	}
-	// Iterate over the events and look for warnings
-	for i := len(events.Items) - 1; i >= 0; i-- {
-		if events.Items[i].Type == v1.EventTypeWarning {
-			return &events.Items[i], true
-		}
-	}
-	return nil, false
-}
-
-func (k *Kaniko) getPodEvents(ctx context.Context, namespace, podName string) *v1.EventList {
-
-	events, err := k.kubeClientSet.ListEvents(ctx, namespace, metav1.ListOptions{
-		FieldSelector: fmt.Sprintf("involvedObject.kind=Pod,involvedObject.name=%s", podName),
-	})
-
-	if err != nil {
-		k.logger.WarnWithCtx(ctx,
-			"Failed to list events for Kaniko pod",
-			"podName", podName,
-			"err", err.Error())
-		return nil
-	}
-	return events
-}
-
-func (k *Kaniko) getJobPod(ctx context.Context, jobName, namespace string, quiet bool) (*v1.Pod, error) {
-	if !quiet {
-		k.logger.DebugWithCtx(ctx, "Getting job pods", "jobName", jobName)
-	}
-	jobPods, err := k.kubeClientSet.ListPods(ctx, namespace, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("job-name=%s", jobName),
-	})
-
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to list job's pods")
-	}
-	if len(jobPods.Items) == 0 {
-		return nil, errors.New("No pods found for job")
-	}
-	if len(jobPods.Items) > 1 {
-		return nil, errors.New("Got too many job pods")
-	}
-	return &jobPods.Items[0], nil
-}
-
-func (k *Kaniko) prettifyLogContents(logContents string) string {
-	scanner := bufio.NewScanner(strings.NewReader(logContents))
-
-	formattedLogLinesArray := &[]string{}
-
-	for scanner.Scan() {
-		logLine := scanner.Text()
-
-		prettifiedLogLine := k.prettifyLogLine(logLine)
-
-		*formattedLogLinesArray = append(*formattedLogLinesArray, prettifiedLogLine)
-	}
-
-	return strings.Join(*formattedLogLinesArray, "\n")
-}
-
-func (k *Kaniko) prettifyLogLine(logLine string) string {
-
-	// remove ansi color characters generated automatically by kaniko - so the log will be human-readable on the UI
-	logLine = common.RemoveANSIColorsFromString(logLine)
-
-	return logLine
-}
-
-func (k *Kaniko) deleteJob(ctx context.Context, namespace string, jobName string) error {
-	k.logger.DebugWithCtx(ctx, "Deleting job", "namespace", namespace, "job", jobName)
-
-	propagationPolicy := metav1.DeletePropagationBackground
-	if err := k.kubeClientSet.DeleteJob(ctx, namespace, jobName, metav1.DeleteOptions{
-		PropagationPolicy: &propagationPolicy,
-	}); err != nil {
-		k.logger.WarnWithCtx(ctx,
-			"Failed to delete kaniko job",
-			"namespace", namespace,
-			"job", jobName,
-			"error", err.Error(),
-		)
-		return errors.Wrap(err, "Failed to delete job")
-	}
-	k.logger.DebugWithCtx(ctx, "Successfully deleted job", "namespace", namespace, "job", jobName)
-	return nil
-}
-
 func (k *Kaniko) matchECRUrl(registryURL string) bool {
 	return strings.Contains(registryURL, ".amazonaws.com") && strings.Contains(registryURL, ".ecr.")
 }
@@ -820,51 +425,4 @@ func (k *Kaniko) resolveAWSRegionFromECR(registryURL string) string {
 // Example: "123456789012.dkr.ecr.us-east-1.amazonaws.com" -> "123456789012"
 func (k *Kaniko) resolveAWSRegistryId(registryURL string) string {
 	return strings.Split(registryURL, ".")[0]
-}
-
-func (k *Kaniko) enrichAndValidateServiceAccount(ctx context.Context, buildOptions *BuildOptions, namespace string) (string, error) {
-	// try to enrich service account from builder configuration
-	enrichedServiceAccount := k.enrichServiceAccountFromBuilderConfiguration(buildOptions)
-
-	// enrich (from project/platform) and validate service account
-	return utils.EnrichAndValidateServiceAccount(ctx,
-		k.kubeClientSet,
-		buildOptions.DefaultPlatformServiceAccount,
-		buildOptions.ProjectSecretTemplate,
-		buildOptions.ProjectSecretDefaultServiceAccountKey,
-		buildOptions.ProjectSecretAllowedServiceAccountsKey,
-		buildOptions.ProjectSecretForbiddenServiceAccountsKey,
-		buildOptions.DefaultForbiddenServiceAccounts,
-		enrichedServiceAccount,
-		buildOptions.ProjectName,
-		namespace,
-		true,
-	)
-}
-
-func (k *Kaniko) enrichServiceAccountFromBuilderConfiguration(buildOptions *BuildOptions) string {
-	// if a builder service account is provided in build options, use it.
-	if buildOptions.BuilderServiceAccount != "" {
-		return buildOptions.BuilderServiceAccount
-	}
-	// otherwise, if default service account is provided in builder configuration, use it.
-	if k.builderConfiguration.DefaultServiceAccount != "" {
-		return k.builderConfiguration.DefaultServiceAccount
-	}
-	return buildOptions.FunctionServiceAccount
-}
-
-// resolveKanikoPodLabels returns the labels to set on the kaniko Job pod
-// template. Returns nil when no labels are configured so the rendered pod
-// metadata is unchanged for installs that don't need this (e.g. on-prem,
-// credential-based cloud).
-func (k *Kaniko) resolveKanikoPodLabels() map[string]string {
-	if len(k.builderConfiguration.KanikoPodLabels) == 0 {
-		return nil
-	}
-	labels := make(map[string]string, len(k.builderConfiguration.KanikoPodLabels))
-	for key, value := range k.builderConfiguration.KanikoPodLabels {
-		labels[key] = value
-	}
-	return labels
 }

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
-	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -50,10 +49,6 @@ func NewKaniko(logger logger.Logger,
 	}
 
 	return &Kaniko{jobRunner: jr}, nil
-}
-
-func (k *Kaniko) GetKind() string {
-	return kanikoKind
 }
 
 func (k *Kaniko) BuildAndPushContainerImage(ctx context.Context,
@@ -106,69 +101,6 @@ func (k *Kaniko) BuildAndPushContainerImage(ctx context.Context,
 		buildOptions.BuildTimeoutSeconds,
 		buildOptions.ReadinessTimeoutSeconds,
 		buildOptions.BuildLogger)
-}
-
-func (k *Kaniko) GetOnbuildStages(onbuildArtifacts []runtime.Artifact) ([]string, error) {
-	onbuildStages := make([]string, 0, len(onbuildArtifacts))
-	stage := 0
-
-	for _, artifact := range onbuildArtifacts {
-		if artifact.ExternalImage {
-			continue
-		}
-
-		stage++
-		if len(artifact.Name) == 0 {
-			artifact.Name = fmt.Sprintf("onbuildStage-%d", stage)
-		}
-
-		baseImage := fmt.Sprintf("FROM %s AS %s", artifact.Image, artifact.Name)
-		onbuildDockerfileContents := fmt.Sprintf("%s\nARG NUCLIO_LABEL\nARG NUCLIO_ARCH\n", baseImage)
-		if strings.TrimSpace(artifact.StageCommands) != "" {
-			onbuildDockerfileContents += artifact.StageCommands + "\n"
-		}
-
-		onbuildStages = append(onbuildStages, onbuildDockerfileContents)
-	}
-
-	return onbuildStages, nil
-}
-
-func (k *Kaniko) GetDefaultRegistryCredentialsSecretName() string {
-	return k.builderConfiguration.DefaultRegistryCredentialsSecretName
-}
-
-func (k *Kaniko) TransformOnbuildArtifactPaths(onbuildArtifacts []runtime.Artifact) (map[string]string, error) {
-	stagedArtifactPaths := make(map[string]string)
-	for _, artifact := range onbuildArtifacts {
-		for source, destination := range artifact.Paths {
-			var transformedSource string
-			if artifact.ExternalImage {
-
-				// Using external image as "stage"
-				// Example: COPY --from=nginx:latest /etc/nginx/nginx.conf /nginx.conf
-				transformedSource = fmt.Sprintf("--from=%s %s", artifact.Image, source)
-			} else {
-
-				// Using previously build image with index `artifactIndex` as "stage"
-				transformedSource = fmt.Sprintf("--from=%s %s", artifact.Name, source)
-			}
-			stagedArtifactPaths[transformedSource] = destination
-		}
-	}
-	return stagedArtifactPaths, nil
-}
-
-func (k *Kaniko) GetBaseImageRegistry(registry string) string {
-	return k.builderConfiguration.DefaultBaseRegistryURL
-}
-
-func (k *Kaniko) GetRegistryKind() string {
-	return k.builderConfiguration.RegistryKind
-}
-
-func (k *Kaniko) GetOnbuildImageRegistry(registry string) string {
-	return k.builderConfiguration.DefaultOnbuildRegistryURL
 }
 
 func (k *Kaniko) compileJobSpec(ctx context.Context,
@@ -239,7 +171,7 @@ func (k *Kaniko) compileJobSpec(ctx context.Context,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      jobName,
 					Namespace: namespace,
-					Labels:    resolvePodLabels(k.builderConfiguration.KanikoPodLabels),
+					Labels:    common.CopyStringMapOrNil(k.builderConfiguration.KanikoPodLabels),
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{

--- a/pkg/containerimagebuilderpusher/kaniko_test.go
+++ b/pkg/containerimagebuilderpusher/kaniko_test.go
@@ -19,64 +19,14 @@ limitations under the License.
 package containerimagebuilderpusher
 
 import (
-	"context"
-	"fmt"
-	"os"
 	"testing"
-	"time"
 
-	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
 )
 
 type KanikoTestSuite struct {
 	suite.Suite
 	kaniko *Kaniko
-}
-
-func (suite *KanikoTestSuite) TestCreateContainerBuildBundleSuccess() {
-	tempDir := suite.T().TempDir()
-	contextDir := suite.T().TempDir()
-
-	testFile := fmt.Sprintf("%s/test.txt", contextDir)
-	suite.Require().NoError(os.WriteFile(testFile, []byte("test"), 0644))
-
-	logger, err := nucliozap.NewNuclioZapTest("test")
-	suite.Require().NoError(err)
-
-	k := &Kaniko{
-		logger:               logger,
-		builderConfiguration: &ContainerBuilderConfiguration{},
-	}
-
-	bundleFilename, assetPath, err := k.createContainerBuildBundle(context.Background(), "test/image:latest", contextDir, tempDir)
-	suite.Require().NoError(err)
-	suite.Require().NotEmpty(bundleFilename)
-	suite.Require().FileExists(assetPath)
-	defer os.Remove(assetPath) // nolint: errcheck
-}
-
-func (suite *KanikoTestSuite) TestCreateContainerBuildBundleSafeFromShellInjection() {
-	tempDir := suite.T().TempDir()
-
-	// contextDir with a semicolon-injected shell command
-	markerFile := fmt.Sprintf("%s/kaniko-injection-marker-%d", os.TempDir(), time.Now().UnixNano())
-	injectionPayload := fmt.Sprintf("/nonexistent-dir; touch %s", markerFile)
-
-	logger, err := nucliozap.NewNuclioZapTest("test")
-	suite.Require().NoError(err)
-
-	k := &Kaniko{
-		logger:               logger,
-		builderConfiguration: &ContainerBuilderConfiguration{},
-	}
-
-	_, _, err = k.createContainerBuildBundle(context.Background(), "test/image:latest", injectionPayload, tempDir)
-	suite.Require().Error(err, "Expected tar to fail on non-existent contextDir")
-
-	_, statErr := os.Stat(markerFile)
-	suite.Require().True(os.IsNotExist(statErr),
-		"Shell injection marker was created — injection succeeded via shell execution")
 }
 
 func (suite *KanikoTestSuite) TestNewContainerBuilderConfigurationParsesKanikoPodLabels() {
@@ -123,30 +73,8 @@ func (suite *KanikoTestSuite) TestNewContainerBuilderConfigurationParsesKanikoPo
 	}
 }
 
-func (suite *KanikoTestSuite) TestResolveKanikoPodLabelsCopiesAndIsolatesFromConfig() {
-	configLabels := map[string]string{"azure.workload.identity/use": "true"}
-	k := &Kaniko{
-		builderConfiguration: &ContainerBuilderConfiguration{
-			KanikoPodLabels: configLabels,
-		},
-	}
-
-	resolved := k.resolveKanikoPodLabels()
-	suite.Equal("true", resolved["azure.workload.identity/use"])
-
-	// Mutating the returned map must not leak back into the shared config map.
-	resolved["mutated"] = "yes"
-	_, leaked := configLabels["mutated"]
-	suite.False(leaked, "resolveKanikoPodLabels must return a copy; mutation leaked into builderConfiguration")
-}
-
-func (suite *KanikoTestSuite) TestResolveKanikoPodLabelsReturnsNilWhenNoLabelsConfigured() {
-	k := &Kaniko{builderConfiguration: &ContainerBuilderConfiguration{}}
-	suite.Nil(k.resolveKanikoPodLabels())
-}
-
 func (suite *KanikoTestSuite) SetupTest() {
-	suite.kaniko = &Kaniko{}
+	suite.kaniko = &Kaniko{jobRunner: &jobRunner{}}
 }
 
 func (suite *KanikoTestSuite) TestResolveAWSRegistryId() {


### PR DESCRIPTION
### 📝 Description
Refactor: extracts the generic Kubernetes-Job-lifecycle machinery out of `kaniko.go` into a shared `jobRunner` struct. No behavior change.

This shared helpers will be used by the Buildah implementation in the following PRs.

---

### 🛠️ Changes Made
- New `pkg/containerimagebuilderpusher/jobrunner.go` holding the `jobRunner` struct: bundle staging, job-name compilation, completion/failure polling, log retrieval, job deletion, service-account enrichment, and pod-label resolution.
- `Kaniko` now embeds `*jobRunner`; its own methods for these concerns were removed.
- Relocated the existing pod-label and bundle-creation unit tests onto the new `jobrunner_test.go`, since they now exercise `jobRunner` rather than `Kaniko` directly.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- `go build`, `go vet`, and `golangci-lint run` clean.
- `go test -tags=test_unit -race -short` clean, including the relocated pod-label tests and the
  bundle-creation tests (success case and shell-injection safety).

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-861
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
