### PR TITLE
[Infra] Consolidate authproxy AuthenticationMode types into pkg/auth

### DIFF
--- a/cmd/authproxy/app/authproxy.go
+++ b/cmd/authproxy/app/authproxy.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/auth/authproxy"
 	"github.com/nuclio/nuclio/pkg/loggersink"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
@@ -84,9 +85,9 @@ func newAuthenticator(rootLogger logger.Logger, config *Config) (authproxy.Authe
 // resolveStaticFunctionAuthConfig builds the fixed auth config for the reverseProxy topology. In basicAuth
 // mode the username/password come from the config (the password is injected from a Secret via secretKeyRef).
 func resolveStaticFunctionAuthConfig(config *Config) authproxy.FunctionAuthConfig {
-	mode := authproxy.AuthenticationMode(config.AuthMode)
+	mode := auth.AuthenticationMode(config.AuthMode)
 	if mode == "" {
-		mode = authproxy.ModeNone
+		mode = auth.AuthenticationModeNone
 	}
 
 	return authproxy.FunctionAuthConfig{

--- a/cmd/authproxy/app/config.go
+++ b/cmd/authproxy/app/config.go
@@ -17,15 +17,14 @@ limitations under the License.
 package app
 
 import (
-	authpkg "github.com/nuclio/nuclio/pkg/auth"
-	"github.com/nuclio/nuclio/pkg/auth/authproxy"
+	"github.com/nuclio/nuclio/pkg/auth"
 
 	"github.com/nuclio/errors"
 )
 
 // Config holds the auth-proxy sidecar configuration.
 type Config struct {
-	Mode               authpkg.ProxyMode
+	Mode               auth.ProxyMode
 	ListenPort         int
 	UpstreamURL        string // the URL of the upstream service to which requests are proxied (reverseProxy mode only)
 	AuthURL            string // the URL of the auth service to which requests are sent for authentication
@@ -36,7 +35,7 @@ type Config struct {
 	Namespace          string
 	KubeconfigPath     string
 	PlatformConfigPath string
-	AuthKind           authpkg.Kind // auth kind used for API/browser authentication
+	AuthKind           auth.Kind // auth kind used for API/browser authentication
 }
 
 func validateConfiguration(config *Config) error {
@@ -45,9 +44,9 @@ func validateConfiguration(config *Config) error {
 	}
 
 	switch config.Mode {
-	case authpkg.ProxyModeReverseProxy:
+	case auth.ProxyModeReverseProxy:
 		return validateReverseProxyConfiguration(config)
-	case authpkg.ProxyModeAuthOnly:
+	case auth.ProxyModeAuthOnly:
 		return validateAuthOnlyConfiguration(config)
 	default:
 		return errors.Errorf("Unknown auth-proxy mode: %s", config.Mode)
@@ -59,26 +58,26 @@ func validateReverseProxyConfiguration(config *Config) error {
 		return errors.New("Upstream URL must be provided")
 	}
 
-	switch authproxy.AuthenticationMode(config.AuthMode) {
-	case authproxy.ModeAPI:
+	switch auth.AuthenticationMode(config.AuthMode) {
+	case auth.AuthenticationModeAPI:
 		if config.AuthURL == "" {
 			return errors.New("Auth URL must be provided for 'api' authentication mode")
 		}
-	case authproxy.ModeBrowser:
+	case auth.AuthenticationModeBrowser:
 		if config.AuthURL == "" {
 			return errors.New("Auth URL must be provided for 'browser' authentication mode")
 		}
 		if config.SigninURL == "" {
 			return errors.New("Sign-in URL must be provided for 'browser' authentication mode")
 		}
-	case authproxy.ModeBasicAuth:
+	case auth.AuthenticationModeBasicAuth:
 		if config.BasicAuthUsername == "" {
 			return errors.New("Basic-auth username must be provided for 'basicAuth' authentication mode")
 		}
 		if config.BasicAuthPassword == "" {
 			return errors.New("Basic-auth password must be provided for 'basicAuth' authentication mode")
 		}
-	case authproxy.ModeNone, "":
+	case auth.AuthenticationModeNone, "":
 		// no additional requirements
 	default:
 		return errors.Errorf("Unknown authentication mode: %s", config.AuthMode)

--- a/cmd/authproxy/main.go
+++ b/cmd/authproxy/main.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/nuclio/nuclio/cmd/authproxy/app"
 	"github.com/nuclio/nuclio/pkg/auth"
-	"github.com/nuclio/nuclio/pkg/auth/authproxy"
 	"github.com/nuclio/nuclio/pkg/common"
 
 	"github.com/nuclio/errors"
@@ -34,7 +33,7 @@ func main() {
 	upstreamURL := flag.String("upstream-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_UPSTREAM_URL", "http://127.0.0.1:6080"), "URL of the upstream service (processor) to forward requests to")
 	authURL := flag.String("auth-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_AUTH_URL", ""), "URL of the authentication endpoint")
 	signinURL := flag.String("signin-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_SIGNIN_URL", ""), "URL unauthenticated browser requests are redirected to sign-in")
-	authMode := flag.String("auth-mode", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_AUTH_MODE", string(authproxy.ModeNone)), "Authentication mode for reverseProxy: none, api, browser or basicAuth")
+	authMode := flag.String("auth-mode", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_AUTH_MODE", string(auth.AuthenticationModeNone)), "Authentication mode for reverseProxy: none, api, browser or basicAuth")
 	basicAuthUsername := flag.String("basic-auth-username", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_BASIC_AUTH_USERNAME", ""), "Basic-auth username (used only when auth-mode=basicAuth)")
 	basicAuthPassword := flag.String("basic-auth-password", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_BASIC_AUTH_PASSWORD", ""), "Basic-auth password, injected from a Secret via secretKeyRef (used only when auth-mode=basicAuth)")
 	namespace := flag.String("namespace", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_NAMESPACE", ""), "Namespace of the target functions")

--- a/pkg/auth/authproxy/authonly.go
+++ b/pkg/auth/authproxy/authonly.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"net/http"
 
-	authpkg "github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/common/headers"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
@@ -67,7 +67,7 @@ func (b *boundAuthenticator) AuthenticateTarget(functionName string) bool {
 func NewAuthOnlyAuthenticator(parentLogger logger.Logger,
 	authURL string,
 	signinURL string,
-	authKind authpkg.Kind,
+	authKind auth.Kind,
 	nuclioClientSet nuclioioclient.Interface,
 	kubeClientSet kubeclient.Client,
 	namespace string) (Authenticator, error) {
@@ -145,7 +145,7 @@ func (a *authOnlyAuthenticator) getAuthSpec(ctx context.Context, functionName st
 
 	// the scrubber is only needed for basicAuth: it replaces $ref: placeholders with the real
 	// credentials stored in the function's dedicated Secret; other modes have no sensitive fields
-	if authConfig.Mode != ModeBasicAuth {
+	if authConfig.Mode != auth.AuthenticationModeBasicAuth {
 		return authConfig, nil
 	}
 
@@ -171,7 +171,7 @@ func functionAuthConfigFromSpec(spec *functionconfig.Spec) (FunctionAuthConfig, 
 	}
 
 	// no HTTP trigger -> nothing to authenticate
-	return FunctionAuthConfig{Mode: ModeNone}, nil
+	return FunctionAuthConfig{Mode: auth.AuthenticationModeNone}, nil
 }
 
 // functionAuthConfigFromAttributes decodes authenticationMode + authentication.basicAuth from an HTTP
@@ -185,9 +185,9 @@ func functionAuthConfigFromAttributes(attributes map[string]interface{}) (Functi
 		return FunctionAuthConfig{}, errors.Wrap(err, "Failed to decode HTTP trigger attributes")
 	}
 
-	mode := AuthenticationMode(decoded.AuthenticationMode)
+	mode := auth.AuthenticationMode(decoded.AuthenticationMode)
 	if mode == "" {
-		mode = ModeNone
+		mode = auth.AuthenticationModeNone
 	}
 
 	authConfig := FunctionAuthConfig{Mode: mode}
@@ -196,7 +196,7 @@ func functionAuthConfigFromAttributes(attributes map[string]interface{}) (Functi
 		authConfig.BasicAuthPassword = decoded.Authentication.BasicAuth.Password
 	}
 
-	if mode == ModeBasicAuth {
+	if mode == auth.AuthenticationModeBasicAuth {
 		if authConfig.BasicAuthUsername == "" {
 			return FunctionAuthConfig{}, errors.New("Basic-auth username must be provided")
 		}

--- a/pkg/auth/authproxy/authonly_test.go
+++ b/pkg/auth/authproxy/authonly_test.go
@@ -23,7 +23,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	authpkg "github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/common/headers"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
@@ -83,12 +83,12 @@ func (suite *AuthOnlyTestSuite) TestBrowserModeResolvedFromCRD() {
 	defer stub.close()
 
 	browserFunction := newHTTPTriggerFunction("browser-func", testNamespace, map[string]interface{}{
-		"authenticationMode": ModeBrowser,
+		"authenticationMode": auth.AuthenticationModeBrowser,
 	})
 
 	kubeClientSet := kubeclient.NewClientWithRetryFromClient(k8sfake.NewClientset())
 	nuclioClientSet := nuclioiofake.NewSimpleClientset(browserFunction)
-	authenticator, err := NewAuthOnlyAuthenticator(suite.logger, stub.server.URL, testSigninURL, authpkg.KindIguazioV4, nuclioClientSet, kubeClientSet, testNamespace)
+	authenticator, err := NewAuthOnlyAuthenticator(suite.logger, stub.server.URL, testSigninURL, auth.KindIguazioV4, nuclioClientSet, kubeClientSet, testNamespace)
 	suite.Require().NoError(err)
 
 	suite.Run("invalid credential redirects to sign-in with rd", func() {
@@ -130,7 +130,7 @@ func (suite *AuthOnlyTestSuite) TestModeResolvedFromCRD() {
 		{
 			name: "none mode allows without auth-url call",
 			function: newHTTPTriggerFunction("none-func", testNamespace, map[string]interface{}{
-				"authenticationMode": ModeNone,
+				"authenticationMode": auth.AuthenticationModeNone,
 			}),
 			expectedAllowed:      true,
 			expectedAuthURLCalls: 0,
@@ -147,7 +147,7 @@ func (suite *AuthOnlyTestSuite) TestModeResolvedFromCRD() {
 		{
 			name: "api mode admits valid token",
 			function: newHTTPTriggerFunction("api-func", testNamespace, map[string]interface{}{
-				"authenticationMode": ModeAPI,
+				"authenticationMode": auth.AuthenticationModeAPI,
 			}),
 			token:                validToken,
 			expectedAllowed:      true,
@@ -156,7 +156,7 @@ func (suite *AuthOnlyTestSuite) TestModeResolvedFromCRD() {
 		{
 			name: "browser mode admits valid token",
 			function: newHTTPTriggerFunction("browser-func", testNamespace, map[string]interface{}{
-				"authenticationMode": ModeBrowser,
+				"authenticationMode": auth.AuthenticationModeBrowser,
 			}),
 			token:                validToken,
 			expectedAllowed:      true,
@@ -165,7 +165,7 @@ func (suite *AuthOnlyTestSuite) TestModeResolvedFromCRD() {
 		{
 			name: "basicAuth mode admits valid credentials without auth-url call",
 			function: newHTTPTriggerFunction("basic-func", testNamespace, map[string]interface{}{
-				"authenticationMode": ModeBasicAuth,
+				"authenticationMode": auth.AuthenticationModeBasicAuth,
 				"authentication": map[string]interface{}{
 					"basicAuth": map[string]interface{}{"username": "user", "password": "pass"},
 				},
@@ -181,7 +181,7 @@ func (suite *AuthOnlyTestSuite) TestModeResolvedFromCRD() {
 
 			kubeClientSet := kubeclient.NewClientWithRetryFromClient(k8sfake.NewClientset())
 			nuclioClientSet := nuclioiofake.NewSimpleClientset(testCase.function)
-			authenticator, err := NewAuthOnlyAuthenticator(suite.logger, stub.server.URL, signinURL, authpkg.KindIguazioV4, nuclioClientSet, kubeClientSet, testNamespace)
+			authenticator, err := NewAuthOnlyAuthenticator(suite.logger, stub.server.URL, signinURL, auth.KindIguazioV4, nuclioClientSet, kubeClientSet, testNamespace)
 			suite.Require().NoError(err)
 
 			request := suite.authenticatedRequest(testCase.token)
@@ -206,7 +206,7 @@ func (suite *AuthOnlyTestSuite) TestGetAuthSpecFunctionNotFound() {
 	// no functions registered in the fake client
 	kubeClientSet := kubeclient.NewClientWithRetryFromClient(k8sfake.NewClientset())
 	nuclioClientSet := nuclioiofake.NewSimpleClientset()
-	authenticator, err := NewAuthOnlyAuthenticator(suite.logger, stub.server.URL, "", authpkg.KindIguazioV4, nuclioClientSet, kubeClientSet, testNamespace)
+	authenticator, err := NewAuthOnlyAuthenticator(suite.logger, stub.server.URL, "", auth.KindIguazioV4, nuclioClientSet, kubeClientSet, testNamespace)
 	suite.Require().NoError(err)
 
 	request := suite.authenticatedRequest(validToken)

--- a/pkg/auth/authproxy/authproxy.go
+++ b/pkg/auth/authproxy/authproxy.go
@@ -27,7 +27,7 @@ import (
 	"net/url"
 	"strings"
 
-	authpkg "github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/auth/factory"
 	"github.com/nuclio/nuclio/pkg/common/headers"
 
@@ -38,10 +38,10 @@ import (
 
 // newAuthInstance creates an auth client for the given kind, configured against authURL.
 // Returns an error for kinds that do not use Iguazio-style URL verification (e.g. KindNop).
-func newAuthInstance(parentLogger logger.Logger, authURL string, authKind authpkg.Kind) (authpkg.Auth, error) {
-	authConfig := authpkg.NewConfig(authKind)
+func newAuthInstance(parentLogger logger.Logger, authURL string, authKind auth.Kind) (auth.Auth, error) {
+	authConfig := auth.NewConfig(authKind)
 	switch authKind {
-	case authpkg.KindIguazio, authpkg.KindIguazioV4:
+	case auth.KindIguazio, auth.KindIguazioV4:
 		if authConfig.Iguazio == nil {
 			return nil, errors.Errorf("auth kind %q does not support URL-based verification", authKind)
 		}
@@ -56,14 +56,14 @@ func newAuthInstance(parentLogger logger.Logger, authURL string, authKind authpk
 // FunctionAuthConfig it verifies basicAuth locally, calls the auth-url for api/browser, and always fails closed on error.
 type abstractAuthenticator struct {
 	logger    logger.Logger
-	auth      authpkg.Auth
+	auth      auth.Auth
 	signinURL *url.URL
 }
 
 // newAbstractAuthenticator builds the shared decision logic. authURL is guaranteed non-empty by the
 // caller for any mode that delegates to the auth-url (api/browser); basicAuth/none modes never reach
 // callAuthURL so the auth instance is effectively unused for them.
-func newAbstractAuthenticator(parentLogger logger.Logger, authURL, signinURL string, authKind authpkg.Kind) (*abstractAuthenticator, error) {
+func newAbstractAuthenticator(parentLogger logger.Logger, authURL, signinURL string, authKind auth.Kind) (*abstractAuthenticator, error) {
 	parsed, err := url.Parse(signinURL)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to parse sign-in URL")
@@ -82,14 +82,14 @@ func newAbstractAuthenticator(parentLogger logger.Logger, authURL, signinURL str
 // decide applies the verdict for the resolved authConfig, writing the rejection response itself on failure.
 func (a *abstractAuthenticator) decide(responseWriter http.ResponseWriter, request *http.Request, authConfig FunctionAuthConfig) bool {
 	switch authConfig.Mode {
-	case ModeNone:
+	case auth.AuthenticationModeNone:
 		a.logger.Info("Authentication disabled, allowing request")
 		return true
-	case ModeBasicAuth:
+	case auth.AuthenticationModeBasicAuth:
 		return a.verifyBasicAuth(responseWriter, request, authConfig)
-	case ModeAPI:
+	case auth.AuthenticationModeAPI:
 		return a.callAuthURL(responseWriter, request, false)
-	case ModeBrowser:
+	case auth.AuthenticationModeBrowser:
 		return a.callAuthURL(responseWriter, request, true)
 	default:
 		a.logger.WarnWith("Unknown authentication mode, failing closed",
@@ -127,7 +127,7 @@ func (a *abstractAuthenticator) callAuthURL(responseWriter http.ResponseWriter, 
 	ctx, cancel := context.WithTimeout(request.Context(), AuthTimeout)
 	defer cancel()
 
-	session, err := a.auth.Authenticate(request.WithContext(ctx), &authpkg.Options{})
+	session, err := a.auth.Authenticate(request.WithContext(ctx), &auth.Options{})
 	if err != nil {
 		a.logger.WarnWithCtx(ctx,
 			"Authentication failed, rejecting request",
@@ -152,7 +152,7 @@ func (a *abstractAuthenticator) reject(responseWriter http.ResponseWriter, reque
 }
 
 // applyIdentityHeaders forwards the authenticated identity to the upstream on the request headers.
-func (a *abstractAuthenticator) applyIdentityHeaders(request *http.Request, session authpkg.Session) {
+func (a *abstractAuthenticator) applyIdentityHeaders(request *http.Request, session auth.Session) {
 	if session == nil {
 		return
 	}

--- a/pkg/auth/authproxy/authproxy_test.go
+++ b/pkg/auth/authproxy/authproxy_test.go
@@ -23,7 +23,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	authpkg "github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/common/headers"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
@@ -63,7 +63,7 @@ func (suite *AuthProxyTestSuite) SetupTest() {
 // TestModeNoneAllows verifies none mode admits without calling the auth-url.
 // validateConfiguration permits an empty authURL for ModeNone, so the test reflects that.
 func (suite *AuthProxyTestSuite) TestModeNoneAllows() {
-	authenticator, err := NewReverseProxyAuthenticator(suite.logger, "", "", authpkg.KindIguazioV4, FunctionAuthConfig{Mode: ModeNone})
+	authenticator, err := NewReverseProxyAuthenticator(suite.logger, "", "", auth.KindIguazioV4, FunctionAuthConfig{Mode: auth.AuthenticationModeNone})
 	suite.Require().NoError(err)
 
 	recorder := httptest.NewRecorder()
@@ -75,7 +75,7 @@ func (suite *AuthProxyTestSuite) TestModeAPI() {
 	stub := suite.newAuthURLStub()
 	defer stub.close()
 
-	authenticator, err := NewReverseProxyAuthenticator(suite.logger, stub.server.URL, "", authpkg.KindIguazioV4, FunctionAuthConfig{Mode: ModeAPI})
+	authenticator, err := NewReverseProxyAuthenticator(suite.logger, stub.server.URL, "", auth.KindIguazioV4, FunctionAuthConfig{Mode: auth.AuthenticationModeAPI})
 	suite.Require().NoError(err)
 
 	suite.Run("valid is admitted with identity headers", func() {
@@ -106,7 +106,7 @@ func (suite *AuthProxyTestSuite) TestModeBrowser() {
 	stub := suite.newAuthURLStub()
 	defer stub.close()
 
-	authenticator, err := NewReverseProxyAuthenticator(suite.logger, stub.server.URL, testSigninURL, authpkg.KindIguazioV4, FunctionAuthConfig{Mode: ModeBrowser})
+	authenticator, err := NewReverseProxyAuthenticator(suite.logger, stub.server.URL, testSigninURL, auth.KindIguazioV4, FunctionAuthConfig{Mode: auth.AuthenticationModeBrowser})
 	suite.Require().NoError(err)
 
 	suite.Run("invalid redirects to sign-in with rd", func() {
@@ -130,8 +130,8 @@ func (suite *AuthProxyTestSuite) TestModeBasicAuth() {
 	authenticator, err := NewReverseProxyAuthenticator(suite.logger,
 		"",
 		"",
-		authpkg.KindIguazioV4,
-		FunctionAuthConfig{Mode: ModeBasicAuth, BasicAuthUsername: "user", BasicAuthPassword: "pass"})
+		auth.KindIguazioV4,
+		FunctionAuthConfig{Mode: auth.AuthenticationModeBasicAuth, BasicAuthUsername: "user", BasicAuthPassword: "pass"})
 	suite.Require().NoError(err)
 
 	suite.Run("valid credentials admitted locally", func() {
@@ -156,7 +156,7 @@ func (suite *AuthProxyTestSuite) TestAuthenticatorKindForwardedAndCannotBypass()
 	stub := suite.newAuthURLStub()
 	defer stub.close()
 
-	authenticator, err := NewReverseProxyAuthenticator(suite.logger, stub.server.URL, "", authpkg.KindIguazioV4, FunctionAuthConfig{Mode: ModeAPI})
+	authenticator, err := NewReverseProxyAuthenticator(suite.logger, stub.server.URL, "", auth.KindIguazioV4, FunctionAuthConfig{Mode: auth.AuthenticationModeAPI})
 	suite.Require().NoError(err)
 
 	suite.Run("kind forwarded on valid credential", func() {
@@ -184,7 +184,7 @@ func (suite *AuthProxyTestSuite) TestFailClosedOnUpstreamError() {
 		}))
 		defer errorServer.Close()
 
-		authenticator, err := NewReverseProxyAuthenticator(suite.logger, errorServer.URL, "", authpkg.KindIguazioV4, FunctionAuthConfig{Mode: ModeAPI})
+		authenticator, err := NewReverseProxyAuthenticator(suite.logger, errorServer.URL, "", auth.KindIguazioV4, FunctionAuthConfig{Mode: auth.AuthenticationModeAPI})
 		suite.Require().NoError(err)
 		recorder := httptest.NewRecorder()
 		suite.Require().False(authenticator.Authenticate(recorder, suite.authenticatedRequest(validToken)))
@@ -194,7 +194,7 @@ func (suite *AuthProxyTestSuite) TestFailClosedOnUpstreamError() {
 	suite.Run("transport error to auth-url", func() {
 
 		// nothing is listening here -> connection refused
-		authenticator, err := NewReverseProxyAuthenticator(suite.logger, "http://127.0.0.1:1", "", authpkg.KindIguazioV4, FunctionAuthConfig{Mode: ModeAPI})
+		authenticator, err := NewReverseProxyAuthenticator(suite.logger, "http://127.0.0.1:1", "", auth.KindIguazioV4, FunctionAuthConfig{Mode: auth.AuthenticationModeAPI})
 		suite.Require().NoError(err)
 		recorder := httptest.NewRecorder()
 		suite.Require().False(authenticator.Authenticate(recorder, suite.authenticatedRequest(validToken)))
@@ -211,10 +211,10 @@ func (suite *AuthProxyTestSuite) TestCRDAuthenticatorResolvesFunctionAuthConfig(
 	const passwordRef = functionconfig.ReferencePrefix + "/spec/triggers/http/attributes/authentication/basicauth/password"
 
 	apiFunction := newHTTPTriggerFunction("api-func", testNamespace, map[string]interface{}{
-		"authenticationMode": ModeAPI,
+		"authenticationMode": auth.AuthenticationModeAPI,
 	})
 	basicAuthFunction := newHTTPTriggerFunction("basic-func", testNamespace, map[string]interface{}{
-		"authenticationMode": ModeBasicAuth,
+		"authenticationMode": auth.AuthenticationModeBasicAuth,
 		"authentication": map[string]interface{}{
 			"basicAuth": map[string]interface{}{"username": "user", "password": "pass"},
 		},
@@ -222,7 +222,7 @@ func (suite *AuthProxyTestSuite) TestCRDAuthenticatorResolvesFunctionAuthConfig(
 	// a basicAuth function whose password is scrubbed: the CRD holds a $ref placeholder and the real
 	// value lives in the function's dedicated Secret, which the authenticator must restore before comparing
 	scrubbedFunction := newHTTPTriggerFunction("scrubbed-func", testNamespace, map[string]interface{}{
-		"authenticationMode": ModeBasicAuth,
+		"authenticationMode": auth.AuthenticationModeBasicAuth,
 		"authentication": map[string]interface{}{
 			"basicAuth": map[string]interface{}{"username": "user", "password": passwordRef},
 		},
@@ -244,7 +244,7 @@ func (suite *AuthProxyTestSuite) TestCRDAuthenticatorResolvesFunctionAuthConfig(
 
 	kubeClientSet := kubeclient.NewClientWithRetryFromClient(k8sfake.NewClientset(functionSecret))
 	nuclioClientSet := nuclioiofake.NewSimpleClientset(apiFunction, basicAuthFunction, scrubbedFunction)
-	authenticator, err := NewAuthOnlyAuthenticator(suite.logger, stub.server.URL, "", authpkg.KindIguazioV4, nuclioClientSet, kubeClientSet, testNamespace)
+	authenticator, err := NewAuthOnlyAuthenticator(suite.logger, stub.server.URL, "", auth.KindIguazioV4, nuclioClientSet, kubeClientSet, testNamespace)
 	suite.Require().NoError(err)
 
 	suite.Run("api function resolved and valid credential admitted", func() {

--- a/pkg/auth/authproxy/factory.go
+++ b/pkg/auth/authproxy/factory.go
@@ -17,7 +17,7 @@ limitations under the License.
 package authproxy
 
 import (
-	authpkg "github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/common"
 	kubeclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
 	nuclioioclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio/clientset/versioned"
@@ -31,18 +31,18 @@ import (
 // nuclioClientSet, kubeClientSet, and namespace are required.
 func NewAuthenticator(
 	parentLogger logger.Logger,
-	mode authpkg.ProxyMode,
+	mode auth.ProxyMode,
 	authURL string,
 	signinURL string,
-	authKind authpkg.Kind,
+	authKind auth.Kind,
 	staticAuthConfig FunctionAuthConfig,
 	kubeconfigPath string,
 	namespace string,
 ) (Authenticator, error) {
 	switch mode {
-	case authpkg.ProxyModeReverseProxy:
+	case auth.ProxyModeReverseProxy:
 		return NewReverseProxyAuthenticator(parentLogger, authURL, signinURL, authKind, staticAuthConfig)
-	case authpkg.ProxyModeAuthOnly:
+	case auth.ProxyModeAuthOnly:
 		clientConfig, err := common.GetClientConfig(kubeconfigPath)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to get client configuration")

--- a/pkg/auth/authproxy/reverseproxy.go
+++ b/pkg/auth/authproxy/reverseproxy.go
@@ -19,7 +19,7 @@ package authproxy
 import (
 	"net/http"
 
-	authpkg "github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/auth"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -37,7 +37,7 @@ type reverseProxyAuthenticator struct {
 func NewReverseProxyAuthenticator(parentLogger logger.Logger,
 	authURL string,
 	signinURL string,
-	authKind authpkg.Kind,
+	authKind auth.Kind,
 	authConfig FunctionAuthConfig) (Authenticator, error) {
 	parentLogger.InfoWith("Creating reverse-proxy authenticator", "authURL", authURL, "signinURL", signinURL, "authMode", authConfig.Mode)
 

--- a/pkg/auth/authproxy/types.go
+++ b/pkg/auth/authproxy/types.go
@@ -19,25 +19,17 @@ package authproxy
 import (
 	"net/http"
 	"time"
+
+	"github.com/nuclio/nuclio/pkg/auth"
 )
 
 // AuthTimeout bounds a single auth-url call on the data path so the sidecar fails
 // closed quickly instead of inheriting pkg/auth's long (up to 60s) retry window.
 const AuthTimeout = 10 * time.Second
 
-// AuthenticationMode is the function level authentication mode
-type AuthenticationMode string
-
-const (
-	ModeNone      AuthenticationMode = "none"
-	ModeAPI       AuthenticationMode = "api"
-	ModeBrowser   AuthenticationMode = "browser"
-	ModeBasicAuth AuthenticationMode = "basicAuth"
-)
-
 // FunctionAuthConfig is the authentication configuration resolved for a single function.
 type FunctionAuthConfig struct {
-	Mode              AuthenticationMode
+	Mode              auth.AuthenticationMode
 	BasicAuthUsername string
 	BasicAuthPassword string // plaintext input; cleared after hashing in reverseProxy mode
 

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -30,6 +30,8 @@ const (
 	AuthenticationModeAccessKey AuthenticationMode = "accessKey"
 	AuthenticationModeOauth2    AuthenticationMode = "oauth2"
 	AuthenticationModeIguazio   AuthenticationMode = "iguazio"
+	AuthenticationModeAPI       AuthenticationMode = "api"
+	AuthenticationModeBrowser   AuthenticationMode = "browser"
 )
 
 type Kind string


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
Continues #4207 — consolidates the `AuthenticationMode` type and its constants (`none`, `api`, `browser`, `basicAuth`) from `pkg/auth/authproxy/types.go` into `pkg/auth/types.go`, aligning them with the existing `AuthenticationMode*` naming convention established in that PR.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links: https://github.com/nuclio/nuclio/pull/4207

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->