### PR TITLE
[Projects] Replace X-Projects-Role header trust with leader identity via session

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/valyala/fasthttp v1.71.0
 	github.com/vmihailenco/msgpack/v4 v4.3.13
 	github.com/xdg-go/scram v1.2.0
+	golang.org/x/crypto v0.52.0
 	golang.org/x/image v0.41.0
 	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
@@ -207,7 +208,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org v0.0.0-20260112195520-a5071408f32f // indirect
-	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -663,6 +663,14 @@ platform: {}
 #         - name: "nuclio_processor_handled_events_total"
 #           template: |-
 #             add_here_your_prometheus_query
+#
+# projectsLeader:
+#   kind: // one of iguazio, mlrun, oris, mock
+#   apiAddress: // the leader's API address
+#   synchronizationInterval: // the periodic project synchronization interval (0 to disable)
+#   projectSync2PCEnabled: // true to enable two-phase-commit validation for leader-origin project requests
+#   syncOnStartup: // true to perform a single project sync from the leader on startup instead of (or in addition to) the periodic interval loop
+#   identity: // required for Oris leader-origin calls
 
 # global is a stanza that is used if this is used as a subchart. Ignore otherwise
 global:

--- a/pkg/dashboard/resource/function.go
+++ b/pkg/dashboard/resource/function.go
@@ -142,7 +142,7 @@ func (fr *functionResource) Create(request *http.Request) (id string, attributes
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fr.getCtxSession(request.Context())),
 			RaiseForbidden:      true,
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: fr.getTrustedProjectsRoleHeader(request),
 		},
 	})
 	if err != nil {
@@ -326,7 +326,7 @@ func (fr *functionResource) storeAndDeployFunction(request *http.Request,
 				AuthSession:                ctx.Value(auth.AuthSessionContextKey).(auth.Session),
 				PermissionOptions: opaclient.PermissionOptions{
 					MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fr.getCtxSession(ctx)),
-					OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+					OverrideHeaderValue: fr.getTrustedProjectsRoleHeader(request),
 				},
 			}); err != nil {
 			fr.Logger.WarnWithCtx(ctx,
@@ -510,7 +510,7 @@ func (fr *functionResource) getFunctionReplicas(request *http.Request) (
 
 	permissionOptions := opaclient.PermissionOptions{
 		MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fr.getCtxSession(ctx)),
-		OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+		OverrideHeaderValue: fr.getTrustedProjectsRoleHeader(request),
 		RaiseForbidden:      true,
 	}
 
@@ -579,7 +579,7 @@ func (fr *functionResource) deleteFunction(request *http.Request) (*restful.Cust
 		AuthSession: fr.getCtxSession(ctx),
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fr.getCtxSession(ctx)),
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: fr.getTrustedProjectsRoleHeader(request),
 		},
 		IgnoreFunctionStateValidation: fr.headerValueIsTrue(request,
 			headers.DeleteFunctionIgnoreStateValidation),
@@ -657,7 +657,7 @@ func (fr *functionResource) redeployFunction(request *http.Request,
 		AuthSession:                fr.getCtxSession(ctx),
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fr.getCtxSession(ctx)),
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: fr.getTrustedProjectsRoleHeader(request),
 		},
 		DesiredState:                *options.DesiredState,
 		CreationStateUpdatedTimeout: fr.getCreationStateUpdatedTimeout(request),
@@ -758,7 +758,7 @@ func (fr *functionResource) resolveGetFunctionOptionsFromRequest(request *http.R
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fr.getCtxSession(ctx)),
 			RaiseForbidden:      raiseForbidden,
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: fr.getTrustedProjectsRoleHeader(request),
 		},
 	}
 
@@ -830,7 +830,7 @@ func (fr *functionResource) populateGetFunctionReplicaLogsStreamOptions(request 
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fr.getCtxSession(request.Context())),
 			RaiseForbidden:      true,
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: fr.getTrustedProjectsRoleHeader(request),
 		},
 	}
 

--- a/pkg/dashboard/resource/functionevent.go
+++ b/pkg/dashboard/resource/functionevent.go
@@ -67,7 +67,7 @@ func (fer *functionEventResource) GetAll(request *http.Request) (map[string]rest
 		AuthSession: fer.getCtxSession(ctx),
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fer.getCtxSession(ctx)),
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: fer.getTrustedProjectsRoleHeader(request),
 		},
 	}
 
@@ -112,7 +112,7 @@ func (fer *functionEventResource) GetByID(request *http.Request, id string) (res
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fer.getCtxSession(ctx)),
 			RaiseForbidden:      true,
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: fer.getTrustedProjectsRoleHeader(request),
 		},
 	})
 
@@ -192,7 +192,7 @@ func (fer *functionEventResource) storeAndDeployFunctionEvent(request *http.Requ
 		AuthSession:         fer.getCtxSession(ctx),
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fer.getCtxSession(ctx)),
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: fer.getTrustedProjectsRoleHeader(request),
 		},
 	})
 	if err != nil {
@@ -216,7 +216,7 @@ func (fer *functionEventResource) getFunctionEvents(request *http.Request, funct
 		AuthSession: fer.getCtxSession(ctx),
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fer.getCtxSession(ctx)),
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: fer.getTrustedProjectsRoleHeader(request),
 		},
 	}
 
@@ -246,7 +246,7 @@ func (fer *functionEventResource) deleteFunctionEvent(request *http.Request) (*r
 		AuthSession: fer.getCtxSession(ctx),
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fer.getCtxSession(ctx)),
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: fer.getTrustedProjectsRoleHeader(request),
 		},
 	}
 	deleteFunctionEventOptions.Meta = *functionEventInfo.Meta
@@ -291,7 +291,7 @@ func (fer *functionEventResource) updateFunctionEvent(request *http.Request) (*r
 		AuthSession:         fer.getCtxSession(ctx),
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(fer.getCtxSession(ctx)),
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: fer.getTrustedProjectsRoleHeader(request),
 		},
 	}); err != nil {
 		fer.Logger.WarnWith("Failed to update function event", "err", err)

--- a/pkg/dashboard/resource/invocation.go
+++ b/pkg/dashboard/resource/invocation.go
@@ -114,7 +114,7 @@ func (tr *invocationResource) handleRequest(responseWriter http.ResponseWriter, 
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(tr.getCtxSession(ctx)),
 			RaiseForbidden:      true,
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: tr.getTrustedProjectsRoleHeader(request),
 		},
 	})
 

--- a/pkg/dashboard/resource/project.go
+++ b/pkg/dashboard/resource/project.go
@@ -86,7 +86,7 @@ func (pr *projectResource) GetAll(request *http.Request) (map[string]restful.Att
 		},
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(pr.getCtxSession(ctx)),
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: pr.getTrustedProjectsRoleHeader(request),
 		},
 		AuthSession:   pr.getCtxSession(ctx),
 		SessionCookie: sessionCookie,
@@ -194,7 +194,7 @@ func (pr *projectResource) Update(request *http.Request, id string) (restful.Att
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(pr.getCtxSession(ctx)),
 			RaiseForbidden:      true,
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: pr.getTrustedProjectsRoleHeader(request),
 		},
 		SkipLeaderEvaluation: pr.headerValueIsTrue(request, headers.MLRunForceSync),
 	}); err != nil {
@@ -286,7 +286,7 @@ func (pr *projectResource) getFunctionsAndFunctionEventsMap(request *http.Reques
 		AuthSession: pr.getCtxSession(ctx),
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(pr.getCtxSession(ctx)),
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: pr.getTrustedProjectsRoleHeader(request),
 		},
 	}
 
@@ -341,7 +341,7 @@ func (pr *projectResource) createProject(request *http.Request, projectInfoInsta
 		AuthSession:   pr.getCtxSession(ctx),
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(pr.getCtxSession(ctx)),
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: pr.getTrustedProjectsRoleHeader(request),
 		},
 		SkipLeaderEvaluation: pr.headerValueIsTrue(request, headers.MLRunForceSync),
 
@@ -363,6 +363,11 @@ func (pr *projectResource) createProject(request *http.Request, projectInfoInsta
 	return
 }
 
+// getRequestOriginAndSessionCookie returns the *claimed* request origin from the legacy
+// X-Projects-Role header. It is not itself a verification: pkg/platform/abstract/project/external.Client
+// verifies the claim against the caller's authenticated session before treating it as leader-origin
+// (see ProjectsLeader.TrustsLeaderOrigin), so a spoofed header here is rejected downstream rather than
+// trusted here.
 func (pr *projectResource) getRequestOriginAndSessionCookie(request *http.Request) (platformconfig.ProjectsLeaderKind, *http.Cookie) {
 	requestOrigin := platformconfig.ProjectsLeaderKind(request.Header.Get(headers.ProjectsRole))
 
@@ -431,7 +436,7 @@ func (pr *projectResource) importProjectIfMissing(request *http.Request, project
 		AuthSession: pr.getCtxSession(ctx),
 		PermissionOptions: opaclient.PermissionOptions{
 			RaiseForbidden:      true,
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: pr.getTrustedProjectsRoleHeader(request),
 		},
 	})
 	if err != nil {
@@ -464,7 +469,7 @@ func (pr *projectResource) importProjectIfMissing(request *http.Request, project
 			ProjectConfig: newProject.GetConfig(),
 			AuthSession:   pr.getCtxSession(ctx),
 			PermissionOptions: opaclient.PermissionOptions{
-				OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+				OverrideHeaderValue: pr.getTrustedProjectsRoleHeader(request),
 			},
 		}); err != nil {
 
@@ -543,7 +548,7 @@ func (pr *projectResource) importFunction(request *http.Request, function *funct
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(pr.getCtxSession(ctx)),
 			RaiseForbidden:      true,
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: pr.getTrustedProjectsRoleHeader(request),
 		},
 	})
 	if err != nil {
@@ -648,7 +653,7 @@ func (pr *projectResource) getProjectByName(request *http.Request, projectName, 
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(pr.getCtxSession(ctx)),
 			RaiseForbidden:      true,
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: pr.getTrustedProjectsRoleHeader(request),
 		},
 		RequestOrigin: requestOrigin,
 		SessionCookie: sessionCookie,
@@ -690,7 +695,7 @@ func (pr *projectResource) deleteProject(request *http.Request) (*restful.Custom
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(pr.getCtxSession(ctx)),
 			RaiseForbidden:      true,
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: pr.getTrustedProjectsRoleHeader(request),
 		},
 		SkipLeaderEvaluation: pr.headerValueIsTrue(request, headers.MLRunForceSync),
 	}); err != nil {

--- a/pkg/dashboard/resource/resource.go
+++ b/pkg/dashboard/resource/resource.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/dashboard"
 	"github.com/nuclio/nuclio/pkg/opa"
 	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/restful"
 
 	"github.com/nuclio/errors"
@@ -123,20 +124,26 @@ func (r *resource) newPermissionOptions(request *http.Request, raiseForbidden bo
 	}
 }
 
-// getTrustedProjectsRoleHeader returns the X-Projects-Role header value only if safe to forward
-// into PermissionOptions.OverrideHeaderValue: either the deployment hasn't migrated off the Iguazio
-// header-trust model, or it has and the caller's session matches the configured leader identity.
+// getTrustedProjectsRoleHeader resolves the value to forward into PermissionOptions.OverrideHeaderValue.
+// For an Oris leader, the legacy X-Projects-Role header plays no role at all: trust is decided purely
+// from the caller's session, and a trusted caller gets the OPA-configured override value regardless of
+// what (if anything) it sent in the header — otherwise a genuinely-trusted leader whose header doesn't
+// happen to match the configured secret would still be denied the bypass. Legacy leader kinds (and no
+// leader configured) keep echoing the raw header, unchanged.
 func (r *resource) getTrustedProjectsRoleHeader(request *http.Request) string {
-	headerValue := request.Header.Get(headers.ProjectsRole)
-	if headerValue == "" {
-		return ""
+	platformConfiguration := r.getDashboard().GetPlatformConfiguration()
+	projectsLeader := platformConfiguration.ProjectsLeader
+
+	if projectsLeader == nil || projectsLeader.Kind != platformconfig.ProjectsLeaderKindOris {
+		return request.Header.Get(headers.ProjectsRole)
 	}
 
-	projectsLeader := r.getDashboard().GetPlatformConfiguration().ProjectsLeader
 	if !projectsLeader.TrustsLeaderOrigin(r.getCtxSession(request.Context())) {
-		r.Logger.WarnWithCtx(request.Context(), "Dropping untrusted X-Projects-Role header value", "claimedProjectsRole", headerValue)
 		return ""
 	}
 
-	return headerValue
+	if platformConfiguration.Opa == nil {
+		return ""
+	}
+	return platformConfiguration.Opa.OverrideHeaderValue
 }

--- a/pkg/dashboard/resource/resource.go
+++ b/pkg/dashboard/resource/resource.go
@@ -119,6 +119,24 @@ func (r *resource) newPermissionOptions(request *http.Request, raiseForbidden bo
 	return opaclient.PermissionOptions{
 		MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(r.getCtxSession(ctx)),
 		RaiseForbidden:      raiseForbidden,
-		OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+		OverrideHeaderValue: r.getTrustedProjectsRoleHeader(request),
 	}
+}
+
+// getTrustedProjectsRoleHeader returns the X-Projects-Role header value only if safe to forward
+// into PermissionOptions.OverrideHeaderValue: either the deployment hasn't migrated off the Iguazio
+// header-trust model, or it has and the caller's session matches the configured leader identity.
+func (r *resource) getTrustedProjectsRoleHeader(request *http.Request) string {
+	headerValue := request.Header.Get(headers.ProjectsRole)
+	if headerValue == "" {
+		return ""
+	}
+
+	projectsLeader := r.getDashboard().GetPlatformConfiguration().ProjectsLeader
+	if !projectsLeader.TrustsLeaderOrigin(r.getCtxSession(request.Context())) {
+		r.Logger.WarnWithCtx(request.Context(), "Dropping untrusted X-Projects-Role header value", "claimedProjectsRole", headerValue)
+		return ""
+	}
+
+	return headerValue
 }

--- a/pkg/dashboard/resource/v3iostream.go
+++ b/pkg/dashboard/resource/v3iostream.go
@@ -103,7 +103,7 @@ func (vsr *v3ioStreamResource) getFunctions(request *http.Request) ([]platform.F
 		AuthSession: vsr.getCtxSession(ctx),
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(vsr.getCtxSession(ctx)),
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: vsr.getTrustedProjectsRoleHeader(request),
 		},
 	}
 
@@ -188,7 +188,7 @@ func (vsr *v3ioStreamResource) validateRequest(request *http.Request) error {
 		AuthSession: vsr.getCtxSession(ctx),
 		PermissionOptions: opaclient.PermissionOptions{
 			MemberIds:           opa.GetUserAndGroupIdsFromAuthSession(vsr.getCtxSession(ctx)),
-			OverrideHeaderValue: request.Header.Get(headers.ProjectsRole),
+			OverrideHeaderValue: vsr.getTrustedProjectsRoleHeader(request),
 		},
 	}); err != nil {
 		return nuclio.NewErrUnauthorized("Unauthorized to read project")

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -52,10 +52,10 @@ import (
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
 	opaclient "github.com/nuclio/opa-client"
-	"github.com/nuclio/zap"
+	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	_ "github.com/nuclio/nuclio/pkg/dashboard/resource"
 )
@@ -1977,8 +1977,8 @@ func (suite *projectTestSuite) TestCreateNoNamespace() {
 // NUC-795 left open) — the request still succeeds via normal per-caller OPA authorization.
 func (suite *projectTestSuite) TestCreateDropsUntrustedProjectsRoleHeader() {
 	suite.dashboardServer.GetPlatformConfiguration().ProjectsLeader = &platformconfig.ProjectsLeader{
-		Kind:           platformconfig.ProjectsLeaderKindOris,
-		LeaderIdentity: "orca-sa",
+		Kind:     platformconfig.ProjectsLeaderKindOris,
+		Identity: "orca-sa",
 	}
 
 	verifyCreateProject := func(createProjectOptions *platform.CreateProjectOptions) bool {

--- a/pkg/dashboard/test/server_test.go
+++ b/pkg/dashboard/test/server_test.go
@@ -1971,6 +1971,78 @@ func (suite *projectTestSuite) TestCreateNoNamespace() {
 	suite.sendRequestNoNamespace("POST")
 }
 
+// TestCreateDropsUntrustedProjectsRoleHeader proves that once a deployment has an Oris leader
+// configured, an X-Projects-Role header from a caller whose session doesn't match the configured
+// leader identity is dropped rather than forwarded into OverrideHeaderValue (closing the bypass
+// NUC-795 left open) — the request still succeeds via normal per-caller OPA authorization.
+func (suite *projectTestSuite) TestCreateDropsUntrustedProjectsRoleHeader() {
+	suite.dashboardServer.GetPlatformConfiguration().ProjectsLeader = &platformconfig.ProjectsLeader{
+		Kind:           platformconfig.ProjectsLeaderKindOris,
+		LeaderIdentity: "orca-sa",
+	}
+
+	verifyCreateProject := func(createProjectOptions *platform.CreateProjectOptions) bool {
+		suite.Require().Empty(createProjectOptions.PermissionOptions.OverrideHeaderValue)
+		return true
+	}
+
+	suite.mockPlatform.
+		On("CreateProject", mock.Anything, mock.MatchedBy(verifyCreateProject)).
+		Return(nil).
+		Once()
+
+	expectedStatusCode := http.StatusCreated
+	requestBody := `{
+	"metadata": {
+		"name": "p1",
+		"namespace": "p1-namespace"
+	}
+}`
+
+	suite.sendRequest("POST",
+		"/api/projects",
+		map[string]string{headers.ProjectsRole: "iguazio"},
+		bytes.NewBufferString(requestBody),
+		&expectedStatusCode,
+		nil)
+
+	suite.mockPlatform.AssertExpectations(suite.T())
+}
+
+// TestCreateKeepsProjectsRoleHeaderWhenNoLeaderConfigured proves zero behavior change for
+// deployments that haven't configured a ProjectsLeader at all (today's typical case): the header
+// is still forwarded verbatim into OverrideHeaderValue.
+func (suite *projectTestSuite) TestCreateKeepsProjectsRoleHeaderWhenNoLeaderConfigured() {
+	suite.dashboardServer.GetPlatformConfiguration().ProjectsLeader = nil
+
+	verifyCreateProject := func(createProjectOptions *platform.CreateProjectOptions) bool {
+		suite.Require().Equal("iguazio", createProjectOptions.PermissionOptions.OverrideHeaderValue)
+		return true
+	}
+
+	suite.mockPlatform.
+		On("CreateProject", mock.Anything, mock.MatchedBy(verifyCreateProject)).
+		Return(nil).
+		Once()
+
+	expectedStatusCode := http.StatusCreated
+	requestBody := `{
+	"metadata": {
+		"name": "p1",
+		"namespace": "p1-namespace"
+	}
+}`
+
+	suite.sendRequest("POST",
+		"/api/projects",
+		map[string]string{headers.ProjectsRole: "iguazio"},
+		bytes.NewBufferString(requestBody),
+		&expectedStatusCode,
+		nil)
+
+	suite.mockPlatform.AssertExpectations(suite.T())
+}
+
 func (suite *projectTestSuite) TestUpdateSuccessful() {
 
 	// verify

--- a/pkg/platform/abstract/project/external/client.go
+++ b/pkg/platform/abstract/project/external/client.go
@@ -19,6 +19,7 @@ package external
 import (
 	"context"
 
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/abstract/project"
@@ -97,10 +98,9 @@ func (c *Client) Get(ctx context.Context, getProjectsOptions *platform.GetProjec
 
 // Create routes the request through 2PC evaluation when the request originates from the
 // leader and the caller has not opted out via x-mlrun-force-sync; otherwise (non-leader
-// origin) the request is forwarded to the external leader HTTP client. The X-Projects-Role
-// header is retained for IG3 compatibility.
+// origin) the request is forwarded to the external leader HTTP client.
 func (c *Client) Create(ctx context.Context, createProjectOptions *platform.CreateProjectOptions) (platform.Project, error) {
-	if createProjectOptions.RequestOrigin == c.platformConfiguration.ProjectsLeader.Kind {
+	if c.isLeaderOriginRequest(createProjectOptions.RequestOrigin, createProjectOptions.AuthSession) {
 		if !createProjectOptions.SkipLeaderEvaluation {
 			shouldApply, existingProject, err := c.evaluateLeaderRequestWithCRD(ctx,
 				createProjectOptions.ProjectConfig.Meta.Name,
@@ -125,7 +125,7 @@ func (c *Client) Create(ctx context.Context, createProjectOptions *platform.Crea
 
 // Update follows the same routing rules as Create.
 func (c *Client) Update(ctx context.Context, updateProjectOptions *platform.UpdateProjectOptions) (platform.Project, error) {
-	if updateProjectOptions.RequestOrigin == c.platformConfiguration.ProjectsLeader.Kind {
+	if c.isLeaderOriginRequest(updateProjectOptions.RequestOrigin, updateProjectOptions.AuthSession) {
 		if !updateProjectOptions.SkipLeaderEvaluation {
 			shouldApply, existingProject, err := c.evaluateLeaderRequestWithCRD(ctx,
 				updateProjectOptions.ProjectConfig.Meta.Name,
@@ -150,7 +150,7 @@ func (c *Client) Update(ctx context.Context, updateProjectOptions *platform.Upda
 
 // Delete follows the same routing rules as Create.
 func (c *Client) Delete(ctx context.Context, deleteProjectOptions *platform.DeleteProjectOptions) error {
-	if deleteProjectOptions.RequestOrigin == c.platformConfiguration.ProjectsLeader.Kind {
+	if c.isLeaderOriginRequest(deleteProjectOptions.RequestOrigin, deleteProjectOptions.AuthSession) {
 		if !deleteProjectOptions.SkipLeaderEvaluation {
 			shouldApply, _, err := c.evaluateLeaderRequestWithCRD(ctx,
 				deleteProjectOptions.Meta.Name,
@@ -171,6 +171,21 @@ func (c *Client) Delete(ctx context.Context, deleteProjectOptions *platform.Dele
 	}
 
 	return platform.ErrSuccessfulDeleteProjectLeader
+}
+
+// isLeaderOriginRequest decides whether a project write should be treated as leader-origin
+// (write directly) or forwarded to the leader. For a legacy (mlrun/iguazio/mock) leader this is
+// the claimed X-Projects-Role header, unchanged. For an Oris leader the header plays no role at
+// all — even the real leader's own requests are recognized purely by session identity — so a
+// spoofed header can no longer get a request into the leader-origin branch. A caller that fails
+// verification simply falls through to the existing forward-to-leader path, same as any other
+// non-leader-origin caller.
+func (c *Client) isLeaderOriginRequest(requestOrigin platformconfig.ProjectsLeaderKind, session auth.Session) bool {
+	projectsLeader := c.platformConfiguration.ProjectsLeader
+	if projectsLeader.Kind != platformconfig.ProjectsLeaderKindOris {
+		return requestOrigin == projectsLeader.Kind
+	}
+	return projectsLeader.TrustsLeaderOrigin(session)
 }
 
 // evaluateLeaderRequestWithCRD runs the full 2PC evaluation pipeline for a leader-origin

--- a/pkg/platform/abstract/project/external/client_test.go
+++ b/pkg/platform/abstract/project/external/client_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/nuclio/nuclio/pkg/auth/iguazio"
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/abstract/project"
 	leadermock "github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader/mock"
@@ -130,6 +131,138 @@ func (suite *ExternalProjectClientTestSuite) TestLeaderDelete() {
 
 	err := suite.Delete(suite.ctx, &deleteProjectOptions)
 	suite.Require().NoError(err)
+}
+
+// TestOrisLeaderCreateForwardsMismatchedSession proves the header plays no role for an Oris
+// leader: even though RequestOrigin claims "oris" (as if from a spoofed or stale header), a
+// caller whose session doesn't match LeaderIdentity is not rejected outright — it falls through
+// to the same forward-to-leader path as any ordinary user request.
+func (suite *ExternalProjectClientTestSuite) TestOrisLeaderCreateForwardsMismatchedSession() {
+	client := suite.newOrisClient("oris-sa")
+	createProjectOptions := platform.CreateProjectOptions{
+		RequestOrigin: platformconfig.ProjectsLeaderKindOris,
+		AuthSession:   &iguazio.AbstractSession{Username: "someone-else"},
+		ProjectConfig: &platform.ProjectConfig{
+			Meta: platform.ProjectMeta{Name: "test-func"},
+		},
+	}
+
+	suite.mockLeaderProjectsClient.
+		On("Create", suite.ctx, &createProjectOptions).
+		Return(nil).
+		Once()
+
+	_, err := client.Create(suite.ctx, &createProjectOptions)
+	suite.Require().ErrorIs(err, platform.ErrSuccessfulCreateProjectLeader)
+
+	suite.mockInternalProjectsClient.AssertNotCalled(suite.T(), "Create", mock.Anything, mock.Anything)
+	suite.mockInternalProjectsClient.AssertNotCalled(suite.T(), "Get", mock.Anything, mock.Anything)
+}
+
+func (suite *ExternalProjectClientTestSuite) TestOrisLeaderCreateForwardsNilSession() {
+	client := suite.newOrisClient("oris-sa")
+	createProjectOptions := platform.CreateProjectOptions{
+		RequestOrigin: platformconfig.ProjectsLeaderKindOris,
+		ProjectConfig: &platform.ProjectConfig{
+			Meta: platform.ProjectMeta{Name: "test-func"},
+		},
+	}
+
+	suite.mockLeaderProjectsClient.
+		On("Create", suite.ctx, &createProjectOptions).
+		Return(nil).
+		Once()
+
+	_, err := client.Create(suite.ctx, &createProjectOptions)
+	suite.Require().ErrorIs(err, platform.ErrSuccessfulCreateProjectLeader)
+
+	suite.mockInternalProjectsClient.AssertNotCalled(suite.T(), "Create", mock.Anything, mock.Anything)
+}
+
+// TestOrisLeaderCreateIgnoresHeaderForMatchingSession proves the header is equally irrelevant
+// in the other direction: a matching session is treated as leader-origin even when RequestOrigin
+// carries no claim at all (empty, as if the caller never sent X-Projects-Role).
+func (suite *ExternalProjectClientTestSuite) TestOrisLeaderCreateIgnoresHeaderForMatchingSession() {
+	client := suite.newOrisClient("oris-sa")
+	createProjectOptions := platform.CreateProjectOptions{
+		AuthSession: &iguazio.AbstractSession{Username: "oris-sa"},
+		ProjectConfig: &platform.ProjectConfig{
+			Meta: platform.ProjectMeta{Name: "test-func"},
+		},
+	}
+
+	suite.expectGetExistingProject("test-func")
+	suite.expectEvaluateLeaderRequest(true)
+	suite.mockInternalProjectsClient.
+		On("Create", suite.ctx, &createProjectOptions).
+		Return(&platform.AbstractProject{}, nil).
+		Once()
+
+	_, err := client.Create(suite.ctx, &createProjectOptions)
+	suite.Require().NoError(err)
+
+	suite.mockLeaderProjectsClient.AssertNotCalled(suite.T(), "Create", mock.Anything, mock.Anything)
+}
+
+func (suite *ExternalProjectClientTestSuite) TestOrisLeaderCreateAllowsMatchingSession() {
+	client := suite.newOrisClient("oris-sa")
+	createProjectOptions := platform.CreateProjectOptions{
+		RequestOrigin: platformconfig.ProjectsLeaderKindOris,
+		AuthSession:   &iguazio.AbstractSession{Username: "oris-sa"},
+		ProjectConfig: &platform.ProjectConfig{
+			Meta: platform.ProjectMeta{Name: "test-func"},
+		},
+	}
+
+	suite.expectGetExistingProject("test-func")
+	suite.expectEvaluateLeaderRequest(true)
+	suite.mockInternalProjectsClient.
+		On("Create", suite.ctx, &createProjectOptions).
+		Return(&platform.AbstractProject{}, nil).
+		Once()
+
+	_, err := client.Create(suite.ctx, &createProjectOptions)
+	suite.Require().NoError(err)
+}
+
+func (suite *ExternalProjectClientTestSuite) TestOrisLeaderUpdateForwardsMismatchedSession() {
+	client := suite.newOrisClient("oris-sa")
+	updateProjectOptions := platform.UpdateProjectOptions{
+		RequestOrigin: platformconfig.ProjectsLeaderKindOris,
+		AuthSession:   &iguazio.AbstractSession{Username: "someone-else"},
+		ProjectConfig: platform.ProjectConfig{
+			Meta: platform.ProjectMeta{Name: "test-func"},
+		},
+	}
+
+	suite.mockLeaderProjectsClient.
+		On("Update", suite.ctx, &updateProjectOptions).
+		Return(nil).
+		Once()
+
+	_, err := client.Update(suite.ctx, &updateProjectOptions)
+	suite.Require().ErrorIs(err, platform.ErrSuccessfulUpdateProjectLeader)
+
+	suite.mockInternalProjectsClient.AssertNotCalled(suite.T(), "Update", mock.Anything, mock.Anything)
+}
+
+func (suite *ExternalProjectClientTestSuite) TestOrisLeaderDeleteForwardsMismatchedSession() {
+	client := suite.newOrisClient("oris-sa")
+	deleteProjectOptions := platform.DeleteProjectOptions{
+		RequestOrigin: platformconfig.ProjectsLeaderKindOris,
+		AuthSession:   &iguazio.AbstractSession{Username: "someone-else"},
+		Meta:          platform.ProjectMeta{Name: "test-func"},
+	}
+
+	suite.mockLeaderProjectsClient.
+		On("Delete", suite.ctx, &deleteProjectOptions).
+		Return(nil).
+		Once()
+
+	err := client.Delete(suite.ctx, &deleteProjectOptions)
+	suite.Require().ErrorIs(err, platform.ErrSuccessfulDeleteProjectLeader)
+
+	suite.mockInternalProjectsClient.AssertNotCalled(suite.T(), "Delete", mock.Anything, mock.Anything)
 }
 
 // TestLeaderCreateSkipsEvaluationWhen2PCDisabled covers the short-circuit path: when
@@ -348,6 +481,21 @@ func (suite *ExternalProjectClientTestSuite) assertLeaderEvaluationSkipped() {
 	suite.mockLeaderProjectsClient.AssertNotCalled(suite.T(), "ProjectSync2PCEnabled")
 	suite.mockInternalProjectsClient.AssertNotCalled(suite.T(), "Get", mock.Anything, mock.Anything)
 	suite.mockLeaderProjectsClient.AssertNotCalled(suite.T(), "EvaluateLeaderRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// newOrisClient builds a Client configured with an Oris leader requiring the given
+// LeaderIdentity, reusing the suite's mocked internal/leader clients.
+func (suite *ExternalProjectClientTestSuite) newOrisClient(leaderIdentity string) *Client {
+	return &Client{
+		platformConfiguration: &platformconfig.Config{
+			ProjectsLeader: &platformconfig.ProjectsLeader{
+				Kind:           platformconfig.ProjectsLeaderKindOris,
+				LeaderIdentity: leaderIdentity,
+			},
+		},
+		internalClient: suite.mockInternalProjectsClient,
+		leaderClient:   suite.mockLeaderProjectsClient,
+	}
 }
 
 func TestExternalProjectClientTestSuite(t *testing.T) {

--- a/pkg/platform/abstract/project/external/client_test.go
+++ b/pkg/platform/abstract/project/external/client_test.go
@@ -135,7 +135,7 @@ func (suite *ExternalProjectClientTestSuite) TestLeaderDelete() {
 
 // TestOrisLeaderCreateForwardsMismatchedSession proves the header plays no role for an Oris
 // leader: even though RequestOrigin claims "oris" (as if from a spoofed or stale header), a
-// caller whose session doesn't match LeaderIdentity is not rejected outright — it falls through
+// caller whose session doesn't match Leader Identity is not rejected outright — it falls through
 // to the same forward-to-leader path as any ordinary user request.
 func (suite *ExternalProjectClientTestSuite) TestOrisLeaderCreateForwardsMismatchedSession() {
 	client := suite.newOrisClient("oris-sa")
@@ -484,13 +484,13 @@ func (suite *ExternalProjectClientTestSuite) assertLeaderEvaluationSkipped() {
 }
 
 // newOrisClient builds a Client configured with an Oris leader requiring the given
-// LeaderIdentity, reusing the suite's mocked internal/leader clients.
+// Identity, reusing the suite's mocked internal/leader clients.
 func (suite *ExternalProjectClientTestSuite) newOrisClient(leaderIdentity string) *Client {
 	return &Client{
 		platformConfiguration: &platformconfig.Config{
 			ProjectsLeader: &platformconfig.ProjectsLeader{
-				Kind:           platformconfig.ProjectsLeaderKindOris,
-				LeaderIdentity: leaderIdentity,
+				Kind:     platformconfig.ProjectsLeaderKindOris,
+				Identity: leaderIdentity,
 			},
 		},
 		internalClient: suite.mockInternalProjectsClient,

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -214,7 +214,9 @@ func (c *Config) EnrichPlatformConfig() error {
 	utils.EnrichProbe(&c.Kube.DefaultLivenessProbe, defaultPlatformConfiguration.Kube.DefaultLivenessProbe)
 	c.enrichElasticSearchConfig()
 	c.enrichRuntimeBaseImages()
-	c.enrichProjectsLeaderConfig()
+	if err := c.enrichProjectsLeaderConfig(); err != nil {
+		return errors.Wrap(err, "Failed to enrich projects leader configuration")
+	}
 	c.enrichAuthentication()
 
 	return nil
@@ -528,9 +530,9 @@ func (c *Config) getLoggerSinksWithLevel(loggerSinkBindings []LoggerSinkBinding)
 	return LoggerSinksWithLevel, nil
 }
 
-func (c *Config) enrichProjectsLeaderConfig() {
+func (c *Config) enrichProjectsLeaderConfig() error {
 	if c.ProjectsLeader == nil {
-		return
+		return nil
 	}
 
 	// ProjectSync2PCEnabled is opt-in; default to false so existing deployments that
@@ -538,6 +540,14 @@ func (c *Config) enrichProjectsLeaderConfig() {
 	if !c.ProjectsLeader.ProjectSync2PCEnabled {
 		c.ProjectsLeader.ProjectSync2PCEnabled = DefaultProjectSync2PCEnabled
 	}
+
+	// Oris leader-origin calls are verified against LeaderIdentity (see ProjectsLeader.TrustsLeaderOrigin);
+	// an unset LeaderIdentity would make every leader-origin call fail closed with no clear cause.
+	if c.ProjectsLeader.Kind == ProjectsLeaderKindOris && c.ProjectsLeader.LeaderIdentity == "" {
+		return errors.New("projectsLeader.leaderIdentity is required when projectsLeader.kind is \"oris\"")
+	}
+
+	return nil
 }
 
 func (c *Config) enrichLocalPlatform() {

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -214,7 +214,7 @@ func (c *Config) EnrichPlatformConfig() error {
 	utils.EnrichProbe(&c.Kube.DefaultLivenessProbe, defaultPlatformConfiguration.Kube.DefaultLivenessProbe)
 	c.enrichElasticSearchConfig()
 	c.enrichRuntimeBaseImages()
-	if err := c.enrichProjectsLeaderConfig(); err != nil {
+	if err := c.enrichAndValidateProjectsLeaderConfig(); err != nil {
 		return errors.Wrap(err, "Failed to enrich projects leader configuration")
 	}
 	c.enrichAuthentication()
@@ -530,7 +530,7 @@ func (c *Config) getLoggerSinksWithLevel(loggerSinkBindings []LoggerSinkBinding)
 	return LoggerSinksWithLevel, nil
 }
 
-func (c *Config) enrichProjectsLeaderConfig() error {
+func (c *Config) enrichAndValidateProjectsLeaderConfig() error {
 	if c.ProjectsLeader == nil {
 		return nil
 	}
@@ -541,10 +541,10 @@ func (c *Config) enrichProjectsLeaderConfig() error {
 		c.ProjectsLeader.ProjectSync2PCEnabled = DefaultProjectSync2PCEnabled
 	}
 
-	// Oris leader-origin calls are verified against LeaderIdentity (see ProjectsLeader.TrustsLeaderOrigin);
-	// an unset LeaderIdentity would make every leader-origin call fail closed with no clear cause.
-	if c.ProjectsLeader.Kind == ProjectsLeaderKindOris && c.ProjectsLeader.LeaderIdentity == "" {
-		return errors.New("projectsLeader.leaderIdentity is required when projectsLeader.kind is \"oris\"")
+	// Oris leader-origin calls are verified against Leader Identity (see ProjectsLeader.TrustsLeaderOrigin);
+	// an unset Identity would make every leader-origin call fail closed with no clear cause.
+	if c.ProjectsLeader.Kind == ProjectsLeaderKindOris && c.ProjectsLeader.Identity == "" {
+		return errors.New("projectsLeader.Identity is required when projectsLeader.kind is \"oris\"")
 	}
 
 	return nil

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/nuclio/logger"
-	"github.com/nuclio/zap"
+	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1106,12 +1106,12 @@ func (suite *PlatformConfigTestSuite) TestTrustsLeaderOrigin() {
 			expected:       true,
 		}, {
 			name:           "mlrun kind trusts unconditionally, even with a nil session",
-			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindMlrun, LeaderIdentity: "orca-sa"},
+			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindMlrun, Identity: "orca-sa"},
 			session:        nil,
 			expected:       true,
 		}, {
 			name:           "iguazio kind trusts unconditionally, even with a mismatched session",
-			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindIguazio, LeaderIdentity: "orca-sa"},
+			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindIguazio, Identity: "orca-sa"},
 			session:        mismatchedSession,
 			expected:       true,
 		}, {
@@ -1121,21 +1121,21 @@ func (suite *PlatformConfigTestSuite) TestTrustsLeaderOrigin() {
 			expected:       true,
 		}, {
 			name:           "oris kind with matching session is trusted",
-			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindOris, LeaderIdentity: "orca-sa"},
+			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindOris, Identity: "orca-sa"},
 			session:        matchingSession,
 			expected:       true,
 		}, {
 			name:           "oris kind with mismatched session is rejected",
-			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindOris, LeaderIdentity: "orca-sa"},
+			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindOris, Identity: "orca-sa"},
 			session:        mismatchedSession,
 			expected:       false,
 		}, {
 			name:           "oris kind with nil session is rejected",
-			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindOris, LeaderIdentity: "orca-sa"},
+			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindOris, Identity: "orca-sa"},
 			session:        nil,
 			expected:       false,
 		}, {
-			name:           "oris kind with empty LeaderIdentity is rejected even given a session",
+			name:           "oris kind with empty Identity is rejected even given a session",
 			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindOris},
 			session:        matchingSession,
 			expected:       false,
@@ -1147,16 +1147,16 @@ func (suite *PlatformConfigTestSuite) TestTrustsLeaderOrigin() {
 	}
 }
 
-func (suite *PlatformConfigTestSuite) TestEnrichProjectsLeaderConfigOrisRequiresLeaderIdentity() {
+func (suite *PlatformConfigTestSuite) TestEnrichAndValidateProjectsLeaderConfigOrisRequiresIdentity() {
 	config := &Config{
 		ProjectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindOris},
 	}
 	suite.Require().Error(config.EnrichPlatformConfig())
 }
 
-func (suite *PlatformConfigTestSuite) TestEnrichProjectsLeaderConfigOrisWithLeaderIdentity() {
+func (suite *PlatformConfigTestSuite) TestEnrichAndValidateProjectsLeaderConfigOrisWithIdentity() {
 	config := &Config{
-		ProjectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindOris, LeaderIdentity: "orca-sa"},
+		ProjectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindOris, Identity: "orca-sa"},
 	}
 	err := config.EnrichPlatformConfig()
 	suite.Require().NoError(err)

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/auth/iguazio"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
@@ -1085,6 +1087,80 @@ func (suite *PlatformConfigTestSuite) TestValidatePlatformConfigElasticSearchMut
 	err := config.ValidatePlatformConfig()
 	suite.Require().Error(err)
 	suite.Contains(err.Error(), "Elasticsearch config")
+}
+
+func (suite *PlatformConfigTestSuite) TestTrustsLeaderOrigin() {
+	matchingSession := &iguazio.AbstractSession{Username: "orca-sa"}
+	mismatchedSession := &iguazio.AbstractSession{Username: "someone-else"}
+
+	for _, testCase := range []struct {
+		name           string
+		projectsLeader *ProjectsLeader
+		session        auth.Session
+		expected       bool
+	}{
+		{
+			name:           "nil ProjectsLeader trusts unconditionally",
+			projectsLeader: nil,
+			session:        nil,
+			expected:       true,
+		}, {
+			name:           "mlrun kind trusts unconditionally, even with a nil session",
+			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindMlrun, LeaderIdentity: "orca-sa"},
+			session:        nil,
+			expected:       true,
+		}, {
+			name:           "iguazio kind trusts unconditionally, even with a mismatched session",
+			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindIguazio, LeaderIdentity: "orca-sa"},
+			session:        mismatchedSession,
+			expected:       true,
+		}, {
+			name:           "mock kind trusts unconditionally",
+			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindMock},
+			session:        nil,
+			expected:       true,
+		}, {
+			name:           "oris kind with matching session is trusted",
+			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindOris, LeaderIdentity: "orca-sa"},
+			session:        matchingSession,
+			expected:       true,
+		}, {
+			name:           "oris kind with mismatched session is rejected",
+			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindOris, LeaderIdentity: "orca-sa"},
+			session:        mismatchedSession,
+			expected:       false,
+		}, {
+			name:           "oris kind with nil session is rejected",
+			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindOris, LeaderIdentity: "orca-sa"},
+			session:        nil,
+			expected:       false,
+		}, {
+			name:           "oris kind with empty LeaderIdentity is rejected even given a session",
+			projectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindOris},
+			session:        matchingSession,
+			expected:       false,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Require().Equal(testCase.expected, testCase.projectsLeader.TrustsLeaderOrigin(testCase.session))
+		})
+	}
+}
+
+func (suite *PlatformConfigTestSuite) TestEnrichProjectsLeaderConfigOrisRequiresLeaderIdentity() {
+	config := &Config{
+		ProjectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindOris},
+	}
+	suite.Require().Error(config.EnrichPlatformConfig())
+}
+
+func (suite *PlatformConfigTestSuite) TestEnrichProjectsLeaderConfigOrisWithLeaderIdentity() {
+	config := &Config{
+		ProjectsLeader: &ProjectsLeader{Kind: ProjectsLeaderKindOris, LeaderIdentity: "orca-sa"},
+	}
+	err := config.EnrichPlatformConfig()
+	suite.Require().NoError(err)
+	suite.Require().Equal(DefaultProjectSync2PCEnabled, config.ProjectsLeader.ProjectSync2PCEnabled)
 }
 
 func TestPlatformConfigTestSuite(t *testing.T) {

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -217,6 +217,19 @@ type ProjectsLeader struct {
 	// SyncOnStartup, when true, performs a single project sync from the leader on startup instead of (or in
 	// addition to) the periodic interval loop.
 	SyncOnStartup bool `json:"syncOnStartup,omitempty"`
+
+	// LeaderIdentity is the authenticated username the leader is expected to present on leader-origin calls.
+	LeaderIdentity string `json:"leaderIdentity,omitempty"`
+}
+
+// TrustsLeaderOrigin reports whether a caller presenting the given session should be trusted as
+// leader-origin. Kinds other than ProjectsLeaderKindOris keep trusting the legacy X-Projects-Role header unconditionally.
+// Oris requires session.GetUsername() to match LeaderIdentity. A nil receiver, nil session, or empty LeaderIdentity all fail closed.
+func (pl *ProjectsLeader) TrustsLeaderOrigin(session auth.Session) bool {
+	if pl == nil || pl.Kind != ProjectsLeaderKindOris {
+		return true
+	}
+	return pl.LeaderIdentity != "" && session != nil && session.GetUsername() == pl.LeaderIdentity
 }
 
 type PlatformKubeConfig struct {

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -218,18 +218,18 @@ type ProjectsLeader struct {
 	// addition to) the periodic interval loop.
 	SyncOnStartup bool `json:"syncOnStartup,omitempty"`
 
-	// LeaderIdentity is the authenticated username the leader is expected to present on leader-origin calls.
-	LeaderIdentity string `json:"leaderIdentity,omitempty"`
+	// Identity is the authenticated username the leader is expected to present on leader-origin calls.
+	Identity string `json:"identity,omitempty"`
 }
 
 // TrustsLeaderOrigin reports whether a caller presenting the given session should be trusted as
 // leader-origin. Kinds other than ProjectsLeaderKindOris keep trusting the legacy X-Projects-Role header unconditionally.
-// Oris requires session.GetUsername() to match LeaderIdentity. A nil receiver, nil session, or empty LeaderIdentity all fail closed.
+// Oris requires session.GetUsername() to match Leader Identity. A nil receiver, nil session, or empty Leader dentity all fail closed.
 func (pl *ProjectsLeader) TrustsLeaderOrigin(session auth.Session) bool {
 	if pl == nil || pl.Kind != ProjectsLeaderKindOris {
 		return true
 	}
-	return pl.LeaderIdentity != "" && session != nil && session.GetUsername() == pl.LeaderIdentity
+	return pl.Identity != "" && session != nil && session.GetUsername() == pl.Identity
 }
 
 type PlatformKubeConfig struct {


### PR DESCRIPTION
### 📝 Description
Nuclio's dashboard currently decides whether a project create/update/delete call is leader-origin (write directly) or user-origin (forward to the leader) by trusting a client-supplied `X-Projects-Role` header. The same header value is also echoed into `opaclient.PermissionOptions.OverrideHeaderValue`, which the OPA client treats as a bypass secret. Both are spoofable by any caller who knows/guesses the configured override string. NUC-795 added a hard OPA check in front of project CRUD but didn't close this header-echo path.

This PR replaces that header-trust with a verified identity check: once a deployment configures `ProjectsLeader.Kind == "oris"`, a caller is only treated as leader-origin if their authenticated session matches a configured `LeaderIdentity` — the header plays no role at all, in either direction, not even for the real leader's own requests. Deployments still on `mlrun`/`iguazio`/`mock` keep today's header-trust behavior unchanged (the IG3 / migration-window fallback).

---

### 🛠️ Changes Made
- `pkg/platformconfig/types.go` — new `ProjectsLeader.LeaderIdentity` field + `TrustsLeaderOrigin(auth.Session) bool` predicate (the single reusable gate).
- `pkg/platformconfig/platformconfig.go` — startup validation: `Kind: oris` with no `LeaderIdentity` configured now fails fast instead of silently rejecting every leader-origin call at runtime.
- `pkg/platform/abstract/project/external/client.go` — `Create`/`Update`/`Delete` now decide leader-origin via a new `isLeaderOriginRequest`: for `Kind: oris`, purely from the caller's session (header ignored entirely); for legacy kinds, the existing header comparison, unchanged. A session mismatch on a claimed-leader request falls through to the existing forward-to-leader path rather than a hard reject.
- `pkg/dashboard/resource/resource.go` — new `getTrustedProjectsRoleHeader` helper; `newPermissionOptions` now routes through it instead of reading the header directly, closing the OPA `OverrideHeaderValue` bypass at its one existing call point (which transitively fixes `apigateway.go` too).
- `pkg/dashboard/resource/{project,function,functionevent,v3iostream,invocation}.go` — ~25 remaining raw `request.Header.Get(headers.ProjectsRole)` reads feeding `OverrideHeaderValue` migrated to the same helper.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable) — none needed; no repo docs reference these types/paths.
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Unit tests: `pkg/platformconfig/platformconfig_test.go` (full `TrustsLeaderOrigin` truth table + startup validation), `pkg/platform/abstract/project/external/client_test.go` (leader-origin decision for matching/mismatched/nil sessions, proving the header is irrelevant in both directions), `pkg/dashboard/test/server_test.go` (end-to-end: header dropped when untrusted, forwarded unchanged when no leader configured).
- `make test-unit` and `go test -race` all green; `make lint` reports 0 issues.
- Manually verified end-to-end on a real system — see "End-to-end verification" below.

---

### ✅ End-to-end verification

Verified this actually works against a real leader-origin call, not just synthetic unit tests. Summary of the setup and what it caught:

- Deployed this branch's dashboard alongside a small local patch to mlrun's nuclio client, making sure mlrun uses its own service-account token when communicating with nuclio.
- With `projectsLeader: {kind: oris, identity: mlrun-api}` configured, confirmed via dashboard logs that a request authenticated as `mlrun-api` is correctly recognized as leader-origin purely from the session — the legacy header played no role.
- That first pass still 403'd. Root cause (fixed in this PR, see the second commit): a verified leader session wasn't enough on its own to get the OPA authorization bypass — `getTrustedProjectsRoleHeader` was forwarding whatever literal `X-Projects-Role` value the caller sent, which didn't match the platform's configured `opa.overrideHeaderValue`. Fixed by forwarding the *configured* override value once the session is verified, rather than echoing the caller's literal header.
- After that fix, a real `mlrun.get_or_create_project()` call succeeded end-to-end through the full path: user → mlrun (escalates to its own SA) → nuclio (verifies the SA session, applies the OPA bypass, writes the project CRD directly).

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-857
- Design docs links: 
  - [Follower Contract HLD](https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/654737417), 
  - [Followers sub-page](https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/661979181), 
  - [Orca as leader HLD](https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/654737409)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

No behavior change for deployments on `mlrun`/`iguazio`/`mock` leader kinds. `oris` is a new, opt-in kind — no existing deployment uses it yet.

---

### 🔍️ Additional Notes
- Requires a companion deployment configuration change to set `kind: oris` + `leaderIdentity` before this can actually be turned on anywhere — not part of this PR.
- Live verification on VM surfaced a separate, pre-existing architectural question worth a follow-up ticket: `pkg/platform/kube/platform.go`'s `checkProjectAuthorization` runs unconditionally before the leader-origin/forward decision, so a non-leader-origin request is locally OPA-authorized before ever reaching the forward-to-leader path — which is arguably at odds with the Follower Contract HLD's "a follower never evaluates user permissions, it forwards to the leader" principle. Out of scope here; flagging for visibility.
