### PR TITLE
[Kube] Keep user supplied environment when applying function augmentented configs

### DIFF
--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -78,27 +78,31 @@ func MergeEnvSlicesInOrder(primaryEnv []v1.EnvVar, secondaryEnv []v1.EnvVar) []v
 	}
 
 	merged := make([]v1.EnvVar, 0, len(secondaryEnv)+len(primaryEnv))
-	mergedNames := make(map[string]bool, len(secondaryEnv)+len(primaryEnv))
+	mergedIndex := make(map[string]int, len(secondaryEnv)+len(primaryEnv))
 
-	// walk the secondary list, replacing variables the primary list overrides. the first occurrence of a
-	// duplicated name wins, as in the deduplication kubernetes itself applies to container env
+	// walk the secondary list, replacing variables the primary list overrides. if a name appears multiple
+	// times, the last occurrence wins (matching Kubernetes env precedence semantics).
 	for _, env := range secondaryEnv {
-		if mergedNames[env.Name] {
-			continue
-		}
 		if primaryEnvVar, found := primaryEnvByName[env.Name]; found {
 			env = primaryEnvVar
 		}
+		if idx, exists := mergedIndex[env.Name]; exists {
+			merged[idx] = env
+			continue
+		}
+		mergedIndex[env.Name] = len(merged)
 		merged = append(merged, env)
-		mergedNames[env.Name] = true
 	}
 
 	// append the variables only the primary list holds
 	for _, env := range primaryEnv {
-		if !mergedNames[env.Name] {
-			merged = append(merged, env)
-			mergedNames[env.Name] = true
+		if idx, exists := mergedIndex[env.Name]; exists {
+			merged[idx] = env
+			continue
 		}
+
+		mergedIndex[env.Name] = len(merged)
+		merged = append(merged, env)
 	}
 
 	return merged

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -66,6 +66,44 @@ func envFromSourceKey(envSource v1.EnvFromSource) string {
 	return ""
 }
 
+// MergeEnvSlicesInOrder merges two lists of environment variables, giving priority to variables from the
+// primary list, while preserving the order of the secondary list. Variables that appear only in the primary
+// list are appended in their original order. Unlike MergeEnvSlices, the returned order is deterministic,
+// which matters when the result is written to a resource spec that would otherwise be diffed (and rolled out)
+// on every reconciliation.
+func MergeEnvSlicesInOrder(primaryEnv []v1.EnvVar, secondaryEnv []v1.EnvVar) []v1.EnvVar {
+	primaryEnvByName := make(map[string]v1.EnvVar, len(primaryEnv))
+	for _, env := range primaryEnv {
+		primaryEnvByName[env.Name] = env
+	}
+
+	merged := make([]v1.EnvVar, 0, len(secondaryEnv)+len(primaryEnv))
+	mergedNames := make(map[string]bool, len(secondaryEnv)+len(primaryEnv))
+
+	// walk the secondary list, replacing variables the primary list overrides. the first occurrence of a
+	// duplicated name wins, as in the deduplication kubernetes itself applies to container env
+	for _, env := range secondaryEnv {
+		if mergedNames[env.Name] {
+			continue
+		}
+		if primaryEnvVar, found := primaryEnvByName[env.Name]; found {
+			env = primaryEnvVar
+		}
+		merged = append(merged, env)
+		mergedNames[env.Name] = true
+	}
+
+	// append the variables only the primary list holds
+	for _, env := range primaryEnv {
+		if !mergedNames[env.Name] {
+			merged = append(merged, env)
+			mergedNames[env.Name] = true
+		}
+	}
+
+	return merged
+}
+
 // MergeEnvSlices merges two lists of environment variables, giving priority to variables from the primary list
 func MergeEnvSlices(primaryEnv []v1.EnvVar, secondaryEnv []v1.EnvVar) []v1.EnvVar {
 	envMap := make(map[string]v1.EnvVar)

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -69,6 +69,77 @@ func (suite *ConfigTestSuite) TestMergeEnvSlices() {
 	}
 }
 
+func (suite *ConfigTestSuite) TestMergeEnvSlicesInOrder() {
+	envVarFromSecret := v1.EnvVar{
+		Name: "from-secret",
+		ValueFrom: &v1.EnvVarSource{
+			SecretKeyRef: &v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{Name: "some-secret"},
+				Key:                  "some-key",
+			},
+		},
+	}
+
+	for _, testCase := range []struct {
+		name               string
+		primaryEnvs        []v1.EnvVar
+		secondaryEnvs      []v1.EnvVar
+		expectedMergedEnvs []v1.EnvVar
+	}{
+		{
+			name:          "secondary-order-kept-primary-only-appended",
+			primaryEnvs:   []v1.EnvVar{{Name: "test3", Value: "c"}, {Name: "test4", Value: "d"}},
+			secondaryEnvs: []v1.EnvVar{{Name: "test1", Value: "a"}, {Name: "test2", Value: "b"}},
+			expectedMergedEnvs: []v1.EnvVar{
+				{Name: "test1", Value: "a"},
+				{Name: "test2", Value: "b"},
+				{Name: "test3", Value: "c"},
+				{Name: "test4", Value: "d"},
+			},
+		},
+		{
+			name:          "same-key-overridden-in-place",
+			primaryEnvs:   []v1.EnvVar{{Name: "test2", Value: "primary"}, {Name: "test3", Value: "c"}},
+			secondaryEnvs: []v1.EnvVar{{Name: "test1", Value: "a"}, {Name: "test2", Value: "secondary"}},
+			expectedMergedEnvs: []v1.EnvVar{
+				{Name: "test1", Value: "a"},
+				{Name: "test2", Value: "primary"},
+				{Name: "test3", Value: "c"},
+			},
+		},
+		{
+			name:               "value-from-preserved",
+			primaryEnvs:        []v1.EnvVar{{Name: "test1", Value: "a"}},
+			secondaryEnvs:      []v1.EnvVar{envVarFromSecret},
+			expectedMergedEnvs: []v1.EnvVar{envVarFromSecret, {Name: "test1", Value: "a"}},
+		},
+		{
+			name:               "duplicated-secondary-name-deduplicated",
+			secondaryEnvs:      []v1.EnvVar{{Name: "test1", Value: "a"}, {Name: "test1", Value: "b"}},
+			expectedMergedEnvs: []v1.EnvVar{{Name: "test1", Value: "a"}},
+		},
+		{
+			name:               "empty-secondary",
+			primaryEnvs:        []v1.EnvVar{{Name: "test1", Value: "a"}},
+			expectedMergedEnvs: []v1.EnvVar{{Name: "test1", Value: "a"}},
+		},
+		{
+			name:               "empty-primary",
+			secondaryEnvs:      []v1.EnvVar{{Name: "test1", Value: "a"}},
+			expectedMergedEnvs: []v1.EnvVar{{Name: "test1", Value: "a"}},
+		},
+		{
+			name:               "both-empty",
+			expectedMergedEnvs: []v1.EnvVar{},
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Require().Equal(testCase.expectedMergedEnvs,
+				MergeEnvSlicesInOrder(testCase.primaryEnvs, testCase.secondaryEnvs))
+		})
+	}
+}
+
 func TestConfigTestSuite(t *testing.T) {
 	suite.Run(t, new(ConfigTestSuite))
 }

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -114,9 +114,9 @@ func (suite *ConfigTestSuite) TestMergeEnvSlicesInOrder() {
 			expectedMergedEnvs: []v1.EnvVar{envVarFromSecret, {Name: "test1", Value: "a"}},
 		},
 		{
-			name:               "duplicated-secondary-name-deduplicated",
+			name:               "duplicated-secondary-name-last-wins",
 			secondaryEnvs:      []v1.EnvVar{{Name: "test1", Value: "a"}, {Name: "test1", Value: "b"}},
-			expectedMergedEnvs: []v1.EnvVar{{Name: "test1", Value: "a"}},
+			expectedMergedEnvs: []v1.EnvVar{{Name: "test1", Value: "b"}},
 		},
 		{
 			name:               "empty-secondary",

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -179,16 +179,27 @@ func (lc *lazyClient) CreateOrUpdate(ctx context.Context,
 
 	resources := lazyResources{}
 
-	platformConfig := lc.platformConfigurationProvider.GetPlatformConfiguration()
-	for _, augmentedConfig := range platformConfig.FunctionAugmentedConfigs {
+	matchingAugmentedConfigs, err := lc.getMatchingFunctionAugmentedConfigs(functionLabels)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get matching function augmented configs")
+	}
 
-		selector, err := metav1.LabelSelectorAsSelector(&augmentedConfig.LabelSelector)
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to get selector from label selector")
+	if len(matchingAugmentedConfigs) > 0 {
+
+		// function augmented configs are a deploy time overlay - they must not leak back into the function CRD,
+		// which the caller persists once this call returns, so apply them onto a copy of the function
+		if function, err = copyFunction(function); err != nil {
+			return nil, errors.Wrap(err, "Failed to copy function before augmenting it")
 		}
 
-		// if the label matches any of the function labels, augment the function with provided function config
-		if selector.Matches(functionLabels) {
+		for _, augmentedConfig := range matchingAugmentedConfigs {
+
+			// unmarshalling the augmented config onto the function overwrites its environment rather than merging
+			// into it, and does so in place - reusing the backing array of the slices it overwrites. detach the
+			// environment from the function first, so that it survives untouched and can be merged back in below
+			preAugmentationEnv, preAugmentationEnvFrom := function.Spec.Env, function.Spec.EnvFrom
+			function.Spec.Env, function.Spec.EnvFrom = nil, nil
+
 			encodedFunctionConfig, err := yaml.Marshal(augmentedConfig.FunctionConfig)
 			if err != nil {
 				return nil, errors.Wrap(err, "Failed to marshal augmented function config")
@@ -197,6 +208,13 @@ func (lc *lazyClient) CreateOrUpdate(ctx context.Context,
 			if err := yaml.Unmarshal(encodedFunctionConfig, function); err != nil {
 				return nil, errors.Wrap(err, "Failed to join augmented function config into target function")
 			}
+
+			// merge the detached environment back in, so that user supplied environment variables survive. the
+			// augmented config takes precedence on name collisions, being platform level configuration.
+			// NOTE: every other slice field (volumes, sidecars, etc.) is still overlaid element by element, as
+			// unmarshalling does it
+			function.Spec.Env = common.MergeEnvSlicesInOrder(function.Spec.Env, preAugmentationEnv)
+			function.Spec.EnvFrom = common.MergeEnvFromSlices(function.Spec.EnvFrom, preAugmentationEnvFrom)
 		}
 	}
 
@@ -1477,12 +1495,17 @@ func (lc *lazyClient) enrichDeploymentFromPlatformConfiguration(function *nuclio
 
 func (lc *lazyClient) getDeploymentAugmentedConfigs(function *nuclioio.NuclioFunction) (
 	[]platformconfig.LabelSelectorAndConfig, error) {
+
+	// NOTE: supports spec only for now. in the future we can remove .Spec and try to merge both meta and spec
+	return lc.getMatchingFunctionAugmentedConfigs(lc.getFunctionLabels(function))
+}
+
+// getMatchingFunctionAugmentedConfigs returns the platform's function augmented configs whose label selector
+// matches the given function labels
+func (lc *lazyClient) getMatchingFunctionAugmentedConfigs(functionLabels labels.Set) (
+	[]platformconfig.LabelSelectorAndConfig, error) {
 	var configs []platformconfig.LabelSelectorAndConfig
 
-	// get the function labels
-	functionLabels := lc.getFunctionLabels(function)
-
-	// get platform config
 	platformConfig := lc.platformConfigurationProvider.GetPlatformConfiguration()
 
 	for _, augmentedConfig := range platformConfig.FunctionAugmentedConfigs {
@@ -1492,14 +1515,32 @@ func (lc *lazyClient) getDeploymentAugmentedConfigs(function *nuclioio.NuclioFun
 			return nil, errors.Wrap(err, "Failed to get selector from label selector")
 		}
 
-		// if the label matches any of the function labels, augment the deployment with provided function config
-		// NOTE: supports spec only for now. in the future we can remove .Spec and try to merge both meta and spec
 		if selector.Matches(functionLabels) {
 			configs = append(configs, augmentedConfig)
 		}
 	}
 
 	return configs, nil
+}
+
+// copyFunction returns a copy of the given function that shares no state with it.
+// nuclioio.NuclioFunction.DeepCopy() alone doesn't cut it - functionconfig.Spec.DeepCopyInto() is a shallow
+// copy (see the TODO there), leaving the spec's slices, maps and pointers shared with the original. the spec is
+// therefore copied by round tripping it through JSON, which is how it is read from the function CRD to begin with
+func copyFunction(function *nuclioio.NuclioFunction) (*nuclioio.NuclioFunction, error) {
+	functionCopy := function.DeepCopy()
+
+	encodedFunctionSpec, err := json.Marshal(&function.Spec)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to marshal function spec")
+	}
+
+	functionCopy.Spec = functionconfig.Spec{}
+	if err := json.Unmarshal(encodedFunctionSpec, &functionCopy.Spec); err != nil {
+		return nil, errors.Wrap(err, "Failed to unmarshal function spec")
+	}
+
+	return functionCopy, nil
 }
 
 func (lc *lazyClient) createOrUpdateHorizontalPodAutoscaler(ctx context.Context,

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -1273,8 +1273,8 @@ func (suite *lazyTestSuite) TestAugmentedConfigMergesFunctionEnvironment() {
 	}
 
 	// keep the user supplied environment aside, to later verify the function instance itself wasn't augmented
-	userEnv := functionInstance.DeepCopy().Spec.Env
-	userEnvFrom := functionInstance.DeepCopy().Spec.EnvFrom
+	userEnv := append([]v1.EnvVar(nil), functionInstance.Spec.Env...)
+	userEnvFrom := append([]v1.EnvFromSource(nil), functionInstance.Spec.EnvFrom...)
 
 	resources, err := suite.client.CreateOrUpdate(suite.ctx, functionInstance, "")
 	suite.Require().NoError(err)

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -1211,6 +1211,144 @@ func (suite *lazyTestSuite) getFunctionInstanceWithDefaultProbes(funcName string
 	return functionInstance
 }
 
+// TestAugmentedConfigMergesFunctionEnvironment verifies that a function augmented config injects its
+// environment into the deployed function without dropping the environment the user supplied
+func (suite *lazyTestSuite) TestAugmentedConfigMergesFunctionEnvironment() {
+	suite.client.SetPlatformConfigurationProvider(&mockedPlatformConfigurationProvider{
+		platformConfiguration: &platformconfig.Config{
+			FunctionAugmentedConfigs: []platformconfig.LabelSelectorAndConfig{
+				{
+					LabelSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "hi",
+						},
+					},
+					FunctionConfig: functionconfig.Config{
+						Spec: functionconfig.Spec{
+							Env: []v1.EnvVar{
+								{Name: "INJECTED_FROM_AUGMENTED_CONFIG", Value: "true"},
+
+								// overrides a user supplied variable of the same name
+								{Name: "SHARED_VAR", Value: "augmented-value"},
+							},
+							EnvFrom: []v1.EnvFromSource{
+								{
+									SecretRef: &v1.SecretEnvSource{
+										LocalObjectReference: v1.LocalObjectReference{Name: "augmented-secret"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	functionInstance := suite.getFunctionInstanceWithDefaultProbes("func-env-test")
+	functionInstance.Labels = map[string]string{
+
+		// matches the augmented config label selector
+		"app": "hi",
+	}
+	functionInstance.Spec.Env = []v1.EnvVar{
+		{Name: "USER_CUSTOM_VAR", Value: "should-survive"},
+		{Name: "SHARED_VAR", Value: "original-value"},
+		{
+			Name: "USER_VAR_FROM_SECRET",
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: "user-secret"},
+					Key:                  "user-key",
+				},
+			},
+		},
+	}
+	functionInstance.Spec.EnvFrom = []v1.EnvFromSource{
+		{
+			ConfigMapRef: &v1.ConfigMapEnvSource{
+				LocalObjectReference: v1.LocalObjectReference{Name: "user-configmap"},
+			},
+		},
+	}
+
+	// keep the user supplied environment aside, to later verify the function instance itself wasn't augmented
+	userEnv := functionInstance.DeepCopy().Spec.Env
+	userEnvFrom := functionInstance.DeepCopy().Spec.EnvFrom
+
+	resources, err := suite.client.CreateOrUpdate(suite.ctx, functionInstance, "")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(resources)
+
+	deployment, err := resources.Deployment()
+	suite.Require().NoError(err)
+	container := deployment.Spec.Template.Spec.Containers[0]
+
+	// user supplied environment variables must not be clobbered by the augmented config
+	suite.Require().Equal("should-survive", suite.getEnvVarByName(container.Env, "USER_CUSTOM_VAR").Value)
+
+	// environment variables from the augmented config must be injected
+	suite.Require().Equal("true", suite.getEnvVarByName(container.Env, "INJECTED_FROM_AUGMENTED_CONFIG").Value)
+
+	// on a name collision, the augmented config wins
+	suite.Require().Equal("augmented-value", suite.getEnvVarByName(container.Env, "SHARED_VAR").Value)
+
+	// a user supplied variable holding a reference keeps it, rather than being flattened to an empty value
+	suite.Require().Equal(userEnv[2].ValueFrom, suite.getEnvVarByName(container.Env, "USER_VAR_FROM_SECRET").ValueFrom)
+
+	// envFrom sources of both the user and the augmented config are kept
+	suite.Require().Equal([]v1.EnvFromSource{
+		{
+			SecretRef: &v1.SecretEnvSource{
+				LocalObjectReference: v1.LocalObjectReference{Name: "augmented-secret"},
+			},
+		},
+		userEnvFrom[0],
+	}, container.EnvFrom)
+
+	// the merged environment keeps the user supplied order, with the augmented-only variables appended
+	suite.Require().Equal([]string{
+		"USER_CUSTOM_VAR",
+		"SHARED_VAR",
+		"USER_VAR_FROM_SECRET",
+		"INJECTED_FROM_AUGMENTED_CONFIG",
+	}, suite.getEnvVarNames(container.Env)[:4])
+
+	// the augmented config is a deploy time overlay - the function instance the caller passed, which the
+	// function operator persists back to the function CRD, must be left as the user wrote it
+	suite.Require().Equal(userEnv, functionInstance.Spec.Env)
+	suite.Require().Equal(userEnvFrom, functionInstance.Spec.EnvFrom)
+
+	// reconciling again must yield the very same environment, in the same order, so that the deployment
+	// isn't rolled out on every reconciliation
+	secondResources, err := suite.client.CreateOrUpdate(suite.ctx, functionInstance, "")
+	suite.Require().NoError(err)
+	secondDeployment, err := secondResources.Deployment()
+	suite.Require().NoError(err)
+	suite.Require().Equal(container.Env, secondDeployment.Spec.Template.Spec.Containers[0].Env)
+	suite.Require().Equal(container.EnvFrom, secondDeployment.Spec.Template.Spec.Containers[0].EnvFrom)
+}
+
+func (suite *lazyTestSuite) getEnvVarByName(env []v1.EnvVar, name string) v1.EnvVar {
+	for _, envVar := range env {
+		if envVar.Name == name {
+			return envVar
+		}
+	}
+
+	suite.Failf("Could not find env var in container environment", "name: %s", name)
+	return v1.EnvVar{}
+}
+
+func (suite *lazyTestSuite) getEnvVarNames(env []v1.EnvVar) []string {
+	var names []string
+	for _, envVar := range env {
+		names = append(names, envVar.Name)
+	}
+
+	return names
+}
+
 func TestLazyTestSuite(t *testing.T) {
 	suite.Run(t, new(lazyTestSuite))
 }

--- a/pkg/platform/kube/test/function/function_test.go
+++ b/pkg/platform/kube/test/function/function_test.go
@@ -603,7 +603,13 @@ func (suite *DeployFunctionTestSuite) TestAugmentedConfig() {
 			LabelSelector: metav1.LabelSelector{
 				MatchLabels: functionLabels,
 			},
-			FunctionConfig: functionconfig.Config{},
+			FunctionConfig: functionconfig.Config{
+				Spec: functionconfig.Spec{
+					Env: []v1.EnvVar{
+						{Name: "INJECTED_FROM_AUGMENTED_CONFIG", Value: "true"},
+					},
+				},
+			},
 			Kubernetes: platformconfig.Kubernetes{
 				Deployment: &appsv1.Deployment{
 					Spec: appsv1.DeploymentSpec{
@@ -623,6 +629,8 @@ func (suite *DeployFunctionTestSuite) TestAugmentedConfig() {
 	functionName := "augmented-config"
 	createFunctionOptions := suite.CompileCreateFunctionOptions(functionName)
 	createFunctionOptions.FunctionConfig.Meta.Labels["my-function"] = "is-labeled"
+	userEnv := []v1.EnvVar{{Name: "USER_CUSTOM_VAR", Value: "should-survive"}}
+	createFunctionOptions.FunctionConfig.Spec.Env = userEnv
 	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
 		deploymentInstance := &appsv1.Deployment{}
 		functionInstance := &nuclioio.NuclioFunction{}
@@ -638,6 +646,14 @@ func (suite *DeployFunctionTestSuite) TestAugmentedConfig() {
 		suite.Require().NotNil(deploymentInstance.Spec.Template.Spec.SecurityContext.RunAsGroup)
 		suite.Require().Equal(runAsUserID, *deploymentInstance.Spec.Template.Spec.SecurityContext.RunAsUser)
 		suite.Require().Equal(runAsGroupID, *deploymentInstance.Spec.Template.Spec.SecurityContext.RunAsGroup)
+
+		// ensure the augmented config environment was injected, without dropping the user supplied environment
+		containerEnv := deploymentInstance.Spec.Template.Spec.Containers[0].Env
+		suite.Require().Contains(containerEnv, userEnv[0])
+		suite.Require().Contains(containerEnv, v1.EnvVar{Name: "INJECTED_FROM_AUGMENTED_CONFIG", Value: "true"})
+
+		// the augmented config is a deploy time overlay - it must not be persisted onto the function itself
+		suite.Require().Equal(userEnv, functionInstance.Spec.Env)
 		return true
 	})
 }


### PR DESCRIPTION
### 📝 Description
A function whose labels match a `platform.functionAugmentedConfigs` entry loses every environment variable its user set: the deployed function ends up with only the variables the augmented config injects, and the loss is persisted back to the `NuclioFunction` CRD, so the dashboard stops showing them altogether.

Fixes #4224.

Three things combine to cause it:

1. The augmented config is applied by unmarshalling it onto the function, and unmarshalling **replaces** slice fields rather than merging them — the augmented `spec.env` replaces the function's own.
2. It replaces them **in place**, reusing the backing array of the slice it overwrites, so holding a reference to the environment beforehand isn't enough to merge it back: the reference sees the overwritten values. (The same in-place merge turns an `envFrom` entry into a hybrid carrying both the user's `configMapRef` and the augmented `secretRef`, which the API server rejects as having more than one source.)
3. The function object is mutated in place, and `functionOperator.setFunctionStatus` persists that same object when it updates the status — writing the deploy time overlay into the function CRD.

---

### 🛠️ Changes Made
- `pkg/platform/kube/functionres/lazy.go`
  - Augmented configs are resolved up front via a new `getMatchingFunctionAugmentedConfigs`, which `getDeploymentAugmentedConfigs` now also uses (one matching implementation instead of two).
  - When any config matches, the overlay is applied to a copy of the function, so it no longer leaks back into the CRD the operator persists.
  - `spec.env` / `spec.envFrom` are detached before the unmarshal and merged back after, so user supplied variables survive with their `valueFrom` sources intact. The augmented config takes precedence on name collisions, being platform level configuration.
  - New `copyFunction`: `nuclioio.NuclioFunction.DeepCopy()` alone isn't a usable copy here, because `functionconfig.Spec.DeepCopyInto()` is a shallow `*out = *s` (it carries a `TODO: proper deep copy`), leaving the spec's slices, maps and pointers shared with the original. The spec is therefore copied by round tripping it through JSON, which is how it reaches the controller from the CRD to begin with.
- `pkg/common/config.go` — new `MergeEnvSlicesInOrder`, which gives priority to the primary (augmented) list while preserving the secondary (user) list's order and appending primary-only variables. Unlike the existing map-based `MergeEnvSlices`, its output order is deterministic, so the deployment isn't diffed and rolled out on every reconciliation.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable) — no docs in the repo reference `functionAugmentedConfigs`
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- `make test-unit`: 1510 tests pass. New coverage:
  - `pkg/platform/kube/functionres/lazy_test.go` — `TestAugmentedConfigMergesFunctionEnvironment`: user variables survive, augmented variables are injected, the augmented config wins on a name collision, a user variable's `valueFrom` is preserved, `envFrom` entries from both sides are kept intact, two consecutive reconciliations produce identical environment ordering, and the function object the caller passed in is left untouched.
  - `pkg/common/config_test.go` — `TestMergeEnvSlicesInOrder` (ordering, in-place override, `valueFrom` preservation, deduplication, empty inputs).
- `pkg/platform/kube/test/function/function_test.go` — `TestAugmentedConfig` extended with an env case (augmented + user variables in the deployment, augmented env not persisted onto the function).
- `make lint`: 0 issues.
- Verified end to end on a kind cluster running the reporter's setup (nuclio 1.17.3 chart, `functionAugmentedConfigs` injecting `INJECTED_FROM_AUGMENTED_CONFIG`):
  - Before: both the deployment container and the `NuclioFunction` CRD held only `INJECTED_FROM_AUGMENTED_CONFIG`.
  - After (controller rebuilt from this branch): the deployment and the running pod hold `USER_CUSTOM_VAR`, `INJECTED_FROM_AUGMENTED_CONFIG` (augmented value winning over a deliberately colliding user value), `USER_VAR_2` and the `NUCLIO_*` variables; the CRD holds exactly the three user variables, with nothing injected into it.
  - Restarting the controller to force a full resync left the deployment's pod template untouched — no environment churn or rolling restart.

---

### 🔗 References
- Ticket link: https://github.com/nuclio/nuclio/issues/4224
- Reproduction environment: https://github.com/ssullivan/nuclio-env-debug

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

Two behavior changes worth calling out, both of them the point of the fix: environment variables from an augmented config are no longer written into the function CRD's spec (they only reach the deployed resources), and the merged environment now has a deterministic order.

---

### 🔍️ Additional Notes
- Only `env` / `envFrom` are merged. Every other slice field (volumes, sidecars, tolerations, …) is still overlaid element by element by the unmarshalling, which can produce the same class of surprise; left as is here to keep the change scoped, and noted in a comment at the call site.
- `functionconfig.Spec.DeepCopyInto()` being shallow is a sharp edge well beyond this code path — anything that assumes `NuclioFunction.DeepCopy()` isolates it from the original is mistaken. Fixing it properly (deepcopy-gen or hand-written, with care for the `map[string]interface{}` attribute fields) looks like a worthwhile follow-up; this PR works around it locally rather than changing a function every informer copy goes through.
- Aside for the reporter: the augmented config entry in the linked repro uses `meta:`, which isn't a field of `LabelSelectorAndConfig` and is silently ignored — leaving an empty `labelSelector`, which matches *every* function rather than the intended `app: hi`. The intended form is `labelSelector.matchLabels`.