### PR TITLE
[Projects] Add Oris project leader scaffolding

### DIFF
--- a/pkg/platform/abstract/project/external/client.go
+++ b/pkg/platform/abstract/project/external/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader/iguazio"
 	"github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader/mlrun"
 	"github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader/mock"
+	"github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader/oris"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
 	"github.com/nuclio/errors"
@@ -224,6 +225,11 @@ func newLeaderClient(parentLogger logger.Logger, platformConfiguration *platform
 	case platformconfig.ProjectsLeaderKindIguazio:
 		skipTLSVerification = true
 		leaderOps = iguazio.NewLeaderOps(parentLogger)
+
+	// oris projects leader
+	case platformconfig.ProjectsLeaderKindOris:
+		skipTLSVerification = true
+		leaderOps = oris.NewLeaderOps(parentLogger, namespace)
 
 	case platformconfig.ProjectsLeaderKindMock:
 		leaderOps = mock.NewLeaderOps()

--- a/pkg/platform/abstract/project/external/leader/abstract/leader.go
+++ b/pkg/platform/abstract/project/external/leader/abstract/leader.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package abstract
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/platform"
+	leaderCommon "github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+)
+
+// LeaderOps provides default implementations of leader.LeaderOps methods that are
+// identical across multiple concrete leaders — e.g. leaders with no async job system,
+// or leaders that do not (yet) support the two-phase-commit project sync protocol.
+//
+// Concrete leader implementations embed this type and override only the methods that
+// differ for their specific leader, mirroring the same embedding pattern abstract.Platform
+// uses for the kube/local platform.Platform implementations.
+type LeaderOps struct{}
+
+// NewLeaderOps creates a new abstract LeaderOps providing the shared default behavior.
+func NewLeaderOps() *LeaderOps {
+	return &LeaderOps{}
+}
+
+// AddAuthSessionHeaders adds the standard authorization header derived from the auth
+// session. Every current leader authenticates this way.
+func (l *LeaderOps) AddAuthSessionHeaders(headers map[string]string, authSession auth.Session) {
+	headers["authorization"] = authSession.CompileAuthorizationHeader()
+}
+
+func (l *LeaderOps) ProjectRequestURL(apiAddress string, apiVersion leaderCommon.APIVersion, projectName string) string {
+	url := fmt.Sprintf("%s/%s/%s", apiAddress, apiVersion, "projects")
+	if projectName != "" {
+		url += fmt.Sprintf("/%s", projectName)
+	}
+	return url
+}
+
+// ShouldWaitForCreateCompletion defaults to false: most leaders have no async job
+// system to poll after creation succeeds.
+func (l *LeaderOps) ShouldWaitForCreateCompletion() bool { return false }
+
+// GetJobStatusRequestCookies defaults to no cookies being required for job status requests.
+func (l *LeaderOps) GetJobStatusRequestCookies(_ *platformconfig.Config) []*http.Cookie { return nil }
+
+// GetJobRequestFilter defaults to no filter being applied to job status requests.
+func (l *LeaderOps) GetJobRequestFilter(_ *time.Time) string { return "" }
+
+// GetAuthSessionCookie defaults to no session cookie being attached to requests.
+func (l *LeaderOps) GetAuthSessionCookie(_ auth.Session) *http.Cookie { return nil }
+
+func (l *LeaderOps) GetDeleteStrategyHeaderName() string {
+	return ""
+}
+
+// ParseJobStatusResponse defaults to "no job, not terminated": leaders without an
+// async job system never have a job to poll.
+func (l *LeaderOps) ParseJobStatusResponse(_ context.Context, _ []byte) (leaderCommon.JobResponse, bool) {
+	return nil, false
+}
+
+// GetJobIdUrl defaults to an empty URL: leaders without an async job system never
+// need to poll job status.
+func (l *LeaderOps) GetJobIdUrl(_, _ string) string { return "" }
+
+// IsJobCompleted defaults to success: leaders without an async job system never have
+// a job to validate.
+func (l *LeaderOps) IsJobCompleted(_ context.Context, _ leaderCommon.JobResponse, _ string) error {
+	return nil
+}
+
+// EvaluateLeaderRequest defaults to an unconditional pass-through: leaders that do not
+// (yet) support the two-phase-commit project sync protocol always apply the incoming change.
+func (l *LeaderOps) EvaluateLeaderRequest(_ context.Context, _ map[string]string, _ platform.Project) (bool, error) {
+	return true, nil
+}
+
+// ProjectSync2PCEnabled defaults to false: two-phase-commit support is opt-in per leader.
+func (l *LeaderOps) ProjectSync2PCEnabled() bool { return false }

--- a/pkg/platform/abstract/project/external/leader/abstract/leader_test.go
+++ b/pkg/platform/abstract/project/external/leader/abstract/leader_test.go
@@ -1,0 +1,102 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package abstract
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/auth"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// stubSession is a minimal auth.Session used only to verify that
+// AddAuthSessionHeaders wires the compiled authorization header through.
+type stubSession struct{}
+
+func (s *stubSession) GetUsername() string              { return "" }
+func (s *stubSession) GetPassword() string              { return "" }
+func (s *stubSession) GetUserID() string                { return "" }
+func (s *stubSession) GetGroupIDs() []string            { return nil }
+func (s *stubSession) GetUserLabels() map[string]string { return nil }
+func (s *stubSession) CompileAuthorizationHeader() string {
+	return "Bearer stub-token"
+}
+
+var _ auth.Session = &stubSession{}
+
+type LeaderOpsTestSuite struct {
+	suite.Suite
+	leaderOps *LeaderOps
+}
+
+func (suite *LeaderOpsTestSuite) SetupSuite() {
+	suite.leaderOps = NewLeaderOps()
+}
+
+func (suite *LeaderOpsTestSuite) TestShouldWaitForCreateCompletion() {
+	suite.Require().False(suite.leaderOps.ShouldWaitForCreateCompletion())
+}
+
+func (suite *LeaderOpsTestSuite) TestGetJobStatusRequestCookies() {
+	suite.Require().Nil(suite.leaderOps.GetJobStatusRequestCookies(nil))
+}
+
+func (suite *LeaderOpsTestSuite) TestGetJobRequestFilter() {
+	suite.Require().Equal("", suite.leaderOps.GetJobRequestFilter(nil))
+}
+
+func (suite *LeaderOpsTestSuite) TestGetAuthSessionCookie() {
+	suite.Require().Nil(suite.leaderOps.GetAuthSessionCookie(&stubSession{}))
+}
+
+func (suite *LeaderOpsTestSuite) TestAddAuthSessionHeaders() {
+	headers := map[string]string{}
+	suite.leaderOps.AddAuthSessionHeaders(headers, &stubSession{})
+	suite.Require().Equal("Bearer stub-token", headers["authorization"])
+}
+
+func (suite *LeaderOpsTestSuite) TestParseJobStatusResponse() {
+	resp, terminated := suite.leaderOps.ParseJobStatusResponse(context.TODO(), nil)
+	suite.Require().Nil(resp)
+	suite.Require().False(terminated)
+}
+
+func (suite *LeaderOpsTestSuite) TestGetJobIdUrl() {
+	suite.Require().Equal("", suite.leaderOps.GetJobIdUrl("address", "job-id"))
+}
+
+func (suite *LeaderOpsTestSuite) TestIsJobCompleted() {
+	suite.Require().NoError(suite.leaderOps.IsJobCompleted(context.TODO(), nil, "project"))
+}
+
+func (suite *LeaderOpsTestSuite) TestEvaluateLeaderRequest() {
+	shouldApply, err := suite.leaderOps.EvaluateLeaderRequest(context.TODO(), map[string]string{}, nil)
+	suite.Require().NoError(err)
+	suite.Require().True(shouldApply)
+}
+
+func (suite *LeaderOpsTestSuite) TestProjectSync2PCEnabled() {
+	suite.Require().False(suite.leaderOps.ProjectSync2PCEnabled())
+}
+
+func TestLeaderOpsTestSuite(t *testing.T) {
+	suite.Run(t, new(LeaderOpsTestSuite))
+}

--- a/pkg/platform/abstract/project/external/leader/mlrun/leader.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/leader.go
@@ -86,7 +86,7 @@ func (l *LeaderOps) ResolveGetProjectResponse(_ bool, body []byte) ([]platform.P
 }
 
 func (l *LeaderOps) GenerateCreateProjectRequestURL(apiAddress string) string {
-	return fmt.Sprintf("%s/%s/%s", apiAddress, string(leaderCommon.APIVersionV1), "projects")
+	return l.ProjectRequestURL(apiAddress, leaderCommon.APIVersionV1, "")
 }
 
 func (l *LeaderOps) HandleCreateResponseErr(ctx context.Context, responseBody []byte, response *http.Response, err error) error {

--- a/pkg/platform/abstract/project/external/leader/mlrun/leader.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/leader.go
@@ -21,26 +21,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
-	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/platform"
 	leaderCommon "github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader"
-	"github.com/nuclio/nuclio/pkg/platformconfig"
+	leaderabstract "github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader/abstract"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
 )
 
-type APIVersion string
-
-const (
-	APIVersionV1 APIVersion = "v1"
-	APIVersionV2 APIVersion = "v2"
-)
-
 type LeaderOps struct {
+	*leaderabstract.LeaderOps
 	logger logger.Logger
 	// namespace is used to enrich the MLRun responses, which omit the namespace
 	namespace             string
@@ -49,6 +41,7 @@ type LeaderOps struct {
 
 func NewLeaderOps(parentLogger logger.Logger, namespace string, projectSync2PCEnabled bool) *LeaderOps {
 	return &LeaderOps{
+		LeaderOps:             leaderabstract.NewLeaderOps(),
 		logger:                parentLogger.GetChild("mlrun"),
 		namespace:             namespace,
 		projectSync2PCEnabled: projectSync2PCEnabled,
@@ -92,13 +85,8 @@ func (l *LeaderOps) ResolveGetProjectResponse(_ bool, body []byte) ([]platform.P
 	return projects.ToProjectList(l.namespace), nil
 }
 
-func (l *LeaderOps) ParseJobStatusResponse(_ context.Context, _ []byte) (leaderCommon.JobResponse, bool) {
-	// MLRun does not have async job handling, so this is a placeholder
-	return nil, false
-}
-
 func (l *LeaderOps) GenerateCreateProjectRequestURL(apiAddress string) string {
-	return fmt.Sprintf("%s/%s/%s", apiAddress, APIVersionV1, "projects")
+	return fmt.Sprintf("%s/%s/%s", apiAddress, string(leaderCommon.APIVersionV1), "projects")
 }
 
 func (l *LeaderOps) HandleCreateResponseErr(ctx context.Context, responseBody []byte, response *http.Response, err error) error {
@@ -119,18 +107,8 @@ func (l *LeaderOps) HandleCreateResponseErr(ctx context.Context, responseBody []
 	return errors.Wrap(err, "Failed to send request to leader")
 }
 
-func (l *LeaderOps) GetJobIdUrl(_, _ string) string {
-	// MLRun does not have async job handling, so this is a placeholder
-	return ""
-}
-
-func (l *LeaderOps) IsJobCompleted(_ context.Context, _ leaderCommon.JobResponse, _ string) error {
-	// MLRun does not have async job handling, so this is a placeholder
-	return nil
-}
-
 func (l *LeaderOps) GenerateUpdateProjectRequestURL(apiAddress, projectName string) string {
-	return l.projectRequestURL(apiAddress, projectName, APIVersionV1)
+	return l.ProjectRequestURL(apiAddress, leaderCommon.APIVersionV1, projectName)
 }
 
 func (l *LeaderOps) GetDeleteExpectedStatusCode() int {
@@ -142,20 +120,16 @@ func (l *LeaderOps) GetDeleteStrategyHeaderName() string {
 }
 
 func (l *LeaderOps) GenerateGetProjectsRequestURL(apiAddress, projectName string) string {
-	url := fmt.Sprintf("%s/%s/projects", apiAddress, APIVersionV1)
-	if projectName != "" {
-		url += fmt.Sprintf("/%s", projectName)
-	}
-	return url
+	return l.ProjectRequestURL(apiAddress, leaderCommon.APIVersionV1, projectName)
 }
 
 func (l *LeaderOps) GenerateGetUpdatedAfterRequestURL(apiAddress string) string {
 	// TODO - for now there is no filter addition to the URL, should be added when MLRun supports updated_at
-	return fmt.Sprintf("%s/%s", apiAddress, "projects")
+	return l.ProjectRequestURL(apiAddress, leaderCommon.APIVersionV1, "")
 }
 
 func (l *LeaderOps) GenerateDeleteProjectRequestURL(apiAddress, projectName string) string {
-	return l.projectRequestURL(apiAddress, projectName, APIVersionV2)
+	return l.ProjectRequestURL(apiAddress, leaderCommon.APIVersionV2, projectName)
 }
 
 // EvaluateLeaderRequest is the entry point for every project write that originates from MLRun.
@@ -222,22 +196,6 @@ func (l *LeaderOps) EvaluateLeaderRequest(_ context.Context, labels map[string]s
 // evaluation is an unconditional pass-through, so the Get would be wasted.
 func (l *LeaderOps) ProjectSync2PCEnabled() bool {
 	return l.projectSync2PCEnabled
-}
-
-func (l *LeaderOps) ShouldWaitForCreateCompletion() bool { return false }
-
-func (l *LeaderOps) GetJobStatusRequestCookies(_ *platformconfig.Config) []*http.Cookie { return nil }
-
-func (l *LeaderOps) GetJobRequestFilter(_ *time.Time) string { return "" }
-
-func (l *LeaderOps) GetAuthSessionCookie(_ auth.Session) *http.Cookie { return nil }
-
-func (l *LeaderOps) AddAuthSessionHeaders(headers map[string]string, authSession auth.Session) {
-	headers["authorization"] = authSession.CompileAuthorizationHeader()
-}
-
-func (l *LeaderOps) projectRequestURL(apiAddress, projectName string, version APIVersion) string {
-	return fmt.Sprintf("%s/%s/%s/%s", apiAddress, version, "projects", projectName)
 }
 
 // validateProvision validates the Provision step (sync-status=creating in request labels).

--- a/pkg/platform/abstract/project/external/leader/mlrun/leader_test.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/leader_test.go
@@ -296,7 +296,7 @@ func (suite *LeaderTestSuite) TestGenerateGetProjectsRequestURL() {
 
 func (suite *LeaderTestSuite) TestGenerateGetUpdatedAfterRequestURL() {
 	url := suite.leaderOps.GenerateGetUpdatedAfterRequestURL("test")
-	suite.Require().Equal("test/projects", url)
+	suite.Require().Equal("test/v1/projects", url)
 }
 
 func (suite *LeaderTestSuite) TestGenerateDeleteProjectRequestURL() {

--- a/pkg/platform/abstract/project/external/leader/oris/leader.go
+++ b/pkg/platform/abstract/project/external/leader/oris/leader.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oris
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/nuclio/nuclio/pkg/platform"
+	leaderCommon "github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader"
+	leaderabstract "github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader/abstract"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+	"github.com/nuclio/nuclio-sdk-go"
+)
+
+// LeaderOps implements leader.LeaderOps for the Oris projects leader.
+type LeaderOps struct {
+	*leaderabstract.LeaderOps
+	logger logger.Logger
+	// namespace is used to enrich Oris responses that omit the namespace.
+	namespace string
+}
+
+// NewLeaderOps creates a new Oris LeaderOps.
+func NewLeaderOps(parentLogger logger.Logger, namespace string) *LeaderOps {
+	return &LeaderOps{
+		LeaderOps: leaderabstract.NewLeaderOps(),
+		logger:    parentLogger.GetChild("oris"),
+		namespace: namespace,
+	}
+}
+
+func (l *LeaderOps) GenerateProjectRequestBody(projectConfig *platform.ProjectConfig) ([]byte, error) {
+	project, err := NewProjectFromProjectConfig(projectConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create project from project config")
+	}
+	return json.Marshal(project)
+}
+
+func (l *LeaderOps) GenerateProjectDeletionRequestBody(projectName string) ([]byte, error) {
+	return []byte{}, nil
+}
+
+func (l *LeaderOps) ResolveCreateProjectResponse(ctx context.Context, body []byte) (leaderCommon.CreateProjectResponse, error) {
+	project := OrisProject{}
+	if err := json.Unmarshal(body, &project); err != nil {
+		return nil, errors.Wrap(err, "Failed to unmarshal response body")
+	}
+
+	l.logger.DebugWithCtx(ctx,
+		"Successfully sent create project request to leader",
+		"projectName", project.Metadata.Name)
+	return &project, nil
+}
+
+func (l *LeaderOps) ResolveGetProjectResponse(_ bool, body []byte) ([]platform.Project, error) {
+	var projects OrisProjectList
+	if err := json.Unmarshal(body, &projects); err != nil {
+		return nil, errors.Wrap(err, "Failed to unmarshal response body")
+	}
+
+	return projects.ToProjectList(l.namespace), nil
+}
+
+func (l *LeaderOps) GenerateCreateProjectRequestURL(apiAddress string) string {
+	return l.ProjectRequestURL(apiAddress, leaderCommon.APIVersionV1, "")
+}
+
+func (l *LeaderOps) HandleCreateResponseErr(ctx context.Context, responseBody []byte, response *http.Response, err error) error {
+	var projectResponse OrisProject
+
+	if unmarshalErr := json.Unmarshal(responseBody, &projectResponse); unmarshalErr == nil && projectResponse.Status.ErrorMessage != "" {
+		l.logger.ErrorWithCtx(ctx,
+			"Create project has failed",
+			"err", err,
+			"responseError", projectResponse.Status.ErrorMessage,
+			"responseStackTrace", projectResponse.Status.StackTrace)
+		if response == nil {
+			return errors.New("Failed to get response from leader, response is nil")
+		}
+		return nuclio.GetByStatusCode(int(projectResponse.Status.StatusCode))(projectResponse.Status.ErrorMessage)
+	}
+	return errors.Wrap(err, "Failed to send request to leader")
+}
+
+func (l *LeaderOps) GetDeleteExpectedStatusCode() int {
+	return http.StatusNoContent
+}
+
+func (l *LeaderOps) GenerateUpdateProjectRequestURL(apiAddress, projectName string) string {
+	return l.ProjectRequestURL(apiAddress, leaderCommon.APIVersionV1, projectName)
+}
+
+func (l *LeaderOps) GenerateGetProjectsRequestURL(apiAddress, projectName string) string {
+	return l.ProjectRequestURL(apiAddress, leaderCommon.APIVersionV1, projectName)
+}
+
+func (l *LeaderOps) GenerateGetUpdatedAfterRequestURL(apiAddress string) string {
+	return l.ProjectRequestURL(apiAddress, leaderCommon.APIVersionV1, "")
+}
+
+func (l *LeaderOps) GenerateDeleteProjectRequestURL(apiAddress, projectName string) string {
+	return l.ProjectRequestURL(apiAddress, leaderCommon.APIVersionV1, projectName)
+}

--- a/pkg/platform/abstract/project/external/leader/oris/leader.go
+++ b/pkg/platform/abstract/project/external/leader/oris/leader.go
@@ -87,7 +87,15 @@ func (l *LeaderOps) GenerateCreateProjectRequestURL(apiAddress string) string {
 func (l *LeaderOps) HandleCreateResponseErr(ctx context.Context, responseBody []byte, response *http.Response, err error) error {
 	var projectResponse OrisProject
 
-	if unmarshalErr := json.Unmarshal(responseBody, &projectResponse); unmarshalErr == nil && projectResponse.Status.ErrorMessage != "" {
+	if unmarshalErr := json.Unmarshal(responseBody, &projectResponse); unmarshalErr != nil {
+		l.logger.WarnWithCtx(ctx,
+			"Failed to unmarshal leader error response body",
+			"err", err,
+			"unmarshalErr", unmarshalErr)
+		return errors.Wrap(unmarshalErr, "Failed to unmarshal response body")
+	}
+
+	if projectResponse.Status.ErrorMessage != "" {
 		l.logger.ErrorWithCtx(ctx,
 			"Create project has failed",
 			"err", err,

--- a/pkg/platform/abstract/project/external/leader/oris/leader_test.go
+++ b/pkg/platform/abstract/project/external/leader/oris/leader_test.go
@@ -1,0 +1,213 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oris
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/platform"
+
+	"github.com/nuclio/logger"
+	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type LeaderTestSuite struct {
+	suite.Suite
+	logger    logger.Logger
+	leaderOps *LeaderOps
+	namespace string
+}
+
+func (suite *LeaderTestSuite) SetupSuite() {
+	var err error
+	suite.logger, err = nucliozap.NewNuclioZapTest("test-oris-leader")
+	suite.Require().NoError(err)
+	suite.namespace = "test-namespace"
+	suite.leaderOps = NewLeaderOps(suite.logger, suite.namespace)
+}
+
+func (suite *LeaderTestSuite) TestGenerateProjectRequestBody() {
+	tests := []struct {
+		name        string
+		project     *platform.ProjectConfig
+		expectError bool
+	}{
+		{
+			name: "ValidProject",
+			project: &platform.ProjectConfig{
+				Meta: platform.ProjectMeta{Name: "test"},
+				Spec: platform.ProjectSpec{Owner: "jsmith", Description: "some description"},
+			},
+		},
+		{
+			name:        "NilProject",
+			project:     nil,
+			expectError: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		suite.Run(testCase.name, func() {
+			result, err := suite.leaderOps.GenerateProjectRequestBody(testCase.project)
+			if testCase.expectError {
+				suite.Require().Error(err)
+				suite.Require().Nil(result)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().NotNil(result)
+				var resultProject OrisProject
+				suite.Require().NoError(json.Unmarshal(result, &resultProject))
+				suite.Require().Equal(testCase.project.Meta.Name, resultProject.Metadata.Name)
+				suite.Require().Equal(testCase.project.Spec.Owner, resultProject.Spec.Owner)
+				suite.Require().Equal(testCase.project.Spec.Description, resultProject.Spec.Description)
+			}
+		})
+	}
+}
+
+func (suite *LeaderTestSuite) TestGenerateProjectDeletionRequestBody() {
+	suite.Run("ValidProjectName", func() {
+		result, err := suite.leaderOps.GenerateProjectDeletionRequestBody("my-project")
+		suite.Require().NoError(err)
+		suite.Require().Empty(result)
+	})
+}
+
+func (suite *LeaderTestSuite) TestResolveCreateProjectResponse() {
+	testCases := []struct {
+		name        string
+		body        []byte
+		expectError bool
+	}{
+		{
+			name: "ValidResponse",
+			body: func() []byte {
+				b, _ := json.Marshal(OrisProject{
+					Metadata: OrisProjectMetadata{Name: "test-project"},
+					Spec:     OrisProjectSpec{Owner: "jsmith", Description: "some description"},
+				})
+				return b
+			}(),
+		},
+		{
+			name:        "InvalidResponse",
+			body:        []byte(`not-json`),
+			expectError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		suite.Run(testCase.name, func() {
+			resp, err := suite.leaderOps.ResolveCreateProjectResponse(context.TODO(), testCase.body)
+			if testCase.expectError {
+				suite.Require().Error(err)
+				suite.Require().Nil(resp)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().NotNil(resp)
+				suite.Require().Equal("", resp.GetLastJobID())
+				responseProject, ok := resp.(*OrisProject)
+				suite.Require().True(ok)
+				suite.Require().Equal("test-project", responseProject.Metadata.Name)
+				suite.Require().Equal("jsmith", responseProject.Spec.Owner)
+				suite.Require().Equal("some description", responseProject.Spec.Description)
+			}
+		})
+	}
+}
+
+func (suite *LeaderTestSuite) TestResolveGetProjectResponse() {
+	body := []byte(`{"items":[
+		{"metadata":{"name":"proj-a","labels":{"team":"ds"},"annotations":{"note":"first"}},"spec":{"owner":"jsmith","description":"first project"}},
+		{"metadata":{"name":"proj-b"},"spec":{"owner":"jdoe","description":"second project"}}
+	]}`)
+	projects, err := suite.leaderOps.ResolveGetProjectResponse(false, body)
+	suite.Require().NoError(err)
+	suite.Require().Len(projects, 2)
+	for _, project := range projects {
+		suite.Require().Equal(suite.namespace, project.GetConfig().Meta.Namespace)
+	}
+
+	firstConfig := projects[0].GetConfig()
+	suite.Require().Equal("proj-a", firstConfig.Meta.Name)
+	suite.Require().Equal(map[string]string{"team": "ds"}, firstConfig.Meta.Labels)
+	suite.Require().Equal(map[string]string{"note": "first"}, firstConfig.Meta.Annotations)
+	suite.Require().Equal("jsmith", firstConfig.Spec.Owner)
+	suite.Require().Equal("first project", firstConfig.Spec.Description)
+}
+
+func (suite *LeaderTestSuite) TestParseJobStatusResponse() {
+	resp, ok := suite.leaderOps.ParseJobStatusResponse(context.TODO(), nil)
+	suite.Require().Nil(resp)
+	suite.Require().False(ok)
+}
+
+func (suite *LeaderTestSuite) TestGenerateCreateProjectRequestURL() {
+	url := suite.leaderOps.GenerateCreateProjectRequestURL("http://localhost/api")
+	suite.Require().Equal("http://localhost/api/v1/projects", url)
+}
+
+func (suite *LeaderTestSuite) TestGenerateUpdateProjectRequestURL() {
+	url := suite.leaderOps.GenerateUpdateProjectRequestURL("http://localhost/api", "test-project")
+	suite.Require().Equal("http://localhost/api/v1/projects/test-project", url)
+}
+
+func (suite *LeaderTestSuite) TestGenerateGetProjectsRequestURL() {
+	url := suite.leaderOps.GenerateGetProjectsRequestURL("http://localhost/api", "test-project")
+	suite.Require().Equal("http://localhost/api/v1/projects/test-project", url)
+}
+
+func (suite *LeaderTestSuite) TestGenerateDeleteProjectRequestURL() {
+	url := suite.leaderOps.GenerateDeleteProjectRequestURL("http://localhost/api", "test-project")
+	suite.Require().Equal("http://localhost/api/v1/projects/test-project", url)
+}
+
+func (suite *LeaderTestSuite) TestGenerateGetUpdatedAfterRequestURL() {
+	url := suite.leaderOps.GenerateGetUpdatedAfterRequestURL("http://localhost/api")
+	suite.Require().Equal("http://localhost/api/v1/projects", url)
+}
+
+func (suite *LeaderTestSuite) TestShouldWaitForCreateCompletion() {
+	suite.Require().False(suite.leaderOps.ShouldWaitForCreateCompletion())
+}
+
+func (suite *LeaderTestSuite) TestGetDeleteExpectedStatusCode() {
+	suite.Require().Equal(204, suite.leaderOps.GetDeleteExpectedStatusCode())
+}
+
+func (suite *LeaderTestSuite) TestProjectSync2PCEnabled() {
+	suite.Require().False(suite.leaderOps.ProjectSync2PCEnabled())
+}
+
+func (suite *LeaderTestSuite) TestEvaluateLeaderRequestPassesThrough() {
+	shouldApply, err := suite.leaderOps.EvaluateLeaderRequest(context.TODO(), map[string]string{}, nil)
+	suite.Require().NoError(err)
+	suite.Require().True(shouldApply)
+}
+
+func (suite *LeaderTestSuite) TestIsJobCompleted() {
+	suite.Require().NoError(suite.leaderOps.IsJobCompleted(context.TODO(), nil, ""))
+}
+
+func TestLeaderTestSuite(t *testing.T) {
+	suite.Run(t, new(LeaderTestSuite))
+}

--- a/pkg/platform/abstract/project/external/leader/oris/leader_test.go
+++ b/pkg/platform/abstract/project/external/leader/oris/leader_test.go
@@ -21,10 +21,12 @@ package oris
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/platform"
 
+	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
@@ -153,6 +155,57 @@ func (suite *LeaderTestSuite) TestResolveGetProjectResponse() {
 	suite.Require().Equal(map[string]string{"note": "first"}, firstConfig.Meta.Annotations)
 	suite.Require().Equal("jsmith", firstConfig.Spec.Owner)
 	suite.Require().Equal("first project", firstConfig.Spec.Description)
+}
+
+func (suite *LeaderTestSuite) TestHandleCreateResponseErr() {
+	testCases := []struct {
+		name         string
+		body         []byte
+		response     *http.Response
+		expectErrStr string
+	}{
+		{
+			name:         "UnmarshalFailure",
+			body:         []byte(`not-json`),
+			response:     &http.Response{StatusCode: http.StatusBadRequest},
+			expectErrStr: "Failed to unmarshal response body",
+		},
+		{
+			name: "ErrorMessagePresent",
+			body: func() []byte {
+				b, _ := json.Marshal(OrisProject{Status: OrisProjectStatus{ErrorMessage: "some error", StatusCode: http.StatusBadRequest}})
+				return b
+			}(),
+			response:     &http.Response{StatusCode: http.StatusBadRequest},
+			expectErrStr: "some error",
+		},
+		{
+			name: "ErrorMessagePresentNilResponse",
+			body: func() []byte {
+				b, _ := json.Marshal(OrisProject{Status: OrisProjectStatus{ErrorMessage: "some error"}})
+				return b
+			}(),
+			response:     nil,
+			expectErrStr: "Failed to get response from leader, response is nil",
+		},
+		{
+			name: "NoErrorMessage",
+			body: func() []byte {
+				b, _ := json.Marshal(OrisProject{Metadata: OrisProjectMetadata{Name: "test-project"}})
+				return b
+			}(),
+			response:     &http.Response{StatusCode: http.StatusOK},
+			expectErrStr: "Failed to send request to leader",
+		},
+	}
+
+	for _, testCase := range testCases {
+		suite.Run(testCase.name, func() {
+			err := suite.leaderOps.HandleCreateResponseErr(context.TODO(), testCase.body, testCase.response, errors.New(""))
+			suite.Require().Error(err)
+			suite.Require().Equal(testCase.expectErrStr, err.Error())
+		})
+	}
 }
 
 func (suite *LeaderTestSuite) TestParseJobStatusResponse() {

--- a/pkg/platform/abstract/project/external/leader/oris/types.go
+++ b/pkg/platform/abstract/project/external/leader/oris/types.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oris
+
+import (
+	"github.com/nuclio/nuclio/pkg/platform"
+	common "github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader"
+
+	"github.com/nuclio/errors"
+)
+
+// OrisProject represents a project as returned by / sent to the Oris leader.
+type OrisProject struct {
+	Metadata OrisProjectMetadata `json:"metadata"`
+	Spec     OrisProjectSpec     `json:"spec"`
+	Status   OrisProjectStatus   `json:"status"`
+}
+
+// GetLastJobID satisfies the leader.CreateProjectResponse interface.
+// TODO: Oris does not yet have async job handling; revisit if it gains one.
+func (p *OrisProject) GetLastJobID() string {
+	return ""
+}
+
+// GetConfig satisfies the platform.Project interface.
+func (p *OrisProject) GetConfig() *platform.ProjectConfig {
+	updatedAt := common.ParseTimeFromTimestamp(p.Metadata.UpdatedAt)
+	return &platform.ProjectConfig{
+		Meta: platform.ProjectMeta{
+			Name:        p.Metadata.Name,
+			Namespace:   p.Metadata.Namespace,
+			Labels:      p.Metadata.Labels,
+			Annotations: p.Metadata.Annotations,
+		},
+		Spec: platform.ProjectSpec{
+			Description: p.Spec.Description,
+			Owner:       p.Spec.Owner,
+		},
+		Status: platform.ProjectStatus{
+			UpdatedAt: &updatedAt,
+		},
+	}
+}
+
+// IsProjectOnline satisfies the platform.Project interface.
+func (p *OrisProject) IsProjectOnline() bool {
+	// TODO: Resolve the real online status according to the Oris leader.
+	return true
+}
+
+// NewProjectFromProjectConfig converts a platform.ProjectConfig into the Oris wire format.
+func NewProjectFromProjectConfig(projectConfig *platform.ProjectConfig) (OrisProject, error) {
+	if projectConfig == nil {
+		return OrisProject{}, errors.New("ProjectConfig is nil")
+	}
+
+	return OrisProject{
+		Metadata: OrisProjectMetadata{
+			Name:        projectConfig.Meta.Name,
+			Labels:      projectConfig.Meta.Labels,
+			Annotations: projectConfig.Meta.Annotations,
+		},
+		Spec: OrisProjectSpec{
+			Description: projectConfig.Spec.Description,
+			Owner:       projectConfig.Spec.Owner,
+		},
+	}, nil
+}
+
+type OrisProjectMetadata struct {
+	Name        string            `json:"name"`
+	Namespace   string            `json:"namespace,omitempty"`
+	UpdatedAt   string            `json:"updatedAt,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+type OrisProjectSpec struct {
+	Owner       string `json:"owner,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type OrisProjectStatus struct {
+	Ctx          string `json:"ctx,omitempty"`
+	StatusCode   int32  `json:"statusCode,omitempty"`
+	ErrorMessage string `json:"errorMessage,omitempty"`
+	StackTrace   string `json:"stackTrace,omitempty"`
+	RedirectUri  string `json:"redirectUri,omitempty"`
+}
+
+type OrisListStatus struct {
+	*OrisProjectStatus
+	Total   int32 `json:"total,omitempty"`
+	HasMore bool  `json:"hasMore,omitempty"`
+}
+
+// OrisProjectList is a placeholder shape for a list-projects response from the Oris leader.
+type OrisProjectList struct {
+	Items  []OrisProject  `json:"items,omitempty"`
+	Status OrisListStatus `json:"status,omitempty"`
+}
+
+// ToProjectList converts an OrisProjectList into the generic platform.Project slice,
+// enriching each entry with namespace since the leader response may omit it.
+func (opl *OrisProjectList) ToProjectList(namespace string) []platform.Project {
+	var projects []platform.Project
+	for _, orisProject := range opl.Items {
+		project := &OrisProject{
+			Metadata: orisProject.Metadata,
+			Spec:     orisProject.Spec,
+			Status:   orisProject.Status,
+		}
+		project.Metadata.Namespace = namespace
+		projects = append(projects, project)
+	}
+	return projects
+}

--- a/pkg/platform/abstract/project/external/leader/types.go
+++ b/pkg/platform/abstract/project/external/leader/types.go
@@ -164,6 +164,13 @@ const (
 	JobStateFailed    JobState = "failed"
 )
 
+type APIVersion string
+
+const (
+	APIVersionV1 APIVersion = "v1"
+	APIVersionV2 APIVersion = "v2"
+)
+
 const (
 	ProjectTimeLayout   = "2006-01-02T15:04:05.000000+00:00"
 	ProjectOnlineStatus = "online"

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -193,6 +193,7 @@ type ProjectsLeaderKind string
 const (
 	ProjectsLeaderKindIguazio ProjectsLeaderKind = "iguazio"
 	ProjectsLeaderKindMlrun   ProjectsLeaderKind = "mlrun"
+	ProjectsLeaderKindOris    ProjectsLeaderKind = "oris"
 	ProjectsLeaderKindMock    ProjectsLeaderKind = "mock"
 )
 


### PR DESCRIPTION
### 📝 Description
Adds scaffolding for a new project leader, **Oris**: a `LeaderOps` implementation, wire-format types, and factory wiring so `platformconfig.ProjectsLeaderKindOris` can be configured as a `projectsLeader`.

Also introduces a `leader/abstract` package with default `LeaderOps` implementations for behavior that's identical across leaders (no-op job polling, standard auth headers, 2PC pass-through), and refactors `mlrun`'s `LeaderOps` to embed it, dropping the now-duplicated methods.

**Notes:**
- The API contract is based on https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/654737409/Orca+as+leader+HLD#User-facing-request-payload 
- This wasn't tested on a real system as the Oris project service is still WIP.

---

### 🛠️ Changes Made
- `pkg/platform/abstract/project/external/leader/oris/`: new `LeaderOps` implementation, `OrisProject`/wire types (aligned with the real Oris project payload, including `spec.owner`), and unit tests.
- `pkg/platform/abstract/project/external/leader/abstract/`: new package providing shared default `LeaderOps` methods for embedding by concrete leaders, plus unit tests.
- `pkg/platform/abstract/project/external/leader/mlrun/`: refactored to embed `abstract.LeaderOps` and drop duplicated method implementations.
- `pkg/platform/abstract/project/external/client.go`: factory wiring for `ProjectsLeaderKindOris`.
- `pkg/platformconfig/types.go`: new `ProjectsLeaderKindOris` constant.
- `pkg/platform/abstract/project/external/leader/types.go`: hoisted `APIVersion`/`APIVersionV1`/`APIVersionV2` out of `mlrun` into the shared `leader` package so `oris` and `mlrun` can both use them.

Oris' create/update/delete URL generation was verified against the real endpoints:
- Create → `POST /api/v1/projects`
- Update → `PUT /api/v1/projects/{name}`
- Delete → `DELETE /api/v1/projects/{name}`

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- All unit tests pass
- `make fmt lint` — 0 issues.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-869
- Design docs links: https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/654737409/Orca+as+leader+HLD#User-facing-request-payload

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
This is scaffolding only — Oris' `LeaderOps` currently has no async job handling and does not participate in the two-phase-commit project sync protocol (both inherited as defaults from `leader/abstract`). Follow-up work will flesh out real behavior as Oris' API stabilizes.