### PR TITLE
[Infra] Consolidate AuthenticationMode type into pkg/auth

### DIFF
--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -21,6 +21,17 @@ import (
 	"time"
 )
 
+// AuthenticationMode is the authentication mode for API gateways and ingress resources.
+type AuthenticationMode string
+
+const (
+	AuthenticationModeNone      AuthenticationMode = "none"
+	AuthenticationModeBasicAuth AuthenticationMode = "basicAuth"
+	AuthenticationModeAccessKey AuthenticationMode = "accessKey"
+	AuthenticationModeOauth2    AuthenticationMode = "oauth2"
+	AuthenticationModeIguazio   AuthenticationMode = "iguazio"
+)
+
 type Kind string
 
 const (

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/dashboard/functiontemplates"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
-	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
 	mockplatform "github.com/nuclio/nuclio/pkg/platform/mock"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/restful"
@@ -3070,7 +3069,7 @@ func (suite *apiGatewayTestSuite) TestGetDetailSuccessful() {
 						Percentage: 20,
 					},
 				},
-				AuthenticationMode: ingress.AuthenticationModeBasicAuth,
+				AuthenticationMode: auth.AuthenticationModeBasicAuth,
 				Authentication: &platform.APIGatewayAuthenticationSpec{
 					BasicAuth: &platform.BasicAuth{
 						Username: "user1",
@@ -3181,7 +3180,7 @@ func (suite *apiGatewayTestSuite) TestGetListSuccessful() {
 			Percentage: 20,
 		},
 	}
-	returnedAPIGateway1.APIGatewayConfig.Spec.AuthenticationMode = ingress.AuthenticationModeBasicAuth
+	returnedAPIGateway1.APIGatewayConfig.Spec.AuthenticationMode = auth.AuthenticationModeBasicAuth
 	returnedAPIGateway1.APIGatewayConfig.Spec.Authentication = &platform.APIGatewayAuthenticationSpec{
 		BasicAuth: &platform.BasicAuth{
 			Username: "user1",
@@ -3663,8 +3662,8 @@ func (suite *miscTestSuite) TestGetFrontendSpec() {
 		},
 		InactivityWindowPresets: []string{"1m", "2m"},
 	}
-	allowedAuthenticationModes := []string{string(ingress.AuthenticationModeNone),
-		string(ingress.AuthenticationModeBasicAuth)}
+	allowedAuthenticationModes := []string{string(auth.AuthenticationModeNone),
+		string(auth.AuthenticationModeBasicAuth)}
 
 	suite.mockPlatform.
 		On("GetExternalIPAddresses").

--- a/pkg/nuctl/command/create.go
+++ b/pkg/nuctl/command/create.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/platform"
-	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
 
 	"github.com/nuclio/errors"
 	"github.com/spf13/cobra"
@@ -172,13 +172,13 @@ func newCreateAPIGatewayCommandeer(ctx context.Context, createCommandeer *create
 
 			// enrich authentication mode
 			if commandeer.authenticationMode != "" {
-				commandeer.apiGatewayConfig.Spec.AuthenticationMode = ingress.AuthenticationMode(commandeer.authenticationMode)
+				commandeer.apiGatewayConfig.Spec.AuthenticationMode = auth.AuthenticationMode(commandeer.authenticationMode)
 			} else {
-				commandeer.apiGatewayConfig.Spec.AuthenticationMode = ingress.AuthenticationModeNone
+				commandeer.apiGatewayConfig.Spec.AuthenticationMode = auth.AuthenticationModeNone
 			}
 
 			// enrich basic-auth spec if it was specified
-			if commandeer.apiGatewayConfig.Spec.AuthenticationMode == ingress.AuthenticationModeBasicAuth {
+			if commandeer.apiGatewayConfig.Spec.AuthenticationMode == auth.AuthenticationModeBasicAuth {
 				if commandeer.basicAuthUsername == "" || commandeer.basicAuthPassword == "" {
 					return errors.New("Basic auth username and password must be specified")
 				}

--- a/pkg/nuctl/test/apigagteway_test.go
+++ b/pkg/nuctl/test/apigagteway_test.go
@@ -27,9 +27,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/common"
 	nuctlcommon "github.com/nuclio/nuclio/pkg/nuctl/command/common"
-	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
 	testk8s "github.com/nuclio/nuclio/test/common/k8s"
 
 	"github.com/rs/xid"
@@ -219,14 +219,14 @@ func (suite *apiGatewayInvokeTestSuite) SetupSuite() {
 }
 
 func (suite *apiGatewayInvokeTestSuite) TestInvokeAuthenticationModeBasicAuth() {
-	suite.testInvoke(ingress.AuthenticationModeBasicAuth)
+	suite.testInvoke(auth.AuthenticationModeBasicAuth)
 }
 
 func (suite *apiGatewayInvokeTestSuite) TestInvokeAuthenticationModeNone() {
-	suite.testInvoke(ingress.AuthenticationModeNone)
+	suite.testInvoke(auth.AuthenticationModeNone)
 }
 
-func (suite *apiGatewayInvokeTestSuite) testInvoke(authenticationMode ingress.AuthenticationMode) {
+func (suite *apiGatewayInvokeTestSuite) testInvoke(authenticationMode auth.AuthenticationMode) {
 	functionName := suite.deployFunction()
 
 	// use nutctl to delete the function when we're done
@@ -249,7 +249,7 @@ func (suite *apiGatewayInvokeTestSuite) testInvoke(authenticationMode ingress.Au
 	}
 
 	// fill basic auth args depending on authentication mode
-	if authenticationMode == ingress.AuthenticationModeBasicAuth {
+	if authenticationMode == auth.AuthenticationModeBasicAuth {
 		namedArgs["basic-auth-username"] = basicAuthUsername
 		namedArgs["basic-auth-password"] = basicAuthPassword
 	}
@@ -280,7 +280,7 @@ func (suite *apiGatewayInvokeTestSuite) testInvoke(authenticationMode ingress.Au
 	// we retry as it takes some time for apigw resource create function ingress
 	err = common.RetryUntilSuccessful(90*time.Second, 1*time.Second, func() bool {
 		request := createHTTPRequest()
-		if authenticationMode == ingress.AuthenticationModeBasicAuth {
+		if authenticationMode == auth.AuthenticationModeBasicAuth {
 			request.SetBasicAuth(basicAuthUsername, basicAuthPassword)
 		}
 		responseBody, statusCode, err := suite.invokeHTTPRequest(request)
@@ -289,14 +289,14 @@ func (suite *apiGatewayInvokeTestSuite) testInvoke(authenticationMode ingress.Au
 	suite.Require().NoError(err)
 
 	// test scenarios where auth is given, but bad credentials were given
-	if authenticationMode != ingress.AuthenticationModeNone {
+	if authenticationMode != auth.AuthenticationModeNone {
 
 		// create request
 		request := createHTTPRequest()
 
 		// fill request request with credentials correspondingly to its ingress auth mode
 		switch authenticationMode {
-		case ingress.AuthenticationModeBasicAuth:
+		case auth.AuthenticationModeBasicAuth:
 			request.SetBasicAuth(basicAuthUsername, "bad-credentials")
 		default:
 			suite.Require().Failf("Must implement a scenario where a test would fail for ingress %s",

--- a/pkg/platform/apigateway_test.go
+++ b/pkg/platform/apigateway_test.go
@@ -22,8 +22,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
-	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
 
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
@@ -53,7 +53,7 @@ func (suite *ScrubberTestSuite) TestScrubBasics() {
 	apiGatewayConfig := &APIGatewayConfig{Meta: APIGatewayMeta{}, Spec: APIGatewaySpec{
 		Host:               "host.com",
 		Name:               "test-scrubber",
-		AuthenticationMode: ingress.AuthenticationModeBasicAuth,
+		AuthenticationMode: auth.AuthenticationModeBasicAuth,
 		Authentication: &APIGatewayAuthenticationSpec{BasicAuth: &BasicAuth{
 			Username: "test",
 			Password: "my-password",

--- a/pkg/platform/kube/apigatewayres/lazy.go
+++ b/pkg/platform/kube/apigatewayres/lazy.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/abstract"
@@ -239,13 +240,13 @@ func (lc *lazyClient) generateNginxIngress(ctx context.Context,
 	}
 
 	switch apiGateway.Spec.AuthenticationMode {
-	case ingress.AuthenticationModeNone:
-		commonIngressSpec.AuthenticationMode = ingress.AuthenticationModeNone
-	case ingress.AuthenticationModeBasicAuth:
+	case auth.AuthenticationModeNone:
+		commonIngressSpec.AuthenticationMode = auth.AuthenticationModeNone
+	case auth.AuthenticationModeBasicAuth:
 		if apiGateway.Spec.Authentication == nil || apiGateway.Spec.Authentication.BasicAuth == nil {
 			return nil, errors.New("Basic auth specified but missing basic auth spec")
 		}
-		commonIngressSpec.AuthenticationMode = ingress.AuthenticationModeBasicAuth
+		commonIngressSpec.AuthenticationMode = auth.AuthenticationModeBasicAuth
 		commonIngressSpec.Authentication = &ingress.Authentication{
 			BasicAuth: &ingress.BasicAuth{
 				Name:     kube.BasicAuthNameFromAPIGatewayName(apiGateway.Name),
@@ -253,17 +254,17 @@ func (lc *lazyClient) generateNginxIngress(ctx context.Context,
 				Password: apiGateway.Spec.Authentication.BasicAuth.Password,
 			},
 		}
-	case ingress.AuthenticationModeOauth2:
-		commonIngressSpec.AuthenticationMode = ingress.AuthenticationModeOauth2
+	case auth.AuthenticationModeOauth2:
+		commonIngressSpec.AuthenticationMode = auth.AuthenticationModeOauth2
 		if apiGateway.Spec.Authentication != nil && apiGateway.Spec.Authentication.DexAuth != nil {
 			commonIngressSpec.Authentication = &ingress.Authentication{
 				DexAuth: apiGateway.Spec.Authentication.DexAuth,
 			}
 		}
-	case ingress.AuthenticationModeAccessKey:
-		commonIngressSpec.AuthenticationMode = ingress.AuthenticationModeAccessKey
-	case ingress.AuthenticationModeIguazio:
-		commonIngressSpec.AuthenticationMode = ingress.AuthenticationModeIguazio
+	case auth.AuthenticationModeAccessKey:
+		commonIngressSpec.AuthenticationMode = auth.AuthenticationModeAccessKey
+	case auth.AuthenticationModeIguazio:
+		commonIngressSpec.AuthenticationMode = auth.AuthenticationModeIguazio
 	default:
 		return nil, errors.New("Unsupported ApiGateway authentication mode provided")
 	}

--- a/pkg/platform/kube/apigatewayres/lazy_test.go
+++ b/pkg/platform/kube/apigatewayres/lazy_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
@@ -155,7 +156,7 @@ func (suite *lazyTestSuite) getTestAPIGateway(primaryFunctionConfig, canaryFunct
 		Spec: platform.APIGatewaySpec{
 			Host:               "some-host.com",
 			Name:               "test-name",
-			AuthenticationMode: ingress.AuthenticationModeBasicAuth,
+			AuthenticationMode: auth.AuthenticationModeBasicAuth,
 			Authentication: &platform.APIGatewayAuthenticationSpec{
 				BasicAuth: &platform.BasicAuth{
 					Username: "moshe",

--- a/pkg/platform/kube/ingress/ingress.go
+++ b/pkg/platform/kube/ingress/ingress.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/common/annotations"
@@ -363,26 +364,26 @@ func (m *Manager) compileAuthAnnotations(ctx context.Context, spec Spec) (map[st
 	var err error
 
 	switch spec.AuthenticationMode {
-	case AuthenticationModeNone:
+	case auth.AuthenticationModeNone:
 		// do nothing
-	case AuthenticationModeBasicAuth:
+	case auth.AuthenticationModeBasicAuth:
 		authIngressAnnotations, basicAuthSecret, err = m.compileBasicAuthAnnotationsAndSecret(ctx, spec)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "Failed to get basic auth annotations")
 		}
-	case AuthenticationModeAccessKey:
+	case auth.AuthenticationModeAccessKey:
 
 		// relevant when running on iguazio platform
 		authIngressAnnotations, err = m.compileIguazioSessionVerificationAnnotations()
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "Failed to get access key auth mode annotations")
 		}
-	case AuthenticationModeOauth2:
+	case auth.AuthenticationModeOauth2:
 		authIngressAnnotations, err = m.compileDexAuthAnnotations(spec)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "Failed to get dex auth annotations")
 		}
-	case AuthenticationModeIguazio:
+	case auth.AuthenticationModeIguazio:
 		authIngressAnnotations, err = m.compileIguazioAuthAnnotations()
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "Failed to get SSO auth annotations")

--- a/pkg/platform/kube/ingress/types.go
+++ b/pkg/platform/kube/ingress/types.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package ingress
 
-import networkingv1 "k8s.io/api/networking/v1"
+import (
+	"github.com/nuclio/nuclio/pkg/auth"
+
+	networkingv1 "k8s.io/api/networking/v1"
+)
 
 type Spec struct {
 	Name                 string
@@ -28,7 +32,7 @@ type Spec struct {
 	PathType             *networkingv1.PathType
 	ServiceName          string
 	ServicePort          int
-	AuthenticationMode   AuthenticationMode
+	AuthenticationMode   auth.AuthenticationMode
 	Authentication       *Authentication
 	WhitelistIPAddresses []string
 	SSLPassthrough       bool
@@ -61,12 +65,3 @@ type DexAuth struct {
 	RedirectUnauthorizedToSignIn bool   `json:"redirectUnauthorizedToSignIn,omitempty"`
 }
 
-type AuthenticationMode string
-
-const (
-	AuthenticationModeNone      AuthenticationMode = "none"
-	AuthenticationModeBasicAuth AuthenticationMode = "basicAuth"
-	AuthenticationModeAccessKey AuthenticationMode = "accessKey"
-	AuthenticationModeOauth2    AuthenticationMode = "oauth2"
-	AuthenticationModeIguazio   AuthenticationMode = "iguazio"
-)

--- a/pkg/platform/kube/ingress/types.go
+++ b/pkg/platform/kube/ingress/types.go
@@ -64,4 +64,3 @@ type DexAuth struct {
 	Oauth2ProxyURL               string `json:"oauth2ProxyUrl,omitempty"`
 	RedirectUnauthorizedToSignIn bool   `json:"redirectUnauthorizedToSignIn,omitempty"`
 }
-

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/auth/nop"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/common/annotations"
@@ -39,7 +40,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform/abstract/project/internalc/kube"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	nuclioclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio"
-	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
 	"github.com/nuclio/nuclio/pkg/platform/kube/logProxy"
 	"github.com/nuclio/nuclio/pkg/platform/kube/logProxy/elastic"
 	"github.com/nuclio/nuclio/pkg/platform/kube/utils"
@@ -1437,7 +1437,7 @@ func (p *Platform) GetScaleToZeroConfiguration() *platformconfig.ScaleToZero {
 }
 
 func (p *Platform) GetAllowedAuthenticationModes() []string {
-	allowedAuthenticationModes := []string{string(ingress.AuthenticationModeNone), string(ingress.AuthenticationModeBasicAuth)}
+	allowedAuthenticationModes := []string{string(auth.AuthenticationModeNone), string(auth.AuthenticationModeBasicAuth)}
 	if len(p.Config.IngressConfig.AllowedAuthenticationModes) > 0 {
 		allowedAuthenticationModes = p.Config.IngressConfig.AllowedAuthenticationModes
 	}
@@ -2542,7 +2542,7 @@ func (p *Platform) validateProbeSpec(probe *v1.Probe) error {
 
 func (p *Platform) validateAPIGatewayAuthentication(apiGatewayConfig *platform.APIGatewayConfig) error {
 	switch apiGatewayConfig.Spec.AuthenticationMode {
-	case ingress.AuthenticationModeIguazio:
+	case auth.AuthenticationModeIguazio:
 		// In iguazio authentication mode, overriding the authentication's annotations is restricted by design
 		// As the parameters optimized for the Iguazio tokens
 		restrictedAnnotations := annotations.GetIguazioAuthenticationModeAnnotations()

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
 	"github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio"
 	mocks2 "github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio/clientset/mocks"
-	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
 	mockplatform "github.com/nuclio/nuclio/pkg/platform/mock"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 
@@ -2400,19 +2399,19 @@ func (suite *FunctionKubePlatformTestSuite) TestUsernameLabelsEnrichment() {
 func (suite *FunctionKubePlatformTestSuite) TestValidateAPIGatewayAuthentication() {
 	for _, testCase := range []struct {
 		name               string
-		authenticationMode ingress.AuthenticationMode
+		authenticationMode auth.AuthenticationMode
 		annotations        map[string]string
 		expectError        bool
 	}{
 		{
 			name:               "Valid iguazio authentication with empty annotations",
-			authenticationMode: ingress.AuthenticationModeIguazio,
+			authenticationMode: auth.AuthenticationModeIguazio,
 			annotations:        map[string]string{},
 			expectError:        false,
 		},
 		{
 			name:               "Valid not iguazio authentication mode with overrides",
-			authenticationMode: ingress.AuthenticationModeNone,
+			authenticationMode: auth.AuthenticationModeNone,
 			annotations: map[string]string{
 				annotations.NginxProxyBodySize: "100",
 			},
@@ -2420,7 +2419,7 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateAPIGatewayAuthentication
 		},
 		{
 			name:               "Iguazio authentication with overrides",
-			authenticationMode: ingress.AuthenticationModeIguazio,
+			authenticationMode: auth.AuthenticationModeIguazio,
 			annotations: map[string]string{
 				annotations.NginxAuthResponseHeaders: "test-header",
 				annotations.NginxProxyBodySize:       "100",
@@ -2434,7 +2433,7 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateAPIGatewayAuthentication
 		},
 		{
 			name:               "Iguazio authentication with a different annotation",
-			authenticationMode: ingress.AuthenticationModeIguazio,
+			authenticationMode: auth.AuthenticationModeIguazio,
 			annotations: map[string]string{
 				"test-annotation": "test-value",
 			},
@@ -3628,7 +3627,7 @@ func (suite *APIGatewayKubePlatformTestSuite) compileAPIGatewayConfig() platform
 		Spec: platform.APIGatewaySpec{
 			Name:               "default-name",
 			Host:               "default-host",
-			AuthenticationMode: ingress.AuthenticationModeNone,
+			AuthenticationMode: auth.AuthenticationModeNone,
 			Upstreams: []platform.APIGatewayUpstreamSpec{
 				{
 					Kind: platform.APIGatewayUpstreamKindNuclioFunction,

--- a/pkg/platform/kube/test/apigateway/api_gateway_test.go
+++ b/pkg/platform/kube/test/apigateway/api_gateway_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/common/annotations"
 	"github.com/nuclio/nuclio/pkg/platform"
@@ -52,7 +53,7 @@ func (suite *DeployAPIGatewayTestSuite) TestDexAuthMode() {
 	}
 	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
 		createAPIGatewayOptions := suite.CompileCreateAPIGatewayOptions(apiGatewayName, functionName)
-		createAPIGatewayOptions.APIGatewayConfig.Spec.AuthenticationMode = ingress.AuthenticationModeOauth2
+		createAPIGatewayOptions.APIGatewayConfig.Spec.AuthenticationMode = auth.AuthenticationModeOauth2
 		err := suite.DeployAPIGateway(createAPIGatewayOptions, func(ingress *networkingv1.Ingress) {
 			suite.Require().NotContains(ingress.Annotations, annotations.NginxAuthSignIn)
 			suite.Require().Contains(ingress.Annotations[annotations.NginxAuthURL], configOauth2ProxyURL)
@@ -62,7 +63,7 @@ func (suite *DeployAPIGatewayTestSuite) TestDexAuthMode() {
 
 		overrideOauth2ProxyURL := "override-oauth2-url"
 		createAPIGatewayOptions = suite.CompileCreateAPIGatewayOptions(apiGatewayName, functionName)
-		createAPIGatewayOptions.APIGatewayConfig.Spec.AuthenticationMode = ingress.AuthenticationModeOauth2
+		createAPIGatewayOptions.APIGatewayConfig.Spec.AuthenticationMode = auth.AuthenticationModeOauth2
 		createAPIGatewayOptions.APIGatewayConfig.Spec.Authentication = &platform.APIGatewayAuthenticationSpec{
 			DexAuth: &ingress.DexAuth{
 				Oauth2ProxyURL:               overrideOauth2ProxyURL,
@@ -115,7 +116,7 @@ def handler(context, event):
 		suite.Require().NotNil(deployResult)
 
 		createAPIGatewayOptions := suite.CompileCreateAPIGatewayOptions(apiGatewayName, functionName)
-		createAPIGatewayOptions.APIGatewayConfig.Spec.AuthenticationMode = ingress.AuthenticationModeIguazio
+		createAPIGatewayOptions.APIGatewayConfig.Spec.AuthenticationMode = auth.AuthenticationModeIguazio
 		createAPIGatewayOptions.APIGatewayConfig.Spec.Host = apiGatewayHost
 		err := suite.DeployAPIGateway(createAPIGatewayOptions, func(ingress *networkingv1.Ingress) {
 			suite.Logger.InfoWith("Created ingress object", " ingress", ingress)
@@ -179,13 +180,13 @@ func (suite *DeployAPIGatewayTestSuite) TestFunctionWithTwoGateways() {
 	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
 		// create first api gateway on top of given function
 		createAPIGatewayOptions1 := suite.CompileCreateAPIGatewayOptions(apiGatewayName1, functionName)
-		createAPIGatewayOptions1.APIGatewayConfig.Spec.AuthenticationMode = ingress.AuthenticationModeNone
+		createAPIGatewayOptions1.APIGatewayConfig.Spec.AuthenticationMode = auth.AuthenticationModeNone
 		createAPIGatewayOptions1.APIGatewayConfig.Spec.Host = "nuclio-host1.com"
 
 		err := suite.DeployAPIGateway(createAPIGatewayOptions1, func(ingressObj *networkingv1.Ingress) {
 			// create second api gateway on top of the same function
 			createAPIGatewayOptions2 := suite.CompileCreateAPIGatewayOptions(apiGatewayName2, functionName)
-			createAPIGatewayOptions2.APIGatewayConfig.Spec.AuthenticationMode = ingress.AuthenticationModeNone
+			createAPIGatewayOptions2.APIGatewayConfig.Spec.AuthenticationMode = auth.AuthenticationModeNone
 			createAPIGatewayOptions2.APIGatewayConfig.Spec.Host = "nuclio-host2.com"
 
 			err := suite.DeployAPIGateway(createAPIGatewayOptions2, func(ingress *networkingv1.Ingress) {
@@ -312,7 +313,7 @@ func (suite *DeployAPIGatewayTestSuite) TestSetSpecificPort() {
 	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
 		// create an api gateway on top of the function with a specific port to the sidecar
 		createAPIGatewayOptions1 := suite.CompileCreateAPIGatewayOptions(apiGatewayName, functionName)
-		createAPIGatewayOptions1.APIGatewayConfig.Spec.AuthenticationMode = ingress.AuthenticationModeNone
+		createAPIGatewayOptions1.APIGatewayConfig.Spec.AuthenticationMode = auth.AuthenticationModeNone
 		createAPIGatewayOptions1.APIGatewayConfig.Spec.Host = "nuclio-host1.com"
 		createAPIGatewayOptions1.APIGatewayConfig.Spec.Upstreams[0].Port = sidecarPort
 

--- a/pkg/platform/kube/test/suite/suite.go
+++ b/pkg/platform/kube/test/suite/suite.go
@@ -43,7 +43,7 @@ import (
 	nuclioioclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio/clientset/versioned"
 	"github.com/nuclio/nuclio/pkg/platform/kube/controller"
 	"github.com/nuclio/nuclio/pkg/platform/kube/functionres"
-	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/platform/kube/test/kubectlclient"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	processorsuite "github.com/nuclio/nuclio/pkg/processor/test/suite"
@@ -758,7 +758,7 @@ func (suite *KubeTestSuite) CompileCreateAPIGatewayOptions(apiGatewayName string
 			},
 			Spec: platform.APIGatewaySpec{
 				Host:               "some-host",
-				AuthenticationMode: ingress.AuthenticationModeNone,
+				AuthenticationMode: auth.AuthenticationModeNone,
 				Upstreams:          upstreams,
 			},
 		},

--- a/pkg/platform/kube/test/suite/suite.go
+++ b/pkg/platform/kube/test/suite/suite.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/errgroup"
@@ -43,7 +44,7 @@ import (
 	nuclioioclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio/clientset/versioned"
 	"github.com/nuclio/nuclio/pkg/platform/kube/controller"
 	"github.com/nuclio/nuclio/pkg/platform/kube/functionres"
-	"github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
 	"github.com/nuclio/nuclio/pkg/platform/kube/test/kubectlclient"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	processorsuite "github.com/nuclio/nuclio/pkg/processor/test/suite"

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -539,7 +539,7 @@ type APIGatewaySpec struct {
 	Name               string                        `json:"name,omitempty"`
 	Description        string                        `json:"description,omitempty"`
 	Path               string                        `json:"path,omitempty"`
-	AuthenticationMode ingress.AuthenticationMode    `json:"authenticationMode,omitempty"`
+	AuthenticationMode auth.AuthenticationMode `json:"authenticationMode,omitempty"`
 	Authentication     *APIGatewayAuthenticationSpec `json:"authentication,omitempty"`
 	Upstreams          []APIGatewayUpstreamSpec      `json:"upstreams,omitempty"`
 }

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -539,7 +539,7 @@ type APIGatewaySpec struct {
 	Name               string                        `json:"name,omitempty"`
 	Description        string                        `json:"description,omitempty"`
 	Path               string                        `json:"path,omitempty"`
-	AuthenticationMode auth.AuthenticationMode `json:"authenticationMode,omitempty"`
+	AuthenticationMode auth.AuthenticationMode       `json:"authenticationMode,omitempty"`
 	Authentication     *APIGatewayAuthenticationSpec `json:"authentication,omitempty"`
 	Upstreams          []APIGatewayUpstreamSpec      `json:"upstreams,omitempty"`
 }


### PR DESCRIPTION
### 📝 Description
Move `type AuthenticationMode string` and its five constants (`none`, `basicAuth`, `accessKey`, `oauth2`, `iguazio`) from `pkg/platform/kube/ingress/types.go` into `pkg/auth/types.go` so there is a single canonical definition.

Having the type owned by `pkg/platform/kube/ingress` was an awkward dependency — callers like `nuctl` and `platform` had to import a deep kube-specific package just to reference an auth concept. Moving it to `pkg/auth` gives it a stable, shallow home that both the existing ingress layer and the upcoming auth-proxy sidecar can import without circular dependencies.

---

### 🛠️ Changes Made
- **`pkg/auth/types.go`** — added `AuthenticationMode` type + 5 constants
- **`pkg/platform/kube/ingress/types.go`** — removed duplicate type/constants; `Spec.AuthenticationMode` now `auth.AuthenticationMode`; added `auth` import
- **`pkg/platform/kube/ingress/ingress.go`** — imported `pkg/auth`; all unqualified constants → `auth.AuthenticationModeXxx`
- **`pkg/platform/types.go`** — `APIGatewaySpec.AuthenticationMode` field type updated (`pkg/auth` was already imported)
- **`pkg/platform/kube/apigatewayres/lazy.go`** — imported `pkg/auth`; all `ingress.AuthenticationModeXxx` → `auth.AuthenticationModeXxx`
- **`pkg/platform/kube/platform.go`** — imported `pkg/auth`; removed now-unused `ingress` import; updated 3 constant references
- **`pkg/nuctl/command/create.go`** — swapped `ingress` import for `auth`; updated type cast + 2 constants
- **Updated test files** — `apigateway_test.go`, `platform_test.go`, `server_test.go`, `apigagteway_test.go`, `api_gateway_test.go`, `suite.go`
- **`pkg/containerimagebuilderpusher/kaniko.go`** — fixed pre-existing `//nolint:errcheck` directive format that prevented `make fmt lint` from passing

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- `make fmt lint` — passes cleanly (0 issues)
- Unit tests: `pkg/auth/...`, `pkg/platform/kube/ingress/...`, `pkg/platform/kube/apigatewayres/...`, `pkg/nuctl/...` — all pass

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Pure refactor — no behavior change. All string values are identical; only the Go type's package path changes.