### PR TITLE
[Buildah] Cloud registry authentication & Multiple secrets

### DIFF
--- a/hack/k8s/helm/nuclio/templates/_helpers.tpl
+++ b/hack/k8s/helm/nuclio/templates/_helpers.tpl
@@ -84,6 +84,14 @@ NOTE: make sure to not quote here, because an empty string is false, but a quote
 {{- end -}}
 {{- end -}}
 
+{{- define "nuclio.registry.credentialsSecretNames" -}}
+{{- if len .Values.registry.secretNames -}}
+{{- .Values.registry.secretNames | join "," -}}
+{{- else -}}
+{{- include "nuclio.registry.credentialsSecretName" . -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "nuclio.registry.pushPullUrlName" -}}
 {{- printf "%s-registry-url" (include "nuclio.fullName" .) | trunc 63 -}}
 {{- end -}}

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -152,12 +152,18 @@ spec:
           value: {{ .Values.dashboard.buildah.image.repository }}:{{ .Values.dashboard.buildah.image.tag }}
         - name: NUCLIO_BUILDAH_CONTAINER_IMAGE_PULL_POLICY
           value: {{ .Values.dashboard.buildah.image.pullPolicy }}
+        - name: NUCLIO_PYTHON_BASE_IMAGE_NAME
+          value: {{ .Values.dashboard.build.initContainerImage.python.repository }}:{{ .Values.dashboard.build.initContainerImage.python.tag }}
+        - name: NUCLIO_PYTHON_BASE_IMAGE_PULL_POLICY
+          value: {{ .Values.dashboard.build.initContainerImage.python.pullPolicy }}
         - name: NUCLIO_BUILDAH_ROOTLESS_MODE
           value: {{ .Values.dashboard.buildah.rootlessMode }}
         - name: NUCLIO_BUILDAH_STORAGE_DRIVER
           value: {{ .Values.dashboard.buildah.storageDriver }}
         - name: NUCLIO_BUILDAH_ISOLATION
           value: {{ .Values.dashboard.buildah.isolation }}
+        - name: NUCLIO_BUILDAH_APPARMOR_PROFILE
+          value: {{ .Values.dashboard.buildah.appArmorProfile }}
         - name: NUCLIO_AZURE_CLI_CONTAINER_IMAGE
           value: {{ .Values.dashboard.build.initContainerImage.azurecli.repository }}:{{ .Values.dashboard.build.initContainerImage.azurecli.tag }}
         - name: NUCLIO_GCLOUD_CLI_CONTAINER_IMAGE
@@ -240,6 +246,10 @@ spec:
           value: {{ .Values.dashboard.monitorDockerDeamon.maxConsecutiveErrors | quote }}
         - name: NUCLIO_REGISTRY_CREDENTIALS_SECRET_NAME
           value: {{ template "nuclio.registry.credentialsSecretName" . }}
+        {{- if len .Values.registry.secretNames }}
+        - name: NUCLIO_REGISTRY_CREDENTIALS_SECRET_NAMES
+          value: {{ template "nuclio.registry.credentialsSecretNames" . }}
+        {{- end }}
         {{- if .Values.registry.kind }}
         - name: NUCLIO_REGISTRY_KIND
           value: {{ .Values.registry.kind }}

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -152,9 +152,9 @@ spec:
           value: {{ .Values.dashboard.buildah.image.repository }}:{{ .Values.dashboard.buildah.image.tag }}
         - name: NUCLIO_BUILDAH_CONTAINER_IMAGE_PULL_POLICY
           value: {{ .Values.dashboard.buildah.image.pullPolicy }}
-        - name: NUCLIO_PYTHON_BASE_IMAGE_NAME
+        - name: NUCLIO_PYTHON_INIT_CONTAINER_IMAGE
           value: {{ .Values.dashboard.build.initContainerImage.python.repository }}:{{ .Values.dashboard.build.initContainerImage.python.tag }}
-        - name: NUCLIO_PYTHON_BASE_IMAGE_PULL_POLICY
+        - name: NUCLIO_PYTHON_INIT_CONTAINER_IMAGE_PULL_POLICY
           value: {{ .Values.dashboard.build.initContainerImage.python.pullPolicy }}
         - name: NUCLIO_BUILDAH_ROOTLESS_MODE
           value: {{ .Values.dashboard.buildah.rootlessMode }}

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -246,7 +246,7 @@ spec:
           value: {{ .Values.dashboard.monitorDockerDeamon.maxConsecutiveErrors | quote }}
         - name: NUCLIO_REGISTRY_CREDENTIALS_SECRET_NAME
           value: {{ template "nuclio.registry.credentialsSecretName" . }}
-        {{- if len .Values.registry.secretNames }}
+        {{- if .Values.registry.secretNames }}
         - name: NUCLIO_REGISTRY_CREDENTIALS_SECRET_NAMES
           value: {{ template "nuclio.registry.credentialsSecretNames" . }}
         {{- end }}

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -225,6 +225,11 @@ dashboard:
       gcloudcli:
         repository: google/cloud-sdk
         tag: 497.0.0-slim
+      # Used by the merge-authfile init container to run the embedded registry-auth merge script.
+      python:
+        repository: gcr.io/iguazio/python
+        tag: "3.11"
+        pullPolicy: IfNotPresent
 
   kaniko:
 
@@ -249,6 +254,10 @@ dashboard:
     # "chroot" (default, no SYS_ADMIN needed) or "oci" (real namespace
     # isolation per RUN step, needs SYS_ADMIN or a user namespace)
     isolation: "chroot"
+
+    # AppArmor profile for the buildah container ("unconfined" by default: needed for overlayfs).
+    # Set to "" to leave the cluster/pod default profile in force.
+    appArmorProfile: "unconfined"
 
     image:
       repository: quay.io/buildah/stable
@@ -518,6 +527,14 @@ registry:
   # chart will create a secret with default name `{releaseName}-registry-credentials`
   #
   # secretName: registry-credentials
+
+  # secretNames lets in-cluster builds (buildah/kaniko) draw credentials for multiple registries
+  # at once - e.g. a push destination plus a separate base-image or onbuild-image registry, each
+  # with its own docker-registry secret.
+  #
+  # secretNames:
+  #   - registry-credentials
+  #   - base-image-registry-credentials
 
   # In some cases the docker server URL in the registry secrets isn't the same as the URL with which
   # you push and pull. For example, in GKE you log into `gcr.io` (or some other regional URL) yet have

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -535,6 +535,7 @@ registry:
   # secretNames:
   #   - registry-credentials
   #   - base-image-registry-credentials
+  secretNames: []
 
   # In some cases the docker server URL in the registry secrets isn't the same as the URL with which
   # you push and pull. For example, in GKE you log into `gcr.io` (or some other regional URL) yet have

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -54,6 +54,12 @@ var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
 var containerHostname string
 var specialCharPattern = regexp.MustCompile(`[^\w@%+=:,./-]`)
 
+// invalidKubernetesNameCharPattern matches runs of characters not allowed in a DNS-1123 label.
+var invalidKubernetesNameCharPattern = regexp.MustCompile(`[^a-z0-9-]+`)
+
+// generateNameRandomSuffixLength is the random suffix the API server appends to GenerateName.
+const generateNameRandomSuffixLength = 5
+
 // IsFile returns true if the object @ path is a file
 func IsFile(path string) bool {
 	info, err := os.Stat(path)
@@ -438,6 +444,48 @@ func GetEnvOrDefaultInt(key string, defaultValue int) int {
 		return defaultValue
 	}
 	return valueInt
+}
+
+// GetEnvOrDefaultStringSlice resolves key as a comma-separated list, dropping blanks and duplicates.
+func GetEnvOrDefaultStringSlice(key string, defaultValue []string) []string {
+	raw, ok := os.LookupEnv(key)
+	if !ok {
+		return defaultValue
+	}
+	var values []string
+	for _, part := range strings.Split(raw, ",") {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			values = append(values, trimmed)
+		}
+	}
+	return RemoveDuplicatesFromSliceString(values)
+}
+
+// SanitizeKubernetesName joins a trusted prefix (verbatim, error if invalid) with an untrusted value
+// (lowercased, runs of invalid chars replaced by "-"), capped at KubernetesDomainLevelMaxLength.
+// forGenerateName appends a "-" and reserves room for the API server's random suffix.
+func SanitizeKubernetesName(prefix, value string, forGenerateName bool) (string, error) {
+	if invalidKubernetesNameCharPattern.MatchString(prefix) {
+		return "", errors.Errorf("Prefix %q contains characters invalid in a Kubernetes name", prefix)
+	}
+
+	maxLength := KubernetesDomainLevelMaxLength
+	if forGenerateName {
+		maxLength -= generateNameRandomSuffixLength + 1
+	}
+	maxLength = max(maxLength-len(prefix), 0)
+
+	sanitizedValue := strings.Trim(invalidKubernetesNameCharPattern.ReplaceAllString(strings.ToLower(value), "-"), "-")
+	if len(sanitizedValue) > maxLength {
+		sanitizedValue = sanitizedValue[:maxLength]
+	}
+
+	// truncation or an empty value can leave a dangling "-"
+	name := strings.TrimRight(prefix+sanitizedValue, "-")
+	if forGenerateName {
+		name += "-"
+	}
+	return name, nil
 }
 
 // IsJavaProjectDir Checks if the given @dirPath is in a java project structure

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -54,12 +54,6 @@ var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
 var containerHostname string
 var specialCharPattern = regexp.MustCompile(`[^\w@%+=:,./-]`)
 
-// invalidKubernetesNameCharPattern matches runs of characters not allowed in a DNS-1123 label.
-var invalidKubernetesNameCharPattern = regexp.MustCompile(`[^a-z0-9-]+`)
-
-// generateNameRandomSuffixLength is the random suffix the API server appends to GenerateName.
-const generateNameRandomSuffixLength = 5
-
 // IsFile returns true if the object @ path is a file
 func IsFile(path string) bool {
 	info, err := os.Stat(path)
@@ -459,33 +453,6 @@ func GetEnvOrDefaultStringSlice(key string, defaultValue []string) []string {
 		}
 	}
 	return RemoveDuplicatesFromSliceString(values)
-}
-
-// SanitizeKubernetesName joins a trusted prefix (verbatim, error if invalid) with an untrusted value
-// (lowercased, runs of invalid chars replaced by "-"), capped at KubernetesDomainLevelMaxLength.
-// forGenerateName appends a "-" and reserves room for the API server's random suffix.
-func SanitizeKubernetesName(prefix, value string, forGenerateName bool) (string, error) {
-	if invalidKubernetesNameCharPattern.MatchString(prefix) {
-		return "", errors.Errorf("Prefix %q contains characters invalid in a Kubernetes name", prefix)
-	}
-
-	maxLength := KubernetesDomainLevelMaxLength
-	if forGenerateName {
-		maxLength -= generateNameRandomSuffixLength + 1
-	}
-	maxLength = max(maxLength-len(prefix), 0)
-
-	sanitizedValue := strings.Trim(invalidKubernetesNameCharPattern.ReplaceAllString(strings.ToLower(value), "-"), "-")
-	if len(sanitizedValue) > maxLength {
-		sanitizedValue = sanitizedValue[:maxLength]
-	}
-
-	// truncation or an empty value can leave a dangling "-"
-	name := strings.TrimRight(prefix+sanitizedValue, "-")
-	if forGenerateName {
-		name += "-"
-	}
-	return name, nil
 }
 
 // IsJavaProjectDir Checks if the given @dirPath is in a java project structure

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -577,6 +577,25 @@ func StripImageTag(image string) string {
 	return image
 }
 
+// GetHostname returns url's hostname, stripping any repository path (GAR URLs carry one; ACR/ECR don't).
+func GetHostname(url string) string {
+	if i := strings.Index(url, "/"); i != -1 {
+		return url[:i]
+	}
+	return url
+}
+
+// NormalizeHosts strips each url to its bare hostname and drops empty/duplicate values.
+func NormalizeHosts(urls ...string) []string {
+	hosts := make([]string, 0, len(urls))
+	for _, url := range urls {
+		if host := GetHostname(url); host != "" {
+			hosts = append(hosts, host)
+		}
+	}
+	return RemoveDuplicatesFromSliceString(hosts)
+}
+
 func AnyPositiveInSliceInt64(numbers []int64) bool {
 	for _, number := range numbers {
 		if number >= 0 {

--- a/pkg/common/helper_test.go
+++ b/pkg/common/helper_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -897,6 +898,103 @@ func (suite *StripImageTagTestSuite) TestStripImageTag() {
 	}
 }
 
+type SanitizeKubernetesNameTestSuite struct {
+	suite.Suite
+}
+
+func (suite *SanitizeKubernetesNameTestSuite) TestSanitizeKubernetesName() {
+	for _, testCase := range []struct {
+		name            string
+		prefix          string
+		value           string
+		forGenerateName bool
+		expected        string
+	}{
+		{
+			name:     "LowercasesAndReplacesInvalidChars",
+			value:    "Registry.Example.Com/My_Func:v1.2",
+			expected: "registry-example-com-my-func-v1-2",
+		},
+		{
+			name:     "RunOfInvalidCharsBecomesOneDash",
+			value:    "a...b",
+			expected: "a-b",
+		},
+		{
+			name:     "LeadingAndTrailingDashesTrimmed",
+			value:    "--a-b--",
+			expected: "a-b",
+		},
+		{
+			name:     "PrefixUsedVerbatim",
+			prefix:   "registry-login-azure-",
+			value:    "myregistry.azurecr.io",
+			expected: "registry-login-azure-myregistry-azurecr-io",
+		},
+		{
+			name:     "EmptyValueLeavesNoDanglingDash",
+			prefix:   "registry-login-aws-",
+			value:    "///:::",
+			expected: "registry-login-aws",
+		},
+		{
+			name:     "TruncatedToLabelLimit",
+			prefix:   "registry-login-aws-",
+			value:    strings.Repeat("a", 80),
+			expected: "registry-login-aws-" + strings.Repeat("a", KubernetesDomainLevelMaxLength-len("registry-login-aws-")),
+		},
+		{
+			name:            "GenerateNameAppendsDashAndReservesSuffix",
+			prefix:          "nuclio-buildjob-",
+			value:           "my-func:latest",
+			forGenerateName: true,
+			expected:        "nuclio-buildjob-my-func-latest-",
+		},
+		{
+			name:            "GenerateNameTruncatesLeavingRoomForSuffix",
+			prefix:          "nuclio-buildjob-",
+			value:           strings.Repeat("x", 80),
+			forGenerateName: true,
+			expected:        "nuclio-buildjob-" + strings.Repeat("x", 41) + "-",
+		},
+		{
+			name:            "GenerateNameTruncationLandingOnDashIsTrimmed",
+			prefix:          "nuclio-buildjob-",
+			value:           strings.Repeat("a", 41) + "." + strings.Repeat("b", 40),
+			forGenerateName: true,
+			expected:        "nuclio-buildjob-" + strings.Repeat("a", 41) + "-",
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			result, err := SanitizeKubernetesName(testCase.prefix, testCase.value, testCase.forGenerateName)
+
+			suite.Require().NoError(err)
+			suite.Equal(testCase.expected, result)
+
+			// the result must always fit a Kubernetes name, including the generated random suffix
+			totalLength := len(result)
+			if testCase.forGenerateName {
+				totalLength += generateNameRandomSuffixLength
+			}
+			suite.LessOrEqual(totalLength, KubernetesDomainLevelMaxLength)
+		})
+	}
+}
+
+func (suite *SanitizeKubernetesNameTestSuite) TestSanitizeKubernetesNameErrorsOnInvalidPrefix() {
+	for _, prefix := range []string{"Nuclio-", "nuclio_", "nuclio/", "nuclio ", "has.dot-"} {
+		_, err := SanitizeKubernetesName(prefix, "value", false)
+		suite.Require().Error(err, "prefix %q should be rejected", prefix)
+	}
+}
+
+func (suite *SanitizeKubernetesNameTestSuite) TestSanitizeKubernetesNameAcceptsValidPrefix() {
+	for _, prefix := range []string{"", "nuclio-", "a-b-c-", "abc123"} {
+		_, err := SanitizeKubernetesName(prefix, "value", false)
+		suite.Require().NoError(err, "prefix %q should be accepted", prefix)
+	}
+}
+
 func TestHelperTestSuite(t *testing.T) {
 	suite.Run(t, new(RetryUntilSuccessfulTestSuite))
 	suite.Run(t, new(RetryUntilSuccessfulOnErrorPatternsTestSuite))
@@ -911,4 +1009,5 @@ func TestHelperTestSuite(t *testing.T) {
 	suite.Run(t, new(ContainsPathTraversalTestSuite))
 	suite.Run(t, new(EnvWithLegacyKeyTestSuite))
 	suite.Run(t, new(StripImageTagTestSuite))
+	suite.Run(t, new(SanitizeKubernetesNameTestSuite))
 }

--- a/pkg/common/helper_test.go
+++ b/pkg/common/helper_test.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
@@ -898,103 +897,6 @@ func (suite *StripImageTagTestSuite) TestStripImageTag() {
 	}
 }
 
-type SanitizeKubernetesNameTestSuite struct {
-	suite.Suite
-}
-
-func (suite *SanitizeKubernetesNameTestSuite) TestSanitizeKubernetesName() {
-	for _, testCase := range []struct {
-		name            string
-		prefix          string
-		value           string
-		forGenerateName bool
-		expected        string
-	}{
-		{
-			name:     "LowercasesAndReplacesInvalidChars",
-			value:    "Registry.Example.Com/My_Func:v1.2",
-			expected: "registry-example-com-my-func-v1-2",
-		},
-		{
-			name:     "RunOfInvalidCharsBecomesOneDash",
-			value:    "a...b",
-			expected: "a-b",
-		},
-		{
-			name:     "LeadingAndTrailingDashesTrimmed",
-			value:    "--a-b--",
-			expected: "a-b",
-		},
-		{
-			name:     "PrefixUsedVerbatim",
-			prefix:   "registry-login-azure-",
-			value:    "myregistry.azurecr.io",
-			expected: "registry-login-azure-myregistry-azurecr-io",
-		},
-		{
-			name:     "EmptyValueLeavesNoDanglingDash",
-			prefix:   "registry-login-aws-",
-			value:    "///:::",
-			expected: "registry-login-aws",
-		},
-		{
-			name:     "TruncatedToLabelLimit",
-			prefix:   "registry-login-aws-",
-			value:    strings.Repeat("a", 80),
-			expected: "registry-login-aws-" + strings.Repeat("a", KubernetesDomainLevelMaxLength-len("registry-login-aws-")),
-		},
-		{
-			name:            "GenerateNameAppendsDashAndReservesSuffix",
-			prefix:          "nuclio-buildjob-",
-			value:           "my-func:latest",
-			forGenerateName: true,
-			expected:        "nuclio-buildjob-my-func-latest-",
-		},
-		{
-			name:            "GenerateNameTruncatesLeavingRoomForSuffix",
-			prefix:          "nuclio-buildjob-",
-			value:           strings.Repeat("x", 80),
-			forGenerateName: true,
-			expected:        "nuclio-buildjob-" + strings.Repeat("x", 41) + "-",
-		},
-		{
-			name:            "GenerateNameTruncationLandingOnDashIsTrimmed",
-			prefix:          "nuclio-buildjob-",
-			value:           strings.Repeat("a", 41) + "." + strings.Repeat("b", 40),
-			forGenerateName: true,
-			expected:        "nuclio-buildjob-" + strings.Repeat("a", 41) + "-",
-		},
-	} {
-		suite.Run(testCase.name, func() {
-			result, err := SanitizeKubernetesName(testCase.prefix, testCase.value, testCase.forGenerateName)
-
-			suite.Require().NoError(err)
-			suite.Equal(testCase.expected, result)
-
-			// the result must always fit a Kubernetes name, including the generated random suffix
-			totalLength := len(result)
-			if testCase.forGenerateName {
-				totalLength += generateNameRandomSuffixLength
-			}
-			suite.LessOrEqual(totalLength, KubernetesDomainLevelMaxLength)
-		})
-	}
-}
-
-func (suite *SanitizeKubernetesNameTestSuite) TestSanitizeKubernetesNameErrorsOnInvalidPrefix() {
-	for _, prefix := range []string{"Nuclio-", "nuclio_", "nuclio/", "nuclio ", "has.dot-"} {
-		_, err := SanitizeKubernetesName(prefix, "value", false)
-		suite.Require().Error(err, "prefix %q should be rejected", prefix)
-	}
-}
-
-func (suite *SanitizeKubernetesNameTestSuite) TestSanitizeKubernetesNameAcceptsValidPrefix() {
-	for _, prefix := range []string{"", "nuclio-", "a-b-c-", "abc123"} {
-		_, err := SanitizeKubernetesName(prefix, "value", false)
-		suite.Require().NoError(err, "prefix %q should be accepted", prefix)
-	}
-}
-
 func TestHelperTestSuite(t *testing.T) {
 	suite.Run(t, new(RetryUntilSuccessfulTestSuite))
 	suite.Run(t, new(RetryUntilSuccessfulOnErrorPatternsTestSuite))
@@ -1009,5 +911,4 @@ func TestHelperTestSuite(t *testing.T) {
 	suite.Run(t, new(ContainsPathTraversalTestSuite))
 	suite.Run(t, new(EnvWithLegacyKeyTestSuite))
 	suite.Run(t, new(StripImageTagTestSuite))
-	suite.Run(t, new(SanitizeKubernetesNameTestSuite))
 }

--- a/pkg/common/helper_test.go
+++ b/pkg/common/helper_test.go
@@ -897,6 +897,42 @@ func (suite *StripImageTagTestSuite) TestStripImageTag() {
 	}
 }
 
+type NormalizeHostsTestSuite struct {
+	suite.Suite
+}
+
+func (suite *NormalizeHostsTestSuite) TestNormalizeHostsStripsRepoPathAndDedupesEmpty() {
+	for _, testCase := range []struct {
+		name     string
+		urls     []string
+		expected []string
+	}{
+		{
+			name:     "StripsRepoPath",
+			urls:     []string{"us-central1-docker.pkg.dev/my-project/my-repo"},
+			expected: []string{"us-central1-docker.pkg.dev"},
+		},
+		{
+			name:     "DropsEmptyAndDuplicates",
+			urls:     []string{"myregistry.azurecr.io", "", "myregistry.azurecr.io"},
+			expected: []string{"myregistry.azurecr.io"},
+		},
+		{
+			name:     "PreservesFirstSeenOrder",
+			urls:     []string{"b.io", "a.io", "b.io"},
+			expected: []string{"b.io", "a.io"},
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Equal(testCase.expected, NormalizeHosts(testCase.urls...))
+		})
+	}
+}
+
+func (suite *NormalizeHostsTestSuite) TestNormalizeHostsAllEmptyReturnsEmpty() {
+	suite.Empty(NormalizeHosts("", ""))
+}
+
 func TestHelperTestSuite(t *testing.T) {
 	suite.Run(t, new(RetryUntilSuccessfulTestSuite))
 	suite.Run(t, new(RetryUntilSuccessfulOnErrorPatternsTestSuite))
@@ -911,4 +947,5 @@ func TestHelperTestSuite(t *testing.T) {
 	suite.Run(t, new(ContainsPathTraversalTestSuite))
 	suite.Run(t, new(EnvWithLegacyKeyTestSuite))
 	suite.Run(t, new(StripImageTagTestSuite))
+	suite.Run(t, new(NormalizeHostsTestSuite))
 }

--- a/pkg/common/k8s.go
+++ b/pkg/common/k8s.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/mitchellh/go-homedir"
@@ -35,6 +36,39 @@ const (
 	// NuclioSelfNamespace is used to get the namespace in which Nuclio is running
 	NuclioSelfNamespace = "@nuclio.selfNamespace"
 )
+
+// invalidKubernetesNameCharPattern matches runs of characters not allowed in a DNS-1123 label.
+var invalidKubernetesNameCharPattern = regexp.MustCompile(`[^a-z0-9-]+`)
+
+// generateNameRandomSuffixLength is the random suffix the API server appends to GenerateName.
+const generateNameRandomSuffixLength = 5
+
+// SanitizeKubernetesName joins a trusted prefix (verbatim, error if invalid) with an untrusted value
+// (lowercased, runs of invalid chars replaced by "-"), capped at KubernetesDomainLevelMaxLength.
+// forGenerateName appends a "-" and reserves room for the API server's random suffix.
+func SanitizeKubernetesName(prefix, value string, forGenerateName bool) (string, error) {
+	if invalidKubernetesNameCharPattern.MatchString(prefix) || strings.HasPrefix(prefix, "-") {
+		return "", errors.Errorf("Prefix %q contains characters invalid in a Kubernetes name", prefix)
+	}
+
+	maxLength := KubernetesDomainLevelMaxLength
+	if forGenerateName {
+		maxLength -= generateNameRandomSuffixLength + 1
+	}
+	maxLength = max(maxLength-len(prefix), 0)
+
+	sanitizedValue := strings.Trim(invalidKubernetesNameCharPattern.ReplaceAllString(strings.ToLower(value), "-"), "-")
+	if len(sanitizedValue) > maxLength {
+		sanitizedValue = sanitizedValue[:maxLength]
+	}
+
+	// truncation or an empty value can leave a dangling "-"
+	name := strings.TrimRight(prefix+sanitizedValue, "-")
+	if forGenerateName {
+		name += "-"
+	}
+	return name, nil
+}
 
 func IsInKubernetesCluster() bool {
 	return len(os.Getenv("KUBERNETES_SERVICE_HOST")) != 0 && len(os.Getenv("KUBERNETES_SERVICE_PORT")) != 0

--- a/pkg/common/k8s_test.go
+++ b/pkg/common/k8s_test.go
@@ -1,0 +1,127 @@
+//go:build test_unit
+
+/*
+Copyright 2023 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type SanitizeKubernetesNameTestSuite struct {
+	suite.Suite
+}
+
+func (suite *SanitizeKubernetesNameTestSuite) TestSanitizeKubernetesName() {
+	for _, testCase := range []struct {
+		name            string
+		prefix          string
+		value           string
+		forGenerateName bool
+		expected        string
+	}{
+		{
+			name:     "LowercasesAndReplacesInvalidChars",
+			value:    "Registry.Example.Com/My_Func:v1.2",
+			expected: "registry-example-com-my-func-v1-2",
+		},
+		{
+			name:     "RunOfInvalidCharsBecomesOneDash",
+			value:    "a...b",
+			expected: "a-b",
+		},
+		{
+			name:     "LeadingAndTrailingDashesTrimmed",
+			value:    "--a-b--",
+			expected: "a-b",
+		},
+		{
+			name:     "PrefixUsedVerbatim",
+			prefix:   "registry-login-azure-",
+			value:    "myregistry.azurecr.io",
+			expected: "registry-login-azure-myregistry-azurecr-io",
+		},
+		{
+			name:     "EmptyValueLeavesNoDanglingDash",
+			prefix:   "registry-login-aws-",
+			value:    "///:::",
+			expected: "registry-login-aws",
+		},
+		{
+			name:     "TruncatedToLabelLimit",
+			prefix:   "registry-login-aws-",
+			value:    strings.Repeat("a", 80),
+			expected: "registry-login-aws-" + strings.Repeat("a", KubernetesDomainLevelMaxLength-len("registry-login-aws-")),
+		},
+		{
+			name:            "GenerateNameAppendsDashAndReservesSuffix",
+			prefix:          "nuclio-buildjob-",
+			value:           "my-func:latest",
+			forGenerateName: true,
+			expected:        "nuclio-buildjob-my-func-latest-",
+		},
+		{
+			name:            "GenerateNameTruncatesLeavingRoomForSuffix",
+			prefix:          "nuclio-buildjob-",
+			value:           strings.Repeat("x", 80),
+			forGenerateName: true,
+			expected:        "nuclio-buildjob-" + strings.Repeat("x", 41) + "-",
+		},
+		{
+			name:            "GenerateNameTruncationLandingOnDashIsTrimmed",
+			prefix:          "nuclio-buildjob-",
+			value:           strings.Repeat("a", 41) + "." + strings.Repeat("b", 40),
+			forGenerateName: true,
+			expected:        "nuclio-buildjob-" + strings.Repeat("a", 41) + "-",
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			result, err := SanitizeKubernetesName(testCase.prefix, testCase.value, testCase.forGenerateName)
+
+			suite.Require().NoError(err)
+			suite.Equal(testCase.expected, result)
+
+			// the result must always fit a Kubernetes name, including the generated random suffix
+			totalLength := len(result)
+			if testCase.forGenerateName {
+				totalLength += generateNameRandomSuffixLength
+			}
+			suite.LessOrEqual(totalLength, KubernetesDomainLevelMaxLength)
+		})
+	}
+}
+
+func (suite *SanitizeKubernetesNameTestSuite) TestSanitizeKubernetesNameErrorsOnInvalidPrefix() {
+	for _, prefix := range []string{"Nuclio-", "nuclio_", "nuclio/", "nuclio ", "has.dot-", "-nuclio-"} {
+		_, err := SanitizeKubernetesName(prefix, "value", false)
+		suite.Require().Error(err, "prefix %q should be rejected", prefix)
+	}
+}
+
+func (suite *SanitizeKubernetesNameTestSuite) TestSanitizeKubernetesNameAcceptsValidPrefix() {
+	for _, prefix := range []string{"", "nuclio-", "a-b-c-", "abc123"} {
+		_, err := SanitizeKubernetesName(prefix, "value", false)
+		suite.Require().NoError(err, "prefix %q should be accepted", prefix)
+	}
+}
+
+func TestK8sTestSuite(t *testing.T) {
+	suite.Run(t, new(SanitizeKubernetesNameTestSuite))
+}

--- a/pkg/containerimagebuilderpusher/buildah.go
+++ b/pkg/containerimagebuilderpusher/buildah.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher/registryhelpers"
 	"github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
 
 	"github.com/nuclio/errors"
@@ -34,9 +35,8 @@ import (
 const (
 	BuildahKind = "buildah"
 
-	buildahAuthDir    = "/var/lib/containers/auth"
-	buildahAuthFile   = buildahAuthDir + "/config.json"
-	buildahAuthVolume = "authdir"
+	buildahAuthDir  = "/var/lib/containers/auth"
+	buildahAuthFile = buildahAuthDir + "/config.json"
 )
 
 type Buildah struct {
@@ -96,35 +96,44 @@ func (b *Buildah) compileJobSpec(ctx context.Context,
 	}
 
 	podSpec := &jobSpec.Spec.Template.Spec
-	b.configureAuthVolume(buildOptions, podSpec)
+	if err := b.configureRegistryAuthentication(ctx, namespace, buildOptions, podSpec); err != nil {
+		return nil, errors.Wrap(err, "Failed to configure registry auth volumes and init containers")
+	}
 	b.configureRootlessMode(podSpec)
+	b.configureAppArmorProfile(jobSpec)
 
 	return jobSpec, nil
 }
 
-// configureAuthVolume mounts the registry auth secret (if any) into the buildah container.
-// TODO: will be extended to support Cloud registry credentials & multiple secrets in the next PR.
-func (b *Buildah) configureAuthVolume(buildOptions *BuildOptions, podSpec *v1.PodSpec) {
-	if buildOptions.SecretName == "" {
+// configureAppArmorProfile relaxes AppArmor for the buildah container, if configured.
+func (b *Buildah) configureAppArmorProfile(jobSpec *batchv1.Job) {
+	profile := b.builderConfiguration.Buildah.AppArmorProfile
+	if profile == "" {
 		return
 	}
 
-	authFolderVolumeMount := v1.VolumeMount{
-		Name:      buildahAuthVolume,
-		MountPath: buildahAuthDir,
-		ReadOnly:  true,
+	podTemplate := &jobSpec.Spec.Template
+	if podTemplate.Annotations == nil {
+		podTemplate.Annotations = map[string]string{}
 	}
+	containerName := podTemplate.Spec.Containers[0].Name
+	podTemplate.Annotations["container.apparmor.security.beta.kubernetes.io/"+containerName] = profile
+}
 
-	podSpec.Volumes = append(podSpec.Volumes, v1.Volume{
-		Name: authFolderVolumeMount.Name,
-		VolumeSource: v1.VolumeSource{
-			Secret: &v1.SecretVolumeSource{
-				SecretName: buildOptions.SecretName,
-				Items:      []v1.KeyToPath{{Key: ".dockerconfigjson", Path: "config.json"}},
-			},
-		},
-	})
-	podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, authFolderVolumeMount)
+// configureRegistryAuthentication mounts the registry auth secret(s) and cloud-provider credentials
+// into the buildah container.
+func (b *Buildah) configureRegistryAuthentication(ctx context.Context, namespace string, buildOptions *BuildOptions, podSpec *v1.PodSpec) error {
+	cloudHosts := registryhelpers.NormalizeHosts(buildOptions.RegistryURL,
+		buildOptions.BaseImageRegistry,
+		buildOptions.OnbuildImageRegistry)
+
+	return b.jobRunner.configureRegistryAuthentication(ctx,
+		namespace,
+		buildOptions,
+		buildahAuthDir,
+		cloudHosts,
+		b.builderConfiguration.Buildah.ImagePullPolicy,
+		podSpec)
 }
 
 // configureRootlessMode wires the buildah container's security context per Buildah.RootlessMode.

--- a/pkg/containerimagebuilderpusher/buildah.go
+++ b/pkg/containerimagebuilderpusher/buildah.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/nuclio/nuclio/pkg/common"
-	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher/registryhelpers"
 	"github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
 
 	"github.com/nuclio/errors"
@@ -123,7 +122,7 @@ func (b *Buildah) configureAppArmorProfile(jobSpec *batchv1.Job) {
 // configureRegistryAuthentication mounts the registry auth secret(s) and cloud-provider credentials
 // into the buildah container.
 func (b *Buildah) configureRegistryAuthentication(ctx context.Context, namespace string, buildOptions *BuildOptions, podSpec *v1.PodSpec) error {
-	cloudHosts := registryhelpers.NormalizeHosts(buildOptions.RegistryURL,
+	cloudHosts := common.NormalizeHosts(buildOptions.RegistryURL,
 		buildOptions.BaseImageRegistry,
 		buildOptions.OnbuildImageRegistry)
 

--- a/pkg/containerimagebuilderpusher/buildah_test.go
+++ b/pkg/containerimagebuilderpusher/buildah_test.go
@@ -23,12 +23,15 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher/registryhelpers"
+	"github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 
 	"github.com/nuclio/logger"
 	"github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/api/core/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
 var (
@@ -49,8 +52,9 @@ func (suite *BuildahTestSuite) SetupTest() {
 
 	suite.buildah = &Buildah{
 		jobRunner: &jobRunner{
-			builderName: BuildahKind,
-			logger:      suite.logger,
+			builderName:   BuildahKind,
+			logger:        suite.logger,
+			kubeClientSet: kube.NewClientWithRetryFromClient(k8sfake.NewClientset()),
 			builderConfiguration: &ContainerBuilderConfiguration{
 				BusyBoxImage: "busybox:stable",
 				Buildah: BuildahConfig{
@@ -168,8 +172,30 @@ func (suite *BuildahTestSuite) TestCompileJobSpecAuthVolumeWithSecret() {
 	suite.Require().Len(podSpec.Containers[0].VolumeMounts, 2)
 
 	authMount := podSpec.Containers[0].VolumeMounts[1]
-	suite.Equal(buildahAuthVolume, authMount.Name)
+	suite.Equal(registryhelpers.AuthVolumeName, authMount.Name)
 	suite.True(authMount.ReadOnly, "auth secret mount must be read-only")
+}
+
+func (suite *BuildahTestSuite) TestCompileJobSpecCloudAuthLoginContainersRunBeforeMerge() {
+	suite.buildah.builderConfiguration.PythonImage = "python:test"
+
+	buildOptions := suite.newBuildOptions()
+	buildOptions.RegistryURL = "myregistry.azurecr.io"
+
+	jobSpec, err := suite.buildah.compileJobSpec(context.Background(), "default", buildOptions, "bundle.tar")
+	suite.Require().NoError(err)
+
+	podSpec := jobSpec.Spec.Template.Spec
+	suite.Require().Len(podSpec.InitContainers, 4)
+	loginContainer := podSpec.InitContainers[2]
+	mergeContainer := podSpec.InitContainers[3]
+	suite.Contains(loginContainer.Name, "registry-login-azure")
+	suite.Equal("merge-authfile", mergeContainer.Name)
+
+	// the login container writes its token into the dir the merge container reads it from
+	tokenDir := registryhelpers.TokenDirVolumeMount().MountPath
+	suite.Contains(loginContainer.Args[1], tokenDir)
+	suite.Contains(mergeContainer.Args, "--cloud-tokens="+tokenDir)
 }
 
 func (suite *BuildahTestSuite) TestNewContainerBuilderConfigurationValidatesRootlessMode() {

--- a/pkg/containerimagebuilderpusher/buildah_test.go
+++ b/pkg/containerimagebuilderpusher/buildah_test.go
@@ -31,7 +31,9 @@ import (
 	"github.com/nuclio/logger"
 	"github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -51,11 +53,16 @@ func (suite *BuildahTestSuite) SetupTest() {
 	suite.logger, err = nucliozap.NewNuclioZapTest("test")
 	suite.Require().NoError(err)
 
+	suite.T().Setenv("NUCLIO_DASHBOARD_DEPLOYMENT_NAME", "nuclio-dashboard")
+	dashboardDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "nuclio-dashboard", Namespace: "default", UID: "dashboard-uid"},
+	}
+
 	suite.buildah = &Buildah{
 		jobRunner: &jobRunner{
 			builderName:   BuildahKind,
 			logger:        suite.logger,
-			kubeClientSet: kube.NewClientWithRetryFromClient(k8sfake.NewClientset()),
+			kubeClientSet: kube.NewClientWithRetryFromClient(k8sfake.NewClientset(dashboardDeployment)),
 			builderConfiguration: &ContainerBuilderConfiguration{
 				BusyBoxImage: "busybox:stable",
 				Buildah: BuildahConfig{

--- a/pkg/containerimagebuilderpusher/buildah_test.go
+++ b/pkg/containerimagebuilderpusher/buildah_test.go
@@ -21,6 +21,7 @@ package containerimagebuilderpusher
 import (
 	"context"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher/registryhelpers"
@@ -194,7 +195,13 @@ func (suite *BuildahTestSuite) TestCompileJobSpecCloudAuthLoginContainersRunBefo
 
 	// the login container writes its token into the dir the merge container reads it from
 	tokenDir := registryhelpers.TokenDirVolumeMount().MountPath
-	suite.Contains(loginContainer.Args[1], tokenDir)
+	tokenPathPassed := false
+	for _, envVar := range loginContainer.Env {
+		if strings.HasPrefix(envVar.Value, tokenDir+"/") {
+			tokenPathPassed = true
+		}
+	}
+	suite.True(tokenPathPassed, "login container does not receive a token path under %s", tokenDir)
 	suite.Contains(mergeContainer.Args, "--cloud-tokens="+tokenDir)
 }
 

--- a/pkg/containerimagebuilderpusher/containerimagebuilder.go
+++ b/pkg/containerimagebuilderpusher/containerimagebuilder.go
@@ -45,7 +45,4 @@ type BuilderPusher interface {
 
 	// GetRegistryKind returns registry kind (onCluster, offCluster or empty value if not specified)
 	GetRegistryKind() string
-
-	// GetDefaultRegistryCredentialsSecretName returns secret with credentials to push/pull from docker registry
-	GetDefaultRegistryCredentialsSecretName() string
 }

--- a/pkg/containerimagebuilderpusher/docker.go
+++ b/pkg/containerimagebuilderpusher/docker.go
@@ -94,10 +94,6 @@ func (d *Docker) GetOnbuildStages(onbuildArtifacts []runtime.Artifact) ([]string
 	return []string{}, nil
 }
 
-func (d *Docker) GetDefaultRegistryCredentialsSecretName() string {
-	return d.builderConfiguration.DefaultRegistryCredentialsSecretName
-}
-
 func (d *Docker) GetRegistryKind() string {
 	return d.builderConfiguration.RegistryKind
 }

--- a/pkg/containerimagebuilderpusher/jobrunner.go
+++ b/pkg/containerimagebuilderpusher/jobrunner.go
@@ -25,11 +25,11 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"regexp"
 	"strings"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher/registryhelpers"
 	"github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
 	"github.com/nuclio/nuclio/pkg/platform/kube/utils"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
@@ -73,12 +73,6 @@ func newJobRunner(builderName string,
 // GetKind returns the backend name this jobRunner was constructed for (e.g. "kaniko", "buildah").
 func (r *jobRunner) GetKind() string {
 	return r.builderName
-}
-
-// GetDefaultRegistryCredentialsSecretName returns the secret with credentials to push/pull from the
-// docker registry. Shared across backends: they all read the same builderConfiguration field.
-func (r *jobRunner) GetDefaultRegistryCredentialsSecretName() string {
-	return r.builderConfiguration.DefaultRegistryCredentialsSecretName
 }
 
 // GetBaseImageRegistry returns the base image registry.
@@ -260,7 +254,11 @@ func (r *jobRunner) compileBaseJobSpec(ctx context.Context,
 		MountPath: "/tmp",
 	}
 
-	jobNamePrefix := r.compileJobNamePrefix(buildOptions.Image)
+	jobNamePrefix := fmt.Sprintf("nuclio-%s-", r.builderConfiguration.JobPrefix)
+	jobName, err := common.SanitizeKubernetesName(jobNamePrefix, buildOptions.Image, true)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to compile build job name prefix")
+	}
 
 	serviceAccount, err := r.enrichAndValidateServiceAccount(ctx, buildOptions, namespace)
 	if err != nil {
@@ -294,7 +292,7 @@ func (r *jobRunner) compileBaseJobSpec(ctx context.Context,
 
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: jobNamePrefix,
+			GenerateName: jobName,
 			Namespace:    namespace,
 		},
 		Spec: batchv1.JobSpec{
@@ -324,6 +322,7 @@ func (r *jobRunner) submitAndWait(ctx context.Context,
 		"jobSpec", jobSpec,
 		"timeoutSeconds", buildOptions.BuildTimeoutSeconds,
 	)
+
 	job, err := r.kubeClientSet.CreateJob(ctx, namespace, jobSpec)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to publish %s job", r.builderName)
@@ -347,28 +346,6 @@ func (r *jobRunner) submitAndWait(ctx context.Context,
 		buildOptions.BuildTimeoutSeconds,
 		buildOptions.ReadinessTimeoutSeconds,
 		buildOptions.BuildLogger)
-}
-
-// compileJobNamePrefix returns a name prefix for use as the job's ObjectMeta.GenerateName
-func (r *jobRunner) compileJobNamePrefix(image string) string {
-
-	image = strings.ReplaceAll(strings.ToLower(image), ":", "-")
-	image = strings.ReplaceAll(image, "/", "-")
-
-	invalidJobNameChars := regexp.MustCompile(`[^a-z0-9.-]`)
-	functionName := strings.Trim(invalidJobNameChars.ReplaceAllString(image, ""), ".-")
-
-	jobNamePrefix := fmt.Sprintf("nuclio-%s.%s-", r.builderConfiguration.JobPrefix, functionName)
-
-	// k8s appends a 5-char random suffix directly onto GenerateName. Truncate so the resulting
-	// job name won't exceed the k8s limit of 63, reserving the last char for a forced "-" so the
-	// cut can never leave a dangling "." or "-" that k8s's GenerateName validation would reject.
-	const generatedSuffixLen = 5
-	if maxLen := 63 - generatedSuffixLen; len(jobNamePrefix) > maxLen {
-		jobNamePrefix = strings.TrimRight(jobNamePrefix[:maxLen-1], ".-") + "-"
-	}
-
-	return jobNamePrefix
 }
 
 func (r *jobRunner) waitForJobCompletion(ctx context.Context,
@@ -688,4 +665,107 @@ func (r *jobRunner) enrichServiceAccountFromBuilderConfiguration(buildOptions *B
 		return r.builderConfiguration.DefaultServiceAccount
 	}
 	return buildOptions.FunctionServiceAccount
+}
+
+// resolveRegistryAuthSecretNames returns platform default secrets plus the function-level secret, deduped.
+func (r *jobRunner) resolveRegistryAuthSecretNames(buildOptions *BuildOptions) []string {
+	names := append([]string{}, r.builderConfiguration.DefaultRegistryCredentialsSecretNames...)
+	if buildOptions.SecretName != "" {
+		names = append(names, buildOptions.SecretName)
+	}
+	return common.RemoveDuplicatesFromSliceString(names)
+}
+
+// configureRegistryAuthentication wires the registry authfile - and, if needed, cloud-provider logins
+// and a merge-authfile init container - into podSpec. cloudHosts is nil for kaniko, which uses its
+// own bundled cloud credential helpers.
+func (r *jobRunner) configureRegistryAuthentication(ctx context.Context,
+	namespace string,
+	buildOptions *BuildOptions,
+	authFileDir string,
+	cloudHosts []string,
+	imagePullPolicy string,
+	podSpec *v1.PodSpec) error {
+
+	authVolumeMount := v1.VolumeMount{Name: registryhelpers.AuthVolumeName, MountPath: authFileDir, ReadOnly: true}
+	cloudAuth := registryhelpers.NeedsCloudLogin(cloudHosts)
+	secretNames := r.resolveRegistryAuthSecretNames(buildOptions)
+
+	if !cloudAuth {
+		// no cloud auth & no secret names, nothing to do
+		if len(secretNames) == 0 {
+			return nil
+		}
+		// no cloud auth & one secret name, create a secret volume
+		if len(secretNames) == 1 {
+			podSpec.Volumes = append(podSpec.Volumes, v1.Volume{
+				Name: registryhelpers.AuthVolumeName,
+				VolumeSource: v1.VolumeSource{
+					Secret: &v1.SecretVolumeSource{
+						SecretName: secretNames[0],
+						Items:      []v1.KeyToPath{{Key: ".dockerconfigjson", Path: "config.json"}},
+					},
+				},
+			})
+			podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, authVolumeMount)
+			return nil
+		}
+	}
+
+	// cloud auth and/or multiple secrets names: use merge auth init container
+	podSpec.Volumes = append(podSpec.Volumes, v1.Volume{
+		Name:         registryhelpers.AuthVolumeName,
+		VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+	})
+	podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, authVolumeMount)
+
+	if cloudAuth {
+		loginContainers, loginVolumes, err := registryhelpers.BuildLoginContainers(cloudHosts,
+			buildOptions.RegistryURL,
+			buildOptions.RepoName,
+			r.builderConfiguration.AuthConfig,
+			imagePullPolicy)
+		if err != nil {
+			return err
+		}
+		tokenDirMount := registryhelpers.TokenDirVolumeMount()
+		podSpec.Volumes = append(podSpec.Volumes, v1.Volume{
+			Name:         tokenDirMount.Name,
+			VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+		})
+		podSpec.InitContainers = append(podSpec.InitContainers, loginContainers...)
+		podSpec.Volumes = append(podSpec.Volumes, loginVolumes...)
+	}
+
+	if err := r.ensureMergeScriptConfigMap(ctx, namespace); err != nil {
+		return err
+	}
+
+	mergeContainer, mergeVolumes := registryhelpers.BuildMergeAuthInitContainer(secretNames,
+		authFileDir,
+		cloudAuth,
+		r.builderConfiguration.AuthConfig)
+	podSpec.InitContainers = append(podSpec.InitContainers, mergeContainer)
+	podSpec.Volumes = append(podSpec.Volumes, mergeVolumes...)
+
+	return nil
+}
+
+// ensureMergeScriptConfigMap applies the namespace-shared ConfigMap carrying the embedded
+// merge_authfile.py script. Server-side apply creates or updates it in one call, needing
+// no conflict handling since every writer applies the content it embeds.
+func (r *jobRunner) ensureMergeScriptConfigMap(ctx context.Context, namespace string) error {
+	configMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      registryhelpers.MergeScriptConfigMapName,
+			Namespace: namespace,
+			Labels:    common.CopyStringMapOrNil(r.builderConfiguration.PodLabels),
+		},
+		Data: map[string]string{"merge_authfile.py": registryhelpers.MergeScriptContents()},
+	}
+
+	if _, err := r.kubeClientSet.ApplyConfigMap(ctx, namespace, configMap); err != nil {
+		return errors.Wrap(err, "Failed to apply registry auth merge script config map")
+	}
+	return nil
 }

--- a/pkg/containerimagebuilderpusher/jobrunner.go
+++ b/pkg/containerimagebuilderpusher/jobrunner.go
@@ -764,8 +764,38 @@ func (r *jobRunner) ensureMergeScriptConfigMap(ctx context.Context, namespace st
 		Data: map[string]string{"merge_authfile.py": registryhelpers.MergeScriptContents()},
 	}
 
+	ownerRef, err := r.getDashboardOwnerReference(ctx, namespace)
+	if err != nil {
+		return errors.Wrap(err, "Failed to resolve nuclio-dashboard owner reference for merge script config map")
+	}
+	configMap.OwnerReferences = []metav1.OwnerReference{*ownerRef}
+
 	if _, err := r.kubeClientSet.ApplyConfigMap(ctx, namespace, configMap); err != nil {
 		return errors.Wrap(err, "Failed to apply registry auth merge script config map")
 	}
 	return nil
+}
+
+// getDashboardOwnerReference resolves the nuclio-dashboard Deployment running in namespace as
+// an owner reference, so dependent objects get garbage-collected with it.
+func (r *jobRunner) getDashboardOwnerReference(ctx context.Context, namespace string) (*metav1.OwnerReference, error) {
+	deploymentName := os.Getenv("NUCLIO_DASHBOARD_DEPLOYMENT_NAME")
+	if deploymentName == "" {
+		return nil, errors.New("NUCLIO_DASHBOARD_DEPLOYMENT_NAME is not set")
+	}
+
+	deployment, err := r.kubeClientSet.GetDeployment(ctx, namespace, deploymentName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to get nuclio-dashboard deployment %s/%s", namespace, deploymentName)
+	}
+
+	controller := true
+	return &metav1.OwnerReference{
+		APIVersion:         "apps/v1",
+		Kind:               "Deployment",
+		Name:               deployment.Name,
+		UID:                deployment.UID,
+		Controller:         &controller,
+		BlockOwnerDeletion: &controller,
+	}, nil
 }

--- a/pkg/containerimagebuilderpusher/jobrunner_test.go
+++ b/pkg/containerimagebuilderpusher/jobrunner_test.go
@@ -22,12 +22,18 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher/registryhelpers"
+	"github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
+
 	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
 type JobRunnerTestSuite struct {
@@ -75,51 +81,34 @@ func (suite *JobRunnerTestSuite) TestCreateContainerBuildBundleSafeFromShellInje
 		"Shell injection marker was created — injection succeeded via shell execution")
 }
 
-func (suite *JobRunnerTestSuite) TestCompileJobNamePrefix() {
+// TestEnsureMergeScriptConfigMap covers the server-side-apply upsert from each initial state.
+func (suite *JobRunnerTestSuite) TestEnsureMergeScriptConfigMap() {
 	for _, testCase := range []struct {
-		name           string
-		jobPrefix      string
-		image          string
-		expectedPrefix string
+		name            string
+		existingScript  string
+		configMapExists bool
 	}{
-		{
-			name:           "ShortNameNoTruncation",
-			jobPrefix:      "buildjob",
-			image:          "my-func:latest",
-			expectedPrefix: "nuclio-buildjob.my-func-latest-",
-		},
-		{
-			name:           "SanitizesInvalidChars",
-			jobPrefix:      "buildjob",
-			image:          "Registry.Example.Com/My_Func:v1.2",
-			expectedPrefix: "nuclio-buildjob.registry.example.com-myfunc-v1.2-",
-		},
-		{
-			name:           "TruncatesLongNameGenerically",
-			jobPrefix:      "buildjob",
-			image:          strings.Repeat("x", 80) + ":latest",
-			expectedPrefix: "nuclio-buildjob." + strings.Repeat("x", 41) + "-",
-		},
-		{
-			name:           "TruncationLandsOnDot",
-			jobPrefix:      "buildjob",
-			image:          strings.Repeat("a", 40) + "." + strings.Repeat("b", 40) + ":latest",
-			expectedPrefix: "nuclio-buildjob." + strings.Repeat("a", 40) + "-",
-		},
-		{
-			name:           "TruncationLandsOnDash",
-			jobPrefix:      "buildjob",
-			image:          strings.Repeat("a", 40) + "-" + strings.Repeat("b", 40) + ":latest",
-			expectedPrefix: "nuclio-buildjob." + strings.Repeat("a", 40) + "-",
-		},
+		{name: "CreatesWhenAbsent"},
+		{name: "UpdatesWhenStale", configMapExists: true, existingScript: "stale contents"},
+		{name: "IdempotentWhenUpToDate", configMapExists: true, existingScript: registryhelpers.MergeScriptContents()},
 	} {
 		suite.Run(testCase.name, func() {
-			suite.jobRunner.builderConfiguration.JobPrefix = testCase.jobPrefix
+			var existingObjects []k8sruntime.Object
+			if testCase.configMapExists {
+				existingObjects = append(existingObjects, &v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: registryhelpers.MergeScriptConfigMapName, Namespace: "default"},
+					Data:       map[string]string{"merge_authfile.py": testCase.existingScript},
+				})
+			}
+			suite.jobRunner.kubeClientSet = kube.NewClientWithRetryFromClient(k8sfake.NewClientset(existingObjects...))
 
-			prefix := suite.jobRunner.compileJobNamePrefix(testCase.image)
+			suite.Require().NoError(suite.jobRunner.ensureMergeScriptConfigMap(context.Background(), "default"))
 
-			suite.Equal(testCase.expectedPrefix, prefix)
-			suite.LessOrEqual(len(prefix), 58, "must leave room for k8s's 5-char GenerateName suffix")
+			configMap, err := suite.jobRunner.kubeClientSet.GetConfigMap(context.Background(),
+				"default",
+				registryhelpers.MergeScriptConfigMapName)
+			suite.Require().NoError(err)
+			suite.Equal(registryhelpers.MergeScriptContents(), configMap.Data["merge_authfile.py"])
 		})
 	}
 }

--- a/pkg/containerimagebuilderpusher/jobrunner_test.go
+++ b/pkg/containerimagebuilderpusher/jobrunner_test.go
@@ -30,6 +30,7 @@ import (
 
 	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -81,19 +82,33 @@ func (suite *JobRunnerTestSuite) TestCreateContainerBuildBundleSafeFromShellInje
 		"Shell injection marker was created — injection succeeded via shell execution")
 }
 
-// TestEnsureMergeScriptConfigMap covers the server-side-apply upsert from each initial state.
+// TestEnsureMergeScriptConfigMap covers the server-side-apply upsert from each initial state,
+// including that the applied config map carries the nuclio-dashboard deployment as owner
+// reference, plus the error case where that deployment can't be resolved.
 func (suite *JobRunnerTestSuite) TestEnsureMergeScriptConfigMap() {
+	dashboardDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "nuclio-dashboard", Namespace: "default", UID: "dashboard-uid"},
+	}
+
 	for _, testCase := range []struct {
-		name            string
-		existingScript  string
-		configMapExists bool
+		name              string
+		existingScript    string
+		configMapExists   bool
+		dashboardDeployed bool
+		expectErr         bool
 	}{
-		{name: "CreatesWhenAbsent"},
-		{name: "UpdatesWhenStale", configMapExists: true, existingScript: "stale contents"},
-		{name: "IdempotentWhenUpToDate", configMapExists: true, existingScript: registryhelpers.MergeScriptContents()},
+		{name: "CreatesWhenAbsent", dashboardDeployed: true},
+		{name: "UpdatesWhenStale", configMapExists: true, existingScript: "stale contents", dashboardDeployed: true},
+		{name: "IdempotentWhenUpToDate", configMapExists: true, existingScript: registryhelpers.MergeScriptContents(), dashboardDeployed: true},
+		{name: "FailsWhenDashboardDeploymentUnresolvable", expectErr: true},
 	} {
 		suite.Run(testCase.name, func() {
+			suite.T().Setenv("NUCLIO_DASHBOARD_DEPLOYMENT_NAME", "nuclio-dashboard")
+
 			var existingObjects []k8sruntime.Object
+			if testCase.dashboardDeployed {
+				existingObjects = append(existingObjects, dashboardDeployment)
+			}
 			if testCase.configMapExists {
 				existingObjects = append(existingObjects, &v1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Name: registryhelpers.MergeScriptConfigMapName, Namespace: "default"},
@@ -102,13 +117,25 @@ func (suite *JobRunnerTestSuite) TestEnsureMergeScriptConfigMap() {
 			}
 			suite.jobRunner.kubeClientSet = kube.NewClientWithRetryFromClient(k8sfake.NewClientset(existingObjects...))
 
-			suite.Require().NoError(suite.jobRunner.ensureMergeScriptConfigMap(context.Background(), "default"))
+			err := suite.jobRunner.ensureMergeScriptConfigMap(context.Background(), "default")
+			if testCase.expectErr {
+				suite.Require().Error(err)
+				return
+			}
+			suite.Require().NoError(err)
 
 			configMap, err := suite.jobRunner.kubeClientSet.GetConfigMap(context.Background(),
 				"default",
 				registryhelpers.MergeScriptConfigMapName)
 			suite.Require().NoError(err)
 			suite.Equal(registryhelpers.MergeScriptContents(), configMap.Data["merge_authfile.py"])
+
+			suite.Require().Len(configMap.OwnerReferences, 1)
+			ownerRef := configMap.OwnerReferences[0]
+			suite.Equal("apps/v1", ownerRef.APIVersion)
+			suite.Equal("Deployment", ownerRef.Kind)
+			suite.Equal(dashboardDeployment.Name, ownerRef.Name)
+			suite.Equal(dashboardDeployment.UID, ownerRef.UID)
 		})
 	}
 }

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher/registryhelpers"
 	"github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
 
 	"github.com/nuclio/errors"
@@ -31,7 +31,11 @@ import (
 	"k8s.io/api/core/v1"
 )
 
-const KanikoKind = "kaniko"
+const (
+	KanikoKind = "kaniko"
+
+	kanikoAuthDir = "/kaniko/.docker"
+)
 
 type Kaniko struct {
 	*jobRunner
@@ -89,7 +93,9 @@ func (k *Kaniko) compileJobSpec(ctx context.Context,
 		return nil, err
 	}
 
-	k.configureSecretVolumeMount(buildOptions, jobSpec)
+	if err := k.configureRegistryAuthentication(ctx, namespace, buildOptions, jobSpec); err != nil {
+		return nil, errors.Wrap(err, "Failed to configure registry auth volume mount")
+	}
 	return jobSpec, nil
 }
 
@@ -144,36 +150,23 @@ func (k *Kaniko) compileKanikoContainer(buildOptions *BuildOptions) v1.Container
 	}
 }
 
-func (k *Kaniko) configureSecretVolumeMount(buildOptions *BuildOptions, kanikoJobSpec *batchv1.Job) {
-	if k.matchECRUrl(buildOptions.RegistryURL) {
+// configureRegistryAuthentication wires the registry authfile into the kaniko container. Kaniko has
+// its own bundled cloud credential helpers, hence the nil cloudHosts - no login containers needed.
+func (k *Kaniko) configureRegistryAuthentication(ctx context.Context, namespace string, buildOptions *BuildOptions, kanikoJobSpec *batchv1.Job) error {
+	if registryhelpers.IsECRHost(buildOptions.RegistryURL) {
 		k.configureECRInitContainerAndMount(buildOptions, kanikoJobSpec)
-
-		// if SecretName is defined - configure mount with docker credentials
-	} else if len(buildOptions.SecretName) > 0 {
-
-		// configure mount with docker credentials
-		kanikoJobSpec.Spec.Template.Spec.Containers[0].VolumeMounts =
-			append(kanikoJobSpec.Spec.Template.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
-				Name:      "docker-config",
-				MountPath: "/kaniko/.docker",
-				ReadOnly:  true,
-			})
-
-		kanikoJobSpec.Spec.Template.Spec.Volumes = append(kanikoJobSpec.Spec.Template.Spec.Volumes, v1.Volume{
-			Name: "docker-config",
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
-					SecretName: buildOptions.SecretName,
-					Items: []v1.KeyToPath{
-						{
-							Key:  ".dockerconfigjson",
-							Path: "config.json",
-						},
-					},
-				},
-			},
-		})
+		return nil
 	}
+
+	podSpec := &kanikoJobSpec.Spec.Template.Spec
+
+	return k.jobRunner.configureRegistryAuthentication(ctx,
+		namespace,
+		buildOptions,
+		kanikoAuthDir,
+		nil,
+		k.builderConfiguration.Kaniko.ImagePullPolicy,
+		podSpec)
 }
 
 func (k *Kaniko) configureECRInitContainerAndMount(buildOptions *BuildOptions, kanikoJobSpec *batchv1.Job) {
@@ -181,8 +174,8 @@ func (k *Kaniko) configureECRInitContainerAndMount(buildOptions *BuildOptions, k
 	// Add init container to create the main and cache repositories
 	// fail silently in order to ignore "repository already exists" errors
 	// if any other error occurs - kaniko will fail similarly
-	region := k.resolveAWSRegionFromECR(buildOptions.RegistryURL)
-	registryID := k.resolveAWSRegistryId(buildOptions.RegistryURL)
+	region := registryhelpers.ECRRegion(buildOptions.RegistryURL)
+	registryID := registryhelpers.ECRRegistryID(buildOptions.RegistryURL)
 	createRepoTemplate := "aws ecr create-repository --repository-name %s --region %s --registry-id %s || true"
 	createMainRepo := fmt.Sprintf(createRepoTemplate, buildOptions.RepoName, region, registryID)
 	createCacheRepo := fmt.Sprintf(createRepoTemplate,
@@ -249,18 +242,4 @@ func (k *Kaniko) configureECRInitContainerAndMount(buildOptions *BuildOptions, k
 			})
 	}
 	kanikoJobSpec.Spec.Template.Spec.InitContainers = append(kanikoJobSpec.Spec.Template.Spec.InitContainers, initContainer)
-}
-
-func (k *Kaniko) matchECRUrl(registryURL string) bool {
-	return strings.Contains(registryURL, ".amazonaws.com") && strings.Contains(registryURL, ".ecr.")
-}
-
-func (k *Kaniko) resolveAWSRegionFromECR(registryURL string) string {
-	return strings.Split(registryURL, ".")[3]
-}
-
-// resolveAWSRegistryId extracts the AWS account ID (registry ID) from an ECR registry URL
-// Example: "123456789012.dkr.ecr.us-east-1.amazonaws.com" -> "123456789012"
-func (k *Kaniko) resolveAWSRegistryId(registryURL string) string {
-	return strings.Split(registryURL, ".")[0]
 }

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -39,6 +39,7 @@ const (
 
 type Kaniko struct {
 	*jobRunner
+	awsHelper *registryhelpers.AWSHelper
 }
 
 func NewKaniko(logger logger.Logger,
@@ -50,7 +51,7 @@ func NewKaniko(logger logger.Logger,
 		return nil, errors.Wrap(err, "Failed to create kaniko job runner")
 	}
 
-	return &Kaniko{jobRunner: jobRunner}, nil
+	return &Kaniko{jobRunner: jobRunner, awsHelper: &registryhelpers.AWSHelper{}}, nil
 }
 
 func (k *Kaniko) BuildAndPushContainerImage(ctx context.Context,
@@ -153,7 +154,7 @@ func (k *Kaniko) compileKanikoContainer(buildOptions *BuildOptions) v1.Container
 // configureRegistryAuthentication wires the registry authfile into the kaniko container. Kaniko has
 // its own bundled cloud credential helpers, hence the nil cloudHosts - no login containers needed.
 func (k *Kaniko) configureRegistryAuthentication(ctx context.Context, namespace string, buildOptions *BuildOptions, kanikoJobSpec *batchv1.Job) error {
-	if registryhelpers.IsECRHost(buildOptions.RegistryURL) {
+	if k.awsHelper.Matches(buildOptions.RegistryURL) {
 		k.configureECRInitContainerAndMount(buildOptions, kanikoJobSpec)
 		return nil
 	}
@@ -174,8 +175,8 @@ func (k *Kaniko) configureECRInitContainerAndMount(buildOptions *BuildOptions, k
 	// Add init container to create the main and cache repositories
 	// fail silently in order to ignore "repository already exists" errors
 	// if any other error occurs - kaniko will fail similarly
-	region := registryhelpers.ECRRegion(buildOptions.RegistryURL)
-	registryID := registryhelpers.ECRRegistryID(buildOptions.RegistryURL)
+	region := k.awsHelper.ECRRegion(buildOptions.RegistryURL)
+	registryID := k.awsHelper.ECRRegistryID(buildOptions.RegistryURL)
 	createRepoTemplate := "aws ecr create-repository --repository-name %s --region %s --registry-id %s || true"
 	createMainRepo := fmt.Sprintf(createRepoTemplate, buildOptions.RepoName, region, registryID)
 	createCacheRepo := fmt.Sprintf(createRepoTemplate,

--- a/pkg/containerimagebuilderpusher/kaniko_test.go
+++ b/pkg/containerimagebuilderpusher/kaniko_test.go
@@ -26,7 +26,6 @@ import (
 
 type KanikoTestSuite struct {
 	suite.Suite
-	kaniko *Kaniko
 }
 
 func (suite *KanikoTestSuite) TestNewContainerBuilderConfigurationParsesKanikoPodLabels() {
@@ -69,68 +68,6 @@ func (suite *KanikoTestSuite) TestNewContainerBuilderConfigurationParsesKanikoPo
 			}
 			suite.Require().NoError(err)
 			suite.Equal(testCase.expected, config.PodLabels)
-		})
-	}
-}
-
-func (suite *KanikoTestSuite) SetupTest() {
-	suite.kaniko = &Kaniko{jobRunner: &jobRunner{}}
-}
-
-func (suite *KanikoTestSuite) TestResolveAWSRegistryId() {
-	for _, testCase := range []struct {
-		name        string
-		registryURL string
-		expected    string
-	}{
-		{
-			name:        "StandardECRURL",
-			registryURL: "123456789012.dkr.ecr.us-east-1.amazonaws.com",
-			expected:    "123456789012",
-		},
-		{
-			name:        "DifferentRegion",
-			registryURL: "987654321098.dkr.ecr.eu-west-1.amazonaws.com",
-			expected:    "987654321098",
-		},
-		{
-			name:        "APRegion",
-			registryURL: "111222333444.dkr.ecr.ap-southeast-1.amazonaws.com",
-			expected:    "111222333444",
-		},
-	} {
-		suite.Run(testCase.name, func() {
-			result := suite.kaniko.resolveAWSRegistryId(testCase.registryURL)
-			suite.Require().Equal(testCase.expected, result)
-		})
-	}
-}
-
-func (suite *KanikoTestSuite) TestResolveAWSRegionFromECR() {
-	for _, testCase := range []struct {
-		name        string
-		registryURL string
-		expected    string
-	}{
-		{
-			name:        "USEast1",
-			registryURL: "123456789012.dkr.ecr.us-east-1.amazonaws.com",
-			expected:    "us-east-1",
-		},
-		{
-			name:        "EUWest1",
-			registryURL: "987654321098.dkr.ecr.eu-west-1.amazonaws.com",
-			expected:    "eu-west-1",
-		},
-		{
-			name:        "APSoutheast1",
-			registryURL: "111222333444.dkr.ecr.ap-southeast-1.amazonaws.com",
-			expected:    "ap-southeast-1",
-		},
-	} {
-		suite.Run(testCase.name, func() {
-			result := suite.kaniko.resolveAWSRegionFromECR(testCase.registryURL)
-			suite.Require().Equal(testCase.expected, result)
 		})
 	}
 }

--- a/pkg/containerimagebuilderpusher/nop.go
+++ b/pkg/containerimagebuilderpusher/nop.go
@@ -62,7 +62,3 @@ func (n Nop) GetRegistryKind() string {
 func (n Nop) GetOnbuildImageRegistry(registry string) string {
 	return ""
 }
-
-func (n Nop) GetDefaultRegistryCredentialsSecretName() string {
-	return ""
-}

--- a/pkg/containerimagebuilderpusher/registryhelpers/aws.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/aws.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registryhelpers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nuclio/nuclio/pkg/common"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// ecrLoginUsername is the fixed username for ECR get-login-password tokens.
+const ecrLoginUsername = "AWS"
+
+// IsECRHost reports whether url is an ECR hostname.
+func IsECRHost(url string) bool {
+	return strings.Contains(url, ".amazonaws.com") && strings.Contains(url, ".ecr.")
+}
+
+// ECRRegion extracts the AWS region from an ECR registry URL.
+func ECRRegion(url string) string {
+	return strings.Split(url, ".")[3]
+}
+
+// ECRRegistryID extracts the AWS account ID (registry ID) from an ECR registry URL.
+func ECRRegistryID(url string) string {
+	return strings.Split(url, ".")[0]
+}
+
+type awsHelper struct{}
+
+// Matches detects an ECR hostname, e.g. <registryId>.dkr.ecr.<region>.amazonaws.com.
+func (h *awsHelper) Matches(host string) bool {
+	return IsECRHost(host)
+}
+
+func (h *awsHelper) BuildLoginContainer(host, repoName, tokenFilePath, credentialsMountPath string,
+	cfg AuthConfig,
+	imagePullPolicy string) (v1.Container, error) {
+
+	region := ECRRegion(host)
+	registryID := ECRRegistryID(host)
+
+	var commandParts []string
+	// Pulling a base/onbuild image never needs repo creation, only the push destination does.
+	if repoName != "" {
+		commandParts = append(commandParts, fmt.Sprintf(`(set -e
+aws ecr create-repository --repository-name %s --region %s --registry-id %s
+aws ecr create-repository --repository-name %s/cache --region %s --registry-id %s
+) || echo "WARNING: failed to ensure ECR repository %s exists" >&2`,
+			repoName, region, registryID, repoName, region, registryID, repoName))
+	}
+	commandParts = append(commandParts, softFailScript(
+		writeCredentialFileScript(tokenFilePath, host, ecrLoginUsername,
+			fmt.Sprintf("aws ecr get-login-password --region %s", region)),
+		host, "ECR"))
+
+	name, err := common.SanitizeKubernetesName("registry-login-aws-", host, false)
+	if err != nil {
+		return v1.Container{}, err
+	}
+
+	container := v1.Container{
+		Name:            name,
+		Image:           cfg.AWSCLIImage,
+		ImagePullPolicy: v1.PullPolicy(imagePullPolicy),
+		Command:         []string{"/bin/sh"},
+		Args:            []string{"-c", strings.Join(commandParts, "\n")},
+		VolumeMounts:    []v1.VolumeMount{TokenDirVolumeMount()},
+	}
+
+	if credentialsMountPath != "" {
+		container.Env = append(container.Env, v1.EnvVar{
+			Name:  "AWS_SHARED_CREDENTIALS_FILE",
+			Value: credentialsMountPath + "/" + providerCredentialsFileName,
+		})
+	} else {
+		// ambient credentials (e.g. IRSA) picked up from the pod's service account
+		container.Env = append(container.Env, v1.EnvVar{
+			Name:  "AWS_SDK_LOAD_CONFIG",
+			Value: "true",
+		})
+	}
+
+	return container, nil
+}

--- a/pkg/containerimagebuilderpusher/registryhelpers/aws.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/aws.go
@@ -29,8 +29,8 @@ import (
 // ecrLoginUsername is the fixed username for ECR get-login-password tokens.
 const ecrLoginUsername = "AWS"
 
-// ecrHostPattern matches an ECR hostname, e.g. <registryId>.dkr.ecr.<region>.amazonaws.com.
-var ecrHostPattern = regexp.MustCompile(`^\d+\.dkr\.ecr\.[a-z0-9-]+\.amazonaws\.com$`)
+// ecrHostPattern matches an ECR private registry hostname, e.g. <accountId>.dkr.ecr.<region>.amazonaws.com.
+var ecrHostPattern = regexp.MustCompile(`^\d{12}\.dkr\.ecr(-fips)?\.[a-z0-9-]+\.amazonaws\.com(\.cn)?$`)
 
 // AWSHelper authenticates to ECR and exposes ECR URL parsing that both the buildah
 // login-container flow and kaniko's bundled credential helper need.
@@ -55,22 +55,26 @@ func (h *AWSHelper) BuildLoginContainer(host, repoName, tokenFilePath, credentia
 	cfg AuthConfig,
 	imagePullPolicy string) (v1.Container, error) {
 
-	region := h.ECRRegion(host)
-	registryID := h.ECRRegistryID(host)
+	envVars := append(credentialFileEnv(host, ecrLoginUsername, tokenFilePath),
+		v1.EnvVar{Name: envVarECRRegion, Value: h.ECRRegion(host)},
+		v1.EnvVar{Name: envVarECRRegistryID, Value: h.ECRRegistryID(host)})
 
 	var commandParts []string
 	// Pulling a base/onbuild image never needs repo creation, only the push destination does.
 	if repoName != "" {
+		envVars = append(envVars, v1.EnvVar{Name: envVarRegistryRepo, Value: repoName})
 		commandParts = append(commandParts, fmt.Sprintf(`(set -e
-aws ecr create-repository --repository-name %s --region %s --registry-id %s
-aws ecr create-repository --repository-name %s/cache --region %s --registry-id %s
-) || echo "WARNING: failed to ensure ECR repository %s exists" >&2`,
-			repoName, region, registryID, repoName, region, registryID, repoName))
+aws ecr create-repository --repository-name "$%s" --region "$%s" --registry-id "$%s"
+aws ecr create-repository --repository-name "$%s"/cache --region "$%s" --registry-id "$%s"
+) || echo "WARNING: failed to ensure ECR repository $%s exists" >&2`,
+			envVarRegistryRepo, envVarECRRegion, envVarECRRegistryID,
+			envVarRegistryRepo, envVarECRRegion, envVarECRRegistryID,
+			envVarRegistryRepo))
 	}
 	commandParts = append(commandParts, softFailScript(
-		writeCredentialFileScript(tokenFilePath, host, ecrLoginUsername,
-			fmt.Sprintf("aws ecr get-login-password --region %s", region)),
-		host, "ECR"))
+		writeCredentialFileScript(
+			fmt.Sprintf(`aws ecr get-login-password --region "$%s"`, envVarECRRegion)),
+		"ECR"))
 
 	name, err := common.SanitizeKubernetesName("registry-login-aws-", host, false)
 	if err != nil {
@@ -83,6 +87,7 @@ aws ecr create-repository --repository-name %s/cache --region %s --registry-id %
 		ImagePullPolicy: v1.PullPolicy(imagePullPolicy),
 		Command:         []string{"/bin/sh"},
 		Args:            []string{"-c", strings.Join(commandParts, "\n")},
+		Env:             envVars,
 		VolumeMounts:    []v1.VolumeMount{TokenDirVolumeMount()},
 	}
 

--- a/pkg/containerimagebuilderpusher/registryhelpers/aws.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/aws.go
@@ -18,6 +18,7 @@ package registryhelpers
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/nuclio/nuclio/pkg/common"
@@ -28,34 +29,34 @@ import (
 // ecrLoginUsername is the fixed username for ECR get-login-password tokens.
 const ecrLoginUsername = "AWS"
 
-// IsECRHost reports whether url is an ECR hostname.
-func IsECRHost(url string) bool {
-	return strings.Contains(url, ".amazonaws.com") && strings.Contains(url, ".ecr.")
+// ecrHostPattern matches an ECR hostname, e.g. <registryId>.dkr.ecr.<region>.amazonaws.com.
+var ecrHostPattern = regexp.MustCompile(`^\d+\.dkr\.ecr\.[a-z0-9-]+\.amazonaws\.com$`)
+
+// AWSHelper authenticates to ECR and exposes ECR URL parsing that both the buildah
+// login-container flow and kaniko's bundled credential helper need.
+type AWSHelper struct{}
+
+// Matches detects an ECR hostname, e.g. <registryId>.dkr.ecr.<region>.amazonaws.com.
+func (h *AWSHelper) Matches(host string) bool {
+	return ecrHostPattern.MatchString(host)
 }
 
 // ECRRegion extracts the AWS region from an ECR registry URL.
-func ECRRegion(url string) string {
+func (h *AWSHelper) ECRRegion(url string) string {
 	return strings.Split(url, ".")[3]
 }
 
 // ECRRegistryID extracts the AWS account ID (registry ID) from an ECR registry URL.
-func ECRRegistryID(url string) string {
+func (h *AWSHelper) ECRRegistryID(url string) string {
 	return strings.Split(url, ".")[0]
 }
 
-type awsHelper struct{}
-
-// Matches detects an ECR hostname, e.g. <registryId>.dkr.ecr.<region>.amazonaws.com.
-func (h *awsHelper) Matches(host string) bool {
-	return IsECRHost(host)
-}
-
-func (h *awsHelper) BuildLoginContainer(host, repoName, tokenFilePath, credentialsMountPath string,
+func (h *AWSHelper) BuildLoginContainer(host, repoName, tokenFilePath, credentialsMountPath string,
 	cfg AuthConfig,
 	imagePullPolicy string) (v1.Container, error) {
 
-	region := ECRRegion(host)
-	registryID := ECRRegistryID(host)
+	region := h.ECRRegion(host)
+	registryID := h.ECRRegistryID(host)
 
 	var commandParts []string
 	// Pulling a base/onbuild image never needs repo creation, only the push destination does.

--- a/pkg/containerimagebuilderpusher/registryhelpers/aws.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/aws.go
@@ -51,9 +51,8 @@ func (h *AWSHelper) ECRRegistryID(url string) string {
 	return strings.Split(url, ".")[0]
 }
 
-func (h *AWSHelper) BuildLoginContainer(host, repoName, tokenFilePath, credentialsMountPath string,
-	cfg AuthConfig,
-	imagePullPolicy string) (v1.Container, error) {
+func (h *AWSHelper) BuildLoginContainer(host, repoName, tokenFilePath, credentialsMountPath, imagePullPolicy string,
+	cfg AuthConfig) (v1.Container, error) {
 
 	envVars := append(credentialFileEnv(host, ecrLoginUsername, tokenFilePath),
 		v1.EnvVar{Name: envVarECRRegion, Value: h.ECRRegion(host)},

--- a/pkg/containerimagebuilderpusher/registryhelpers/aws_test.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/aws_test.go
@@ -26,6 +26,11 @@ import (
 
 type AWSTestSuite struct {
 	suite.Suite
+	helper *AWSHelper
+}
+
+func (suite *AWSTestSuite) SetupTest() {
+	suite.helper = &AWSHelper{}
 }
 
 func (suite *AWSTestSuite) TestECRRegistryID() {
@@ -51,7 +56,7 @@ func (suite *AWSTestSuite) TestECRRegistryID() {
 		},
 	} {
 		suite.Run(testCase.name, func() {
-			suite.Require().Equal(testCase.expected, ECRRegistryID(testCase.registryURL))
+			suite.Require().Equal(testCase.expected, suite.helper.ECRRegistryID(testCase.registryURL))
 		})
 	}
 }
@@ -79,12 +84,12 @@ func (suite *AWSTestSuite) TestECRRegion() {
 		},
 	} {
 		suite.Run(testCase.name, func() {
-			suite.Require().Equal(testCase.expected, ECRRegion(testCase.registryURL))
+			suite.Require().Equal(testCase.expected, suite.helper.ECRRegion(testCase.registryURL))
 		})
 	}
 }
 
-func (suite *AWSTestSuite) TestIsECRHost() {
+func (suite *AWSTestSuite) TestMatches() {
 	for _, testCase := range []struct {
 		name     string
 		url      string
@@ -95,7 +100,7 @@ func (suite *AWSTestSuite) TestIsECRHost() {
 		{name: "AzureHost", url: "myregistry.azurecr.io", expected: false},
 	} {
 		suite.Run(testCase.name, func() {
-			suite.Require().Equal(testCase.expected, IsECRHost(testCase.url))
+			suite.Require().Equal(testCase.expected, suite.helper.Matches(testCase.url))
 		})
 	}
 }

--- a/pkg/containerimagebuilderpusher/registryhelpers/aws_test.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/aws_test.go
@@ -1,0 +1,105 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registryhelpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type AWSTestSuite struct {
+	suite.Suite
+}
+
+func (suite *AWSTestSuite) TestECRRegistryID() {
+	for _, testCase := range []struct {
+		name        string
+		registryURL string
+		expected    string
+	}{
+		{
+			name:        "StandardECRURL",
+			registryURL: "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+			expected:    "123456789012",
+		},
+		{
+			name:        "DifferentRegion",
+			registryURL: "987654321098.dkr.ecr.eu-west-1.amazonaws.com",
+			expected:    "987654321098",
+		},
+		{
+			name:        "APRegion",
+			registryURL: "111222333444.dkr.ecr.ap-southeast-1.amazonaws.com",
+			expected:    "111222333444",
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Require().Equal(testCase.expected, ECRRegistryID(testCase.registryURL))
+		})
+	}
+}
+
+func (suite *AWSTestSuite) TestECRRegion() {
+	for _, testCase := range []struct {
+		name        string
+		registryURL string
+		expected    string
+	}{
+		{
+			name:        "USEast1",
+			registryURL: "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+			expected:    "us-east-1",
+		},
+		{
+			name:        "EUWest1",
+			registryURL: "987654321098.dkr.ecr.eu-west-1.amazonaws.com",
+			expected:    "eu-west-1",
+		},
+		{
+			name:        "APSoutheast1",
+			registryURL: "111222333444.dkr.ecr.ap-southeast-1.amazonaws.com",
+			expected:    "ap-southeast-1",
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Require().Equal(testCase.expected, ECRRegion(testCase.registryURL))
+		})
+	}
+}
+
+func (suite *AWSTestSuite) TestIsECRHost() {
+	for _, testCase := range []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{name: "ECRHost", url: "123456789012.dkr.ecr.us-east-1.amazonaws.com", expected: true},
+		{name: "ArtifactoryHost", url: "system-registry.artifactory.example.com", expected: false},
+		{name: "AzureHost", url: "myregistry.azurecr.io", expected: false},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Require().Equal(testCase.expected, IsECRHost(testCase.url))
+		})
+	}
+}
+
+func TestAWSTestSuite(t *testing.T) {
+	suite.Run(t, new(AWSTestSuite))
+}

--- a/pkg/containerimagebuilderpusher/registryhelpers/azure.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/azure.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registryhelpers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nuclio/nuclio/pkg/common"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// acrLoginUsername is the fixed GUID for ACR access-token auth.
+const acrLoginUsername = "00000000-0000-0000-0000-000000000000"
+
+type azureHelper struct{}
+
+func (h *azureHelper) Matches(host string) bool {
+	return strings.HasSuffix(host, ".azurecr.io")
+}
+
+func (h *azureHelper) BuildLoginContainer(host, repoName, tokenFilePath, credentialsMountPath string,
+	cfg AuthConfig,
+	imagePullPolicy string) (v1.Container, error) {
+
+	registryName := strings.Split(host, ".")[0]
+
+	// Exchange the federated token (from workload identity) for an az-cli session, if present.
+	command := softFailScript(fmt.Sprintf(`if [ -n "$AZURE_FEDERATED_TOKEN_FILE" ]; then
+  az login --service-principal -u "$AZURE_CLIENT_ID" -t "$AZURE_TENANT_ID" --federated-token "$(cat "$AZURE_FEDERATED_TOKEN_FILE")" >/dev/null
+fi
+%s`, writeCredentialFileScript(tokenFilePath, host, acrLoginUsername,
+		fmt.Sprintf("az acr login --name %s --expose-token --output tsv --query accessToken", registryName))),
+		host, "ACR")
+
+	name, err := common.SanitizeKubernetesName("registry-login-azure-", host, false)
+	if err != nil {
+		return v1.Container{}, err
+	}
+
+	container := v1.Container{
+		Name:            name,
+		Image:           cfg.AzureCLIImage,
+		ImagePullPolicy: v1.PullPolicy(imagePullPolicy),
+		Command:         []string{"/bin/sh"},
+		Args:            []string{"-c", command},
+		VolumeMounts:    []v1.VolumeMount{TokenDirVolumeMount()},
+	}
+
+	if credentialsMountPath != "" {
+		container.Env = append(container.Env, v1.EnvVar{
+			Name:  "AZURE_AUTH_LOCATION",
+			Value: credentialsMountPath + "/" + providerCredentialsFileName,
+		})
+	}
+
+	return container, nil
+}

--- a/pkg/containerimagebuilderpusher/registryhelpers/azure.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/azure.go
@@ -18,6 +18,7 @@ package registryhelpers
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/nuclio/nuclio/pkg/common"
@@ -28,25 +29,30 @@ import (
 // acrLoginUsername is the fixed GUID for ACR access-token auth.
 const acrLoginUsername = "00000000-0000-0000-0000-000000000000"
 
+// acrHostPattern matches an ACR login-server hostname, e.g. <registryName>[-<dnlHash>].azurecr.io.
+var acrHostPattern = regexp.MustCompile(`(?i)^[a-z0-9]{5,50}(-[a-z0-9]+)?\.azurecr\.(io|cn|us)$`)
+
 type azureHelper struct{}
 
 func (h *azureHelper) Matches(host string) bool {
-	return strings.HasSuffix(host, ".azurecr.io")
+	return acrHostPattern.MatchString(host)
 }
 
 func (h *azureHelper) BuildLoginContainer(host, repoName, tokenFilePath, credentialsMountPath string,
 	cfg AuthConfig,
 	imagePullPolicy string) (v1.Container, error) {
 
-	registryName := strings.Split(host, ".")[0]
+	envVars := append(credentialFileEnv(host, acrLoginUsername, tokenFilePath),
+		v1.EnvVar{Name: envVarACRRegistryName, Value: strings.Split(host, ".")[0]})
 
 	// Exchange the federated token (from workload identity) for an az-cli session, if present.
 	command := softFailScript(fmt.Sprintf(`if [ -n "$AZURE_FEDERATED_TOKEN_FILE" ]; then
   az login --service-principal -u "$AZURE_CLIENT_ID" -t "$AZURE_TENANT_ID" --federated-token "$(cat "$AZURE_FEDERATED_TOKEN_FILE")" >/dev/null
 fi
-%s`, writeCredentialFileScript(tokenFilePath, host, acrLoginUsername,
-		fmt.Sprintf("az acr login --name %s --expose-token --output tsv --query accessToken", registryName))),
-		host, "ACR")
+%s`, writeCredentialFileScript(
+		fmt.Sprintf(`az acr login --name "$%s" --expose-token --output tsv --query accessToken`,
+			envVarACRRegistryName))),
+		"ACR")
 
 	name, err := common.SanitizeKubernetesName("registry-login-azure-", host, false)
 	if err != nil {
@@ -59,6 +65,7 @@ fi
 		ImagePullPolicy: v1.PullPolicy(imagePullPolicy),
 		Command:         []string{"/bin/sh"},
 		Args:            []string{"-c", command},
+		Env:             envVars,
 		VolumeMounts:    []v1.VolumeMount{TokenDirVolumeMount()},
 	}
 

--- a/pkg/containerimagebuilderpusher/registryhelpers/azure.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/azure.go
@@ -38,9 +38,8 @@ func (h *azureHelper) Matches(host string) bool {
 	return acrHostPattern.MatchString(host)
 }
 
-func (h *azureHelper) BuildLoginContainer(host, repoName, tokenFilePath, credentialsMountPath string,
-	cfg AuthConfig,
-	imagePullPolicy string) (v1.Container, error) {
+func (h *azureHelper) BuildLoginContainer(host, repoName, tokenFilePath, credentialsMountPath, imagePullPolicy string,
+	cfg AuthConfig) (v1.Container, error) {
 
 	envVars := append(credentialFileEnv(host, acrLoginUsername, tokenFilePath),
 		v1.EnvVar{Name: envVarACRRegistryName, Value: strings.Split(host, ".")[0]})

--- a/pkg/containerimagebuilderpusher/registryhelpers/cloudregistry.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/cloudregistry.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package registryhelpers authenticates to cloud registry vendors and merges docker-config
+// secrets and cloud credentials into one authfile for the buildah and kaniko backends.
+package registryhelpers
+
+import (
+	"fmt"
+
+	"github.com/nuclio/errors"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	// AuthVolumeName is the authfile volume's name.
+	AuthVolumeName = "authdir"
+
+	authTokensVolumeName = "authtokens"
+	authTokensMountPath  = "/tmp/registry-auth-tokens"
+
+	providerCredentialsMountPath = "/tmp/registry-provider-credentials"
+
+	// providerCredentialsFileName is the key every provider secret carries, after AWS's
+	// ~/.aws/credentials convention; used the same way for Azure and GCP.
+	providerCredentialsFileName = "credentials"
+)
+
+// AuthConfig carries the images and provider secret the auth/merge init containers need.
+type AuthConfig struct {
+	AWSCLIImage                string
+	AzureCLIImage              string
+	GCloudCLIImage             string
+	RegistryProviderSecretName string
+	PythonImage                string
+	PythonImagePullPolicy      string
+}
+
+// CloudRegistryHelper authenticates to one cloud registry vendor.
+type CloudRegistryHelper interface {
+	// Matches reports whether host belongs to this vendor.
+	Matches(host string) bool
+
+	// BuildLoginContainer returns the init container writing host's token to tokenFilePath. repoName
+	// is set only for the push destination, for vendors that provision repos (ECR);
+	// credentialsMountPath is where the static provider secret is mounted, or "" if none.
+	BuildLoginContainer(host, repoName, tokenFilePath, credentialsMountPath string,
+		cfg AuthConfig,
+		imagePullPolicy string) (v1.Container, error)
+}
+
+// cloudRegistryHelpers is the static, ordered set of supported vendors.
+var cloudRegistryHelpers = []CloudRegistryHelper{&awsHelper{}, &azureHelper{}, &gcpHelper{}}
+
+// helperFor returns the CloudRegistryHelper matching host, or nil.
+func helperFor(host string) CloudRegistryHelper {
+	for _, helper := range cloudRegistryHelpers {
+		if helper.Matches(host) {
+			return helper
+		}
+	}
+	return nil
+}
+
+// NeedsCloudLogin reports whether any of hosts is a supported cloud registry.
+func NeedsCloudLogin(hosts []string) bool {
+	for _, host := range hosts {
+		if helperFor(host) != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// TokenDirVolumeMount is the shared dir login containers write credential files into.
+func TokenDirVolumeMount() v1.VolumeMount {
+	return v1.VolumeMount{Name: authTokensVolumeName, MountPath: authTokensMountPath}
+}
+
+// BuildLoginContainers returns one login init container per host that resolves to a cloud vendor.
+func BuildLoginContainers(hosts []string,
+	pushDestination string,
+	repoName string,
+	cfg AuthConfig,
+	imagePullPolicy string) ([]v1.Container, []v1.Volume, error) {
+
+	pushHost := hostOf(pushDestination)
+	tokenDir := TokenDirVolumeMount()
+
+	var volumes []v1.Volume
+	credentialsMountPath := ""
+	if cfg.RegistryProviderSecretName != "" {
+		credentialsMountPath = providerCredentialsMountPath
+		volumes = append(volumes, v1.Volume{
+			Name:         cfg.RegistryProviderSecretName,
+			VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: cfg.RegistryProviderSecretName}},
+		})
+	}
+
+	var containers []v1.Container
+	tokenIndex := 0
+
+	for _, host := range hosts {
+		helper := helperFor(host)
+		if helper == nil {
+			continue
+		}
+
+		hostRepoName := ""
+		if host == pushHost {
+			hostRepoName = repoName
+		}
+		tokenFilePath := fmt.Sprintf("%s/%d.token", tokenDir.MountPath, tokenIndex)
+
+		container, err := helper.BuildLoginContainer(host, hostRepoName, tokenFilePath, credentialsMountPath, cfg, imagePullPolicy)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "Failed to build registry login init container for host: %s", host)
+		}
+		if credentialsMountPath != "" {
+			container.VolumeMounts = append(container.VolumeMounts,
+				v1.VolumeMount{Name: cfg.RegistryProviderSecretName, MountPath: credentialsMountPath})
+		}
+
+		containers = append(containers, container)
+		tokenIndex++
+	}
+
+	return containers, volumes, nil
+}

--- a/pkg/containerimagebuilderpusher/registryhelpers/cloudregistry.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/cloudregistry.go
@@ -39,16 +39,6 @@ const (
 	providerCredentialsFileName = "credentials"
 )
 
-// AuthConfig carries the images and provider secret the auth/merge init containers need.
-type AuthConfig struct {
-	AWSCLIImage                string
-	AzureCLIImage              string
-	GCloudCLIImage             string
-	RegistryProviderSecretName string
-	PythonImage                string
-	PythonImagePullPolicy      string
-}
-
 // CloudRegistryHelper authenticates to one cloud registry vendor.
 type CloudRegistryHelper interface {
 	// Matches reports whether host belongs to this vendor.

--- a/pkg/containerimagebuilderpusher/registryhelpers/cloudregistry.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/cloudregistry.go
@@ -21,6 +21,8 @@ package registryhelpers
 import (
 	"fmt"
 
+	"github.com/nuclio/nuclio/pkg/common"
+
 	"github.com/nuclio/errors"
 	v1 "k8s.io/api/core/v1"
 )
@@ -53,22 +55,12 @@ type CloudRegistryHelper interface {
 }
 
 // cloudRegistryHelpers is the static, ordered set of supported vendors.
-var cloudRegistryHelpers = []CloudRegistryHelper{&awsHelper{}, &azureHelper{}, &gcpHelper{}}
-
-// helperFor returns the CloudRegistryHelper matching host, or nil.
-func helperFor(host string) CloudRegistryHelper {
-	for _, helper := range cloudRegistryHelpers {
-		if helper.Matches(host) {
-			return helper
-		}
-	}
-	return nil
-}
+var cloudRegistryHelpers = []CloudRegistryHelper{&AWSHelper{}, &azureHelper{}, &gcpHelper{}}
 
 // NeedsCloudLogin reports whether any of hosts is a supported cloud registry.
 func NeedsCloudLogin(hosts []string) bool {
 	for _, host := range hosts {
-		if helperFor(host) != nil {
+		if cloudRegistryHelperFromHost(host) != nil {
 			return true
 		}
 	}
@@ -87,7 +79,7 @@ func BuildLoginContainers(hosts []string,
 	cfg AuthConfig,
 	imagePullPolicy string) ([]v1.Container, []v1.Volume, error) {
 
-	pushHost := hostOf(pushDestination)
+	pushHost := common.GetHostname(pushDestination)
 	tokenDir := TokenDirVolumeMount()
 
 	var volumes []v1.Volume
@@ -104,7 +96,7 @@ func BuildLoginContainers(hosts []string,
 	tokenIndex := 0
 
 	for _, host := range hosts {
-		helper := helperFor(host)
+		helper := cloudRegistryHelperFromHost(host)
 		if helper == nil {
 			continue
 		}
@@ -129,4 +121,14 @@ func BuildLoginContainers(hosts []string,
 	}
 
 	return containers, volumes, nil
+}
+
+// cloudRegistryHelperFromHost returns the CloudRegistryHelper matching host, or nil.
+func cloudRegistryHelperFromHost(host string) CloudRegistryHelper {
+	for _, helper := range cloudRegistryHelpers {
+		if helper.Matches(host) {
+			return helper
+		}
+	}
+	return nil
 }

--- a/pkg/containerimagebuilderpusher/registryhelpers/cloudregistry.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/cloudregistry.go
@@ -34,7 +34,8 @@ const (
 	authTokensVolumeName = "authtokens"
 	authTokensMountPath  = "/tmp/registry-auth-tokens"
 
-	providerCredentialsMountPath = "/tmp/registry-provider-credentials"
+	providerCredentialsVolumeName = "registry-provider-credentials"
+	providerCredentialsMountPath  = "/tmp/registry-provider-credentials"
 
 	// providerCredentialsFileName is the key every provider secret carries, after AWS's
 	// ~/.aws/credentials convention; used the same way for Azure and GCP.
@@ -49,9 +50,8 @@ type CloudRegistryHelper interface {
 	// BuildLoginContainer returns the init container writing host's token to tokenFilePath. repoName
 	// is set only for the push destination, for vendors that provision repos (ECR);
 	// credentialsMountPath is where the static provider secret is mounted, or "" if none.
-	BuildLoginContainer(host, repoName, tokenFilePath, credentialsMountPath string,
-		cfg AuthConfig,
-		imagePullPolicy string) (v1.Container, error)
+	BuildLoginContainer(host, repoName, tokenFilePath, credentialsMountPath, imagePullPolicy string,
+		cfg AuthConfig) (v1.Container, error)
 }
 
 // cloudRegistryHelpers is the static, ordered set of supported vendors.
@@ -87,7 +87,7 @@ func BuildLoginContainers(hosts []string,
 	if cfg.RegistryProviderSecretName != "" {
 		credentialsMountPath = providerCredentialsMountPath
 		volumes = append(volumes, v1.Volume{
-			Name:         cfg.RegistryProviderSecretName,
+			Name:         providerCredentialsVolumeName,
 			VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: cfg.RegistryProviderSecretName}},
 		})
 	}
@@ -107,13 +107,13 @@ func BuildLoginContainers(hosts []string,
 		}
 		tokenFilePath := fmt.Sprintf("%s/%d.token", tokenDir.MountPath, tokenIndex)
 
-		container, err := helper.BuildLoginContainer(host, hostRepoName, tokenFilePath, credentialsMountPath, cfg, imagePullPolicy)
+		container, err := helper.BuildLoginContainer(host, hostRepoName, tokenFilePath, credentialsMountPath, imagePullPolicy, cfg)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "Failed to build registry login init container for host: %s", host)
 		}
 		if credentialsMountPath != "" {
 			container.VolumeMounts = append(container.VolumeMounts,
-				v1.VolumeMount{Name: cfg.RegistryProviderSecretName, MountPath: credentialsMountPath})
+				v1.VolumeMount{Name: providerCredentialsVolumeName, MountPath: credentialsMountPath})
 		}
 
 		containers = append(containers, container)

--- a/pkg/containerimagebuilderpusher/registryhelpers/cloudregistry_test.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/cloudregistry_test.go
@@ -1,0 +1,87 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registryhelpers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type CloudRegistryTestSuite struct {
+	suite.Suite
+}
+
+func (suite *CloudRegistryTestSuite) TestHelperForPicksTheRightVendor() {
+	for _, testCase := range []struct {
+		name     string
+		host     string
+		expected string
+	}{
+		{name: "ACR", host: "myregistry.azurecr.io", expected: "*registryhelpers.azureHelper"},
+		{name: "GAR", host: "us-central1-docker.pkg.dev", expected: "*registryhelpers.gcpHelper"},
+		{name: "ECR", host: "123456789012.dkr.ecr.us-east-1.amazonaws.com", expected: "*registryhelpers.awsHelper"},
+		{name: "PlainDockerHub", host: "index.docker.io", expected: ""},
+		{name: "Empty", host: "", expected: ""},
+	} {
+		suite.Run(testCase.name, func() {
+			helper := helperFor(testCase.host)
+			if testCase.expected == "" {
+				suite.Nil(helper)
+				return
+			}
+			suite.Require().NotNil(helper)
+			suite.Equal(testCase.expected, fmt.Sprintf("%T", helper))
+		})
+	}
+}
+
+func (suite *CloudRegistryTestSuite) TestNeedsCloudLogin() {
+	suite.True(NeedsCloudLogin([]string{"index.docker.io", "myregistry.azurecr.io"}))
+	suite.False(NeedsCloudLogin([]string{"index.docker.io", "ghcr.io"}))
+	suite.False(NeedsCloudLogin(nil))
+	suite.False(NeedsCloudLogin([]string{}))
+}
+
+func (suite *CloudRegistryTestSuite) TestBuildLoginContainersSharesOneProviderSecretVolume() {
+	hosts := []string{"myregistry.azurecr.io", "us-central1-docker.pkg.dev"}
+	cfg := AuthConfig{RegistryProviderSecretName: "registry-provider-creds"}
+
+	containers, volumes, err := BuildLoginContainers(hosts, "", "", cfg, "IfNotPresent")
+	suite.Require().NoError(err)
+
+	suite.Require().Len(volumes, 1)
+	suite.Equal("registry-provider-creds", volumes[0].Name)
+
+	suite.Require().Len(containers, 2)
+	for _, container := range containers {
+		found := false
+		for _, mount := range container.VolumeMounts {
+			if mount.Name == "registry-provider-creds" {
+				found = true
+			}
+		}
+		suite.True(found, "container %s missing provider secret mount", container.Name)
+	}
+}
+
+func TestCloudRegistryTestSuite(t *testing.T) {
+	suite.Run(t, new(CloudRegistryTestSuite))
+}

--- a/pkg/containerimagebuilderpusher/registryhelpers/cloudregistry_test.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/cloudregistry_test.go
@@ -29,7 +29,7 @@ type CloudRegistryTestSuite struct {
 	suite.Suite
 }
 
-func (suite *CloudRegistryTestSuite) TestHelperForPicksTheRightVendor() {
+func (suite *CloudRegistryTestSuite) TestCloudRegistryHelperFromHostPicksTheRightVendor() {
 	for _, testCase := range []struct {
 		name     string
 		host     string
@@ -37,12 +37,12 @@ func (suite *CloudRegistryTestSuite) TestHelperForPicksTheRightVendor() {
 	}{
 		{name: "ACR", host: "myregistry.azurecr.io", expected: "*registryhelpers.azureHelper"},
 		{name: "GAR", host: "us-central1-docker.pkg.dev", expected: "*registryhelpers.gcpHelper"},
-		{name: "ECR", host: "123456789012.dkr.ecr.us-east-1.amazonaws.com", expected: "*registryhelpers.awsHelper"},
+		{name: "ECR", host: "123456789012.dkr.ecr.us-east-1.amazonaws.com", expected: "*registryhelpers.AWSHelper"},
 		{name: "PlainDockerHub", host: "index.docker.io", expected: ""},
 		{name: "Empty", host: "", expected: ""},
 	} {
 		suite.Run(testCase.name, func() {
-			helper := helperFor(testCase.host)
+			helper := cloudRegistryHelperFromHost(testCase.host)
 			if testCase.expected == "" {
 				suite.Nil(helper)
 				return

--- a/pkg/containerimagebuilderpusher/registryhelpers/cloudregistry_test.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/cloudregistry_test.go
@@ -68,13 +68,14 @@ func (suite *CloudRegistryTestSuite) TestBuildLoginContainersSharesOneProviderSe
 	suite.Require().NoError(err)
 
 	suite.Require().Len(volumes, 1)
-	suite.Equal("registry-provider-creds", volumes[0].Name)
+	suite.Equal(providerCredentialsVolumeName, volumes[0].Name)
+	suite.Equal("registry-provider-creds", volumes[0].Secret.SecretName)
 
 	suite.Require().Len(containers, 2)
 	for _, container := range containers {
 		found := false
 		for _, mount := range container.VolumeMounts {
-			if mount.Name == "registry-provider-creds" {
+			if mount.Name == providerCredentialsVolumeName {
 				found = true
 			}
 		}

--- a/pkg/containerimagebuilderpusher/registryhelpers/gcp.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/gcp.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registryhelpers
+
+import (
+	"strings"
+
+	"github.com/nuclio/nuclio/pkg/common"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// gcloudLoginUsername is the fixed username for GAR OAuth2 access tokens.
+const gcloudLoginUsername = "oauth2accesstoken"
+
+type gcpHelper struct{}
+
+func (h *gcpHelper) Matches(host string) bool {
+	return strings.HasSuffix(host, "-docker.pkg.dev")
+}
+
+func (h *gcpHelper) BuildLoginContainer(host, repoName, tokenFilePath, credentialsMountPath string,
+	cfg AuthConfig,
+	imagePullPolicy string) (v1.Container, error) {
+
+	// GKE workload identity supplies ambient credentials; a mounted secret overrides via env below.
+	command := softFailScript(
+		writeCredentialFileScript(tokenFilePath, host, gcloudLoginUsername, "gcloud auth print-access-token"),
+		host, "GAR")
+
+	name, err := common.SanitizeKubernetesName("registry-login-gcp-", host, false)
+	if err != nil {
+		return v1.Container{}, err
+	}
+
+	container := v1.Container{
+		Name:            name,
+		Image:           cfg.GCloudCLIImage,
+		ImagePullPolicy: v1.PullPolicy(imagePullPolicy),
+		Command:         []string{"/bin/sh"},
+		Args:            []string{"-c", command},
+		VolumeMounts:    []v1.VolumeMount{TokenDirVolumeMount()},
+	}
+
+	if credentialsMountPath != "" {
+		container.Env = append(container.Env, v1.EnvVar{
+			Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+			Value: credentialsMountPath + "/" + providerCredentialsFileName,
+		})
+	}
+
+	return container, nil
+}

--- a/pkg/containerimagebuilderpusher/registryhelpers/gcp.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/gcp.go
@@ -36,9 +36,8 @@ func (h *gcpHelper) Matches(host string) bool {
 	return garHostPattern.MatchString(host)
 }
 
-func (h *gcpHelper) BuildLoginContainer(host, repoName, tokenFilePath, credentialsMountPath string,
-	cfg AuthConfig,
-	imagePullPolicy string) (v1.Container, error) {
+func (h *gcpHelper) BuildLoginContainer(host, repoName, tokenFilePath, credentialsMountPath, imagePullPolicy string,
+	cfg AuthConfig) (v1.Container, error) {
 
 	// GKE workload identity supplies ambient credentials; a mounted secret overrides via env below.
 	command := softFailScript(

--- a/pkg/containerimagebuilderpusher/registryhelpers/gcp.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/gcp.go
@@ -17,7 +17,7 @@ limitations under the License.
 package registryhelpers
 
 import (
-	"strings"
+	"regexp"
 
 	"github.com/nuclio/nuclio/pkg/common"
 
@@ -27,10 +27,13 @@ import (
 // gcloudLoginUsername is the fixed username for GAR OAuth2 access tokens.
 const gcloudLoginUsername = "oauth2accesstoken"
 
+// garHostPattern matches a GAR hostname, e.g. <region>-docker.pkg.dev.
+var garHostPattern = regexp.MustCompile(`^[a-z0-9-]+-docker\.pkg\.dev$`)
+
 type gcpHelper struct{}
 
 func (h *gcpHelper) Matches(host string) bool {
-	return strings.HasSuffix(host, "-docker.pkg.dev")
+	return garHostPattern.MatchString(host)
 }
 
 func (h *gcpHelper) BuildLoginContainer(host, repoName, tokenFilePath, credentialsMountPath string,
@@ -39,8 +42,8 @@ func (h *gcpHelper) BuildLoginContainer(host, repoName, tokenFilePath, credentia
 
 	// GKE workload identity supplies ambient credentials; a mounted secret overrides via env below.
 	command := softFailScript(
-		writeCredentialFileScript(tokenFilePath, host, gcloudLoginUsername, "gcloud auth print-access-token"),
-		host, "GAR")
+		writeCredentialFileScript("gcloud auth print-access-token"),
+		"GAR")
 
 	name, err := common.SanitizeKubernetesName("registry-login-gcp-", host, false)
 	if err != nil {
@@ -53,6 +56,7 @@ func (h *gcpHelper) BuildLoginContainer(host, repoName, tokenFilePath, credentia
 		ImagePullPolicy: v1.PullPolicy(imagePullPolicy),
 		Command:         []string{"/bin/sh"},
 		Args:            []string{"-c", command},
+		Env:             credentialFileEnv(host, gcloudLoginUsername, tokenFilePath),
 		VolumeMounts:    []v1.VolumeMount{TokenDirVolumeMount()},
 	}
 

--- a/pkg/containerimagebuilderpusher/registryhelpers/merge.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/merge.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registryhelpers
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+
+	_ "embed"
+)
+
+const (
+	authSourcesVolumeName = "authsrc"
+	authSourcesMountPath  = "/tmp/registry-auth-sources"
+
+	authScriptVolumeName = "authscript"
+	authScriptMountPath  = "/tmp/registry-auth-script"
+	authScriptFileName   = "merge_authfile.py"
+
+	MergeScriptConfigMapName = "nuclio-registry-auth-merge-script"
+)
+
+//go:embed merge_authfile.py
+var mergeAuthFileScript string
+
+// MergeScriptContents returns the embedded merge_authfile.py script, for use as ConfigMap data.
+func MergeScriptContents() string {
+	return mergeAuthFileScript
+}
+
+// BuildMergeAuthInitContainer returns the merge-authfile init container and its volumes; it runs the
+// embedded Python merge script, delivered via the MergeScriptConfigMapName ConfigMap.
+func BuildMergeAuthInitContainer(secretNames []string,
+	authFileDir string,
+	withCloudTokens bool,
+	cfg AuthConfig) (v1.Container, []v1.Volume) {
+
+	sources := make([]v1.VolumeProjection, 0, len(secretNames))
+	for i, secretName := range secretNames {
+		optional := true
+		sources = append(sources, v1.VolumeProjection{
+			Secret: &v1.SecretProjection{
+				LocalObjectReference: v1.LocalObjectReference{Name: secretName},
+				Items: []v1.KeyToPath{
+					{Key: ".dockerconfigjson", Path: fmt.Sprintf("%d.json", i)},
+				},
+				Optional: &optional,
+			},
+		})
+	}
+
+	volumes := []v1.Volume{
+		{
+			Name:         authSourcesVolumeName,
+			VolumeSource: v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: sources}},
+		},
+		{
+			Name: authScriptVolumeName,
+			VolumeSource: v1.VolumeSource{
+				ConfigMap: &v1.ConfigMapVolumeSource{
+					LocalObjectReference: v1.LocalObjectReference{Name: MergeScriptConfigMapName},
+				},
+			},
+		},
+	}
+
+	args := []string{
+		fmt.Sprintf("--secrets=%s", authSourcesMountPath),
+		fmt.Sprintf("--target=%s/config.json", authFileDir),
+	}
+	volumeMounts := []v1.VolumeMount{
+		{Name: AuthVolumeName, MountPath: authFileDir},
+		{Name: authSourcesVolumeName, MountPath: authSourcesMountPath, ReadOnly: true},
+		{Name: authScriptVolumeName, MountPath: authScriptMountPath, ReadOnly: true},
+	}
+	if withCloudTokens {
+		tokenMount := TokenDirVolumeMount()
+		args = append(args, fmt.Sprintf("--cloud-tokens=%s", tokenMount.MountPath))
+		volumeMounts = append(volumeMounts, tokenMount)
+	}
+
+	container := v1.Container{
+		Name:            "merge-authfile",
+		Image:           cfg.PythonImage,
+		ImagePullPolicy: v1.PullPolicy(cfg.PythonImagePullPolicy),
+		Command:         []string{"python3", fmt.Sprintf("%s/%s", authScriptMountPath, authScriptFileName)},
+		Args:            args,
+		VolumeMounts:    volumeMounts,
+	}
+
+	return container, volumes
+}

--- a/pkg/containerimagebuilderpusher/registryhelpers/merge.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/merge.go
@@ -62,10 +62,15 @@ func BuildMergeAuthInitContainer(secretNames []string,
 		})
 	}
 
+	authSourcesVolumeSource := v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}
+	if len(sources) > 0 {
+		authSourcesVolumeSource = v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: sources}}
+	}
+
 	volumes := []v1.Volume{
 		{
 			Name:         authSourcesVolumeName,
-			VolumeSource: v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: sources}},
+			VolumeSource: authSourcesVolumeSource,
 		},
 		{
 			Name: authScriptVolumeName,

--- a/pkg/containerimagebuilderpusher/registryhelpers/merge.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/merge.go
@@ -52,14 +52,12 @@ func BuildMergeAuthInitContainer(secretNames []string,
 
 	sources := make([]v1.VolumeProjection, 0, len(secretNames))
 	for i, secretName := range secretNames {
-		optional := true
 		sources = append(sources, v1.VolumeProjection{
 			Secret: &v1.SecretProjection{
 				LocalObjectReference: v1.LocalObjectReference{Name: secretName},
 				Items: []v1.KeyToPath{
 					{Key: ".dockerconfigjson", Path: fmt.Sprintf("%d.json", i)},
 				},
-				Optional: &optional,
 			},
 		})
 	}

--- a/pkg/containerimagebuilderpusher/registryhelpers/merge_authfile.py
+++ b/pkg/containerimagebuilderpusher/registryhelpers/merge_authfile.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Merges docker-config-json secrets and cloud registry credential tokens into one authfile.
+
+Runs as a build-job init container, stdlib only (no third-party dependencies).
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+
+
+def warn(message):
+    print("WARNING: " + message, file=sys.stderr)
+
+
+def files_with_suffix(directory, suffix):
+    try:
+        names = sorted(os.listdir(directory))
+    except OSError:
+        return []
+    return [os.path.join(directory, name) for name in names if name.endswith(suffix)]
+
+
+def read_credential_file(path):
+    try:
+        with open(path, "r") as f:
+            contents = f.read()
+    except OSError as exc:
+        warn("failed to read registry credential token {}: {}".format(path, exc))
+        return None, None
+
+    lines = contents.split("\n", 2)
+    if len(lines) < 3:
+        warn("malformed registry credential token {}: expected 3 lines, got {}".format(path, len(lines)))
+        return None, None
+
+    host = lines[0].strip()
+    username = lines[1].strip()
+    token = lines[2].strip()
+    if not host or not username or not token:
+        warn("malformed registry credential token {}: empty host/username/token".format(path))
+        return None, None
+
+    auth = base64.b64encode((username + ":" + token).encode("utf-8")).decode("ascii")
+    return host, {"auth": auth}
+
+
+def merge_auth_files(secrets_dir, tokens_dir, target_path):
+    auths = {}
+    rest = {}
+
+    secret_paths = files_with_suffix(secrets_dir, ".json")
+    print("found {} registry auth source(s) in {}".format(len(secret_paths), secrets_dir))
+
+    for path in secret_paths:
+        try:
+            with open(path, "r") as f:
+                doc = json.load(f)
+        except (OSError, ValueError) as exc:
+            warn("failed to read/parse registry auth source {}: {}".format(path, exc))
+            continue
+
+        host_auths = doc.get("auths")
+        if isinstance(host_auths, dict):
+            hosts = []
+            for host, entry in host_auths.items():
+                auths[host] = entry
+                hosts.append(host)
+            print("merged registry auth source {}: hosts={}".format(path, hosts))
+        else:
+            print("merged registry auth source {}: no hosts".format(path))
+
+        for key, value in doc.items():
+            if key != "auths":
+                rest[key] = value
+
+    token_paths = files_with_suffix(tokens_dir, ".token") if tokens_dir else []
+    print("found {} cloud registry credential token(s) in {}".format(len(token_paths), tokens_dir))
+
+    for path in token_paths:
+        host, entry = read_credential_file(path)
+        if host is not None:
+            auths[host] = entry
+            print("applied cloud registry credential token {} for host {}".format(path, host))
+
+    rest["auths"] = auths
+    merged = json.dumps(rest)
+
+    target_dir = os.path.dirname(target_path)
+    if target_dir:
+        os.makedirs(target_dir, exist_ok=True)
+    with open(target_path, "w") as f:
+        f.write(merged)
+    print("wrote merged authfile to {} with {} host(s)".format(target_path, len(auths)))
+
+    for path in token_paths:
+        try:
+            os.remove(path)
+        except OSError as exc:
+            warn("failed to remove consumed registry credential token {}: {}".format(path, exc))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--secrets", default="", help="Directory of numbered docker-config-json sources")
+    parser.add_argument("--cloud-tokens", default="", help="Directory of numbered cloud registry credential token files")
+    parser.add_argument("--target", required=True, help="Authfile to write")
+    args = parser.parse_args()
+
+    merge_auth_files(args.secrets, args.cloud_tokens, args.target)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkg/containerimagebuilderpusher/registryhelpers/merge_authfile.py
+++ b/pkg/containerimagebuilderpusher/registryhelpers/merge_authfile.py
@@ -29,9 +29,17 @@ def warn(message):
     print("WARNING: " + message, file=sys.stderr)
 
 
+def _natural_sort_key(name):
+    # Numeric-prefixed names sort by value (0, 1, ..., 10, 11); anything else
+    # (shouldn't occur given how these dirs are populated) sorts after all
+    # numeric names instead of raising, so an unexpected filename can't crash the merge.
+    prefix = name.split(".", 1)[0]
+    return (0, int(prefix)) if prefix.isdigit() else (1, name)
+
+
 def files_with_suffix(directory, suffix):
     try:
-        names = sorted(os.listdir(directory))
+        names = sorted(os.listdir(directory), key=_natural_sort_key)
     except OSError:
         return []
     return [os.path.join(directory, name) for name in names if name.endswith(suffix)]

--- a/pkg/containerimagebuilderpusher/registryhelpers/merge_authfile.py
+++ b/pkg/containerimagebuilderpusher/registryhelpers/merge_authfile.py
@@ -71,7 +71,6 @@ def read_credential_file(path):
 
 def merge_auth_files(secrets_dir, tokens_dir, target_path):
     auths = {}
-    rest = {}
 
     secret_paths = files_with_suffix(secrets_dir, ".json")
     print("found {} registry auth source(s) in {}".format(len(secret_paths), secrets_dir))
@@ -84,6 +83,9 @@ def merge_auth_files(secrets_dir, tokens_dir, target_path):
             warn("failed to read/parse registry auth source {}: {}".format(path, exc))
             continue
 
+        # Only "auths" is merged: other config.json keys (credsStore, credHelpers, ...)
+        # would shell out to a credential helper binary that isn't in the buildah image,
+        # bypassing the merged auths this script exists to produce.
         host_auths = doc.get("auths")
         if isinstance(host_auths, dict):
             hosts = []
@@ -94,10 +96,6 @@ def merge_auth_files(secrets_dir, tokens_dir, target_path):
         else:
             print("merged registry auth source {}: no hosts".format(path))
 
-        for key, value in doc.items():
-            if key != "auths":
-                rest[key] = value
-
     token_paths = files_with_suffix(tokens_dir, ".token") if tokens_dir else []
     print("found {} cloud registry credential token(s) in {}".format(len(token_paths), tokens_dir))
 
@@ -107,8 +105,7 @@ def merge_auth_files(secrets_dir, tokens_dir, target_path):
             auths[host] = entry
             print("applied cloud registry credential token {} for host {}".format(path, host))
 
-    rest["auths"] = auths
-    merged = json.dumps(rest)
+    merged = json.dumps({"auths": auths})
 
     target_dir = os.path.dirname(target_path)
     if target_dir:

--- a/pkg/containerimagebuilderpusher/registryhelpers/merge_integration_test.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/merge_integration_test.go
@@ -1,0 +1,211 @@
+//go:build test_integration && test_local
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registryhelpers
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/dockerclient"
+
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+// mergeTestPythonImage mirrors the NUCLIO_PYTHON_BASE_IMAGE_NAME default in types.go.
+const mergeTestPythonImage = "gcr.io/iguazio/python:3.11"
+
+// MergeIntegrationTestSuite runs the real merge-authfile container spec against a Docker container,
+// verifying both the spec and the embedded script's behavior end to end.
+type MergeIntegrationTestSuite struct {
+	suite.Suite
+	dockerClient dockerclient.Client
+}
+
+func (suite *MergeIntegrationTestSuite) SetupSuite() {
+	testLogger, err := nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+
+	suite.dockerClient, err = dockerclient.NewShellClient(testLogger, nil)
+	suite.Require().NoError(err, "Docker must be reachable to run this suite")
+}
+
+// hostScratchDir returns a fresh temp dir under $HOME, not the OS temp dir: Docker-in-a-VM usually
+// only bind-mounts $HOME, so a volume outside it silently mounts empty.
+func (suite *MergeIntegrationTestSuite) hostScratchDir() string {
+	homeDir, err := os.UserHomeDir()
+	suite.Require().NoError(err)
+
+	baseDir := filepath.Join(homeDir, ".nuclio-test-tmp")
+	suite.Require().NoError(os.MkdirAll(baseDir, 0o755))
+
+	dir, err := os.MkdirTemp(baseDir, "merge-authfile-")
+	suite.Require().NoError(err)
+	suite.T().Cleanup(func() {
+		_ = os.RemoveAll(dir) // nolint: errcheck
+	})
+	return dir
+}
+
+// runMerge writes secretFiles/tokenFiles to host temp dirs and runs the real merge-authfile container
+// spec via docker, returning the resulting authfile contents and the container's output.
+func (suite *MergeIntegrationTestSuite) runMerge(secretFiles, tokenFiles map[string]string) (string, string) {
+	secretsHostDir := suite.hostScratchDir()
+	authHostDir := suite.hostScratchDir()
+	scriptHostDir := suite.hostScratchDir()
+
+	for name, contents := range secretFiles {
+		suite.Require().NoError(os.WriteFile(filepath.Join(secretsHostDir, name), []byte(contents), 0o644))
+	}
+
+	withCloudTokens := len(tokenFiles) > 0
+	tokensHostDir := ""
+	if withCloudTokens {
+		tokensHostDir = suite.hostScratchDir()
+		for name, contents := range tokenFiles {
+			suite.Require().NoError(os.WriteFile(filepath.Join(tokensHostDir, name), []byte(contents), 0o644))
+		}
+	}
+
+	suite.Require().NoError(os.WriteFile(
+		filepath.Join(scriptHostDir, authScriptFileName), []byte(MergeScriptContents()), 0o644))
+
+	secretNames := make([]string, len(secretFiles))
+	container, _ := BuildMergeAuthInitContainer(secretNames, "/authdir", withCloudTokens,
+		AuthConfig{PythonImage: mergeTestPythonImage})
+
+	volumes := map[string]string{
+		authHostDir:    "/authdir",
+		secretsHostDir: authSourcesMountPath,
+		scriptHostDir:  authScriptMountPath,
+	}
+	if withCloudTokens {
+		volumes[tokensHostDir] = TokenDirVolumeMount().MountPath
+	}
+
+	command := strings.Join(append(container.Command, container.Args...), " ")
+
+	var output string
+	_, err := suite.dockerClient.RunContainer(mergeTestPythonImage, &dockerclient.RunOptions{
+		Command:          command,
+		Volumes:          volumes,
+		Remove:           true,
+		Attach:           true,
+		ImageMayNotExist: true,
+		Stdout:           &output,
+	})
+	suite.Require().NoError(err, "container output: %s", output)
+
+	authfileContents, err := os.ReadFile(filepath.Join(authHostDir, "config.json"))
+	suite.Require().NoError(err)
+
+	return string(authfileContents), output
+}
+
+func (suite *MergeIntegrationTestSuite) readAuths(authfileContents string) map[string]map[string]string {
+	var doc struct {
+		Auths map[string]struct {
+			Auth string `json:"auth"`
+		} `json:"auths"`
+	}
+	suite.Require().NoError(json.Unmarshal([]byte(authfileContents), &doc))
+
+	result := map[string]map[string]string{}
+	for host, entry := range doc.Auths {
+		decoded, err := base64.StdEncoding.DecodeString(entry.Auth)
+		suite.Require().NoError(err)
+		result[host] = map[string]string{"auth": string(decoded)}
+	}
+	return result
+}
+
+func (suite *MergeIntegrationTestSuite) TestMergeAuthFilesSecretsOnly() {
+	authfile, _ := suite.runMerge(map[string]string{
+		"0.json": `{"auths":{"registry-a.io":{"auth":"YQ=="}}}`,
+		"1.json": `{"auths":{"registry-b.io":{"auth":"Yg=="}}}`,
+	}, nil)
+
+	auths := suite.readAuths(authfile)
+	suite.Contains(auths, "registry-a.io")
+	suite.Contains(auths, "registry-b.io")
+}
+
+func (suite *MergeIntegrationTestSuite) TestMergeAuthFilesTokensOnly() {
+	authfile, output := suite.runMerge(nil, map[string]string{
+		"0.token": "myregistry.azurecr.io\n00000000-0000-0000-0000-000000000000\nsome-token\n",
+	})
+
+	suite.NotContains(output, "some-token")
+
+	auths := suite.readAuths(authfile)
+	suite.Equal("00000000-0000-0000-0000-000000000000:some-token", auths["myregistry.azurecr.io"]["auth"])
+}
+
+func (suite *MergeIntegrationTestSuite) TestMergeAuthFilesTokenWinsOverSecretForSameHost() {
+	authfile, _ := suite.runMerge(
+		map[string]string{"0.json": `{"auths":{"shared.io":{"auth":"c3RhbGU6c3RhbGU="}}}`}, // stale:stale
+		map[string]string{"0.token": "shared.io\nfreshuser\nfreshtoken\n"},
+	)
+
+	auths := suite.readAuths(authfile)
+	suite.Equal("freshuser:freshtoken", auths["shared.io"]["auth"])
+}
+
+func (suite *MergeIntegrationTestSuite) TestMergeAuthFilesTokenOrdering() {
+	authfile, _ := suite.runMerge(nil, map[string]string{
+		"0.token": "host.io\nuser0\ntoken0\n",
+		"1.token": "host.io\nuser1\ntoken1\n",
+	})
+
+	auths := suite.readAuths(authfile)
+	suite.Equal("user1:token1", auths["host.io"]["auth"])
+}
+
+func (suite *MergeIntegrationTestSuite) TestMergeAuthFilesMalformedTokenSkipped() {
+	authfile, _ := suite.runMerge(nil, map[string]string{
+		"0.token": "onlyonelie",
+		"1.token": "host.io\nuser\n\n", // empty token
+	})
+
+	auths := suite.readAuths(authfile)
+	suite.Empty(auths)
+}
+
+func (suite *MergeIntegrationTestSuite) TestMergeAuthFilesPassesThroughNonAuthsKeys() {
+	authfile, _ := suite.runMerge(map[string]string{
+		"0.json": `{"auths":{"registry-a.io":{"auth":"YQ=="}},"credsStore":"ecr-login"}`,
+	}, nil)
+
+	var doc map[string]interface{}
+	suite.Require().NoError(json.Unmarshal([]byte(authfile), &doc))
+	suite.Equal("ecr-login", doc["credsStore"])
+}
+
+func (suite *MergeIntegrationTestSuite) TestMergeAuthFilesMissingSecrets() {
+	authfile, _ := suite.runMerge(nil, nil)
+	suite.JSONEq(`{"auths":{}}`, authfile)
+}
+
+func TestMergeIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(MergeIntegrationTestSuite))
+}

--- a/pkg/containerimagebuilderpusher/registryhelpers/merge_integration_test.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/merge_integration_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-// mergeTestPythonImage mirrors the NUCLIO_PYTHON_BASE_IMAGE_NAME default in types.go.
+// mergeTestPythonImage mirrors the NUCLIO_PYTHON_INIT_CONTAINER_IMAGE default in types.go.
 const mergeTestPythonImage = "gcr.io/iguazio/python:3.11"
 
 // MergeIntegrationTestSuite runs the real merge-authfile container spec against a Docker container,

--- a/pkg/containerimagebuilderpusher/registryhelpers/merge_integration_test.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/merge_integration_test.go
@@ -206,14 +206,15 @@ func (suite *MergeIntegrationTestSuite) TestMergeAuthFilesMalformedTokenSkipped(
 	suite.Empty(auths)
 }
 
-func (suite *MergeIntegrationTestSuite) TestMergeAuthFilesPassesThroughNonAuthsKeys() {
+func (suite *MergeIntegrationTestSuite) TestMergeAuthFilesDropsNonAuthsKeys() {
 	authfile, _ := suite.runMerge(map[string]string{
 		"0.json": `{"auths":{"registry-a.io":{"auth":"YQ=="}},"credsStore":"ecr-login"}`,
 	}, nil)
 
 	var doc map[string]interface{}
 	suite.Require().NoError(json.Unmarshal([]byte(authfile), &doc))
-	suite.Equal("ecr-login", doc["credsStore"])
+	suite.NotContains(doc, "credsStore")
+	suite.Len(doc, 1)
 }
 
 func (suite *MergeIntegrationTestSuite) TestMergeAuthFilesMissingSecrets() {

--- a/pkg/containerimagebuilderpusher/registryhelpers/merge_integration_test.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/merge_integration_test.go
@@ -181,6 +181,21 @@ func (suite *MergeIntegrationTestSuite) TestMergeAuthFilesTokenOrdering() {
 	suite.Equal("user1:token1", auths["host.io"]["auth"])
 }
 
+func (suite *MergeIntegrationTestSuite) TestMergeAuthFilesTokenOrderingDoubleDigit() {
+	authfile, _ := suite.runMerge(nil, map[string]string{
+		"0.token":  "host.io\nuser0\ntoken0\n",
+		"1.token":  "host.io\nuser1\ntoken1\n",
+		"2.token":  "host.io\nuser2\ntoken2\n",
+		"10.token": "host.io\nuser10\ntoken10\n",
+	})
+
+	// Lexicographic sort would order these "0", "1", "10", "2" (since "10.token" < "2.token"
+	// as strings), letting "2.token" win last; natural sort orders them 0, 1, 2, 10 so the
+	// highest-index token ("10.token") wins.
+	auths := suite.readAuths(authfile)
+	suite.Equal("user10:token10", auths["host.io"]["auth"])
+}
+
 func (suite *MergeIntegrationTestSuite) TestMergeAuthFilesMalformedTokenSkipped() {
 	authfile, _ := suite.runMerge(nil, map[string]string{
 		"0.token": "onlyonelie",

--- a/pkg/containerimagebuilderpusher/registryhelpers/merge_test.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/merge_test.go
@@ -1,0 +1,132 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registryhelpers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// MergeTestSuite covers the container/volume spec built by BuildMergeAuthInitContainer; the script's
+// merging behavior is covered by MergeIntegrationTestSuite, which runs the real container.
+type MergeTestSuite struct {
+	suite.Suite
+}
+
+func (suite *MergeTestSuite) TestBuildMergeAuthInitContainerImageAndCommand() {
+	container, _ := BuildMergeAuthInitContainer(
+		[]string{"secret-a", "secret-b"},
+		"/tmp/registry-auth",
+		true,
+		AuthConfig{PythonImage: "python:3.11", PythonImagePullPolicy: "Always"})
+
+	suite.Equal("merge-authfile", container.Name)
+	suite.Equal("python:3.11", container.Image)
+	suite.Equal("Always", string(container.ImagePullPolicy))
+	suite.Equal([]string{"python3", authScriptMountPath + "/" + authScriptFileName}, container.Command)
+}
+
+func (suite *MergeTestSuite) TestBuildMergeAuthInitContainerArgsWithCloudTokens() {
+	container, _ := BuildMergeAuthInitContainer(
+		[]string{"secret-a"},
+		"/tmp/registry-auth",
+		true,
+		AuthConfig{})
+
+	suite.Equal([]string{
+		fmt.Sprintf("--secrets=%s", authSourcesMountPath),
+		"--target=/tmp/registry-auth/config.json",
+		fmt.Sprintf("--cloud-tokens=%s", TokenDirVolumeMount().MountPath),
+	}, container.Args)
+}
+
+func (suite *MergeTestSuite) TestBuildMergeAuthInitContainerArgsWithoutCloudTokens() {
+	container, _ := BuildMergeAuthInitContainer(
+		[]string{"secret-a"},
+		"/tmp/registry-auth",
+		false,
+		AuthConfig{})
+
+	suite.Equal([]string{
+		fmt.Sprintf("--secrets=%s", authSourcesMountPath),
+		"--target=/tmp/registry-auth/config.json",
+	}, container.Args)
+}
+
+func (suite *MergeTestSuite) TestBuildMergeAuthInitContainerVolumesAndMounts() {
+	container, volumes := BuildMergeAuthInitContainer(
+		[]string{"secret-a", "secret-b"},
+		"/tmp/registry-auth",
+		true,
+		AuthConfig{})
+
+	// volumes: projected secrets + script configmap
+	suite.Require().Len(volumes, 2)
+
+	sourcesVolume := volumes[0]
+	suite.Equal(authSourcesVolumeName, sourcesVolume.Name)
+	suite.Require().NotNil(sourcesVolume.Projected)
+	suite.Require().Len(sourcesVolume.Projected.Sources, 2)
+	suite.Equal("secret-a", sourcesVolume.Projected.Sources[0].Secret.Name)
+	suite.Equal("0.json", sourcesVolume.Projected.Sources[0].Secret.Items[0].Path)
+	suite.Equal("secret-b", sourcesVolume.Projected.Sources[1].Secret.Name)
+	suite.Equal("1.json", sourcesVolume.Projected.Sources[1].Secret.Items[0].Path)
+
+	scriptVolume := volumes[1]
+	suite.Equal(authScriptVolumeName, scriptVolume.Name)
+	suite.Require().NotNil(scriptVolume.ConfigMap)
+	suite.Equal(MergeScriptConfigMapName, scriptVolume.ConfigMap.Name)
+
+	// mounts: authfile (writable), sources (ro), script (ro), tokens (since withCloudTokens=true)
+	suite.Require().Len(container.VolumeMounts, 4)
+	suite.Equal(AuthVolumeName, container.VolumeMounts[0].Name)
+	suite.Equal("/tmp/registry-auth", container.VolumeMounts[0].MountPath)
+	suite.False(container.VolumeMounts[0].ReadOnly)
+
+	suite.Equal(authSourcesVolumeName, container.VolumeMounts[1].Name)
+	suite.True(container.VolumeMounts[1].ReadOnly)
+
+	suite.Equal(authScriptVolumeName, container.VolumeMounts[2].Name)
+	suite.True(container.VolumeMounts[2].ReadOnly)
+
+	suite.Equal(TokenDirVolumeMount().Name, container.VolumeMounts[3].Name)
+}
+
+func (suite *MergeTestSuite) TestBuildMergeAuthInitContainerNoTokenMountWithoutCloudTokens() {
+	container, _ := BuildMergeAuthInitContainer(
+		[]string{"secret-a"},
+		"/tmp/registry-auth",
+		false,
+		AuthConfig{})
+
+	suite.Require().Len(container.VolumeMounts, 3)
+	for _, mount := range container.VolumeMounts {
+		suite.NotEqual(TokenDirVolumeMount().Name, mount.Name)
+	}
+}
+
+func (suite *MergeTestSuite) TestMergeScriptContentsIsTheEmbeddedScript() {
+	suite.Contains(MergeScriptContents(), "def merge_auth_files")
+}
+
+func TestMergeTestSuite(t *testing.T) {
+	suite.Run(t, new(MergeTestSuite))
+}

--- a/pkg/containerimagebuilderpusher/registryhelpers/merge_test.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/merge_test.go
@@ -123,6 +123,17 @@ func (suite *MergeTestSuite) TestBuildMergeAuthInitContainerNoTokenMountWithoutC
 	}
 }
 
+// A ProjectedVolumeSource with no sources fails Kubernetes API validation, so the cloud-auth-only
+// case (no registry secrets configured) must fall back to an EmptyDir instead.
+func (suite *MergeTestSuite) TestBuildMergeAuthInitContainerEmptyDirWithoutSecretNames() {
+	_, volumes := BuildMergeAuthInitContainer(nil, "/tmp/registry-auth", true, AuthConfig{})
+
+	sourcesVolume := volumes[0]
+	suite.Equal(authSourcesVolumeName, sourcesVolume.Name)
+	suite.Nil(sourcesVolume.Projected)
+	suite.NotNil(sourcesVolume.EmptyDir)
+}
+
 func (suite *MergeTestSuite) TestMergeScriptContentsIsTheEmbeddedScript() {
 	suite.Contains(MergeScriptContents(), "def merge_auth_files")
 }

--- a/pkg/containerimagebuilderpusher/registryhelpers/types.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/types.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package registryhelpers
 
 // AuthConfig carries the images and provider secret the auth/merge init containers need.

--- a/pkg/containerimagebuilderpusher/registryhelpers/types.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/types.go
@@ -1,0 +1,11 @@
+package registryhelpers
+
+// AuthConfig carries the images and provider secret the auth/merge init containers need.
+type AuthConfig struct {
+	AWSCLIImage                string
+	AzureCLIImage              string
+	GCloudCLIImage             string
+	RegistryProviderSecretName string
+	PythonImage                string
+	PythonImagePullPolicy      string
+}

--- a/pkg/containerimagebuilderpusher/registryhelpers/types.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/types.go
@@ -16,6 +16,18 @@ limitations under the License.
 
 package registryhelpers
 
+// Env var names the login scripts read their values from, instead of having them interpolated
+// into the script text.
+const (
+	envVarRegistryHost      = "REGISTRY_HOST"
+	envVarRegistryUsername  = "REGISTRY_USERNAME"
+	envVarRegistryRepo      = "REGISTRY_REPO"
+	envVarRegistryTokenFile = "REGISTRY_TOKEN_FILE"
+	envVarECRRegion         = "ECR_REGION"
+	envVarECRRegistryID     = "ECR_REGISTRY_ID"
+	envVarACRRegistryName   = "ACR_REGISTRY_NAME"
+)
+
 // AuthConfig carries the images and provider secret the auth/merge init containers need.
 type AuthConfig struct {
 	AWSCLIImage                string

--- a/pkg/containerimagebuilderpusher/registryhelpers/util.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/util.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registryhelpers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nuclio/nuclio/pkg/common"
+)
+
+// writeCredentialFileScript emits a shell snippet that writes a three-line credential file
+// (host, username, token) to path. tokenCommand must print the bare token on stdout.
+func writeCredentialFileScript(path, host, username, tokenCommand string) string {
+	return fmt.Sprintf("{ echo %s; echo %s; %s; } > %s",
+		common.Quote(host), common.Quote(username), tokenCommand, common.Quote(path))
+}
+
+// softFailScript wraps script to log a warning and exit 0 on failure instead of aborting the pod.
+func softFailScript(script, host, kind string) string {
+	return fmt.Sprintf(`(set -e
+%s
+) || echo "WARNING: failed to fetch %s login token for %s" >&2`, script, kind, host)
+}
+
+// NormalizeHosts strips each url to its bare hostname and drops empty/duplicate values.
+func NormalizeHosts(urls ...string) []string {
+	hosts := make([]string, 0, len(urls))
+	for _, url := range urls {
+		if host := hostOf(url); host != "" {
+			hosts = append(hosts, host)
+		}
+	}
+	return common.RemoveDuplicatesFromSliceString(hosts)
+}
+
+// hostOf returns url's hostname, stripping any repository path (GAR URLs carry one; ACR/ECR don't).
+func hostOf(url string) string {
+	if i := strings.Index(url, "/"); i != -1 {
+		return url[:i]
+	}
+	return url
+}

--- a/pkg/containerimagebuilderpusher/registryhelpers/util.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/util.go
@@ -18,7 +18,6 @@ package registryhelpers
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/nuclio/nuclio/pkg/common"
 )
@@ -35,23 +34,4 @@ func softFailScript(script, host, kind string) string {
 	return fmt.Sprintf(`(set -e
 %s
 ) || echo "WARNING: failed to fetch %s login token for %s" >&2`, script, kind, host)
-}
-
-// NormalizeHosts strips each url to its bare hostname and drops empty/duplicate values.
-func NormalizeHosts(urls ...string) []string {
-	hosts := make([]string, 0, len(urls))
-	for _, url := range urls {
-		if host := hostOf(url); host != "" {
-			hosts = append(hosts, host)
-		}
-	}
-	return common.RemoveDuplicatesFromSliceString(hosts)
-}
-
-// hostOf returns url's hostname, stripping any repository path (GAR URLs carry one; ACR/ECR don't).
-func hostOf(url string) string {
-	if i := strings.Index(url, "/"); i != -1 {
-		return url[:i]
-	}
-	return url
 }

--- a/pkg/containerimagebuilderpusher/registryhelpers/util.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/util.go
@@ -19,19 +19,32 @@ package registryhelpers
 import (
 	"fmt"
 
-	"github.com/nuclio/nuclio/pkg/common"
+	v1 "k8s.io/api/core/v1"
 )
 
 // writeCredentialFileScript emits a shell snippet that writes a three-line credential file
-// (host, username, token) to path. tokenCommand must print the bare token on stdout.
-func writeCredentialFileScript(path, host, username, tokenCommand string) string {
-	return fmt.Sprintf("{ echo %s; echo %s; %s; } > %s",
-		common.Quote(host), common.Quote(username), tokenCommand, common.Quote(path))
+// (host, username, token) to the envVarRegistryTokenFile path. tokenCommand must print the bare
+// token on stdout. Values come from env vars, so none of them can be parsed as shell code.
+func writeCredentialFileScript(tokenCommand string) string {
+	return fmt.Sprintf(`{ echo "$%s"; echo "$%s"; %s; } > "$%s"`,
+		envVarRegistryHost,
+		envVarRegistryUsername,
+		tokenCommand,
+		envVarRegistryTokenFile)
+}
+
+// credentialFileEnv returns the env vars every login script reads.
+func credentialFileEnv(host, username, tokenFilePath string) []v1.EnvVar {
+	return []v1.EnvVar{
+		{Name: envVarRegistryHost, Value: host},
+		{Name: envVarRegistryUsername, Value: username},
+		{Name: envVarRegistryTokenFile, Value: tokenFilePath},
+	}
 }
 
 // softFailScript wraps script to log a warning and exit 0 on failure instead of aborting the pod.
-func softFailScript(script, host, kind string) string {
+func softFailScript(script, kind string) string {
 	return fmt.Sprintf(`(set -e
 %s
-) || echo "WARNING: failed to fetch %s login token for %s" >&2`, script, kind, host)
+) || echo "WARNING: failed to fetch %s login token for $%s" >&2`, script, kind, envVarRegistryHost)
 }

--- a/pkg/containerimagebuilderpusher/registryhelpers/util_test.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/util_test.go
@@ -1,0 +1,79 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registryhelpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type UtilTestSuite struct {
+	suite.Suite
+}
+
+func (suite *UtilTestSuite) TestNormalizeHostsStripsRepoPathAndDedupesEmpty() {
+	for _, testCase := range []struct {
+		name     string
+		urls     []string
+		expected []string
+	}{
+		{
+			name:     "StripsRepoPath",
+			urls:     []string{"us-central1-docker.pkg.dev/my-project/my-repo"},
+			expected: []string{"us-central1-docker.pkg.dev"},
+		},
+		{
+			name:     "DropsEmptyAndDuplicates",
+			urls:     []string{"myregistry.azurecr.io", "", "myregistry.azurecr.io"},
+			expected: []string{"myregistry.azurecr.io"},
+		},
+		{
+			name:     "PreservesFirstSeenOrder",
+			urls:     []string{"b.io", "a.io", "b.io"},
+			expected: []string{"b.io", "a.io"},
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Equal(testCase.expected, NormalizeHosts(testCase.urls...))
+		})
+	}
+}
+
+func (suite *UtilTestSuite) TestNormalizeHostsAllEmptyReturnsEmpty() {
+	suite.Empty(NormalizeHosts("", ""))
+}
+
+func (suite *UtilTestSuite) TestWriteCredentialFileScriptEmitsUnquotedSafeTokens() {
+	script := writeCredentialFileScript("/tmp/registry-auth-tokens/0.token", "myregistry.azurecr.io",
+		"00000000-0000-0000-0000-000000000000", "az acr login --name myregistry --expose-token")
+
+	suite.Equal(`{ echo myregistry.azurecr.io; echo 00000000-0000-0000-0000-000000000000; `+
+		`az acr login --name myregistry --expose-token; } > /tmp/registry-auth-tokens/0.token`, script)
+}
+
+func (suite *UtilTestSuite) TestWriteCredentialFileScriptQuotesShellMetacharacters() {
+	script := writeCredentialFileScript("/tmp/token", "host's; rm -rf /", "user", "cat token")
+
+	suite.Contains(script, `'host'"'"'s; rm -rf /'`)
+}
+
+func TestUtilTestSuite(t *testing.T) {
+	suite.Run(t, new(UtilTestSuite))
+}

--- a/pkg/containerimagebuilderpusher/registryhelpers/util_test.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/util_test.go
@@ -28,38 +28,6 @@ type UtilTestSuite struct {
 	suite.Suite
 }
 
-func (suite *UtilTestSuite) TestNormalizeHostsStripsRepoPathAndDedupesEmpty() {
-	for _, testCase := range []struct {
-		name     string
-		urls     []string
-		expected []string
-	}{
-		{
-			name:     "StripsRepoPath",
-			urls:     []string{"us-central1-docker.pkg.dev/my-project/my-repo"},
-			expected: []string{"us-central1-docker.pkg.dev"},
-		},
-		{
-			name:     "DropsEmptyAndDuplicates",
-			urls:     []string{"myregistry.azurecr.io", "", "myregistry.azurecr.io"},
-			expected: []string{"myregistry.azurecr.io"},
-		},
-		{
-			name:     "PreservesFirstSeenOrder",
-			urls:     []string{"b.io", "a.io", "b.io"},
-			expected: []string{"b.io", "a.io"},
-		},
-	} {
-		suite.Run(testCase.name, func() {
-			suite.Equal(testCase.expected, NormalizeHosts(testCase.urls...))
-		})
-	}
-}
-
-func (suite *UtilTestSuite) TestNormalizeHostsAllEmptyReturnsEmpty() {
-	suite.Empty(NormalizeHosts("", ""))
-}
-
 func (suite *UtilTestSuite) TestWriteCredentialFileScriptEmitsUnquotedSafeTokens() {
 	script := writeCredentialFileScript("/tmp/registry-auth-tokens/0.token", "myregistry.azurecr.io",
 		"00000000-0000-0000-0000-000000000000", "az acr login --name myregistry --expose-token")

--- a/pkg/containerimagebuilderpusher/registryhelpers/util_test.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/util_test.go
@@ -28,18 +28,11 @@ type UtilTestSuite struct {
 	suite.Suite
 }
 
-func (suite *UtilTestSuite) TestWriteCredentialFileScriptEmitsUnquotedSafeTokens() {
-	script := writeCredentialFileScript("/tmp/registry-auth-tokens/0.token", "myregistry.azurecr.io",
-		"00000000-0000-0000-0000-000000000000", "az acr login --name myregistry --expose-token")
+func (suite *UtilTestSuite) TestWriteCredentialFileScriptReferencesEnvVarsOnly() {
+	script := writeCredentialFileScript(`az acr login --name "$ACR_REGISTRY_NAME" --expose-token`)
 
-	suite.Equal(`{ echo myregistry.azurecr.io; echo 00000000-0000-0000-0000-000000000000; `+
-		`az acr login --name myregistry --expose-token; } > /tmp/registry-auth-tokens/0.token`, script)
-}
-
-func (suite *UtilTestSuite) TestWriteCredentialFileScriptQuotesShellMetacharacters() {
-	script := writeCredentialFileScript("/tmp/token", "host's; rm -rf /", "user", "cat token")
-
-	suite.Contains(script, `'host'"'"'s; rm -rf /'`)
+	suite.Equal(`{ echo "$REGISTRY_HOST"; echo "$REGISTRY_USERNAME"; `+
+		`az acr login --name "$ACR_REGISTRY_NAME" --expose-token; } > "$REGISTRY_TOKEN_FILE"`, script)
 }
 
 func TestUtilTestSuite(t *testing.T) {

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher/registryhelpers"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 
 	"github.com/nuclio/errors"
@@ -41,6 +42,8 @@ type BuildOptions struct {
 	BuildFlags                               map[string]bool
 	BuildArgs                                map[string]string
 	RegistryURL                              string
+	BaseImageRegistry                        string
+	OnbuildImageRegistry                     string
 	RepoName                                 string
 	SecretName                               string
 	OutputImageFile                          string
@@ -80,28 +83,29 @@ type BuildahConfig struct {
 	RootlessMode  string
 	StorageDriver string
 	Isolation     string
+
+	AppArmorProfile string
 }
 
 type ContainerBuilderConfiguration struct {
-	Kind                                 string
-	RegistryProviderSecretName           string
-	JobPrefix                            string
-	JobDeletionTimeout                   time.Duration
-	DefaultRegistryCredentialsSecretName string
-	DefaultBaseRegistryURL               string
-	DefaultOnbuildRegistryURL            string
-	RegistryKind                         string
-	DefaultServiceAccount                string
-	CacheRepo                            string
-	InsecurePushRegistry                 bool
-	InsecurePullRegistry                 bool
-	PushImagesRetries                    int
+	Kind                                  string
+	JobPrefix                             string
+	JobDeletionTimeout                    time.Duration
+	DefaultRegistryCredentialsSecretName  string
+	DefaultRegistryCredentialsSecretNames []string
 
-	// Images used in init containers
-	BusyBoxImage   string
-	AWSCLIImage    string
-	AzureCLIImage  string
-	GCloudCLIImage string
+	DefaultBaseRegistryURL    string
+	DefaultOnbuildRegistryURL string
+	RegistryKind              string
+	DefaultServiceAccount     string
+	CacheRepo                 string
+	InsecurePushRegistry      bool
+	InsecurePullRegistry      bool
+	PushImagesRetries         int
+
+	registryhelpers.AuthConfig
+
+	BusyBoxImage string
 
 	// PodLabels are extra labels set on the build job pod template, for either backend.
 	PodLabels map[string]string
@@ -162,6 +166,24 @@ func NewContainerBuilderConfiguration(existing *ContainerBuilderConfiguration) (
 	if containerBuilderConfiguration.DefaultRegistryCredentialsSecretName == "" {
 		containerBuilderConfiguration.DefaultRegistryCredentialsSecretName =
 			common.GetEnvOrDefaultString("NUCLIO_REGISTRY_CREDENTIALS_SECRET_NAME", "")
+	}
+
+	// merge singular + list + env list into one ordered, deduped list
+	secretNames := append([]string{}, containerBuilderConfiguration.DefaultRegistryCredentialsSecretNames...)
+	secretNames = append(secretNames, common.GetEnvOrDefaultStringSlice("NUCLIO_REGISTRY_CREDENTIALS_SECRET_NAMES", nil)...)
+	if containerBuilderConfiguration.DefaultRegistryCredentialsSecretName != "" {
+		secretNames = append([]string{containerBuilderConfiguration.DefaultRegistryCredentialsSecretName}, secretNames...)
+	}
+	containerBuilderConfiguration.DefaultRegistryCredentialsSecretNames = common.RemoveDuplicatesFromSliceString(secretNames)
+
+	if containerBuilderConfiguration.PythonImage == "" {
+		containerBuilderConfiguration.PythonImage =
+			common.GetEnvOrDefaultString("NUCLIO_PYTHON_BASE_IMAGE_NAME", "gcr.io/iguazio/python:3.11")
+	}
+
+	if containerBuilderConfiguration.PythonImagePullPolicy == "" {
+		containerBuilderConfiguration.PythonImagePullPolicy =
+			common.GetEnvOrDefaultString("NUCLIO_PYTHON_BASE_IMAGE_PULL_POLICY", "IfNotPresent")
 	}
 
 	if containerBuilderConfiguration.RegistryKind == "" {
@@ -258,6 +280,11 @@ func NewContainerBuilderConfiguration(existing *ContainerBuilderConfiguration) (
 	if containerBuilderConfiguration.Buildah.Isolation != "chroot" && containerBuilderConfiguration.Buildah.Isolation != "oci" {
 		return nil, errors.Errorf("Invalid buildah isolation: %s (must be \"chroot\" or \"oci\")",
 			containerBuilderConfiguration.Buildah.Isolation)
+	}
+
+	if containerBuilderConfiguration.Buildah.AppArmorProfile == "" {
+		containerBuilderConfiguration.Buildah.AppArmorProfile = common.GetEnvOrDefaultString(
+			"NUCLIO_BUILDAH_APPARMOR_PROFILE", "unconfined")
 	}
 
 	if containerBuilderConfiguration.AzureCLIImage == "" {

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -178,12 +178,12 @@ func NewContainerBuilderConfiguration(existing *ContainerBuilderConfiguration) (
 
 	if containerBuilderConfiguration.PythonImage == "" {
 		containerBuilderConfiguration.PythonImage =
-			common.GetEnvOrDefaultString("NUCLIO_PYTHON_BASE_IMAGE_NAME", "gcr.io/iguazio/python:3.11")
+			common.GetEnvOrDefaultString("NUCLIO_PYTHON_INIT_CONTAINER_IMAGE", "gcr.io/iguazio/python:3.11")
 	}
 
 	if containerBuilderConfiguration.PythonImagePullPolicy == "" {
 		containerBuilderConfiguration.PythonImagePullPolicy =
-			common.GetEnvOrDefaultString("NUCLIO_PYTHON_BASE_IMAGE_PULL_POLICY", "IfNotPresent")
+			common.GetEnvOrDefaultString("NUCLIO_PYTHON_INIT_CONTAINER_IMAGE_PULL_POLICY", "IfNotPresent")
 	}
 
 	if containerBuilderConfiguration.RegistryKind == "" {

--- a/pkg/containerimagebuilderpusher/types_test.go
+++ b/pkg/containerimagebuilderpusher/types_test.go
@@ -67,6 +67,52 @@ func (suite *ContainerBuilderConfigurationTestSuite) TestNilExistingBehavesEnvOn
 	suite.Equal("from-env:latest", config.Kaniko.Image)
 }
 
+func (suite *ContainerBuilderConfigurationTestSuite) TestSecretNamesMergeSingularAndList() {
+	suite.T().Setenv("NUCLIO_REGISTRY_CREDENTIALS_SECRET_NAMES", "from-env")
+
+	existing := &ContainerBuilderConfiguration{
+		DefaultRegistryCredentialsSecretName:  "singular",
+		DefaultRegistryCredentialsSecretNames: []string{"from-list"},
+	}
+
+	config, err := NewContainerBuilderConfiguration(existing)
+	suite.Require().NoError(err)
+
+	suite.Equal([]string{"singular", "from-list", "from-env"}, config.DefaultRegistryCredentialsSecretNames)
+}
+
+func (suite *ContainerBuilderConfigurationTestSuite) TestPythonImageDefaultsToIguazioPython() {
+	config, err := NewContainerBuilderConfiguration(nil)
+	suite.Require().NoError(err)
+
+	suite.Equal("gcr.io/iguazio/python:3.11", config.PythonImage)
+}
+
+func (suite *ContainerBuilderConfigurationTestSuite) TestPythonImageHonorsEnv() {
+	suite.T().Setenv("NUCLIO_PYTHON_BASE_IMAGE_NAME", "custom-image:latest")
+
+	config, err := NewContainerBuilderConfiguration(nil)
+	suite.Require().NoError(err)
+
+	suite.Equal("custom-image:latest", config.PythonImage)
+}
+
+func (suite *ContainerBuilderConfigurationTestSuite) TestPythonImagePullPolicyDefaultsToIfNotPresent() {
+	config, err := NewContainerBuilderConfiguration(nil)
+	suite.Require().NoError(err)
+
+	suite.Equal("IfNotPresent", config.PythonImagePullPolicy)
+}
+
+func (suite *ContainerBuilderConfigurationTestSuite) TestPythonImagePullPolicyHonorsEnv() {
+	suite.T().Setenv("NUCLIO_PYTHON_BASE_IMAGE_PULL_POLICY", "Always")
+
+	config, err := NewContainerBuilderConfiguration(nil)
+	suite.Require().NoError(err)
+
+	suite.Equal("Always", config.PythonImagePullPolicy)
+}
+
 func TestContainerBuilderConfigurationTestSuite(t *testing.T) {
 	suite.Run(t, new(ContainerBuilderConfigurationTestSuite))
 }

--- a/pkg/containerimagebuilderpusher/types_test.go
+++ b/pkg/containerimagebuilderpusher/types_test.go
@@ -89,7 +89,7 @@ func (suite *ContainerBuilderConfigurationTestSuite) TestPythonImageDefaultsToIg
 }
 
 func (suite *ContainerBuilderConfigurationTestSuite) TestPythonImageHonorsEnv() {
-	suite.T().Setenv("NUCLIO_PYTHON_BASE_IMAGE_NAME", "custom-image:latest")
+	suite.T().Setenv("NUCLIO_PYTHON_INIT_CONTAINER_IMAGE", "custom-image:latest")
 
 	config, err := NewContainerBuilderConfiguration(nil)
 	suite.Require().NoError(err)
@@ -105,7 +105,7 @@ func (suite *ContainerBuilderConfigurationTestSuite) TestPythonImagePullPolicyDe
 }
 
 func (suite *ContainerBuilderConfigurationTestSuite) TestPythonImagePullPolicyHonorsEnv() {
-	suite.T().Setenv("NUCLIO_PYTHON_BASE_IMAGE_PULL_POLICY", "Always")
+	suite.T().Setenv("NUCLIO_PYTHON_INIT_CONTAINER_IMAGE_PULL_POLICY", "Always")
 
 	config, err := NewContainerBuilderConfiguration(nil)
 	suite.Require().NoError(err)

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1131,11 +1131,6 @@ func (ap *Platform) GetOnbuildImageRegistry(registry string, runtime runtime.Run
 	return ap.ContainerBuilder.GetOnbuildImageRegistry(registry), nil
 }
 
-// GetDefaultRegistryCredentialsSecretName returns secret with credentials to push/pull from docker registry
-func (ap *Platform) GetDefaultRegistryCredentialsSecretName() string {
-	return ap.ContainerBuilder.GetDefaultRegistryCredentialsSecretName()
-}
-
 func (ap *Platform) GetRegistryKind() string {
 	if ap.ContainerBuilder != nil {
 		return ap.ContainerBuilder.GetRegistryKind()

--- a/pkg/platform/kube/clients/kube/client.go
+++ b/pkg/platform/kube/clients/kube/client.go
@@ -31,9 +31,13 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
+
+// fieldManager identifies nuclio as the owner of fields written via server-side apply.
+const fieldManager = "nuclio"
 
 type clientWithRetry struct {
 	kubernetes.Interface
@@ -140,6 +144,18 @@ func (r *clientWithRetry) DeleteConfigMap(ctx context.Context, namespace string,
 			Delete(ctx, name, deleteOptions)
 	}, r.retries, r.delay)
 	return
+}
+
+func (r *clientWithRetry) ApplyConfigMap(ctx context.Context, namespace string, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	applyConfig := corev1apply.ConfigMap(configMap.Name, namespace).
+		WithLabels(configMap.Labels).
+		WithData(configMap.Data)
+
+	return clients.RequestWithRetry[*corev1.ConfigMap](func() (*corev1.ConfigMap, error) {
+		return r.CoreV1().
+			ConfigMaps(namespace).
+			Apply(ctx, applyConfig, metav1.ApplyOptions{FieldManager: fieldManager, Force: true})
+	}, r.retries, r.delay)
 }
 
 func (r *clientWithRetry) ListServices(ctx context.Context, namespace string, options metav1.ListOptions) (*corev1.ServiceList, error) {

--- a/pkg/platform/kube/clients/kube/client.go
+++ b/pkg/platform/kube/clients/kube/client.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
+	metav1apply "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -147,9 +148,21 @@ func (r *clientWithRetry) DeleteConfigMap(ctx context.Context, namespace string,
 }
 
 func (r *clientWithRetry) ApplyConfigMap(ctx context.Context, namespace string, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	ownerRefs := make([]*metav1apply.OwnerReferenceApplyConfiguration, 0, len(configMap.OwnerReferences))
+	for _, ref := range configMap.OwnerReferences {
+		ownerRefs = append(ownerRefs, metav1apply.OwnerReference().
+			WithAPIVersion(ref.APIVersion).
+			WithKind(ref.Kind).
+			WithName(ref.Name).
+			WithUID(ref.UID).
+			WithController(*ref.Controller).
+			WithBlockOwnerDeletion(*ref.BlockOwnerDeletion))
+	}
+
 	applyConfig := corev1apply.ConfigMap(configMap.Name, namespace).
 		WithLabels(configMap.Labels).
-		WithData(configMap.Data)
+		WithData(configMap.Data).
+		WithOwnerReferences(ownerRefs...)
 
 	return clients.RequestWithRetry[*corev1.ConfigMap](func() (*corev1.ConfigMap, error) {
 		return r.CoreV1().

--- a/pkg/platform/kube/clients/kube/types.go
+++ b/pkg/platform/kube/clients/kube/types.go
@@ -66,6 +66,9 @@ type Client interface {
 	// DeleteConfigMap deletes a ConfigMap by name.
 	DeleteConfigMap(ctx context.Context, namespace string, name string, deleteOptions metav1.DeleteOptions) error
 
+	// ApplyConfigMap creates or updates a ConfigMap in a single server-side-apply call by name.
+	ApplyConfigMap(ctx context.Context, namespace string, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error)
+
 	// --- Services ---
 
 	// GetService fetches a Service by name in the given namespace.

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -387,10 +387,6 @@ func (mp *Platform) GetRegistryKind() string {
 	return ""
 }
 
-func (mp *Platform) GetDefaultRegistryCredentialsSecretName() string {
-	return "nuclio-registry-credentials"
-}
-
 func (mp *Platform) SaveFunctionDeployLogs(ctx context.Context, functionName, namespace string) error {
 	return nil
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -220,9 +220,6 @@ type Platform interface {
 	// GetBaseImage returns the base image resolved for the runtime (explicit or default)
 	GetBaseImage(runtime runtime.Runtime) string
 
-	// GetDefaultRegistryCredentialsSecretName returns secret with credentials to push/pull from docker registry
-	GetDefaultRegistryCredentialsSecretName() string
-
 	// GetRegistryKind returns platform registry kind
 	GetRegistryKind() string
 

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1147,16 +1147,18 @@ func (b *Builder) buildProcessorImage(ctx context.Context) (string, error) {
 
 			// Conjunct Pull with NoCache
 			// To ensure that when forcing a function build, the base images would be pulled as well.
-			Pull:                b.options.FunctionConfig.Spec.Build.NoCache,
-			NoCache:             b.options.FunctionConfig.Spec.Build.NoCache,
-			NoBaseImagePull:     b.GetNoBaseImagePull(),
-			BuildFlags:          buildFlags,
-			BuildArgs:           buildArgs,
-			RegistryURL:         registryURL,
-			RepoName:            b.resolveRepoName(registryURL),
-			SecretName:          b.resolveImagePullSecrets(),
-			OutputImageFile:     b.options.OutputImageFile,
-			BuildTimeoutSeconds: b.resolveBuildTimeoutSeconds(),
+			Pull:                 b.options.FunctionConfig.Spec.Build.NoCache,
+			NoCache:              b.options.FunctionConfig.Spec.Build.NoCache,
+			NoBaseImagePull:      b.GetNoBaseImagePull(),
+			BuildFlags:           buildFlags,
+			BuildArgs:            buildArgs,
+			RegistryURL:          registryURL,
+			BaseImageRegistry:    baseImageRegistry,
+			OnbuildImageRegistry: onbuildImageRegistry,
+			RepoName:             b.resolveRepoName(registryURL),
+			SecretName:           b.options.FunctionConfig.Spec.ImagePullSecrets,
+			OutputImageFile:      b.options.OutputImageFile,
+			BuildTimeoutSeconds:  b.resolveBuildTimeoutSeconds(),
 
 			// kaniko pod attributes
 			NodeSelector:           enrichedNodeSelector,
@@ -1181,13 +1183,6 @@ func (b *Builder) buildProcessorImage(ctx context.Context) (string, error) {
 		})
 
 	return taggedImageName, err
-}
-
-func (b *Builder) resolveImagePullSecrets() string {
-	if b.options.FunctionConfig.Spec.ImagePullSecrets == "" {
-		return b.platform.GetDefaultRegistryCredentialsSecretName()
-	}
-	return b.options.FunctionConfig.Spec.ImagePullSecrets
 }
 
 func (b *Builder) resolveRepoName(registryURL string) string {


### PR DESCRIPTION
### 📝 Description

**Motivation**
Buildah, unlike kaniko, ships no cloud credential helpers, so an in-cluster buildah build had no way to authenticate against a managed registry (AWS ECR, Azure ACR, Google Artifact Registry). This PR adds that. While at it, it also adds **multi-secret support**, which is backported to kaniko. Apart from that, no functional change to kaniko.

**Why multiple secrets**
A build often spans more than one registry host: the image is pushed to registry A while the base image and/or onbuild image are pulled from registries B and C. Previously a build job could authenticate to exactly one registry, from exactly one `dockerconfigjson` secret mounted straight into the builder as `config.json`.

**How it works**
The model moves from *"mount one secret"* to *"materialize one merged authfile"*:

- **Cloud login init containers**: one per registry host that matches a supported provider, running on that vendor's CLI image. Each mints a short-lived token using the pod's ambient cloud identity and writes it as a numbered credential file into a shared token `emptyDir`.
- **`merge-authfile` init container**: runs a small stdlib-only Python script that merges the docker-config secrets plus the minted tokens into a single `config.json` on a shared `emptyDir`, which the builder then mounts read-only

**Backwards compatibility & Kaniko**
- The single-secret, no-cloud case keeps the old direct-mount shortcut, so the common path gains no extra container.
- Kaniko delegates to the same shared path but with no cloud hosts (it has its own helpers), so it gains only the multi-secret merging.

---

### 🛠️ Changes Made

- **New `pkg/containerimagebuilderpusher/registryhelpers` package**: vendor abstraction (`Matches(host)` + `BuildLoginContainer(...)`) with one implementation per provider (ECR, ACR, GAR), the login-container fan-out, and the authfile merge container plus its embedded Python script. Kept free of buildah/kaniko coupling so both backends share it. ECR additionally provisions the target repository when it is the push destination
- **Shared decision point in `jobrunner.go`**: `configureRegistryAuthentication` resolves the secret list (platform defaults first, then the function's own secret, deduped) and picks the pod shape: nothing / old direct secret mount / merged authfile
- **`buildah.go`**: replaces the single-secret `configureAuthVolume` with the shared path, deriving cloud hosts from the push registry plus both pull registries. Also adds an AppArmor profile annotation (default `unconfined`, required for overlayfs)
- **`kaniko.go`**: same shared path, no cloud hosts; ECR URL parsing moved to `registryhelpers`. The existing ECR push-destination short-circuit is unchanged
- **Config surface**: new `DefaultRegistryCredentialsSecretNames` list alongside the legacy singular field (legacy value keeps its lowest-precedence position); new `BaseImageRegistry` / `OnbuildImageRegistry` build options; env vars for the secret-names list, the Python init-container image and the AppArmor profile; matching Helm values (`registry.secretNames`, `dashboard.build.initContainerImage.python.*`, `dashboard.buildah.appArmorProfile`). Rendering is byte-identical for existing installs
- **`ApplyConfigMap` on the kube client**: genuine server-side apply, used to reconcile the merge-script ConfigMap in one request
- **`common.SanitizeKubernetesName`**: replaces two hand-rolled name sanitizers with one DNS-1123 helper shared by job names and init-container names; plus `GetEnvOrDefaultStringSlice` for the comma-separated secret-names env var
- **Cleanup**: `GetDefaultRegistryCredentialsSecretName` removed from the platform and builder-pusher interfaces; defaults are now resolved as a list inside the builder configuration

---

### ✅ Checklist

- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

- Unit tests
- Integration suite runs the real merge container against the production Python image
- Manual end-to-end builds on On-premise, Azure (ACR) and GCP (GAR)
- AWS (ECR) manual testing is pending a suitable test environment, a story has been opened to cover it

---

### 🔗 References

- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes

Build-pod redacted logs from the manual runs

**On-premise, single combined secret:**
the direct-mount shortcut is taken, no `merge-authfile` container is created at all, so there are no merge logs

**On-premise, two secrets:**

```
merge-authfile  found 2 registry auth source(s) in /tmp/registry-auth-sources
merge-authfile  merged registry auth source /tmp/registry-auth-sources/0.json: hosts=['example-system-registry-docker-local.jfrog.io', 'example-user-registry-docker-local.jfrog.io']
merge-authfile  merged registry auth source /tmp/registry-auth-sources/1.json: hosts=['example-dev-snapshot-docker-local.jfrog.io', 'example-dev-snapshot-docker.jfrog.io']
merge-authfile  found 0 cloud registry credential token(s) in
merge-authfile  wrote merged authfile to /var/lib/containers/auth/config.json with 4 host(s)
```

**GCP, single cloud registry, no secrets:**

```
registry-login-gcp-us-central1-docker-pkg-dev
merge-authfile  found 0 registry auth source(s) in /tmp/registry-auth-sources
merge-authfile  found 1 cloud registry credential token(s) in /tmp/registry-auth-tokens
merge-authfile  applied cloud registry credential token /tmp/registry-auth-tokens/0.token for host us-central1-docker.pkg.dev
merge-authfile  wrote merged authfile to /var/lib/containers/auth/config.json with 1 host(s)
```

**Azure, two cloud registries authenticated in one build:**

```
registry-login-azure-examplebuildahacr-azurecr-io
registry-login-azure-examplesystemacr-azurecr-io
merge-authfile  found 0 registry auth source(s) in /tmp/registry-auth-sources
merge-authfile  found 2 cloud registry credential token(s) in /tmp/registry-auth-tokens
merge-authfile  applied cloud registry credential token /tmp/registry-auth-tokens/0.token for host examplebuildahacr.azurecr.io
merge-authfile  applied cloud registry credential token /tmp/registry-auth-tokens/1.token for host examplesystemacr.azurecr.io
merge-authfile  wrote merged authfile to /var/lib/containers/auth/config.json with 2 host(s)
```