### PR TITLE
[auth-proxy sidecar] Use scrubber to get the basic auth secret

### DIFF
--- a/cmd/authproxy/app/authproxy.go
+++ b/cmd/authproxy/app/authproxy.go
@@ -17,10 +17,16 @@ limitations under the License.
 package app
 
 import (
+	"os"
+
 	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/auth/authproxy"
+	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/loggersink"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
+	"github.com/nuclio/nuclio/pkg/processor"
+	processorconfig "github.com/nuclio/nuclio/pkg/processor/config"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -72,27 +78,93 @@ func Run(config *Config) error {
 
 // newAuthenticator creates kube clients when needed and delegates to the pkg-level factory.
 func newAuthenticator(rootLogger logger.Logger, config *Config) (authproxy.Authenticator, error) {
+	staticAuthConfig, err := resolveStaticFunctionAuthConfig(rootLogger, config)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to resolve function auth config")
+	}
 	return authproxy.NewAuthenticator(rootLogger,
 		config.Mode,
 		config.AuthURL,
 		config.SigninURL,
 		config.AuthKind,
-		resolveStaticFunctionAuthConfig(config),
+		staticAuthConfig,
 		config.KubeconfigPath,
 		config.Namespace)
 }
 
 // resolveStaticFunctionAuthConfig builds the fixed auth config for the reverseProxy topology. In basicAuth
-// mode the username/password come from the config (the password is injected from a Secret via secretKeyRef).
-func resolveStaticFunctionAuthConfig(config *Config) auth.FunctionAuthConfig {
+// mode the username/password are read from the mounted function config file (restored from the secret).
+func resolveStaticFunctionAuthConfig(parentLogger logger.Logger, config *Config) (auth.FunctionAuthConfig, error) {
 	mode := auth.AuthenticationMode(config.AuthMode)
 	if mode == "" {
 		mode = auth.AuthenticationModeNone
 	}
 
+	if mode != auth.AuthenticationModeBasicAuth {
+		return auth.FunctionAuthConfig{Mode: mode}, nil
+	}
+
+	username, password, err := readBasicAuthCredentials(parentLogger, config.FunctionConfigPath)
+	if err != nil {
+		return auth.FunctionAuthConfig{}, errors.Wrap(err, "Failed to read basic-auth credentials from function config")
+	}
 	return auth.FunctionAuthConfig{
 		Mode:              mode,
-		BasicAuthUsername: config.BasicAuthUsername,
-		BasicAuthPassword: config.BasicAuthPassword,
+		BasicAuthUsername: username,
+		BasicAuthPassword: password,
+	}, nil
+}
+
+// readBasicAuthCredentials reads the function config from configPath, restores scrubbed values from the
+// mounted secret (when NUCLIO_RESTORE_FUNCTION_CONFIG_FROM_SECRET is set), and extracts the basicAuth
+// username and password from the HTTP trigger. Called once at sidecar startup; the dashboard has already
+// validated that exactly one HTTP trigger with basicAuth exists.
+func readBasicAuthCredentials(parentLogger logger.Logger, configPath string) (string, string, error) {
+	configFile, err := os.Open(configPath)
+	if err != nil {
+		return "", "", errors.Wrap(err, "Failed to open function configuration file")
 	}
+	defer configFile.Close() // nolint: errcheck
+
+	reader, err := processorconfig.NewReader()
+	if err != nil {
+		return "", "", errors.Wrap(err, "Failed to create configuration reader")
+	}
+
+	var processorConfiguration processor.Configuration
+	if err := reader.Read(configFile, &processorConfiguration); err != nil {
+		return "", "", errors.Wrap(err, "Failed to read function configuration")
+	}
+
+	functionConfig := &processorConfiguration.Config
+
+	if restoreFromSecret := common.GetEnvOrDefaultBool(common.RestoreConfigFromSecretEnvVar, false); restoreFromSecret {
+		scrubber := functionconfig.NewScrubber(parentLogger, nil, nil)
+		secretsMap, err := scrubber.LoadSecretsMap()
+		if err != nil {
+			return "", "", errors.Wrap(err, "Failed to load secrets map")
+		}
+		if len(secretsMap) > 0 {
+			restoredInterface, err := scrubber.Restore(functionConfig, secretsMap)
+			if err != nil {
+				return "", "", errors.Wrap(err, "Failed to restore function config from secret")
+			}
+			functionConfig = functionconfig.GetFunctionConfigFromInterface(restoredInterface)
+		}
+	}
+
+	httpTriggers := functionconfig.GetTriggersByKind(functionConfig.Spec.Triggers, "http")
+	if len(httpTriggers) == 0 {
+		return "", "", errors.New("No HTTP trigger found in function config")
+	}
+
+	var trigger functionconfig.Trigger
+	for _, trigger = range httpTriggers {
+		break
+	}
+	authConfig, err := auth.FunctionAuthConfigFromAttributes(trigger.Attributes, auth.AuthenticationModeBasicAuth)
+	if err != nil {
+		return "", "", errors.Wrap(err, "Failed to read basicAuth credentials from HTTP trigger")
+	}
+	return authConfig.BasicAuthUsername, authConfig.BasicAuthPassword, nil
 }

--- a/cmd/authproxy/app/authproxy.go
+++ b/cmd/authproxy/app/authproxy.go
@@ -129,15 +129,16 @@ func readBasicAuthCredentials(parentLogger logger.Logger, configPath string) (st
 			if err != nil {
 				return "", "", errors.Wrap(err, "Failed to load secrets map")
 			}
-			if len(secretsMap) > 0 {
-				restoredInterface, err := scrubber.Restore(functionConfig, secretsMap)
-				if err != nil {
-					return "", "", errors.Wrap(err, "Failed to restore function config from secret")
-				}
-				functionConfig = functionconfig.GetFunctionConfigFromInterface(restoredInterface)
-				if functionConfig == nil {
-					return "", "", errors.New("Failed to convert restored function config")
-				}
+			if len(secretsMap) == 0 {
+				return "", "", errors.New("Secrets map is empty, cannot restore masked function config credentials")
+			}
+			restoredInterface, err := scrubber.Restore(functionConfig, secretsMap)
+			if err != nil {
+				return "", "", errors.Wrap(err, "Failed to restore function config from secret")
+			}
+			functionConfig = functionconfig.GetFunctionConfigFromInterface(restoredInterface)
+			if functionConfig == nil {
+				return "", "", errors.New("Failed to convert restored function config")
 			}
 		}
 	}

--- a/cmd/authproxy/app/authproxy.go
+++ b/cmd/authproxy/app/authproxy.go
@@ -150,18 +150,18 @@ func readBasicAuthCredentials(parentLogger logger.Logger, configPath string) (st
 				return "", "", errors.Wrap(err, "Failed to restore function config from secret")
 			}
 			functionConfig = functionconfig.GetFunctionConfigFromInterface(restoredInterface)
+			if functionConfig == nil {
+				return "", "", errors.New("Failed to convert restored function config")
+			}
 		}
 	}
 
 	httpTriggers := functionconfig.GetTriggersByKind(functionConfig.Spec.Triggers, "http")
-	if len(httpTriggers) == 0 {
+	trigger := functionconfig.GetFirstTrigger(httpTriggers)
+	if trigger == nil {
 		return "", "", errors.New("No HTTP trigger found in function config")
 	}
 
-	var trigger functionconfig.Trigger
-	for _, trigger = range httpTriggers {
-		break
-	}
 	authConfig, err := auth.FunctionAuthConfigFromAttributes(trigger.Attributes, auth.AuthenticationModeBasicAuth)
 	if err != nil {
 		return "", "", errors.Wrap(err, "Failed to read basicAuth credentials from HTTP trigger")

--- a/cmd/authproxy/app/authproxy.go
+++ b/cmd/authproxy/app/authproxy.go
@@ -17,16 +17,12 @@ limitations under the License.
 package app
 
 import (
-	"os"
-
 	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/auth/authproxy"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/loggersink"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
-	"github.com/nuclio/nuclio/pkg/processor"
-	processorconfig "github.com/nuclio/nuclio/pkg/processor/config"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -116,50 +112,39 @@ func resolveStaticFunctionAuthConfig(parentLogger logger.Logger, config *Config)
 }
 
 // readBasicAuthCredentials reads the function config from configPath, restores scrubbed values from the
-// mounted secret (when NUCLIO_RESTORE_FUNCTION_CONFIG_FROM_SECRET is set), and extracts the basicAuth
-// username and password from the HTTP trigger. Called once at sidecar startup; the dashboard has already
-// validated that exactly one HTTP trigger with basicAuth exists.
+// mounted secret (when masking is enabled and NUCLIO_RESTORE_FUNCTION_CONFIG_FROM_SECRET is set), and
+// extracts the basicAuth username and password from the single HTTP trigger.
 func readBasicAuthCredentials(parentLogger logger.Logger, configPath string) (string, string, error) {
-	configFile, err := os.Open(configPath)
+	functionConfig, err := functionconfig.ReadConfigFromFile(configPath)
 	if err != nil {
-		return "", "", errors.Wrap(err, "Failed to open function configuration file")
-	}
-	defer configFile.Close() // nolint: errcheck
-
-	reader, err := processorconfig.NewReader()
-	if err != nil {
-		return "", "", errors.Wrap(err, "Failed to create configuration reader")
-	}
-
-	var processorConfiguration processor.Configuration
-	if err := reader.Read(configFile, &processorConfiguration); err != nil {
 		return "", "", errors.Wrap(err, "Failed to read function configuration")
 	}
 
-	functionConfig := &processorConfiguration.Config
-
-	if restoreFromSecret := common.GetEnvOrDefaultBool(common.RestoreConfigFromSecretEnvVar, false); restoreFromSecret {
-		scrubber := functionconfig.NewScrubber(parentLogger, nil, nil)
-		secretsMap, err := scrubber.LoadSecretsMap()
-		if err != nil {
-			return "", "", errors.Wrap(err, "Failed to load secrets map")
-		}
-		if len(secretsMap) > 0 {
-			restoredInterface, err := scrubber.Restore(functionConfig, secretsMap)
+	// Sensitive fields are scrubbed to "$ref:" placeholders unless masking is explicitly disabled.
+	// Only restore from the mounted Secret when scrubbing is active; otherwise credentials are already plaintext.
+	if !functionConfig.Spec.DisableSensitiveFieldsMasking {
+		if restoreFromSecret := common.GetEnvOrDefaultBool(common.RestoreConfigFromSecretEnvVar, false); restoreFromSecret {
+			scrubber := functionconfig.NewScrubber(parentLogger, nil, nil)
+			secretsMap, err := scrubber.LoadSecretsMap()
 			if err != nil {
-				return "", "", errors.Wrap(err, "Failed to restore function config from secret")
+				return "", "", errors.Wrap(err, "Failed to load secrets map")
 			}
-			functionConfig = functionconfig.GetFunctionConfigFromInterface(restoredInterface)
-			if functionConfig == nil {
-				return "", "", errors.New("Failed to convert restored function config")
+			if len(secretsMap) > 0 {
+				restoredInterface, err := scrubber.Restore(functionConfig, secretsMap)
+				if err != nil {
+					return "", "", errors.Wrap(err, "Failed to restore function config from secret")
+				}
+				functionConfig = functionconfig.GetFunctionConfigFromInterface(restoredInterface)
+				if functionConfig == nil {
+					return "", "", errors.New("Failed to convert restored function config")
+				}
 			}
 		}
 	}
 
-	httpTriggers := functionconfig.GetTriggersByKind(functionConfig.Spec.Triggers, "http")
-	trigger := functionconfig.GetFirstTrigger(httpTriggers)
-	if trigger == nil {
-		return "", "", errors.New("No HTTP trigger found in function config")
+	trigger, err := functionconfig.GetHTTPTrigger(functionConfig.Spec.Triggers)
+	if err != nil {
+		return "", "", errors.Wrap(err, "Failed to get HTTP trigger from function config")
 	}
 
 	authConfig, err := auth.FunctionAuthConfigFromAttributes(trigger.Attributes, auth.AuthenticationModeBasicAuth)

--- a/cmd/authproxy/app/config.go
+++ b/cmd/authproxy/app/config.go
@@ -30,8 +30,7 @@ type Config struct {
 	AuthURL            string // the URL of the auth service to which requests are sent for authentication
 	SigninURL          string // the URL of the sign-in service to which requests are redirected for sign-in (browser mode only)
 	AuthMode           string
-	BasicAuthUsername  string
-	BasicAuthPassword  string
+	FunctionConfigPath string // path to the mounted function config; credentials are read from it when auth-mode=basicAuth
 	Namespace          string
 	KubeconfigPath     string
 	PlatformConfigPath string
@@ -71,11 +70,8 @@ func validateReverseProxyConfiguration(config *Config) error {
 			return errors.New("Sign-in URL must be provided for 'browser' authentication mode")
 		}
 	case auth.AuthenticationModeBasicAuth:
-		if config.BasicAuthUsername == "" {
-			return errors.New("Basic-auth username must be provided for 'basicAuth' authentication mode")
-		}
-		if config.BasicAuthPassword == "" {
-			return errors.New("Basic-auth password must be provided for 'basicAuth' authentication mode")
+		if config.FunctionConfigPath == "" {
+			return errors.New("Function config path must be provided for 'basicAuth' authentication mode")
 		}
 	case auth.AuthenticationModeNone, "":
 		// no additional requirements

--- a/cmd/authproxy/main.go
+++ b/cmd/authproxy/main.go
@@ -34,8 +34,7 @@ func main() {
 	authURL := flag.String("auth-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_AUTH_URL", ""), "URL of the authentication endpoint")
 	signinURL := flag.String("signin-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_SIGNIN_URL", ""), "URL unauthenticated browser requests are redirected to sign-in")
 	authMode := flag.String("auth-mode", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_AUTH_MODE", string(auth.AuthenticationModeNone)), "Authentication mode for reverseProxy: none, api, browser or basicAuth")
-	basicAuthUsername := flag.String("basic-auth-username", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_BASIC_AUTH_USERNAME", ""), "Basic-auth username (used only when auth-mode=basicAuth)")
-	basicAuthPassword := flag.String("basic-auth-password", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_BASIC_AUTH_PASSWORD", ""), "Basic-auth password, injected from a Secret via secretKeyRef (used only when auth-mode=basicAuth)")
+	functionConfigPath := flag.String("function-config", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_FUNCTION_CONFIG_PATH", "/etc/nuclio/config/processor/processor.yaml"), "Path to the mounted function configuration file (used only when auth-mode=basicAuth)")
 	namespace := flag.String("namespace", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_NAMESPACE", ""), "Namespace of the target functions")
 	kubeconfigPath := flag.String("kubeconfig-path", os.Getenv("KUBECONFIG"), "Path of kubeconfig file")
 	platformConfigurationPath := flag.String("platform-config", "/etc/nuclio/config/platform/platform.yaml", "Path of platform configuration file")
@@ -49,8 +48,7 @@ func main() {
 		AuthURL:            *authURL,
 		SigninURL:          *signinURL,
 		AuthMode:           *authMode,
-		BasicAuthUsername:  *basicAuthUsername,
-		BasicAuthPassword:  *basicAuthPassword,
+		FunctionConfigPath: *functionConfigPath,
 		Namespace:          *namespace,
 		KubeconfigPath:     *kubeconfigPath,
 		PlatformConfigPath: *platformConfigurationPath,

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -36,7 +36,6 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform/abstract"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/processor"
-	"github.com/nuclio/nuclio/pkg/processor/config"
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
 	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
 	"github.com/nuclio/nuclio/pkg/processor/healthcheck"
@@ -293,23 +292,20 @@ func (p *Processor) Stop() {
 }
 
 func (p *Processor) readConfiguration(configurationPath string) (*processor.Configuration, error) {
-	var processorConfiguration processor.Configuration
-
-	processorConfigurationReader, err := processorconfig.NewReader()
+	functionConfig, err := functionconfig.ReadConfigFromFile(configurationPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create configuration file reader")
+		return nil, errors.Wrap(err, "Failed to read function configuration")
 	}
 
-	functionconfigFile, err := os.Open(configurationPath)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to open configuration file")
+	// EventTimeout is a processor-specific concern and not validated in the shared ReadConfigFromFile helper.
+	if functionConfig.Spec.EventTimeout != "" {
+		if _, err := functionConfig.Spec.GetEventTimeout(); err != nil {
+			return nil, errors.Wrapf(err, "Can't parse Spec.EventTimeout (%q) into time.Duration",
+				functionConfig.Spec.EventTimeout)
+		}
 	}
 
-	if err := processorConfigurationReader.Read(functionconfigFile, &processorConfiguration); err != nil {
-		return nil, errors.Wrap(err, "Failed to open configuration file")
-	}
-
-	return &processorConfiguration, nil
+	return &processor.Configuration{Config: *functionConfig}, nil
 }
 
 // restoreFunctionConfig restores a scrubbed function configuration to the original values from the

--- a/cmd/processor/app/processor.go
+++ b/cmd/processor/app/processor.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"path"
 	"sync"
 	"syscall"
 	"time"
@@ -320,7 +319,7 @@ func (p *Processor) restoreFunctionConfig(config *functionconfig.Config) (*funct
 	// initialize scrubber, we don't care about sensitive fields and kubeClientSet
 	scrubber := functionconfig.NewScrubber(p.logger, nil, nil)
 
-	secretsMap, err := p.getSecretsMap(scrubber)
+	secretsMap, err := scrubber.LoadSecretsMap()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get secrets map")
 	}
@@ -337,42 +336,6 @@ func (p *Processor) restoreFunctionConfig(config *functionconfig.Config) (*funct
 	}
 
 	return functionconfig.GetFunctionConfigFromInterface(restoredFunctionConfig), nil
-}
-
-func (p *Processor) getSecretsMap(scrubber *functionconfig.Scrubber) (map[string]string, error) {
-
-	// the env var is mainly for testing
-	filePath := os.Getenv("NUCLIO_FUNCTION_SECRET_VOLUME_PATH")
-	if filePath == "" {
-		filePath = functionconfig.FunctionSecretMountPath
-	}
-
-	contentPath := path.Join(filePath, functionconfig.SecretContentKey)
-
-	// check if a secret is mounted
-	if _, err := os.Stat(contentPath); err != nil {
-		p.logger.WarnWith("Failed to check if secret file exists",
-			"path", contentPath,
-			"err", err)
-		if os.IsNotExist(err) {
-			return nil, errors.New("Secret is not mounted to function pod")
-		}
-		return nil, errors.Wrap(err, "Failed to check if secret file exists")
-	}
-
-	p.logger.Debug("Secret is mounted to function pod, restoring function config")
-
-	// read secret content from file
-	encodedSecret, err := os.ReadFile(contentPath)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to read function secret")
-	}
-
-	if string(encodedSecret) == "" {
-		return map[string]string{}, nil
-	}
-
-	return scrubber.DecodeSecretsMapContent(string(encodedSecret))
 }
 
 func (p *Processor) createTriggers(processorConfiguration *processor.Configuration) ([]trigger.Trigger, error) {

--- a/pkg/auth/authproxy/authonly.go
+++ b/pkg/auth/authproxy/authonly.go
@@ -164,10 +164,10 @@ func (a *authOnlyAuthenticator) getAuthSpec(ctx context.Context, functionName st
 
 // functionAuthConfigFromSpec resolves the authentication config from the function's HTTP trigger.
 func functionAuthConfigFromSpec(spec *functionconfig.Spec) (auth.FunctionAuthConfig, error) {
-	for _, httpTrigger := range functionconfig.GetTriggersByKind(spec.Triggers, "http") {
-		return auth.FunctionAuthConfigFromAttributes(httpTrigger.Attributes, auth.AuthenticationModeNone)
+	httpTrigger, err := functionconfig.GetHTTPTrigger(spec.Triggers)
+	if err != nil {
+		// no HTTP trigger - nothing to authenticate
+		return auth.FunctionAuthConfig{Mode: auth.AuthenticationModeNone}, nil
 	}
-
-	// no HTTP trigger -> nothing to authenticate
-	return auth.FunctionAuthConfig{Mode: auth.AuthenticationModeNone}, nil
+	return auth.FunctionAuthConfigFromAttributes(httpTrigger.Attributes, auth.AuthenticationModeNone)
 }

--- a/pkg/functionconfig/reader.go
+++ b/pkg/functionconfig/reader.go
@@ -147,6 +147,26 @@ func (r *Reader) enrichPostMergeConfig(config, codeEntryConfig *Config) {
 	}
 }
 
+// ReadConfigFromFile reads a processor config YAML at path and returns the embedded function config.
+func ReadConfigFromFile(path string) (*Config, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to open function configuration file; path: %s", path)
+	}
+	defer f.Close() // nolint: errcheck
+
+	bodyBytes, err := io.ReadAll(f)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to read function configuration file; path: %s", path)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(bodyBytes, &cfg); err != nil {
+		return nil, errors.Wrap(err, "Failed to parse function configuration")
+	}
+	return &cfg, nil
+}
+
 // There is already validation of the function config pre merge, and validation post merge.
 // This validation function is for validation during the merge itself which is mainly to convey to the user
 // about validity of the configuration file itself, and therefore help the user understand where his problem lies.

--- a/pkg/functionconfig/reader.go
+++ b/pkg/functionconfig/reader.go
@@ -149,13 +149,7 @@ func (r *Reader) enrichPostMergeConfig(config, codeEntryConfig *Config) {
 
 // ReadConfigFromFile reads a processor config YAML at path and returns the embedded function config.
 func ReadConfigFromFile(path string) (*Config, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to open function configuration file; path: %s", path)
-	}
-	defer f.Close() // nolint: errcheck
-
-	bodyBytes, err := io.ReadAll(f)
+	bodyBytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to read function configuration file; path: %s", path)
 	}

--- a/pkg/functionconfig/scrubber.go
+++ b/pkg/functionconfig/scrubber.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -194,6 +196,41 @@ func (s *Scrubber) ConvertMapToConfig(mapConfig interface{}) (interface{}, error
 	}
 
 	return functionConfig, nil
+}
+
+// LoadSecretsMap reads the encoded secret from the mounted secret volume and decodes it.
+// It is the canonical implementation shared by the processor and the auth-proxy sidecar.
+func (s *Scrubber) LoadSecretsMap() (map[string]string, error) {
+	filePath := os.Getenv("NUCLIO_FUNCTION_SECRET_VOLUME_PATH")
+	if filePath == "" {
+		filePath = FunctionSecretMountPath
+	}
+	contentPath := path.Join(filePath, SecretContentKey)
+
+	// check if a secret is mounted
+	if _, err := os.Stat(contentPath); err != nil {
+		s.Logger.WarnWith("Failed to check if secret file exists",
+			"path", contentPath,
+			"err", err)
+		if os.IsNotExist(err) {
+			return nil, errors.New("Secret is not mounted to function pod")
+		}
+		return nil, errors.Wrap(err, "Failed to check secret file")
+	}
+
+	s.Logger.Debug("Secret is mounted to function pod, restoring function config")
+
+	// read secret content from file
+	encodedSecret, err := os.ReadFile(contentPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to read function secret")
+	}
+
+	if string(encodedSecret) == "" {
+		return map[string]string{}, nil
+	}
+
+	return s.DecodeSecretsMapContent(string(encodedSecret))
 }
 
 func (s *Scrubber) createFlexVolumeSecrets(ctx context.Context,

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -331,6 +331,14 @@ func GetTriggersByKind(triggers map[string]Trigger, kind string) map[string]Trig
 	return matchingTrigger
 }
 
+// GetFirstTrigger returns a pointer to one trigger from the map, or nil if the map is empty.
+func GetFirstTrigger(triggers map[string]Trigger) *Trigger {
+	for _, trigger := range triggers {
+		return &trigger
+	}
+	return nil
+}
+
 // GetTriggersByKinds returns a map of triggers by their kinds
 func GetTriggersByKinds(triggers map[string]Trigger, kinds []string) map[string]Trigger {
 	matchingTrigger := map[string]Trigger{}

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -331,12 +331,16 @@ func GetTriggersByKind(triggers map[string]Trigger, kind string) map[string]Trig
 	return matchingTrigger
 }
 
-// GetFirstTrigger returns a pointer to one trigger from the map, or nil if the map is empty.
-func GetFirstTrigger(triggers map[string]Trigger) *Trigger {
-	for _, trigger := range triggers {
-		return &trigger
+// GetHTTPTrigger returns the single HTTP trigger from triggers, or an error if there is not exactly one.
+func GetHTTPTrigger(triggers map[string]Trigger) (Trigger, error) {
+	httpTriggers := GetTriggersByKind(triggers, "http")
+	if len(httpTriggers) > 1 {
+		return Trigger{}, errors.New("Expected exactly one HTTP trigger in function config")
 	}
-	return nil
+	for _, trigger := range triggers {
+		return trigger, nil
+	}
+	return Trigger{}, errors.New("No HTTP trigger found in function config")
 }
 
 // GetTriggersByKinds returns a map of triggers by their kinds


### PR DESCRIPTION
### 📝 Description
Instead of injecting basicAuth credentials into the auth-proxy sidecar via CLI flags (which would require the deployer to extract and re-pass them), the sidecar now reads them directly from the already-mounted processor config file — the same file the processor itself uses — and restores scrubbed `$ref:` placeholders using the mounted function secret.

Depends on / follow-up to https://github.com/nuclio/nuclio/pull/4225 and https://github.com/nuclio/nuclio/pull/4206.

---

### 🛠️ Changes Made
- **`pkg/functionconfig/scrubber.go`** — Added `LoadSecretsMap()` as a public method: reads and decodes the encoded secret from the mounted secret volume. Extracted from the processor's private implementation so both the processor and the auth-proxy sidecar share one canonical path.
- **`cmd/processor/app/processor.go`** — Removed the private `getSecretsMap()`; delegates to `scrubber.LoadSecretsMap()`.
- **`cmd/authproxy/app/config.go`** — Replaced `BasicAuthUsername`/`BasicAuthPassword` fields with `FunctionConfigPath`; updated `validateReverseProxyConfiguration` to require the path instead of credentials when `auth-mode=basicAuth`.
- **`cmd/authproxy/main.go`** — Replaced `--basic-auth-username` / `--basic-auth-password` flags with `--function-config` (default: `/etc/nuclio/config/processor/processor.yaml`).
- **`cmd/authproxy/app/authproxy.go`** — `resolveStaticFunctionAuthConfig` (reverseProxy only) now reads the processor config file, optionally restores scrubbed credentials via `scrubber.LoadSecretsMap()`, and extracts the basicAuth username/password from the HTTP trigger. Guarded by `NUCLIO_RESTORE_FUNCTION_CONFIG_FROM_SECRET`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Dev tests — deployed the updated auth-proxy image to a running function pod with basicAuth configured
  - Sidecar correctly read and restored credentials from the mounted config and enforced HTTP Basic authentication on requests.
  - 
<img width="1042" height="365" alt="image" src="https://github.com/user-attachments/assets/2652c629-d5c1-4b4b-b1fd-3e9c3707d3f7" />
   - The password was referenced as expected:

```
$ kubectl -n oris get nucliofunctions.nuclio.io test4 -oyaml | grep -B 2 -A 2 password
        authentication:
          basicAuth:
            password: $ref:/spec/triggers/http3/attributes/authentication/basicauth/password
            username: testuser
        authenticationMode: basicAuth
```

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:  https://github.com/nuclio/nuclio/pull/4206 https://github.com/nuclio/nuclio/pull/4225

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
- `resolveStaticFunctionAuthConfig` is now only called when `mode=reverseProxy`; the `authOnly` authenticator resolves credentials per-request from the function CRD and is unaffected.