### PR TITLE
[Buildah] Implement builder backend

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -554,6 +554,14 @@ func CompileImageName(registryURL string, imageName string) string {
 	return strings.TrimSuffix(registryURL, "/") + "/" + imageName
 }
 
+// StripImageTag strips the trailing ":tag" from an image reference, leaving the bare repo path.
+func StripImageTag(image string) string {
+	if lastSlash, lastColon := strings.LastIndex(image, "/"), strings.LastIndex(image, ":"); lastColon > lastSlash {
+		return image[:lastColon]
+	}
+	return image
+}
+
 func AnyPositiveInSliceInt64(numbers []int64) bool {
 	for _, number := range numbers {
 		if number >= 0 {

--- a/pkg/common/helper_test.go
+++ b/pkg/common/helper_test.go
@@ -860,6 +860,43 @@ func (suite *EnvWithLegacyKeyTestSuite) TestGetEnvOrDefaultBoolWithLegacyKey() {
 	}
 }
 
+type StripImageTagTestSuite struct {
+	suite.Suite
+}
+
+func (suite *StripImageTagTestSuite) TestStripImageTag() {
+	for _, testCase := range []struct {
+		name     string
+		image    string
+		expected string
+	}{
+		{
+			name:     "tagAfterSlash",
+			image:    "registry.example.com/my-func:latest",
+			expected: "registry.example.com/my-func",
+		},
+		{
+			name:     "tagWithoutRegistry",
+			image:    "my-func:some-tag",
+			expected: "my-func",
+		},
+		{
+			name:     "noTag",
+			image:    "registry.example.com/my-func",
+			expected: "registry.example.com/my-func",
+		},
+		{
+			name:     "portInHostNoTag",
+			image:    "registry.example.com:5000/my-func",
+			expected: "registry.example.com:5000/my-func",
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Require().Equal(testCase.expected, StripImageTag(testCase.image))
+		})
+	}
+}
+
 func TestHelperTestSuite(t *testing.T) {
 	suite.Run(t, new(RetryUntilSuccessfulTestSuite))
 	suite.Run(t, new(RetryUntilSuccessfulOnErrorPatternsTestSuite))
@@ -873,4 +910,5 @@ func TestHelperTestSuite(t *testing.T) {
 	suite.Run(t, new(IsPathWithinDirTestSuite))
 	suite.Run(t, new(ContainsPathTraversalTestSuite))
 	suite.Run(t, new(EnvWithLegacyKeyTestSuite))
+	suite.Run(t, new(StripImageTagTestSuite))
 }

--- a/pkg/containerimagebuilderpusher/buildah.go
+++ b/pkg/containerimagebuilderpusher/buildah.go
@@ -113,6 +113,7 @@ func (b *Buildah) configureAuthVolume(buildOptions *BuildOptions, podSpec *v1.Po
 	authFolderVolumeMount := v1.VolumeMount{
 		Name:      buildahAuthVolume,
 		MountPath: buildahAuthDir,
+		ReadOnly:  true,
 	}
 
 	podSpec.Volumes = append(podSpec.Volumes, v1.Volume{
@@ -218,7 +219,8 @@ func (b *Buildah) compileBuildahContainer(buildOptions *BuildOptions) v1.Contain
 		pushArgs = append(pushArgs, "--tls-verify=false")
 	}
 
-	pushArgs = append(pushArgs, envRef(destination), fmt.Sprintf("docker://%s", envRef(destination)))
+	envDestination := envRef(destination)
+	pushArgs = append(pushArgs, envDestination, fmt.Sprintf("docker://%s", envDestination))
 
 	budCmd := "buildah bud " + strings.Join(buildArgs, " ")
 	pushCmd := "buildah push " + strings.Join(pushArgs, " ")

--- a/pkg/containerimagebuilderpusher/buildah.go
+++ b/pkg/containerimagebuilderpusher/buildah.go
@@ -18,14 +18,26 @@ package containerimagebuilderpusher
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"strings"
 
+	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/api/core/v1"
 )
 
-const BuildahKind = "buildah"
+const (
+	BuildahKind = "buildah"
+
+	buildahAuthDir    = "/var/lib/containers/auth"
+	buildahAuthFile   = buildahAuthDir + "/config.json"
+	buildahAuthVolume = "authdir"
+)
 
 type Buildah struct {
 	*jobRunner
@@ -46,5 +58,168 @@ func NewBuildah(logger logger.Logger,
 func (b *Buildah) BuildAndPushContainerImage(ctx context.Context,
 	buildOptions *BuildOptions,
 	namespace string) error {
-	return errors.New("Buildah build/push is not implemented yet")
+	bundleFilename, assetPath, err := b.createContainerBuildBundle(ctx,
+		buildOptions.Image,
+		buildOptions.ContextDir,
+		buildOptions.TempDir)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create container build bundle")
+	}
+
+	// Remove bundle file from assets once we are done
+	defer os.Remove(assetPath) // nolint: errcheck
+
+	// Generate job spec
+	jobSpec, err := b.compileJobSpec(ctx, namespace, buildOptions, bundleFilename)
+	if err != nil {
+		return errors.Wrap(err, "Failed to compile buildah job spec")
+	}
+
+	return b.submitAndWait(ctx, namespace, buildOptions, jobSpec)
+}
+
+func (b *Buildah) compileJobSpec(ctx context.Context,
+	namespace string,
+	buildOptions *BuildOptions,
+	bundleFilename string) (*batchv1.Job, error) {
+
+	buildahContainer := b.compileBuildahContainer(buildOptions)
+
+	jobSpec, err := b.compileBaseJobSpec(ctx,
+		namespace,
+		buildOptions,
+		bundleFilename,
+		buildahContainer,
+		b.builderConfiguration.Buildah.ImagePullPolicy)
+	if err != nil {
+		return nil, err
+	}
+
+	podSpec := &jobSpec.Spec.Template.Spec
+	podSpec.SecurityContext = buildOptions.SecurityContext
+	b.configureAuthVolume(buildOptions, podSpec)
+	b.configureRootlessMode(podSpec)
+
+	return jobSpec, nil
+}
+
+// configureAuthVolume mounts the registry auth secret (if any) into the buildah container.
+// TODO: will be extended to support Cloud registry credentials & multiple secrets in the next PR.
+func (b *Buildah) configureAuthVolume(buildOptions *BuildOptions, podSpec *v1.PodSpec) {
+	if buildOptions.SecretName == "" {
+		return
+	}
+
+	authFolderVolumeMount := v1.VolumeMount{
+		Name:      buildahAuthVolume,
+		MountPath: buildahAuthDir,
+	}
+
+	podSpec.Volumes = append(podSpec.Volumes, v1.Volume{
+		Name: authFolderVolumeMount.Name,
+		VolumeSource: v1.VolumeSource{
+			Secret: &v1.SecretVolumeSource{
+				SecretName: buildOptions.SecretName,
+				Items:      []v1.KeyToPath{{Key: ".dockerconfigjson", Path: "config.json"}},
+			},
+		},
+	})
+	podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, authFolderVolumeMount)
+}
+
+// configureRootlessMode wires the buildah container's security context per Buildah.RootlessMode.
+func (b *Buildah) configureRootlessMode(podSpec *v1.PodSpec) {
+	if b.builderConfiguration.Buildah.RootlessMode == "hostusers" {
+		hostUsers := false
+		podSpec.HostUsers = &hostUsers
+		return
+	}
+
+	allowPrivilegeEscalation := true
+	podSpec.Containers[0].SecurityContext = &v1.SecurityContext{
+		Capabilities: &v1.Capabilities{
+			Add: []v1.Capability{"SETUID", "SETGID"},
+		},
+		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+	}
+}
+
+func (b *Buildah) compileBuildahContainer(buildOptions *BuildOptions) v1.Container {
+
+	tmpFolderVolumeMount := v1.VolumeMount{
+		Name:      "tmp",
+		MountPath: "/tmp",
+	}
+
+	destination := common.CompileImageName(buildOptions.RegistryURL, buildOptions.Image)
+
+	envVars := []v1.EnvVar{
+		{
+			Name:  "REGISTRY_AUTH_FILE",
+			Value: buildahAuthFile,
+		},
+	}
+
+	// envRef avoids shell injection of free-text values into the command line.
+	envRef := func(value string) string {
+		name := fmt.Sprintf("BUILDAH_ARG_%d", len(envVars))
+		envVars = append(envVars, v1.EnvVar{Name: name, Value: value})
+		return fmt.Sprintf(`"$%s"`, name)
+	}
+
+	buildArgs := []string{
+		"--layers",
+		fmt.Sprintf("--storage-driver=%s", envRef(b.builderConfiguration.Buildah.StorageDriver)),
+		fmt.Sprintf("--isolation=%s", envRef(b.builderConfiguration.Buildah.Isolation)),
+		fmt.Sprintf("--file=%s", envRef(buildOptions.DockerfileInfo.DockerfilePath)),
+		fmt.Sprintf("--tag=%s", envRef(destination)),
+	}
+
+	if b.builderConfiguration.InsecurePullRegistry {
+		buildArgs = append(buildArgs, "--tls-verify=false")
+	}
+
+	if b.builderConfiguration.CacheRepo != "" {
+		buildArgs = append(buildArgs,
+			fmt.Sprintf("--cache-to=%s", envRef(b.builderConfiguration.CacheRepo)),
+			fmt.Sprintf("--cache-from=%s", envRef(b.builderConfiguration.CacheRepo)))
+	}
+
+	if buildOptions.NoCache {
+		buildArgs = append(buildArgs, "--no-cache")
+	}
+
+	for buildArgName, buildArgValue := range buildOptions.BuildArgs {
+		buildArg := fmt.Sprintf("%s=%s", buildArgName, buildArgValue)
+		buildArgs = append(buildArgs, fmt.Sprintf("--build-arg=%s", envRef(buildArg)))
+	}
+
+	// Add the build context directory as last positional argument
+	buildArgs = append(buildArgs, envRef(buildOptions.ContextDir))
+
+	pushArgs := []string{
+		fmt.Sprintf("--storage-driver=%s", envRef(b.builderConfiguration.Buildah.StorageDriver)),
+		fmt.Sprintf("--retry=%d", b.builderConfiguration.PushImagesRetries),
+	}
+
+	if b.builderConfiguration.InsecurePushRegistry {
+		pushArgs = append(pushArgs, "--tls-verify=false")
+	}
+
+	pushArgs = append(pushArgs, envRef(destination), fmt.Sprintf("docker://%s", envRef(destination)))
+
+	budCmd := "buildah bud " + strings.Join(buildArgs, " ")
+	pushCmd := "buildah push " + strings.Join(pushArgs, " ")
+	buildahCommand := strings.Join([]string{"set -eu", budCmd, pushCmd}, "\n")
+
+	return v1.Container{
+		Name:            "buildah",
+		Image:           b.builderConfiguration.Buildah.Image,
+		ImagePullPolicy: v1.PullPolicy(b.builderConfiguration.Buildah.ImagePullPolicy),
+		Command:         []string{"/bin/sh"},
+		Args:            []string{"-c", buildahCommand},
+		Env:             envVars,
+		VolumeMounts:    []v1.VolumeMount{tmpFolderVolumeMount},
+		Resources:       buildOptions.Resources,
+	}
 }

--- a/pkg/containerimagebuilderpusher/buildah.go
+++ b/pkg/containerimagebuilderpusher/buildah.go
@@ -96,7 +96,6 @@ func (b *Buildah) compileJobSpec(ctx context.Context,
 	}
 
 	podSpec := &jobSpec.Spec.Template.Spec
-	podSpec.SecurityContext = buildOptions.SecurityContext
 	b.configureAuthVolume(buildOptions, podSpec)
 	b.configureRootlessMode(podSpec)
 
@@ -153,29 +152,8 @@ func stripImageTag(image string) string {
 	return image
 }
 
-func (b *Buildah) compileBuildahContainer(buildOptions *BuildOptions) v1.Container {
-
-	tmpFolderVolumeMount := v1.VolumeMount{
-		Name:      "tmp",
-		MountPath: "/tmp",
-	}
-
-	destination := common.CompileImageName(buildOptions.RegistryURL, buildOptions.Image)
-
-	envVars := []v1.EnvVar{
-		{
-			Name:  "REGISTRY_AUTH_FILE",
-			Value: buildahAuthFile,
-		},
-	}
-
-	// envRef avoids shell injection of free-text values into the command line.
-	envRef := func(value string) string {
-		name := fmt.Sprintf("BUILDAH_ARG_%d", len(envVars))
-		envVars = append(envVars, v1.EnvVar{Name: name, Value: value})
-		return fmt.Sprintf(`"$%s"`, name)
-	}
-
+// compileBuildahBudArgs assembles the "buildah bud" argument list.
+func (b *Buildah) compileBuildahBudArgs(buildOptions *BuildOptions, destination string, envRef func(string) string) []string {
 	buildArgs := []string{
 		"--layers",
 		fmt.Sprintf("--storage-driver=%s", envRef(b.builderConfiguration.Buildah.StorageDriver)),
@@ -207,9 +185,13 @@ func (b *Buildah) compileBuildahContainer(buildOptions *BuildOptions) v1.Contain
 		buildArgs = append(buildArgs, fmt.Sprintf("--build-arg=%s", envRef(buildArg)))
 	}
 
-	// Add the build context directory as last positional argument
 	buildArgs = append(buildArgs, envRef(buildOptions.ContextDir))
 
+	return buildArgs
+}
+
+// compileBuildahPushArgs assembles the "buildah push" argument list.
+func (b *Buildah) compileBuildahPushArgs(destination string, envRef func(string) string) []string {
 	pushArgs := []string{
 		fmt.Sprintf("--storage-driver=%s", envRef(b.builderConfiguration.Buildah.StorageDriver)),
 		fmt.Sprintf("--retry=%d", b.builderConfiguration.PushImagesRetries),
@@ -221,6 +203,35 @@ func (b *Buildah) compileBuildahContainer(buildOptions *BuildOptions) v1.Contain
 
 	envDestination := envRef(destination)
 	pushArgs = append(pushArgs, envDestination, fmt.Sprintf("docker://%s", envDestination))
+
+	return pushArgs
+}
+
+func (b *Buildah) compileBuildahContainer(buildOptions *BuildOptions) v1.Container {
+
+	tmpFolderVolumeMount := v1.VolumeMount{
+		Name:      "tmp",
+		MountPath: "/tmp",
+	}
+
+	destination := common.CompileImageName(buildOptions.RegistryURL, buildOptions.Image)
+
+	envVars := []v1.EnvVar{
+		{
+			Name:  "REGISTRY_AUTH_FILE",
+			Value: buildahAuthFile,
+		},
+	}
+
+	// envRef avoids shell injection of free-text values into the command line.
+	envRef := func(value string) string {
+		name := fmt.Sprintf("BUILDAH_ARG_%d", len(envVars))
+		envVars = append(envVars, v1.EnvVar{Name: name, Value: value})
+		return fmt.Sprintf(`"$%s"`, name)
+	}
+
+	buildArgs := b.compileBuildahBudArgs(buildOptions, destination, envRef)
+	pushArgs := b.compileBuildahPushArgs(destination, envRef)
 
 	budCmd := "buildah bud " + strings.Join(buildArgs, " ")
 	pushCmd := "buildah push " + strings.Join(pushArgs, " ")

--- a/pkg/containerimagebuilderpusher/buildah.go
+++ b/pkg/containerimagebuilderpusher/buildah.go
@@ -144,14 +144,6 @@ func (b *Buildah) configureRootlessMode(podSpec *v1.PodSpec) {
 	}
 }
 
-// stripImageTag strips the trailing ":tag" from an image reference, leaving the bare repo path.
-func stripImageTag(image string) string {
-	if lastSlash, lastColon := strings.LastIndex(image, "/"), strings.LastIndex(image, ":"); lastColon > lastSlash {
-		return image[:lastColon]
-	}
-	return image
-}
-
 // compileBuildahBudArgs assembles the "buildah bud" argument list.
 func (b *Buildah) compileBuildahBudArgs(buildOptions *BuildOptions, destination string, envRef func(string) string) []string {
 	buildArgs := []string{
@@ -172,7 +164,7 @@ func (b *Buildah) compileBuildahBudArgs(buildOptions *BuildOptions, destination 
 		cacheRepo := b.builderConfiguration.CacheRepo
 		if cacheRepo == "" {
 			// Mirror Kaniko's default cache repo when none is configured
-			cacheRepo = stripImageTag(destination) + "/cache"
+			cacheRepo = common.StripImageTag(destination) + "/cache"
 		}
 		envCacheRepo := envRef(cacheRepo)
 		buildArgs = append(buildArgs,

--- a/pkg/containerimagebuilderpusher/buildah.go
+++ b/pkg/containerimagebuilderpusher/buildah.go
@@ -144,6 +144,14 @@ func (b *Buildah) configureRootlessMode(podSpec *v1.PodSpec) {
 	}
 }
 
+// stripImageTag strips the trailing ":tag" from an image reference, leaving the bare repo path.
+func stripImageTag(image string) string {
+	if lastSlash, lastColon := strings.LastIndex(image, "/"), strings.LastIndex(image, ":"); lastColon > lastSlash {
+		return image[:lastColon]
+	}
+	return image
+}
+
 func (b *Buildah) compileBuildahContainer(buildOptions *BuildOptions) v1.Container {
 
 	tmpFolderVolumeMount := v1.VolumeMount{
@@ -179,14 +187,18 @@ func (b *Buildah) compileBuildahContainer(buildOptions *BuildOptions) v1.Contain
 		buildArgs = append(buildArgs, "--tls-verify=false")
 	}
 
-	if b.builderConfiguration.CacheRepo != "" {
-		buildArgs = append(buildArgs,
-			fmt.Sprintf("--cache-to=%s", envRef(b.builderConfiguration.CacheRepo)),
-			fmt.Sprintf("--cache-from=%s", envRef(b.builderConfiguration.CacheRepo)))
-	}
-
 	if buildOptions.NoCache {
 		buildArgs = append(buildArgs, "--no-cache")
+	} else {
+		cacheRepo := b.builderConfiguration.CacheRepo
+		if cacheRepo == "" {
+			// Mirror Kaniko's default cache repo when none is configured
+			cacheRepo = stripImageTag(destination) + "/cache"
+		}
+		envCacheRepo := envRef(cacheRepo)
+		buildArgs = append(buildArgs,
+			fmt.Sprintf("--cache-to=%s", envCacheRepo),
+			fmt.Sprintf("--cache-from=%s", envCacheRepo))
 	}
 
 	for buildArgName, buildArgValue := range buildOptions.BuildArgs {

--- a/pkg/containerimagebuilderpusher/buildah_test.go
+++ b/pkg/containerimagebuilderpusher/buildah_test.go
@@ -31,6 +31,11 @@ import (
 	"k8s.io/api/core/v1"
 )
 
+var (
+	budTLSVerifyRegexp  = regexp.MustCompile(`buildah bud[^\n]*--tls-verify=false`)
+	pushTLSVerifyRegexp = regexp.MustCompile(`buildah push[^\n]*--tls-verify=false`)
+)
+
 type BuildahTestSuite struct {
 	suite.Suite
 	logger  logger.Logger
@@ -60,16 +65,6 @@ func (suite *BuildahTestSuite) SetupTest() {
 	}
 }
 
-func (suite *BuildahTestSuite) newBuildOptions() *BuildOptions {
-	return &BuildOptions{
-		Image:       "my-func:latest",
-		ContextDir:  "/some/context",
-		RegistryURL: "registry.example.com",
-		DockerfileInfo: &runtime.ProcessorDockerfileInfo{
-			DockerfilePath: "/some/context/Dockerfile",
-		},
-	}
-}
 
 func (suite *BuildahTestSuite) TestCompileBuildahContainerTLSVerifyFlags() {
 	for _, testCase := range []struct {
@@ -107,8 +102,8 @@ func (suite *BuildahTestSuite) TestCompileBuildahContainerTLSVerifyFlags() {
 			suite.Require().Len(container.Args, 2)
 			command := container.Args[1]
 
-			budTLSVerify := regexp.MustCompile(`buildah bud[^\n]*--tls-verify=false`).MatchString(command)
-			pushTLSVerify := regexp.MustCompile(`buildah push[^\n]*--tls-verify=false`).MatchString(command)
+			budTLSVerify := budTLSVerifyRegexp.MatchString(command)
+			pushTLSVerify := pushTLSVerifyRegexp.MatchString(command)
 
 			suite.Equal(testCase.expectPullTLSVerify, budTLSVerify)
 			suite.Equal(testCase.expectPushTLSVerify, pushTLSVerify)
@@ -259,6 +254,17 @@ func (suite *BuildahTestSuite) TestNewContainerBuilderConfigurationValidatesIsol
 			suite.Require().NoError(err)
 			suite.Equal(testCase.expected, config.Buildah.Isolation)
 		})
+	}
+}
+
+func (suite *BuildahTestSuite) newBuildOptions() *BuildOptions {
+	return &BuildOptions{
+		Image:       "my-func:latest",
+		ContextDir:  "/some/context",
+		RegistryURL: "registry.example.com",
+		DockerfileInfo: &runtime.ProcessorDockerfileInfo{
+			DockerfilePath: "/some/context/Dockerfile",
+		},
 	}
 }
 

--- a/pkg/containerimagebuilderpusher/buildah_test.go
+++ b/pkg/containerimagebuilderpusher/buildah_test.go
@@ -171,7 +171,11 @@ func (suite *BuildahTestSuite) TestCompileJobSpecAuthVolumeWithSecret() {
 
 	podSpec := jobSpec.Spec.Template.Spec
 	suite.Len(podSpec.Volumes, 2)
-	suite.Len(podSpec.Containers[0].VolumeMounts, 2)
+	suite.Require().Len(podSpec.Containers[0].VolumeMounts, 2)
+
+	authMount := podSpec.Containers[0].VolumeMounts[1]
+	suite.Equal(buildahAuthVolume, authMount.Name)
+	suite.True(authMount.ReadOnly, "auth secret mount must be read-only")
 }
 
 func (suite *BuildahTestSuite) TestNewContainerBuilderConfigurationValidatesRootlessMode() {

--- a/pkg/containerimagebuilderpusher/buildah_test.go
+++ b/pkg/containerimagebuilderpusher/buildah_test.go
@@ -65,7 +65,6 @@ func (suite *BuildahTestSuite) SetupTest() {
 	}
 }
 
-
 func (suite *BuildahTestSuite) TestCompileBuildahContainerTLSVerifyFlags() {
 	for _, testCase := range []struct {
 		name                 string

--- a/pkg/containerimagebuilderpusher/buildah_test.go
+++ b/pkg/containerimagebuilderpusher/buildah_test.go
@@ -19,13 +19,159 @@ limitations under the License.
 package containerimagebuilderpusher
 
 import (
+	"context"
+	"regexp"
 	"testing"
 
+	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
+	"k8s.io/api/core/v1"
 )
 
 type BuildahTestSuite struct {
 	suite.Suite
+	logger  logger.Logger
+	buildah *Buildah
+}
+
+func (suite *BuildahTestSuite) SetupTest() {
+	var err error
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+
+	suite.buildah = &Buildah{
+		jobRunner: &jobRunner{
+			builderName: BuildahKind,
+			logger:      suite.logger,
+			builderConfiguration: &ContainerBuilderConfiguration{
+				BusyBoxImage: "busybox:stable",
+				Buildah: BuildahConfig{
+					Image:           "quay.io/buildah/stable:v1.43.1",
+					ImagePullPolicy: "IfNotPresent",
+					RootlessMode:    "caps",
+					StorageDriver:   "overlay",
+					Isolation:       "chroot",
+				},
+			},
+		},
+	}
+}
+
+func (suite *BuildahTestSuite) newBuildOptions() *BuildOptions {
+	return &BuildOptions{
+		Image:       "my-func:latest",
+		ContextDir:  "/some/context",
+		RegistryURL: "registry.example.com",
+		DockerfileInfo: &runtime.ProcessorDockerfileInfo{
+			DockerfilePath: "/some/context/Dockerfile",
+		},
+	}
+}
+
+func (suite *BuildahTestSuite) TestCompileBuildahContainerTLSVerifyFlags() {
+	for _, testCase := range []struct {
+		name                 string
+		insecurePullRegistry bool
+		insecurePushRegistry bool
+		expectPullTLSVerify  bool
+		expectPushTLSVerify  bool
+	}{
+		{name: "SecurePullSecurePush"},
+		{
+			name:                 "InsecurePullSecurePush",
+			insecurePullRegistry: true,
+			expectPullTLSVerify:  true,
+		},
+		{
+			name:                 "SecurePullInsecurePush",
+			insecurePushRegistry: true,
+			expectPushTLSVerify:  true,
+		},
+		{
+			name:                 "InsecurePullInsecurePush",
+			insecurePullRegistry: true,
+			insecurePushRegistry: true,
+			expectPullTLSVerify:  true,
+			expectPushTLSVerify:  true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.buildah.builderConfiguration.InsecurePullRegistry = testCase.insecurePullRegistry
+			suite.buildah.builderConfiguration.InsecurePushRegistry = testCase.insecurePushRegistry
+
+			container := suite.buildah.compileBuildahContainer(suite.newBuildOptions())
+
+			suite.Require().Len(container.Args, 2)
+			command := container.Args[1]
+
+			budTLSVerify := regexp.MustCompile(`buildah bud[^\n]*--tls-verify=false`).MatchString(command)
+			pushTLSVerify := regexp.MustCompile(`buildah push[^\n]*--tls-verify=false`).MatchString(command)
+
+			suite.Equal(testCase.expectPullTLSVerify, budTLSVerify)
+			suite.Equal(testCase.expectPushTLSVerify, pushTLSVerify)
+		})
+	}
+}
+
+func (suite *BuildahTestSuite) TestCompileJobSpecRootlessMode() {
+	for _, testCase := range []struct {
+		name               string
+		rootlessMode       string
+		expectHostUsers    bool
+		expectCapabilities bool
+	}{
+		{name: "Caps", rootlessMode: "caps", expectCapabilities: true},
+		{name: "Hostusers", rootlessMode: "hostusers", expectHostUsers: true},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.buildah.builderConfiguration.Buildah.RootlessMode = testCase.rootlessMode
+
+			jobSpec, err := suite.buildah.compileJobSpec(context.Background(), "default", suite.newBuildOptions(), "bundle.tar")
+			suite.Require().NoError(err)
+
+			podSpec := jobSpec.Spec.Template.Spec
+
+			if testCase.expectHostUsers {
+				suite.Require().NotNil(podSpec.HostUsers)
+				suite.False(*podSpec.HostUsers)
+				suite.Nil(podSpec.Containers[0].SecurityContext)
+			} else {
+				suite.Nil(podSpec.HostUsers)
+			}
+
+			if testCase.expectCapabilities {
+				suite.Require().NotNil(podSpec.Containers[0].SecurityContext)
+				suite.Contains(podSpec.Containers[0].SecurityContext.Capabilities.Add, v1.Capability("SETUID"))
+				suite.Contains(podSpec.Containers[0].SecurityContext.Capabilities.Add, v1.Capability("SETGID"))
+				suite.True(*podSpec.Containers[0].SecurityContext.AllowPrivilegeEscalation)
+			}
+		})
+	}
+}
+
+func (suite *BuildahTestSuite) TestCompileJobSpecNoAuthVolumeWithoutSecret() {
+	jobSpec, err := suite.buildah.compileJobSpec(context.Background(), "default", suite.newBuildOptions(), "bundle.tar")
+	suite.Require().NoError(err)
+
+	podSpec := jobSpec.Spec.Template.Spec
+	suite.Len(podSpec.Volumes, 1)
+	suite.Equal("tmp", podSpec.Volumes[0].Name)
+	suite.Len(podSpec.Containers[0].VolumeMounts, 1)
+}
+
+func (suite *BuildahTestSuite) TestCompileJobSpecAuthVolumeWithSecret() {
+	buildOptions := suite.newBuildOptions()
+	buildOptions.SecretName = "my-registry-secret"
+
+	jobSpec, err := suite.buildah.compileJobSpec(context.Background(), "default", buildOptions, "bundle.tar")
+	suite.Require().NoError(err)
+
+	podSpec := jobSpec.Spec.Template.Spec
+	suite.Len(podSpec.Volumes, 2)
+	suite.Len(podSpec.Containers[0].VolumeMounts, 2)
 }
 
 func (suite *BuildahTestSuite) TestNewContainerBuilderConfigurationValidatesRootlessMode() {

--- a/pkg/containerimagebuilderpusher/jobrunner.go
+++ b/pkg/containerimagebuilderpusher/jobrunner.go
@@ -209,7 +209,7 @@ func (r *jobRunner) bundleFetchInitContainers(bundleFilename string,
 	resources v1.ResourceRequirements) []v1.Container {
 
 	assetsURL := fmt.Sprintf("http://%s:8070/build/%s", os.Getenv("NUCLIO_DASHBOARD_DEPLOYMENT_NAME"), bundleFilename)
-	getAssetCommand := fmt.Sprintf("while true; do wget -T 5 -c %s -P %s && break; done", assetsURL, tmpFolderVolumeMount.MountPath)
+	getAssetCommand := fmt.Sprintf("while true; do wget -T 5 -c %s -P %s && break; sleep 2; done", assetsURL, tmpFolderVolumeMount.MountPath)
 
 	return []v1.Container{
 		{
@@ -351,8 +351,11 @@ func (r *jobRunner) submitAndWait(ctx context.Context,
 // compileJobNamePrefix returns a name prefix for use as the job's ObjectMeta.GenerateName
 func (r *jobRunner) compileJobNamePrefix(image string) string {
 
+	image = strings.ReplaceAll(strings.ToLower(image), ":", "-")
+	image = strings.ReplaceAll(image, "/", "-")
+
 	invalidJobNameChars := regexp.MustCompile(`[^a-z0-9.-]`)
-	functionName := strings.Trim(invalidJobNameChars.ReplaceAllString(strings.ToLower(image), ""), ".-")
+	functionName := strings.Trim(invalidJobNameChars.ReplaceAllString(image, ""), ".-")
 
 	jobNamePrefix := fmt.Sprintf("nuclio-%s.%s-", r.builderConfiguration.JobPrefix, functionName)
 
@@ -361,7 +364,7 @@ func (r *jobRunner) compileJobNamePrefix(image string) string {
 	// cut can never leave a dangling "." or "-" that k8s's GenerateName validation would reject.
 	const generatedSuffixLen = 5
 	if maxLen := 63 - generatedSuffixLen; len(jobNamePrefix) > maxLen {
-		jobNamePrefix = jobNamePrefix[:maxLen-1] + "-"
+		jobNamePrefix = strings.TrimRight(jobNamePrefix[:maxLen-1], ".-") + "-"
 	}
 
 	return jobNamePrefix

--- a/pkg/containerimagebuilderpusher/jobrunner.go
+++ b/pkg/containerimagebuilderpusher/jobrunner.go
@@ -289,6 +289,7 @@ func (r *jobRunner) compileBaseJobSpec(ctx context.Context,
 		PriorityClassName:  buildOptions.PriorityClassName,
 		Tolerations:        buildOptions.Tolerations,
 		ServiceAccountName: serviceAccount,
+		SecurityContext:    buildOptions.SecurityContext,
 	}
 
 	return &batchv1.Job{

--- a/pkg/containerimagebuilderpusher/jobrunner.go
+++ b/pkg/containerimagebuilderpusher/jobrunner.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,7 +50,6 @@ type jobRunner struct {
 	kubeClientSet        kube.Client
 	logger               logger.Logger
 	builderConfiguration *ContainerBuilderConfiguration
-	jobNameRegex         *regexp.Regexp
 }
 
 // newJobRunner constructs a jobRunner for the backend named builderName (e.g. "kaniko", "buildah").
@@ -62,16 +62,11 @@ func newJobRunner(builderName string,
 		return nil, errors.New("Missing builder configuration")
 	}
 
-	// Valid job name is composed of a DNS-1123 subdomains which in turn must contain only lower case
-	// alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com')
-	jobNameRegex := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
-
 	return &jobRunner{
 		builderName:          builderName,
 		logger:               parentLogger.GetChild(builderName),
 		kubeClientSet:        kubeClientSet,
 		builderConfiguration: builderConfiguration,
-		jobNameRegex:         jobNameRegex,
 	}, nil
 }
 
@@ -207,31 +202,169 @@ func (r *jobRunner) createContainerBuildBundle(ctx context.Context,
 	return path.Base(tarFile.Name()), assetPath, nil
 }
 
-func (r *jobRunner) compileJobName(ctx context.Context, image string) string {
+// bundleFetchInitContainers returns the fetch-bundle and extract-bundle init containers shared by every backend.
+func (r *jobRunner) bundleFetchInitContainers(bundleFilename string,
+	initContainerPullPolicy string,
+	tmpFolderVolumeMount v1.VolumeMount,
+	resources v1.ResourceRequirements) []v1.Container {
 
-	functionName := strings.ReplaceAll(image, "/", "")
-	functionName = strings.ReplaceAll(functionName, ":", "")
-	functionName = strings.ReplaceAll(functionName, "-", "")
-	randomSuffix := common.GenerateRandomString(10, common.SmallLettersAndNumbers)
-	nuclioPrefix := "nuclio-"
+	assetsURL := fmt.Sprintf("http://%s:8070/build/%s", os.Getenv("NUCLIO_DASHBOARD_DEPLOYMENT_NAME"), bundleFilename)
+	getAssetCommand := fmt.Sprintf("while true; do wget -T 5 -c %s -P %s && break; done", assetsURL, tmpFolderVolumeMount.MountPath)
 
-	// Truncate function name so the job name won't exceed k8s limit of 63
-	functionNameLimit := 63 - (len(r.builderConfiguration.JobPrefix) + len(randomSuffix) + len(nuclioPrefix) + 2)
-	if len(functionName) > functionNameLimit {
-		functionName = functionName[0:functionNameLimit]
+	return []v1.Container{
+		{
+			Name:            "fetch-bundle",
+			Image:           r.builderConfiguration.BusyBoxImage,
+			ImagePullPolicy: v1.PullPolicy(initContainerPullPolicy),
+			Command: []string{
+				"/bin/sh",
+			},
+			Args: []string{
+				"-c",
+				getAssetCommand,
+			},
+			VolumeMounts: []v1.VolumeMount{tmpFolderVolumeMount},
+			Resources:    resources,
+		},
+		{
+			Name:            "extract-bundle",
+			Image:           r.builderConfiguration.BusyBoxImage,
+			ImagePullPolicy: v1.PullPolicy(initContainerPullPolicy),
+			Command: []string{
+				"tar",
+				"-xvf",
+				fmt.Sprintf("%s/%s", tmpFolderVolumeMount.MountPath, bundleFilename),
+				"-C",
+				"/",
+			},
+			VolumeMounts: []v1.VolumeMount{tmpFolderVolumeMount},
+			Resources:    resources,
+		},
+	}
+}
+
+// compileBaseJobSpec assembles the Job/Pod skeleton shared by every backend; callers splice in any
+// backend-specific volumes/init-containers/podspec tweaks afterwards.
+func (r *jobRunner) compileBaseJobSpec(ctx context.Context,
+	namespace string,
+	buildOptions *BuildOptions,
+	bundleFilename string,
+	mainContainer v1.Container,
+	initContainerPullPolicy string) (*batchv1.Job, error) {
+
+	completions := int32(1)
+	backoffLimit := int32(0)
+
+	tmpFolderVolumeMount := v1.VolumeMount{
+		Name:      "tmp",
+		MountPath: "/tmp",
 	}
 
-	jobName := fmt.Sprintf("%s%s.%s.%s", nuclioPrefix, r.builderConfiguration.JobPrefix, functionName, randomSuffix)
+	jobNamePrefix := r.compileJobNamePrefix(buildOptions.Image)
 
-	// Fallback
-	if !r.jobNameRegex.MatchString(jobName) {
-		r.logger.DebugWithCtx(ctx,
-			"Job name does not match k8s regex. Won't use function name",
-			"jobName", jobName)
-		jobName = fmt.Sprintf("%s.%s", r.builderConfiguration.JobPrefix, randomSuffix)
+	serviceAccount, err := r.enrichAndValidateServiceAccount(ctx, buildOptions, namespace)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to enrich and validate service account")
 	}
 
-	return jobName
+	// mainContainer is expected to already mount tmpFolderVolumeMount (it needs the bundle contents).
+	podSpec := v1.PodSpec{
+		Containers: []v1.Container{mainContainer},
+		InitContainers: r.bundleFetchInitContainers(bundleFilename,
+			initContainerPullPolicy,
+			tmpFolderVolumeMount,
+			buildOptions.Resources),
+		Volumes: []v1.Volume{
+			{
+				Name: tmpFolderVolumeMount.Name,
+				VolumeSource: v1.VolumeSource{
+					EmptyDir: &v1.EmptyDirVolumeSource{},
+				},
+			},
+		},
+		RestartPolicy:      v1.RestartPolicyNever,
+		NodeSelector:       buildOptions.NodeSelector,
+		NodeName:           buildOptions.NodeName,
+		Affinity:           buildOptions.Affinity,
+		PriorityClassName:  buildOptions.PriorityClassName,
+		Tolerations:        buildOptions.Tolerations,
+		ServiceAccountName: serviceAccount,
+	}
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: jobNamePrefix,
+			Namespace:    namespace,
+		},
+		Spec: batchv1.JobSpec{
+			Completions:           &completions,
+			ActiveDeadlineSeconds: &buildOptions.BuildTimeoutSeconds,
+			BackoffLimit:          &backoffLimit,
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Labels:    common.CopyStringMapOrNil(r.builderConfiguration.PodLabels),
+				},
+				Spec: podSpec,
+			},
+		},
+	}, nil
+}
+
+// submitAndWait creates jobSpec, schedules its delayed deletion, and waits for it to complete.
+func (r *jobRunner) submitAndWait(ctx context.Context,
+	namespace string,
+	buildOptions *BuildOptions,
+	jobSpec *batchv1.Job) error {
+
+	r.logger.DebugWithCtx(ctx,
+		"Creating job",
+		"namespace", namespace,
+		"jobSpec", jobSpec,
+		"timeoutSeconds", buildOptions.BuildTimeoutSeconds,
+	)
+	job, err := r.kubeClientSet.CreateJob(ctx, namespace, jobSpec)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to publish %s job", r.builderName)
+	}
+
+	// Cleanup after JobDeletionTimeout, allowing the dev to inspect job/pod information before deletion
+	defer time.AfterFunc(r.builderConfiguration.JobDeletionTimeout, func() {
+
+		// Detached context so ctx cancellation doesn't skip the deletion
+		detachedCtx := context.WithoutCancel(ctx)
+		if err := r.deleteJob(detachedCtx, namespace, job.Name); err != nil {
+			r.logger.WarnWithCtx(ctx,
+				"Failed to delete job",
+				"err", err.Error())
+		}
+	})
+
+	return r.waitForJobCompletion(ctx,
+		namespace,
+		job.Name,
+		buildOptions.BuildTimeoutSeconds,
+		buildOptions.ReadinessTimeoutSeconds,
+		buildOptions.BuildLogger)
+}
+
+// compileJobNamePrefix returns a name prefix for use as the job's ObjectMeta.GenerateName
+func (r *jobRunner) compileJobNamePrefix(image string) string {
+
+	invalidJobNameChars := regexp.MustCompile(`[^a-z0-9.-]`)
+	functionName := strings.Trim(invalidJobNameChars.ReplaceAllString(strings.ToLower(image), ""), ".-")
+
+	jobNamePrefix := fmt.Sprintf("nuclio-%s.%s-", r.builderConfiguration.JobPrefix, functionName)
+
+	// k8s appends a 5-char random suffix directly onto GenerateName. Truncate so the resulting
+	// job name won't exceed the k8s limit of 63, reserving the last char for a forced "-" so the
+	// cut can never leave a dangling "." or "-" that k8s's GenerateName validation would reject.
+	const generatedSuffixLen = 5
+	if maxLen := 63 - generatedSuffixLen; len(jobNamePrefix) > maxLen {
+		jobNamePrefix = jobNamePrefix[:maxLen-1] + "-"
+	}
+
+	return jobNamePrefix
 }
 
 func (r *jobRunner) waitForJobCompletion(ctx context.Context,

--- a/pkg/containerimagebuilderpusher/jobrunner_test.go
+++ b/pkg/containerimagebuilderpusher/jobrunner_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -78,6 +79,64 @@ func (suite *JobRunnerTestSuite) TestCreateContainerBuildBundleSafeFromShellInje
 	_, statErr := os.Stat(markerFile)
 	suite.Require().True(os.IsNotExist(statErr),
 		"Shell injection marker was created — injection succeeded via shell execution")
+}
+
+func (suite *JobRunnerTestSuite) TestCompileJobNamePrefix() {
+	for _, testCase := range []struct {
+		name           string
+		jobPrefix      string
+		image          string
+		expectedPrefix string
+	}{
+		{
+			name:           "ShortNameNoTruncation",
+			jobPrefix:      "buildjob",
+			image:          "my-func:latest",
+			expectedPrefix: "nuclio-buildjob.my-func-latest-",
+		},
+		{
+			name:           "SanitizesInvalidChars",
+			jobPrefix:      "buildjob",
+			image:          "Registry.Example.Com/My_Func:v1.2",
+			expectedPrefix: "nuclio-buildjob.registry.example.com-myfunc-v1.2-",
+		},
+		{
+			name:           "TruncatesLongNameGenerically",
+			jobPrefix:      "buildjob",
+			image:          strings.Repeat("x", 80) + ":latest",
+			expectedPrefix: "nuclio-buildjob." + strings.Repeat("x", 41) + "-",
+		},
+		{
+			name:           "TruncationLandsOnDot",
+			jobPrefix:      "buildjob",
+			image:          strings.Repeat("a", 40) + "." + strings.Repeat("b", 40) + ":latest",
+			expectedPrefix: "nuclio-buildjob." + strings.Repeat("a", 40) + "-",
+		},
+		{
+			name:           "TruncationLandsOnDash",
+			jobPrefix:      "buildjob",
+			image:          strings.Repeat("a", 40) + "-" + strings.Repeat("b", 40) + ":latest",
+			expectedPrefix: "nuclio-buildjob." + strings.Repeat("a", 40) + "-",
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			logger, err := nucliozap.NewNuclioZapTest("test")
+			suite.Require().NoError(err)
+
+			r := &jobRunner{
+				builderName: "test",
+				logger:      logger,
+				builderConfiguration: &ContainerBuilderConfiguration{
+					JobPrefix: testCase.jobPrefix,
+				},
+			}
+
+			prefix := r.compileJobNamePrefix(testCase.image)
+
+			suite.Equal(testCase.expectedPrefix, prefix)
+			suite.LessOrEqual(len(prefix), 58, "must leave room for k8s's 5-char GenerateName suffix")
+		})
+	}
 }
 
 func TestJobRunnerTestSuite(t *testing.T) {

--- a/pkg/containerimagebuilderpusher/jobrunner_test.go
+++ b/pkg/containerimagebuilderpusher/jobrunner_test.go
@@ -32,6 +32,18 @@ import (
 
 type JobRunnerTestSuite struct {
 	suite.Suite
+	jobRunner *jobRunner
+}
+
+func (suite *JobRunnerTestSuite) SetupTest() {
+	logger, err := nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+
+	suite.jobRunner = &jobRunner{
+		builderName:          "test",
+		logger:               logger,
+		builderConfiguration: &ContainerBuilderConfiguration{},
+	}
 }
 
 func (suite *JobRunnerTestSuite) TestCreateContainerBuildBundleSuccess() {
@@ -41,16 +53,7 @@ func (suite *JobRunnerTestSuite) TestCreateContainerBuildBundleSuccess() {
 	testFile := fmt.Sprintf("%s/test.txt", contextDir)
 	suite.Require().NoError(os.WriteFile(testFile, []byte("test"), 0644))
 
-	logger, err := nucliozap.NewNuclioZapTest("test")
-	suite.Require().NoError(err)
-
-	r := &jobRunner{
-		builderName:          "test",
-		logger:               logger,
-		builderConfiguration: &ContainerBuilderConfiguration{},
-	}
-
-	bundleFilename, assetPath, err := r.createContainerBuildBundle(context.Background(), "test/image:latest", contextDir, tempDir)
+	bundleFilename, assetPath, err := suite.jobRunner.createContainerBuildBundle(context.Background(), "test/image:latest", contextDir, tempDir)
 	suite.Require().NoError(err)
 	suite.Require().NotEmpty(bundleFilename)
 	suite.Require().FileExists(assetPath)
@@ -64,16 +67,7 @@ func (suite *JobRunnerTestSuite) TestCreateContainerBuildBundleSafeFromShellInje
 	markerFile := fmt.Sprintf("%s/kaniko-injection-marker-%d", os.TempDir(), time.Now().UnixNano())
 	injectionPayload := fmt.Sprintf("/nonexistent-dir; touch %s", markerFile)
 
-	logger, err := nucliozap.NewNuclioZapTest("test")
-	suite.Require().NoError(err)
-
-	r := &jobRunner{
-		builderName:          "test",
-		logger:               logger,
-		builderConfiguration: &ContainerBuilderConfiguration{},
-	}
-
-	_, _, err = r.createContainerBuildBundle(context.Background(), "test/image:latest", injectionPayload, tempDir)
+	_, _, err := suite.jobRunner.createContainerBuildBundle(context.Background(), "test/image:latest", injectionPayload, tempDir)
 	suite.Require().Error(err, "Expected tar to fail on non-existent contextDir")
 
 	_, statErr := os.Stat(markerFile)
@@ -120,18 +114,9 @@ func (suite *JobRunnerTestSuite) TestCompileJobNamePrefix() {
 		},
 	} {
 		suite.Run(testCase.name, func() {
-			logger, err := nucliozap.NewNuclioZapTest("test")
-			suite.Require().NoError(err)
+			suite.jobRunner.builderConfiguration.JobPrefix = testCase.jobPrefix
 
-			r := &jobRunner{
-				builderName: "test",
-				logger:      logger,
-				builderConfiguration: &ContainerBuilderConfiguration{
-					JobPrefix: testCase.jobPrefix,
-				},
-			}
-
-			prefix := r.compileJobNamePrefix(testCase.image)
+			prefix := suite.jobRunner.compileJobNamePrefix(testCase.image)
 
 			suite.Equal(testCase.expectedPrefix, prefix)
 			suite.LessOrEqual(len(prefix), 58, "must leave room for k8s's 5-char GenerateName suffix")

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
@@ -30,7 +29,6 @@ import (
 	"github.com/nuclio/logger"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const KanikoKind = "kaniko"
@@ -70,37 +68,8 @@ func (k *Kaniko) BuildAndPushContainerImage(ctx context.Context,
 	if err != nil {
 		return errors.Wrap(err, "Failed to compile kaniko job spec")
 	}
-	// create job
-	k.logger.DebugWithCtx(ctx,
-		"Creating job",
-		"namespace", namespace,
-		"jobSpec", jobSpec,
-		"timeoutSeconds", buildOptions.BuildTimeoutSeconds,
-	)
-	job, err := k.kubeClientSet.CreateJob(ctx, namespace, jobSpec)
-	if err != nil {
-		return errors.Wrap(err, "Failed to publish kaniko job")
-	}
 
-	// Cleanup after 30 minutes, allowing to dev to inspect job / pod information before getting deleted
-	defer time.AfterFunc(k.builderConfiguration.JobDeletionTimeout, func() {
-
-		// Create a detached context to avoid cancellation of the deletion process
-		detachedCtx := context.WithoutCancel(ctx)
-		if err := k.deleteJob(detachedCtx, namespace, job.Name); err != nil {
-			k.logger.WarnWithCtx(ctx,
-				"Failed to delete job",
-				"err", err.Error())
-		}
-	})
-
-	// Wait for kaniko to finish
-	return k.waitForJobCompletion(ctx,
-		namespace,
-		job.Name,
-		buildOptions.BuildTimeoutSeconds,
-		buildOptions.ReadinessTimeoutSeconds,
-		buildOptions.BuildLogger)
+	return k.submitAndWait(ctx, namespace, buildOptions, jobSpec)
 }
 
 func (k *Kaniko) compileJobSpec(ctx context.Context,
@@ -108,8 +77,29 @@ func (k *Kaniko) compileJobSpec(ctx context.Context,
 	buildOptions *BuildOptions,
 	bundleFilename string) (*batchv1.Job, error) {
 
-	completions := int32(1)
-	backoffLimit := int32(0)
+	kanikoContainer := k.compileKanikoContainer(buildOptions)
+
+	jobSpec, err := k.compileBaseJobSpec(ctx,
+		namespace,
+		buildOptions,
+		bundleFilename,
+		kanikoContainer,
+		k.builderConfiguration.Kaniko.ImagePullPolicy)
+	if err != nil {
+		return nil, err
+	}
+
+	k.configureSecretVolumeMount(buildOptions, jobSpec)
+	return jobSpec, nil
+}
+
+func (k *Kaniko) compileKanikoContainer(buildOptions *BuildOptions) v1.Container {
+
+	tmpFolderVolumeMount := v1.VolumeMount{
+		Name:      "tmp",
+		MountPath: "/tmp",
+	}
+
 	buildArgs := []string{
 		fmt.Sprintf("--dockerfile=%s", buildOptions.DockerfileInfo.DockerfilePath),
 		fmt.Sprintf("--context=%s", buildOptions.ContextDir),
@@ -144,98 +134,14 @@ func (k *Kaniko) compileJobSpec(ctx context.Context,
 		buildArgs = append(buildArgs, fmt.Sprintf("--build-arg=%s=%s", buildArgName, buildArgValue))
 	}
 
-	tmpFolderVolumeMount := v1.VolumeMount{
-		Name:      "tmp",
-		MountPath: "/tmp",
+	return v1.Container{
+		Name:            "kaniko-executor",
+		Image:           k.builderConfiguration.Kaniko.Image,
+		ImagePullPolicy: v1.PullPolicy(k.builderConfiguration.Kaniko.ImagePullPolicy),
+		Args:            buildArgs,
+		VolumeMounts:    []v1.VolumeMount{tmpFolderVolumeMount},
+		Resources:       buildOptions.Resources,
 	}
-	jobName := k.compileJobName(ctx, buildOptions.Image)
-
-	assetsURL := fmt.Sprintf("http://%s:8070/build/%s", os.Getenv("NUCLIO_DASHBOARD_DEPLOYMENT_NAME"), bundleFilename)
-	getAssetCommand := fmt.Sprintf("while true; do wget -T 5 -c %s -P %s && break; done", assetsURL, tmpFolderVolumeMount.MountPath)
-
-	serviceAccount, err := k.enrichAndValidateServiceAccount(ctx, buildOptions, namespace)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to enrich and validate service account")
-	}
-
-	kanikoJobSpec := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      jobName,
-			Namespace: namespace,
-		},
-		Spec: batchv1.JobSpec{
-			Completions:           &completions,
-			ActiveDeadlineSeconds: &buildOptions.BuildTimeoutSeconds,
-			BackoffLimit:          &backoffLimit,
-			Template: v1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      jobName,
-					Namespace: namespace,
-					Labels:    common.CopyStringMapOrNil(k.builderConfiguration.PodLabels),
-				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Name:            "kaniko-executor",
-							Image:           k.builderConfiguration.Kaniko.Image,
-							ImagePullPolicy: v1.PullPolicy(k.builderConfiguration.Kaniko.ImagePullPolicy),
-							Args:            buildArgs,
-							VolumeMounts:    []v1.VolumeMount{tmpFolderVolumeMount},
-							Resources:       buildOptions.Resources,
-						},
-					},
-					InitContainers: []v1.Container{
-						{
-							Name:            "fetch-bundle",
-							Image:           k.builderConfiguration.BusyBoxImage,
-							ImagePullPolicy: v1.PullPolicy(k.builderConfiguration.Kaniko.ImagePullPolicy),
-							Command: []string{
-								"/bin/sh",
-							},
-							Args: []string{
-								"-c",
-								getAssetCommand,
-							},
-							VolumeMounts: []v1.VolumeMount{tmpFolderVolumeMount},
-							Resources:    buildOptions.Resources,
-						},
-						{
-							Name:            "extract-bundle",
-							Image:           k.builderConfiguration.BusyBoxImage,
-							ImagePullPolicy: v1.PullPolicy(k.builderConfiguration.Kaniko.ImagePullPolicy),
-							Command: []string{
-								"tar",
-								"-xvf",
-								fmt.Sprintf("%s/%s", tmpFolderVolumeMount.MountPath, bundleFilename),
-								"-C",
-								"/",
-							},
-							VolumeMounts: []v1.VolumeMount{tmpFolderVolumeMount},
-							Resources:    buildOptions.Resources,
-						},
-					},
-					Volumes: []v1.Volume{
-						{
-							Name: tmpFolderVolumeMount.Name,
-							VolumeSource: v1.VolumeSource{
-								EmptyDir: &v1.EmptyDirVolumeSource{},
-							},
-						},
-					},
-					RestartPolicy:      v1.RestartPolicyNever,
-					NodeSelector:       buildOptions.NodeSelector,
-					NodeName:           buildOptions.NodeName,
-					Affinity:           buildOptions.Affinity,
-					PriorityClassName:  buildOptions.PriorityClassName,
-					Tolerations:        buildOptions.Tolerations,
-					ServiceAccountName: serviceAccount,
-				},
-			},
-		},
-	}
-
-	k.configureSecretVolumeMount(buildOptions, kanikoJobSpec)
-	return kanikoJobSpec, nil
 }
 
 func (k *Kaniko) configureSecretVolumeMount(buildOptions *BuildOptions, kanikoJobSpec *batchv1.Job) {


### PR DESCRIPTION
### 📝 Description
Implements the Buildah container-image builder backend and refactors more of the shared Kubernetes Job-building logic so Kaniko and Buildah reuse the same code instead of duplicating it.

---

### 🛠️ Changes Made
- Implemented `Buildah.BuildAndPushContainerImage`: compiles a `buildah bud` + `buildah push` shell command, with all user/config-supplied values passed via env-var indirection to avoid shell injection.
- Implemented Buildah backend with support for flags already supported by Kaniko: insecure pull/push registries, `--no-cache`, build args, `--layers`, `--cache-to`/`--cache-from`, and `--retry` on push.
- Extracted `bundleFetchInitContainers`, `compileBaseJobSpec`, and `submitAndWait` in `jobrunner.go` so both backends share the same Job/Pod skeleton, init-container fetch/extract logic, and create-wait-cleanup lifecycle; refactored Kaniko to use these shared helpers.
- Replaced random-suffix job-name generation + regex validation/fallback with Kubernetes' native `ObjectMeta.GenerateName`, removing the `jobNameRegex` field. (related to this [comment](https://github.com/nuclio/nuclio/pull/4198#discussion_r3610014395))

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Unit tests
- Tested both Kaniko and Buildah backends on a real cluster (deployed a function with each builder kind toggled via `NUCLIO_CONTAINER_BUILDER_KIND`), confirming both build and push successfully end-to-end.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---
### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

**Shell/argument injection prevention**

Every user/config-supplied value is passed to the buildah container as an env var, and the shell command only ever references `"$BUILDAH_ARG_N"` - never the raw value inlined into the command string.

This prevents shell and argument injection entirely, without needing to sanitize or validate any of the input values.

Example of the resulting pod spec:

```yaml
spec:
  containers:
  - args:
    - -c
    - |-
      set -eu
      buildah bud --layers --storage-driver="$BUILDAH_ARG_1" --isolation="$BUILDAH_ARG_2" --file="$BUILDAH_ARG_3" --tag="$BUILDAH_ARG_4" --cache-to="$BUILDAH_ARG_5" --cache-from="$BUILDAH_ARG_5" --build-arg="$BUILDAH_ARG_6" --build-arg="$BUILDAH_ARG_7" --build-arg="$BUILDAH_ARG_8" "$BUILDAH_ARG_9"
      buildah push --storage-driver="$BUILDAH_ARG_10" --retry=3 "$BUILDAH_ARG_11" docker://"$BUILDAH_ARG_12"
    command:
    - /bin/sh
    env:
    - name: REGISTRY_AUTH_FILE
      value: /var/lib/containers/auth/config.json
    - name: BUILDAH_ARG_1
      value: overlay
    - name: BUILDAH_ARG_2
      value: chroot
    - name: BUILDAH_ARG_3
      value: /tmp/nuclio-build-3848105887/staging/Dockerfile.processor
    - name: BUILDAH_ARG_4
      value: registry.example.com/user-repo/test-buildah-processor:latest
    - name: BUILDAH_ARG_5
      value: registry.example.com/user-repo/test-buildah-processor/cache
    - name: BUILDAH_ARG_6
      value: NUCLIO_LABEL=nuc688-1784821124
    - name: BUILDAH_ARG_7
      value: NUCLIO_ARCH=amd64
    - name: BUILDAH_ARG_8
      value: NUCLIO_BUILD_LOCAL_HANDLER_DIR=handler
    - name: BUILDAH_ARG_9
      value: /tmp/nuclio-build-3848105887/staging
    - name: BUILDAH_ARG_10
      value: overlay
    - name: BUILDAH_ARG_11
      value: registry.example.com/user-repo/test-buildah-processor:latest
    - name: BUILDAH_ARG_12
      value: registry.example.com/user-repo/test-buildah-processor:latest
```



**Buildah cluster build logs**

```
› fetch-bundle
fetch-bundle Connecting to nuclio-dashboard:8070 (10.x.x.x:8070)
fetch-bundle saving to '/tmp/2359000183-test-buildah-processor_latest.tar.gz'
fetch-bundle 2359000183-test-buil 100% |********************************|  1206  0:00:00 ETA
fetch-bundle '/tmp/2359000183-test-buildah-processor_latest.tar.gz' saved

› extract-bundle
extract-bundle tmp/nuclio-build-1884538946/staging/
extract-bundle tmp/nuclio-build-1884538946/staging/handler/
extract-bundle tmp/nuclio-build-1884538946/staging/handler/main.go
extract-bundle tmp/nuclio-build-1884538946/staging/Dockerfile.processor

› buildah
buildah time="2026-07-23T15:43:34Z" level=warning msg="missing \"NUCLIO_BUILD_OFFLINE\" build argument. Try adding \"--build-arg NUCLIO_BUILD_OFFLINE=<VALUE>\" to the command line"
buildah [1/2] STEP 1/9: FROM registry.example.com/nuclio/handler-builder-golang-onbuild:1.17.1-amd64-alpine AS golang-onbuild
buildah Trying to pull registry.example.com/nuclio/handler-builder-golang-onbuild:1.17.1-amd64-alpine...
buildah Getting image source signatures
buildah Copying blob sha256:<...> (multiple layers omitted)
buildah Copying config sha256:c4edda28b33eb416161fca61f13b5988f9f092fe77fb874cb1099623badc7ff6
buildah Writing manifest to image destination
buildah [1/2] STEP 2/9: ARG NUCLIO_LABEL
buildah --> Pushing cache [registry.example.com/user-repo/test-buildah-processor/cache]:08b314415bc64e3b3a12a8258064a77abe09e5a6c75fb11f150bb84f5dfd0c4c
buildah --> 4aab087b4cae
buildah [1/2] STEP 3/9: ARG NUCLIO_ARCH
buildah --> Pushing cache [registry.example.com/user-repo/test-buildah-processor/cache]:1d945cd9703e9844dfab0e42b9f6027b5ff871cdb840bbff1c0f977290f250ab
buildah --> 2b2a313ab0c1
buildah [1/2] STEP 4/9: ARG NUCLIO_BUILD_LOCAL_HANDLER_DIR=.
buildah --> Pushing cache [registry.example.com/user-repo/test-buildah-processor/cache]:2c6297bd095f2df7da3afbd434946dc13df7249c89d12e997ee52578323aae0e
buildah --> 18cd420479d2
buildah [1/2] STEP 5/9: WORKDIR /handler
buildah --> Pushing cache [registry.example.com/user-repo/test-buildah-processor/cache]:85ba7b9565e774c7934806b6802e819471b8ee6ccb75ffb2118fa4eb6f379fd7
buildah --> b64ad39c0631
buildah [1/2] STEP 6/9: COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} ./
buildah --> Pushing cache [registry.example.com/user-repo/test-buildah-processor/cache]:5e904b8f4d5791cfa406873585f25f55ecf5b9aa3daaee95238c28257faf7f7a
buildah --> aa58d1735a90
buildah [1/2] STEP 7/9: ARG NUCLIO_BUILD_OFFLINE
buildah --> Pushing cache [registry.example.com/user-repo/test-buildah-processor/cache]:3e8fe09ef737016be71698d714a9102fcd4106358ac8e99a3a7836d725ded525
buildah --> 47f3b3f262be
buildah [1/2] STEP 8/9: RUN mv /moduler.sh . && sync && ./moduler.sh
buildah + '[' '!' -f go.mod ]
buildah + mv /processor_go.mod go.mod
buildah + mv /processor_go.sum go.sum
buildah + go mod tidy
buildah go: downloading github.com/nuclio/nuclio-sdk-go v0.5.3
buildah go: downloading github.com/nuclio/logger v0.0.1
buildah + rm -rf /processor_go.mod /processor_go.sum
buildah --> Pushing cache [registry.example.com/user-repo/test-buildah-processor/cache]:9c59f90d5a842e0ab38a63b46fffc387f4374bcc5215038af17c52ce77a75fe5
buildah --> 0069b4922084
buildah [1/2] STEP 9/9: RUN go build -mod=mod -buildmode=plugin -o /home/nuclio/bin/handler.so .
buildah --> Pushing cache [registry.example.com/user-repo/test-buildah-processor/cache]:6eb94fe3759518b05ffd1629aa44f451eaaeba770493b48f18b81e3965ccd461
buildah --> b82d5bc119ca
buildah [2/2] STEP 1/7: FROM registry.example.com/library/alpine:3.24.1
buildah Trying to pull registry.example.com/library/alpine:3.24.1...
buildah Getting image source signatures
buildah Copying blob sha256:<...>
buildah Copying config sha256:d529dd0c6e5597ac7e4a3e2dea65c3fcc6173f4cae713c409265c1dd9914a11b
buildah Writing manifest to image destination
buildah [2/2] STEP 2/7: ARG NUCLIO_LABEL
buildah --> Pushing cache [registry.example.com/user-repo/test-buildah-processor/cache]:321f44a86ba2e7b105162fd604c20394c1ceb65681a48de4b3072f3364da88d8
buildah --> c68423574df4
buildah [2/2] STEP 3/7: ARG NUCLIO_ARCH
buildah --> Pushing cache [registry.example.com/user-repo/test-buildah-processor/cache]:4e870140d9b0abda723828663cb6a323664bfb3054898b24c7082b2678f023e4
buildah --> 68b049a297ec
buildah [2/2] STEP 4/7: ARG NUCLIO_BUILD_LOCAL_HANDLER_DIR
buildah --> Pushing cache [registry.example.com/user-repo/test-buildah-processor/cache]:ef39bd6527718ee3cb0cb7fdafe52e02d7ce03021025845743d6ec6f1ed6db06
buildah --> 32e7de55b6ac
buildah [2/2] STEP 5/7: COPY --from=golang-onbuild /home/nuclio/bin/handler.so /opt/nuclio/handler.so
buildah --> Pushing cache [registry.example.com/user-repo/test-buildah-processor/cache]:411365c25ca74698cbe038bb7fbfa1cddd92dbe0f1fa10d98580b3729034558e
buildah --> fd1c36f59190
buildah [2/2] STEP 6/7: COPY --from=golang-onbuild /home/nuclio/bin/processor /usr/local/bin/processor
buildah --> Pushing cache [registry.example.com/user-repo/test-buildah-processor/cache]:718987ceb3c264bfe342d443b7f21792ea8628d7d044492f60e261c49508bc12
buildah --> 38119cf3972d
buildah [2/2] STEP 7/7: CMD [ "processor" ]
buildah [2/2] COMMIT registry.example.com/user-repo/test-buildah-processor:latest
buildah --> Pushing cache [registry.example.com/user-repo/test-buildah-processor/cache]:be8f92fda637774121accfc61a44d58e9874464506022a20c27947bbd75f3127
buildah --> 65ab8a6e6d5a
buildah Successfully tagged registry.example.com/user-repo/test-buildah-processor:latest
buildah 65ab8a6e6d5a87350c827e8eab398c8fbe1622cd3e59327a76e5dea3a4409a7d
buildah Getting image source signatures
buildah Copying blob sha256:<...>
buildah Copying config sha256:65ab8a6e6d5a87350c827e8eab398c8fbe1622cd3e59327a76e5dea3a4409a7d
buildah Writing manifest to image destination
```



**Kaniko build logs (for comparison)**

```
› fetch-bundle
fetch-bundle Connecting to nuclio-dashboard:8070 (10.x.x.x:8070)
fetch-bundle saving to '/tmp/1272186396-test-buildah-processor_latest.tar.gz'
fetch-bundle 1272186396-test-buil 100% |********************************|  1207  0:00:00 ETA
fetch-bundle '/tmp/1272186396-test-buildah-processor_latest.tar.gz' saved

› extract-bundle
extract-bundle tmp/nuclio-build-2311637080/staging/
extract-bundle tmp/nuclio-build-2311637080/staging/handler/
extract-bundle tmp/nuclio-build-2311637080/staging/handler/main.go
extract-bundle tmp/nuclio-build-2311637080/staging/Dockerfile.processor

› kaniko-executor
kaniko-executor INFO[0001] Resolved base name registry.example.com/nuclio/handler-builder-golang-onbuild:1.17.1-amd64-alpine to golang-onbuild
kaniko-executor INFO[0001] Retrieving image manifest registry.example.com/nuclio/handler-builder-golang-onbuild:1.17.1-amd64-alpine
kaniko-executor INFO[0001] Retrieving image registry.example.com/nuclio/handler-builder-golang-onbuild:1.17.1-amd64-alpine from registry registry.example.com
kaniko-executor INFO[0002] Retrieving image manifest registry.example.com/nuclio/handler-builder-golang-onbuild:1.17.1-amd64-alpine
kaniko-executor INFO[0002] Returning cached image manifest
kaniko-executor INFO[0002] Retrieving image manifest registry.example.com/library/alpine:3.24.1
kaniko-executor INFO[0002] Retrieving image registry.example.com/library/alpine:3.24.1 from registry registry.example.com
kaniko-executor INFO[0003] Retrieving image manifest registry.example.com/library/alpine:3.24.1
kaniko-executor INFO[0003] Returning cached image manifest
kaniko-executor INFO[0003] Built cross stage deps: map[0:[/home/nuclio/bin/handler.so /home/nuclio/bin/processor]]
kaniko-executor INFO[0003] Executing 0 build triggers
kaniko-executor INFO[0003] Building stage 'registry.example.com/nuclio/handler-builder-golang-onbuild:1.17.1-amd64-alpine' [idx: '0', base-idx: '-1']
kaniko-executor INFO[0003] Checking for cached layer registry.example.com/user-repo/test-buildah-processor/cache:e9cadcaf47e2f18940f839801e0959cbd2d8477646a389c28bef271655522b8f...
kaniko-executor INFO[0004] No cached layer found for cmd RUN mv /moduler.sh . && sync && ./moduler.sh
kaniko-executor INFO[0004] Unpacking rootfs as cmd COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} ./ requires it.
kaniko-executor INFO[0019] ARG NUCLIO_LABEL
kaniko-executor INFO[0019] No files changed in this command, skipping snapshotting.
kaniko-executor INFO[0019] ARG NUCLIO_ARCH
kaniko-executor INFO[0019] WORKDIR /handler
kaniko-executor INFO[0019] COPY ${NUCLIO_BUILD_LOCAL_HANDLER_DIR} ./
kaniko-executor INFO[0019] Taking snapshot of files...
kaniko-executor INFO[0019] ARG NUCLIO_BUILD_OFFLINE
kaniko-executor INFO[0019] RUN mv /moduler.sh . && sync && ./moduler.sh
kaniko-executor INFO[0019] Initializing snapshotter ...
kaniko-executor INFO[0019] Taking snapshot of full filesystem...
kaniko-executor INFO[0022] Running: [/bin/sh -c mv /moduler.sh . && sync && ./moduler.sh]
kaniko-executor + '[' '!' -f go.mod ]
kaniko-executor + mv /processor_go.mod go.mod
kaniko-executor + mv /processor_go.sum go.sum
kaniko-executor + go mod tidy
kaniko-executor go: downloading github.com/nuclio/nuclio-sdk-go v0.5.3
kaniko-executor go: downloading github.com/nuclio/logger v0.0.1
kaniko-executor + rm -rf /processor_go.mod /processor_go.sum
kaniko-executor INFO[0026] Taking snapshot of full filesystem...
kaniko-executor INFO[0030] Pushing layer registry.example.com/user-repo/test-buildah-processor/cache:e9cadcaf47e2f18940f839801e0959cbd2d8477646a389c28bef271655522b8f to cache now
kaniko-executor INFO[0030] RUN go build -mod=mod -buildmode=plugin -o /home/nuclio/bin/handler.so .
kaniko-executor INFO[0030] Running: [/bin/sh -c go build -mod=mod -buildmode=plugin -o /home/nuclio/bin/handler.so .]
kaniko-executor INFO[0038] Pushed registry.example.com/user-repo/test-buildah-processor/cache@sha256:12feeeb2ef859715ae8fb7211ace02e4f640ad084070aeca8fba474ea418c570
kaniko-executor INFO[0055] Taking snapshot of full filesystem...
kaniko-executor INFO[0059] Pushing layer registry.example.com/user-repo/test-buildah-processor/cache:3bbbbb2cae2a0f1c784da2a99aebe6ab0fb0cdb8ef40002fea75f1ff249a4724 to cache now
kaniko-executor INFO[0064] Pushed registry.example.com/user-repo/test-buildah-processor/cache@sha256:b5a6e924d7a984bb8718956a202445f9be13749b883b0fd330b64d89fe17abe6
kaniko-executor INFO[0064] Saving file home/nuclio/bin/processor for later use
kaniko-executor INFO[0064] Saving file home/nuclio/bin/handler.so for later use
kaniko-executor INFO[0064] Deleting filesystem...
kaniko-executor INFO[0065] Executing 0 build triggers
kaniko-executor INFO[0065] Building stage 'registry.example.com/library/alpine:3.24.1' [idx: '1', base-idx: '-1']
kaniko-executor INFO[0065] Unpacking rootfs as cmd COPY --from=golang-onbuild /home/nuclio/bin/handler.so /opt/nuclio/handler.so requires it.
kaniko-executor INFO[0067] COPY --from=golang-onbuild /home/nuclio/bin/handler.so /opt/nuclio/handler.so
kaniko-executor INFO[0067] Taking snapshot of files...
kaniko-executor INFO[0068] COPY --from=golang-onbuild /home/nuclio/bin/processor /usr/local/bin/processor
kaniko-executor INFO[0068] Taking snapshot of files...
kaniko-executor INFO[0069] CMD [ "processor" ]
kaniko-executor INFO[0069] Pushing image to registry.example.com/user-repo/test-buildah-processor:latest
kaniko-executor INFO[0075] Pushed registry.example.com/user-repo/test-buildah-processor@sha256:3fe4c12ed3726c90a67e3f906705ce64ae11b5ac511c58125cc1ca9b4284ed86
```

**Build Log (Buildah)**

```
info Deploying function[name: "buildah", requestID: "<redacted>"]
info Building[builderKind: "buildah", name: "buildah", requestID: "<redacted>", versionInfo: "..."]
info Staging files and preparing base images[name: "deployer"]
info Building processor image[baseImage: "registry.example.com/library/alpine:3.24.1", name: "deployer", registryURL: "registry.example.com/user-repo", requestID: "<redacted>", taggedImageName: "test-buildah-processor:latest"]
info Build complete[image: "test-buildah-processor:latest", name: "deployer", requestID: "<redacted>"]
info Function deploy complete[externalInvocationURLs: [], functionName: "buildah", httpPort: 0, internalInvocationURLs: ["nuclio-buildah.emilio.svc.cluster.local:8080"], name: "deployer", requestID: "<redacted>"]
```