### PR TITLE
[Kafka] Do not commit offsets for events discarded during worker drain

### DIFF
--- a/pkg/common/headers/headers.go
+++ b/pkg/common/headers/headers.go
@@ -91,7 +91,7 @@ const (
 	// discarded (never handed to the handler) because the worker was draining during a
 	// function restart or stream rebalance. Stream triggers (kafka, v3iostream) treat it
 	// as a no-ack so the event's offset is not committed and it is redelivered once the
-	// worker is back, preserving at-least-once delivery (NUC-855). It is an internal signal
+	// worker is back, preserving at-least-once delivery. It is an internal signal
 	// set by the wrapper, never by user handler code, which is why it is kept separate from
 	// the user-facing StreamNoAck header.
 	StreamEventDiscarded = "X-Nuclio-Stream-Event-Discarded"

--- a/pkg/common/headers/headers.go
+++ b/pkg/common/headers/headers.go
@@ -87,6 +87,15 @@ const (
 	StreamNoAck    = "X-Nuclio-Stream-No-Ack"
 	Arguments      = "X-Nuclio-Arguments"
 
+	// StreamEventDiscarded is set by the runtime wrapper on the response of an event it
+	// discarded (never handed to the handler) because the worker was draining during a
+	// function restart or stream rebalance. Stream triggers (kafka, v3iostream) treat it
+	// as a no-ack so the event's offset is not committed and it is redelivered once the
+	// worker is back, preserving at-least-once delivery (NUC-855). It is an internal signal
+	// set by the wrapper, never by user handler code, which is why it is kept separate from
+	// the user-facing StreamNoAck header.
+	StreamEventDiscarded = "X-Nuclio-Stream-Event-Discarded"
+
 	// streaming file via HTTP trigger
 	FileStreamDeleteAfterSend = "X-nuclio-filestream-delete-after-send"
 	FileStreamPath            = "X-nuclio-filestream-path"

--- a/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_async_wrapper.py
@@ -25,6 +25,7 @@ import asyncio
 import selectors
 
 from wrapper_common import (
+    Constants,
     EventSocketDisconnected,
     WrapperFatalException,
     EventSocketException,
@@ -168,8 +169,13 @@ class AsyncWrapper(AbstractWrapper):
                     self._logger.debug("Event discarded")
 
                     # respond with an error so the processor does not block forever waiting for
-                    # a response to the discarded event (its default event timeout is infinite)
-                    await self._write_response_error('Event discarded: worker drained', sock)
+                    # a response to the discarded event (its default event timeout is infinite).
+                    # the discard marker header tells stream triggers not to ack it, so it is
+                    # redelivered once the worker is back instead of being silently lost (NUC-855).
+                    await self._write_response_error(
+                        'Event discarded: worker drained',
+                        sock,
+                        headers={Constants.stream_event_discarded_header: True})
 
                 # Release event reference
                 del event

--- a/pkg/processor/runtime/python/py/_nuclio_wrapper.py
+++ b/pkg/processor/runtime/python/py/_nuclio_wrapper.py
@@ -21,6 +21,7 @@ import nuclio_sdk.helpers
 import nuclio_sdk.json_encoder
 import nuclio_sdk.logger
 from wrapper_common import (
+    Constants,
     WrapperFatalException,
     EventSocketDisconnected,
     EventSocketException,
@@ -104,8 +105,13 @@ class Wrapper(AbstractWrapper):
                     self._logger.debug_with('Event has been discarded', event=event)
 
                     # respond with an error so the processor does not block forever waiting for
-                    # a response to the discarded event (its default event timeout is infinite)
-                    await self._write_response_error('Event discarded: worker drained', self._event_sock)
+                    # a response to the discarded event (its default event timeout is infinite).
+                    # the discard marker header tells stream triggers not to ack it, so it is
+                    # redelivered once the worker is back instead of being silently lost (NUC-855).
+                    await self._write_response_error(
+                        'Event discarded: worker drained',
+                        self._event_sock,
+                        headers={Constants.stream_event_discarded_header: True})
 
                 # allow event to be garbage collected by deleting the reference
                 del event
@@ -159,9 +165,9 @@ class Wrapper(AbstractWrapper):
             'attributes': {'ready': 'true'}
         })
 
-    async def _write_response_error(self, body, sock=None):
+    async def _write_response_error(self, body, sock=None, headers=None):
         sock = self._event_sock if not sock else sock
-        await super()._write_response_error(body=body, sock=sock)
+        await super()._write_response_error(body=body, sock=sock, headers=headers)
 
     async def _handle_event(self, event, sock=None):
         sock = self._event_sock if not sock else sock

--- a/pkg/processor/runtime/python/py/test_server_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_server_wrapper.py
@@ -219,7 +219,8 @@ class TestSubmitEvents(BaseTestSubmitEvents):
 
         # the discard response must carry the no-ack marker header so stream triggers
         # do not commit the offset and the event is redelivered instead of silently lost
-        self.assertIs(True, response['headers']['X-Nuclio-Stream-Event-Discarded'])
+        from wrapper_common import Constants
+        self.assertIs(True, response['headers'][Constants.stream_event_discarded_header])
 
     async def _send_events(self, events, single_connection=True):
         data = []

--- a/pkg/processor/runtime/python/py/test_server_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_server_wrapper.py
@@ -217,6 +217,10 @@ class TestSubmitEvents(BaseTestSubmitEvents):
         self.assertEqual(500, response['status_code'])
         self.assertIn('discarded', response['body'])
 
+        # the discard response must carry the no-ack marker header so stream triggers
+        # do not commit the offset and the event is redelivered instead of silently lost
+        self.assertIs(True, response['headers']['X-Nuclio-Stream-Event-Discarded'])
+
     async def _send_events(self, events, single_connection=True):
         data = []
         if single_connection:

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -553,6 +553,10 @@ class TestSubmitEvents(BaseTestSubmitEvents):
         self.assertEqual(500, responses[0]['body']['status_code'])
         self.assertIn('discarded', responses[0]['body']['body'])
 
+        # the discard response must carry the no-ack marker header so stream triggers
+        # do not commit the offset and the event is redelivered instead of silently lost
+        self.assertIs(True, responses[0]['body']['headers']['X-Nuclio-Stream-Event-Discarded'])
+
     async def _collect_packets_async(self, entrypoint_output):
         return [
             (prefix, payload)

--- a/pkg/processor/runtime/python/py/test_wrapper.py
+++ b/pkg/processor/runtime/python/py/test_wrapper.py
@@ -555,7 +555,8 @@ class TestSubmitEvents(BaseTestSubmitEvents):
 
         # the discard response must carry the no-ack marker header so stream triggers
         # do not commit the offset and the event is redelivered instead of silently lost
-        self.assertIs(True, responses[0]['body']['headers']['X-Nuclio-Stream-Event-Discarded'])
+        from wrapper_common import Constants
+        self.assertIs(True, responses[0]['body']['headers'][Constants.stream_event_discarded_header])
 
     async def _collect_packets_async(self, entrypoint_output):
         return [

--- a/pkg/processor/runtime/python/py/wrapper_common.py
+++ b/pkg/processor/runtime/python/py/wrapper_common.py
@@ -47,6 +47,12 @@ class Constants:
     drain_signal = signal.SIGUSR2
     continue_signal = signal.SIGCONT
 
+    # response header set on an event discarded while draining, telling the stream trigger
+    # not to ack it so it is redelivered instead of silently lost (NUC-855). Must match the
+    # Go constant headers.StreamEventDiscarded exactly (case-sensitive) since the trigger
+    # matches the header key verbatim.
+    stream_event_discarded_header = 'X-Nuclio-Stream-Event-Discarded'
+
 
 class WrapperFatalException(Exception):
     """
@@ -380,14 +386,17 @@ class AbstractWrapper(object):
         self._logger.error_with(error_message, exc=str(exc), traceback=traceback.format_exc())
         await self._write_response_error(encoded_error_response or error_message, sock)
 
-    async def _write_response_error(self, body, sock):
+    async def _write_response_error(self, body, sock, headers=None):
         try:
-            encoded_response = self._json_encoder.encode({
+            response = {
                 'body': body,
                 'body_encoding': 'text',
                 'content_type': 'text/plain',
                 'status_code': 500,
-            })
+            }
+            if headers:
+                response['headers'] = headers
+            encoded_response = self._json_encoder.encode(response)
 
             # try write the formatted exception back to processor
             await self._write_packet_to_processor(sock, 'r' + encoded_response)

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -501,6 +501,17 @@ func (k *kafka) eventSubmitter(claim sarama.ConsumerGroupClaim, submittedEventCh
 				"err", processErr)
 		}
 
+		// an event the worker discarded while draining (function restart / rebalance) was never
+		// handed to the handler, so it must not be acked - otherwise its offset is committed and
+		// the message is silently lost. Convert it to a no-ack so it is redelivered once the
+		// worker is back. This is enforced regardless of the explicit-ack mode.
+		if processErr == nil && processor.EventDiscardedDuringDrain(response) {
+			k.Logger.DebugWith("Event discarded during drain, will not ack",
+				"partition", submittedEvent.event.kafkaMessage.Partition,
+				"offset", submittedEvent.event.kafkaMessage.Offset)
+			processErr = processor.StreamNoAckError{}
+		}
+
 		switch k.configuration.ExplicitAckMode {
 		case functionconfig.ExplicitAckModeEnable:
 

--- a/pkg/processor/trigger/v3iostream/trigger.go
+++ b/pkg/processor/trigger/v3iostream/trigger.go
@@ -283,6 +283,16 @@ func (vs *v3iostream) eventSubmitter(claim streamconsumergroup.Claim, submittedE
 				"err", processErr)
 		}
 
+		// an event the worker discarded while draining (function restart / rebalance) was never
+		// handed to the handler, so it must not be acked - otherwise its offset is committed and
+		// the message is silently lost. Convert it to a no-ack so it is redelivered once the
+		// worker is back (NUC-855). This is enforced regardless of the explicit-ack mode.
+		if processErr == nil && processor.EventDiscardedDuringDrain(response) {
+			vs.Logger.DebugWith("Event discarded during drain, will not ack",
+				"shardID", submittedEvent.event.record.ShardID)
+			processErr = processor.StreamNoAckError{}
+		}
+
 		switch vs.configuration.ExplicitAckMode {
 		case functionconfig.ExplicitAckModeEnable:
 

--- a/pkg/processor/trigger/v3iostream/trigger.go
+++ b/pkg/processor/trigger/v3iostream/trigger.go
@@ -286,7 +286,7 @@ func (vs *v3iostream) eventSubmitter(claim streamconsumergroup.Claim, submittedE
 		// an event the worker discarded while draining (function restart / rebalance) was never
 		// handed to the handler, so it must not be acked - otherwise its offset is committed and
 		// the message is silently lost. Convert it to a no-ack so it is redelivered once the
-		// worker is back (NUC-855). This is enforced regardless of the explicit-ack mode.
+		// worker is back. This is enforced regardless of the explicit-ack mode.
 		if processErr == nil && processor.EventDiscardedDuringDrain(response) {
 			vs.Logger.DebugWith("Event discarded during drain, will not ack",
 				"shardID", submittedEvent.event.record.ShardID)

--- a/pkg/processor/types.go
+++ b/pkg/processor/types.go
@@ -41,7 +41,7 @@ func (s StreamNoAckError) Error() string {
 // rebalance). Such events must not be acked, otherwise the stream trigger commits their
 // offset and they are silently lost. The wrapper signals this via the StreamEventDiscarded
 // response header; stream triggers convert it into a StreamNoAckError so the event is
-// redelivered once the worker is back, preserving at-least-once delivery (NUC-855).
+// redelivered once the worker is back, preserving at-least-once delivery
 func EventDiscardedDuringDrain(response nuclio.ProcessingResult) bool {
 	if response == nil {
 		return false

--- a/pkg/processor/types.go
+++ b/pkg/processor/types.go
@@ -17,8 +17,11 @@ limitations under the License.
 package processor
 
 import (
+	"github.com/nuclio/nuclio/pkg/common/headers"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
+
+	"github.com/nuclio/nuclio-sdk-go"
 )
 
 // Configuration is processor configuration
@@ -31,4 +34,19 @@ type StreamNoAckError struct{}
 
 func (s StreamNoAckError) Error() string {
 	return "stream-no-ack"
+}
+
+// EventDiscardedDuringDrain reports whether the runtime discarded the event without
+// handing it to the handler because the worker was draining (function restart / stream
+// rebalance). Such events must not be acked, otherwise the stream trigger commits their
+// offset and they are silently lost. The wrapper signals this via the StreamEventDiscarded
+// response header; stream triggers convert it into a StreamNoAckError so the event is
+// redelivered once the worker is back, preserving at-least-once delivery (NUC-855).
+func EventDiscardedDuringDrain(response nuclio.ProcessingResult) bool {
+	if response == nil {
+		return false
+	}
+
+	discarded, ok := response.GetHeaders()[headers.StreamEventDiscarded].(bool)
+	return ok && discarded
 }

--- a/pkg/processor/types_test.go
+++ b/pkg/processor/types_test.go
@@ -1,0 +1,87 @@
+//go:build test_unit
+
+/*
+Copyright 2024 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package processor
+
+import (
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/common/headers"
+
+	"github.com/nuclio/nuclio-sdk-go"
+	"github.com/stretchr/testify/suite"
+)
+
+type TypesTestSuite struct {
+	suite.Suite
+}
+
+func (suite *TypesTestSuite) TestEventDiscardedDuringDrain() {
+	for _, testCase := range []struct {
+		name     string
+		response nuclio.ProcessingResult
+		expected bool
+	}{
+		{
+			name:     "NilResponse",
+			response: nil,
+			expected: false,
+		},
+		{
+			name:     "NoHeaders",
+			response: &nuclio.Response{},
+			expected: false,
+		},
+		{
+			name: "DiscardedHeaderTrue",
+			response: &nuclio.Response{
+				Headers: map[string]interface{}{headers.StreamEventDiscarded: true},
+			},
+			expected: true,
+		},
+		{
+			name: "DiscardedHeaderFalse",
+			response: &nuclio.Response{
+				Headers: map[string]interface{}{headers.StreamEventDiscarded: false},
+			},
+			expected: false,
+		},
+		{
+			name: "DiscardedHeaderNonBool",
+			response: &nuclio.Response{
+				Headers: map[string]interface{}{headers.StreamEventDiscarded: "true"},
+			},
+			expected: false,
+		},
+		{
+			name: "UnrelatedHeader",
+			response: &nuclio.Response{
+				Headers: map[string]interface{}{headers.StreamNoAck: true},
+			},
+			expected: false,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Equal(testCase.expected, EventDiscardedDuringDrain(testCase.response))
+		})
+	}
+}
+
+func TestTypesTestSuite(t *testing.T) {
+	suite.Run(t, new(TypesTestSuite))
+}


### PR DESCRIPTION
### 📝 Description
Kafka-triggered functions silently lost messages when the function was restarted/redeployed while messages were in flight.

During a drain (function restart or consumer-group rebalance) the runtime wrapper stops handing events to the handler and, since ML-12573, answers each in-flight event with an HTTP-500 "Event discarded: worker drained" response so the processor does not block forever (its default event timeout is infinite). The problem: the Go RPC layer treats a 500 status code as a **successful** round-trip (`postProcessResponseCheckForFailure` only returns a Go error when the internal `err` field is set, never for a status code). As a result `eventSubmitter` saw `processErr == nil` and the stream trigger marked the Kafka offset for a message that **no worker ever processed**. Sarama then auto-committed that offset, so the message was never redelivered — permanent, silent data loss.

This matched the reproduction evidence exactly: the per-drain "event discarded" log-line count equaled the missing-message count 1-for-1 (24/24 on 1.17.1, 32/32 on 1.17.2), the committed consumer-group offsets summed to the full expected total, and each loss fell precisely in the pod-transition window.

The fix restores at-least-once delivery: an event the worker discards while draining is no longer acked, so its offset is not committed and the message is redelivered once the worker is back. This reuses the trigger's existing `StreamNoAckError` "do not commit" path, and is applied to both stream triggers (`kafka` and `v3iostream`) regardless of explicit-ack mode.

---

### 🛠️ Changes Made
- **`pkg/common/headers/headers.go`** — added an internal `StreamEventDiscarded` (`X-Nuclio-Stream-Event-Discarded`) response header. Kept separate from the user-facing `StreamNoAck` header so no user-facing semantics change.
- **`pkg/processor/runtime/python/py/wrapper_common.py`** — `_write_response_error` now accepts an optional `headers` argument (backward compatible; omitted when empty); added the `Constants.stream_event_discarded_header` constant documenting that it must match the Go header verbatim.
- **`pkg/processor/runtime/python/py/_nuclio_wrapper.py` / `_nuclio_async_wrapper.py`** — the drain-discard path now tags the 500 response with the discard header so the trigger knows the event was never handled.
- **`pkg/processor/types.go`** — added `EventDiscardedDuringDrain(response)` helper that detects the discard header, mirroring the existing `resolveNoAckMessage` header-check pattern.
- **`pkg/processor/trigger/kafka/trigger.go` / `pkg/processor/trigger/v3iostream/trigger.go`** — in `eventSubmitter`, a discarded response is converted to `StreamNoAckError{}` **before** the explicit-ack-mode switch, so the offset is never committed in any ack mode. Because both the normal path and the `drainOnRebalance` path gate offset marking on `err == nil` from the same `done` channel, this single point covers both.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable) — n/a, no user-facing docs affected
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- **`pkg/processor/types_test.go`** (new) — table-driven unit test for `EventDiscardedDuringDrain`: nil response, missing header, header `true`/`false`, non-bool value, and an unrelated header.
- **`pkg/processor/runtime/python/py/test_wrapper.py` / `test_server_wrapper.py`** — extended the existing discard tests to assert the discard response carries `X-Nuclio-Stream-Event-Discarded: true`.
- `go build` and `golangci-lint run` clean on all changed Go packages (`pkg/processor`, `pkg/common/headers`, `pkg/processor/trigger/kafka`, `pkg/processor/trigger/v3iostream`).
- `go test -tags=test_unit` passes for `pkg/processor` and `pkg/processor/trigger/kafka`.
- `make fmt` applied. Python files are `py_compile`-clean (the Python wrapper unit tests run in the pinned `make test-python` container; the local `nuclio_sdk` is a different version).

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-855
- Design docs links:
- External links: Related origin REG-2630; drain-discard 500 response introduced in ML-12573

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- The fix targets the Python runtime, which is the only runtime that implements drain-time event discarding; other runtimes keep processing in-flight events and are unaffected.
- Known limitation (out of scope): with a non-default `ackWindowSize > 0`, the sliding-window ack can still advance past a discarded offset when a later message succeeds — this is inherent to that opt-in feature and separate from this bug. The default (`ackWindowSize == 0`) reproducer is fully fixed.
- The end-to-end reproduction (`test_nuclio_stream_trigger_restart_redeploy`) lives in the naipi/webui suite and is not part of this repo; consider a follow-up `test_local`/`test_kube` integration test exercising restart-during-production if desired.
