### PR TITLE
[Dashboard] Enable configuring http auth in function level

### DIFF
--- a/cmd/authproxy/app/authproxy.go
+++ b/cmd/authproxy/app/authproxy.go
@@ -84,13 +84,13 @@ func newAuthenticator(rootLogger logger.Logger, config *Config) (authproxy.Authe
 
 // resolveStaticFunctionAuthConfig builds the fixed auth config for the reverseProxy topology. In basicAuth
 // mode the username/password come from the config (the password is injected from a Secret via secretKeyRef).
-func resolveStaticFunctionAuthConfig(config *Config) authproxy.FunctionAuthConfig {
+func resolveStaticFunctionAuthConfig(config *Config) auth.FunctionAuthConfig {
 	mode := auth.AuthenticationMode(config.AuthMode)
 	if mode == "" {
 		mode = auth.AuthenticationModeNone
 	}
 
-	return authproxy.FunctionAuthConfig{
+	return auth.FunctionAuthConfig{
 		Mode:              mode,
 		BasicAuthUsername: config.BasicAuthUsername,
 		BasicAuthPassword: config.BasicAuthPassword,

--- a/pkg/auth/authproxy/authonly.go
+++ b/pkg/auth/authproxy/authonly.go
@@ -26,9 +26,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	kubeclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
 	nuclioioclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio/clientset/versioned"
-	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
 
-	"github.com/mitchellh/mapstructure"
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -129,18 +127,18 @@ func (a *authOnlyAuthenticator) authenticateTarget(responseWriter http.ResponseW
 
 // getAuthSpec reads the target function's CRD, extracts its auth config, and (only for basicAuth)
 // restores scrubbed credentials from the function's dedicated Secret.
-func (a *authOnlyAuthenticator) getAuthSpec(ctx context.Context, functionName string) (FunctionAuthConfig, error) {
+func (a *authOnlyAuthenticator) getAuthSpec(ctx context.Context, functionName string) (auth.FunctionAuthConfig, error) {
 	function, err := a.nuclioClientSet.
 		NuclioV1beta1().
 		NuclioFunctions(a.namespace).
 		Get(ctx, functionName, metav1.GetOptions{})
 	if err != nil {
-		return FunctionAuthConfig{}, errors.Wrapf(err, "Failed to get function %s", functionName)
+		return auth.FunctionAuthConfig{}, errors.Wrapf(err, "Failed to get function %s", functionName)
 	}
 
 	authConfig, err := functionAuthConfigFromSpec(&function.Spec)
 	if err != nil {
-		return FunctionAuthConfig{}, errors.Wrapf(err, "Failed to read auth config for function %s", functionName)
+		return auth.FunctionAuthConfig{}, errors.Wrapf(err, "Failed to read auth config for function %s", functionName)
 	}
 
 	// the scrubber is only needed for basicAuth: it replaces $ref: placeholders with the real
@@ -158,52 +156,18 @@ func (a *authOnlyAuthenticator) getAuthSpec(ctx context.Context, functionName st
 	}
 	restoredConfig, err := a.scrubber.RestoreFunctionConfig(ctx, functionConfig, common.KubePlatformName)
 	if err != nil {
-		return FunctionAuthConfig{}, errors.Wrapf(err, "Failed to restore function %s secrets", functionName)
+		return auth.FunctionAuthConfig{}, errors.Wrapf(err, "Failed to restore function %s secrets", functionName)
 	}
 
 	return functionAuthConfigFromSpec(&restoredConfig.Spec)
 }
 
 // functionAuthConfigFromSpec resolves the authentication config from the function's HTTP trigger.
-func functionAuthConfigFromSpec(spec *functionconfig.Spec) (FunctionAuthConfig, error) {
+func functionAuthConfigFromSpec(spec *functionconfig.Spec) (auth.FunctionAuthConfig, error) {
 	for _, httpTrigger := range functionconfig.GetTriggersByKind(spec.Triggers, "http") {
-		return functionAuthConfigFromAttributes(httpTrigger.Attributes)
+		return auth.FunctionAuthConfigFromAttributes(httpTrigger.Attributes, auth.AuthenticationModeNone)
 	}
 
 	// no HTTP trigger -> nothing to authenticate
-	return FunctionAuthConfig{Mode: auth.AuthenticationModeNone}, nil
-}
-
-// functionAuthConfigFromAttributes decodes authenticationMode + authentication.basicAuth from an HTTP
-// trigger's free-form attributes (HLD §2.1.2), reusing the shared ingress.Authentication spec for the credentials.
-func functionAuthConfigFromAttributes(attributes map[string]interface{}) (FunctionAuthConfig, error) {
-	decoded := struct {
-		AuthenticationMode string                  `mapstructure:"authenticationMode"`
-		Authentication     *ingress.Authentication `mapstructure:"authentication"`
-	}{}
-	if err := mapstructure.Decode(attributes, &decoded); err != nil {
-		return FunctionAuthConfig{}, errors.Wrap(err, "Failed to decode HTTP trigger attributes")
-	}
-
-	mode := auth.AuthenticationMode(decoded.AuthenticationMode)
-	if mode == "" {
-		mode = auth.AuthenticationModeNone
-	}
-
-	authConfig := FunctionAuthConfig{Mode: mode}
-	if decoded.Authentication != nil && decoded.Authentication.BasicAuth != nil {
-		authConfig.BasicAuthUsername = decoded.Authentication.BasicAuth.Username
-		authConfig.BasicAuthPassword = decoded.Authentication.BasicAuth.Password
-	}
-
-	if mode == auth.AuthenticationModeBasicAuth {
-		if authConfig.BasicAuthUsername == "" {
-			return FunctionAuthConfig{}, errors.New("Basic-auth username must be provided")
-		}
-		if authConfig.BasicAuthPassword == "" {
-			return FunctionAuthConfig{}, errors.New("Basic-auth password must be provided")
-		}
-	}
-
-	return authConfig, nil
+	return auth.FunctionAuthConfig{Mode: auth.AuthenticationModeNone}, nil
 }

--- a/pkg/auth/authproxy/authproxy.go
+++ b/pkg/auth/authproxy/authproxy.go
@@ -53,7 +53,7 @@ func newAuthInstance(parentLogger logger.Logger, authURL string, authKind auth.K
 }
 
 // abstractAuthenticator holds the shared authentication logic embedded by every topology. Given a resolved
-// FunctionAuthConfig it verifies basicAuth locally, calls the auth-url for api/browser, and always fails closed on error.
+// auth.FunctionAuthConfig it verifies basicAuth locally, calls the auth-url for api/browser, and always fails closed on error.
 type abstractAuthenticator struct {
 	logger    logger.Logger
 	auth      auth.Auth
@@ -80,7 +80,7 @@ func newAbstractAuthenticator(parentLogger logger.Logger, authURL, signinURL str
 }
 
 // decide applies the verdict for the resolved authConfig, writing the rejection response itself on failure.
-func (a *abstractAuthenticator) decide(responseWriter http.ResponseWriter, request *http.Request, authConfig FunctionAuthConfig) bool {
+func (a *abstractAuthenticator) decide(responseWriter http.ResponseWriter, request *http.Request, authConfig auth.FunctionAuthConfig) bool {
 	switch authConfig.Mode {
 	case auth.AuthenticationModeNone:
 		a.logger.Info("Authentication disabled, allowing request")
@@ -102,7 +102,7 @@ func (a *abstractAuthenticator) decide(responseWriter http.ResponseWriter, reque
 // verifyBasicAuth checks HTTP Basic credentials locally (never delegated to the auth-url).
 // reverseProxy mode: (when a bcrypt hash is present) the incoming password is verified against it.
 // authOnly mode: (where the password is ephemeral) a constant-time string comparison is used.
-func (a *abstractAuthenticator) verifyBasicAuth(responseWriter http.ResponseWriter, request *http.Request, authConfig FunctionAuthConfig) bool {
+func (a *abstractAuthenticator) verifyBasicAuth(responseWriter http.ResponseWriter, request *http.Request, authConfig auth.FunctionAuthConfig) bool {
 	username, password, ok := request.BasicAuth()
 	if ok && subtle.ConstantTimeCompare([]byte(username), []byte(authConfig.BasicAuthUsername)) == 1 {
 		var passwordMatch bool

--- a/pkg/auth/authproxy/authproxy_test.go
+++ b/pkg/auth/authproxy/authproxy_test.go
@@ -63,7 +63,7 @@ func (suite *AuthProxyTestSuite) SetupTest() {
 // TestModeNoneAllows verifies none mode admits without calling the auth-url.
 // validateConfiguration permits an empty authURL for ModeNone, so the test reflects that.
 func (suite *AuthProxyTestSuite) TestModeNoneAllows() {
-	authenticator, err := NewReverseProxyAuthenticator(suite.logger, "", "", auth.KindIguazioV4, FunctionAuthConfig{Mode: auth.AuthenticationModeNone})
+	authenticator, err := NewReverseProxyAuthenticator(suite.logger, "", "", auth.KindIguazioV4, auth.FunctionAuthConfig{Mode: auth.AuthenticationModeNone})
 	suite.Require().NoError(err)
 
 	recorder := httptest.NewRecorder()
@@ -75,7 +75,7 @@ func (suite *AuthProxyTestSuite) TestModeAPI() {
 	stub := suite.newAuthURLStub()
 	defer stub.close()
 
-	authenticator, err := NewReverseProxyAuthenticator(suite.logger, stub.server.URL, "", auth.KindIguazioV4, FunctionAuthConfig{Mode: auth.AuthenticationModeAPI})
+	authenticator, err := NewReverseProxyAuthenticator(suite.logger, stub.server.URL, "", auth.KindIguazioV4, auth.FunctionAuthConfig{Mode: auth.AuthenticationModeAPI})
 	suite.Require().NoError(err)
 
 	suite.Run("valid is admitted with identity headers", func() {
@@ -106,7 +106,7 @@ func (suite *AuthProxyTestSuite) TestModeBrowser() {
 	stub := suite.newAuthURLStub()
 	defer stub.close()
 
-	authenticator, err := NewReverseProxyAuthenticator(suite.logger, stub.server.URL, testSigninURL, auth.KindIguazioV4, FunctionAuthConfig{Mode: auth.AuthenticationModeBrowser})
+	authenticator, err := NewReverseProxyAuthenticator(suite.logger, stub.server.URL, testSigninURL, auth.KindIguazioV4, auth.FunctionAuthConfig{Mode: auth.AuthenticationModeBrowser})
 	suite.Require().NoError(err)
 
 	suite.Run("invalid redirects to sign-in with rd", func() {
@@ -131,7 +131,7 @@ func (suite *AuthProxyTestSuite) TestModeBasicAuth() {
 		"",
 		"",
 		auth.KindIguazioV4,
-		FunctionAuthConfig{Mode: auth.AuthenticationModeBasicAuth, BasicAuthUsername: "user", BasicAuthPassword: "pass"})
+		auth.FunctionAuthConfig{Mode: auth.AuthenticationModeBasicAuth, BasicAuthUsername: "user", BasicAuthPassword: "pass"})
 	suite.Require().NoError(err)
 
 	suite.Run("valid credentials admitted locally", func() {
@@ -156,7 +156,7 @@ func (suite *AuthProxyTestSuite) TestAuthenticatorKindForwardedAndCannotBypass()
 	stub := suite.newAuthURLStub()
 	defer stub.close()
 
-	authenticator, err := NewReverseProxyAuthenticator(suite.logger, stub.server.URL, "", auth.KindIguazioV4, FunctionAuthConfig{Mode: auth.AuthenticationModeAPI})
+	authenticator, err := NewReverseProxyAuthenticator(suite.logger, stub.server.URL, "", auth.KindIguazioV4, auth.FunctionAuthConfig{Mode: auth.AuthenticationModeAPI})
 	suite.Require().NoError(err)
 
 	suite.Run("kind forwarded on valid credential", func() {
@@ -184,7 +184,7 @@ func (suite *AuthProxyTestSuite) TestFailClosedOnUpstreamError() {
 		}))
 		defer errorServer.Close()
 
-		authenticator, err := NewReverseProxyAuthenticator(suite.logger, errorServer.URL, "", auth.KindIguazioV4, FunctionAuthConfig{Mode: auth.AuthenticationModeAPI})
+		authenticator, err := NewReverseProxyAuthenticator(suite.logger, errorServer.URL, "", auth.KindIguazioV4, auth.FunctionAuthConfig{Mode: auth.AuthenticationModeAPI})
 		suite.Require().NoError(err)
 		recorder := httptest.NewRecorder()
 		suite.Require().False(authenticator.Authenticate(recorder, suite.authenticatedRequest(validToken)))
@@ -194,7 +194,7 @@ func (suite *AuthProxyTestSuite) TestFailClosedOnUpstreamError() {
 	suite.Run("transport error to auth-url", func() {
 
 		// nothing is listening here -> connection refused
-		authenticator, err := NewReverseProxyAuthenticator(suite.logger, "http://127.0.0.1:1", "", auth.KindIguazioV4, FunctionAuthConfig{Mode: auth.AuthenticationModeAPI})
+		authenticator, err := NewReverseProxyAuthenticator(suite.logger, "http://127.0.0.1:1", "", auth.KindIguazioV4, auth.FunctionAuthConfig{Mode: auth.AuthenticationModeAPI})
 		suite.Require().NoError(err)
 		recorder := httptest.NewRecorder()
 		suite.Require().False(authenticator.Authenticate(recorder, suite.authenticatedRequest(validToken)))

--- a/pkg/auth/authproxy/factory.go
+++ b/pkg/auth/authproxy/factory.go
@@ -35,7 +35,7 @@ func NewAuthenticator(
 	authURL string,
 	signinURL string,
 	authKind auth.Kind,
-	staticAuthConfig FunctionAuthConfig,
+	staticAuthConfig auth.FunctionAuthConfig,
 	kubeconfigPath string,
 	namespace string,
 ) (Authenticator, error) {

--- a/pkg/auth/authproxy/reverseproxy.go
+++ b/pkg/auth/authproxy/reverseproxy.go
@@ -30,7 +30,7 @@ import (
 // rendered into the pod once (per function), so every request uses the same resolved FunctionAuthConfig.
 type reverseProxyAuthenticator struct {
 	*abstractAuthenticator
-	authConfig FunctionAuthConfig
+	authConfig auth.FunctionAuthConfig
 }
 
 // NewReverseProxyAuthenticator creates an Authenticator with a fixed FunctionAuthConfig (function-pod topology).
@@ -38,7 +38,7 @@ func NewReverseProxyAuthenticator(parentLogger logger.Logger,
 	authURL string,
 	signinURL string,
 	authKind auth.Kind,
-	authConfig FunctionAuthConfig) (Authenticator, error) {
+	authConfig auth.FunctionAuthConfig) (Authenticator, error) {
 	parentLogger.InfoWith("Creating reverse-proxy authenticator", "authURL", authURL, "signinURL", signinURL, "authMode", authConfig.Mode)
 
 	// If basicAuth is configured, the plaintext password is hashed with bcrypt and discarded so it is never held in memory

--- a/pkg/auth/authproxy/types.go
+++ b/pkg/auth/authproxy/types.go
@@ -19,24 +19,11 @@ package authproxy
 import (
 	"net/http"
 	"time"
-
-	"github.com/nuclio/nuclio/pkg/auth"
 )
 
 // AuthTimeout bounds a single auth-url call on the data path so the sidecar fails
 // closed quickly instead of inheriting pkg/auth's long (up to 60s) retry window.
 const AuthTimeout = 10 * time.Second
-
-// FunctionAuthConfig is the authentication configuration resolved for a single function.
-type FunctionAuthConfig struct {
-	Mode              auth.AuthenticationMode
-	BasicAuthUsername string
-	BasicAuthPassword string // plaintext input; cleared after hashing in reverseProxy mode
-
-	// BasicAuthPasswordHash is the bcrypt hash of BasicAuthPassword. Set by NewReverseProxyAuthenticator
-	// so the plaintext is never held in memory for the pod's lifetime.
-	BasicAuthPasswordHash []byte
-}
 
 // Authenticator authenticates an incoming request, resolving the target function from the request itself.
 type Authenticator interface {

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -19,6 +19,9 @@ package auth
 import (
 	"net/http"
 	"time"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/nuclio/errors"
 )
 
 // AuthenticationMode is the authentication mode for API gateways and ingress resources.
@@ -32,6 +35,9 @@ const (
 	AuthenticationModeIguazio   AuthenticationMode = "iguazio"
 	AuthenticationModeAPI       AuthenticationMode = "api"
 	AuthenticationModeBrowser   AuthenticationMode = "browser"
+
+	// AttributeAuthenticationMode is the key for the authentication mode in HTTP trigger attributes.
+	AttributeAuthenticationMode = "authenticationMode"
 )
 
 type Kind string
@@ -70,6 +76,65 @@ func ContextKeyByKind(kind Kind) SessionContextKey {
 	default:
 		return NopContextKey
 	}
+}
+
+// Function level authentication configuration, resolved from the HTTP trigger's attributes.
+
+// FunctionAuthConfig is the authentication configuration resolved for a single function.
+type FunctionAuthConfig struct {
+	Mode              AuthenticationMode
+	BasicAuthUsername string
+	BasicAuthPassword string // plaintext input; cleared after hashing in reverseProxy mode
+
+	// BasicAuthPasswordHash is the bcrypt hash of BasicAuthPassword. Set by NewReverseProxyAuthenticator
+	// so the plaintext is never held in memory for the pod's lifetime.
+	BasicAuthPasswordHash []byte
+}
+
+// httpTriggerAuthAttrs is the decode target for the HTTP trigger's auth-related attributes.
+type httpTriggerAuthAttrs struct {
+	AuthenticationMode string `mapstructure:"authenticationMode"`
+	Authentication     *struct {
+		BasicAuth *struct {
+			Username string `mapstructure:"username"`
+			Password string `mapstructure:"password"`
+		} `mapstructure:"basicAuth"`
+	} `mapstructure:"authentication"`
+}
+
+// FunctionAuthConfigFromAttributes decodes authenticationMode + authentication.basicAuth from an HTTP
+// trigger's free-form attributes.
+func FunctionAuthConfigFromAttributes(attributes map[string]interface{}, defaultMode AuthenticationMode) (FunctionAuthConfig, error) {
+	var decoded httpTriggerAuthAttrs
+	if err := mapstructure.Decode(attributes, &decoded); err != nil {
+		return FunctionAuthConfig{}, errors.Wrap(err, "Failed to decode HTTP trigger attributes")
+	}
+
+	mode := AuthenticationMode(decoded.AuthenticationMode)
+	if mode == "" {
+		mode = defaultMode
+	}
+
+	authConfig := FunctionAuthConfig{Mode: mode}
+	switch mode {
+	case AuthenticationModeNone, AuthenticationModeAPI, AuthenticationModeBrowser:
+		// known modes that don't require any additional config
+	case AuthenticationModeBasicAuth:
+		if decoded.Authentication != nil && decoded.Authentication.BasicAuth != nil {
+			authConfig.BasicAuthUsername = decoded.Authentication.BasicAuth.Username
+			authConfig.BasicAuthPassword = decoded.Authentication.BasicAuth.Password
+		}
+		if authConfig.BasicAuthUsername == "" {
+			return FunctionAuthConfig{}, errors.New("Basic-auth username must be provided")
+		}
+		if authConfig.BasicAuthPassword == "" {
+			return FunctionAuthConfig{}, errors.New("Basic-auth password must be provided")
+		}
+	default:
+		return FunctionAuthConfig{}, errors.Errorf("Unknown authentication mode: %s", decoded.AuthenticationMode)
+	}
+
+	return authConfig, nil
 }
 
 type IguazioConfig struct {

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -91,6 +91,19 @@ type FunctionAuthConfig struct {
 	BasicAuthPasswordHash []byte
 }
 
+// Validate checks mode-specific required fields.
+func (c FunctionAuthConfig) Validate() error {
+	if c.Mode == AuthenticationModeBasicAuth {
+		if c.BasicAuthUsername == "" {
+			return errors.New("Basic-auth username must be provided")
+		}
+		if c.BasicAuthPassword == "" {
+			return errors.New("Basic-auth password must be provided")
+		}
+	}
+	return nil
+}
+
 // httpTriggerAuthAttrs is the decode target for the HTTP trigger's auth-related attributes.
 type httpTriggerAuthAttrs struct {
 	AuthenticationMode string `mapstructure:"authenticationMode"`
@@ -124,16 +137,13 @@ func FunctionAuthConfigFromAttributes(attributes map[string]interface{}, default
 			authConfig.BasicAuthUsername = decoded.Authentication.BasicAuth.Username
 			authConfig.BasicAuthPassword = decoded.Authentication.BasicAuth.Password
 		}
-		if authConfig.BasicAuthUsername == "" {
-			return FunctionAuthConfig{}, errors.New("Basic-auth username must be provided")
-		}
-		if authConfig.BasicAuthPassword == "" {
-			return FunctionAuthConfig{}, errors.New("Basic-auth password must be provided")
-		}
 	default:
 		return FunctionAuthConfig{}, errors.Errorf("Unknown authentication mode: %s", decoded.AuthenticationMode)
 	}
 
+	if err := authConfig.Validate(); err != nil {
+		return FunctionAuthConfig{}, err
+	}
 	return authConfig, nil
 }
 

--- a/pkg/functionconfig/scrubber_test.go
+++ b/pkg/functionconfig/scrubber_test.go
@@ -371,6 +371,46 @@ func (suite *ScrubberTestSuite) TestGenerateFunctionSecretNameWithFlexVolume() {
 	}
 }
 
+func (suite *ScrubberTestSuite) TestScrubHTTPTriggerBasicAuthPassword() {
+	functionConfig := &Config{
+		Spec: Spec{
+			Triggers: map[string]Trigger{
+				"http": {
+					Kind: "http",
+					Attributes: map[string]interface{}{
+						"authenticationMode": "basicAuth",
+						"authentication": map[string]interface{}{
+							"basicAuth": map[string]interface{}{
+								"username": "user",
+								"password": "s3cr3t",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scrubbedInterface, _, secretMap, err := suite.scrubber.Scrub(suite.ctx, functionConfig, "name", "namespace")
+	suite.Require().NoError(err)
+	scrubbedFunctionConfig := GetFunctionConfigFromInterface(scrubbedInterface)
+
+	scrubbedAuth := scrubbedFunctionConfig.Spec.Triggers["http"].
+		Attributes["authentication"].(map[string]interface{})["basicAuth"].(map[string]interface{})
+
+	// password becomes a $ref, username is untouched
+	suite.Require().Contains(scrubbedAuth["password"], ReferencePrefix)
+	suite.Require().Equal("user", scrubbedAuth["username"])
+	suite.Require().NotEmpty(secretMap)
+
+	restoredInterface, err := suite.scrubber.Restore(scrubbedFunctionConfig, secretMap)
+	suite.Require().NoError(err)
+	restoredFunctionConfig := GetFunctionConfigFromInterface(restoredInterface)
+	restoredAuth := restoredFunctionConfig.Spec.Triggers["http"].
+		Attributes["authentication"].(map[string]interface{})["basicAuth"].(map[string]interface{})
+	suite.Require().Equal("s3cr3t", restoredAuth["password"])
+}
+
 // getSensitiveFieldsRegex returns a list of regexes for sensitive fields paths
 // this is implemented here to avoid a circular dependency between platformconfig and functionconfig
 func (suite *ScrubberTestSuite) getSensitiveFieldsPathsRegex() []*regexp.Regexp {
@@ -391,6 +431,8 @@ func (suite *ScrubberTestSuite) getSensitiveFieldsPathsRegex() []*regexp.Regexp 
 		"^/Spec/Triggers/.+/Password$",
 		// Nested path in any map element
 		"^/Spec/Triggers/.+/Attributes/password$",
+		// HTTP function-level basic auth password
+		"^/spec/triggers/.+/attributes/authentication/basicauth/password$",
 
 		// Annotations
 		"^/metadata/annotations/nuclio\\.io/kafka-ca-cert$",

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1774,6 +1774,9 @@ func (ap *Platform) validateTriggers(functionConfig *functionconfig.Config) erro
 			if err := ap.validateStreamingFlushPeriod(triggerKey, &triggerInstance); err != nil {
 				return nuclio.WrapErrBadRequest(err)
 			}
+			if err := ap.validateHTTPTriggerAuthentication(triggerKey, &triggerInstance); err != nil {
+				return err
+			}
 		}
 
 		// explicit ack is only allowed for Static Allocation mode
@@ -1945,6 +1948,18 @@ func (ap *Platform) validateIngresses(triggers map[string]functionconfig.Trigger
 	return nil
 }
 
+// validateHTTPTriggerAuthentication validates the HTTP trigger's function-level authentication attributes.
+// It is gated by IsFunctionAuthenticationEnabled: when the flag is off the validation is ignored.
+func (ap *Platform) validateHTTPTriggerAuthentication(triggerKey string, triggerInstance *functionconfig.Trigger) error {
+	if !ap.IsFunctionAuthenticationEnabled() {
+		return nil
+	}
+	if _, err := auth.FunctionAuthConfigFromAttributes(triggerInstance.Attributes, ap.Config.Authentication.DefaultAuthenticationMode); err != nil {
+		return nuclio.WrapErrBadRequest(errors.Wrapf(err, "Invalid function authentication for HTTP trigger %q", triggerKey))
+	}
+	return nil
+}
+
 func (ap *Platform) enrichMinMaxReplicas(functionConfig *functionconfig.Config) {
 
 	// if min replicas was not set, and max replicas is set, assign max replicas to min replicas
@@ -2003,6 +2018,7 @@ func (ap *Platform) enrichTriggers(ctx context.Context, functionConfig *function
 		}
 		if triggerInstance.Kind == "http" {
 			ap.enrichHTTPTriggerStreamingFlushPeriod(ctx, triggerName, &triggerInstance, functionConfig)
+			ap.enrichHTTPTriggerAuthenticationMode(ctx, triggerName, &triggerInstance, functionConfig)
 		}
 		if triggerInstance.Kind == "rabbit-mq" {
 			if err := ap.enrichRabbitMQTrigger(ctx, triggerName, &triggerInstance); err != nil {
@@ -2014,6 +2030,30 @@ func (ap *Platform) enrichTriggers(ctx context.Context, functionConfig *function
 	}
 
 	return nil
+}
+
+// enrichHTTPTriggerAuthenticationMode stamps the platform-wide default authentication mode onto an HTTP
+// trigger when function-level authentication is enabled and the trigger does not set one explicitly.
+func (ap *Platform) enrichHTTPTriggerAuthenticationMode(ctx context.Context, triggerName string, triggerInstance *functionconfig.Trigger, functionConfig *functionconfig.Config) {
+	if !ap.IsFunctionAuthenticationEnabled() {
+		return
+	}
+	defaultMode := ap.Config.Authentication.DefaultAuthenticationMode
+	if defaultMode == "" || defaultMode == auth.AuthenticationModeNone {
+		return
+	}
+	if triggerInstance.Attributes == nil {
+		triggerInstance.Attributes = make(map[string]interface{})
+	}
+	if mode, ok := triggerInstance.Attributes[auth.AttributeAuthenticationMode]; ok && mode != "" {
+		return
+	}
+	ap.Logger.DebugWithCtx(ctx,
+		"Enriching authentication mode for HTTP trigger",
+		"functionName", functionConfig.Meta.Name,
+		"trigger", triggerName,
+		"authenticationMode", defaultMode)
+	triggerInstance.Attributes[auth.AttributeAuthenticationMode] = defaultMode
 }
 
 func (ap *Platform) enrichHTTPTriggerStreamingFlushPeriod(ctx context.Context, triggerName string, triggerInstance *functionconfig.Trigger, functionConfig *functionconfig.Config) {

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1959,7 +1959,7 @@ func (ap *Platform) validateHTTPTriggerAuthentication(triggerKey string, trigger
 		return nuclio.WrapErrBadRequest(errors.Wrapf(err, "Invalid function authentication for HTTP trigger %q", triggerKey))
 	}
 	if authConfig.Mode == auth.AuthenticationModeBasicAuth &&
-		authConfig.BasicAuthUsername == "" || authConfig.BasicAuthPassword == "" {
+		(authConfig.BasicAuthUsername == "" || authConfig.BasicAuthPassword == "") {
 		return nuclio.NewErrBadRequest(fmt.Sprintf("Basic auth mode requires username and password for HTTP trigger %q", triggerKey))
 	}
 	return nil

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1954,13 +1954,9 @@ func (ap *Platform) validateHTTPTriggerAuthentication(triggerKey string, trigger
 	if !ap.IsFunctionAuthenticationEnabled() {
 		return nil
 	}
-	authConfig, err := auth.FunctionAuthConfigFromAttributes(triggerInstance.Attributes, ap.Config.Authentication.DefaultAuthenticationMode)
+	_, err := auth.FunctionAuthConfigFromAttributes(triggerInstance.Attributes, ap.Config.Authentication.DefaultMode)
 	if err != nil {
 		return nuclio.WrapErrBadRequest(errors.Wrapf(err, "Invalid function authentication for HTTP trigger %q", triggerKey))
-	}
-	if authConfig.Mode == auth.AuthenticationModeBasicAuth &&
-		(authConfig.BasicAuthUsername == "" || authConfig.BasicAuthPassword == "") {
-		return nuclio.NewErrBadRequest(fmt.Sprintf("Basic auth mode requires username and password for HTTP trigger %q", triggerKey))
 	}
 	return nil
 }
@@ -2043,7 +2039,7 @@ func (ap *Platform) enrichHTTPTriggerAuthenticationMode(ctx context.Context, tri
 	if !ap.IsFunctionAuthenticationEnabled() {
 		return
 	}
-	defaultMode := ap.Config.Authentication.DefaultAuthenticationMode
+	defaultMode := ap.Config.Authentication.DefaultMode
 	if defaultMode == "" || defaultMode == auth.AuthenticationModeNone {
 		return
 	}

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1954,8 +1954,13 @@ func (ap *Platform) validateHTTPTriggerAuthentication(triggerKey string, trigger
 	if !ap.IsFunctionAuthenticationEnabled() {
 		return nil
 	}
-	if _, err := auth.FunctionAuthConfigFromAttributes(triggerInstance.Attributes, ap.Config.Authentication.DefaultAuthenticationMode); err != nil {
+	authConfig, err := auth.FunctionAuthConfigFromAttributes(triggerInstance.Attributes, ap.Config.Authentication.DefaultAuthenticationMode)
+	if err != nil {
 		return nuclio.WrapErrBadRequest(errors.Wrapf(err, "Invalid function authentication for HTTP trigger %q", triggerKey))
+	}
+	if authConfig.Mode == auth.AuthenticationModeBasicAuth &&
+		authConfig.BasicAuthUsername == "" || authConfig.BasicAuthPassword == "" {
+		return nuclio.NewErrBadRequest(fmt.Sprintf("Basic auth mode requires username and password for HTTP trigger %q", triggerKey))
 	}
 	return nil
 }

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -2763,16 +2763,16 @@ func (suite *AbstractPlatformTestSuite) TestEnrichHTTPTriggerAuthenticationMode(
 		{
 			name:         "flag on stamps default when absent",
 			flagEnabled:  true,
-			defaultMode:  "api",
+			defaultMode:  auth.AuthenticationModeAPI,
 			attributes:   map[string]interface{}{},
 			expectedMode: auth.AuthenticationModeAPI,
 		},
 		{
 			name:         "explicit mode preserved",
 			flagEnabled:  true,
-			defaultMode:  "api",
-			attributes:   map[string]interface{}{"authenticationMode": "basicAuth"},
-			expectedMode: "basicAuth",
+			defaultMode:  auth.AuthenticationModeAPI,
+			attributes:   map[string]interface{}{auth.AttributeAuthenticationMode: auth.AuthenticationModeBasicAuth},
+			expectedMode: auth.AuthenticationModeBasicAuth,
 		},
 		{
 			name:         "empty default not stamped",
@@ -2784,7 +2784,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichHTTPTriggerAuthenticationMode(
 		{
 			name:         "none default not stamped",
 			flagEnabled:  true,
-			defaultMode:  "none",
+			defaultMode:  auth.AuthenticationModeNone,
 			attributes:   map[string]interface{}{},
 			expectedMode: nil,
 		},
@@ -2792,7 +2792,7 @@ func (suite *AbstractPlatformTestSuite) TestEnrichHTTPTriggerAuthenticationMode(
 		suite.Run(testCase.name, func() {
 			suite.Platform.Config.Authentication = &platformconfig.Authentication{
 				FunctionAuthenticationEnabled: testCase.flagEnabled,
-				DefaultAuthenticationMode:     testCase.defaultMode,
+				DefaultMode:                   testCase.defaultMode,
 			}
 			defer func() { suite.Platform.Config.Authentication = nil }()
 
@@ -2815,30 +2815,30 @@ func (suite *AbstractPlatformTestSuite) TestValidateHTTPTriggerAuthentication() 
 		{
 			name:        "flag off ignores attributes",
 			flagEnabled: false,
-			attributes:  map[string]interface{}{"authenticationMode": "bogus"},
+			attributes:  map[string]interface{}{auth.AttributeAuthenticationMode: "bogus"},
 		},
 		{
 			name:        "valid mode",
 			flagEnabled: true,
-			attributes:  map[string]interface{}{"authenticationMode": "api"},
+			attributes:  map[string]interface{}{auth.AttributeAuthenticationMode: string(auth.AuthenticationModeAPI)},
 		},
 		{
 			name:        "invalid mode rejected",
 			flagEnabled: true,
-			attributes:  map[string]interface{}{"authenticationMode": "bogus"},
+			attributes:  map[string]interface{}{auth.AttributeAuthenticationMode: "bogus"},
 			expectError: true,
 		},
 		{
 			name:        "basicAuth without credentials rejected",
 			flagEnabled: true,
-			attributes:  map[string]interface{}{"authenticationMode": "basicAuth"},
+			attributes:  map[string]interface{}{auth.AttributeAuthenticationMode: string(auth.AuthenticationModeBasicAuth)},
 			expectError: true,
 		},
 		{
 			name:        "basicAuth with credentials",
 			flagEnabled: true,
 			attributes: map[string]interface{}{
-				"authenticationMode": "basicAuth",
+				auth.AttributeAuthenticationMode: string(auth.AuthenticationModeBasicAuth),
 				"authentication": map[string]interface{}{
 					"basicAuth": map[string]interface{}{
 						"username": "user",

--- a/pkg/platform/abstract/platform_test.go
+++ b/pkg/platform/abstract/platform_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher"
 	"github.com/nuclio/nuclio/pkg/dockerclient"
@@ -2742,6 +2743,126 @@ func (suite *AbstractPlatformTestSuite) testGetProcessorLogsTestFromFile(functio
 	expectedBriefErrorsMessageFileBytes, err := os.ReadFile(path.Join(functionLogsFilePath, BriefErrorsMessageFile))
 	suite.Require().NoError(err, "Failed to read brief errors message file")
 	suite.Assert().Equal(string(expectedBriefErrorsMessageFileBytes), briefErrorsMessage)
+}
+
+func (suite *AbstractPlatformTestSuite) TestEnrichHTTPTriggerAuthenticationMode() {
+	for _, testCase := range []struct {
+		name         string
+		flagEnabled  bool
+		defaultMode  auth.AuthenticationMode
+		attributes   map[string]interface{}
+		expectedMode interface{}
+	}{
+		{
+			name:         "flag off does not stamp",
+			flagEnabled:  false,
+			defaultMode:  auth.AuthenticationModeAPI,
+			attributes:   map[string]interface{}{},
+			expectedMode: nil,
+		},
+		{
+			name:         "flag on stamps default when absent",
+			flagEnabled:  true,
+			defaultMode:  "api",
+			attributes:   map[string]interface{}{},
+			expectedMode: auth.AuthenticationModeAPI,
+		},
+		{
+			name:         "explicit mode preserved",
+			flagEnabled:  true,
+			defaultMode:  "api",
+			attributes:   map[string]interface{}{"authenticationMode": "basicAuth"},
+			expectedMode: "basicAuth",
+		},
+		{
+			name:         "empty default not stamped",
+			flagEnabled:  true,
+			defaultMode:  "",
+			attributes:   map[string]interface{}{},
+			expectedMode: nil,
+		},
+		{
+			name:         "none default not stamped",
+			flagEnabled:  true,
+			defaultMode:  "none",
+			attributes:   map[string]interface{}{},
+			expectedMode: nil,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Platform.Config.Authentication = &platformconfig.Authentication{
+				FunctionAuthenticationEnabled: testCase.flagEnabled,
+				DefaultAuthenticationMode:     testCase.defaultMode,
+			}
+			defer func() { suite.Platform.Config.Authentication = nil }()
+
+			trigger := functionconfig.Trigger{Kind: "http", Name: "http0", Attributes: testCase.attributes}
+			functionConfig := functionconfig.NewConfig()
+			suite.Platform.enrichHTTPTriggerAuthenticationMode(suite.ctx, "http0", &trigger, functionConfig)
+
+			suite.Require().Equal(testCase.expectedMode, trigger.Attributes["authenticationMode"])
+		})
+	}
+}
+
+func (suite *AbstractPlatformTestSuite) TestValidateHTTPTriggerAuthentication() {
+	for _, testCase := range []struct {
+		name        string
+		flagEnabled bool
+		attributes  map[string]interface{}
+		expectError bool
+	}{
+		{
+			name:        "flag off ignores attributes",
+			flagEnabled: false,
+			attributes:  map[string]interface{}{"authenticationMode": "bogus"},
+		},
+		{
+			name:        "valid mode",
+			flagEnabled: true,
+			attributes:  map[string]interface{}{"authenticationMode": "api"},
+		},
+		{
+			name:        "invalid mode rejected",
+			flagEnabled: true,
+			attributes:  map[string]interface{}{"authenticationMode": "bogus"},
+			expectError: true,
+		},
+		{
+			name:        "basicAuth without credentials rejected",
+			flagEnabled: true,
+			attributes:  map[string]interface{}{"authenticationMode": "basicAuth"},
+			expectError: true,
+		},
+		{
+			name:        "basicAuth with credentials",
+			flagEnabled: true,
+			attributes: map[string]interface{}{
+				"authenticationMode": "basicAuth",
+				"authentication": map[string]interface{}{
+					"basicAuth": map[string]interface{}{
+						"username": "user",
+						"password": "pass",
+					},
+				},
+			},
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Platform.Config.Authentication = &platformconfig.Authentication{
+				FunctionAuthenticationEnabled: testCase.flagEnabled,
+			}
+			defer func() { suite.Platform.Config.Authentication = nil }()
+
+			trigger := functionconfig.Trigger{Kind: "http", Name: "http0", Attributes: testCase.attributes}
+			err := suite.Platform.validateHTTPTriggerAuthentication("http0", &trigger)
+			if testCase.expectError {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+			}
+		})
+	}
 }
 
 func TestAbstractPlatformTestSuite(t *testing.T) {

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1437,6 +1437,10 @@ func (p *Platform) GetScaleToZeroConfiguration() *platformconfig.ScaleToZero {
 }
 
 func (p *Platform) GetAllowedAuthenticationModes() []string {
+	if p.IsFunctionAuthenticationEnabled() {
+		return p.Config.Authentication.GetAllowedFunctionAuthenticationModes()
+	}
+
 	allowedAuthenticationModes := []string{string(auth.AuthenticationModeNone), string(auth.AuthenticationModeBasicAuth)}
 	if len(p.Config.IngressConfig.AllowedAuthenticationModes) > 0 {
 		allowedAuthenticationModes = p.Config.IngressConfig.AllowedAuthenticationModes

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -1441,6 +1441,8 @@ func (p *Platform) GetAllowedAuthenticationModes() []string {
 		return p.Config.Authentication.GetAllowedFunctionAuthenticationModes()
 	}
 
+	// When function-level auth is disabled, fall back to the ingress-level allowed modes so that
+	// existing API-gateway / ingress auth configuration continues to be honored without change.
 	allowedAuthenticationModes := []string{string(auth.AuthenticationModeNone), string(auth.AuthenticationModeBasicAuth)}
 	if len(p.Config.IngressConfig.AllowedAuthenticationModes) > 0 {
 		allowedAuthenticationModes = p.Config.IngressConfig.AllowedAuthenticationModes

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -2481,7 +2481,7 @@ func (suite *FunctionKubePlatformTestSuite) TestGetAllowedAuthenticationModesWit
 			name: "function auth enabled, config values",
 			config: &platformconfig.Config{Authentication: &platformconfig.Authentication{
 				FunctionAuthenticationEnabled: true,
-				AllowedAuthenticationModes:    []string{"test1", "test2"},
+				AllowedModes:                  []string{"test1", "test2"},
 			}},
 			expectedResult: []string{"test1", "test2"},
 		},

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 
@@ -2456,6 +2457,44 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateAPIGatewayAuthentication
 			} else {
 				suite.Require().Nil(err)
 			}
+		})
+	}
+}
+
+func (suite *FunctionKubePlatformTestSuite) TestGetAllowedAuthenticationModesWithFunctionAuth() {
+	for _, testCase := range []struct {
+		name           string
+		config         *platformconfig.Config
+		expectedResult []string
+	}{
+		{
+			name:           "no function auth",
+			config:         &platformconfig.Config{Authentication: &platformconfig.Authentication{}},
+			expectedResult: []string{"basicAuth", "none"},
+		},
+		{
+			name:           "function auth enabled, default values",
+			config:         &platformconfig.Config{Authentication: &platformconfig.Authentication{FunctionAuthenticationEnabled: true}},
+			expectedResult: []string{"api", "basicAuth", "browser", "none"},
+		},
+		{
+			name: "function auth enabled, config values",
+			config: &platformconfig.Config{Authentication: &platformconfig.Authentication{
+				FunctionAuthenticationEnabled: true,
+				AllowedAuthenticationModes:    []string{"test1", "test2"},
+			}},
+			expectedResult: []string{"test1", "test2"},
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			previousConfig := suite.platform.Config
+			defer func() {
+				suite.platform.Config = previousConfig
+			}()
+			suite.platform.Config = testCase.config
+			result := suite.platform.GetAllowedAuthenticationModes()
+			sort.Strings(result)
+			suite.Require().Equal(result, testCase.expectedResult)
 		})
 	}
 }

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -2470,12 +2470,12 @@ func (suite *FunctionKubePlatformTestSuite) TestGetAllowedAuthenticationModesWit
 		{
 			name:           "no function auth",
 			config:         &platformconfig.Config{Authentication: &platformconfig.Authentication{}},
-			expectedResult: []string{"basicAuth", "none"},
+			expectedResult: []string{string(auth.AuthenticationModeBasicAuth), string(auth.AuthenticationModeNone)},
 		},
 		{
 			name:           "function auth enabled, default values",
 			config:         &platformconfig.Config{Authentication: &platformconfig.Authentication{FunctionAuthenticationEnabled: true}},
-			expectedResult: []string{"api", "basicAuth", "browser", "none"},
+			expectedResult: []string{string(auth.AuthenticationModeAPI), string(auth.AuthenticationModeBasicAuth), string(auth.AuthenticationModeBrowser), string(auth.AuthenticationModeNone)},
 		},
 		{
 			name: "function auth enabled, config values",

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -19,6 +19,7 @@ package platformconfig
 import (
 	"context"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/auth"
@@ -419,7 +420,25 @@ func (c *Config) ValidatePlatformConfig() error {
 		return errors.Wrap(err, "Failed to validate Elasticsearch config")
 	}
 
+	if err := c.validateAuthentication(); err != nil {
+		return errors.Wrap(err, "Failed to validate authentication config")
+	}
+
 	return nil
+}
+
+func (c *Config) validateAuthentication() error {
+	if c.Authentication == nil {
+		return errors.New("Authentication config is nil after enrichment")
+	}
+	mode := string(c.Authentication.DefaultAuthenticationMode)
+	for _, valid := range c.Authentication.GetAllowedFunctionAuthenticationModes() {
+		if mode == valid {
+			return nil
+		}
+	}
+	return errors.Errorf("Invalid default authentication mode, must be one of %s: %s",
+		strings.Join(c.Authentication.GetAllowedFunctionAuthenticationModes(), ", "), mode)
 }
 
 func (c *Config) validateRuntimeBaseImages() error {
@@ -575,6 +594,9 @@ func (c *Config) enrichAuthentication() {
 	}
 	if c.Authentication.AuthKind == "" {
 		c.Authentication.AuthKind = c.Opa.AuthKind
+	}
+	if c.Authentication.DefaultAuthenticationMode == "" {
+		c.Authentication.DefaultAuthenticationMode = auth.AuthenticationModeNone
 	}
 }
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -431,7 +431,7 @@ func (c *Config) validateAuthentication() error {
 	if c.Authentication == nil {
 		return errors.New("Authentication config is nil after enrichment")
 	}
-	mode := string(c.Authentication.DefaultAuthenticationMode)
+	mode := string(c.Authentication.DefaultMode)
 	authModes := c.Authentication.GetAllowedFunctionAuthenticationModes()
 	for _, valid := range authModes {
 		if mode == valid {
@@ -596,8 +596,8 @@ func (c *Config) enrichAuthentication() {
 	if c.Authentication.AuthKind == "" {
 		c.Authentication.AuthKind = c.Opa.AuthKind
 	}
-	if c.Authentication.DefaultAuthenticationMode == "" {
-		c.Authentication.DefaultAuthenticationMode = auth.AuthenticationModeNone
+	if c.Authentication.DefaultMode == "" {
+		c.Authentication.DefaultMode = auth.AuthenticationModeNone
 	}
 }
 

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -432,13 +432,14 @@ func (c *Config) validateAuthentication() error {
 		return errors.New("Authentication config is nil after enrichment")
 	}
 	mode := string(c.Authentication.DefaultAuthenticationMode)
-	for _, valid := range c.Authentication.GetAllowedFunctionAuthenticationModes() {
+	authModes := c.Authentication.GetAllowedFunctionAuthenticationModes()
+	for _, valid := range authModes {
 		if mode == valid {
 			return nil
 		}
 	}
 	return errors.Errorf("Invalid default authentication mode, must be one of %s: %s",
-		strings.Join(c.Authentication.GetAllowedFunctionAuthenticationModes(), ", "), mode)
+		strings.Join(authModes, ", "), mode)
 }
 
 func (c *Config) validateRuntimeBaseImages() error {

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -431,6 +431,11 @@ func (c *Config) validateAuthentication() error {
 	if c.Authentication == nil {
 		return errors.New("Authentication config is nil after enrichment")
 	}
+	// basicAuth cannot be the platform-wide default: it requires per-function credentials
+	// (username + password) that cannot be supplied at the platform config level.
+	if c.Authentication.DefaultMode == auth.AuthenticationModeBasicAuth {
+		return errors.New("Default authentication mode cannot be 'basicAuth': basicAuth requires per-function credentials")
+	}
 	mode := string(c.Authentication.DefaultMode)
 	authModes := c.Authentication.GetAllowedFunctionAuthenticationModes()
 	for _, valid := range authModes {

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -1163,6 +1163,51 @@ func (suite *PlatformConfigTestSuite) TestEnrichAndValidateProjectsLeaderConfigO
 	suite.Require().Equal(DefaultProjectSync2PCEnabled, config.ProjectsLeader.ProjectSync2PCEnabled)
 }
 
+func (suite *PlatformConfigTestSuite) TestEnrichAuthenticationDefaultMode() {
+	for _, testCase := range []struct {
+		name         string
+		config       *Config
+		expectedMode auth.AuthenticationMode
+	}{
+		{name: "none", config: &Config{}, expectedMode: "none"},
+		{name: "api enrich", config: &Config{Authentication: &Authentication{DefaultAuthenticationMode: "api"}}, expectedMode: "api"},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Require().NoError(testCase.config.EnrichPlatformConfig())
+			suite.Require().NotNil(testCase.config.Authentication)
+			suite.Require().Equal(testCase.expectedMode, testCase.config.Authentication.DefaultAuthenticationMode)
+		})
+	}
+}
+
+func (suite *PlatformConfigTestSuite) TestValidatePlatformConfigDefaultAuthenticationMode() {
+	for _, testCase := range []struct {
+		name        string
+		mode        auth.AuthenticationMode
+		expectError bool
+	}{
+		{name: "none", mode: "none"},
+		{name: "api", mode: "api"},
+		{name: "browser", mode: "browser"},
+		{name: "basicAuth", mode: "basicAuth"},
+		{name: "invalid", mode: "bogus", expectError: true},
+	} {
+		suite.Run(testCase.name, func() {
+			config := &Config{
+				RuntimeBaseImages: map[string]string{"test-runtime": "test-image"},
+				Authentication:    &Authentication{DefaultAuthenticationMode: testCase.mode},
+			}
+			err := config.ValidatePlatformConfig()
+			if testCase.expectError {
+				suite.Require().Error(err)
+				suite.Contains(err.Error(), "authentication config")
+				return
+			}
+			suite.Require().NoError(err)
+		})
+	}
+}
+
 func TestPlatformConfigTestSuite(t *testing.T) {
 	suite.Run(t, new(PlatformConfigTestSuite))
 }

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -1170,17 +1170,17 @@ func (suite *PlatformConfigTestSuite) TestEnrichAuthenticationDefaultMode() {
 		expectedMode auth.AuthenticationMode
 	}{
 		{name: "none", config: &Config{}, expectedMode: "none"},
-		{name: "api enrich", config: &Config{Authentication: &Authentication{DefaultAuthenticationMode: "api"}}, expectedMode: "api"},
+		{name: "api enrich", config: &Config{Authentication: &Authentication{DefaultMode: "api"}}, expectedMode: "api"},
 	} {
 		suite.Run(testCase.name, func() {
 			suite.Require().NoError(testCase.config.EnrichPlatformConfig())
 			suite.Require().NotNil(testCase.config.Authentication)
-			suite.Require().Equal(testCase.expectedMode, testCase.config.Authentication.DefaultAuthenticationMode)
+			suite.Require().Equal(testCase.expectedMode, testCase.config.Authentication.DefaultMode)
 		})
 	}
 }
 
-func (suite *PlatformConfigTestSuite) TestValidatePlatformConfigDefaultAuthenticationMode() {
+func (suite *PlatformConfigTestSuite) TestValidatePlatformConfigDefaultMode() {
 	for _, testCase := range []struct {
 		name        string
 		mode        auth.AuthenticationMode
@@ -1195,7 +1195,7 @@ func (suite *PlatformConfigTestSuite) TestValidatePlatformConfigDefaultAuthentic
 		suite.Run(testCase.name, func() {
 			config := &Config{
 				RuntimeBaseImages: map[string]string{"test-runtime": "test-image"},
-				Authentication:    &Authentication{DefaultAuthenticationMode: testCase.mode},
+				Authentication:    &Authentication{DefaultMode: testCase.mode},
 			}
 			err := config.ValidatePlatformConfig()
 			if testCase.expectError {

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -1169,8 +1169,8 @@ func (suite *PlatformConfigTestSuite) TestEnrichAuthenticationDefaultMode() {
 		config       *Config
 		expectedMode auth.AuthenticationMode
 	}{
-		{name: "none", config: &Config{}, expectedMode: "none"},
-		{name: "api enrich", config: &Config{Authentication: &Authentication{DefaultMode: "api"}}, expectedMode: "api"},
+		{name: "none", config: &Config{}, expectedMode: auth.AuthenticationModeNone},
+		{name: "api enrich", config: &Config{Authentication: &Authentication{DefaultMode: auth.AuthenticationModeAPI}}, expectedMode: auth.AuthenticationModeAPI},
 	} {
 		suite.Run(testCase.name, func() {
 			suite.Require().NoError(testCase.config.EnrichPlatformConfig())
@@ -1186,10 +1186,10 @@ func (suite *PlatformConfigTestSuite) TestValidatePlatformConfigDefaultMode() {
 		mode        auth.AuthenticationMode
 		expectError bool
 	}{
-		{name: "none", mode: "none"},
-		{name: "api", mode: "api"},
-		{name: "browser", mode: "browser"},
-		{name: "basicAuth", mode: "basicAuth"},
+		{name: "none", mode: auth.AuthenticationModeNone},
+		{name: "api", mode: auth.AuthenticationModeAPI},
+		{name: "browser", mode: auth.AuthenticationModeBrowser},
+		{name: "basicAuth rejected as default", mode: auth.AuthenticationModeBasicAuth, expectError: true},
 		{name: "invalid", mode: "bogus", expectError: true},
 	} {
 		suite.Run(testCase.name, func() {

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -521,11 +521,11 @@ type Authentication struct {
 	AuthKind auth.Kind `json:"authKind,omitempty"`
 
 	// AllowedModes lists the function-level authentication modes the platform permits.
-	AllowedModes []string `json:"allowedAuthenticationModes,omitempty"`
+	AllowedModes []string `json:"allowedModes,omitempty"`
 
 	// DefaultMode is the platform-wide default function-level authentication mode
 	// stamped onto an HTTP trigger when it does not set one explicitly.
-	DefaultMode auth.AuthenticationMode `json:"defaultAuthenticationMode,omitempty"`
+	DefaultMode auth.AuthenticationMode `json:"defaultMode,omitempty"`
 }
 
 // GetAllowedFunctionAuthenticationModes returns the allowed function-level authentication modes.

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -520,19 +520,24 @@ type Authentication struct {
 	// Defaults to the value set in the OPA config (Opa.AuthKind).
 	AuthKind auth.Kind `json:"authKind,omitempty"`
 
-	// AllowedAuthenticationModes lists the function-level authentication modes the platform permits.
-	AllowedAuthenticationModes []string `json:"allowedAuthenticationModes,omitempty"`
+	// AllowedModes lists the function-level authentication modes the platform permits.
+	AllowedModes []string `json:"allowedAuthenticationModes,omitempty"`
 
-	// DefaultAuthenticationMode is the platform-wide default function-level authentication mode
+	// DefaultMode is the platform-wide default function-level authentication mode
 	// stamped onto an HTTP trigger when it does not set one explicitly.
-	DefaultAuthenticationMode auth.AuthenticationMode `json:"defaultAuthenticationMode,omitempty"`
+	DefaultMode auth.AuthenticationMode `json:"defaultAuthenticationMode,omitempty"`
 }
 
 // GetAllowedFunctionAuthenticationModes returns the allowed function-level authentication modes.
-// Returns AllowedAuthenticationModes when configured; otherwise the built-in default set.
+// Returns AllowedModes when configured; otherwise the built-in default set.
 func (a *Authentication) GetAllowedFunctionAuthenticationModes() []string {
-	if len(a.AllowedAuthenticationModes) > 0 {
-		return a.AllowedAuthenticationModes
+	if len(a.AllowedModes) > 0 {
+		return a.AllowedModes
 	}
-	return []string{"none", "api", "browser", "basicAuth"}
+	return []string{
+		string(auth.AuthenticationModeNone),
+		string(auth.AuthenticationModeAPI),
+		string(auth.AuthenticationModeBrowser),
+		string(auth.AuthenticationModeBasicAuth),
+	}
 }

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -476,6 +476,8 @@ func (sfc *SensitiveFieldsConfig) GetDefaultSensitiveFields() []string {
 		"^/spec/triggers/.+/attributes/accesscertificate$",
 		"^/spec/triggers/.+/attributes/sasl/password$",
 		"^/spec/triggers/.+/attributes/sasl/oauth/clientsecret$",
+		// - http function-level basic auth
+		"^/spec/triggers/.+/attributes/authentication/basicauth/password$",
 		// - kafka annotations
 		"^/metadata/annotations/nuclio\\.io/kafka-ca-cert$",
 		"^/metadata/annotations/nuclio\\.io/kafka-access-key$",
@@ -517,4 +519,20 @@ type Authentication struct {
 	// AuthKind is the auth client kind used by the auth-proxy sidecar for API/browser authentication.
 	// Defaults to the value set in the OPA config (Opa.AuthKind).
 	AuthKind auth.Kind `json:"authKind,omitempty"`
+
+	// AllowedAuthenticationModes lists the function-level authentication modes the platform permits.
+	AllowedAuthenticationModes []string `json:"allowedAuthenticationModes,omitempty"`
+
+	// DefaultAuthenticationMode is the platform-wide default function-level authentication mode
+	// stamped onto an HTTP trigger when it does not set one explicitly.
+	DefaultAuthenticationMode auth.AuthenticationMode `json:"defaultAuthenticationMode,omitempty"`
+}
+
+// GetAllowedFunctionAuthenticationModes returns the allowed function-level authentication modes.
+// Returns AllowedAuthenticationModes when configured; otherwise the built-in default set.
+func (a *Authentication) GetAllowedFunctionAuthenticationModes() []string {
+	if len(a.AllowedAuthenticationModes) > 0 {
+		return a.AllowedAuthenticationModes
+	}
+	return []string{"none", "api", "browser", "basicAuth"}
 }


### PR DESCRIPTION
### 📝 Description
Adds function-level authentication configuration on HTTP triggers, gated by the `functionAuthenticationEnabled` platform flag.

When the flag is on, the `authenticationMode` field (`none` / `api` / `browser` / `basicAuth`) and optional `authentication.basicAuth` credentials are accepted on HTTP trigger attributes and validated during function createOrUpdate. The basicAuth password is automatically scrubbed to a `$ref` by the existing secret-scrubbing pipeline (never stored in plaintext).

Also introduces a platform-wide `defaultAuthenticationMode` that is stamped onto any HTTP trigger that does not set one explicitly.

---

### 🛠️ Changes Made
- **`pkg/auth/authproxy/types.go`** — Exported `FunctionAuthConfigFromAttributes` as a shared function (previously private in `authonly.go`); added `AttributeAuthenticationMode` constant
- **`pkg/auth/authproxy/authonly.go`** — Removed the duplicate private decoder; now delegates to the shared function above
- **`pkg/platform/abstract/platform.go`** — Added `validateHTTPTriggerAuthentication` (validates mode + basicAuth credentials on HTTP triggers, gated by flag) and `enrichHTTPTriggerAuthenticationMode` (stamps the platform default onto triggers that don't set one)
- **`pkg/platformconfig/types.go`** — Added `DefaultAuthenticationMode`, `AllowedAuthenticationModes` fields and `GetAllowedFunctionAuthenticationModes()` to `Authentication`; added basicAuth password path to `GetDefaultSensitiveFields()`
- **`pkg/platformconfig/platformconfig.go`** — Added `validateAuthentication()` called from `ValidatePlatformConfig()`; enriches `DefaultAuthenticationMode` to `"none"` by default
- **`pkg/platform/kube/platform.go`** — `GetAllowedAuthenticationModes()` delegates to `GetAllowedFunctionAuthenticationModes()` when function auth is enabled
- **`pkg/functionconfig/scrubber_test.go`** — Added test covering scrub + restore of the basicAuth password path

---

### ✅ Checklist
- [x] I updated the documentation (if applicable) -> Will be added in a dedicated CR
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Unit tests
- Dev tests- patched `nuclio-dashboard` to my setup and validated:
  - Invalid http.trigger.authentication attributes fail with appropriate error
  - Valid configurations are being populated properly to the function's CRD resource.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-830
- Design docs links: https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/594641703/HLD+BE+Nuclio+Function-level+Authentication
- External links: https://ecliptos.atlassian.net/browse/ORIS-3607

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- All new behavior is behind the `functionAuthenticationEnabled` platform config flag — flag off leaves today's behavior completely unchanged.
- `defaultAuthenticationMode` cannot be set to `basicAuth` — that mode requires additional per-function credentials that cannot be provided at the platform config level. This is a known limitation and left as-is for now.