### PR TITLE
[Dashboard] Add docker-cli-buildx support for dashboard image

### DIFF
--- a/cmd/dashboard/docker/Dockerfile
+++ b/cmd/dashboard/docker/Dockerfile
@@ -95,6 +95,7 @@ RUN apk --update --no-cache add \
         parallel \
         ca-certificates \
         git \
+        docker-cli-buildx \
     && apk upgrade --no-cache \
     && wget -O /tmp/templates.zip $NUCLIO_TEMPLATES_ZIP_GITHUB_URL
 


### PR DESCRIPTION
fixes: #3968 
Added Buildx support to the dashboard image

### Testing
- Built the modified dashboard image successfully using:
make dashboard

<img width="1292" height="950" alt="image" src="https://github.com/user-attachments/assets/0bb9d30c-4a6c-412d-b1c3-59ff3d1687e5" />

<img width="1292" height="950" alt="image" src="https://github.com/user-attachments/assets/fd594d3a-85dd-40e4-838b-9b13e22653d8" />

- Dashboard container started successfuly and buildx plugin is available inside it -

<img width="1450" height="279" alt="image" src="https://github.com/user-attachments/assets/2ab5cb11-d09d-4301-8c81-685e68d35926" />

@beasteers