### PR TITLE
[Controller] Configure auth-proxy sidecar

### DIFF
--- a/cmd/authproxy/app/authproxy.go
+++ b/cmd/authproxy/app/authproxy.go
@@ -17,8 +17,6 @@ limitations under the License.
 package app
 
 import (
-	"context"
-
 	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/auth/authproxy"
 	"github.com/nuclio/nuclio/pkg/common"
@@ -62,12 +60,12 @@ func Run(config *Config) error {
 		return errors.Wrap(err, "Failed to create handler")
 	}
 
-	listenAddresses, err := resolveListenAddresses(config.Mode, config.ListenPorts)
+	listenAddress, err := resolveListenAddress(config.Mode, config.ListenPort)
 	if err != nil {
-		return errors.Wrap(err, "Failed to resolve listen addresses")
+		return errors.Wrap(err, "Failed to resolve listen address")
 	}
 
-	return startServers(context.Background(), rootLogger, listenAddresses, handler)
+	return newServer(rootLogger, listenAddress, handler).start()
 }
 
 // newAuthenticator creates kube clients when needed and delegates to the pkg-level factory.

--- a/cmd/authproxy/app/authproxy.go
+++ b/cmd/authproxy/app/authproxy.go
@@ -17,6 +17,8 @@ limitations under the License.
 package app
 
 import (
+	"context"
+
 	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/auth/authproxy"
 	"github.com/nuclio/nuclio/pkg/common"
@@ -60,16 +62,12 @@ func Run(config *Config) error {
 		return errors.Wrap(err, "Failed to create handler")
 	}
 
-	listenAddress, err := resolveListenAddress(config.Mode, config.ListenPort)
+	listenAddresses, err := resolveListenAddresses(config.Mode, config.ListenPorts)
 	if err != nil {
-		return errors.Wrap(err, "Failed to resolve listen address")
+		return errors.Wrap(err, "Failed to resolve listen addresses")
 	}
 
-	server := newServer(rootLogger, listenAddress, handler)
-	if err := server.start(); err != nil {
-		return errors.Wrap(err, "Failed to start auth-proxy server")
-	}
-	select {}
+	return startServers(context.Background(), rootLogger, listenAddresses, handler)
 }
 
 // newAuthenticator creates kube clients when needed and delegates to the pkg-level factory.

--- a/cmd/authproxy/app/config.go
+++ b/cmd/authproxy/app/config.go
@@ -25,7 +25,7 @@ import (
 // Config holds the auth-proxy sidecar configuration.
 type Config struct {
 	Mode               auth.ProxyMode
-	ListenPorts        []int  // every port the auth-proxy listens on; all fan in to the same UpstreamURL
+	ListenPort         int
 	UpstreamURL        string // the URL of the upstream service to which requests are proxied (reverseProxy mode only)
 	AuthURL            string // the URL of the auth service to which requests are sent for authentication
 	SigninURL          string // the URL of the sign-in service to which requests are redirected for sign-in (browser mode only)
@@ -38,7 +38,7 @@ type Config struct {
 }
 
 func validateConfiguration(config *Config) error {
-	if err := validatePorts(config); err != nil {
+	if err := validatePort(config.ListenPort); err != nil {
 		return errors.Wrap(err, "Invalid port configuration")
 	}
 
@@ -96,33 +96,15 @@ func validateAuthOnlyConfiguration(config *Config) error {
 	return nil
 }
 
-func validatePorts(config *Config) error {
-	if len(config.ListenPorts) == 0 {
-		return errors.New("At least one listen port must be provided")
+func validatePort(listenPort int) error {
+	// TCP ports are 16-bit unsigned integers, so the valid range is 1-65535 (0 is reserved)
+	if listenPort < 1 || listenPort > 65535 {
+		return errors.Errorf("Invalid listen port: %d", listenPort)
 	}
 
-	// authOnly is only ever reached over a single, internal loopback address (see resolveListenAddresses)
-	if config.Mode == auth.ProxyModeAuthOnly && len(config.ListenPorts) != 1 {
-		return errors.Errorf("authOnly mode requires exactly one listen port, got %d", len(config.ListenPorts))
-	}
-
-	seenPorts := make(map[int]bool, len(config.ListenPorts))
-	for _, listenPort := range config.ListenPorts {
-
-		// TCP ports are 16-bit unsigned integers, so the valid range is 1-65535 (0 is reserved)
-		if listenPort < 1 || listenPort > 65535 {
-			return errors.Errorf("Invalid listen port: %d", listenPort)
-		}
-
-		// ports 1 through 1023 are known as privileged ports or well-known ports, so we should avoid using them
-		if listenPort < 1024 {
-			return errors.Errorf("Listen port is reserved for well-known services; please use a port above 1023; invalid port: %d", listenPort)
-		}
-
-		if seenPorts[listenPort] {
-			return errors.Errorf("Duplicate listen port: %d", listenPort)
-		}
-		seenPorts[listenPort] = true
+	// ports 1 through 1023 are known as privileged ports or well-known ports, so we should avoid using them
+	if listenPort < 1024 {
+		return errors.Errorf("Listen port is reserved for well-known services; please use a port above 1023; invalid port: %d", listenPort)
 	}
 
 	return nil

--- a/cmd/authproxy/app/config.go
+++ b/cmd/authproxy/app/config.go
@@ -25,7 +25,7 @@ import (
 // Config holds the auth-proxy sidecar configuration.
 type Config struct {
 	Mode               auth.ProxyMode
-	ListenPort         int
+	ListenPorts        []int  // every port the auth-proxy listens on; all fan in to the same UpstreamURL
 	UpstreamURL        string // the URL of the upstream service to which requests are proxied (reverseProxy mode only)
 	AuthURL            string // the URL of the auth service to which requests are sent for authentication
 	SigninURL          string // the URL of the sign-in service to which requests are redirected for sign-in (browser mode only)
@@ -97,14 +97,32 @@ func validateAuthOnlyConfiguration(config *Config) error {
 }
 
 func validatePorts(config *Config) error {
-	// TCP ports are 16-bit unsigned integers, so the valid range is 1-65535 (0 is reserved)
-	if config.ListenPort < 1 || config.ListenPort > 65535 {
-		return errors.Errorf("Invalid listen port: %d", config.ListenPort)
+	if len(config.ListenPorts) == 0 {
+		return errors.New("At least one listen port must be provided")
 	}
 
-	// ports 1 through 1023 are known as privileged ports or well-known ports, so we should avoid using them
-	if config.ListenPort < 1024 {
-		return errors.Errorf("Listen port is reserved for well-known services; please use a port above 1023; invalid port: %d", config.ListenPort)
+	// authOnly is only ever reached over a single, internal loopback address (see resolveListenAddresses)
+	if config.Mode == auth.ProxyModeAuthOnly && len(config.ListenPorts) != 1 {
+		return errors.Errorf("authOnly mode requires exactly one listen port, got %d", len(config.ListenPorts))
+	}
+
+	seenPorts := make(map[int]bool, len(config.ListenPorts))
+	for _, listenPort := range config.ListenPorts {
+
+		// TCP ports are 16-bit unsigned integers, so the valid range is 1-65535 (0 is reserved)
+		if listenPort < 1 || listenPort > 65535 {
+			return errors.Errorf("Invalid listen port: %d", listenPort)
+		}
+
+		// ports 1 through 1023 are known as privileged ports or well-known ports, so we should avoid using them
+		if listenPort < 1024 {
+			return errors.Errorf("Listen port is reserved for well-known services; please use a port above 1023; invalid port: %d", listenPort)
+		}
+
+		if seenPorts[listenPort] {
+			return errors.Errorf("Duplicate listen port: %d", listenPort)
+		}
+		seenPorts[listenPort] = true
 	}
 
 	return nil

--- a/cmd/authproxy/app/server.go
+++ b/cmd/authproxy/app/server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -25,6 +26,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/auth/authproxy"
 	httptrigger "github.com/nuclio/nuclio/pkg/processor/trigger/http"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -68,17 +70,22 @@ func newHandler(parentLogger logger.Logger,
 	}
 }
 
-// resolveListenAddress returns the address the given mode listens on: reverseProxy is exposed to the
-// cluster on listenPort; authOnly is reachable only from within the pod (loopback).
-func resolveListenAddress(mode auth.ProxyMode, listenPort int) (string, error) {
-	switch mode {
-	case auth.ProxyModeReverseProxy:
-		return fmt.Sprintf(":%d", listenPort), nil
-	case auth.ProxyModeAuthOnly:
-		return fmt.Sprintf("127.0.0.1:%d", listenPort), nil
-	default:
-		return "", errors.Errorf("Unknown auth-proxy mode: %s", mode)
+// resolveListenAddresses returns the addresses the given mode listens on: reverseProxy is exposed to the
+// cluster on every one of listenPorts (e.g. all of a function's published ports); authOnly is reachable
+// only from within the pod (loopback), and only ever has a single listen port (see config.go:validatePorts).
+func resolveListenAddresses(mode auth.ProxyMode, listenPorts []int) ([]string, error) {
+	listenAddresses := make([]string, 0, len(listenPorts))
+	for _, listenPort := range listenPorts {
+		switch mode {
+		case auth.ProxyModeReverseProxy:
+			listenAddresses = append(listenAddresses, fmt.Sprintf(":%d", listenPort))
+		case auth.ProxyModeAuthOnly:
+			listenAddresses = append(listenAddresses, fmt.Sprintf("127.0.0.1:%d", listenPort))
+		default:
+			return nil, errors.Errorf("Unknown auth-proxy mode: %s", mode)
+		}
 	}
+	return listenAddresses, nil
 }
 
 func (s *server) start() error {
@@ -137,4 +144,33 @@ func newAuthOnlyHandler(authenticator authproxy.Authenticator) http.Handler {
 		}
 	})
 	return mux
+}
+
+// startServers builds and starts one server per listen address, all serving the same handler
+// concurrently, so a single auth-proxy process fronts every listen address (e.g. all of a function's ports)
+func startServers(ctx context.Context, parentLogger logger.Logger, listenAddresses []string, handler http.Handler) error {
+	errorWG, groupCtx := errgroup.WithContext(ctx)
+	servers := make([]*server, 0, len(listenAddresses))
+	for _, listenAddress := range listenAddresses {
+		listenerServer := newServer(parentLogger, listenAddress, handler)
+		servers = append(servers, listenerServer)
+		errorWG.Go(listenerServer.start)
+	}
+
+	stop := context.AfterFunc(groupCtx, func() {
+		closeServers(parentLogger, servers)
+	})
+	defer stop()
+
+	return errorWG.Wait()
+}
+
+func closeServers(parentLogger logger.Logger, servers []*server) {
+	for _, listenerServer := range servers {
+		if err := listenerServer.httpServer.Close(); err != nil && err != http.ErrServerClosed {
+			parentLogger.WarnWith("Failed to close auth-proxy listener",
+				"listenAddress", listenerServer.httpServer.Addr,
+				"err", err.Error())
+		}
+	}
 }

--- a/cmd/authproxy/app/server.go
+++ b/cmd/authproxy/app/server.go
@@ -17,7 +17,6 @@ limitations under the License.
 package app
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -29,7 +28,6 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
-	"golang.org/x/sync/errgroup"
 )
 
 // server fronts a function or the DLX.
@@ -70,22 +68,17 @@ func newHandler(parentLogger logger.Logger,
 	}
 }
 
-// resolveListenAddresses returns the addresses the given mode listens on: reverseProxy is exposed to the
-// cluster on every one of listenPorts (e.g. all of a function's published ports); authOnly is reachable
-// only from within the pod (loopback), and only ever has a single listen port (see config.go:validatePorts).
-func resolveListenAddresses(mode auth.ProxyMode, listenPorts []int) ([]string, error) {
-	listenAddresses := make([]string, 0, len(listenPorts))
-	for _, listenPort := range listenPorts {
-		switch mode {
-		case auth.ProxyModeReverseProxy:
-			listenAddresses = append(listenAddresses, fmt.Sprintf(":%d", listenPort))
-		case auth.ProxyModeAuthOnly:
-			listenAddresses = append(listenAddresses, fmt.Sprintf("127.0.0.1:%d", listenPort))
-		default:
-			return nil, errors.Errorf("Unknown auth-proxy mode: %s", mode)
-		}
+// resolveListenAddress returns the address the given mode listens on: reverseProxy is exposed to the
+// cluster; authOnly is reachable only from within the pod (loopback).
+func resolveListenAddress(mode auth.ProxyMode, listenPort int) (string, error) {
+	switch mode {
+	case auth.ProxyModeReverseProxy:
+		return fmt.Sprintf(":%d", listenPort), nil
+	case auth.ProxyModeAuthOnly:
+		return fmt.Sprintf("127.0.0.1:%d", listenPort), nil
+	default:
+		return "", errors.Errorf("Unknown auth-proxy mode: %s", mode)
 	}
-	return listenAddresses, nil
 }
 
 func (s *server) start() error {
@@ -144,33 +137,4 @@ func newAuthOnlyHandler(authenticator authproxy.Authenticator) http.Handler {
 		}
 	})
 	return mux
-}
-
-// startServers builds and starts one server per listen address, all serving the same handler
-// concurrently, so a single auth-proxy process fronts every listen address (e.g. all of a function's ports)
-func startServers(ctx context.Context, parentLogger logger.Logger, listenAddresses []string, handler http.Handler) error {
-	errorWG, groupCtx := errgroup.WithContext(ctx)
-	servers := make([]*server, 0, len(listenAddresses))
-	for _, listenAddress := range listenAddresses {
-		listenerServer := newServer(parentLogger, listenAddress, handler)
-		servers = append(servers, listenerServer)
-		errorWG.Go(listenerServer.start)
-	}
-
-	stop := context.AfterFunc(groupCtx, func() {
-		closeServers(parentLogger, servers)
-	})
-	defer stop()
-
-	return errorWG.Wait()
-}
-
-func closeServers(parentLogger logger.Logger, servers []*server) {
-	for _, listenerServer := range servers {
-		if err := listenerServer.httpServer.Close(); err != nil && err != http.ErrServerClosed {
-			parentLogger.WarnWith("Failed to close auth-proxy listener",
-				"listenAddress", listenerServer.httpServer.Addr,
-				"err", err.Error())
-		}
-	}
 }

--- a/cmd/authproxy/app/server.go
+++ b/cmd/authproxy/app/server.go
@@ -26,10 +26,10 @@ import (
 	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/auth/authproxy"
 	httptrigger "github.com/nuclio/nuclio/pkg/processor/trigger/http"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
+	"golang.org/x/sync/errgroup"
 )
 
 // server fronts a function or the DLX.

--- a/cmd/authproxy/app/server_test.go
+++ b/cmd/authproxy/app/server_test.go
@@ -19,10 +19,14 @@ limitations under the License.
 package app
 
 import (
+	"context"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/nuclio/nuclio/pkg/auth"
 	httptrigger "github.com/nuclio/nuclio/pkg/processor/trigger/http"
@@ -57,24 +61,36 @@ type upstreamStub struct {
 type ServerTestSuite struct {
 	suite.Suite
 	logger logger.Logger
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 func (suite *ServerTestSuite) SetupTest() {
 	var err error
 	suite.logger, err = nucliozap.NewNuclioZapTest("auth-proxy-test")
 	suite.Require().NoError(err)
+
+	suite.ctx, suite.cancel = context.WithCancel(context.Background())
 }
 
-// TestModeListenAddress verifies the only listen-address difference between the modes: reverseProxy is
-// exposed on the configurable port, authOnly is bound to loopback (reachable only from within the pod).
-func (suite *ServerTestSuite) TestModeListenAddress() {
+func (suite *ServerTestSuite) TearDownTest() {
+	if suite.cancel != nil {
+		suite.cancel()
+	}
+}
+
+// TestModeListenAddresses verifies the only listen-address difference between the modes: reverseProxy is
+// exposed on every configured port, authOnly is bound to loopback (reachable only from within the pod).
+func (suite *ServerTestSuite) TestModeListenAddresses() {
 	for _, testCase := range []struct {
-		name                  string
-		mode                  auth.ProxyMode
-		expectedListenAddress string
+		name                    string
+		mode                    auth.ProxyMode
+		listenPorts             []int
+		expectedListenAddresses []string
 	}{
-		{name: "reverseProxy is exposed", mode: auth.ProxyModeReverseProxy, expectedListenAddress: ":8080"},
-		{name: "authOnly is loopback", mode: auth.ProxyModeAuthOnly, expectedListenAddress: "127.0.0.1:8080"},
+		{name: "reverseProxy is exposed", mode: auth.ProxyModeReverseProxy, listenPorts: []int{8080}, expectedListenAddresses: []string{":8080"}},
+		{name: "authOnly is loopback", mode: auth.ProxyModeAuthOnly, listenPorts: []int{8080}, expectedListenAddresses: []string{"127.0.0.1:8080"}},
+		{name: "reverseProxy fronts multiple ports", mode: auth.ProxyModeReverseProxy, listenPorts: []int{8080, 8443}, expectedListenAddresses: []string{":8080", ":8443"}},
 	} {
 		suite.Run(testCase.name, func() {
 			handler, err := newHandler(suite.logger,
@@ -83,11 +99,14 @@ func (suite *ServerTestSuite) TestModeListenAddress() {
 				&fakeAuthenticator{authorized: true})
 			suite.Require().NoError(err)
 
-			listenAddress, err := resolveListenAddress(testCase.mode, 8080)
+			listenAddresses, err := resolveListenAddresses(testCase.mode, testCase.listenPorts)
 			suite.Require().NoError(err)
+			suite.Require().Equal(testCase.expectedListenAddresses, listenAddresses)
 
-			server := newServer(suite.logger, listenAddress, handler)
-			suite.Require().Equal(testCase.expectedListenAddress, server.httpServer.Addr)
+			for _, listenAddress := range listenAddresses {
+				server := newServer(suite.logger, listenAddress, handler)
+				suite.Require().Equal(listenAddress, server.httpServer.Addr)
+			}
 		})
 	}
 }
@@ -100,9 +119,119 @@ func (suite *ServerTestSuite) TestUnknownModeRejected() {
 	suite.Require().Error(err)
 	suite.Require().Contains(err.Error(), "Unknown auth-proxy mode")
 
-	_, err = resolveListenAddress("unknown-mode", 8080)
+	_, err = resolveListenAddresses("unknown-mode", []int{8080})
 	suite.Require().Error(err)
 	suite.Require().Contains(err.Error(), "Unknown auth-proxy mode")
+}
+
+// TestMultiplePortsShareHandlerAndUpstream verifies that when the auth-proxy fronts multiple ports, every
+// listener serves the same handler and forwards to the same upstream.
+func (suite *ServerTestSuite) TestMultiplePortsShareHandlerAndUpstream() {
+	upstream := suite.newTestUpstreamStub()
+	defer upstream.server.Close()
+
+	authenticator := &fakeAuthenticator{authorized: true}
+	handler, err := newReverseProxyHandler(suite.logger, upstream.server.URL, authenticator)
+	suite.Require().NoError(err)
+
+	firstPort, err := freeLoopbackPort()
+	suite.Require().NoError(err)
+	secondPort, err := freeLoopbackPort()
+	suite.Require().NoError(err)
+
+	listenAddresses := []string{
+		fmt.Sprintf("127.0.0.1:%d", firstPort),
+		fmt.Sprintf("127.0.0.1:%d", secondPort),
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- startServers(suite.ctx, suite.logger, listenAddresses, handler)
+	}()
+
+	for _, listenAddress := range listenAddresses {
+		suite.requireServing(listenAddress)
+	}
+
+	statusCode, body := suite.doRequestToAddress(listenAddresses[0], "/invoke")
+	suite.Require().Equal(http.StatusOK, statusCode)
+	suite.Require().Equal("upstream-response", body)
+
+	statusCode, body = suite.doRequestToAddress(listenAddresses[1], "/invoke")
+	suite.Require().Equal(http.StatusOK, statusCode)
+	suite.Require().Equal("upstream-response", body)
+
+	suite.Require().Equal(2, upstream.hits)
+	suite.Require().Equal(2, authenticator.calls)
+
+	suite.cancel()
+	suite.Require().NoError(<-done)
+}
+
+// TestStartServersPropagatesListenerFailure verifies that if one listener fails to bind, startServers
+// closes the other listeners and returns the error instead of hanging forever.
+func (suite *ServerTestSuite) TestStartServersPropagatesListenerFailure() {
+	upstream := suite.newTestUpstreamStub()
+	defer upstream.server.Close()
+
+	handler, err := newReverseProxyHandler(suite.logger, upstream.server.URL, &fakeAuthenticator{authorized: true})
+	suite.Require().NoError(err)
+
+	// occupy a port so the second listener deterministically fails to bind to the very same address
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	suite.Require().NoError(err)
+	defer occupied.Close() // nolint: errcheck
+
+	healthyPort, err := freeLoopbackPort()
+	suite.Require().NoError(err)
+
+	listenAddresses := []string{
+		fmt.Sprintf("127.0.0.1:%d", healthyPort),
+		occupied.Addr().String(),
+	}
+
+	err = startServers(suite.ctx, suite.logger, listenAddresses, handler)
+	suite.Require().Error(err)
+}
+
+// freeLoopbackPort asks the OS for an unused loopback port by briefly binding to port 0.
+func freeLoopbackPort() (int, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer listener.Close() // nolint: errcheck
+	return listener.Addr().(*net.TCPAddr).Port, nil
+}
+
+// requireServing polls listenAddress until it accepts connections or the deadline elapses.
+func (suite *ServerTestSuite) requireServing(listenAddress string) {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.Dial("tcp", listenAddress)
+		if err == nil {
+			conn.Close() // nolint: errcheck
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	suite.FailNow("Server never started listening", "listenAddress", listenAddress)
+}
+
+// doRequestToAddress performs an HTTP GET against an already-listening address (as opposed to doRequest,
+// which spins up its own httptest.Server).
+func (suite *ServerTestSuite) doRequestToAddress(listenAddress string, path string) (int, string) {
+	response, err := http.Get(fmt.Sprintf("http://%s%s", listenAddress, path))
+	suite.Require().NoError(err)
+	defer func(body io.ReadCloser) {
+		if err := body.Close(); err != nil {
+			suite.logger.WarnWith("Failed to close response body", "err", err)
+		}
+	}(response.Body)
+
+	body, err := io.ReadAll(response.Body)
+	suite.Require().NoError(err)
+	return response.StatusCode, string(body)
 }
 
 // TestReverseProxyForwardsWhenAuthorized verifies an authorized request is proxied to the upstream.

--- a/cmd/authproxy/app/server_test.go
+++ b/cmd/authproxy/app/server_test.go
@@ -19,13 +19,11 @@ limitations under the License.
 package app
 
 import (
-	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/nuclio/nuclio/pkg/auth"
 	httptrigger "github.com/nuclio/nuclio/pkg/processor/trigger/http"
@@ -125,36 +123,6 @@ func (suite *ServerTestSuite) TestStartServerFailsOnOccupiedPort() {
 
 	err = newServer(suite.logger, occupied.Addr().String(), handler).start()
 	suite.Require().Error(err)
-}
-
-// requireServing polls listenAddress until it accepts connections or the deadline elapses.
-func (suite *ServerTestSuite) requireServing(listenAddress string) {
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		conn, err := net.Dial("tcp", listenAddress)
-		if err == nil {
-			conn.Close() // nolint: errcheck
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	suite.FailNow("Server never started listening", "listenAddress", listenAddress)
-}
-
-// doRequestToAddress performs an HTTP GET against an already-listening address (as opposed to doRequest,
-// which spins up its own httptest.Server).
-func (suite *ServerTestSuite) doRequestToAddress(listenAddress string, path string) (int, string) {
-	response, err := http.Get(fmt.Sprintf("http://%s%s", listenAddress, path))
-	suite.Require().NoError(err)
-	defer func(body io.ReadCloser) {
-		if err := body.Close(); err != nil {
-			suite.logger.WarnWith("Failed to close response body", "err", err)
-		}
-	}(response.Body)
-
-	body, err := io.ReadAll(response.Body)
-	suite.Require().NoError(err)
-	return response.StatusCode, string(body)
 }
 
 // TestReverseProxyForwardsWhenAuthorized verifies an authorized request is proxied to the upstream.

--- a/cmd/authproxy/app/server_test.go
+++ b/cmd/authproxy/app/server_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package app
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net"
@@ -61,36 +60,25 @@ type upstreamStub struct {
 type ServerTestSuite struct {
 	suite.Suite
 	logger logger.Logger
-	ctx    context.Context
-	cancel context.CancelFunc
 }
 
 func (suite *ServerTestSuite) SetupTest() {
 	var err error
 	suite.logger, err = nucliozap.NewNuclioZapTest("auth-proxy-test")
 	suite.Require().NoError(err)
-
-	suite.ctx, suite.cancel = context.WithCancel(context.Background())
-}
-
-func (suite *ServerTestSuite) TearDownTest() {
-	if suite.cancel != nil {
-		suite.cancel()
-	}
 }
 
 // TestModeListenAddresses verifies the only listen-address difference between the modes: reverseProxy is
-// exposed on every configured port, authOnly is bound to loopback (reachable only from within the pod).
+// exposed on the configured port, authOnly is bound to loopback (reachable only from within the pod).
 func (suite *ServerTestSuite) TestModeListenAddresses() {
 	for _, testCase := range []struct {
-		name                    string
-		mode                    auth.ProxyMode
-		listenPorts             []int
-		expectedListenAddresses []string
+		name                  string
+		mode                  auth.ProxyMode
+		listenPort            int
+		expectedListenAddress string
 	}{
-		{name: "reverseProxy is exposed", mode: auth.ProxyModeReverseProxy, listenPorts: []int{8080}, expectedListenAddresses: []string{":8080"}},
-		{name: "authOnly is loopback", mode: auth.ProxyModeAuthOnly, listenPorts: []int{8080}, expectedListenAddresses: []string{"127.0.0.1:8080"}},
-		{name: "reverseProxy fronts multiple ports", mode: auth.ProxyModeReverseProxy, listenPorts: []int{8080, 8443}, expectedListenAddresses: []string{":8080", ":8443"}},
+		{name: "reverseProxy is exposed", mode: auth.ProxyModeReverseProxy, listenPort: 8080, expectedListenAddress: ":8080"},
+		{name: "authOnly is loopback", mode: auth.ProxyModeAuthOnly, listenPort: 8080, expectedListenAddress: "127.0.0.1:8080"},
 	} {
 		suite.Run(testCase.name, func() {
 			handler, err := newHandler(suite.logger,
@@ -99,14 +87,12 @@ func (suite *ServerTestSuite) TestModeListenAddresses() {
 				&fakeAuthenticator{authorized: true})
 			suite.Require().NoError(err)
 
-			listenAddresses, err := resolveListenAddresses(testCase.mode, testCase.listenPorts)
+			listenAddress, err := resolveListenAddress(testCase.mode, testCase.listenPort)
 			suite.Require().NoError(err)
-			suite.Require().Equal(testCase.expectedListenAddresses, listenAddresses)
+			suite.Require().Equal(testCase.expectedListenAddress, listenAddress)
 
-			for _, listenAddress := range listenAddresses {
-				server := newServer(suite.logger, listenAddress, handler)
-				suite.Require().Equal(listenAddress, server.httpServer.Addr)
-			}
+			server := newServer(suite.logger, listenAddress, handler)
+			suite.Require().Equal(listenAddress, server.httpServer.Addr)
 		})
 	}
 }
@@ -119,89 +105,26 @@ func (suite *ServerTestSuite) TestUnknownModeRejected() {
 	suite.Require().Error(err)
 	suite.Require().Contains(err.Error(), "Unknown auth-proxy mode")
 
-	_, err = resolveListenAddresses("unknown-mode", []int{8080})
+	_, err = resolveListenAddress("unknown-mode", 8080)
 	suite.Require().Error(err)
 	suite.Require().Contains(err.Error(), "Unknown auth-proxy mode")
 }
 
-// TestMultiplePortsShareHandlerAndUpstream verifies that when the auth-proxy fronts multiple ports, every
-// listener serves the same handler and forwards to the same upstream.
-func (suite *ServerTestSuite) TestMultiplePortsShareHandlerAndUpstream() {
-	upstream := suite.newTestUpstreamStub()
-	defer upstream.server.Close()
-
-	authenticator := &fakeAuthenticator{authorized: true}
-	handler, err := newReverseProxyHandler(suite.logger, upstream.server.URL, authenticator)
-	suite.Require().NoError(err)
-
-	firstPort, err := freeLoopbackPort()
-	suite.Require().NoError(err)
-	secondPort, err := freeLoopbackPort()
-	suite.Require().NoError(err)
-
-	listenAddresses := []string{
-		fmt.Sprintf("127.0.0.1:%d", firstPort),
-		fmt.Sprintf("127.0.0.1:%d", secondPort),
-	}
-
-	done := make(chan error, 1)
-	go func() {
-		done <- startServers(suite.ctx, suite.logger, listenAddresses, handler)
-	}()
-
-	for _, listenAddress := range listenAddresses {
-		suite.requireServing(listenAddress)
-	}
-
-	statusCode, body := suite.doRequestToAddress(listenAddresses[0], "/invoke")
-	suite.Require().Equal(http.StatusOK, statusCode)
-	suite.Require().Equal("upstream-response", body)
-
-	statusCode, body = suite.doRequestToAddress(listenAddresses[1], "/invoke")
-	suite.Require().Equal(http.StatusOK, statusCode)
-	suite.Require().Equal("upstream-response", body)
-
-	suite.Require().Equal(2, upstream.hits)
-	suite.Require().Equal(2, authenticator.calls)
-
-	suite.cancel()
-	suite.Require().NoError(<-done)
-}
-
-// TestStartServersPropagatesListenerFailure verifies that if one listener fails to bind, startServers
-// closes the other listeners and returns the error instead of hanging forever.
-func (suite *ServerTestSuite) TestStartServersPropagatesListenerFailure() {
+// TestStartServerFailsOnOccupiedPort verifies that server.start returns an error when the port is already in use.
+func (suite *ServerTestSuite) TestStartServerFailsOnOccupiedPort() {
 	upstream := suite.newTestUpstreamStub()
 	defer upstream.server.Close()
 
 	handler, err := newReverseProxyHandler(suite.logger, upstream.server.URL, &fakeAuthenticator{authorized: true})
 	suite.Require().NoError(err)
 
-	// occupy a port so the second listener deterministically fails to bind to the very same address
+	// occupy a port so the listener deterministically fails to bind
 	occupied, err := net.Listen("tcp", "127.0.0.1:0")
 	suite.Require().NoError(err)
 	defer occupied.Close() // nolint: errcheck
 
-	healthyPort, err := freeLoopbackPort()
-	suite.Require().NoError(err)
-
-	listenAddresses := []string{
-		fmt.Sprintf("127.0.0.1:%d", healthyPort),
-		occupied.Addr().String(),
-	}
-
-	err = startServers(suite.ctx, suite.logger, listenAddresses, handler)
+	err = newServer(suite.logger, occupied.Addr().String(), handler).start()
 	suite.Require().Error(err)
-}
-
-// freeLoopbackPort asks the OS for an unused loopback port by briefly binding to port 0.
-func freeLoopbackPort() (int, error) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return 0, err
-	}
-	defer listener.Close() // nolint: errcheck
-	return listener.Addr().(*net.TCPAddr).Port, nil
 }
 
 // requireServing polls listenAddress until it accepts connections or the deadline elapses.

--- a/cmd/authproxy/main.go
+++ b/cmd/authproxy/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
 	"github.com/nuclio/nuclio/cmd/authproxy/app"
 	"github.com/nuclio/nuclio/pkg/auth"
@@ -29,7 +30,7 @@ import (
 
 func main() {
 	mode := flag.String("mode", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_MODE", string(auth.ProxyModeReverseProxy)), "Auth-proxy mode: reverseProxy or authOnly")
-	listenPort := flag.Int("listen-port", common.GetEnvOrDefaultInt("NUCLIO_AUTHPROXY_LISTEN_PORT", 8080), "Port the auth-proxy listens on")
+	listenPorts := flag.String("listen-ports", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_LISTEN_PORTS", "8080"), "Comma-separated list of ports the auth-proxy listens on")
 	upstreamURL := flag.String("upstream-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_UPSTREAM_URL", "http://127.0.0.1:6080"), "URL of the upstream service (processor) to forward requests to")
 	authURL := flag.String("auth-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_AUTH_URL", ""), "URL of the authentication endpoint")
 	signinURL := flag.String("signin-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_SIGNIN_URL", ""), "URL unauthenticated browser requests are redirected to sign-in")
@@ -41,9 +42,15 @@ func main() {
 	authKind := flag.String("auth-kind", auth.KindNop, "Authentication kind for API/browser authentication (e.g. iguazio, iguazio-v4, nop)")
 	flag.Parse()
 
+	listenPortsSlice, err := common.StringSliceToIntSlice(strings.Split(strings.TrimSpace(*listenPorts), ","))
+	if err != nil {
+		errors.PrintErrorStack(os.Stderr, errors.Wrap(err, "Failed to parse listen ports"), 5)
+		os.Exit(1)
+	}
+
 	if err := app.Run(&app.Config{
 		Mode:               auth.ProxyMode(*mode),
-		ListenPort:         *listenPort,
+		ListenPorts:        listenPortsSlice,
 		UpstreamURL:        *upstreamURL,
 		AuthURL:            *authURL,
 		SigninURL:          *signinURL,

--- a/cmd/authproxy/main.go
+++ b/cmd/authproxy/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/nuclio/nuclio/cmd/authproxy/app"
@@ -30,7 +31,7 @@ import (
 
 func main() {
 	mode := flag.String("mode", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_MODE", string(auth.ProxyModeReverseProxy)), "Auth-proxy mode: reverseProxy or authOnly")
-	listenPorts := flag.String("listen-ports", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_LISTEN_PORTS", "8080"), "Comma-separated list of ports the auth-proxy listens on")
+	listenPort := flag.String("listen-port", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_LISTEN_PORT", "8080"), "Port the auth-proxy listens on")
 	upstreamURL := flag.String("upstream-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_UPSTREAM_URL", "http://127.0.0.1:6080"), "URL of the upstream service (processor) to forward requests to")
 	authURL := flag.String("auth-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_AUTH_URL", ""), "URL of the authentication endpoint")
 	signinURL := flag.String("signin-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_SIGNIN_URL", ""), "URL unauthenticated browser requests are redirected to sign-in")
@@ -42,15 +43,15 @@ func main() {
 	authKind := flag.String("auth-kind", auth.KindNop, "Authentication kind for API/browser authentication (e.g. iguazio, iguazio-v4, nop)")
 	flag.Parse()
 
-	listenPortsSlice, err := common.StringSliceToIntSlice(strings.Split(strings.TrimSpace(*listenPorts), ","))
+	listenPortInt, err := strconv.Atoi(strings.TrimSpace(*listenPort))
 	if err != nil {
-		errors.PrintErrorStack(os.Stderr, errors.Wrap(err, "Failed to parse listen ports"), 5)
+		errors.PrintErrorStack(os.Stderr, errors.Wrap(err, "Failed to parse listen port"), 5)
 		os.Exit(1)
 	}
 
 	if err := app.Run(&app.Config{
 		Mode:               auth.ProxyMode(*mode),
-		ListenPorts:        listenPortsSlice,
+		ListenPort:         listenPortInt,
 		UpstreamURL:        *upstreamURL,
 		AuthURL:            *authURL,
 		SigninURL:          *signinURL,

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -147,6 +147,22 @@ func FunctionAuthConfigFromAttributes(attributes map[string]interface{}, default
 	return authConfig, nil
 }
 
+// FunctionLevelAuthenticationModes are the authentication modes valid for an HTTP trigger's
+// authenticationMode attribute: mode-based API authentication, browser-redirect authentication, and
+// static basic-auth credentials. AuthenticationModeNone (no additional authentication) is deliberately
+// excluded - it means the function-level auth-proxy gate itself does not apply.
+var FunctionLevelAuthenticationModes = map[AuthenticationMode]struct{}{
+	AuthenticationModeAPI:       {},
+	AuthenticationModeBrowser:   {},
+	AuthenticationModeBasicAuth: {},
+}
+
+// IsFunctionLevelAuthenticationMode reports whether mode is one of FunctionLevelAuthenticationModes.
+func IsFunctionLevelAuthenticationMode(mode string) bool {
+	_, ok := FunctionLevelAuthenticationModes[AuthenticationMode(mode)]
+	return ok
+}
+
 type IguazioConfig struct {
 	Timeout                time.Duration
 	VerificationURL        string

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/common"
 
 	"github.com/nuclio/errors"
@@ -329,6 +330,12 @@ func GetTriggersByKind(triggers map[string]Trigger, kind string) map[string]Trig
 	}
 
 	return matchingTrigger
+}
+
+// IsAuthenticationEnabled reports whether the trigger has a function-level authentication mode set.
+func IsAuthenticationEnabled(trigger *Trigger) bool {
+	mode, _ := trigger.Attributes[auth.AttributeAuthenticationMode].(string)
+	return auth.IsFunctionLevelAuthenticationMode(mode)
 }
 
 // GetHTTPTrigger returns the single HTTP trigger from triggers, or an error if there is not exactly one.

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -333,8 +333,7 @@ func GetTriggersByKind(triggers map[string]Trigger, kind string) map[string]Trig
 }
 
 // IsAuthenticationEnabled reports whether the trigger has a function-level authentication mode set.
-func IsAuthenticationEnabled(trigger *Trigger) bool {
-	mode, _ := trigger.Attributes[auth.AttributeAuthenticationMode].(string)
+func IsAuthenticationEnabled(mode string) bool {
 	return auth.IsFunctionLevelAuthenticationMode(mode)
 }
 
@@ -351,6 +350,17 @@ func GetHTTPTrigger(triggers map[string]Trigger) (Trigger, error) {
 		return trigger, nil
 	}
 	return Trigger{}, ErrHTTPTriggerNotFound
+}
+
+// GetHTTPTriggerMode returns the function-level authentication mode declared on the function's single HTTP
+// trigger, or an error if there is not exactly one HTTP trigger.
+func GetHTTPTriggerMode(triggers map[string]Trigger) (string, error) {
+	httpTrigger, err := GetHTTPTrigger(triggers)
+	if err != nil {
+		return "", err
+	}
+	mode, _ := httpTrigger.Attributes[auth.AttributeAuthenticationMode].(string)
+	return mode, nil
 }
 
 // GetTriggersByKinds returns a map of triggers by their kinds

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -338,16 +338,19 @@ func IsAuthenticationEnabled(trigger *Trigger) bool {
 	return auth.IsFunctionLevelAuthenticationMode(mode)
 }
 
+// ErrHTTPTriggerNotFound is returned by GetHTTPTrigger when no HTTP trigger exists.
+var ErrHTTPTriggerNotFound = errors.New("No HTTP trigger found in function config")
+
 // GetHTTPTrigger returns the single HTTP trigger from triggers, or an error if there is not exactly one.
 func GetHTTPTrigger(triggers map[string]Trigger) (Trigger, error) {
 	httpTriggers := GetTriggersByKind(triggers, "http")
 	if len(httpTriggers) > 1 {
 		return Trigger{}, errors.New("Expected exactly one HTTP trigger in function config")
 	}
-	for _, trigger := range triggers {
+	for _, trigger := range httpTriggers {
 		return trigger, nil
 	}
-	return Trigger{}, errors.New("No HTTP trigger found in function config")
+	return Trigger{}, ErrHTTPTriggerNotFound
 }
 
 // GetTriggersByKinds returns a map of triggers by their kinds

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1966,19 +1966,6 @@ func (ap *Platform) validateHTTPTriggerAuthentication(triggerKey string, trigger
 	return nil
 }
 
-// validateHTTPTriggerAuthentication validates the HTTP trigger's function-level authentication attributes.
-// It is gated by IsFunctionAuthenticationEnabled: when the flag is off the validation is ignored.
-func (ap *Platform) validateHTTPTriggerAuthentication(triggerKey string, triggerInstance *functionconfig.Trigger) error {
-	if !ap.IsFunctionAuthenticationEnabled() {
-		return nil
-	}
-	_, err := auth.FunctionAuthConfigFromAttributes(triggerInstance.Attributes, ap.Config.Authentication.DefaultMode)
-	if err != nil {
-		return nuclio.WrapErrBadRequest(errors.Wrapf(err, "Invalid function authentication for HTTP trigger %q", triggerKey))
-	}
-	return nil
-}
-
 func (ap *Platform) enrichMinMaxReplicas(functionConfig *functionconfig.Config) {
 
 	// if min replicas was not set, and max replicas is set, assign max replicas to min replicas

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1967,8 +1967,13 @@ func (ap *Platform) validateHTTPTriggerAuthentication(triggerKey string, trigger
 	if !ap.IsFunctionAuthenticationEnabled() {
 		return nil
 	}
-	if _, err := auth.FunctionAuthConfigFromAttributes(triggerInstance.Attributes, ap.Config.Authentication.DefaultAuthenticationMode); err != nil {
+	authConfig, err := auth.FunctionAuthConfigFromAttributes(triggerInstance.Attributes, ap.Config.Authentication.DefaultAuthenticationMode)
+	if err != nil {
 		return nuclio.WrapErrBadRequest(errors.Wrapf(err, "Invalid function authentication for HTTP trigger %q", triggerKey))
+	}
+	if authConfig.Mode == auth.AuthenticationModeBasicAuth &&
+		authConfig.BasicAuthUsername == "" || authConfig.BasicAuthPassword == "" {
+		return nuclio.NewErrBadRequest(fmt.Sprintf("Basic auth mode requires username and password for HTTP trigger %q", triggerKey))
 	}
 	return nil
 }

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1972,7 +1972,7 @@ func (ap *Platform) validateHTTPTriggerAuthentication(triggerKey string, trigger
 		return nuclio.WrapErrBadRequest(errors.Wrapf(err, "Invalid function authentication for HTTP trigger %q", triggerKey))
 	}
 	if authConfig.Mode == auth.AuthenticationModeBasicAuth &&
-		authConfig.BasicAuthUsername == "" || authConfig.BasicAuthPassword == "" {
+		(authConfig.BasicAuthUsername == "" || authConfig.BasicAuthPassword == "") {
 		return nuclio.NewErrBadRequest(fmt.Sprintf("Basic auth mode requires username and password for HTTP trigger %q", triggerKey))
 	}
 	return nil

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1961,6 +1961,18 @@ func (ap *Platform) validateHTTPTriggerAuthentication(triggerKey string, trigger
 	return nil
 }
 
+// validateHTTPTriggerAuthentication validates the HTTP trigger's function-level authentication attributes.
+// It is gated by IsFunctionAuthenticationEnabled: when the flag is off the validation is ignored.
+func (ap *Platform) validateHTTPTriggerAuthentication(triggerKey string, triggerInstance *functionconfig.Trigger) error {
+	if !ap.IsFunctionAuthenticationEnabled() {
+		return nil
+	}
+	if _, err := auth.FunctionAuthConfigFromAttributes(triggerInstance.Attributes, ap.Config.Authentication.DefaultAuthenticationMode); err != nil {
+		return nuclio.WrapErrBadRequest(errors.Wrapf(err, "Invalid function authentication for HTTP trigger %q", triggerKey))
+	}
+	return nil
+}
+
 func (ap *Platform) enrichMinMaxReplicas(functionConfig *functionconfig.Config) {
 
 	// if min replicas was not set, and max replicas is set, assign max replicas to min replicas

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -70,6 +70,14 @@ const (
 	FunctionContainerHTTPPortName        = "http"
 	FunctionContainerMetricPortName      = "metrics"
 	DefaultTargetCPU                     = 75
+
+	// FunctionContainerHTTPLoopbackPort is the port the processor listens on when the auth-proxy sidecar
+	// is injected in front of it: only reachable from within the pod (127.0.0.1), never exposed by the Service.
+	FunctionContainerHTTPLoopbackPort = 6080
+
+	// AuthProxySidecarContainerName is the reserved name of the platform-injected auth-proxy sidecar
+	// (see functionres.injectAuthProxySidecar). User-defined sidecars may not use this name.
+	AuthProxySidecarContainerName = "auth-proxy"
 )
 
 type Platform struct {
@@ -1069,10 +1077,7 @@ func (ap *Platform) GetDisableDefaultHttpTrigger() bool {
 }
 
 func (ap *Platform) IsFunctionAuthenticationEnabled() bool {
-	if ap.Config.Authentication == nil {
-		return false
-	}
-	return ap.Config.Authentication.FunctionAuthenticationEnabled
+	return ap.Config.IsFunctionAuthenticationEnabled()
 }
 
 // GetAllowedAuthenticationModes returns allowed authentication modes

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1967,13 +1967,9 @@ func (ap *Platform) validateHTTPTriggerAuthentication(triggerKey string, trigger
 	if !ap.IsFunctionAuthenticationEnabled() {
 		return nil
 	}
-	authConfig, err := auth.FunctionAuthConfigFromAttributes(triggerInstance.Attributes, ap.Config.Authentication.DefaultAuthenticationMode)
+	_, err := auth.FunctionAuthConfigFromAttributes(triggerInstance.Attributes, ap.Config.Authentication.DefaultMode)
 	if err != nil {
 		return nuclio.WrapErrBadRequest(errors.Wrapf(err, "Invalid function authentication for HTTP trigger %q", triggerKey))
-	}
-	if authConfig.Mode == auth.AuthenticationModeBasicAuth &&
-		(authConfig.BasicAuthUsername == "" || authConfig.BasicAuthPassword == "") {
-		return nuclio.NewErrBadRequest(fmt.Sprintf("Basic auth mode requires username and password for HTTP trigger %q", triggerKey))
 	}
 	return nil
 }

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -28,6 +28,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/common/annotations"
 	"github.com/nuclio/nuclio/pkg/common/headers"
@@ -1402,6 +1403,105 @@ func (lc *lazyClient) populateSupplementaryContainers(ctx context.Context,
 
 		deploymentSpec.Template.Spec.Containers = append(deploymentSpec.Template.Spec.Containers, *sidecarSpec)
 	}
+	if lc.functionAuthenticationEnabled(function) {
+		lc.injectAuthProxySidecar(ctx, function, deploymentSpec, volumeMounts)
+	}
+}
+
+// functionAuthenticationEnabled reports whether the auth-proxy sidecar should be injected in front of the
+// function: gated by the platform-wide feature flag AND the function's HTTP trigger declaring a
+// function-level authenticationMode (anything other than none/unset).
+func (lc *lazyClient) functionAuthenticationEnabled(function *nuclioio.NuclioFunction) bool {
+	if !lc.platformConfigurationProvider.GetPlatformConfiguration().IsFunctionAuthenticationEnabled() {
+		return false
+	}
+
+	//TODO - change to GetHTTPTrigger once PR#4226 will be merged
+	httpTriggers := functionconfig.GetTriggersByKind(function.Spec.Triggers, "http")
+	var httpTrigger *functionconfig.Trigger
+	for _, trigger := range httpTriggers {
+		httpTrigger = &trigger
+		break
+	}
+
+	if httpTrigger == nil {
+		return false
+	}
+
+	return functionconfig.IsAuthenticationEnabled(httpTrigger)
+}
+
+// injectAuthProxySidecar appends the platform's auth-proxy sidecar to the pod: it terminates
+// authentication for the function's traffic (the Kubernetes Service is repointed to it, see
+// populateServiceSpec) and forwards allowed requests to the processor, which by this point only listens
+// on the pod-local loopback (see rewriteHTTPTriggerURLToLoopback).
+func (lc *lazyClient) injectAuthProxySidecar(ctx context.Context,
+	function *nuclioio.NuclioFunction,
+	deploymentSpec *appsv1.DeploymentSpec,
+	volumeMounts []v1.VolumeMount) {
+
+	platformConfig := lc.platformConfigurationProvider.GetPlatformConfiguration()
+
+	// functionAuthenticationEnabled already found a valid HTTP trigger + authentication mode
+	//TODO - change to GetHTTPTrigger once PR#4226 will be merged
+	httpTriggers := functionconfig.GetTriggersByKind(function.Spec.Triggers, "http")
+	var httpTrigger *functionconfig.Trigger
+	for _, trigger := range httpTriggers {
+		httpTrigger = &trigger
+		break
+	}
+	if httpTrigger == nil {
+		lc.logger.WarnWithCtx(ctx, "No HTTP trigger found for function, skipping auth-proxy injection", "functionName", function.Name)
+		return
+	}
+
+	authMode, _ := httpTrigger.Attributes[auth.AttributeAuthenticationMode].(string)
+
+	args := []string{
+		fmt.Sprintf("--mode=%s", auth.ProxyModeReverseProxy),
+		fmt.Sprintf("--listen-ports=%d", abstract.FunctionContainerHTTPPort),
+		fmt.Sprintf("--upstream-url=http://127.0.0.1:%d", abstract.FunctionContainerHTTPLoopbackPort),
+		fmt.Sprintf("--auth-mode=%s", authMode),
+	}
+	if platformConfig.Authentication.AuthURL != "" {
+		args = append(args, fmt.Sprintf("--auth-url=%s", platformConfig.Authentication.AuthURL))
+	}
+	if platformConfig.Authentication.SignInURL != "" {
+		args = append(args, fmt.Sprintf("--signin-url=%s", platformConfig.Authentication.SignInURL))
+	}
+	if platformConfig.Authentication.AuthKind != "" {
+		args = append(args, fmt.Sprintf("--auth-kind=%s", platformConfig.Authentication.AuthKind))
+	}
+
+	container := v1.Container{
+		Name:         abstract.AuthProxySidecarContainerName,
+		Image:        platformConfig.Authentication.SidecarImage,
+		Args:         args,
+		VolumeMounts: volumeMounts,
+		Ports: []v1.ContainerPort{
+			{
+				Name:          abstract.FunctionContainerHTTPPortName,
+				ContainerPort: abstract.FunctionContainerHTTPPort,
+				Protocol:      v1.ProtocolTCP,
+			},
+		},
+	}
+
+	// basicAuth credentials are scrubbed onto the function's own secret; the sidecar restores them itself
+	// from the mounted processor config + secret (see cmd/authproxy/app/authproxy.go:readBasicAuthCredentials),
+	// mirroring how the processor restores its own configuration.
+	if auth.AuthenticationMode(authMode) == auth.AuthenticationModeBasicAuth {
+		container.Env = append(container.Env, v1.EnvVar{
+			Name:  common.RestoreConfigFromSecretEnvVar,
+			Value: "true",
+		})
+	}
+
+	lc.platformConfigurationProvider.GetPlatformConfiguration().EnrichSupplementaryContainerResources(ctx,
+		lc.logger,
+		&container.Resources)
+
+	deploymentSpec.Template.Spec.Containers = append(deploymentSpec.Template.Spec.Containers, container)
 }
 
 func (lc *lazyClient) resolveDeploymentStrategy(function *nuclioio.NuclioFunction) appsv1.DeploymentStrategyType {
@@ -2447,12 +2547,17 @@ func (lc *lazyClient) populateDeploymentContainer(ctx context.Context,
 	if function.Spec.EnvFrom != nil {
 		container.EnvFrom = function.Spec.EnvFrom
 	}
-	container.Ports = []v1.ContainerPort{
-		{
-			Name:          abstract.FunctionContainerHTTPPortName,
-			ContainerPort: abstract.FunctionContainerHTTPPort,
-			Protocol:      v1.ProtocolTCP,
-		},
+
+	// when the auth-proxy sidecar is injected, it - not the processor - owns the main HTTP port; the
+	// processor listens only on the pod-local loopback (see rewriteHTTPTriggerURLToLoopback)
+	if !lc.functionAuthenticationEnabled(function) {
+		container.Ports = []v1.ContainerPort{
+			{
+				Name:          abstract.FunctionContainerHTTPPortName,
+				ContainerPort: abstract.FunctionContainerHTTPPort,
+				Protocol:      v1.ProtocolTCP,
+			},
+		}
 	}
 
 	// iterate through metric sinks. if prometheus pull is configured, add containerMetricPort
@@ -2518,6 +2623,11 @@ func (lc *lazyClient) populateConfigMap(functionLabels labels.Set,
 	// create configMap contents - generate a processor configuration based on the function CR
 	configMapContents := bytes.Buffer{}
 
+	functionSpec := function.Spec
+	if lc.functionAuthenticationEnabled(function) {
+		functionSpec = rewriteHTTPTriggerURLToLoopback(functionSpec)
+	}
+
 	if err := configWriter.Write(&configMapContents, &processor.Configuration{
 		Config: functionconfig.Config{
 			Meta: functionconfig.Meta{
@@ -2526,7 +2636,7 @@ func (lc *lazyClient) populateConfigMap(functionLabels labels.Set,
 				Labels:      functionLabels,
 				Annotations: function.Annotations,
 			},
-			Spec: function.Spec,
+			Spec: functionSpec,
 		},
 	}); err != nil {
 
@@ -2545,6 +2655,23 @@ func (lc *lazyClient) populateConfigMap(functionLabels labels.Set,
 	}
 
 	return nil
+}
+
+// rewriteHTTPTriggerURLToLoopback returns a copy of spec whose HTTP trigger(s) listen on the pod-local
+// loopback instead of the wildcard address, so the processor is only reachable from within the pod - i.e.
+// via the auth-proxy sidecar that fronts it (see injectAuthProxySidecar). The given spec is never mutated:
+// its Triggers map is copied before being modified.
+func rewriteHTTPTriggerURLToLoopback(spec functionconfig.Spec) functionconfig.Spec {
+	triggers := make(map[string]functionconfig.Trigger, len(spec.Triggers))
+    //TODO - change to GetHTTPTrigger once PR#4226 will be merged
+	for triggerName, trigger := range spec.Triggers {
+		if trigger.Kind == "http" {
+			trigger.URL = fmt.Sprintf("127.0.0.1:%d", abstract.FunctionContainerHTTPLoopbackPort)
+		}
+		triggers[triggerName] = trigger
+	}
+	spec.Triggers = triggers
+	return spec
 }
 
 func (lc *lazyClient) getFunctionVolumeAndMounts(ctx context.Context,

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1416,19 +1416,12 @@ func (lc *lazyClient) functionAuthenticationEnabled(function *nuclioio.NuclioFun
 		return false
 	}
 
-	//TODO - change to GetHTTPTrigger once PR#4226 will be merged
-	httpTriggers := functionconfig.GetTriggersByKind(function.Spec.Triggers, "http")
-	var httpTrigger *functionconfig.Trigger
-	for _, trigger := range httpTriggers {
-		httpTrigger = &trigger
-		break
-	}
-
-	if httpTrigger == nil {
+	httpTrigger, err := functionconfig.GetHTTPTrigger(function.Spec.Triggers)
+	if err != nil {
 		return false
 	}
 
-	return functionconfig.IsAuthenticationEnabled(httpTrigger)
+	return functionconfig.IsAuthenticationEnabled(&httpTrigger)
 }
 
 // injectAuthProxySidecar appends the platform's auth-proxy sidecar to the pod: it terminates
@@ -1443,15 +1436,9 @@ func (lc *lazyClient) injectAuthProxySidecar(ctx context.Context,
 	platformConfig := lc.platformConfigurationProvider.GetPlatformConfiguration()
 
 	// functionAuthenticationEnabled already found a valid HTTP trigger + authentication mode
-	//TODO - change to GetHTTPTrigger once PR#4226 will be merged
-	httpTriggers := functionconfig.GetTriggersByKind(function.Spec.Triggers, "http")
-	var httpTrigger *functionconfig.Trigger
-	for _, trigger := range httpTriggers {
-		httpTrigger = &trigger
-		break
-	}
-	if httpTrigger == nil {
-		lc.logger.WarnWithCtx(ctx, "No HTTP trigger found for function, skipping auth-proxy injection", "functionName", function.Name)
+	httpTrigger, err := functionconfig.GetHTTPTrigger(function.Spec.Triggers)
+	if err != nil {
+		lc.logger.WarnWithCtx(ctx, "Failed to get http trigger for function, skipping auth-proxy injection", "functionName", function.Name, "err", err)
 		return
 	}
 
@@ -2663,7 +2650,6 @@ func (lc *lazyClient) populateConfigMap(functionLabels labels.Set,
 // its Triggers map is copied before being modified.
 func rewriteHTTPTriggerURLToLoopback(spec functionconfig.Spec) functionconfig.Spec {
 	triggers := make(map[string]functionconfig.Trigger, len(spec.Triggers))
-    //TODO - change to GetHTTPTrigger once PR#4226 will be merged
 	for triggerName, trigger := range spec.Triggers {
 		if trigger.Kind == "http" {
 			trigger.URL = fmt.Sprintf("127.0.0.1:%d", abstract.FunctionContainerHTTPLoopbackPort)

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1416,12 +1416,12 @@ func (lc *lazyClient) functionAuthenticationEnabled(function *nuclioio.NuclioFun
 		return false
 	}
 
-	httpTrigger, err := functionconfig.GetHTTPTrigger(function.Spec.Triggers)
+	authMode, err := functionconfig.GetHTTPTriggerMode(function.Spec.Triggers)
 	if err != nil {
 		return false
 	}
 
-	return functionconfig.IsAuthenticationEnabled(&httpTrigger)
+	return functionconfig.IsAuthenticationEnabled(authMode)
 }
 
 // injectAuthProxySidecar appends the platform's auth-proxy sidecar to the pod: it terminates
@@ -1436,13 +1436,11 @@ func (lc *lazyClient) injectAuthProxySidecar(ctx context.Context,
 	platformConfig := lc.platformConfigurationProvider.GetPlatformConfiguration()
 
 	// functionAuthenticationEnabled already found a valid HTTP trigger + authentication mode
-	httpTrigger, err := functionconfig.GetHTTPTrigger(function.Spec.Triggers)
+	authMode, err := functionconfig.GetHTTPTriggerMode(function.Spec.Triggers)
 	if err != nil {
-		lc.logger.WarnWithCtx(ctx, "Failed to get http trigger for function, skipping auth-proxy injection", "functionName", function.Name, "err", err)
+		lc.logger.WarnWithCtx(ctx, "Failed to get http trigger mode for function, skipping auth-proxy injection", "functionName", function.Name, "err", err)
 		return
 	}
-
-	authMode, _ := httpTrigger.Attributes[auth.AttributeAuthenticationMode].(string)
 
 	args := []string{
 		fmt.Sprintf("--mode=%s", auth.ProxyModeReverseProxy),

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1444,7 +1444,7 @@ func (lc *lazyClient) injectAuthProxySidecar(ctx context.Context,
 
 	args := []string{
 		fmt.Sprintf("--mode=%s", auth.ProxyModeReverseProxy),
-		fmt.Sprintf("--listen-ports=%d", abstract.FunctionContainerHTTPPort),
+		fmt.Sprintf("--listen-port=%d", abstract.FunctionContainerHTTPPort),
 		fmt.Sprintf("--upstream-url=http://127.0.0.1:%d", abstract.FunctionContainerHTTPLoopbackPort),
 		fmt.Sprintf("--auth-mode=%s", authMode),
 	}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1462,7 +1462,7 @@ func (lc *lazyClient) injectAuthProxySidecar(ctx context.Context,
 
 	container := v1.Container{
 		Name:         abstract.AuthProxySidecarContainerName,
-		Image:        platformConfig.Authentication.SidecarImage,
+		Image:        platformConfig.Authentication.AuthSidecarImage,
 		Args:         args,
 		VolumeMounts: volumeMounts,
 		Ports: []v1.ContainerPort{

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -667,7 +667,7 @@ func (suite *lazyTestSuite) TestInjectAuthProxySidecar() {
 				platformConfiguration: &platformconfig.Config{
 					Authentication: &platformconfig.Authentication{
 						FunctionAuthenticationEnabled: true,
-						SidecarImage:                  "nuclio/auth-proxy:latest",
+						AuthSidecarImage:              "nuclio/auth-proxy:latest",
 						AuthURL:                       "http://auth.example.com",
 						SignInURL:                     "http://signin.example.com",
 						AuthKind:                      auth.KindIguazio,

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -702,7 +702,7 @@ func (suite *lazyTestSuite) TestInjectAuthProxySidecar() {
 			suite.Require().Equal(abstract.AuthProxySidecarContainerName, sidecar.Name)
 			suite.Require().Equal("nuclio/auth-proxy:latest", sidecar.Image)
 			suite.Require().Contains(sidecar.Args, "--mode=reverseProxy")
-			suite.Require().Contains(sidecar.Args, fmt.Sprintf("--listen-ports=%d", abstract.FunctionContainerHTTPPort))
+			suite.Require().Contains(sidecar.Args, fmt.Sprintf("--listen-port=%d", abstract.FunctionContainerHTTPPort))
 			suite.Require().Contains(sidecar.Args,
 				fmt.Sprintf("--upstream-url=http://127.0.0.1:%d", abstract.FunctionContainerHTTPLoopbackPort))
 			suite.Require().Contains(sidecar.Args, fmt.Sprintf("--auth-mode=%s", testCase.authenticationMode))

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -20,11 +20,13 @@ package functionres
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/common/annotations"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
@@ -33,6 +35,8 @@ import (
 	"github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
 	nuclioiofake "github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio/clientset/versioned/fake"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
+	"github.com/nuclio/nuclio/pkg/processor"
+	processorconfig "github.com/nuclio/nuclio/pkg/processor/config"
 
 	"dario.cat/mergo"
 	"github.com/google/go-cmp/cmp"
@@ -561,6 +565,294 @@ func (suite *lazyTestSuite) TestScaleToZeroSpecificAnnotations() {
 		&networkingv1.IngressSpec{})
 	suite.Require().NoError(err)
 	suite.Require().Equal("added", ingressMeta.Annotations["something"])
+}
+
+// TestFunctionAuthenticationEnabled verifies the auth-proxy gate: the platform-wide feature flag AND a
+// function-level authenticationMode (other than none/unset) on the HTTP trigger must both hold.
+func (suite *lazyTestSuite) TestFunctionAuthenticationEnabled() {
+	for _, testCase := range []struct {
+		name                          string
+		functionAuthenticationEnabled bool
+		authenticationMode            string
+		noHTTPTrigger                 bool
+		expected                      bool
+	}{
+		{
+			name:                          "disabled when feature flag is off",
+			functionAuthenticationEnabled: false,
+			authenticationMode:            string(auth.AuthenticationModeBasicAuth),
+		},
+		{
+			name:                          "disabled when authenticationMode is none",
+			functionAuthenticationEnabled: true,
+			authenticationMode:            string(auth.AuthenticationModeNone),
+		},
+		{
+			name:                          "disabled when authenticationMode is unset",
+			functionAuthenticationEnabled: true,
+		},
+		{
+			name:                          "disabled when there is no HTTP trigger",
+			functionAuthenticationEnabled: true,
+			authenticationMode:            string(auth.AuthenticationModeBasicAuth),
+			noHTTPTrigger:                 true,
+		},
+		{
+			name:                          "enabled for basicAuth",
+			functionAuthenticationEnabled: true,
+			authenticationMode:            string(auth.AuthenticationModeBasicAuth),
+			expected:                      true,
+		},
+		{
+			name:                          "enabled for api",
+			functionAuthenticationEnabled: true,
+			authenticationMode:            string(auth.AuthenticationModeAPI),
+			expected:                      true,
+		},
+		{
+			name:                          "enabled for browser",
+			functionAuthenticationEnabled: true,
+			authenticationMode:            string(auth.AuthenticationModeBrowser),
+			expected:                      true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.client.SetPlatformConfigurationProvider(&mockedPlatformConfigurationProvider{
+				platformConfiguration: &platformconfig.Config{
+					Authentication: &platformconfig.Authentication{
+						FunctionAuthenticationEnabled: testCase.functionAuthenticationEnabled,
+					},
+				},
+			})
+
+			functionInstance := &nuclioio.NuclioFunction{}
+			if !testCase.noHTTPTrigger {
+				httpTrigger := functionconfig.GetDefaultHTTPTrigger()
+				httpTrigger.Attributes = map[string]interface{}{
+					auth.AttributeAuthenticationMode: testCase.authenticationMode,
+				}
+				functionInstance.Spec.Triggers = map[string]functionconfig.Trigger{
+					"http": httpTrigger,
+				}
+			}
+
+			suite.Require().Equal(testCase.expected, suite.client.functionAuthenticationEnabled(functionInstance))
+		})
+	}
+}
+
+// TestInjectAuthProxySidecar verifies the auth-proxy sidecar is appended with the expected image/args/ports,
+// and that the config-restore env var is only set for basicAuth mode (api/browser have no credentials to
+// restore).
+func (suite *lazyTestSuite) TestInjectAuthProxySidecar() {
+	for _, testCase := range []struct {
+		name                string
+		authenticationMode  auth.AuthenticationMode
+		expectedRestoreEnvs []v1.EnvVar
+	}{
+		{
+			name:               "basicAuth restores config from the mounted secret",
+			authenticationMode: auth.AuthenticationModeBasicAuth,
+			expectedRestoreEnvs: []v1.EnvVar{
+				{Name: common.RestoreConfigFromSecretEnvVar, Value: "true"},
+			},
+		},
+		{
+			name:               "api mode does not need to restore anything",
+			authenticationMode: auth.AuthenticationModeAPI,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.client.SetPlatformConfigurationProvider(&mockedPlatformConfigurationProvider{
+				platformConfiguration: &platformconfig.Config{
+					Authentication: &platformconfig.Authentication{
+						FunctionAuthenticationEnabled: true,
+						SidecarImage:                  "nuclio/auth-proxy:latest",
+						AuthURL:                       "http://auth.example.com",
+						SignInURL:                     "http://signin.example.com",
+						AuthKind:                      auth.KindIguazio,
+					},
+				},
+			})
+
+			httpTrigger := functionconfig.GetDefaultHTTPTrigger()
+			httpTrigger.Attributes = map[string]interface{}{
+				auth.AttributeAuthenticationMode: string(testCase.authenticationMode),
+			}
+			functionInstance := &nuclioio.NuclioFunction{}
+			functionInstance.Name = "func-name"
+			functionInstance.Spec.Triggers = map[string]functionconfig.Trigger{
+				"http": httpTrigger,
+			}
+
+			deploymentSpec := &appsv1.DeploymentSpec{
+				Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{Name: common.FunctionContainerName},
+						},
+					},
+				},
+			}
+
+			suite.client.injectAuthProxySidecar(suite.ctx, functionInstance, deploymentSpec, nil)
+
+			suite.Require().Len(deploymentSpec.Template.Spec.Containers, 2)
+			sidecar := deploymentSpec.Template.Spec.Containers[1]
+			suite.Require().Equal(abstract.AuthProxySidecarContainerName, sidecar.Name)
+			suite.Require().Equal("nuclio/auth-proxy:latest", sidecar.Image)
+			suite.Require().Contains(sidecar.Args, "--mode=reverseProxy")
+			suite.Require().Contains(sidecar.Args, fmt.Sprintf("--listen-ports=%d", abstract.FunctionContainerHTTPPort))
+			suite.Require().Contains(sidecar.Args,
+				fmt.Sprintf("--upstream-url=http://127.0.0.1:%d", abstract.FunctionContainerHTTPLoopbackPort))
+			suite.Require().Contains(sidecar.Args, fmt.Sprintf("--auth-mode=%s", testCase.authenticationMode))
+			suite.Require().Contains(sidecar.Args, "--auth-url=http://auth.example.com")
+			suite.Require().Contains(sidecar.Args, "--signin-url=http://signin.example.com")
+			suite.Require().Contains(sidecar.Args, fmt.Sprintf("--auth-kind=%s", auth.KindIguazio))
+			suite.Require().Equal([]v1.ContainerPort{
+				{
+					Name:          abstract.FunctionContainerHTTPPortName,
+					ContainerPort: abstract.FunctionContainerHTTPPort,
+					Protocol:      v1.ProtocolTCP,
+				},
+			}, sidecar.Ports)
+			suite.Require().Equal(testCase.expectedRestoreEnvs, sidecar.Env)
+		})
+	}
+}
+
+// TestPopulateSupplementaryContainersInjectsAuthProxyWhenGated verifies the auth-proxy sidecar is only
+// appended to the pod when function-level authentication is gated on.
+func (suite *lazyTestSuite) TestPopulateSupplementaryContainersInjectsAuthProxyWhenGated() {
+	for _, testCase := range []struct {
+		name                   string
+		functionAuthEnabled    bool
+		expectAuthProxySidecar bool
+	}{
+		{name: "not injected when gate is off", functionAuthEnabled: false, expectAuthProxySidecar: false},
+		{name: "injected when gate is on", functionAuthEnabled: true, expectAuthProxySidecar: true},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.client.SetPlatformConfigurationProvider(&mockedPlatformConfigurationProvider{
+				platformConfiguration: &platformconfig.Config{
+					Authentication: &platformconfig.Authentication{
+						FunctionAuthenticationEnabled: testCase.functionAuthEnabled,
+					},
+				},
+			})
+
+			httpTrigger := functionconfig.GetDefaultHTTPTrigger()
+			httpTrigger.Attributes = map[string]interface{}{
+				auth.AttributeAuthenticationMode: string(auth.AuthenticationModeBasicAuth),
+			}
+			functionInstance := &nuclioio.NuclioFunction{}
+			functionInstance.Spec.Triggers = map[string]functionconfig.Trigger{
+				"http": httpTrigger,
+			}
+
+			deploymentSpec := &appsv1.DeploymentSpec{
+				Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{Name: common.FunctionContainerName},
+						},
+					},
+				},
+			}
+
+			suite.client.populateSupplementaryContainers(suite.ctx, functionInstance, deploymentSpec, nil)
+
+			hasAuthProxy := false
+			for _, container := range deploymentSpec.Template.Spec.Containers {
+				if container.Name == abstract.AuthProxySidecarContainerName {
+					hasAuthProxy = true
+				}
+			}
+			suite.Require().Equal(testCase.expectAuthProxySidecar, hasAuthProxy)
+		})
+	}
+}
+
+// TestPopulateDeploymentContainerRemovesHTTPPortWhenAuthProxyFronts verifies the processor container no
+// longer declares the main HTTP port once the auth-proxy sidecar takes over listening on it.
+func (suite *lazyTestSuite) TestPopulateDeploymentContainerRemovesHTTPPortWhenAuthProxyFronts() {
+	for _, testCase := range []struct {
+		name                string
+		functionAuthEnabled bool
+		expectHTTPPort      bool
+	}{
+		{name: "keeps HTTP port when gate is off", functionAuthEnabled: false, expectHTTPPort: true},
+		{name: "removes HTTP port when gate is on", functionAuthEnabled: true, expectHTTPPort: false},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.client.SetPlatformConfigurationProvider(&mockedPlatformConfigurationProvider{
+				platformConfiguration: &platformconfig.Config{
+					Authentication: &platformconfig.Authentication{
+						FunctionAuthenticationEnabled: testCase.functionAuthEnabled,
+					},
+				},
+			})
+
+			httpTrigger := functionconfig.GetDefaultHTTPTrigger()
+			httpTrigger.Attributes = map[string]interface{}{
+				auth.AttributeAuthenticationMode: string(auth.AuthenticationModeBasicAuth),
+			}
+			functionInstance := suite.getFunctionInstanceWithDefaultProbes("func-name")
+			functionInstance.Spec.Triggers = map[string]functionconfig.Trigger{
+				"http": httpTrigger,
+			}
+
+			functionLabels := suite.client.getFunctionLabels(functionInstance)
+			container := &v1.Container{}
+			suite.client.populateDeploymentContainer(suite.ctx, functionLabels, functionInstance, container)
+
+			hasHTTPPort := false
+			for _, port := range container.Ports {
+				if port.Name == abstract.FunctionContainerHTTPPortName {
+					hasHTTPPort = true
+				}
+			}
+			suite.Require().Equal(testCase.expectHTTPPort, hasHTTPPort)
+		})
+	}
+}
+
+// TestPopulateConfigMapRewritesHTTPTriggerURLToLoopback verifies the processor's HTTP trigger is
+// configured to listen on the pod-local loopback (reachable only via the auth-proxy sidecar) once the
+// gate is on, and that the function's own Spec is never mutated in the process.
+func (suite *lazyTestSuite) TestPopulateConfigMapRewritesHTTPTriggerURLToLoopback() {
+	suite.client.SetPlatformConfigurationProvider(&mockedPlatformConfigurationProvider{
+		platformConfiguration: &platformconfig.Config{
+			Authentication: &platformconfig.Authentication{
+				FunctionAuthenticationEnabled: true,
+			},
+		},
+	})
+
+	httpTrigger := functionconfig.GetDefaultHTTPTrigger()
+	httpTrigger.Attributes = map[string]interface{}{
+		auth.AttributeAuthenticationMode: string(auth.AuthenticationModeBasicAuth),
+	}
+	functionInstance := &nuclioio.NuclioFunction{}
+	functionInstance.Name = "func-name"
+	functionInstance.Spec.Triggers = map[string]functionconfig.Trigger{
+		"http": httpTrigger,
+	}
+
+	functionLabels := suite.client.getFunctionLabels(functionInstance)
+	configMap := &v1.ConfigMap{}
+	suite.Require().NoError(suite.client.populateConfigMap(functionLabels, functionInstance, configMap))
+
+	reader, err := processorconfig.NewReader()
+	suite.Require().NoError(err)
+
+	var writtenConfiguration processor.Configuration
+	suite.Require().NoError(reader.Read(strings.NewReader(configMap.Data["processor.yaml"]), &writtenConfiguration))
+	suite.Require().Equal(fmt.Sprintf("127.0.0.1:%d", abstract.FunctionContainerHTTPLoopbackPort),
+		writtenConfiguration.Config.Spec.Triggers["http"].URL)
+
+	// the original function spec must remain untouched
+	suite.Require().Empty(functionInstance.Spec.Triggers["http"].URL)
 }
 
 func (suite *lazyTestSuite) TestTriggerDefinedMultipleIngresses() {

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -2243,15 +2243,16 @@ func (p *Platform) validateSidecarNameNotReserved(functionConfig *functionconfig
 		return nil
 	}
 
-	//TODO - change to GetHTTPTrigger once PR#4226 will be merged
-	httpTriggers := functionconfig.GetTriggersByKind(functionConfig.Spec.Triggers, "http")
-	var httpTrigger *functionconfig.Trigger
-	for _, trigger := range httpTriggers {
-		httpTrigger = &trigger
-		break
+	httpTrigger, err := functionconfig.GetHTTPTrigger(functionConfig.Spec.Triggers)
+	if err != nil {
+		// no HTTP trigger means auth proxy is not relevant, so the sidecar name is not reserved
+		if errors.Is(err, functionconfig.ErrHTTPTriggerNotFound) {
+			return nil
+		}
+		return nuclio.WrapErrBadRequest(err)
 	}
 
-	if httpTrigger == nil || !functionconfig.IsAuthenticationEnabled(httpTrigger) {
+	if !functionconfig.IsAuthenticationEnabled(&httpTrigger) {
 		return nil
 	}
 
@@ -2307,13 +2308,15 @@ func (p *Platform) validateContainerPorts(functionConfig *functionconfig.Config,
 
 			// when function-level auth is active, the loopback port is also reserved
 			if p.IsFunctionAuthenticationEnabled() {
-				//TODO - change to GetHTTPTrigger once PR#4226 will be merged
-				var httpTrigger *functionconfig.Trigger
-				for _, trigger := range functionconfig.GetTriggersByKind(functionConfig.Spec.Triggers, "http") {
-					httpTrigger = &trigger
-					break
+				httpTrigger, err := functionconfig.GetHTTPTrigger(functionConfig.Spec.Triggers)
+				if err != nil {
+					// if there is no HTTP trigger, no need to validate the loopback port
+					if errors.Is(err, functionconfig.ErrHTTPTriggerNotFound) {
+						return nil
+					}
+					return nuclio.WrapErrBadRequest(err)
 				}
-				if httpTrigger != nil && functionconfig.IsAuthenticationEnabled(httpTrigger) &&
+				if functionconfig.IsAuthenticationEnabled(&httpTrigger) &&
 					port.ContainerPort == abstract.FunctionContainerHTTPLoopbackPort {
 					return nuclio.NewErrBadRequest(fmt.Sprintf("Container port %d is reserved for Nuclio internal use", port.ContainerPort))
 				}

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -2219,12 +2219,15 @@ func (p *Platform) validateAPIGatewayIngresses(ctx context.Context, apiGatewayCo
 }
 
 func (p *Platform) validateSidecarSpec(functionConfig *functionconfig.Config) error {
+	portNames := make(map[string]bool)
+	portNumbers := make(map[int32]bool)
+
 	for _, sidecar := range functionConfig.Spec.Sidecars {
 		if err := p.validateContainerSpec(sidecar); err != nil {
 			return nuclio.WrapErrBadRequest(err)
 		}
 
-		if err := p.validateContainerPorts(functionConfig, sidecar); err != nil {
+		if err := p.validateContainerPorts(functionConfig, sidecar, portNames, portNumbers); err != nil {
 			return nuclio.WrapErrBadRequest(err)
 		}
 
@@ -2285,11 +2288,11 @@ func (p *Platform) validateContainerSpec(container *v1.Container) error {
 	return nil
 }
 
-func (p *Platform) validateContainerPorts(functionConfig *functionconfig.Config, container *v1.Container) error {
+func (p *Platform) validateContainerPorts(functionConfig *functionconfig.Config,
+	container *v1.Container,
+	portNames map[string]bool,
+	portNumbers map[int32]bool) error {
 	if container.Ports != nil {
-		portNames := make(map[string]bool)
-		portNumbers := make(map[int32]bool)
-
 		for _, port := range container.Ports {
 			// validate container port exists
 			if port.ContainerPort == 0 {
@@ -2335,14 +2338,14 @@ func (p *Platform) validateContainerPorts(functionConfig *functionconfig.Config,
 				return nuclio.NewErrBadRequest(fmt.Sprintf("Port name %s is reserved for Nuclio internal use", port.Name))
 			}
 
-			// validate port name is unique
+			// validate port name is unique across all sidecar containers
 			if _, exists := portNames[port.Name]; exists {
-				return nuclio.NewErrBadRequest(fmt.Sprintf("Port name %s is duplicated in container %s", port.Name, container.Name))
+				return nuclio.NewErrBadRequest(fmt.Sprintf("Port name %s is duplicated across sidecar containers", port.Name))
 			}
 
-			// validate port number is unique
+			// validate port number is unique across all sidecar containers
 			if _, exists := portNumbers[port.ContainerPort]; exists {
-				return nuclio.NewErrBadRequest(fmt.Sprintf("Port number %d is duplicated in container %s", port.ContainerPort, container.Name))
+				return nuclio.NewErrBadRequest(fmt.Sprintf("Port number %d is duplicated across sidecar containers", port.ContainerPort))
 			}
 
 			portNames[port.Name] = true

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -2246,7 +2246,7 @@ func (p *Platform) validateSidecarNameNotReserved(functionConfig *functionconfig
 		return nil
 	}
 
-	httpTrigger, err := functionconfig.GetHTTPTrigger(functionConfig.Spec.Triggers)
+	authMode, err := functionconfig.GetHTTPTriggerMode(functionConfig.Spec.Triggers)
 	if err != nil {
 		// no HTTP trigger means auth proxy is not relevant, so the sidecar name is not reserved
 		if errors.Is(err, functionconfig.ErrHTTPTriggerNotFound) {
@@ -2255,7 +2255,7 @@ func (p *Platform) validateSidecarNameNotReserved(functionConfig *functionconfig
 		return nuclio.WrapErrBadRequest(err)
 	}
 
-	if !functionconfig.IsAuthenticationEnabled(&httpTrigger) {
+	if !functionconfig.IsAuthenticationEnabled(authMode) {
 		return nil
 	}
 
@@ -2311,7 +2311,7 @@ func (p *Platform) validateContainerPorts(functionConfig *functionconfig.Config,
 
 			// when function-level auth is active, the loopback port is also reserved
 			if p.IsFunctionAuthenticationEnabled() {
-				httpTrigger, err := functionconfig.GetHTTPTrigger(functionConfig.Spec.Triggers)
+				authMode, err := functionconfig.GetHTTPTriggerMode(functionConfig.Spec.Triggers)
 				if err != nil {
 					// if there is no HTTP trigger, no need to validate the loopback port
 					if errors.Is(err, functionconfig.ErrHTTPTriggerNotFound) {
@@ -2319,7 +2319,7 @@ func (p *Platform) validateContainerPorts(functionConfig *functionconfig.Config,
 					}
 					return nuclio.WrapErrBadRequest(err)
 				}
-				if functionconfig.IsAuthenticationEnabled(&httpTrigger) &&
+				if functionconfig.IsAuthenticationEnabled(authMode) &&
 					port.ContainerPort == abstract.FunctionContainerHTTPLoopbackPort {
 					return nuclio.NewErrBadRequest(fmt.Sprintf("Container port %d is reserved for Nuclio internal use", port.ContainerPort))
 				}

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -2224,11 +2224,41 @@ func (p *Platform) validateSidecarSpec(functionConfig *functionconfig.Config) er
 			return nuclio.WrapErrBadRequest(err)
 		}
 
-		if err := p.validateContainerPorts(sidecar); err != nil {
+		if err := p.validateContainerPorts(functionConfig, sidecar); err != nil {
+			return nuclio.WrapErrBadRequest(err)
+		}
+
+		if err := p.validateSidecarNameNotReserved(functionConfig, sidecar); err != nil {
 			return nuclio.WrapErrBadRequest(err)
 		}
 	}
 
+	return nil
+}
+
+// validateSidecarNameNotReserved rejects a user-supplied sidecar named abstract.AuthProxySidecarContainerName,
+// which is reserved for the platform-injected auth-proxy sidecar (see functionres.injectAuthProxySidecar).
+func (p *Platform) validateSidecarNameNotReserved(functionConfig *functionconfig.Config, sidecar *v1.Container) error {
+	if !p.IsFunctionAuthenticationEnabled() {
+		return nil
+	}
+
+	//TODO - change to GetHTTPTrigger once PR#4226 will be merged
+	httpTriggers := functionconfig.GetTriggersByKind(functionConfig.Spec.Triggers, "http")
+	var httpTrigger *functionconfig.Trigger
+	for _, trigger := range httpTriggers {
+		httpTrigger = &trigger
+		break
+	}
+
+	if httpTrigger == nil || !functionconfig.IsAuthenticationEnabled(httpTrigger) {
+		return nil
+	}
+
+	if sidecar.Name == abstract.AuthProxySidecarContainerName {
+		return nuclio.NewErrBadRequest(fmt.Sprintf("Reserved sidecar name: %s",
+			abstract.AuthProxySidecarContainerName))
+	}
 	return nil
 }
 
@@ -2254,7 +2284,7 @@ func (p *Platform) validateContainerSpec(container *v1.Container) error {
 	return nil
 }
 
-func (p *Platform) validateContainerPorts(container *v1.Container) error {
+func (p *Platform) validateContainerPorts(functionConfig *functionconfig.Config, container *v1.Container) error {
 	if container.Ports != nil {
 		portNames := make(map[string]bool)
 		portNumbers := make(map[int32]bool)
@@ -2273,6 +2303,20 @@ func (p *Platform) validateContainerPorts(container *v1.Container) error {
 				abstract.FunctionContainerMetricPort,
 			}, int(port.ContainerPort)) {
 				return nuclio.NewErrBadRequest(fmt.Sprintf("Container port %d is reserved for Nuclio internal use", port.ContainerPort))
+			}
+
+			// when function-level auth is active, the loopback port is also reserved
+			if p.IsFunctionAuthenticationEnabled() {
+				//TODO - change to GetHTTPTrigger once PR#4226 will be merged
+				var httpTrigger *functionconfig.Trigger
+				for _, trigger := range functionconfig.GetTriggersByKind(functionConfig.Spec.Triggers, "http") {
+					httpTrigger = &trigger
+					break
+				}
+				if httpTrigger != nil && functionconfig.IsAuthenticationEnabled(httpTrigger) &&
+					port.ContainerPort == abstract.FunctionContainerHTTPLoopbackPort {
+					return nuclio.NewErrBadRequest(fmt.Sprintf("Container port %d is reserved for Nuclio internal use", port.ContainerPort))
+				}
 			}
 
 			// validate port name exists

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -696,7 +696,7 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateSidecarContainers() {
 			shouldFailValidation: true,
 		},
 		{
-			name: "invalidReservedAuthProxySidecarName",
+			name: "reservedAuthProxySidecarNameAndAuthProxyDisabled",
 			sidecars: []*v1.Container{
 				{
 					Name:  abstract.AuthProxySidecarContainerName,
@@ -709,7 +709,6 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateSidecarContainers() {
 					},
 				},
 			},
-			shouldFailValidation: true,
 		},
 	} {
 		suite.Run(testCase.name, func() {

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -500,6 +500,58 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateSidecarContainers() {
 			},
 		},
 		{
+			name: "invalidDuplicateContainerPortNumberAcrossSidecars",
+			sidecars: []*v1.Container{
+				{
+					Name:  sidcarContainerName,
+					Image: "nginx",
+					Ports: []v1.ContainerPort{
+						{
+							Name:          sidcarPortName,
+							ContainerPort: 80,
+						},
+					},
+				},
+				{
+					Name:  "sidecar2",
+					Image: "alpine",
+					Ports: []v1.ContainerPort{
+						{
+							Name:          fmt.Sprintf("%s-2", sidcarPortName),
+							ContainerPort: 80,
+						},
+					},
+				},
+			},
+			shouldFailValidation: true,
+		},
+		{
+			name: "invalidDuplicateContainerPortNameAcrossSidecars",
+			sidecars: []*v1.Container{
+				{
+					Name:  sidcarContainerName,
+					Image: "nginx",
+					Ports: []v1.ContainerPort{
+						{
+							Name:          sidcarPortName,
+							ContainerPort: 80,
+						},
+					},
+				},
+				{
+					Name:  "sidecar2",
+					Image: "alpine",
+					Ports: []v1.ContainerPort{
+						{
+							Name:          sidcarPortName,
+							ContainerPort: 90,
+						},
+					},
+				},
+			},
+			shouldFailValidation: true,
+		},
+		{
 			name: "invalidNoName",
 			sidecars: []*v1.Container{
 				{

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -695,6 +695,22 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateSidecarContainers() {
 			},
 			shouldFailValidation: true,
 		},
+		{
+			name: "invalidReservedAuthProxySidecarName",
+			sidecars: []*v1.Container{
+				{
+					Name:  abstract.AuthProxySidecarContainerName,
+					Image: "nginx",
+					Ports: []v1.ContainerPort{
+						{
+							Name:          sidcarPortName,
+							ContainerPort: 80,
+						},
+					},
+				},
+			},
+			shouldFailValidation: true,
+		},
 	} {
 		suite.Run(testCase.name, func() {
 			suite.mockedPlatform.

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -428,9 +428,19 @@ func (c *Config) ValidatePlatformConfig() error {
 }
 
 func (c *Config) validateAuthentication() error {
+	if !c.IsFunctionAuthenticationEnabled() {
+		return nil
+	}
+
 	if c.Authentication == nil {
 		return errors.New("Authentication config is nil after enrichment")
 	}
+
+	// without an image, the platform would inject a sidecar container k8s rejects the deployment for
+	if c.Authentication.AuthSidecarImage == "" {
+		return errors.New("AuthSidecarImage must be set when functionAuthenticationEnabled is true")
+	}
+
 	// basicAuth cannot be the platform-wide default: it requires per-function credentials
 	// (username + password) that cannot be supplied at the platform config level.
 	if c.Authentication.DefaultMode == auth.AuthenticationModeBasicAuth {

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -594,6 +594,15 @@ func (c *Config) enrichLocalPlatform() {
 	}
 }
 
+// IsFunctionAuthenticationEnabled reports whether the platform-wide function-level authentication
+// feature flag is enabled (gates injecting the auth-proxy sidecar in front of function pods).
+func (c *Config) IsFunctionAuthenticationEnabled() bool {
+	if c.Authentication == nil {
+		return false
+	}
+	return c.Authentication.FunctionAuthenticationEnabled
+}
+
 func (c *Config) enrichAuthentication() {
 	if c.Authentication == nil {
 		c.Authentication = &Authentication{}

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -1195,7 +1195,40 @@ func (suite *PlatformConfigTestSuite) TestValidatePlatformConfigDefaultMode() {
 		suite.Run(testCase.name, func() {
 			config := &Config{
 				RuntimeBaseImages: map[string]string{"test-runtime": "test-image"},
-				Authentication:    &Authentication{DefaultMode: testCase.mode},
+				Authentication: &Authentication{
+					FunctionAuthenticationEnabled: true,
+					AuthSidecarImage:              "nuclio/auth-proxy:latest",
+					DefaultMode:                   testCase.mode,
+				},
+			}
+			err := config.ValidatePlatformConfig()
+			if testCase.expectError {
+				suite.Require().Error(err)
+				suite.Contains(err.Error(), "authentication config")
+				return
+			}
+			suite.Require().NoError(err)
+		})
+	}
+}
+
+func (suite *PlatformConfigTestSuite) TestValidatePlatformConfigAuthSidecarImage() {
+	for _, testCase := range []struct {
+		name             string
+		authSidecarImage string
+		expectError      bool
+	}{
+		{name: "empty image rejected", authSidecarImage: "", expectError: true},
+		{name: "image set", authSidecarImage: "nuclio/auth-proxy:latest"},
+	} {
+		suite.Run(testCase.name, func() {
+			config := &Config{
+				RuntimeBaseImages: map[string]string{"test-runtime": "test-image"},
+				Authentication: &Authentication{
+					FunctionAuthenticationEnabled: true,
+					AuthSidecarImage:              testCase.authSidecarImage,
+					DefaultMode:                   auth.AuthenticationModeNone,
+				},
 			}
 			err := config.ValidatePlatformConfig()
 			if testCase.expectError {

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -520,6 +520,9 @@ type Authentication struct {
 	// Defaults to the value set in the OPA config (Opa.AuthKind).
 	AuthKind auth.Kind `json:"authKind,omitempty"`
 
+	// SidecarImage is the image used for the platform-injected auth-proxy sidecar container.
+	SidecarImage string `json:"sidecarImage,omitempty"`
+
 	// AllowedModes lists the function-level authentication modes the platform permits.
 	AllowedModes []string `json:"allowedModes,omitempty"`
 

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -520,8 +520,8 @@ type Authentication struct {
 	// Defaults to the value set in the OPA config (Opa.AuthKind).
 	AuthKind auth.Kind `json:"authKind,omitempty"`
 
-	// SidecarImage is the image used for the platform-injected auth-proxy sidecar container.
-	SidecarImage string `json:"sidecarImage,omitempty"`
+	// AuthSidecarImage is the image used for the platform-injected auth-proxy sidecar container.
+	AuthSidecarImage string `json:"authSidecarImage,omitempty"`
 
 	// AllowedModes lists the function-level authentication modes the platform permits.
 	AllowedModes []string `json:"allowedModes,omitempty"`


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

Implements the controller-side injection of the auth-proxy sidecar for function-level authentication.

When a function's HTTP trigger is configured with a function-level `authenticationMode` and the platform `functionAuthenticationEnabled` feature flag is on, the controller injects a dedicated auth-proxy sidecar into the function pod at deploy time. The sidecar owns the main HTTP port (8080) and forwards authenticated requests to the processor, which is rewritten to listen only on the pod-local loopback (6080) so it is unreachable from outside the pod without going through the proxy.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

- `pkg/platform/kube/functionres/lazy.go` — `injectAuthProxySidecar`: builds the auth-proxy container (image, args, ports, resource limits) and appends it to the deployment spec; `functionAuthenticationEnabled`: gates injection on the platform feature flag + HTTP trigger auth mode; `rewriteHTTPTriggerURLToLoopback`: rewrites the processor's HTTP trigger URL to `127.0.0.1:6080` so it only accepts traffic from within the pod
- `pkg/auth/types.go` + `pkg/platformconfig/types.go` / `platformconfig.go` — added `Authentication` config block (`SidecarImage`, `AuthURL`, `SignInURL`, `AuthKind`) to platform config; added `FunctionContainerHTTPLoopbackPort = 6080` constant
- `pkg/functionconfig/types.go` — added `IsAuthenticationEnabled(trigger *Trigger) bool` helper (reads `authenticationMode` from trigger attributes and delegates to `auth.IsFunctionLevelAuthenticationMode`)
- `pkg/platform/kube/platform.go` — added `validateSidecarNameNotReserved` (rejects user sidecars named after the reserved auth-proxy container); extended `validateContainerPorts` to also reject port 6080 when function-level auth is active

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->
<!-- - Any special cases covered. -->


---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-829
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
- Having a multiple ports -> upstream URLs mapping that was discussed [here](https://github.com/nuclio/nuclio/pull/4234#discussion_r3681479758) will be discussed offline and another PR will be open with those fixes is needed