### PR TITLE
[Docker] Shell-escape docker ps filters to prevent command injection

### DIFF
--- a/pkg/dockerclient/shell.go
+++ b/pkg/dockerclient/shell.go
@@ -659,21 +659,22 @@ func (c *ShellClient) GetContainers(options *GetContainerOptions) ([]Container, 
 		stoppedContainersArgument = "--all "
 	}
 
+	// filter values are interpolated into a command run via /bin/sh -c, so shell-quote each
+	// filter token as a single arg — label values in particular carry unvalidated namespaces
 	nameFilterArgument := ""
 	if options.Name != "" {
-		nameFilterArgument = fmt.Sprintf(`--filter "name=^/%s$" `, options.Name)
+		nameFilterArgument = fmt.Sprintf("--filter %s ", common.Quote(fmt.Sprintf("name=^/%s$", options.Name)))
 	}
 
 	idFilterArgument := ""
 	if options.ID != "" {
-		idFilterArgument = fmt.Sprintf(`--filter "id=%s"`, options.ID)
+		idFilterArgument = fmt.Sprintf("--filter %s", common.Quote(fmt.Sprintf("id=%s", options.ID)))
 	}
 
 	labelFilterArgument := ""
 	for labelName, labelValue := range options.Labels {
-		labelFilterArgument += fmt.Sprintf(`--filter "label=%s=%s" `,
-			labelName,
-			labelValue)
+		labelFilterArgument += fmt.Sprintf("--filter %s ",
+			common.Quote(fmt.Sprintf("label=%s=%s", labelName, labelValue)))
 	}
 
 	runResult, err := c.runCommand(nil,

--- a/pkg/dockerclient/shell_test.go
+++ b/pkg/dockerclient/shell_test.go
@@ -308,6 +308,40 @@ func (suite *ShellClientTestSuite) TestRunFailValidation() {
 	}
 }
 
+func (suite *ShellClientTestSuite) TestGetContainersEscapesLabelFilterInjection() {
+
+	// on the local platform a remote, unauthenticated client controls the function namespace,
+	// which flows into the `nuclio.io/namespace` label value passed here. it must be shell-escaped
+	// before interpolation into `docker ps --filter`, otherwise a double quote breaks out of the
+	// filter token and injects arbitrary shell run as root in the dashboard container (GHSA-2893-rq73-w22x).
+	var capturedArgs []interface{}
+	suite.mockedCmdRunner.
+		On("Run",
+			mock.Anything,
+			"docker ps --quiet %s %s %s %s",
+			mock.MatchedBy(func(vars []interface{}) bool {
+				capturedArgs = vars
+				return true
+			})).
+		Return(cmdrunner.RunResult{
+			Output: "",
+		}, nil).
+		Once()
+
+	_, err := suite.shellClient.GetContainers(&GetContainerOptions{
+		Labels: map[string]string{"nuclio.io/namespace": `n";touch /tmp/pwned;echo "`},
+	})
+	suite.Require().NoError(err)
+
+	// the whole label filter must be a single shell-quoted token; the metacharacters stay
+	// literal inside the quotes instead of terminating the docker ps command
+	labelFilterArgument := capturedArgs[3].(string)
+	suite.Require().Contains(labelFilterArgument,
+		`--filter 'label=nuclio.io/namespace=n";touch /tmp/pwned;echo "'`)
+
+	suite.mockedCmdRunner.AssertExpectations(suite.T())
+}
+
 func TestShellRunnerTestSuite(t *testing.T) {
 	suite.Run(t, new(ShellClientTestSuite))
 }


### PR DESCRIPTION
### 📝 Description
Fixes GHSA-2893-rq73-w22x — an unauthenticated OS command injection (CWE-78, CVSS 9.0) on the local Docker platform. `ShellClient.GetContainers` interpolated the `docker ps --filter` values into a command executed via `/bin/sh -c`. The label value carries the attacker-controlled function namespace (only `Name`/`ID` are validated), so a crafted namespace breaks out of the double-quoted filter token and runs arbitrary shell as root inside the dashboard container — which holds the Docker socket, chaining to host compromise. This change quotes each filter token as a single shell argument so injected metacharacters stay literal.

---

### 🛠️ Changes Made
- `pkg/dockerclient/shell.go`: build the `name`, `id`, and `label` `docker ps --filter` tokens with `common.Quote` instead of raw interpolation into a double-quoted string — the same escaping idiom already used for `docker run --env/--label`.
- `pkg/dockerclient/shell_test.go`: add `TestGetContainersEscapesLabelFilterInjection`, asserting a malicious `nuclio.io/namespace` label value stays confined to one shell-quoted filter token.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- `go test -tags test_unit ./pkg/dockerclient/` passes, including the new regression test; the payload `n";touch /tmp/pwned;echo "` is confined to a single quoted filter token instead of terminating the `docker ps` command.

---

### 🔗 References
- Ticket link: https://github.com/nuclio/nuclio/security/advisories/GHSA-2893-rq73-w22x
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- The vulnerable path is reachable only on the local Docker platform (`pkg/platform/local`); the Kubernetes platform does not use the docker shell client, so k8s deployments are not exposed.