### PR TITLE
[auth-proxy sidecar] Mount basic-auth password from Secret volume

### DIFF
--- a/cmd/authproxy/app/authproxy.go
+++ b/cmd/authproxy/app/authproxy.go
@@ -17,12 +17,16 @@ limitations under the License.
 package app
 
 import (
+	"os"
+	"strings"
+
 	"github.com/nuclio/nuclio/pkg/auth/authproxy"
 	"github.com/nuclio/nuclio/pkg/loggersink"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
+	"golang.org/x/crypto/bcrypt"
 
 	// register logger sinks (stdout, appinsights) into the loggersink registry via init()
 	_ "github.com/nuclio/nuclio/pkg/sinks"
@@ -71,27 +75,46 @@ func Run(config *Config) error {
 
 // newAuthenticator creates kube clients when needed and delegates to the pkg-level factory.
 func newAuthenticator(rootLogger logger.Logger, config *Config) (authproxy.Authenticator, error) {
+	staticConfig, err := resolveStaticFunctionAuthConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to resolve static function auth config")
+	}
 	return authproxy.NewAuthenticator(rootLogger,
 		config.Mode,
 		config.AuthURL,
 		config.SigninURL,
 		config.AuthKind,
-		resolveStaticFunctionAuthConfig(config),
+		staticConfig,
 		config.KubeconfigPath,
 		config.Namespace)
 }
 
-// resolveStaticFunctionAuthConfig builds the fixed auth config for the reverseProxy topology. In basicAuth
-// mode the username/password come from the config (the password is injected from a Secret via secretKeyRef).
-func resolveStaticFunctionAuthConfig(config *Config) authproxy.FunctionAuthConfig {
+// resolveStaticFunctionAuthConfig builds the fixed auth config for the reverseProxy topology.
+// For basicAuth mode it reads the password from the Secret-volume file, bcrypt-hashes it, and stores
+// only the hash in FunctionAuthConfig so plaintext never enters that struct.
+func resolveStaticFunctionAuthConfig(config *Config) (authproxy.FunctionAuthConfig, error) {
 	mode := authproxy.AuthenticationMode(config.AuthMode)
 	if mode == "" {
 		mode = authproxy.ModeNone
 	}
 
-	return authproxy.FunctionAuthConfig{
+	functionAuthConfig := authproxy.FunctionAuthConfig{
 		Mode:              mode,
 		BasicAuthUsername: config.BasicAuthUsername,
-		BasicAuthPassword: config.BasicAuthPassword,
 	}
+
+	if config.BasicAuthPasswordPath != "" {
+		data, err := os.ReadFile(config.BasicAuthPasswordPath)
+		if err != nil {
+			return authproxy.FunctionAuthConfig{}, errors.Wrapf(err, "Failed to read basic-auth password file '%s'", config.BasicAuthPasswordPath)
+		}
+		hash, err := bcrypt.GenerateFromPassword([]byte(strings.TrimSpace(string(data))), bcrypt.DefaultCost)
+		if err != nil {
+			return authproxy.FunctionAuthConfig{}, errors.Wrap(err, "Failed to hash basic-auth password")
+		}
+		functionAuthConfig.BasicAuthPasswordHash = hash
+		config.BasicAuthPasswordPath = ""
+	}
+
+	return functionAuthConfig, nil
 }

--- a/cmd/authproxy/app/config.go
+++ b/cmd/authproxy/app/config.go
@@ -25,18 +25,18 @@ import (
 
 // Config holds the auth-proxy sidecar configuration.
 type Config struct {
-	Mode               authpkg.ProxyMode
-	ListenPort         int
-	UpstreamURL        string // the URL of the upstream service to which requests are proxied (reverseProxy mode only)
-	AuthURL            string // the URL of the auth service to which requests are sent for authentication
-	SigninURL          string // the URL of the sign-in service to which requests are redirected for sign-in (browser mode only)
-	AuthMode           string
-	BasicAuthUsername  string
-	BasicAuthPassword  string
-	Namespace          string
-	KubeconfigPath     string
-	PlatformConfigPath string
-	AuthKind           authpkg.Kind // auth kind used for API/browser authentication
+	Mode                  authpkg.ProxyMode
+	ListenPort            int
+	UpstreamURL           string // the URL of the upstream service to which requests are proxied (reverseProxy mode only)
+	AuthURL               string // the URL of the auth service to which requests are sent for authentication
+	SigninURL             string // the URL of the sign-in service to which requests are redirected for sign-in (browser mode only)
+	AuthMode              string
+	BasicAuthUsername     string
+	BasicAuthPasswordPath string // path to a Secret-volume file; read, hashed, and zeroed by resolveStaticFunctionAuthConfig
+	Namespace             string
+	KubeconfigPath        string
+	PlatformConfigPath    string
+	AuthKind              authpkg.Kind // auth kind used for API/browser authentication
 }
 
 func validateConfiguration(config *Config) error {
@@ -75,8 +75,8 @@ func validateReverseProxyConfiguration(config *Config) error {
 		if config.BasicAuthUsername == "" {
 			return errors.New("Basic-auth username must be provided for 'basicAuth' authentication mode")
 		}
-		if config.BasicAuthPassword == "" {
-			return errors.New("Basic-auth password must be provided for 'basicAuth' authentication mode")
+		if config.BasicAuthPasswordPath == "" {
+			return errors.New("Basic-auth password path must be provided for 'basicAuth' authentication mode")
 		}
 	case authproxy.ModeNone, "":
 		// no additional requirements

--- a/cmd/authproxy/app/server_test.go
+++ b/cmd/authproxy/app/server_test.go
@@ -22,14 +22,17 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/auth/authproxy"
 	httptrigger "github.com/nuclio/nuclio/pkg/processor/trigger/http"
 
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // fakeAuthenticator is a test double for authproxy.Authenticator; it records calls and, on reject,
@@ -202,4 +205,66 @@ func (suite *ServerTestSuite) doRequest(handler http.Handler, path string) (int,
 
 func TestServerTestSuite(t *testing.T) {
 	suite.Run(t, new(ServerTestSuite))
+}
+
+// ResolveStaticConfigTestSuite covers resolveStaticFunctionAuthConfig: the app-layer function that reads
+// the Secret-volume file, bcrypt-hashes the password, and clears the path so plaintext never persists.
+type ResolveStaticConfigTestSuite struct {
+	suite.Suite
+}
+
+func (suite *ResolveStaticConfigTestSuite) TestHappyPath() {
+	f := suite.writeTempPassword("s3cret")
+	defer os.Remove(f)
+
+	cfg := &Config{AuthMode: string(authproxy.ModeBasicAuth), BasicAuthUsername: "user", BasicAuthPasswordPath: f}
+	result, err := resolveStaticFunctionAuthConfig(cfg)
+	suite.Require().NoError(err)
+
+	suite.Require().Equal(authproxy.ModeBasicAuth, result.Mode)
+	suite.Require().Equal("user", result.BasicAuthUsername)
+	suite.Require().NoError(bcrypt.CompareHashAndPassword(result.BasicAuthPasswordHash, []byte("s3cret")))
+	suite.Require().Empty(cfg.BasicAuthPasswordPath, "path must be cleared after reading")
+}
+
+// TestWhitespaceTrimming verifies that a trailing newline (common in Secret files) is stripped before hashing.
+func (suite *ResolveStaticConfigTestSuite) TestWhitespaceTrimming() {
+	f := suite.writeTempPassword("s3cret\n")
+	defer os.Remove(f)
+
+	cfg := &Config{AuthMode: string(authproxy.ModeBasicAuth), BasicAuthUsername: "user", BasicAuthPasswordPath: f}
+	result, err := resolveStaticFunctionAuthConfig(cfg)
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(bcrypt.CompareHashAndPassword(result.BasicAuthPasswordHash, []byte("s3cret")),
+		"hash must verify against trimmed password, not password+newline")
+	suite.Require().Error(bcrypt.CompareHashAndPassword(result.BasicAuthPasswordHash, []byte("s3cret\n")),
+		"hash must not verify against untrimmed password")
+}
+
+func (suite *ResolveStaticConfigTestSuite) TestMissingFile() {
+	cfg := &Config{AuthMode: string(authproxy.ModeBasicAuth), BasicAuthUsername: "user", BasicAuthPasswordPath: "/nonexistent/path/password"}
+	_, err := resolveStaticFunctionAuthConfig(cfg)
+	suite.Require().Error(err)
+	suite.Require().Contains(err.Error(), "Failed to read basic-auth password file")
+}
+
+func (suite *ResolveStaticConfigTestSuite) TestNoPasswordPath() {
+	cfg := &Config{AuthMode: string(authproxy.ModeBasicAuth), BasicAuthUsername: "user"}
+	result, err := resolveStaticFunctionAuthConfig(cfg)
+	suite.Require().NoError(err)
+	suite.Require().Nil(result.BasicAuthPasswordHash)
+}
+
+func (suite *ResolveStaticConfigTestSuite) writeTempPassword(content string) string {
+	f, err := os.CreateTemp("", "basic-auth-password-*")
+	suite.Require().NoError(err)
+	_, err = f.WriteString(content)
+	suite.Require().NoError(err)
+	suite.Require().NoError(f.Close())
+	return f.Name()
+}
+
+func TestResolveStaticConfigTestSuite(t *testing.T) {
+	suite.Run(t, new(ResolveStaticConfigTestSuite))
 }

--- a/cmd/authproxy/main.go
+++ b/cmd/authproxy/main.go
@@ -36,7 +36,7 @@ func main() {
 	signinURL := flag.String("signin-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_SIGNIN_URL", ""), "URL unauthenticated browser requests are redirected to sign-in")
 	authMode := flag.String("auth-mode", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_AUTH_MODE", string(authproxy.ModeNone)), "Authentication mode for reverseProxy: none, api, browser or basicAuth")
 	basicAuthUsername := flag.String("basic-auth-username", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_BASIC_AUTH_USERNAME", ""), "Basic-auth username (used only when auth-mode=basicAuth)")
-	basicAuthPassword := flag.String("basic-auth-password", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_BASIC_AUTH_PASSWORD", ""), "Basic-auth password, injected from a Secret via secretKeyRef (used only when auth-mode=basicAuth)")
+	basicAuthPasswordPath := flag.String("basic-auth-password-path", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_BASIC_AUTH_PASSWORD_PATH", ""), "Path to file containing the basic-auth password, mounted from a Secret volume (used only when auth-mode=basicAuth)")
 	namespace := flag.String("namespace", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_NAMESPACE", ""), "Namespace of the target functions")
 	kubeconfigPath := flag.String("kubeconfig-path", os.Getenv("KUBECONFIG"), "Path of kubeconfig file")
 	platformConfigurationPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
@@ -44,18 +44,18 @@ func main() {
 	flag.Parse()
 
 	if err := app.Run(&app.Config{
-		Mode:               auth.ProxyMode(*mode),
-		ListenPort:         *listenPort,
-		UpstreamURL:        *upstreamURL,
-		AuthURL:            *authURL,
-		SigninURL:          *signinURL,
-		AuthMode:           *authMode,
-		BasicAuthUsername:  *basicAuthUsername,
-		BasicAuthPassword:  *basicAuthPassword,
-		Namespace:          *namespace,
-		KubeconfigPath:     *kubeconfigPath,
-		PlatformConfigPath: *platformConfigurationPath,
-		AuthKind:           auth.Kind(*authKind),
+		Mode:                  auth.ProxyMode(*mode),
+		ListenPort:            *listenPort,
+		UpstreamURL:           *upstreamURL,
+		AuthURL:               *authURL,
+		SigninURL:             *signinURL,
+		AuthMode:              *authMode,
+		BasicAuthUsername:     *basicAuthUsername,
+		BasicAuthPasswordPath: *basicAuthPasswordPath,
+		Namespace:             *namespace,
+		KubeconfigPath:        *kubeconfigPath,
+		PlatformConfigPath:    *platformConfigurationPath,
+		AuthKind:              auth.Kind(*authKind),
 	}); err != nil {
 		errors.PrintErrorStack(os.Stderr, err, 5)
 		os.Exit(1)

--- a/pkg/auth/authproxy/authproxy_test.go
+++ b/pkg/auth/authproxy/authproxy_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/crypto/bcrypt"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
@@ -126,13 +127,22 @@ func (suite *AuthProxyTestSuite) TestModeBrowser() {
 
 // TestModeBasicAuth verifies basicAuth is verified locally, never via the auth-url.
 // validateConfiguration permits an empty authURL for ModeBasicAuth, so the test reflects that.
+// The caller (app layer) is responsible for hashing before constructing; the constructor receives
+// only the hash, never the plaintext.
 func (suite *AuthProxyTestSuite) TestModeBasicAuth() {
+	hash, err := bcrypt.GenerateFromPassword([]byte("pass"), bcrypt.DefaultCost)
+	suite.Require().NoError(err)
+
 	authenticator, err := NewReverseProxyAuthenticator(suite.logger,
 		"",
 		"",
 		authpkg.KindIguazioV4,
-		FunctionAuthConfig{Mode: ModeBasicAuth, BasicAuthUsername: "user", BasicAuthPassword: "pass"})
+		FunctionAuthConfig{Mode: ModeBasicAuth, BasicAuthUsername: "user", BasicAuthPasswordHash: hash})
 	suite.Require().NoError(err)
+
+	rpa := authenticator.(*reverseProxyAuthenticator)
+	suite.Require().Empty(rpa.authConfig.BasicAuthPassword, "plaintext must never be stored in FunctionAuthConfig")
+	suite.Require().NotEmpty(rpa.authConfig.BasicAuthPasswordHash, "bcrypt hash must be present")
 
 	suite.Run("valid credentials admitted locally", func() {
 		request := suite.authenticatedRequest("")
@@ -141,11 +151,25 @@ func (suite *AuthProxyTestSuite) TestModeBasicAuth() {
 		suite.Require().True(authenticator.Authenticate(recorder, request))
 	})
 
-	suite.Run("invalid credentials rejected with 401", func() {
+	suite.Run("wrong password rejected with 401", func() {
 		request := suite.authenticatedRequest("")
 		request.SetBasicAuth("user", "wrong")
 		recorder := httptest.NewRecorder()
 		suite.Require().False(authenticator.Authenticate(recorder, request))
+		suite.Require().Equal(http.StatusUnauthorized, recorder.Code)
+	})
+
+	suite.Run("wrong username rejected with 401", func() {
+		request := suite.authenticatedRequest("")
+		request.SetBasicAuth("other", "pass")
+		recorder := httptest.NewRecorder()
+		suite.Require().False(authenticator.Authenticate(recorder, request))
+		suite.Require().Equal(http.StatusUnauthorized, recorder.Code)
+	})
+
+	suite.Run("missing credentials rejected with 401", func() {
+		recorder := httptest.NewRecorder()
+		suite.Require().False(authenticator.Authenticate(recorder, suite.authenticatedRequest("")))
 		suite.Require().Equal(http.StatusUnauthorized, recorder.Code)
 	})
 }
@@ -269,6 +293,14 @@ func (suite *AuthProxyTestSuite) TestCRDAuthenticatorResolvesFunctionAuthConfig(
 	suite.Run("scrubbed basicAuth rejects wrong password", func() {
 		request := suite.authenticatedRequestFor("", "scrubbed-func")
 		request.SetBasicAuth("user", "wrong")
+		recorder := httptest.NewRecorder()
+		suite.Require().False(authenticator.Authenticate(recorder, request))
+		suite.Require().Equal(http.StatusUnauthorized, recorder.Code)
+	})
+
+	suite.Run("basicAuth rejects wrong username", func() {
+		request := suite.authenticatedRequestFor("", "basic-func")
+		request.SetBasicAuth("other", "pass")
 		recorder := httptest.NewRecorder()
 		suite.Require().False(authenticator.Authenticate(recorder, request))
 		suite.Require().Equal(http.StatusUnauthorized, recorder.Code)

--- a/pkg/auth/authproxy/reverseproxy.go
+++ b/pkg/auth/authproxy/reverseproxy.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
-	"golang.org/x/crypto/bcrypt"
 )
 
 // reverseProxyAuthenticator serves the running-function (reverseProxy) topology: its auth config is
@@ -41,15 +40,6 @@ func NewReverseProxyAuthenticator(parentLogger logger.Logger,
 	authConfig FunctionAuthConfig) (Authenticator, error) {
 	parentLogger.InfoWith("Creating reverse-proxy authenticator", "authURL", authURL, "signinURL", signinURL, "authMode", authConfig.Mode)
 
-	// If basicAuth is configured, the plaintext password is hashed with bcrypt and discarded so it is never held in memory
-	if authConfig.BasicAuthPassword != "" {
-		hash, err := bcrypt.GenerateFromPassword([]byte(authConfig.BasicAuthPassword), bcrypt.DefaultCost)
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to hash basic-auth password")
-		}
-		authConfig.BasicAuthPasswordHash = hash
-		authConfig.BasicAuthPassword = ""
-	}
 	abstract, err := newAbstractAuthenticator(parentLogger, authURL, signinURL, authKind)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create reverse-proxy authenticator")

--- a/pkg/auth/authproxy/types.go
+++ b/pkg/auth/authproxy/types.go
@@ -39,10 +39,10 @@ const (
 type FunctionAuthConfig struct {
 	Mode              AuthenticationMode
 	BasicAuthUsername string
-	BasicAuthPassword string // plaintext input; cleared after hashing in reverseProxy mode
+	BasicAuthPassword string // plaintext; used in authOnly mode where the password is resolved from the function CRD/Secret at request time
 
-	// BasicAuthPasswordHash is the bcrypt hash of BasicAuthPassword. Set by NewReverseProxyAuthenticator
-	// so the plaintext is never held in memory for the pod's lifetime.
+	// BasicAuthPasswordHash holds the bcrypt hash of the password. Set by the app layer before the
+	// reverseProxyAuthenticator is constructed, so plaintext never enters the struct in that topology.
 	BasicAuthPasswordHash []byte
 }
 


### PR DESCRIPTION
### 📝 Description
The basic-auth password are injected into the sidecar process via `secretKeyRef` (env var). This
changes it to a Secret volume mount: at startup the sidecar reads the password file, bcrypt-hashes it, and
discards the path, so plaintext never lives in `FunctionAuthConfig` or in-process memory for the pod's
lifetime. Hashing responsibility moves from `NewReverseProxyAuthenticator` to the app layer.

---

### 🛠️ Changes Made
- Replace `--basic-auth-password` flag / `NUCLIO_AUTHPROXY_BASIC_AUTH_PASSWORD` env with `--basic-auth-password-path` / `NUCLIO_AUTHPROXY_BASIC_AUTH_PASSWORD_PATH` (Secret volume file path)
- `resolveStaticFunctionAuthConfig` now returns an error; reads the file, trims whitespace, bcrypt-hashes, zeroes the path field
- Remove bcrypt hashing from `NewReverseProxyAuthenticator` — constructor receives the hash, never the plaintext
- Update `FunctionAuthConfig` comments to reflect the topology split (reverseProxy vs authOnly CRD path)
- Add uniform struct-literal alignment in `main.go`

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Unit tests
- Manually tested on vmdev132ig4
<img width="1108" height="398" alt="image" src="https://github.com/user-attachments/assets/404a26ab-5546-4782-bb05-a027446b8bdf" />


---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

The auth-proxy sidecar has not been officially released yet, so the flag/env rename (`--basic-auth-password` → `--basic-auth-password-path`) is not a breaking change.

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->