### PR TITLE
[Local] Validate namespace before shell interpolation in local store

### DIFF
--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -332,10 +332,14 @@ func (s *Store) getResources(resourceDir string,
 
 	// the namespace is user-supplied (e.g. via the X-Nuclio-*-Namespace headers) and gets
 	// interpolated into a shell command below; reject anything that isn't a valid k8s name so
-	// shell metacharacters can never reach the command line (CWE-78)
-	if errorMessages := validation.IsQualifiedName(resourceNamespace); len(errorMessages) != 0 {
-		return nuclio.NewErrBadRequest("Namespace doesn't conform to k8s naming convention. Errors: " +
-			strings.Join(errorMessages, ", "))
+	// shell metacharacters can never reach the command line (CWE-78). An empty namespace is the
+	// unset/default case (never attacker-supplied — the headers only inject a non-empty value),
+	// so it is left to the existing default-namespace handling.
+	if resourceNamespace != "" {
+		if errorMessages := validation.IsQualifiedName(resourceNamespace); len(errorMessages) != 0 {
+			return nuclio.NewErrBadRequest("Namespace doesn't conform to k8s naming convention. Errors: " +
+				strings.Join(errorMessages, ", "))
+		}
 	}
 
 	var commandStdout, resourcePath string

--- a/pkg/platform/local/client/store.go
+++ b/pkg/platform/local/client/store.go
@@ -37,6 +37,7 @@ import (
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/nuclio/nuclio-sdk-go"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 const (
@@ -329,6 +330,14 @@ func (s *Store) getResources(resourceDir string,
 	resourceName string,
 	rowHandler func([]byte) error) error {
 
+	// the namespace is user-supplied (e.g. via the X-Nuclio-*-Namespace headers) and gets
+	// interpolated into a shell command below; reject anything that isn't a valid k8s name so
+	// shell metacharacters can never reach the command line (CWE-78)
+	if errorMessages := validation.IsQualifiedName(resourceNamespace); len(errorMessages) != 0 {
+		return nuclio.NewErrBadRequest("Namespace doesn't conform to k8s naming convention. Errors: " +
+			strings.Join(errorMessages, ", "))
+	}
+
 	var commandStdout, resourcePath string
 	var err error
 
@@ -338,9 +347,10 @@ func (s *Store) getResources(resourceDir string,
 		// Quote the path to prevent shell metacharacter injection.
 		commandStdout, _, err = s.runCommand(nil, "/bin/cat %s", common.Quote(resourcePath))
 	} else {
-		resourcePath = path.Join(s.getResourceNamespaceDir(resourceDir, resourceNamespace), "*")
-		// Wildcard: keep shell wrapper for glob expansion; wildcard is hardcoded, not user-supplied.
-		commandStdout, _, err = s.runCommand(nil, `/bin/sh -c "/bin/cat %s"`, resourcePath)
+		// the wildcard must stay unquoted for glob expansion, but the namespace segment is
+		// user-supplied, so quote it (defense in depth on top of the validation above)
+		namespaceDir := s.getResourceNamespaceDir(resourceDir, resourceNamespace)
+		commandStdout, _, err = s.runCommand(nil, `/bin/sh -c "/bin/cat %s"`, common.Quote(namespaceDir)+"/*")
 	}
 	if err != nil {
 

--- a/pkg/platform/local/client/store_test.go
+++ b/pkg/platform/local/client/store_test.go
@@ -89,3 +89,16 @@ func TestGetResourcesListsValidNamespace(t *testing.T) {
 	assert.Contains(t, dockerClient.executedCommands[0], "/bin/cat")
 	assert.Contains(t, dockerClient.executedCommands[0], "mynamespace")
 }
+
+// TestGetResourcesAllowsEmptyNamespace guards against over-validation: an empty namespace is the
+// unset/default case (used internally, e.g. to lazily initialize the local-storage reader) and must
+// not be rejected — only attacker-supplied non-empty namespaces are validated.
+func TestGetResourcesAllowsEmptyNamespace(t *testing.T) {
+	dockerClient := &capturingDockerClient{MockDockerClient: &dockerclient.MockDockerClient{}}
+	s := &Store{dockerClient: dockerClient}
+
+	err := s.getResources(functionsDir, "", "", func([]byte) error { return nil })
+
+	assert.NoError(t, err)
+	assert.Len(t, dockerClient.executedCommands, 1, "an empty namespace must still reach the list command")
+}

--- a/pkg/platform/local/client/store_test.go
+++ b/pkg/platform/local/client/store_test.go
@@ -23,9 +23,22 @@ import (
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/dockerclient"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// capturingDockerClient records the command handed to ExecInContainer so tests can assert
+// what would actually run in the local-storage container
+type capturingDockerClient struct {
+	*dockerclient.MockDockerClient
+	executedCommands []string
+}
+
+func (c *capturingDockerClient) ExecInContainer(containerID string, execOptions *dockerclient.ExecOptions) error {
+	c.executedCommands = append(c.executedCommands, execOptions.Command)
+	return nil
+}
 
 // TestGetResourcesNamedPathIsQuoted verifies that a resource path derived from
 // a malicious function name is shell-quoted before being used in a command,
@@ -44,4 +57,35 @@ func TestGetResourcesNamedPathIsQuoted(t *testing.T) {
 	// shell metacharacters, neutralising them.
 	quoted := common.Quote(resourcePath)
 	assert.True(t, strings.HasPrefix(quoted, "'"), "expected path to be single-quoted, got: %s", quoted)
+}
+
+// TestGetResourcesRejectsInjectedNamespace verifies that the list-all path rejects a namespace
+// carrying shell metacharacters before any command runs. The namespace is attacker-controlled via
+// the X-Nuclio-*-Namespace headers and is interpolated into `/bin/sh -c "/bin/cat <path>"`; the
+// GHSA-jx7q-cpg6-669g fix quoted only the named-resource path, leaving this one exploitable
+// (GHSA-mq8w-f7w8-5rgg).
+func TestGetResourcesRejectsInjectedNamespace(t *testing.T) {
+	dockerClient := &capturingDockerClient{MockDockerClient: &dockerclient.MockDockerClient{}}
+	s := &Store{dockerClient: dockerClient}
+
+	// list-all path (empty resource name)
+	err := s.getResources(functionsDir, `x" || touch /tmp/pwned #`, "", func([]byte) error { return nil })
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "k8s naming convention")
+	assert.Empty(t, dockerClient.executedCommands, "no shell command must run for an invalid namespace")
+}
+
+// TestGetResourcesListsValidNamespace verifies a well-formed namespace still reaches the
+// list-all command unharmed.
+func TestGetResourcesListsValidNamespace(t *testing.T) {
+	dockerClient := &capturingDockerClient{MockDockerClient: &dockerclient.MockDockerClient{}}
+	s := &Store{dockerClient: dockerClient}
+
+	err := s.getResources(functionsDir, "mynamespace", "", func([]byte) error { return nil })
+
+	assert.NoError(t, err)
+	assert.Len(t, dockerClient.executedCommands, 1)
+	assert.Contains(t, dockerClient.executedCommands[0], "/bin/cat")
+	assert.Contains(t, dockerClient.executedCommands[0], "mynamespace")
 }


### PR DESCRIPTION
### 📝 Description
Hardens the local (Docker) platform store against shell interpolation of the resource namespace (see private advisory GHSA-mq8w-f7w8-5rgg, a bypass of the incomplete GHSA-jx7q-cpg6-669g fix). `getResources` interpolates the namespace into a `docker exec … /bin/sh -c "/bin/cat <path>"` command. The prior fix quoted only the named-resource path; the list-all path (empty resource name) still embedded the unvalidated namespace inside the inner double-quoted string, so a namespace supplied via the `X-Nuclio-*-Namespace` headers could break out and run arbitrary commands in the dashboard container. Because that container holds the Docker socket, this is a host-compromise vector on the local platform. The Kubernetes platform is unaffected (it uses the CRD backend, not shell commands).

---

### 🛠️ Changes Made
- `pkg/platform/local/client/store.go`: reject namespaces that are not valid k8s names (`validation.IsQualifiedName`) at the `getResources` sink before any command is built — a single chokepoint covering functions, projects, and function events. Additionally shell-quote the namespace segment of the list-all path (defense in depth; the `*` wildcard stays unquoted for glob expansion).
- `pkg/platform/local/client/store_test.go`: add regression tests asserting an injected namespace is rejected with no command executed, and that a valid namespace still lists.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- `go test -tags test_unit ./pkg/platform/local/client/` passes, including the new regression tests and the existing named-path quoting test.

---

### 🔗 References
- Ticket link: GHSA-mq8w-f7w8-5rgg (private security advisory)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Validation is the authoritative control here: the list-all path runs a nested shell, where single-quote escaping alone would not neutralize an embedded double quote — rejecting non-conforming namespaces removes the metacharacters entirely.
- The affected code path is reachable only on the local Docker platform; Kubernetes deployments do not use the docker shell client and are not exposed.