### PR TITLE
[Controller] Support multiple ports in auth proxy

### DIFF
--- a/cmd/authproxy/app/authproxy.go
+++ b/cmd/authproxy/app/authproxy.go
@@ -69,7 +69,7 @@ func newServers(rootLogger logger.Logger,
 	servers := make([]*server, len(config.Routes))
 
 	for index, route := range config.Routes {
-		handler, err := newHandler(rootLogger, config.Mode, route, authenticator)
+		handler, err := newHandler(rootLogger, config.Mode, route.UpstreamURL, authenticator)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed to create handler for listen port %d", route.ListenPort)
 		}

--- a/cmd/authproxy/app/authproxy.go
+++ b/cmd/authproxy/app/authproxy.go
@@ -17,6 +17,8 @@ limitations under the License.
 package app
 
 import (
+	"context"
+
 	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/auth/authproxy"
 	"github.com/nuclio/nuclio/pkg/common"
@@ -52,20 +54,35 @@ func Run(config *Config) error {
 		return errors.Wrap(err, "Failed to create authenticator")
 	}
 
-	handler, err := newHandler(rootLogger,
-		config.Mode,
-		config.UpstreamURL,
-		authenticator)
+	servers, err := newServers(rootLogger, config, authenticator)
 	if err != nil {
-		return errors.Wrap(err, "Failed to create handler")
+		return errors.Wrap(err, "Failed to create servers")
 	}
 
-	listenAddress, err := resolveListenAddress(config.Mode, config.ListenPort)
-	if err != nil {
-		return errors.Wrap(err, "Failed to resolve listen address")
+	return startServers(context.Background(), rootLogger, servers)
+}
+
+// newServers builds one server per configured route.
+func newServers(rootLogger logger.Logger,
+	config *Config,
+	authenticator authproxy.Authenticator) ([]*server, error) {
+	servers := make([]*server, len(config.Routes))
+
+	for index, route := range config.Routes {
+		handler, err := newHandler(rootLogger, config.Mode, route, authenticator)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to create handler for listen port %d", route.ListenPort)
+		}
+
+		listenAddress, err := resolveListenAddress(config.Mode, route.ListenPort)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to resolve listen address for listen port %d", route.ListenPort)
+		}
+
+		servers[index] = newServer(rootLogger, listenAddress, handler)
 	}
 
-	return newServer(rootLogger, listenAddress, handler).start()
+	return servers, nil
 }
 
 // newAuthenticator creates kube clients when needed and delegates to the pkg-level factory.

--- a/cmd/authproxy/app/config.go
+++ b/cmd/authproxy/app/config.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/auth/authproxy"
 
 	"github.com/nuclio/errors"
 )
@@ -25,10 +26,9 @@ import (
 // Config holds the auth-proxy sidecar configuration.
 type Config struct {
 	Mode               auth.ProxyMode
-	ListenPort         int
-	UpstreamURL        string // the URL of the upstream service to which requests are proxied (reverseProxy mode only)
-	AuthURL            string // the URL of the auth service to which requests are sent for authentication
-	SigninURL          string // the URL of the sign-in service to which requests are redirected for sign-in (browser mode only)
+	Routes             []authproxy.Route // every port the auth-proxy listens on, each with its own upstream
+	AuthURL            string            // the URL of the auth service to which requests are sent for authentication
+	SigninURL          string            // the URL of the sign-in service to which requests are redirected for sign-in (browser mode only)
 	AuthMode           string
 	FunctionConfigPath string // path to the mounted function config; credentials are read from it when auth-mode=basicAuth
 	Namespace          string
@@ -38,8 +38,8 @@ type Config struct {
 }
 
 func validateConfiguration(config *Config) error {
-	if err := validatePort(config.ListenPort); err != nil {
-		return errors.Wrap(err, "Invalid port configuration")
+	if err := validateRoutes(config); err != nil {
+		return errors.Wrap(err, "Invalid route configuration")
 	}
 
 	switch config.Mode {
@@ -53,10 +53,6 @@ func validateConfiguration(config *Config) error {
 }
 
 func validateReverseProxyConfiguration(config *Config) error {
-	if config.UpstreamURL == "" {
-		return errors.New("Upstream URL must be provided")
-	}
-
 	switch auth.AuthenticationMode(config.AuthMode) {
 	case auth.AuthenticationModeAPI:
 		if config.AuthURL == "" {
@@ -91,6 +87,48 @@ func validateAuthOnlyConfiguration(config *Config) error {
 	}
 	if config.SigninURL == "" {
 		return errors.New("Sign-in URL must be provided in authOnly mode")
+	}
+
+	return nil
+}
+
+func validateRoutes(config *Config) error {
+	if len(config.Routes) == 0 {
+		return errors.New("At least one route must be provided")
+	}
+
+	seenListenPorts := make(map[int]bool, len(config.Routes))
+	for _, route := range config.Routes {
+		if err := validatePort(route.ListenPort); err != nil {
+			return err
+		}
+
+		if seenListenPorts[route.ListenPort] {
+			return errors.Errorf("Duplicate listen port: %d", route.ListenPort)
+		}
+		seenListenPorts[route.ListenPort] = true
+	}
+
+	switch config.Mode {
+	case auth.ProxyModeReverseProxy:
+
+		// every listener forwards, so each route needs its own upstream
+		for _, route := range config.Routes {
+			if route.UpstreamURL == "" {
+				return errors.Errorf("Upstream URL must be provided for listen port: %d", route.ListenPort)
+			}
+		}
+	case auth.ProxyModeAuthOnly:
+
+		// authOnly is only ever reached over a single, internal loopback address
+		if len(config.Routes) != 1 {
+			return errors.Errorf("authOnly mode requires exactly one route, got %d", len(config.Routes))
+		}
+
+		// authOnly does not forward, so an upstream is always a configuration mistake
+		if config.Routes[0].UpstreamURL != "" {
+			return errors.New("Upstream URL must not be provided in authOnly mode")
+		}
 	}
 
 	return nil

--- a/cmd/authproxy/app/config_test.go
+++ b/cmd/authproxy/app/config_test.go
@@ -1,0 +1,124 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/auth/authproxy"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ConfigTestSuite struct {
+	suite.Suite
+}
+
+// TestValidateRoutes verifies the per-port rules and the per-mode rules: reverseProxy needs an upstream on
+// every route, authOnly is reached over a single loopback address and must not be given one at all.
+func (suite *ConfigTestSuite) TestValidateRoutes() {
+	for _, testCase := range []struct {
+		name                 string
+		mode                 auth.ProxyMode
+		routes               []authproxy.Route
+		expectedErrorMessage string
+	}{
+		{
+			name:   "reverseProxy with a single route",
+			mode:   auth.ProxyModeReverseProxy,
+			routes: []authproxy.Route{{ListenPort: 8080, UpstreamURL: "http://127.0.0.1:6080"}},
+		},
+		{
+			name: "reverseProxy fronting several ports",
+			mode: auth.ProxyModeReverseProxy,
+			routes: []authproxy.Route{
+				{ListenPort: 8080, UpstreamURL: "http://127.0.0.1:6080"},
+				{ListenPort: 6081, UpstreamURL: "http://127.0.0.1:8050"},
+			},
+		},
+		{
+			name:   "authOnly with a port only",
+			mode:   auth.ProxyModeAuthOnly,
+			routes: []authproxy.Route{{ListenPort: 8080}},
+		},
+		{
+			name:                 "no routes at all",
+			mode:                 auth.ProxyModeReverseProxy,
+			routes:               []authproxy.Route{},
+			expectedErrorMessage: "At least one route must be provided",
+		},
+		{
+			name:                 "listen port out of range",
+			mode:                 auth.ProxyModeReverseProxy,
+			routes:               []authproxy.Route{{ListenPort: 70000, UpstreamURL: "http://127.0.0.1:6080"}},
+			expectedErrorMessage: "Invalid listen port",
+		},
+		{
+			name:                 "well-known listen port",
+			mode:                 auth.ProxyModeReverseProxy,
+			routes:               []authproxy.Route{{ListenPort: 80, UpstreamURL: "http://127.0.0.1:6080"}},
+			expectedErrorMessage: "reserved for well-known services",
+		},
+		{
+			name: "duplicate listen port",
+			mode: auth.ProxyModeReverseProxy,
+			routes: []authproxy.Route{
+				{ListenPort: 8080, UpstreamURL: "http://127.0.0.1:6080"},
+				{ListenPort: 8080, UpstreamURL: "http://127.0.0.1:8050"},
+			},
+			expectedErrorMessage: "Duplicate listen port: 8080",
+		},
+		{
+			name: "reverseProxy route without an upstream",
+			mode: auth.ProxyModeReverseProxy,
+			routes: []authproxy.Route{
+				{ListenPort: 8080, UpstreamURL: "http://127.0.0.1:6080"},
+				{ListenPort: 6081},
+			},
+			expectedErrorMessage: "Upstream URL must be provided for listen port: 6081",
+		},
+		{
+			name:                 "authOnly with more than one route",
+			mode:                 auth.ProxyModeAuthOnly,
+			routes:               []authproxy.Route{{ListenPort: 8080}, {ListenPort: 6081}},
+			expectedErrorMessage: "authOnly mode requires exactly one route, got 2",
+		},
+		{
+			name:                 "authOnly given an upstream",
+			mode:                 auth.ProxyModeAuthOnly,
+			routes:               []authproxy.Route{{ListenPort: 8080, UpstreamURL: "http://127.0.0.1:6080"}},
+			expectedErrorMessage: "Upstream URL must not be provided in authOnly mode",
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			err := validateRoutes(&Config{Mode: testCase.mode, Routes: testCase.routes})
+			if testCase.expectedErrorMessage == "" {
+				suite.Require().NoError(err)
+				return
+			}
+			suite.Require().Error(err)
+			suite.Require().Contains(err.Error(), testCase.expectedErrorMessage)
+		})
+	}
+}
+
+func TestConfigTestSuite(t *testing.T) {
+	suite.Run(t, new(ConfigTestSuite))
+}

--- a/cmd/authproxy/app/server.go
+++ b/cmd/authproxy/app/server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -28,6 +29,7 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
+	"golang.org/x/sync/errgroup"
 )
 
 // server fronts a function or the DLX.
@@ -47,16 +49,16 @@ func newServer(parentLogger logger.Logger, listenAddress string, handler http.Ha
 	}
 }
 
-// newHandler builds the HTTP handler for the given mode: reverseProxy authenticates each request and
-// forwards it to the processor; authOnly serves the DLX /auth endpoint.
+// newHandler builds the HTTP handler for the given route: reverseProxy authenticates each request and
+// forwards it to the route's upstream; authOnly serves the DLX /auth endpoint.
 func newHandler(parentLogger logger.Logger,
 	mode auth.ProxyMode,
-	upstreamURL string,
+	route authproxy.Route,
 	authenticator authproxy.Authenticator) (http.Handler, error) {
 
 	switch mode {
 	case auth.ProxyModeReverseProxy:
-		handler, err := newReverseProxyHandler(parentLogger, upstreamURL, authenticator)
+		handler, err := newReverseProxyHandler(parentLogger, route.UpstreamURL, authenticator)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to create reverse-proxy handler")
 		}
@@ -84,7 +86,7 @@ func resolveListenAddress(mode auth.ProxyMode, listenPort int) (string, error) {
 func (s *server) start() error {
 	s.logger.InfoWith("Starting auth-proxy", "listenAddress", s.httpServer.Addr)
 
-	if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	if err := s.httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return errors.Wrap(err, "Auth-proxy server failed to start")
 	}
 
@@ -137,4 +139,32 @@ func newAuthOnlyHandler(authenticator authproxy.Authenticator) http.Handler {
 		}
 	})
 	return mux
+}
+
+// startServers starts every server concurrently, so a single auth-proxy process fronts all of a function's ports.
+// Startup is all-or-nothing: a listener that fails to bind closes the others and the error is returned.
+func startServers(ctx context.Context, parentLogger logger.Logger, servers []*server) error {
+	errorWG, groupCtx := errgroup.WithContext(ctx)
+	for _, listenerServer := range servers {
+		errorWG.Go(listenerServer.start)
+	}
+
+	stop := context.AfterFunc(groupCtx, func() {
+		closeServers(parentLogger, servers)
+	})
+	defer stop()
+
+	return errorWG.Wait()
+}
+
+// closeServers unblocks the remaining listeners once the group context is cancelled; their start then
+// returns http.ErrServerClosed, which start treats as a clean stop so Wait can report the original error.
+func closeServers(parentLogger logger.Logger, servers []*server) {
+	for _, listenerServer := range servers {
+		if err := listenerServer.httpServer.Close(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			parentLogger.WarnWith("Failed to close auth-proxy listener",
+				"listenAddress", listenerServer.httpServer.Addr,
+				"err", err.Error())
+		}
+	}
 }

--- a/cmd/authproxy/app/server.go
+++ b/cmd/authproxy/app/server.go
@@ -53,12 +53,12 @@ func newServer(parentLogger logger.Logger, listenAddress string, handler http.Ha
 // forwards it to the route's upstream; authOnly serves the DLX /auth endpoint.
 func newHandler(parentLogger logger.Logger,
 	mode auth.ProxyMode,
-	route authproxy.Route,
+	upstreamURL string,
 	authenticator authproxy.Authenticator) (http.Handler, error) {
 
 	switch mode {
 	case auth.ProxyModeReverseProxy:
-		handler, err := newReverseProxyHandler(parentLogger, route.UpstreamURL, authenticator)
+		handler, err := newReverseProxyHandler(parentLogger, upstreamURL, authenticator)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to create reverse-proxy handler")
 		}

--- a/cmd/authproxy/app/server_test.go
+++ b/cmd/authproxy/app/server_test.go
@@ -91,7 +91,7 @@ func (suite *ServerTestSuite) TestModeListenAddresses() {
 		suite.Run(testCase.name, func() {
 			handler, err := newHandler(suite.logger,
 				testCase.mode,
-				authproxy.Route{ListenPort: testCase.listenPort, UpstreamURL: "http://127.0.0.1:6080"},
+				"http://127.0.0.1:6080",
 				&fakeAuthenticator{authorized: true})
 			suite.Require().NoError(err)
 
@@ -108,7 +108,7 @@ func (suite *ServerTestSuite) TestModeListenAddresses() {
 func (suite *ServerTestSuite) TestUnknownModeRejected() {
 	_, err := newHandler(suite.logger,
 		"unknown-mode",
-		authproxy.Route{ListenPort: 8080, UpstreamURL: "http://127.0.0.1:6080"},
+		"http://127.0.0.1:6080",
 		&fakeAuthenticator{authorized: true})
 	suite.Require().Error(err)
 	suite.Require().Contains(err.Error(), "Unknown auth-proxy mode")

--- a/cmd/authproxy/app/server_test.go
+++ b/cmd/authproxy/app/server_test.go
@@ -19,13 +19,13 @@ limitations under the License.
 package app
 
 import (
-	"io"
-	"net"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/auth/authproxy"
 	httptrigger "github.com/nuclio/nuclio/pkg/processor/trigger/http"
 
 	"github.com/nuclio/logger"
@@ -58,12 +58,22 @@ type upstreamStub struct {
 type ServerTestSuite struct {
 	suite.Suite
 	logger logger.Logger
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 func (suite *ServerTestSuite) SetupTest() {
 	var err error
 	suite.logger, err = nucliozap.NewNuclioZapTest("auth-proxy-test")
 	suite.Require().NoError(err)
+
+	suite.ctx, suite.cancel = context.WithCancel(context.Background())
+}
+
+func (suite *ServerTestSuite) TearDownTest() {
+	if suite.cancel != nil {
+		suite.cancel()
+	}
 }
 
 // TestModeListenAddresses verifies the only listen-address difference between the modes: reverseProxy is
@@ -81,7 +91,7 @@ func (suite *ServerTestSuite) TestModeListenAddresses() {
 		suite.Run(testCase.name, func() {
 			handler, err := newHandler(suite.logger,
 				testCase.mode,
-				"http://127.0.0.1:6080",
+				authproxy.Route{ListenPort: testCase.listenPort, UpstreamURL: "http://127.0.0.1:6080"},
 				&fakeAuthenticator{authorized: true})
 			suite.Require().NoError(err)
 
@@ -98,7 +108,7 @@ func (suite *ServerTestSuite) TestModeListenAddresses() {
 func (suite *ServerTestSuite) TestUnknownModeRejected() {
 	_, err := newHandler(suite.logger,
 		"unknown-mode",
-		"http://127.0.0.1:6080",
+		authproxy.Route{ListenPort: 8080, UpstreamURL: "http://127.0.0.1:6080"},
 		&fakeAuthenticator{authorized: true})
 	suite.Require().Error(err)
 	suite.Require().Contains(err.Error(), "Unknown auth-proxy mode")
@@ -108,21 +118,63 @@ func (suite *ServerTestSuite) TestUnknownModeRejected() {
 	suite.Require().Contains(err.Error(), "Unknown auth-proxy mode")
 }
 
-// TestStartServerFailsOnOccupiedPort verifies that server.start returns an error when the port is already in use.
-func (suite *ServerTestSuite) TestStartServerFailsOnOccupiedPort() {
-	upstream := suite.newTestUpstreamStub()
-	defer upstream.server.Close()
+// TestStartServersPropagatesListenerFailure verifies that if one listener fails to bind, startServers
+// closes the other listeners and returns the error instead of hanging forever. Startup is
+// all-or-nothing on purpose: a Service port with no proxy behind it would bypass authentication.
+func (suite *ServerTestSuite) TestStartServersPropagatesListenerFailure() {
+	handler := newAuthOnlyHandler(&fakeAuthenticator{authorized: true})
 
-	handler, err := newReverseProxyHandler(suite.logger, upstream.server.URL, &fakeAuthenticator{authorized: true})
-	suite.Require().NoError(err)
+	servers := []*server{
 
-	// occupy a port so the listener deterministically fails to bind
-	occupied, err := net.Listen("tcp", "127.0.0.1:0")
-	suite.Require().NoError(err)
-	defer occupied.Close() // nolint: errcheck
+		// port 0 has the OS assign a free port, so this listener binds and then blocks serving
+		newServer(suite.logger, "127.0.0.1:0", handler),
 
-	err = newServer(suite.logger, occupied.Addr().String(), handler).start()
+		// an out-of-range port never resolves, so this listener deterministically fails to bind
+		newServer(suite.logger, "127.0.0.1:99999", handler),
+	}
+
+	err := startServers(suite.ctx, suite.logger, servers)
 	suite.Require().Error(err)
+}
+
+// TestRoutesForwardToTheirOwnUpstream verifies that when the auth-proxy fronts several ports, newServers
+// wires each listener to the upstream configured for that route - not to a shared one. The servers' handlers
+// are driven directly, so the per-route wiring is asserted without binding any port.
+func (suite *ServerTestSuite) TestRoutesForwardToTheirOwnUpstream() {
+	functionUpstream := suite.newTestUpstreamStubWithBody("function-response")
+	defer functionUpstream.server.Close()
+	sidecarUpstream := suite.newTestUpstreamStubWithBody("sidecar-response")
+	defer sidecarUpstream.server.Close()
+
+	authenticator := &fakeAuthenticator{authorized: true}
+
+	config := &Config{
+		Mode: auth.ProxyModeReverseProxy,
+		Routes: []authproxy.Route{
+			{ListenPort: 8080, UpstreamURL: functionUpstream.server.URL},
+			{ListenPort: 6081, UpstreamURL: sidecarUpstream.server.URL},
+		},
+	}
+
+	servers, err := newServers(suite.logger, config, authenticator)
+	suite.Require().NoError(err)
+	suite.Require().Len(servers, 2)
+
+	// the listen address is what binds the route to its port; assert it alongside the upstream it reaches
+	suite.Require().Equal(":8080", servers[0].httpServer.Addr)
+	suite.Require().Equal(":6081", servers[1].httpServer.Addr)
+
+	statusCode, body := suite.doRequest(servers[0].httpServer.Handler, "/invoke")
+	suite.Require().Equal(http.StatusOK, statusCode)
+	suite.Require().Equal("function-response", body)
+
+	statusCode, body = suite.doRequest(servers[1].httpServer.Handler, "/invoke")
+	suite.Require().Equal(http.StatusOK, statusCode)
+	suite.Require().Equal("sidecar-response", body)
+
+	suite.Require().Equal(1, functionUpstream.hits)
+	suite.Require().Equal(1, sidecarUpstream.hits)
+	suite.Require().Equal(2, authenticator.calls)
 }
 
 // TestReverseProxyForwardsWhenAuthorized verifies an authorized request is proxied to the upstream.
@@ -194,30 +246,25 @@ func (suite *ServerTestSuite) TestAuthOnlyHandler() {
 }
 
 func (suite *ServerTestSuite) newTestUpstreamStub() *upstreamStub {
+	return suite.newTestUpstreamStubWithBody("upstream-response")
+}
+
+// newTestUpstreamStubWithBody serves a distinguishable body so a test can tell which upstream was hit.
+func (suite *ServerTestSuite) newTestUpstreamStubWithBody(body string) *upstreamStub {
 	stub := &upstreamStub{}
 	stub.server = httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
 		stub.hits++
 		responseWriter.WriteHeader(http.StatusOK)
-		_, _ = responseWriter.Write([]byte("upstream-response"))
+		_, _ = responseWriter.Write([]byte(body))
 	}))
 	return stub
 }
 
+// doRequest drives the handler in-memory - no listener, no port, no client - and returns what it wrote.
 func (suite *ServerTestSuite) doRequest(handler http.Handler, path string) (int, string) {
-	server := httptest.NewServer(handler)
-	defer server.Close()
-
-	response, err := http.Get(server.URL + path)
-	suite.Require().NoError(err)
-	defer func(body io.ReadCloser) {
-		if err := body.Close(); err != nil {
-			suite.logger.WarnWith("Failed to close response body", "err", err)
-		}
-	}(response.Body)
-
-	body, err := io.ReadAll(response.Body)
-	suite.Require().NoError(err)
-	return response.StatusCode, string(body)
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, path, nil))
+	return recorder.Code, recorder.Body.String()
 }
 
 func TestServerTestSuite(t *testing.T) {

--- a/cmd/authproxy/main.go
+++ b/cmd/authproxy/main.go
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	mode := flag.String("mode", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_MODE", string(auth.ProxyModeReverseProxy)), "Auth-proxy mode: reverseProxy or authOnly")
-	routes := flag.String("routes", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_ROUTES", "8080=http://127.0.0.1:6080"), "Comma-separated listenPort=upstreamURL routes the auth-proxy serves; the first fronts the processor. In authOnly mode, a single port with no upstream")
+	routes := flag.String("routes", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_ROUTES", "6080=http://127.0.0.1:8080"), "Comma-separated listenPort=upstreamURL routes the auth-proxy serves; the first fronts the processor. In authOnly mode, a single port with no upstream")
 	authURL := flag.String("auth-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_AUTH_URL", ""), "URL of the authentication endpoint")
 	signinURL := flag.String("signin-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_SIGNIN_URL", ""), "URL unauthenticated browser requests are redirected to sign-in")
 	authMode := flag.String("auth-mode", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_AUTH_MODE", string(auth.AuthenticationModeNone)), "Authentication mode for reverseProxy: none, api, browser or basicAuth")

--- a/cmd/authproxy/main.go
+++ b/cmd/authproxy/main.go
@@ -19,11 +19,10 @@ package main
 import (
 	"flag"
 	"os"
-	"strconv"
-	"strings"
 
 	"github.com/nuclio/nuclio/cmd/authproxy/app"
 	"github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/auth/authproxy"
 	"github.com/nuclio/nuclio/pkg/common"
 
 	"github.com/nuclio/errors"
@@ -31,8 +30,7 @@ import (
 
 func main() {
 	mode := flag.String("mode", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_MODE", string(auth.ProxyModeReverseProxy)), "Auth-proxy mode: reverseProxy or authOnly")
-	listenPort := flag.String("listen-port", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_LISTEN_PORT", "8080"), "Port the auth-proxy listens on")
-	upstreamURL := flag.String("upstream-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_UPSTREAM_URL", "http://127.0.0.1:6080"), "URL of the upstream service (processor) to forward requests to")
+	routes := flag.String("routes", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_ROUTES", "8080=http://127.0.0.1:6080"), "Comma-separated listenPort=upstreamURL routes the auth-proxy serves; the first fronts the processor. In authOnly mode, a single port with no upstream")
 	authURL := flag.String("auth-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_AUTH_URL", ""), "URL of the authentication endpoint")
 	signinURL := flag.String("signin-url", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_SIGNIN_URL", ""), "URL unauthenticated browser requests are redirected to sign-in")
 	authMode := flag.String("auth-mode", common.GetEnvOrDefaultString("NUCLIO_AUTHPROXY_AUTH_MODE", string(auth.AuthenticationModeNone)), "Authentication mode for reverseProxy: none, api, browser or basicAuth")
@@ -43,16 +41,15 @@ func main() {
 	authKind := flag.String("auth-kind", auth.KindNop, "Authentication kind for API/browser authentication (e.g. iguazio, iguazio-v4, nop)")
 	flag.Parse()
 
-	listenPortInt, err := strconv.Atoi(strings.TrimSpace(*listenPort))
+	parsedRoutes, err := authproxy.ParseRoutes(*routes)
 	if err != nil {
-		errors.PrintErrorStack(os.Stderr, errors.Wrap(err, "Failed to parse listen port"), 5)
+		errors.PrintErrorStack(os.Stderr, errors.Wrap(err, "Failed to parse routes"), 5)
 		os.Exit(1)
 	}
 
 	if err := app.Run(&app.Config{
 		Mode:               auth.ProxyMode(*mode),
-		ListenPort:         listenPortInt,
-		UpstreamURL:        *upstreamURL,
+		Routes:             parsedRoutes,
 		AuthURL:            *authURL,
 		SigninURL:          *signinURL,
 		AuthMode:           *authMode,

--- a/pkg/auth/authproxy/route.go
+++ b/pkg/auth/authproxy/route.go
@@ -41,13 +41,13 @@ func LoopbackRoute(listenPort int, upstreamPort int) Route {
 
 // FormatRoutes renders routes into the --routes argument value.
 func FormatRoutes(routes []Route) string {
-	formattedRoutes := make([]string, 0, len(routes))
-	for _, route := range routes {
+	formattedRoutes := make([]string, len(routes))
+	for routeIndex, route := range routes {
 		if route.UpstreamURL == "" {
-			formattedRoutes = append(formattedRoutes, strconv.Itoa(route.ListenPort))
+			formattedRoutes[routeIndex] = strconv.Itoa(route.ListenPort)
 			continue
 		}
-		formattedRoutes = append(formattedRoutes, fmt.Sprintf("%d=%s", route.ListenPort, route.UpstreamURL))
+		formattedRoutes[routeIndex] = fmt.Sprintf("%d=%s", route.ListenPort, route.UpstreamURL)
 	}
 	return strings.Join(formattedRoutes, ",")
 }
@@ -56,8 +56,10 @@ func FormatRoutes(routes []Route) string {
 // A bare "listenPort" yields an empty upstream, which is what authOnly mode expects since it does no
 // forwarding.
 func ParseRoutes(routes string) ([]Route, error) {
-	parsedRoutes := make([]Route, 0)
-	for _, routeSpec := range strings.Split(routes, ",") {
+	routeSpecs := strings.Split(routes, ",")
+	parsedRoutes := make([]Route, len(routeSpecs))
+	routeIndex := 0
+	for _, routeSpec := range routeSpecs {
 		routeSpec = strings.TrimSpace(routeSpec)
 		if routeSpec == "" {
 			continue
@@ -69,12 +71,12 @@ func ParseRoutes(routes string) ([]Route, error) {
 			return nil, errors.Wrapf(err, "Failed to parse listen port of route: %s", routeSpec)
 		}
 
-		route := Route{ListenPort: listenPort}
+		parsedRoutes[routeIndex] = Route{ListenPort: listenPort}
 		if hasUpstream {
-			route.UpstreamURL = strings.TrimSpace(upstreamURL)
+			parsedRoutes[routeIndex].UpstreamURL = strings.TrimSpace(upstreamURL)
 		}
-		parsedRoutes = append(parsedRoutes, route)
+		routeIndex++
 	}
 
-	return parsedRoutes, nil
+	return parsedRoutes[:routeIndex], nil
 }

--- a/pkg/auth/authproxy/route.go
+++ b/pkg/auth/authproxy/route.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authproxy
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/nuclio/errors"
+)
+
+// Route describes one auth-proxy listener: the port it binds inside the pod and the pod-local upstream it
+// forwards to.
+type Route struct {
+	ListenPort  int
+	UpstreamURL string // empty in authOnly mode, which does no forwarding
+}
+
+// LoopbackRoute returns a route forwarding listenPort to a pod-local upstream port.
+func LoopbackRoute(listenPort int, upstreamPort int) Route {
+	return Route{
+		ListenPort:  listenPort,
+		UpstreamURL: fmt.Sprintf("http://127.0.0.1:%d", upstreamPort),
+	}
+}
+
+// FormatRoutes renders routes into the --routes argument value.
+func FormatRoutes(routes []Route) string {
+	formattedRoutes := make([]string, 0, len(routes))
+	for _, route := range routes {
+		if route.UpstreamURL == "" {
+			formattedRoutes = append(formattedRoutes, strconv.Itoa(route.ListenPort))
+			continue
+		}
+		formattedRoutes = append(formattedRoutes, fmt.Sprintf("%d=%s", route.ListenPort, route.UpstreamURL))
+	}
+	return strings.Join(formattedRoutes, ",")
+}
+
+// ParseRoutes parses the --routes argument value: a comma-separated list of "listenPort=upstreamURL" pairs.
+// A bare "listenPort" yields an empty upstream, which is what authOnly mode expects since it does no
+// forwarding.
+func ParseRoutes(routes string) ([]Route, error) {
+	parsedRoutes := make([]Route, 0)
+	for _, routeSpec := range strings.Split(routes, ",") {
+		routeSpec = strings.TrimSpace(routeSpec)
+		if routeSpec == "" {
+			continue
+		}
+
+		listenPortSpec, upstreamURL, hasUpstream := strings.Cut(routeSpec, "=")
+		listenPort, err := strconv.Atoi(strings.TrimSpace(listenPortSpec))
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to parse listen port of route: %s", routeSpec)
+		}
+
+		route := Route{ListenPort: listenPort}
+		if hasUpstream {
+			route.UpstreamURL = strings.TrimSpace(upstreamURL)
+		}
+		parsedRoutes = append(parsedRoutes, route)
+	}
+
+	return parsedRoutes, nil
+}

--- a/pkg/auth/authproxy/route.go
+++ b/pkg/auth/authproxy/route.go
@@ -57,8 +57,7 @@ func FormatRoutes(routes []Route) string {
 // forwarding.
 func ParseRoutes(routes string) ([]Route, error) {
 	routeSpecs := strings.Split(routes, ",")
-	parsedRoutes := make([]Route, len(routeSpecs))
-	routeIndex := 0
+	var parsedRoutes []Route
 	for _, routeSpec := range routeSpecs {
 		routeSpec = strings.TrimSpace(routeSpec)
 		if routeSpec == "" {
@@ -71,12 +70,12 @@ func ParseRoutes(routes string) ([]Route, error) {
 			return nil, errors.Wrapf(err, "Failed to parse listen port of route: %s", routeSpec)
 		}
 
-		parsedRoutes[routeIndex] = Route{ListenPort: listenPort}
+		route := Route{ListenPort: listenPort}
 		if hasUpstream {
-			parsedRoutes[routeIndex].UpstreamURL = strings.TrimSpace(upstreamURL)
+			route.UpstreamURL = strings.TrimSpace(upstreamURL)
 		}
-		routeIndex++
+		parsedRoutes = append(parsedRoutes, route)
 	}
 
-	return parsedRoutes[:routeIndex], nil
+	return parsedRoutes, nil
 }

--- a/pkg/auth/authproxy/route_test.go
+++ b/pkg/auth/authproxy/route_test.go
@@ -1,0 +1,127 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authproxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type RouteTestSuite struct {
+	suite.Suite
+}
+
+// TestParseRoutes verifies the listenPort=upstreamURL syntax, including the bare-port form authOnly uses.
+func (suite *RouteTestSuite) TestParseRoutes() {
+	for _, testCase := range []struct {
+		name           string
+		routes         string
+		expectedRoutes []Route
+		expectError    bool
+	}{
+		{
+			name:           "single route",
+			routes:         "8080=http://127.0.0.1:6080",
+			expectedRoutes: []Route{{ListenPort: 8080, UpstreamURL: "http://127.0.0.1:6080"}},
+		},
+		{
+			name:   "function route followed by sidecar routes",
+			routes: "8080=http://127.0.0.1:6080,6081=http://127.0.0.1:8050,6082=http://127.0.0.1:9000",
+			expectedRoutes: []Route{
+				{ListenPort: 8080, UpstreamURL: "http://127.0.0.1:6080"},
+				{ListenPort: 6081, UpstreamURL: "http://127.0.0.1:8050"},
+				{ListenPort: 6082, UpstreamURL: "http://127.0.0.1:9000"},
+			},
+		},
+		{
+			name:           "bare port yields no upstream",
+			routes:         "8080",
+			expectedRoutes: []Route{{ListenPort: 8080}},
+		},
+		{
+			name:           "trailing separator yields no upstream",
+			routes:         "8080=",
+			expectedRoutes: []Route{{ListenPort: 8080}},
+		},
+		{
+			name:           "surrounding whitespace is tolerated",
+			routes:         " 8080 = http://127.0.0.1:6080 , 6081 = http://127.0.0.1:8050 ",
+			expectedRoutes: []Route{{ListenPort: 8080, UpstreamURL: "http://127.0.0.1:6080"}, {ListenPort: 6081, UpstreamURL: "http://127.0.0.1:8050"}},
+		},
+		{
+			name:           "empty string yields no routes",
+			routes:         "",
+			expectedRoutes: []Route{},
+		},
+		{
+			name:        "non-numeric listen port is rejected",
+			routes:      "not-a-port=http://127.0.0.1:6080",
+			expectError: true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			parsedRoutes, err := ParseRoutes(testCase.routes)
+			if testCase.expectError {
+				suite.Require().Error(err)
+				return
+			}
+			suite.Require().NoError(err)
+			suite.Require().Equal(testCase.expectedRoutes, parsedRoutes)
+		})
+	}
+}
+
+// TestFormatRoutesRoundTrip verifies the controller renders what the auth-proxy parses back.
+func (suite *RouteTestSuite) TestFormatRoutesRoundTrip() {
+	for _, testCase := range []struct {
+		name           string
+		routes         []Route
+		expectedRoutes string
+	}{
+		{
+			name:           "function route only",
+			routes:         []Route{LoopbackRoute(8080, 6080)},
+			expectedRoutes: "8080=http://127.0.0.1:6080",
+		},
+		{
+			name:           "function route plus sidecar routes",
+			routes:         []Route{LoopbackRoute(8080, 6080), LoopbackRoute(6081, 8050)},
+			expectedRoutes: "8080=http://127.0.0.1:6080,6081=http://127.0.0.1:8050",
+		},
+		{
+			name:           "route without an upstream renders as a bare port",
+			routes:         []Route{{ListenPort: 8080}},
+			expectedRoutes: "8080",
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			formattedRoutes := FormatRoutes(testCase.routes)
+			suite.Require().Equal(testCase.expectedRoutes, formattedRoutes)
+
+			parsedRoutes, err := ParseRoutes(formattedRoutes)
+			suite.Require().NoError(err)
+			suite.Require().Equal(testCase.routes, parsedRoutes)
+		})
+	}
+}
+
+func TestRouteTestSuite(t *testing.T) {
+	suite.Run(t, new(RouteTestSuite))
+}

--- a/pkg/auth/authproxy/route_test.go
+++ b/pkg/auth/authproxy/route_test.go
@@ -68,7 +68,12 @@ func (suite *RouteTestSuite) TestParseRoutes() {
 		{
 			name:           "empty string yields no routes",
 			routes:         "",
-			expectedRoutes: []Route{},
+			expectedRoutes: nil,
+		},
+		{
+			name:           "empty string with spaces yields no routes",
+			routes:         "   ",
+			expectedRoutes: nil,
 		},
 		{
 			name:        "non-numeric listen port is rejected",

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package auth
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -58,6 +59,27 @@ const (
 	// ProxyModeAuthOnly serves only the /auth endpoint (called by the DLX); does no forwarding.
 	ProxyModeAuthOnly ProxyMode = "authOnly"
 )
+
+const (
+	// FunctionContainerHTTPLoopbackPort is the port the processor listens on when the auth-proxy sidecar
+	// is injected in front of it: only reachable from within the pod (127.0.0.1), never exposed by the Service.
+	FunctionContainerHTTPLoopbackPort = 6080
+
+	// AuthProxySidecarListenPortRangeStart and AuthProxySidecarListenPortRangeEnd bound the band the
+	// auth-proxy listens on to front user sidecar ports. A user sidecar keeps binding its own port, so the
+	// proxy cannot reuse it; instead the Service's targetPort is repointed at a port from this band.
+	AuthProxySidecarListenPortRangeStart = 6081
+	AuthProxySidecarListenPortRangeEnd   = 6199
+
+	// AuthProxySidecarContainerName is the reserved name of the platform-injected auth-proxy sidecar.
+	// User-defined sidecars may not use this name.
+	AuthProxySidecarContainerName = "auth-proxy"
+)
+
+// AuthProxySidecarPortName returns the container-port name the auth-proxy sidecar binds for a listen port.
+func AuthProxySidecarPortName(listenPort int) string {
+	return fmt.Sprintf("authproxy-%d", listenPort)
+}
 
 type SessionContextKey string
 

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package auth
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
@@ -59,19 +58,6 @@ const (
 	// ProxyModeAuthOnly serves only the /auth endpoint (called by the DLX); does no forwarding.
 	ProxyModeAuthOnly ProxyMode = "authOnly"
 )
-
-const (
-	// AuthProxySidecarListenPortRangeStart and AuthProxySidecarListenPortRangeEnd bound the band the
-	// auth-proxy listens on to front user sidecar ports. A user sidecar keeps binding its own port, so the
-	// proxy cannot reuse it; instead the Service's targetPort is repointed at a port from this band.
-	AuthProxySidecarListenPortRangeStart = 6081
-	AuthProxySidecarListenPortRangeEnd   = 6199
-)
-
-// AuthProxySidecarPortName returns the container-port name the auth-proxy sidecar binds for a listen port.
-func AuthProxySidecarPortName(listenPort int) string {
-	return fmt.Sprintf("authproxy-%d", listenPort)
-}
 
 type SessionContextKey string
 

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -61,19 +61,11 @@ const (
 )
 
 const (
-	// FunctionContainerHTTPLoopbackPort is the port the processor listens on when the auth-proxy sidecar
-	// is injected in front of it: only reachable from within the pod (127.0.0.1), never exposed by the Service.
-	FunctionContainerHTTPLoopbackPort = 6080
-
 	// AuthProxySidecarListenPortRangeStart and AuthProxySidecarListenPortRangeEnd bound the band the
 	// auth-proxy listens on to front user sidecar ports. A user sidecar keeps binding its own port, so the
 	// proxy cannot reuse it; instead the Service's targetPort is repointed at a port from this band.
 	AuthProxySidecarListenPortRangeStart = 6081
 	AuthProxySidecarListenPortRangeEnd   = 6199
-
-	// AuthProxySidecarContainerName is the reserved name of the platform-injected auth-proxy sidecar.
-	// User-defined sidecars may not use this name.
-	AuthProxySidecarContainerName = "auth-proxy"
 )
 
 // AuthProxySidecarPortName returns the container-port name the auth-proxy sidecar binds for a listen port.

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -363,6 +363,21 @@ func GetHTTPTriggerMode(triggers map[string]Trigger) (string, error) {
 	return mode, nil
 }
 
+// AuthenticationEnabledForTriggers reports whether the function's single HTTP trigger declares a
+// function-level authentication mode. A function with no HTTP trigger simply is not authenticated; any other
+// problem with the triggers is returned.
+func AuthenticationEnabledForTriggers(triggers map[string]Trigger) (bool, error) {
+	mode, err := GetHTTPTriggerMode(triggers)
+	if err != nil {
+		if errors.Is(err, ErrHTTPTriggerNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return IsAuthenticationEnabled(mode), nil
+}
+
 // GetTriggersByKinds returns a map of triggers by their kinds
 func GetTriggersByKinds(triggers map[string]Trigger, kinds []string) map[string]Trigger {
 	matchingTrigger := map[string]Trigger{}

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -78,7 +78,19 @@ const (
 	// AuthProxySidecarContainerName is the reserved name of the platform-injected auth-proxy sidecar
 	// (see functionres.injectAuthProxySidecar). User-defined sidecars may not use this name.
 	AuthProxySidecarContainerName = "auth-proxy"
+
+	// AuthProxySidecarListenPortRangeStart and AuthProxySidecarListenPortRangeEnd bound the band the
+	// auth-proxy listens on to front user sidecar ports. A user sidecar keeps binding its own port, so the
+	// proxy cannot reuse it; instead the Service's targetPort is repointed at a port from this band
+	// (see functionres.authProxySidecarPortMapping).
+	AuthProxySidecarListenPortRangeStart = 6081
+	AuthProxySidecarListenPortRangeEnd   = 6199
 )
+
+// AuthProxySidecarPortName returns the container-port name the auth-proxy sidecar binds for a listen port.
+func AuthProxySidecarPortName(listenPort int) string {
+	return fmt.Sprintf("authproxy-%d", listenPort)
+}
 
 type Platform struct {
 	Logger                  logger.Logger

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -71,9 +71,10 @@ const (
 	FunctionContainerMetricPortName      = "metrics"
 	DefaultTargetCPU                     = 75
 
-	// FunctionContainerHTTPLoopbackPort is the port the processor listens on when the auth-proxy sidecar
-	// is injected in front of it: only reachable from within the pod (127.0.0.1), never exposed by the Service.
-	FunctionContainerHTTPLoopbackPort = 6080
+	// AuthProxyProcessorListenPort is the port the auth-proxy sidecar listens on to front the processor's
+	// HTTP port. The processor keeps binding its own port, so the proxy cannot reuse it - the Service's
+	// targetPort is repointed here instead (see functionres.processorAuthProxyRoute).
+	AuthProxyProcessorListenPort = 6080
 
 	// AuthProxySidecarContainerName is the reserved name of the platform-injected auth-proxy sidecar
 	// (see functionres.injectAuthProxySidecar). User-defined sidecars may not use this name.

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1458,14 +1458,14 @@ func (lc *lazyClient) functionAuthenticationEnabled(function *nuclioio.NuclioFun
 
 // processorAuthProxyRoute is the auth-proxy's route for the processor: it listens on a port of its own and
 // forwards to the processor's HTTP port on the pod-local loopback
-func processorAuthProxyRoute() authproxy.Route {
+func (lc *lazyClient) processorAuthProxyRoute() authproxy.Route {
 	return authproxy.LoopbackRoute(abstract.AuthProxyProcessorListenPort, abstract.FunctionContainerHTTPPort)
 }
 
 // authProxySidecarPortMapping maps each user sidecar container port to the auth-proxy listen port that fronts
 // it. A user sidecar keeps binding its own port, so the proxy cannot reuse it - each port gets one from the
 // reserved band instead, assigned in spec order.
-func authProxySidecarPortMapping(function *nuclioio.NuclioFunction) (map[int32]int32, error) {
+func (lc *lazyClient) authProxySidecarPortMapping(function *nuclioio.NuclioFunction) (map[int32]int32, error) {
 	portMapping := map[int32]int32{}
 	nextListenPort := int32(abstract.AuthProxySidecarListenPortRangeStart)
 
@@ -1493,8 +1493,8 @@ func authProxySidecarPortMapping(function *nuclioio.NuclioFunction) (map[int32]i
 // route; the rest front user sidecar ports. The sidecars are walked in spec order rather than over the port
 // mapping, since map iteration order is randomized and would churn the sidecar's --routes argument - and with
 // it the deployment spec - on every reconcile.
-func authProxyRoutes(function *nuclioio.NuclioFunction) ([]authproxy.Route, error) {
-	portMapping, err := authProxySidecarPortMapping(function)
+func (lc *lazyClient) authProxyRoutes(function *nuclioio.NuclioFunction) ([]authproxy.Route, error) {
+	portMapping, err := lc.authProxySidecarPortMapping(function)
 	if err != nil {
 		return nil, err
 	}
@@ -1502,7 +1502,7 @@ func authProxyRoutes(function *nuclioio.NuclioFunction) ([]authproxy.Route, erro
 	// one route per mapped sidecar port, plus the processor's; sidecar port numbers are unique across
 	// containers (see kube.Platform.validateContainerPorts), so the mapping holds one entry per declared port
 	routes := make([]authproxy.Route, len(portMapping)+1)
-	routes[0] = processorAuthProxyRoute()
+	routes[0] = lc.processorAuthProxyRoute()
 
 	routeIndex := 1
 	for _, sidecar := range function.Spec.Sidecars {
@@ -1533,7 +1533,7 @@ func (lc *lazyClient) injectAuthProxySidecar(ctx context.Context,
 
 	// the proxy must front every port the Service publishes, so a port it cannot front fails the whole
 	// injection - a partially fronted function would expose an unauthenticated port
-	routes, err := authProxyRoutes(function)
+	routes, err := lc.authProxyRoutes(function)
 	if err != nil {
 		return errors.Wrap(err, "Failed to resolve auth-proxy sidecar routes")
 	}
@@ -2234,7 +2234,7 @@ func (lc *lazyClient) populateServiceSpec(ctx context.Context,
 
 		// with the feature off, sidecarPortMapping stays empty and every port targets the sidecar as before
 		if authProxyFronting {
-			resolvedPortMapping, err := authProxySidecarPortMapping(function)
+			resolvedPortMapping, err := lc.authProxySidecarPortMapping(function)
 			if err != nil {
 				return errors.Wrap(err, "Failed to resolve auth-proxy sidecar ports")
 			}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1447,12 +1447,13 @@ func (lc *lazyClient) functionAuthenticationEnabled(function *nuclioio.NuclioFun
 		return false
 	}
 
-	authMode, err := functionconfig.GetHTTPTriggerMode(function.Spec.Triggers)
+	// a malformed trigger set is reported by validation, not here: this only decides whether to inject
+	authenticationEnabled, err := functionconfig.AuthenticationEnabledForTriggers(function.Spec.Triggers)
 	if err != nil {
 		return false
 	}
 
-	return functionconfig.IsAuthenticationEnabled(authMode)
+	return authenticationEnabled
 }
 
 // processorAuthProxyRoute is the auth-proxy's route for the processor: it owns the function's main HTTP port

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1146,7 +1146,7 @@ func (lc *lazyClient) createOrUpdateService(ctx context.Context,
 	createService := func() (interface{}, error) {
 		spec := v1.ServiceSpec{}
 		if err := lc.populateServiceSpec(ctx, functionLabels, function, &spec); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "Failed to populate service spec")
 		}
 
 		return lc.kubeClientSet.CreateService(ctx,
@@ -1167,7 +1167,7 @@ func (lc *lazyClient) createOrUpdateService(ctx context.Context,
 		// update existing
 		service.Labels = functionLabels
 		if err := lc.populateServiceSpec(ctx, functionLabels, function, &service.Spec); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "Failed to populate service spec")
 		}
 
 		return lc.kubeClientSet.UpdateService(ctx, function.Namespace, service)
@@ -1285,7 +1285,7 @@ func (lc *lazyClient) createOrUpdateDeployment(ctx context.Context,
 		}
 
 		if err := lc.populateSupplementaryContainers(ctx, function, &deploymentSpec, volumeMounts); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "Failed to populate supplementary containers")
 		}
 
 		deployment := &appsv1.Deployment{
@@ -1365,7 +1365,7 @@ func (lc *lazyClient) createOrUpdateDeployment(ctx context.Context,
 		}
 
 		if err := lc.populateSupplementaryContainers(ctx, function, &deployment.Spec, volumeMounts); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "Failed to populate supplementary containers")
 		}
 
 		// enrich deployment spec with default fields that were passed inside the platform configuration
@@ -1455,9 +1455,9 @@ func (lc *lazyClient) functionAuthenticationEnabled(function *nuclioio.NuclioFun
 	return functionconfig.IsAuthenticationEnabled(authMode)
 }
 
-// functionAuthProxyRoute is the auth-proxy's route for the function itself: it owns the main HTTP port and
-// forwards to the processor on the pod-local loopback
-func functionAuthProxyRoute() authproxy.Route {
+// processorAuthProxyRoute is the auth-proxy's route for the processor: it owns the function's main HTTP port
+// and forwards to the processor on the pod-local loopback
+func processorAuthProxyRoute() authproxy.Route {
 	return authproxy.LoopbackRoute(abstract.FunctionContainerHTTPPort, abstract.FunctionContainerHTTPLoopbackPort)
 }
 
@@ -1466,18 +1466,18 @@ func functionAuthProxyRoute() authproxy.Route {
 // reserved band instead, assigned in spec order.
 func authProxySidecarPortMapping(function *nuclioio.NuclioFunction) (map[int32]int32, error) {
 	portMapping := map[int32]int32{}
-	nextListenPort := int32(auth.AuthProxySidecarListenPortRangeStart)
+	nextListenPort := int32(abstract.AuthProxySidecarListenPortRangeStart)
 
 	for _, sidecar := range function.Spec.Sidecars {
 		for _, port := range sidecar.Ports {
-			if port.ContainerPort >= auth.AuthProxySidecarListenPortRangeStart &&
-				port.ContainerPort <= auth.AuthProxySidecarListenPortRangeEnd {
+			if port.ContainerPort >= abstract.AuthProxySidecarListenPortRangeStart &&
+				port.ContainerPort <= abstract.AuthProxySidecarListenPortRangeEnd {
 				return nil, errors.Errorf("Sidecar port is reserved for the auth-proxy; port: %d", port.ContainerPort)
 			}
 
-			if nextListenPort > auth.AuthProxySidecarListenPortRangeEnd {
+			if nextListenPort > abstract.AuthProxySidecarListenPortRangeEnd {
 				return nil, errors.Errorf("Too many sidecar ports to front; maximum is %d",
-					auth.AuthProxySidecarListenPortRangeEnd-auth.AuthProxySidecarListenPortRangeStart+1)
+					abstract.AuthProxySidecarListenPortRangeEnd-abstract.AuthProxySidecarListenPortRangeStart+1)
 			}
 
 			portMapping[port.ContainerPort] = nextListenPort
@@ -1501,7 +1501,7 @@ func authProxyRoutes(function *nuclioio.NuclioFunction) ([]authproxy.Route, erro
 	// one route per mapped sidecar port, plus the function's own; sidecar port numbers are unique across
 	// containers (see kube.Platform.validateContainerPorts), so the mapping holds one entry per declared port
 	routes := make([]authproxy.Route, len(portMapping)+1)
-	routes[0] = functionAuthProxyRoute()
+	routes[0] = processorAuthProxyRoute()
 
 	routeIndex := 1
 	for _, sidecar := range function.Spec.Sidecars {
@@ -1540,7 +1540,7 @@ func (lc *lazyClient) injectAuthProxySidecar(ctx context.Context,
 	containerPorts := make([]v1.ContainerPort, 0, len(routes))
 	for _, route := range routes {
 		containerPorts = append(containerPorts, v1.ContainerPort{
-			Name:          auth.AuthProxySidecarPortName(route.ListenPort),
+			Name:          abstract.AuthProxySidecarPortName(route.ListenPort),
 			ContainerPort: int32(route.ListenPort),
 			Protocol:      v1.ProtocolTCP,
 		})

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -1456,10 +1456,10 @@ func (lc *lazyClient) functionAuthenticationEnabled(function *nuclioio.NuclioFun
 	return authenticationEnabled
 }
 
-// processorAuthProxyRoute is the auth-proxy's route for the processor: it owns the function's main HTTP port
-// and forwards to the processor on the pod-local loopback
+// processorAuthProxyRoute is the auth-proxy's route for the processor: it listens on a port of its own and
+// forwards to the processor's HTTP port on the pod-local loopback
 func processorAuthProxyRoute() authproxy.Route {
-	return authproxy.LoopbackRoute(abstract.FunctionContainerHTTPPort, abstract.FunctionContainerHTTPLoopbackPort)
+	return authproxy.LoopbackRoute(abstract.AuthProxyProcessorListenPort, abstract.FunctionContainerHTTPPort)
 }
 
 // authProxySidecarPortMapping maps each user sidecar container port to the auth-proxy listen port that fronts
@@ -1489,7 +1489,7 @@ func authProxySidecarPortMapping(function *nuclioio.NuclioFunction) (map[int32]i
 	return portMapping, nil
 }
 
-// authProxyRoutes returns the auth-proxy's listeners for the function. The first is always the function's own
+// authProxyRoutes returns the auth-proxy's listeners for the function. The first is always the processor's
 // route; the rest front user sidecar ports. The sidecars are walked in spec order rather than over the port
 // mapping, since map iteration order is randomized and would churn the sidecar's --routes argument - and with
 // it the deployment spec - on every reconcile.
@@ -1499,7 +1499,7 @@ func authProxyRoutes(function *nuclioio.NuclioFunction) ([]authproxy.Route, erro
 		return nil, err
 	}
 
-	// one route per mapped sidecar port, plus the function's own; sidecar port numbers are unique across
+	// one route per mapped sidecar port, plus the processor's; sidecar port numbers are unique across
 	// containers (see kube.Platform.validateContainerPorts), so the mapping holds one entry per declared port
 	routes := make([]authproxy.Route, len(portMapping)+1)
 	routes[0] = processorAuthProxyRoute()
@@ -1516,8 +1516,8 @@ func authProxyRoutes(function *nuclioio.NuclioFunction) ([]authproxy.Route, erro
 
 // injectAuthProxySidecar appends the platform's auth-proxy sidecar to the pod: it terminates
 // authentication for the function's traffic (the Kubernetes Service is repointed to it, see
-// populateServiceSpec) and forwards allowed requests to the processor, which by this point only listens
-// on the pod-local loopback (see rewriteHTTPTriggerURLToLoopback), and to any user sidecar port.
+// populateServiceSpec) and forwards allowed requests over the pod-local loopback to the processor and to
+// any user sidecar port.
 func (lc *lazyClient) injectAuthProxySidecar(ctx context.Context,
 	function *nuclioio.NuclioFunction,
 	deploymentSpec *appsv1.DeploymentSpec,
@@ -2208,15 +2208,32 @@ func (lc *lazyClient) populateServiceSpec(ctx context.Context,
 			"ports", spec.Ports)
 	}
 
+	// With function-level authentication enabled, the Service target port is
+	// redirected to the auth-proxy to prevent authentication bypass. Offline states
+	// are excluded because DLX authenticates requests on the function's HTTP port.
+	authProxyFronting := lc.functionAuthenticationEnabled(function) &&
+		function.Status.State != functionconfig.FunctionStateScaledToZero &&
+		function.Status.State != functionconfig.FunctionStateWaitingForScaleResourcesToZero &&
+		function.Status.State != functionconfig.FunctionStateWaitingForScaleResourcesFromZero
+
+	// the block above rebuilds the http port only on some passes, so its target is set here on every pass -
+	// otherwise it would not follow the function in and out of the states the DLX serves
+	httpTargetPort := int32(abstract.FunctionContainerHTTPPort)
+	if authProxyFronting {
+		httpTargetPort = int32(abstract.AuthProxyProcessorListenPort)
+	}
+	for portIndex, port := range spec.Ports {
+		if port.Name == abstract.FunctionContainerHTTPPortName {
+			spec.Ports[portIndex].TargetPort = intstr.FromInt32(httpTargetPort)
+		}
+	}
+
 	// add additional ports for sidecars
 	if function.Spec.Sidecars != nil {
 		sidecarPortMapping := map[int32]int32{}
 
-		// only when function-level auth is on does a sidecar port need to land on the auth-proxy rather than
-		// on the sidecar container; otherwise an in-cluster caller reaching the Service would bypass
-		// authentication. The client-facing Port never changes - only the TargetPort moves to the proxy.
-		// With the feature off, sidecarPortMapping stays empty and every port targets the sidecar as before.
-		if lc.functionAuthenticationEnabled(function) {
+		// with the feature off, sidecarPortMapping stays empty and every port targets the sidecar as before
+		if authProxyFronting {
 			resolvedPortMapping, err := authProxySidecarPortMapping(function)
 			if err != nil {
 				return errors.Wrap(err, "Failed to resolve auth-proxy sidecar ports")
@@ -2679,18 +2696,12 @@ func (lc *lazyClient) populateDeploymentContainer(ctx context.Context,
 	// re-derive the ports from scratch: on update this container is the one read back from the existing
 	// deployment, so appending to whatever it already carries would both
 	// accumulate duplicates and keep ports that no longer apply
-	container.Ports = nil
-
-	// when the auth-proxy sidecar is injected, it - not the processor - owns the main HTTP port; the
-	// processor listens only on the pod-local loopback (see rewriteHTTPTriggerURLToLoopback)
-	if !lc.functionAuthenticationEnabled(function) {
-		container.Ports = []v1.ContainerPort{
-			{
-				Name:          abstract.FunctionContainerHTTPPortName,
-				ContainerPort: abstract.FunctionContainerHTTPPort,
-				Protocol:      v1.ProtocolTCP,
-			},
-		}
+	container.Ports = []v1.ContainerPort{
+		{
+			Name:          abstract.FunctionContainerHTTPPortName,
+			ContainerPort: abstract.FunctionContainerHTTPPort,
+			Protocol:      v1.ProtocolTCP,
+		},
 	}
 
 	// iterate through metric sinks. if prometheus pull is configured, add containerMetricPort
@@ -2707,10 +2718,18 @@ func (lc *lazyClient) populateDeploymentContainer(ctx context.Context,
 	utils.EnrichProbe(&function.Spec.ReadinessProbe, defaultPlatformConfiguration.Kube.DefaultReadinessProbe)
 	utils.EnrichProbe(&function.Spec.LivenessProbe, defaultPlatformConfiguration.Kube.DefaultLivenessProbe)
 
+	// readiness goes through the auth-proxy when one fronts the function, so the pod turns ready only once
+	// both the proxy and the processor serve.
+	// Liveness stays direct on the health check port, so a proxy fault never restarts the function container.
+	readinessProbePort := abstract.FunctionContainerHTTPPort
+	if lc.functionAuthenticationEnabled(function) {
+		readinessProbePort = abstract.AuthProxyProcessorListenPort
+	}
+
 	container.ReadinessProbe = &v1.Probe{
 		ProbeHandler: v1.ProbeHandler{
 			HTTPGet: &v1.HTTPGetAction{
-				Port: intstr.FromInt(abstract.FunctionContainerHTTPPort),
+				Port: intstr.FromInt(readinessProbePort),
 				Path: http.InternalHealthPath,
 			},
 		},
@@ -2756,11 +2775,6 @@ func (lc *lazyClient) populateConfigMap(functionLabels labels.Set,
 	// create configMap contents - generate a processor configuration based on the function CR
 	configMapContents := bytes.Buffer{}
 
-	functionSpec := function.Spec
-	if lc.functionAuthenticationEnabled(function) {
-		functionSpec = rewriteHTTPTriggerURLToLoopback(functionSpec)
-	}
-
 	if err := configWriter.Write(&configMapContents, &processor.Configuration{
 		Config: functionconfig.Config{
 			Meta: functionconfig.Meta{
@@ -2769,7 +2783,7 @@ func (lc *lazyClient) populateConfigMap(functionLabels labels.Set,
 				Labels:      functionLabels,
 				Annotations: function.Annotations,
 			},
-			Spec: functionSpec,
+			Spec: function.Spec,
 		},
 	}); err != nil {
 
@@ -2788,22 +2802,6 @@ func (lc *lazyClient) populateConfigMap(functionLabels labels.Set,
 	}
 
 	return nil
-}
-
-// rewriteHTTPTriggerURLToLoopback returns a copy of spec whose HTTP trigger(s) listen on the pod-local
-// loopback instead of the wildcard address, so the processor is only reachable from within the pod - i.e.
-// via the auth-proxy sidecar that fronts it (see injectAuthProxySidecar). The given spec is never mutated:
-// its Triggers map is copied before being modified.
-func rewriteHTTPTriggerURLToLoopback(spec functionconfig.Spec) functionconfig.Spec {
-	triggers := make(map[string]functionconfig.Trigger, len(spec.Triggers))
-	for triggerName, trigger := range spec.Triggers {
-		if trigger.Kind == "http" {
-			trigger.URL = fmt.Sprintf("127.0.0.1:%d", abstract.FunctionContainerHTTPLoopbackPort)
-		}
-		triggers[triggerName] = trigger
-	}
-	spec.Triggers = triggers
-	return spec
 }
 
 func (lc *lazyClient) getFunctionVolumeAndMounts(ctx context.Context,

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/auth/authproxy"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/common/annotations"
 	"github.com/nuclio/nuclio/pkg/common/headers"
@@ -1144,7 +1145,9 @@ func (lc *lazyClient) createOrUpdateService(ctx context.Context,
 
 	createService := func() (interface{}, error) {
 		spec := v1.ServiceSpec{}
-		lc.populateServiceSpec(ctx, functionLabels, function, &spec)
+		if err := lc.populateServiceSpec(ctx, functionLabels, function, &spec); err != nil {
+			return nil, err
+		}
 
 		return lc.kubeClientSet.CreateService(ctx,
 			function.Namespace,
@@ -1163,7 +1166,9 @@ func (lc *lazyClient) createOrUpdateService(ctx context.Context,
 
 		// update existing
 		service.Labels = functionLabels
-		lc.populateServiceSpec(ctx, functionLabels, function, &service.Spec)
+		if err := lc.populateServiceSpec(ctx, functionLabels, function, &service.Spec); err != nil {
+			return nil, err
+		}
 
 		return lc.kubeClientSet.UpdateService(ctx, function.Namespace, service)
 	}
@@ -1279,7 +1284,9 @@ func (lc *lazyClient) createOrUpdateDeployment(ctx context.Context,
 			}
 		}
 
-		lc.populateSupplementaryContainers(ctx, function, &deploymentSpec, volumeMounts)
+		if err := lc.populateSupplementaryContainers(ctx, function, &deploymentSpec, volumeMounts); err != nil {
+			return nil, err
+		}
 
 		deployment := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1357,7 +1364,9 @@ func (lc *lazyClient) createOrUpdateDeployment(ctx context.Context,
 			}
 		}
 
-		lc.populateSupplementaryContainers(ctx, function, &deployment.Spec, volumeMounts)
+		if err := lc.populateSupplementaryContainers(ctx, function, &deployment.Spec, volumeMounts); err != nil {
+			return nil, err
+		}
 
 		// enrich deployment spec with default fields that were passed inside the platform configuration
 		// performed on update too, in case the platform config has been modified after the creation of this deployment
@@ -1385,7 +1394,7 @@ func (lc *lazyClient) createOrUpdateDeployment(ctx context.Context,
 func (lc *lazyClient) populateSupplementaryContainers(ctx context.Context,
 	function *nuclioio.NuclioFunction,
 	deploymentSpec *appsv1.DeploymentSpec,
-	volumeMounts []v1.VolumeMount) {
+	volumeMounts []v1.VolumeMount) error {
 
 	// create init containers if provided
 	if len(function.Spec.InitContainers) > 0 {
@@ -1422,8 +1431,12 @@ func (lc *lazyClient) populateSupplementaryContainers(ctx context.Context,
 		deploymentSpec.Template.Spec.Containers = append(deploymentSpec.Template.Spec.Containers, *sidecarSpec)
 	}
 	if lc.functionAuthenticationEnabled(function) {
-		lc.injectAuthProxySidecar(ctx, function, deploymentSpec, volumeMounts)
+		if err := lc.injectAuthProxySidecar(ctx, function, deploymentSpec, volumeMounts); err != nil {
+			return errors.Wrap(err, "Failed to inject auth-proxy sidecar")
+		}
 	}
+
+	return nil
 }
 
 // functionAuthenticationEnabled reports whether the auth-proxy sidecar should be injected in front of the
@@ -1442,28 +1455,101 @@ func (lc *lazyClient) functionAuthenticationEnabled(function *nuclioio.NuclioFun
 	return functionconfig.IsAuthenticationEnabled(authMode)
 }
 
+// functionAuthProxyRoute is the auth-proxy's route for the function itself: it owns the main HTTP port and
+// forwards to the processor on the pod-local loopback
+func functionAuthProxyRoute() authproxy.Route {
+	return authproxy.LoopbackRoute(abstract.FunctionContainerHTTPPort, abstract.FunctionContainerHTTPLoopbackPort)
+}
+
+// authProxySidecarPortMapping maps each user sidecar container port to the auth-proxy listen port that fronts
+// it. A user sidecar keeps binding its own port, so the proxy cannot reuse it - each port gets one from the
+// reserved band instead, assigned in spec order.
+func authProxySidecarPortMapping(function *nuclioio.NuclioFunction) (map[int32]int32, error) {
+	portMapping := map[int32]int32{}
+	nextListenPort := int32(auth.AuthProxySidecarListenPortRangeStart)
+
+	for _, sidecar := range function.Spec.Sidecars {
+		for _, port := range sidecar.Ports {
+			if port.ContainerPort >= auth.AuthProxySidecarListenPortRangeStart &&
+				port.ContainerPort <= auth.AuthProxySidecarListenPortRangeEnd {
+				return nil, errors.Errorf("Sidecar port is reserved for the auth-proxy; port: %d", port.ContainerPort)
+			}
+
+			if nextListenPort > auth.AuthProxySidecarListenPortRangeEnd {
+				return nil, errors.Errorf("Too many sidecar ports to front; maximum is %d",
+					auth.AuthProxySidecarListenPortRangeEnd-auth.AuthProxySidecarListenPortRangeStart+1)
+			}
+
+			portMapping[port.ContainerPort] = nextListenPort
+			nextListenPort++
+		}
+	}
+
+	return portMapping, nil
+}
+
+// authProxyRoutes returns the auth-proxy's listeners for the function. The first is always the function's own
+// route; the rest front user sidecar ports. The sidecars are walked in spec order rather than over the port
+// mapping, since map iteration order is randomized and would churn the sidecar's --routes argument - and with
+// it the deployment spec - on every reconcile.
+func authProxyRoutes(function *nuclioio.NuclioFunction) ([]authproxy.Route, error) {
+	portMapping, err := authProxySidecarPortMapping(function)
+	if err != nil {
+		return nil, err
+	}
+
+	// one route per mapped sidecar port, plus the function's own; sidecar port numbers are unique across
+	// containers (see kube.Platform.validateContainerPorts), so the mapping holds one entry per declared port
+	routes := make([]authproxy.Route, len(portMapping)+1)
+	routes[0] = functionAuthProxyRoute()
+
+	routeIndex := 1
+	for _, sidecar := range function.Spec.Sidecars {
+		for _, port := range sidecar.Ports {
+			routes[routeIndex] = authproxy.LoopbackRoute(int(portMapping[port.ContainerPort]), int(port.ContainerPort))
+			routeIndex++
+		}
+	}
+	return routes, nil
+}
+
 // injectAuthProxySidecar appends the platform's auth-proxy sidecar to the pod: it terminates
 // authentication for the function's traffic (the Kubernetes Service is repointed to it, see
 // populateServiceSpec) and forwards allowed requests to the processor, which by this point only listens
-// on the pod-local loopback (see rewriteHTTPTriggerURLToLoopback).
+// on the pod-local loopback (see rewriteHTTPTriggerURLToLoopback), and to any user sidecar port.
 func (lc *lazyClient) injectAuthProxySidecar(ctx context.Context,
 	function *nuclioio.NuclioFunction,
 	deploymentSpec *appsv1.DeploymentSpec,
-	volumeMounts []v1.VolumeMount) {
+	volumeMounts []v1.VolumeMount) error {
 
 	platformConfig := lc.platformConfigurationProvider.GetPlatformConfiguration()
 
 	// functionAuthenticationEnabled already found a valid HTTP trigger + authentication mode
 	authMode, err := functionconfig.GetHTTPTriggerMode(function.Spec.Triggers)
 	if err != nil {
-		lc.logger.WarnWithCtx(ctx, "Failed to get http trigger mode for function, skipping auth-proxy injection", "functionName", function.Name, "err", err)
-		return
+		return errors.Wrap(err, "Failed to get http trigger mode for function")
+	}
+
+	// the proxy must front every port the Service publishes, so a port it cannot front fails the whole
+	// injection - a partially fronted function would expose an unauthenticated port
+	routes, err := authProxyRoutes(function)
+	if err != nil {
+		return errors.Wrap(err, "Failed to resolve auth-proxy sidecar routes")
+	}
+
+	containerPorts := make([]v1.ContainerPort, 0, len(routes))
+	for _, route := range routes {
+		containerPorts = append(containerPorts, v1.ContainerPort{
+			Name:          auth.AuthProxySidecarPortName(route.ListenPort),
+			ContainerPort: int32(route.ListenPort),
+			Protocol:      v1.ProtocolTCP,
+		})
 	}
 
 	args := []string{
+		"auth-proxy",
 		fmt.Sprintf("--mode=%s", auth.ProxyModeReverseProxy),
-		fmt.Sprintf("--listen-port=%d", abstract.FunctionContainerHTTPPort),
-		fmt.Sprintf("--upstream-url=http://127.0.0.1:%d", abstract.FunctionContainerHTTPLoopbackPort),
+		fmt.Sprintf("--routes=%s", authproxy.FormatRoutes(routes)),
 		fmt.Sprintf("--auth-mode=%s", authMode),
 	}
 	if platformConfig.Authentication.AuthURL != "" {
@@ -1481,13 +1567,7 @@ func (lc *lazyClient) injectAuthProxySidecar(ctx context.Context,
 		Image:        platformConfig.Authentication.AuthSidecarImage,
 		Args:         args,
 		VolumeMounts: volumeMounts,
-		Ports: []v1.ContainerPort{
-			{
-				Name:          abstract.FunctionContainerHTTPPortName,
-				ContainerPort: abstract.FunctionContainerHTTPPort,
-				Protocol:      v1.ProtocolTCP,
-			},
-		},
+		Ports:        containerPorts,
 	}
 
 	// basicAuth credentials are scrubbed onto the function's own secret; the sidecar restores them itself
@@ -1505,6 +1585,7 @@ func (lc *lazyClient) injectAuthProxySidecar(ctx context.Context,
 		&container.Resources)
 
 	deploymentSpec.Template.Spec.Containers = append(deploymentSpec.Template.Spec.Containers, container)
+	return nil
 }
 
 func (lc *lazyClient) resolveDeploymentStrategy(function *nuclioio.NuclioFunction) appsv1.DeploymentStrategyType {
@@ -2079,7 +2160,7 @@ func (lc *lazyClient) serializeFunctionJSON(function *nuclioio.NuclioFunction) (
 func (lc *lazyClient) populateServiceSpec(ctx context.Context,
 	functionLabels labels.Set,
 	function *nuclioio.NuclioFunction,
-	spec *v1.ServiceSpec) {
+	spec *v1.ServiceSpec) error {
 
 	if function.Status.State == functionconfig.FunctionStateScaledToZero ||
 		function.Status.State == functionconfig.FunctionStateWaitingForScaleResourcesToZero ||
@@ -2128,15 +2209,33 @@ func (lc *lazyClient) populateServiceSpec(ctx context.Context,
 
 	// add additional ports for sidecars
 	if function.Spec.Sidecars != nil {
+		sidecarPortMapping := map[int32]int32{}
+
+		// only when function-level auth is on does a sidecar port need to land on the auth-proxy rather than
+		// on the sidecar container; otherwise an in-cluster caller reaching the Service would bypass
+		// authentication. The client-facing Port never changes - only the TargetPort moves to the proxy.
+		// With the feature off, sidecarPortMapping stays empty and every port targets the sidecar as before.
+		if lc.functionAuthenticationEnabled(function) {
+			resolvedPortMapping, err := authProxySidecarPortMapping(function)
+			if err != nil {
+				return errors.Wrap(err, "Failed to resolve auth-proxy sidecar ports")
+			}
+			sidecarPortMapping = resolvedPortMapping
+		}
+
 		if len(spec.Ports) == 0 {
 			spec.Ports = []v1.ServicePort{}
 		}
 		for _, sidecar := range function.Spec.Sidecars {
 			for _, port := range sidecar.Ports {
+				targetPort := port.ContainerPort
+				if proxyListenPort, found := sidecarPortMapping[port.ContainerPort]; found {
+					targetPort = proxyListenPort
+				}
 				spec.Ports = lc.addOrUpdatePort(spec.Ports, v1.ServicePort{
 					Name:       port.Name,
 					Port:       port.ContainerPort,
-					TargetPort: intstr.FromInt32(port.ContainerPort),
+					TargetPort: intstr.FromInt32(targetPort),
 				})
 			}
 		}
@@ -2147,6 +2246,8 @@ func (lc *lazyClient) populateServiceSpec(ctx context.Context,
 
 	// make sure the ports exist (add if not)
 	spec.Ports = lc.ensureServicePortsExist(spec.Ports, platformServicePorts)
+
+	return nil
 }
 
 func (lc *lazyClient) addOrUpdatePort(ports []v1.ServicePort, port v1.ServicePort) []v1.ServicePort {
@@ -2573,6 +2674,11 @@ func (lc *lazyClient) populateDeploymentContainer(ctx context.Context,
 	if function.Spec.EnvFrom != nil {
 		container.EnvFrom = function.Spec.EnvFrom
 	}
+
+	// re-derive the ports from scratch: on update this container is the one read back from the existing
+	// deployment, so appending to whatever it already carries would both
+	// accumulate duplicates and keep ports that no longer apply
+	container.Ports = nil
 
 	// when the auth-proxy sidecar is injected, it - not the processor - owns the main HTTP port; the
 	// processor listens only on the pod-local loopback (see rewriteHTTPTriggerURLToLoopback)

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -713,7 +713,7 @@ func (suite *lazyTestSuite) TestInjectAuthProxySidecar() {
 			suite.Require().Contains(sidecar.Args, fmt.Sprintf("--auth-kind=%s", auth.KindIguazio))
 			suite.Require().Equal([]v1.ContainerPort{
 				{
-					Name:          auth.AuthProxySidecarPortName(abstract.FunctionContainerHTTPPort),
+					Name:          abstract.AuthProxySidecarPortName(abstract.FunctionContainerHTTPPort),
 					ContainerPort: abstract.FunctionContainerHTTPPort,
 					Protocol:      v1.ProtocolTCP,
 				},
@@ -762,23 +762,23 @@ func (suite *lazyTestSuite) TestInjectAuthProxySidecarFrontsSidecarPorts() {
 	suite.Require().Contains(sidecar.Args, fmt.Sprintf("--routes=%d=http://127.0.0.1:%d,%d=http://127.0.0.1:9000,%d=http://127.0.0.1:8050",
 		abstract.FunctionContainerHTTPPort,
 		abstract.FunctionContainerHTTPLoopbackPort,
-		auth.AuthProxySidecarListenPortRangeStart,
-		auth.AuthProxySidecarListenPortRangeStart+1))
+		abstract.AuthProxySidecarListenPortRangeStart,
+		abstract.AuthProxySidecarListenPortRangeStart+1))
 
 	suite.Require().Equal([]v1.ContainerPort{
 		{
-			Name:          auth.AuthProxySidecarPortName(abstract.FunctionContainerHTTPPort),
+			Name:          abstract.AuthProxySidecarPortName(abstract.FunctionContainerHTTPPort),
 			ContainerPort: abstract.FunctionContainerHTTPPort,
 			Protocol:      v1.ProtocolTCP,
 		},
 		{
-			Name:          auth.AuthProxySidecarPortName(auth.AuthProxySidecarListenPortRangeStart),
-			ContainerPort: auth.AuthProxySidecarListenPortRangeStart,
+			Name:          abstract.AuthProxySidecarPortName(abstract.AuthProxySidecarListenPortRangeStart),
+			ContainerPort: abstract.AuthProxySidecarListenPortRangeStart,
 			Protocol:      v1.ProtocolTCP,
 		},
 		{
-			Name:          auth.AuthProxySidecarPortName(auth.AuthProxySidecarListenPortRangeStart + 1),
-			ContainerPort: auth.AuthProxySidecarListenPortRangeStart + 1,
+			Name:          abstract.AuthProxySidecarPortName(abstract.AuthProxySidecarListenPortRangeStart + 1),
+			ContainerPort: abstract.AuthProxySidecarListenPortRangeStart + 1,
 			Protocol:      v1.ProtocolTCP,
 		},
 	}, sidecar.Ports)
@@ -802,7 +802,7 @@ func (suite *lazyTestSuite) TestInjectAuthProxySidecarFailsOnBadSidecarPort() {
 		{
 			Name: "sidecar-a",
 			Ports: []v1.ContainerPort{
-				{Name: "reserved", ContainerPort: auth.AuthProxySidecarListenPortRangeStart},
+				{Name: "reserved", ContainerPort: abstract.AuthProxySidecarListenPortRangeStart},
 			},
 		},
 	}
@@ -837,8 +837,8 @@ func (suite *lazyTestSuite) TestAuthProxyRoutes() {
 			},
 			expectedRoutes: []authproxy.Route{
 				authproxy.LoopbackRoute(abstract.FunctionContainerHTTPPort, abstract.FunctionContainerHTTPLoopbackPort),
-				authproxy.LoopbackRoute(auth.AuthProxySidecarListenPortRangeStart, 9000),
-				authproxy.LoopbackRoute(auth.AuthProxySidecarListenPortRangeStart+1, 8050),
+				authproxy.LoopbackRoute(abstract.AuthProxySidecarListenPortRangeStart, 9000),
+				authproxy.LoopbackRoute(abstract.AuthProxySidecarListenPortRangeStart+1, 8050),
 			},
 		},
 		{
@@ -849,22 +849,22 @@ func (suite *lazyTestSuite) TestAuthProxyRoutes() {
 			},
 			expectedRoutes: []authproxy.Route{
 				authproxy.LoopbackRoute(abstract.FunctionContainerHTTPPort, abstract.FunctionContainerHTTPLoopbackPort),
-				authproxy.LoopbackRoute(auth.AuthProxySidecarListenPortRangeStart, 8050),
-				authproxy.LoopbackRoute(auth.AuthProxySidecarListenPortRangeStart+1, 9000),
+				authproxy.LoopbackRoute(abstract.AuthProxySidecarListenPortRangeStart, 8050),
+				authproxy.LoopbackRoute(abstract.AuthProxySidecarListenPortRangeStart+1, 9000),
 			},
 		},
 		{
 			name: "a sidecar port inside the reserved band is rejected",
 			sidecars: []*v1.Container{
 				{Name: "sidecar-a", Ports: []v1.ContainerPort{
-					{Name: "reserved", ContainerPort: auth.AuthProxySidecarListenPortRangeStart},
+					{Name: "reserved", ContainerPort: abstract.AuthProxySidecarListenPortRangeStart},
 				}},
 			},
 			expectError: true,
 		},
 		{
 			name:        "more sidecar ports than the band can hold is rejected",
-			sidecars:    []*v1.Container{suite.compileSidecarWithPortCount(auth.AuthProxySidecarListenPortRangeEnd - auth.AuthProxySidecarListenPortRangeStart + 2)},
+			sidecars:    []*v1.Container{suite.compileSidecarWithPortCount(abstract.AuthProxySidecarListenPortRangeEnd - abstract.AuthProxySidecarListenPortRangeStart + 2)},
 			expectError: true,
 		},
 	} {
@@ -919,8 +919,8 @@ func (suite *lazyTestSuite) TestPopulateServiceSpecSidecarPorts() {
 			},
 			expectedPorts: []v1.ServicePort{
 				{Name: abstract.FunctionContainerHTTPPortName, Port: abstract.FunctionContainerHTTPPort},
-				{Name: "port-1", Port: 9000, TargetPort: intstr.FromInt32(auth.AuthProxySidecarListenPortRangeStart)},
-				{Name: "port-2", Port: 8050, TargetPort: intstr.FromInt32(auth.AuthProxySidecarListenPortRangeStart + 1)},
+				{Name: "port-1", Port: 9000, TargetPort: intstr.FromInt32(abstract.AuthProxySidecarListenPortRangeStart)},
+				{Name: "port-2", Port: 8050, TargetPort: intstr.FromInt32(abstract.AuthProxySidecarListenPortRangeStart + 1)},
 			},
 		},
 		{
@@ -928,7 +928,7 @@ func (suite *lazyTestSuite) TestPopulateServiceSpecSidecarPorts() {
 			functionAuthEnabled: true,
 			sidecars: []*v1.Container{
 				{Name: "sidecar-a", Ports: []v1.ContainerPort{
-					{Name: "reserved", ContainerPort: auth.AuthProxySidecarListenPortRangeStart},
+					{Name: "reserved", ContainerPort: abstract.AuthProxySidecarListenPortRangeStart},
 				}},
 			},
 			expectError: true,

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -705,16 +705,16 @@ func (suite *lazyTestSuite) TestInjectAuthProxySidecar() {
 			suite.Require().Equal("nuclio/auth-proxy:latest", sidecar.Image)
 			suite.Require().Contains(sidecar.Args, "--mode=reverseProxy")
 			suite.Require().Contains(sidecar.Args, fmt.Sprintf("--routes=%d=http://127.0.0.1:%d",
-				abstract.FunctionContainerHTTPPort,
-				abstract.FunctionContainerHTTPLoopbackPort))
+				abstract.AuthProxyProcessorListenPort,
+				abstract.FunctionContainerHTTPPort))
 			suite.Require().Contains(sidecar.Args, fmt.Sprintf("--auth-mode=%s", testCase.authenticationMode))
 			suite.Require().Contains(sidecar.Args, "--auth-url=http://auth.example.com")
 			suite.Require().Contains(sidecar.Args, "--signin-url=http://signin.example.com")
 			suite.Require().Contains(sidecar.Args, fmt.Sprintf("--auth-kind=%s", auth.KindIguazio))
 			suite.Require().Equal([]v1.ContainerPort{
 				{
-					Name:          abstract.AuthProxySidecarPortName(abstract.FunctionContainerHTTPPort),
-					ContainerPort: abstract.FunctionContainerHTTPPort,
+					Name:          abstract.AuthProxySidecarPortName(abstract.AuthProxyProcessorListenPort),
+					ContainerPort: abstract.AuthProxyProcessorListenPort,
 					Protocol:      v1.ProtocolTCP,
 				},
 			}, sidecar.Ports)
@@ -760,15 +760,15 @@ func (suite *lazyTestSuite) TestInjectAuthProxySidecarFrontsSidecarPorts() {
 	sidecar := deploymentSpec.Template.Spec.Containers[1]
 
 	suite.Require().Contains(sidecar.Args, fmt.Sprintf("--routes=%d=http://127.0.0.1:%d,%d=http://127.0.0.1:9000,%d=http://127.0.0.1:8050",
+		abstract.AuthProxyProcessorListenPort,
 		abstract.FunctionContainerHTTPPort,
-		abstract.FunctionContainerHTTPLoopbackPort,
 		abstract.AuthProxySidecarListenPortRangeStart,
 		abstract.AuthProxySidecarListenPortRangeStart+1))
 
 	suite.Require().Equal([]v1.ContainerPort{
 		{
-			Name:          abstract.AuthProxySidecarPortName(abstract.FunctionContainerHTTPPort),
-			ContainerPort: abstract.FunctionContainerHTTPPort,
+			Name:          abstract.AuthProxySidecarPortName(abstract.AuthProxyProcessorListenPort),
+			ContainerPort: abstract.AuthProxyProcessorListenPort,
 			Protocol:      v1.ProtocolTCP,
 		},
 		{
@@ -814,8 +814,9 @@ func (suite *lazyTestSuite) TestInjectAuthProxySidecarFailsOnBadSidecarPort() {
 	suite.Require().Len(deploymentSpec.Template.Spec.Containers, 1)
 }
 
-// TestAuthProxyRoutes verifies the route set: the function's own route always comes first and is unchanged,
-// sidecar routes are assigned from the reserved band in spec order, and the band's limits are enforced.
+// TestAuthProxyRoutes verifies the route set: the processor's route always comes first and takes the band's
+// first slot, sidecar routes are assigned the slots after it in spec order, and the band's limits are
+// enforced. Every route forwards to the port its container already binds - none is asked to rebind.
 func (suite *lazyTestSuite) TestAuthProxyRoutes() {
 	for _, testCase := range []struct {
 		name           string
@@ -824,9 +825,9 @@ func (suite *lazyTestSuite) TestAuthProxyRoutes() {
 		expectError    bool
 	}{
 		{
-			name: "no sidecars leaves only the function route",
+			name: "no sidecars leaves only the processor route",
 			expectedRoutes: []authproxy.Route{
-				authproxy.LoopbackRoute(abstract.FunctionContainerHTTPPort, abstract.FunctionContainerHTTPLoopbackPort),
+				authproxy.LoopbackRoute(abstract.AuthProxyProcessorListenPort, abstract.FunctionContainerHTTPPort),
 			},
 		},
 		{
@@ -836,7 +837,7 @@ func (suite *lazyTestSuite) TestAuthProxyRoutes() {
 				{Name: "sidecar-b", Ports: []v1.ContainerPort{{Name: "low", ContainerPort: 8050}}},
 			},
 			expectedRoutes: []authproxy.Route{
-				authproxy.LoopbackRoute(abstract.FunctionContainerHTTPPort, abstract.FunctionContainerHTTPLoopbackPort),
+				authproxy.LoopbackRoute(abstract.AuthProxyProcessorListenPort, abstract.FunctionContainerHTTPPort),
 				authproxy.LoopbackRoute(abstract.AuthProxySidecarListenPortRangeStart, 9000),
 				authproxy.LoopbackRoute(abstract.AuthProxySidecarListenPortRangeStart+1, 8050),
 			},
@@ -848,7 +849,7 @@ func (suite *lazyTestSuite) TestAuthProxyRoutes() {
 				{Name: "sidecar-a", Ports: []v1.ContainerPort{{Name: "high", ContainerPort: 9000}}},
 			},
 			expectedRoutes: []authproxy.Route{
-				authproxy.LoopbackRoute(abstract.FunctionContainerHTTPPort, abstract.FunctionContainerHTTPLoopbackPort),
+				authproxy.LoopbackRoute(abstract.AuthProxyProcessorListenPort, abstract.FunctionContainerHTTPPort),
 				authproxy.LoopbackRoute(abstract.AuthProxySidecarListenPortRangeStart, 8050),
 				authproxy.LoopbackRoute(abstract.AuthProxySidecarListenPortRangeStart+1, 9000),
 			},
@@ -887,9 +888,10 @@ func (suite *lazyTestSuite) TestAuthProxyRoutes() {
 	}
 }
 
-// TestPopulateServiceSpecSidecarPorts verifies a sidecar's Service port keeps its client-facing number but
-// targets the auth-proxy when function-level authentication is on, so reaching the Service cannot bypass it.
-func (suite *lazyTestSuite) TestPopulateServiceSpecSidecarPorts() {
+// TestPopulateServiceSpecPorts verifies every published port keeps its client-facing number and targets the
+// auth-proxy when function-level authentication is on - the processor's HTTP port included, so the rule is
+// the same for the function and its sidecars and reaching the Service cannot bypass authentication.
+func (suite *lazyTestSuite) TestPopulateServiceSpecPorts() {
 	for _, testCase := range []struct {
 		name                string
 		functionAuthEnabled bool
@@ -898,18 +900,22 @@ func (suite *lazyTestSuite) TestPopulateServiceSpecSidecarPorts() {
 		expectError         bool
 	}{
 		{
-			name:                "auth off keeps the sidecar port targeting the sidecar",
+			name:                "auth off targets every port at the container binding it",
 			functionAuthEnabled: false,
 			sidecars: []*v1.Container{
 				{Name: "sidecar-a", Ports: []v1.ContainerPort{{Name: "port-1", ContainerPort: 8050}}},
 			},
 			expectedPorts: []v1.ServicePort{
-				{Name: abstract.FunctionContainerHTTPPortName, Port: abstract.FunctionContainerHTTPPort},
+				{
+					Name:       abstract.FunctionContainerHTTPPortName,
+					Port:       abstract.FunctionContainerHTTPPort,
+					TargetPort: intstr.FromInt32(abstract.FunctionContainerHTTPPort),
+				},
 				{Name: "port-1", Port: 8050, TargetPort: intstr.FromInt32(8050)},
 			},
 		},
 		{
-			name:                "auth on repoints the sidecar port at the auth-proxy",
+			name:                "auth on repoints the http port and the sidecar ports at the auth-proxy",
 			functionAuthEnabled: true,
 			sidecars: []*v1.Container{
 				{Name: "sidecar-a", Ports: []v1.ContainerPort{
@@ -918,7 +924,11 @@ func (suite *lazyTestSuite) TestPopulateServiceSpecSidecarPorts() {
 				}},
 			},
 			expectedPorts: []v1.ServicePort{
-				{Name: abstract.FunctionContainerHTTPPortName, Port: abstract.FunctionContainerHTTPPort},
+				{
+					Name:       abstract.FunctionContainerHTTPPortName,
+					Port:       abstract.FunctionContainerHTTPPort,
+					TargetPort: intstr.FromInt32(abstract.AuthProxyProcessorListenPort),
+				},
 				{Name: "port-1", Port: 9000, TargetPort: intstr.FromInt32(abstract.AuthProxySidecarListenPortRangeStart)},
 				{Name: "port-2", Port: 8050, TargetPort: intstr.FromInt32(abstract.AuthProxySidecarListenPortRangeStart + 1)},
 			},
@@ -1055,16 +1065,17 @@ func (suite *lazyTestSuite) TestPopulateSupplementaryContainersInjectsAuthProxyW
 	}
 }
 
-// TestPopulateDeploymentContainerRemovesHTTPPortWhenAuthProxyFronts verifies the processor container no
-// longer declares the main HTTP port once the auth-proxy sidecar takes over listening on it.
-func (suite *lazyTestSuite) TestPopulateDeploymentContainerRemovesHTTPPortWhenAuthProxyFronts() {
+// TestPopulateDeploymentContainerKeepsHTTPPort verifies the processor keeps declaring - and binding - its own
+// HTTP port whether or not the auth-proxy fronts it. The proxy listens on a port of its own, so the processor
+// is never displaced.
+func (suite *lazyTestSuite) TestPopulateDeploymentContainerKeepsHTTPPort() {
 	for _, testCase := range []struct {
 		name                string
 		functionAuthEnabled bool
 		expectHTTPPort      bool
 	}{
 		{name: "keeps HTTP port when gate is off", functionAuthEnabled: false, expectHTTPPort: true},
-		{name: "removes HTTP port when gate is on", functionAuthEnabled: true, expectHTTPPort: false},
+		{name: "keeps HTTP port when gate is on", functionAuthEnabled: true, expectHTTPPort: true},
 	} {
 		suite.Run(testCase.name, func() {
 			suite.client.SetPlatformConfigurationProvider(&mockedPlatformConfigurationProvider{
@@ -1118,9 +1129,10 @@ func (suite *lazyTestSuite) TestPopulateDeploymentContainerPortsAreIdempotent() 
 			},
 		},
 		{
-			name:                "auth on drops the http port and keeps one metrics port",
+			name:                "auth on keeps the http port and one metrics port",
 			functionAuthEnabled: true,
 			expectedPorts: []v1.ContainerPort{
+				{Name: abstract.FunctionContainerHTTPPortName, ContainerPort: abstract.FunctionContainerHTTPPort, Protocol: v1.ProtocolTCP},
 				{Name: abstract.FunctionContainerMetricPortName, ContainerPort: abstract.FunctionContainerMetricPort, Protocol: v1.ProtocolTCP},
 			},
 		},
@@ -1165,10 +1177,10 @@ func (suite *lazyTestSuite) TestPopulateDeploymentContainerPortsAreIdempotent() 
 	}
 }
 
-// TestPopulateConfigMapRewritesHTTPTriggerURLToLoopback verifies the processor's HTTP trigger is
-// configured to listen on the pod-local loopback (reachable only via the auth-proxy sidecar) once the
-// gate is on, and that the function's own Spec is never mutated in the process.
-func (suite *lazyTestSuite) TestPopulateConfigMapRewritesHTTPTriggerURLToLoopback() {
+// TestPopulateConfigMapKeepsHTTPTriggerURL verifies the processor's HTTP trigger is written through
+// untouched with the gate on: the auth-proxy takes a port of its own, so the processor is never moved off
+// the address it would otherwise listen on.
+func (suite *lazyTestSuite) TestPopulateConfigMapKeepsHTTPTriggerURL() {
 	suite.client.SetPlatformConfigurationProvider(&mockedPlatformConfigurationProvider{
 		platformConfiguration: &platformconfig.Config{
 			Authentication: &platformconfig.Authentication{
@@ -1196,11 +1208,122 @@ func (suite *lazyTestSuite) TestPopulateConfigMapRewritesHTTPTriggerURLToLoopbac
 
 	var writtenConfiguration processor.Configuration
 	suite.Require().NoError(reader.Read(strings.NewReader(configMap.Data["processor.yaml"]), &writtenConfiguration))
-	suite.Require().Equal(fmt.Sprintf("127.0.0.1:%d", abstract.FunctionContainerHTTPLoopbackPort),
-		writtenConfiguration.Config.Spec.Triggers["http"].URL)
+	suite.Require().Empty(writtenConfiguration.Config.Spec.Triggers["http"].URL)
+}
 
-	// the original function spec must remain untouched
-	suite.Require().Empty(functionInstance.Spec.Triggers["http"].URL)
+// TestPopulateServiceSpecKeepsTargetPortWhileServedByDLX verifies a scaled-to-zero function's http port is
+// not repointed at the auth-proxy: the Service selector points at the DLX pods, which listen on the
+// function's own HTTP port only, so a repointed TargetPort would black-hole the request meant to scale the
+// function back up.
+func (suite *lazyTestSuite) TestPopulateServiceSpecKeepsTargetPortWhileServedByDLX() {
+	for _, testCase := range []struct {
+		name               string
+		functionState      functionconfig.FunctionState
+		expectedTargetPort int32
+	}{
+		{
+			name:               "ready function targets the auth-proxy",
+			functionState:      functionconfig.FunctionStateReady,
+			expectedTargetPort: abstract.AuthProxyProcessorListenPort,
+		},
+		{
+			name:               "scaled to zero targets the DLX",
+			functionState:      functionconfig.FunctionStateScaledToZero,
+			expectedTargetPort: abstract.FunctionContainerHTTPPort,
+		},
+		{
+			name:               "scaling to zero targets the DLX",
+			functionState:      functionconfig.FunctionStateWaitingForScaleResourcesToZero,
+			expectedTargetPort: abstract.FunctionContainerHTTPPort,
+		},
+		{
+			name:               "scaling from zero targets the DLX",
+			functionState:      functionconfig.FunctionStateWaitingForScaleResourcesFromZero,
+			expectedTargetPort: abstract.FunctionContainerHTTPPort,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.client.SetPlatformConfigurationProvider(&mockedPlatformConfigurationProvider{
+				platformConfiguration: &platformconfig.Config{
+					Authentication: &platformconfig.Authentication{
+						FunctionAuthenticationEnabled: true,
+						AuthSidecarImage:              "nuclio/auth-proxy:latest",
+					},
+				},
+			})
+
+			functionInstance := suite.compileAuthenticatedFunction()
+			functionInstance.Status.State = testCase.functionState
+
+			// stand in for the service read back on update, rendered while the function was ready
+			serviceSpec := &v1.ServiceSpec{
+				Ports: []v1.ServicePort{
+					{
+						Name:       abstract.FunctionContainerHTTPPortName,
+						Port:       abstract.FunctionContainerHTTPPort,
+						NodePort:   30000,
+						TargetPort: intstr.FromInt32(abstract.AuthProxyProcessorListenPort),
+					},
+				},
+			}
+			suite.Require().NoError(
+				suite.client.populateServiceSpec(suite.ctx, nil, functionInstance, serviceSpec))
+
+			suite.Require().Equal(intstr.FromInt32(testCase.expectedTargetPort), serviceSpec.Ports[0].TargetPort)
+		})
+	}
+}
+
+// TestPopulateDeploymentContainerReadinessProbePort verifies readiness is probed through the auth-proxy when
+// one fronts the function, so the pod turns ready only once both the proxy and the processor serve. Liveness
+// stays direct on the health-check port, so a proxy fault never restarts the function container.
+func (suite *lazyTestSuite) TestPopulateDeploymentContainerReadinessProbePort() {
+	for _, testCase := range []struct {
+		name                       string
+		functionAuthEnabled        bool
+		expectedReadinessProbePort int
+	}{
+		{
+			name:                       "auth off probes the processor directly",
+			functionAuthEnabled:        false,
+			expectedReadinessProbePort: abstract.FunctionContainerHTTPPort,
+		},
+		{
+			name:                       "auth on probes through the auth-proxy",
+			functionAuthEnabled:        true,
+			expectedReadinessProbePort: abstract.AuthProxyProcessorListenPort,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.client.SetPlatformConfigurationProvider(&mockedPlatformConfigurationProvider{
+				platformConfiguration: &platformconfig.Config{
+					Authentication: &platformconfig.Authentication{
+						FunctionAuthenticationEnabled: testCase.functionAuthEnabled,
+					},
+				},
+			})
+
+			httpTrigger := functionconfig.GetDefaultHTTPTrigger()
+			httpTrigger.Attributes = map[string]interface{}{
+				auth.AttributeAuthenticationMode: string(auth.AuthenticationModeBrowser),
+			}
+			functionInstance := suite.getFunctionInstanceWithDefaultProbes("func-name")
+			functionInstance.Spec.Triggers = map[string]functionconfig.Trigger{
+				"http": httpTrigger,
+			}
+
+			container := &v1.Container{}
+			suite.client.populateDeploymentContainer(suite.ctx,
+				suite.client.getFunctionLabels(functionInstance),
+				functionInstance,
+				container)
+
+			suite.Require().Equal(intstr.FromInt(testCase.expectedReadinessProbePort),
+				container.ReadinessProbe.HTTPGet.Port)
+			suite.Require().Equal(intstr.FromInt(abstract.FunctionContainerHealthCheckHTTPPort),
+				container.LivenessProbe.HTTPGet.Port)
+		})
+	}
 }
 
 func (suite *lazyTestSuite) TestTriggerDefinedMultipleIngresses() {

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/auth/authproxy"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/common/annotations"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
@@ -50,6 +51,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -695,23 +697,23 @@ func (suite *lazyTestSuite) TestInjectAuthProxySidecar() {
 				},
 			}
 
-			suite.client.injectAuthProxySidecar(suite.ctx, functionInstance, deploymentSpec, nil)
+			suite.Require().NoError(suite.client.injectAuthProxySidecar(suite.ctx, functionInstance, deploymentSpec, nil))
 
 			suite.Require().Len(deploymentSpec.Template.Spec.Containers, 2)
 			sidecar := deploymentSpec.Template.Spec.Containers[1]
 			suite.Require().Equal(abstract.AuthProxySidecarContainerName, sidecar.Name)
 			suite.Require().Equal("nuclio/auth-proxy:latest", sidecar.Image)
 			suite.Require().Contains(sidecar.Args, "--mode=reverseProxy")
-			suite.Require().Contains(sidecar.Args, fmt.Sprintf("--listen-port=%d", abstract.FunctionContainerHTTPPort))
-			suite.Require().Contains(sidecar.Args,
-				fmt.Sprintf("--upstream-url=http://127.0.0.1:%d", abstract.FunctionContainerHTTPLoopbackPort))
+			suite.Require().Contains(sidecar.Args, fmt.Sprintf("--routes=%d=http://127.0.0.1:%d",
+				abstract.FunctionContainerHTTPPort,
+				abstract.FunctionContainerHTTPLoopbackPort))
 			suite.Require().Contains(sidecar.Args, fmt.Sprintf("--auth-mode=%s", testCase.authenticationMode))
 			suite.Require().Contains(sidecar.Args, "--auth-url=http://auth.example.com")
 			suite.Require().Contains(sidecar.Args, "--signin-url=http://signin.example.com")
 			suite.Require().Contains(sidecar.Args, fmt.Sprintf("--auth-kind=%s", auth.KindIguazio))
 			suite.Require().Equal([]v1.ContainerPort{
 				{
-					Name:          abstract.FunctionContainerHTTPPortName,
+					Name:          auth.AuthProxySidecarPortName(abstract.FunctionContainerHTTPPort),
 					ContainerPort: abstract.FunctionContainerHTTPPort,
 					Protocol:      v1.ProtocolTCP,
 				},
@@ -719,6 +721,285 @@ func (suite *lazyTestSuite) TestInjectAuthProxySidecar() {
 			suite.Require().Equal(testCase.expectedRestoreEnvs, sidecar.Env)
 		})
 	}
+}
+
+// TestInjectAuthProxySidecarFrontsSidecarPorts verifies the auth-proxy also listens for every user sidecar
+// port, forwarding each to that sidecar over loopback, and declares the matching container ports.
+func (suite *lazyTestSuite) TestInjectAuthProxySidecarFrontsSidecarPorts() {
+	suite.client.SetPlatformConfigurationProvider(&mockedPlatformConfigurationProvider{
+		platformConfiguration: &platformconfig.Config{
+			Authentication: &platformconfig.Authentication{
+				FunctionAuthenticationEnabled: true,
+				AuthSidecarImage:              "nuclio/auth-proxy:latest",
+			},
+		},
+	})
+
+	functionInstance := suite.compileAuthenticatedFunction()
+
+	// listen ports are handed out in spec order, so sidecar-a's port gets the first port of the band
+	functionInstance.Spec.Sidecars = []*v1.Container{
+		{
+			Name: "sidecar-a",
+			Ports: []v1.ContainerPort{
+				{Name: "port-high", ContainerPort: 9000, Protocol: v1.ProtocolTCP},
+			},
+		},
+		{
+			Name: "sidecar-b",
+			Ports: []v1.ContainerPort{
+				{Name: "port-low", ContainerPort: 8050, Protocol: v1.ProtocolTCP},
+			},
+		},
+	}
+
+	deploymentSpec := suite.compileDeploymentSpecWithFunctionContainer()
+	suite.Require().NoError(suite.client.injectAuthProxySidecar(suite.ctx, functionInstance, deploymentSpec, nil))
+
+	suite.Require().Len(deploymentSpec.Template.Spec.Containers, 2)
+	sidecar := deploymentSpec.Template.Spec.Containers[1]
+
+	suite.Require().Contains(sidecar.Args, fmt.Sprintf("--routes=%d=http://127.0.0.1:%d,%d=http://127.0.0.1:9000,%d=http://127.0.0.1:8050",
+		abstract.FunctionContainerHTTPPort,
+		abstract.FunctionContainerHTTPLoopbackPort,
+		auth.AuthProxySidecarListenPortRangeStart,
+		auth.AuthProxySidecarListenPortRangeStart+1))
+
+	suite.Require().Equal([]v1.ContainerPort{
+		{
+			Name:          auth.AuthProxySidecarPortName(abstract.FunctionContainerHTTPPort),
+			ContainerPort: abstract.FunctionContainerHTTPPort,
+			Protocol:      v1.ProtocolTCP,
+		},
+		{
+			Name:          auth.AuthProxySidecarPortName(auth.AuthProxySidecarListenPortRangeStart),
+			ContainerPort: auth.AuthProxySidecarListenPortRangeStart,
+			Protocol:      v1.ProtocolTCP,
+		},
+		{
+			Name:          auth.AuthProxySidecarPortName(auth.AuthProxySidecarListenPortRangeStart + 1),
+			ContainerPort: auth.AuthProxySidecarListenPortRangeStart + 1,
+			Protocol:      v1.ProtocolTCP,
+		},
+	}, sidecar.Ports)
+}
+
+// TestInjectAuthProxySidecarFailsOnBadSidecarPort verifies an unusable sidecar port fails the injection
+// outright: the proxy must front every port the Service publishes, so a partially fronted pod - which would
+// leave a sidecar port reachable without authentication - is never built.
+func (suite *lazyTestSuite) TestInjectAuthProxySidecarFailsOnBadSidecarPort() {
+	suite.client.SetPlatformConfigurationProvider(&mockedPlatformConfigurationProvider{
+		platformConfiguration: &platformconfig.Config{
+			Authentication: &platformconfig.Authentication{
+				FunctionAuthenticationEnabled: true,
+				AuthSidecarImage:              "nuclio/auth-proxy:latest",
+			},
+		},
+	})
+
+	functionInstance := suite.compileAuthenticatedFunction()
+	functionInstance.Spec.Sidecars = []*v1.Container{
+		{
+			Name: "sidecar-a",
+			Ports: []v1.ContainerPort{
+				{Name: "reserved", ContainerPort: auth.AuthProxySidecarListenPortRangeStart},
+			},
+		},
+	}
+
+	deploymentSpec := suite.compileDeploymentSpecWithFunctionContainer()
+	err := suite.client.injectAuthProxySidecar(suite.ctx, functionInstance, deploymentSpec, nil)
+
+	suite.Require().Error(err)
+	suite.Require().Len(deploymentSpec.Template.Spec.Containers, 1)
+}
+
+// TestAuthProxyRoutes verifies the route set: the function's own route always comes first and is unchanged,
+// sidecar routes are assigned from the reserved band in spec order, and the band's limits are enforced.
+func (suite *lazyTestSuite) TestAuthProxyRoutes() {
+	for _, testCase := range []struct {
+		name           string
+		sidecars       []*v1.Container
+		expectedRoutes []authproxy.Route
+		expectError    bool
+	}{
+		{
+			name: "no sidecars leaves only the function route",
+			expectedRoutes: []authproxy.Route{
+				authproxy.LoopbackRoute(abstract.FunctionContainerHTTPPort, abstract.FunctionContainerHTTPLoopbackPort),
+			},
+		},
+		{
+			name: "sidecar ports are assigned from the band in spec order across containers",
+			sidecars: []*v1.Container{
+				{Name: "sidecar-a", Ports: []v1.ContainerPort{{Name: "high", ContainerPort: 9000}}},
+				{Name: "sidecar-b", Ports: []v1.ContainerPort{{Name: "low", ContainerPort: 8050}}},
+			},
+			expectedRoutes: []authproxy.Route{
+				authproxy.LoopbackRoute(abstract.FunctionContainerHTTPPort, abstract.FunctionContainerHTTPLoopbackPort),
+				authproxy.LoopbackRoute(auth.AuthProxySidecarListenPortRangeStart, 9000),
+				authproxy.LoopbackRoute(auth.AuthProxySidecarListenPortRangeStart+1, 8050),
+			},
+		},
+		{
+			name: "route order is stable across repeated calls for the same spec",
+			sidecars: []*v1.Container{
+				{Name: "sidecar-b", Ports: []v1.ContainerPort{{Name: "low", ContainerPort: 8050}}},
+				{Name: "sidecar-a", Ports: []v1.ContainerPort{{Name: "high", ContainerPort: 9000}}},
+			},
+			expectedRoutes: []authproxy.Route{
+				authproxy.LoopbackRoute(abstract.FunctionContainerHTTPPort, abstract.FunctionContainerHTTPLoopbackPort),
+				authproxy.LoopbackRoute(auth.AuthProxySidecarListenPortRangeStart, 8050),
+				authproxy.LoopbackRoute(auth.AuthProxySidecarListenPortRangeStart+1, 9000),
+			},
+		},
+		{
+			name: "a sidecar port inside the reserved band is rejected",
+			sidecars: []*v1.Container{
+				{Name: "sidecar-a", Ports: []v1.ContainerPort{
+					{Name: "reserved", ContainerPort: auth.AuthProxySidecarListenPortRangeStart},
+				}},
+			},
+			expectError: true,
+		},
+		{
+			name:        "more sidecar ports than the band can hold is rejected",
+			sidecars:    []*v1.Container{suite.compileSidecarWithPortCount(auth.AuthProxySidecarListenPortRangeEnd - auth.AuthProxySidecarListenPortRangeStart + 2)},
+			expectError: true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			functionInstance := &nuclioio.NuclioFunction{}
+			functionInstance.Spec.Sidecars = testCase.sidecars
+
+			// repeated to catch a nondeterministic route order, which would churn the sidecar's --routes
+			// argument and roll the deployment on every reconcile
+			for range 10 {
+				routes, err := authProxyRoutes(functionInstance)
+				if testCase.expectError {
+					suite.Require().Error(err)
+					return
+				}
+				suite.Require().NoError(err)
+				suite.Require().Equal(testCase.expectedRoutes, routes)
+			}
+		})
+	}
+}
+
+// TestPopulateServiceSpecSidecarPorts verifies a sidecar's Service port keeps its client-facing number but
+// targets the auth-proxy when function-level authentication is on, so reaching the Service cannot bypass it.
+func (suite *lazyTestSuite) TestPopulateServiceSpecSidecarPorts() {
+	for _, testCase := range []struct {
+		name                string
+		functionAuthEnabled bool
+		sidecars            []*v1.Container
+		expectedPorts       []v1.ServicePort
+		expectError         bool
+	}{
+		{
+			name:                "auth off keeps the sidecar port targeting the sidecar",
+			functionAuthEnabled: false,
+			sidecars: []*v1.Container{
+				{Name: "sidecar-a", Ports: []v1.ContainerPort{{Name: "port-1", ContainerPort: 8050}}},
+			},
+			expectedPorts: []v1.ServicePort{
+				{Name: abstract.FunctionContainerHTTPPortName, Port: abstract.FunctionContainerHTTPPort},
+				{Name: "port-1", Port: 8050, TargetPort: intstr.FromInt32(8050)},
+			},
+		},
+		{
+			name:                "auth on repoints the sidecar port at the auth-proxy",
+			functionAuthEnabled: true,
+			sidecars: []*v1.Container{
+				{Name: "sidecar-a", Ports: []v1.ContainerPort{
+					{Name: "port-1", ContainerPort: 9000},
+					{Name: "port-2", ContainerPort: 8050},
+				}},
+			},
+			expectedPorts: []v1.ServicePort{
+				{Name: abstract.FunctionContainerHTTPPortName, Port: abstract.FunctionContainerHTTPPort},
+				{Name: "port-1", Port: 9000, TargetPort: intstr.FromInt32(auth.AuthProxySidecarListenPortRangeStart)},
+				{Name: "port-2", Port: 8050, TargetPort: intstr.FromInt32(auth.AuthProxySidecarListenPortRangeStart + 1)},
+			},
+		},
+		{
+			name:                "auth on fails when a sidecar port cannot be fronted",
+			functionAuthEnabled: true,
+			sidecars: []*v1.Container{
+				{Name: "sidecar-a", Ports: []v1.ContainerPort{
+					{Name: "reserved", ContainerPort: auth.AuthProxySidecarListenPortRangeStart},
+				}},
+			},
+			expectError: true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.client.SetPlatformConfigurationProvider(&mockedPlatformConfigurationProvider{
+				platformConfiguration: &platformconfig.Config{
+					Authentication: &platformconfig.Authentication{
+						FunctionAuthenticationEnabled: testCase.functionAuthEnabled,
+						AuthSidecarImage:              "nuclio/auth-proxy:latest",
+					},
+				},
+			})
+
+			functionInstance := suite.compileAuthenticatedFunction()
+			functionInstance.Spec.Sidecars = testCase.sidecars
+
+			serviceSpec := &v1.ServiceSpec{}
+			err := suite.client.populateServiceSpec(suite.ctx, nil, functionInstance, serviceSpec)
+			if testCase.expectError {
+				suite.Require().Error(err)
+				return
+			}
+			suite.Require().NoError(err)
+
+			suite.Require().Equal(testCase.expectedPorts, serviceSpec.Ports)
+
+			// the function's spec must never be mutated while rendering the service
+			suite.Require().Equal(testCase.sidecars, functionInstance.Spec.Sidecars)
+		})
+	}
+}
+
+// compileAuthenticatedFunction returns a function whose HTTP trigger declares an authentication mode, so
+// functionAuthenticationEnabled is gated only by the platform configuration.
+func (suite *lazyTestSuite) compileAuthenticatedFunction() *nuclioio.NuclioFunction {
+	httpTrigger := functionconfig.GetDefaultHTTPTrigger()
+	httpTrigger.Attributes = map[string]interface{}{
+		auth.AttributeAuthenticationMode: string(auth.AuthenticationModeAPI),
+	}
+
+	functionInstance := &nuclioio.NuclioFunction{}
+	functionInstance.Name = "func-name"
+	functionInstance.Spec.Triggers = map[string]functionconfig.Trigger{
+		"http": httpTrigger,
+	}
+	return functionInstance
+}
+
+func (suite *lazyTestSuite) compileDeploymentSpecWithFunctionContainer() *appsv1.DeploymentSpec {
+	return &appsv1.DeploymentSpec{
+		Template: v1.PodTemplateSpec{
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: common.FunctionContainerName},
+				},
+			},
+		},
+	}
+}
+
+func (suite *lazyTestSuite) compileSidecarWithPortCount(portCount int) *v1.Container {
+	sidecar := &v1.Container{Name: "sidecar-many-ports"}
+	for portIndex := 0; portIndex < portCount; portIndex++ {
+		sidecar.Ports = append(sidecar.Ports, v1.ContainerPort{
+			Name:          fmt.Sprintf("port-%d", portIndex),
+			ContainerPort: int32(20000 + portIndex),
+		})
+	}
+	return sidecar
 }
 
 // TestPopulateSupplementaryContainersInjectsAuthProxyWhenGated verifies the auth-proxy sidecar is only
@@ -760,7 +1041,8 @@ func (suite *lazyTestSuite) TestPopulateSupplementaryContainersInjectsAuthProxyW
 				},
 			}
 
-			suite.client.populateSupplementaryContainers(suite.ctx, functionInstance, deploymentSpec, nil)
+			suite.Require().NoError(
+				suite.client.populateSupplementaryContainers(suite.ctx, functionInstance, deploymentSpec, nil))
 
 			hasAuthProxy := false
 			for _, container := range deploymentSpec.Template.Spec.Containers {
@@ -813,6 +1095,72 @@ func (suite *lazyTestSuite) TestPopulateDeploymentContainerRemovesHTTPPortWhenAu
 				}
 			}
 			suite.Require().Equal(testCase.expectHTTPPort, hasHTTPPort)
+		})
+	}
+}
+
+// TestPopulateDeploymentContainerPortsAreIdempotent verifies the processor's ports are re-derived rather
+// than appended to. On update the container comes from the existing deployment, so a container already
+// carrying the ports of a previous render must come out with exactly the ports that apply now - otherwise
+// the metrics port accumulates and the pod spec is rejected for a duplicate port name.
+func (suite *lazyTestSuite) TestPopulateDeploymentContainerPortsAreIdempotent() {
+	for _, testCase := range []struct {
+		name                string
+		functionAuthEnabled bool
+		expectedPorts       []v1.ContainerPort
+	}{
+		{
+			name:                "auth off keeps the http port and one metrics port",
+			functionAuthEnabled: false,
+			expectedPorts: []v1.ContainerPort{
+				{Name: abstract.FunctionContainerHTTPPortName, ContainerPort: abstract.FunctionContainerHTTPPort, Protocol: v1.ProtocolTCP},
+				{Name: abstract.FunctionContainerMetricPortName, ContainerPort: abstract.FunctionContainerMetricPort, Protocol: v1.ProtocolTCP},
+			},
+		},
+		{
+			name:                "auth on drops the http port and keeps one metrics port",
+			functionAuthEnabled: true,
+			expectedPorts: []v1.ContainerPort{
+				{Name: abstract.FunctionContainerMetricPortName, ContainerPort: abstract.FunctionContainerMetricPort, Protocol: v1.ProtocolTCP},
+			},
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.client.SetPlatformConfigurationProvider(&mockedPlatformConfigurationProvider{
+				platformConfiguration: &platformconfig.Config{
+					Authentication: &platformconfig.Authentication{
+						FunctionAuthenticationEnabled: testCase.functionAuthEnabled,
+					},
+					Metrics: platformconfig.Metrics{
+						Sinks:     map[string]platformconfig.MetricSink{"pp": {Kind: "prometheusPull"}},
+						Functions: []string{"pp"},
+					},
+				},
+			})
+
+			httpTrigger := functionconfig.GetDefaultHTTPTrigger()
+			httpTrigger.Attributes = map[string]interface{}{
+				auth.AttributeAuthenticationMode: string(auth.AuthenticationModeBrowser),
+			}
+			functionInstance := suite.getFunctionInstanceWithDefaultProbes("func-name")
+			functionInstance.Spec.Triggers = map[string]functionconfig.Trigger{
+				"http": httpTrigger,
+			}
+			functionLabels := suite.client.getFunctionLabels(functionInstance)
+
+			// stand in for the container read back from an existing deployment rendered before auth was on
+			container := &v1.Container{
+				Ports: []v1.ContainerPort{
+					{Name: abstract.FunctionContainerHTTPPortName, ContainerPort: abstract.FunctionContainerHTTPPort, Protocol: v1.ProtocolTCP},
+					{Name: abstract.FunctionContainerMetricPortName, ContainerPort: abstract.FunctionContainerMetricPort, Protocol: v1.ProtocolTCP},
+				},
+			}
+
+			// reconciling repeatedly must converge on the same ports
+			for range 3 {
+				suite.client.populateDeploymentContainer(suite.ctx, functionLabels, functionInstance, container)
+				suite.Require().Equal(testCase.expectedPorts, container.Ports)
+			}
 		})
 	}
 }

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -876,7 +876,7 @@ func (suite *lazyTestSuite) TestAuthProxyRoutes() {
 			// repeated to catch a nondeterministic route order, which would churn the sidecar's --routes
 			// argument and roll the deployment on every reconcile
 			for range 10 {
-				routes, err := authProxyRoutes(functionInstance)
+				routes, err := suite.client.authProxyRoutes(functionInstance)
 				if testCase.expectError {
 					suite.Require().Error(err)
 					return

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -2365,10 +2365,10 @@ func (p *Platform) validateContainerPorts(functionConfig *functionconfig.Config,
 				return nuclio.NewErrBadRequest(fmt.Sprintf("Container port %d is reserved for Nuclio internal use", port.ContainerPort))
 			}
 
-			// when function-level auth is active, the processor's loopback port and the band the auth-proxy
-			// listens on to front sidecar ports are also reserved
+			// when function-level auth is active, the port the auth-proxy fronts the processor on and the
+			// band it listens on to front sidecar ports are also reserved
 			if authProxyEnabled &&
-				(port.ContainerPort == abstract.FunctionContainerHTTPLoopbackPort ||
+				(port.ContainerPort == abstract.AuthProxyProcessorListenPort ||
 					(port.ContainerPort >= abstract.AuthProxySidecarListenPortRangeStart &&
 						port.ContainerPort <= abstract.AuthProxySidecarListenPortRangeEnd)) {
 				return nuclio.NewErrBadRequest(fmt.Sprintf("Container port is reserved for Nuclio internal use: %d", port.ContainerPort))

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -2262,11 +2262,9 @@ func (p *Platform) functionAuthenticationEnabled(functionConfig *functionconfig.
 // validateSidecarNameNotReserved rejects a user-supplied sidecar named abstract.AuthProxySidecarContainerName,
 // which is reserved for the platform-injected auth-proxy sidecar (see functionres.injectAuthProxySidecar).
 func (p *Platform) validateSidecarNameNotReserved(functionConfig *functionconfig.Config, sidecar *v1.Container) error {
-	authProxyEnabled, err := p.functionAuthenticationEnabled(functionConfig)
-	if err != nil {
+	if authProxyEnabled, err := p.functionAuthenticationEnabled(functionConfig); err != nil {
 		return err
-	}
-	if !authProxyEnabled {
+	} else if !authProxyEnabled {
 		return nil
 	}
 
@@ -2281,11 +2279,9 @@ func (p *Platform) validateSidecarNameNotReserved(functionConfig *functionconfig
 // bind to front a sidecar port. Container-port names are unique within a pod
 func (p *Platform) validateSidecarPortNames(functionConfig *functionconfig.Config,
 	portNames map[string]bool) error {
-	authProxyEnabled, err := p.functionAuthenticationEnabled(functionConfig)
-	if err != nil {
+	if authProxyEnabled, err := p.functionAuthenticationEnabled(functionConfig); err != nil {
 		return err
-	}
-	if !authProxyEnabled {
+	} else if !authProxyEnabled {
 		return nil
 	}
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -2236,30 +2236,43 @@ func (p *Platform) validateSidecarSpec(functionConfig *functionconfig.Config) er
 		}
 	}
 
-	if err := p.validateSidecarPortNamesFreeForAuthProxy(functionConfig, portNames); err != nil {
+	if err := p.validateSidecarPortNames(functionConfig, portNames); err != nil {
 		return nuclio.WrapErrBadRequest(err)
 	}
 
 	return nil
 }
 
-// validateSidecarNameNotReserved rejects a user-supplied sidecar named abstract.AuthProxySidecarContainerName,
-// which is reserved for the platform-injected auth-proxy sidecar (see functionres.injectAuthProxySidecar).
-func (p *Platform) validateSidecarNameNotReserved(functionConfig *functionconfig.Config, sidecar *v1.Container) error {
+// functionAuthenticationEnabled reports whether the auth-proxy sidecar will be injected in front of the
+// function - gated by the platform-wide feature flag AND the function's HTTP trigger declaring a
+// function-level authenticationMode. It decides which of the auth-proxy's reservations apply
+// (see functionres.lazyClient.functionAuthenticationEnabled, which gates the injection itself).
+func (p *Platform) functionAuthenticationEnabled(functionConfig *functionconfig.Config) (bool, error) {
 	if !p.IsFunctionAuthenticationEnabled() {
-		return nil
+		return false, nil
 	}
 
 	authMode, err := functionconfig.GetHTTPTriggerMode(functionConfig.Spec.Triggers)
 	if err != nil {
-		// no HTTP trigger means auth proxy is not relevant, so the sidecar name is not reserved
+
+		// no HTTP trigger means the auth-proxy is not relevant, so none of its reservations apply
 		if errors.Is(err, functionconfig.ErrHTTPTriggerNotFound) {
-			return nil
+			return false, nil
 		}
-		return nuclio.WrapErrBadRequest(err)
+		return false, nuclio.WrapErrBadRequest(err)
 	}
 
-	if !functionconfig.IsAuthenticationEnabled(authMode) {
+	return functionconfig.IsAuthenticationEnabled(authMode), nil
+}
+
+// validateSidecarNameNotReserved rejects a user-supplied sidecar named abstract.AuthProxySidecarContainerName,
+// which is reserved for the platform-injected auth-proxy sidecar (see functionres.injectAuthProxySidecar).
+func (p *Platform) validateSidecarNameNotReserved(functionConfig *functionconfig.Config, sidecar *v1.Container) error {
+	authProxyEnabled, err := p.functionAuthenticationEnabled(functionConfig)
+	if err != nil {
+		return err
+	}
+	if !authProxyEnabled {
 		return nil
 	}
 
@@ -2270,24 +2283,15 @@ func (p *Platform) validateSidecarNameNotReserved(functionConfig *functionconfig
 	return nil
 }
 
-// validateSidecarPortNamesFreeForAuthProxy rejects a user-defined sidecar port name that the auth-proxy
-// sidecar will itself bind to front a sidecar port. Container-port names are unique within a pod
-func (p *Platform) validateSidecarPortNamesFreeForAuthProxy(functionConfig *functionconfig.Config,
+// validateSidecarPortNames rejects a user-defined sidecar port name that the auth-proxy sidecar will itself
+// bind to front a sidecar port. Container-port names are unique within a pod
+func (p *Platform) validateSidecarPortNames(functionConfig *functionconfig.Config,
 	portNames map[string]bool) error {
-	if !p.IsFunctionAuthenticationEnabled() {
-		return nil
-	}
-
-	authMode, err := functionconfig.GetHTTPTriggerMode(functionConfig.Spec.Triggers)
+	authProxyEnabled, err := p.functionAuthenticationEnabled(functionConfig)
 	if err != nil {
-		// no HTTP trigger means auth proxy is not relevant
-		if errors.Is(err, functionconfig.ErrHTTPTriggerNotFound) {
-			return nil
-		}
-		return nuclio.WrapErrBadRequest(err)
+		return err
 	}
-
-	if !functionconfig.IsAuthenticationEnabled(authMode) {
+	if !authProxyEnabled {
 		return nil
 	}
 
@@ -2310,11 +2314,11 @@ func authProxySidecarPortNames(functionConfig *functionconfig.Config) []string {
 
 	portNames := make([]string, 0, sidecarPortCount)
 	for portIndex := 0; portIndex < sidecarPortCount; portIndex++ {
-		listenPort := auth.AuthProxySidecarListenPortRangeStart + portIndex
-		if listenPort > auth.AuthProxySidecarListenPortRangeEnd {
+		listenPort := abstract.AuthProxySidecarListenPortRangeStart + portIndex
+		if listenPort > abstract.AuthProxySidecarListenPortRangeEnd {
 			break
 		}
-		portNames = append(portNames, auth.AuthProxySidecarPortName(listenPort))
+		portNames = append(portNames, abstract.AuthProxySidecarPortName(listenPort))
 	}
 	return portNames
 }
@@ -2346,6 +2350,11 @@ func (p *Platform) validateContainerPorts(functionConfig *functionconfig.Config,
 	portNames map[string]bool,
 	portNumbers map[int32]bool) error {
 	if container.Ports != nil {
+		authProxyEnabled, err := p.functionAuthenticationEnabled(functionConfig)
+		if err != nil {
+			return err
+		}
+
 		for _, port := range container.Ports {
 			// validate container port exists
 			if port.ContainerPort == 0 {
@@ -2364,22 +2373,11 @@ func (p *Platform) validateContainerPorts(functionConfig *functionconfig.Config,
 
 			// when function-level auth is active, the processor's loopback port and the band the auth-proxy
 			// listens on to front sidecar ports are also reserved
-			if p.IsFunctionAuthenticationEnabled() {
-				authMode, err := functionconfig.GetHTTPTriggerMode(functionConfig.Spec.Triggers)
-				if err != nil {
-					// if there is no HTTP trigger, no need to validate the auth-proxy's ports
-					if errors.Is(err, functionconfig.ErrHTTPTriggerNotFound) {
-						return nil
-					}
-					return nuclio.WrapErrBadRequest(err)
-				}
-				if functionconfig.IsAuthenticationEnabled(authMode) {
-					if port.ContainerPort == abstract.FunctionContainerHTTPLoopbackPort ||
-						(port.ContainerPort >= auth.AuthProxySidecarListenPortRangeStart &&
-							port.ContainerPort <= auth.AuthProxySidecarListenPortRangeEnd) {
-						return nuclio.NewErrBadRequest(fmt.Sprintf("Container port is reserved for Nuclio internal use: %d", port.ContainerPort))
-					}
-				}
+			if authProxyEnabled &&
+				(port.ContainerPort == abstract.FunctionContainerHTTPLoopbackPort ||
+					(port.ContainerPort >= abstract.AuthProxySidecarListenPortRangeStart &&
+						port.ContainerPort <= abstract.AuthProxySidecarListenPortRangeEnd)) {
+				return nuclio.NewErrBadRequest(fmt.Sprintf("Container port is reserved for Nuclio internal use: %d", port.ContainerPort))
 			}
 
 			// validate port name exists

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -2236,6 +2236,10 @@ func (p *Platform) validateSidecarSpec(functionConfig *functionconfig.Config) er
 		}
 	}
 
+	if err := p.validateSidecarPortNamesFreeForAuthProxy(functionConfig, portNames); err != nil {
+		return nuclio.WrapErrBadRequest(err)
+	}
+
 	return nil
 }
 
@@ -2264,6 +2268,55 @@ func (p *Platform) validateSidecarNameNotReserved(functionConfig *functionconfig
 			abstract.AuthProxySidecarContainerName))
 	}
 	return nil
+}
+
+// validateSidecarPortNamesFreeForAuthProxy rejects a user-defined sidecar port name that the auth-proxy
+// sidecar will itself bind to front a sidecar port. Container-port names are unique within a pod
+func (p *Platform) validateSidecarPortNamesFreeForAuthProxy(functionConfig *functionconfig.Config,
+	portNames map[string]bool) error {
+	if !p.IsFunctionAuthenticationEnabled() {
+		return nil
+	}
+
+	authMode, err := functionconfig.GetHTTPTriggerMode(functionConfig.Spec.Triggers)
+	if err != nil {
+		// no HTTP trigger means auth proxy is not relevant
+		if errors.Is(err, functionconfig.ErrHTTPTriggerNotFound) {
+			return nil
+		}
+		return nuclio.WrapErrBadRequest(err)
+	}
+
+	if !functionconfig.IsAuthenticationEnabled(authMode) {
+		return nil
+	}
+
+	for _, authProxyPortName := range authProxySidecarPortNames(functionConfig) {
+		if portNames[authProxyPortName] {
+			return nuclio.NewErrBadRequest(fmt.Sprintf(
+				"Port name is taken by the auth-proxy sidecar: %s", authProxyPortName))
+		}
+	}
+	return nil
+}
+
+// authProxySidecarPortNames returns the container-port names the auth-proxy sidecar will bind to front the
+// function's sidecar ports. The mapping is positional, so the names follow from the number of sidecar ports.
+func authProxySidecarPortNames(functionConfig *functionconfig.Config) []string {
+	sidecarPortCount := 0
+	for _, sidecar := range functionConfig.Spec.Sidecars {
+		sidecarPortCount += len(sidecar.Ports)
+	}
+
+	portNames := make([]string, 0, sidecarPortCount)
+	for portIndex := 0; portIndex < sidecarPortCount; portIndex++ {
+		listenPort := auth.AuthProxySidecarListenPortRangeStart + portIndex
+		if listenPort > auth.AuthProxySidecarListenPortRangeEnd {
+			break
+		}
+		portNames = append(portNames, auth.AuthProxySidecarPortName(listenPort))
+	}
+	return portNames
 }
 
 func (p *Platform) validateInitContainersSpec(functionConfig *functionconfig.Config) error {
@@ -2309,19 +2362,23 @@ func (p *Platform) validateContainerPorts(functionConfig *functionconfig.Config,
 				return nuclio.NewErrBadRequest(fmt.Sprintf("Container port %d is reserved for Nuclio internal use", port.ContainerPort))
 			}
 
-			// when function-level auth is active, the loopback port is also reserved
+			// when function-level auth is active, the processor's loopback port and the band the auth-proxy
+			// listens on to front sidecar ports are also reserved
 			if p.IsFunctionAuthenticationEnabled() {
 				authMode, err := functionconfig.GetHTTPTriggerMode(functionConfig.Spec.Triggers)
 				if err != nil {
-					// if there is no HTTP trigger, no need to validate the loopback port
+					// if there is no HTTP trigger, no need to validate the auth-proxy's ports
 					if errors.Is(err, functionconfig.ErrHTTPTriggerNotFound) {
 						return nil
 					}
 					return nuclio.WrapErrBadRequest(err)
 				}
-				if functionconfig.IsAuthenticationEnabled(authMode) &&
-					port.ContainerPort == abstract.FunctionContainerHTTPLoopbackPort {
-					return nuclio.NewErrBadRequest(fmt.Sprintf("Container port %d is reserved for Nuclio internal use", port.ContainerPort))
+				if functionconfig.IsAuthenticationEnabled(authMode) {
+					if port.ContainerPort == abstract.FunctionContainerHTTPLoopbackPort ||
+						(port.ContainerPort >= auth.AuthProxySidecarListenPortRangeStart &&
+							port.ContainerPort <= auth.AuthProxySidecarListenPortRangeEnd) {
+						return nuclio.NewErrBadRequest(fmt.Sprintf("Container port is reserved for Nuclio internal use: %d", port.ContainerPort))
+					}
 				}
 			}
 

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -2245,24 +2245,18 @@ func (p *Platform) validateSidecarSpec(functionConfig *functionconfig.Config) er
 
 // functionAuthenticationEnabled reports whether the auth-proxy sidecar will be injected in front of the
 // function - gated by the platform-wide feature flag AND the function's HTTP trigger declaring a
-// function-level authenticationMode. It decides which of the auth-proxy's reservations apply
-// (see functionres.lazyClient.functionAuthenticationEnabled, which gates the injection itself).
+// function-level authenticationMode.
 func (p *Platform) functionAuthenticationEnabled(functionConfig *functionconfig.Config) (bool, error) {
 	if !p.IsFunctionAuthenticationEnabled() {
 		return false, nil
 	}
 
-	authMode, err := functionconfig.GetHTTPTriggerMode(functionConfig.Spec.Triggers)
+	authenticationEnabled, err := functionconfig.AuthenticationEnabledForTriggers(functionConfig.Spec.Triggers)
 	if err != nil {
-
-		// no HTTP trigger means the auth-proxy is not relevant, so none of its reservations apply
-		if errors.Is(err, functionconfig.ErrHTTPTriggerNotFound) {
-			return false, nil
-		}
 		return false, nuclio.WrapErrBadRequest(err)
 	}
 
-	return functionconfig.IsAuthenticationEnabled(authMode), nil
+	return authenticationEnabled, nil
 }
 
 // validateSidecarNameNotReserved rejects a user-supplied sidecar named abstract.AuthProxySidecarContainerName,

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -799,6 +799,104 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateSidecarContainers() {
 	}
 }
 
+// TestValidateSidecarContainersWithFunctionAuthentication verifies the extra reservations that only apply
+// once the auth-proxy fronts the function's sidecar ports: the band it listens on, and the port names it
+// binds for the sidecar ports it fronts.
+func (suite *FunctionKubePlatformTestSuite) TestValidateSidecarContainersWithFunctionAuthentication() {
+	for _, testCase := range []struct {
+		name                 string
+		authenticationMode   auth.AuthenticationMode
+		ports                []v1.ContainerPort
+		shouldFailValidation bool
+	}{
+		{
+			name:               "port outside the reserved band is allowed",
+			authenticationMode: auth.AuthenticationModeAPI,
+			ports:              []v1.ContainerPort{{Name: "sidecar-port", ContainerPort: 8050}},
+		},
+		{
+			name:                 "port at the start of the reserved band is rejected",
+			authenticationMode:   auth.AuthenticationModeAPI,
+			ports:                []v1.ContainerPort{{Name: "sidecar-port", ContainerPort: auth.AuthProxySidecarListenPortRangeStart}},
+			shouldFailValidation: true,
+		},
+		{
+			name:                 "port at the end of the reserved band is rejected",
+			authenticationMode:   auth.AuthenticationModeAPI,
+			ports:                []v1.ContainerPort{{Name: "sidecar-port", ContainerPort: auth.AuthProxySidecarListenPortRangeEnd}},
+			shouldFailValidation: true,
+		},
+		{
+			name:               "port in the reserved band is allowed when authentication is off",
+			authenticationMode: auth.AuthenticationModeNone,
+			ports:              []v1.ContainerPort{{Name: "sidecar-port", ContainerPort: auth.AuthProxySidecarListenPortRangeStart}},
+		},
+		{
+			name:               "port name the auth-proxy will not bind is allowed",
+			authenticationMode: auth.AuthenticationModeAPI,
+			ports: []v1.ContainerPort{
+				{
+					Name:          auth.AuthProxySidecarPortName(auth.AuthProxySidecarListenPortRangeEnd),
+					ContainerPort: 8050,
+				},
+			},
+		},
+		{
+			name:               "port name the auth-proxy will bind is rejected",
+			authenticationMode: auth.AuthenticationModeAPI,
+			ports: []v1.ContainerPort{
+				{
+					Name:          auth.AuthProxySidecarPortName(auth.AuthProxySidecarListenPortRangeStart),
+					ContainerPort: 8050,
+				},
+			},
+			shouldFailValidation: true,
+		},
+		{
+			name:               "port name the auth-proxy would bind is allowed when authentication is off",
+			authenticationMode: auth.AuthenticationModeNone,
+			ports: []v1.ContainerPort{
+				{
+					Name:          auth.AuthProxySidecarPortName(auth.AuthProxySidecarListenPortRangeStart),
+					ContainerPort: 8050,
+				},
+			},
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			previousAuthentication := suite.platform.Config.Authentication
+			defer func() {
+				suite.platform.Config.Authentication = previousAuthentication
+			}()
+			suite.platform.Config.Authentication = &platformconfig.Authentication{
+				FunctionAuthenticationEnabled: true,
+			}
+
+			httpTrigger := functionconfig.GetDefaultHTTPTrigger()
+			httpTrigger.Attributes = map[string]interface{}{
+				auth.AttributeAuthenticationMode: string(testCase.authenticationMode),
+			}
+
+			functionConfig := *functionconfig.NewConfig()
+			functionConfig.Spec.Triggers = map[string]functionconfig.Trigger{"http": httpTrigger}
+			functionConfig.Spec.Sidecars = []*v1.Container{
+				{
+					Name:  "sidecar1",
+					Image: "nginx",
+					Ports: testCase.ports,
+				},
+			}
+
+			err := suite.platform.validateSidecarSpec(&functionConfig)
+			if testCase.shouldFailValidation {
+				suite.Require().Error(err, "Validation passed unexpectedly")
+			} else {
+				suite.Require().NoError(err, "Validation failed unexpectedly")
+			}
+		})
+	}
+}
+
 func (suite *FunctionKubePlatformTestSuite) TestEnrichContainerSpecEnvFrom() {
 	s3Secret := v1.EnvFromSource{
 		SecretRef: &v1.SecretEnvSource{

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -817,26 +817,26 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateSidecarContainersWithFun
 		{
 			name:                 "port at the start of the reserved band is rejected",
 			authenticationMode:   auth.AuthenticationModeAPI,
-			ports:                []v1.ContainerPort{{Name: "sidecar-port", ContainerPort: auth.AuthProxySidecarListenPortRangeStart}},
+			ports:                []v1.ContainerPort{{Name: "sidecar-port", ContainerPort: abstract.AuthProxySidecarListenPortRangeStart}},
 			shouldFailValidation: true,
 		},
 		{
 			name:                 "port at the end of the reserved band is rejected",
 			authenticationMode:   auth.AuthenticationModeAPI,
-			ports:                []v1.ContainerPort{{Name: "sidecar-port", ContainerPort: auth.AuthProxySidecarListenPortRangeEnd}},
+			ports:                []v1.ContainerPort{{Name: "sidecar-port", ContainerPort: abstract.AuthProxySidecarListenPortRangeEnd}},
 			shouldFailValidation: true,
 		},
 		{
 			name:               "port in the reserved band is allowed when authentication is off",
 			authenticationMode: auth.AuthenticationModeNone,
-			ports:              []v1.ContainerPort{{Name: "sidecar-port", ContainerPort: auth.AuthProxySidecarListenPortRangeStart}},
+			ports:              []v1.ContainerPort{{Name: "sidecar-port", ContainerPort: abstract.AuthProxySidecarListenPortRangeStart}},
 		},
 		{
 			name:               "port name the auth-proxy will not bind is allowed",
 			authenticationMode: auth.AuthenticationModeAPI,
 			ports: []v1.ContainerPort{
 				{
-					Name:          auth.AuthProxySidecarPortName(auth.AuthProxySidecarListenPortRangeEnd),
+					Name:          abstract.AuthProxySidecarPortName(abstract.AuthProxySidecarListenPortRangeEnd),
 					ContainerPort: 8050,
 				},
 			},
@@ -846,7 +846,7 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateSidecarContainersWithFun
 			authenticationMode: auth.AuthenticationModeAPI,
 			ports: []v1.ContainerPort{
 				{
-					Name:          auth.AuthProxySidecarPortName(auth.AuthProxySidecarListenPortRangeStart),
+					Name:          abstract.AuthProxySidecarPortName(abstract.AuthProxySidecarListenPortRangeStart),
 					ContainerPort: 8050,
 				},
 			},
@@ -857,7 +857,7 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateSidecarContainersWithFun
 			authenticationMode: auth.AuthenticationModeNone,
 			ports: []v1.ContainerPort{
 				{
-					Name:          auth.AuthProxySidecarPortName(auth.AuthProxySidecarListenPortRangeStart),
+					Name:          abstract.AuthProxySidecarPortName(abstract.AuthProxySidecarListenPortRangeStart),
 					ContainerPort: 8050,
 				},
 			},

--- a/pkg/platform/kube/test/function/function_test.go
+++ b/pkg/platform/kube/test/function/function_test.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"sort"
@@ -32,16 +33,19 @@ import (
 	"testing"
 	"time"
 
-	kubeclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
-
+	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
 	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platform/abstract"
 	"github.com/nuclio/nuclio/pkg/platform/kube"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+	kubeclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
 	kubesuite "github.com/nuclio/nuclio/pkg/platform/kube/test/suite"
 	"github.com/nuclio/nuclio/pkg/platformconfig"
 	"github.com/nuclio/nuclio/pkg/processor/build"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 	"github.com/nuclio/nuclio/pkg/processor/trigger/cron"
 
@@ -51,6 +55,7 @@ import (
 	"github.com/nuclio/errors"
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/suite"
+	"github.com/v3io/version-go"
 	appsv1 "k8s.io/api/apps/v1"
 	autosv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/api/core/v1"
@@ -1871,6 +1876,162 @@ func (suite *DeployFunctionTestSuite) TestDeployFromGitPythonRuntime() {
 	})
 }
 
+
+// TestDeployFunctionWithSidecarBasicAuth is TestDeployFunctionWithSidecarMultiplePorts with function-level
+// basic-auth turned on: the auth-proxy is injected and fronts every port the Service publishes - the
+// function's own and both of the sidecar's - so none of them can be reached without credentials.
+func (suite *DeployFunctionTestSuite) TestDeployFunctionWithSidecarBasicAuth() {
+	functionName := "func-with-sidecar-basic-auth"
+	username, password := "test-user", "test-123"
+
+	// restore whatever the suite was configured with, rather than assuming the zero value
+	originalAuthentication := *suite.PlatformConfiguration.Authentication
+	defer func() {
+		*suite.PlatformConfiguration.Authentication = originalAuthentication
+	}()
+
+	suite.PlatformConfiguration.Authentication.FunctionAuthenticationEnabled = true
+
+	// build and push the auth-proxy sidecar image the same way processor images are built in other
+	// integration tests, so the test doesn't depend on CI having pre-built and pre-pushed it
+	suite.PlatformConfiguration.Authentication.AuthSidecarImage = suite.buildAndPushAuthProxySidecarImage()
+
+	createFunctionOptions := suite.CompileCreateFunctionOptions(functionName)
+
+	sidecarContainerName := "sidecar-test"
+	commands := []string{
+		"sh",
+		"-c",
+		"for i in {1..10}; do echo $i; sleep 10; done; echo 'Done'",
+	}
+
+	// create a busybox sidecar, same as TestDeployFunctionWithSidecarMultiplePorts
+	createFunctionOptions.FunctionConfig.Spec.Sidecars = []*v1.Container{
+		{
+			Name:    sidecarContainerName,
+			Image:   "busybox",
+			Command: commands,
+			Ports: []v1.ContainerPort{{Name: "port-1", ContainerPort: 8050, Protocol: v1.ProtocolTCP},
+				{Name: "port-2", ContainerPort: 22, Protocol: v1.ProtocolTCP},
+			},
+		},
+	}
+
+	// the HTTP trigger's authentication mode is what makes the platform inject the auth-proxy in front of the pod
+	createFunctionOptions.FunctionConfig.Spec.Triggers = map[string]functionconfig.Trigger{
+		"http-with-auth": {
+			Kind: "http",
+			Attributes: map[string]interface{}{
+				auth.AttributeAuthenticationMode: string(auth.AuthenticationModeBasicAuth),
+				"authentication": map[string]interface{}{
+					"basicAuth": map[string]interface{}{
+						"username": username,
+						"password": password,
+					},
+				},
+			},
+		},
+	}
+
+	// keep plaintext passwords in the function config, so the test can validate the secret was created and mounted
+	createFunctionOptions.FunctionConfig.Spec.DisableSensitiveFieldsMasking = true
+
+	// pulling the proxy image and starting a third container might take longer than the default timeout
+	createFunctionOptions.FunctionConfig.Spec.ReadinessTimeoutSeconds = 240
+
+	suite.DeployFunction(createFunctionOptions, func(deployResult *platform.CreateFunctionResult) bool {
+		suite.Require().NotNil(deployResult)
+
+		// get the function pod and validate it has the sidecar
+		pods := suite.GetFunctionPods(functionName)
+		pod := pods[0]
+
+		suite.Require().Len(pod.Spec.Containers, 3)
+
+		resultSidecarContainer := suite.getContainer(pod.Spec.Containers, sidecarContainerName)
+		suite.Require().NotNil(resultSidecarContainer)
+		suite.Require().Equal(sidecarContainerName, resultSidecarContainer.Name)
+		suite.Require().Equal("busybox", resultSidecarContainer.Image)
+		suite.Require().Equal(commands, resultSidecarContainer.Command)
+		suite.Require().Equal(2, len(resultSidecarContainer.Ports))
+
+		// the processor and the sidecar keep binding the ports they always did, so the proxy takes ports of
+		// its own - one per published port
+		authproxySidecarContainer := suite.getContainer(pod.Spec.Containers, abstract.AuthProxySidecarContainerName)
+		suite.Require().NotNil(authproxySidecarContainer)
+		suite.Require().Equal(abstract.AuthProxySidecarContainerName, authproxySidecarContainer.Name)
+		suite.Require().Equal(3, len(authproxySidecarContainer.Ports))
+
+		// get the logs from the sidecar container to validate it ran
+		podLogOpts := v1.PodLogOptions{
+			Container: sidecarContainerName,
+		}
+		err := common.RetryUntilSuccessful(20*time.Second, 1*time.Second, func() bool {
+			return suite.validatePodLogsContainData(pod.Name, &podLogOpts, []string{"Done"})
+		})
+		suite.Require().NoError(err)
+
+		for _, testCase := range []struct {
+			portName string
+			port     int32
+
+			// the auth-proxy listen port the service now targets, instead of the container's own port
+			targetPort int32
+
+			// busybox listens on neither of its declared ports, so an authorized request there gets past the
+			// gate and fails on the proxy's upstream dial - which is the point: the gate is no longer the
+			// sidecar's own port
+			authorizedStatusCode int
+		}{
+			{
+				portName:             abstract.FunctionContainerHTTPPortName,
+				port:                 abstract.FunctionContainerHTTPPort,
+				targetPort:           abstract.AuthProxyProcessorListenPort,
+				authorizedStatusCode: http.StatusOK,
+			},
+			{
+				portName:             "port-1",
+				port:                 8050,
+				targetPort:           abstract.AuthProxySidecarListenPortRangeStart,
+				authorizedStatusCode: http.StatusBadGateway,
+			},
+			{
+				portName:             "port-2",
+				port:                 22,
+				targetPort:           abstract.AuthProxySidecarListenPortRangeStart + 1,
+				authorizedStatusCode: http.StatusBadGateway,
+			},
+		} {
+			servicePort := suite.getFunctionServicePort(functionName, testCase.portName)
+
+			// the published port number is unchanged; only its target moves to the auth-proxy
+			suite.Require().Equal(testCase.port, servicePort.Port, "portName: %s", testCase.portName)
+			suite.Require().Equal(testCase.targetPort, servicePort.TargetPort.IntVal,
+				"portName: %s", testCase.portName)
+			suite.Require().NotZero(servicePort.NodePort, "portName: %s", testCase.portName)
+
+			// retry the authorized request, so the assertions below are not racing endpoint propagation or
+			// the proxy's first accept
+			err = common.RetryUntilSuccessful(90*time.Second, 2*time.Second, func() bool {
+				return suite.invokeFunctionNodePort(servicePort.NodePort, username, password) ==
+					testCase.authorizedStatusCode
+			})
+			suite.Require().NoError(err, "Port did not answer the authorized status code; portName: %s",
+				testCase.portName)
+
+			// with no credentials, and with the wrong ones, the proxy rejects before the upstream is reached
+			suite.Require().Equal(http.StatusUnauthorized,
+				suite.invokeFunctionNodePort(servicePort.NodePort, "", ""),
+				"portName: %s", testCase.portName)
+			suite.Require().Equal(http.StatusUnauthorized,
+				suite.invokeFunctionNodePort(servicePort.NodePort, username, "wrong-password"),
+				"portName: %s", testCase.portName)
+		}
+
+		return true
+	})
+}
+
 func (suite *DeployFunctionTestSuite) createPlatformConfigmapWithJSONLogger() *v1.ConfigMap {
 
 	// create a platform config configmap with a json logger sink (this is how it is on production)
@@ -1925,6 +2086,89 @@ func (suite *DeployFunctionTestSuite) validatePodLogsContainData(podName string,
 	return false
 }
 
+// getFunctionServicePort returns the function service's port by name.
+func (suite *DeployFunctionTestSuite) getFunctionServicePort(functionName, portName string) v1.ServicePort {
+	serviceInstance := &v1.Service{}
+	suite.GetResourceAndUnmarshal("service", kube.ServiceNameFromFunctionName(functionName), serviceInstance)
+
+	for _, servicePort := range serviceInstance.Spec.Ports {
+		if servicePort.Name == portName {
+			return servicePort
+		}
+	}
+
+	suite.Require().Fail("Service has no such port", "portName: %s", portName)
+	return v1.ServicePort{}
+}
+
+// invokeFunctionNodePort issues a request to a service node port and returns the status code. Going through
+// the service is the point: the request lands on whatever the port's targetPort points at - the auth-proxy,
+// once function-level authentication is on. An empty username sends no credentials at all. The path is "/"
+// rather than the health path, which the proxy serves unauthenticated on every route.
+func (suite *DeployFunctionTestSuite) invokeFunctionNodePort(nodePort int32, username, password string) int {
+	request, err := http.NewRequest(http.MethodGet,
+		fmt.Sprintf("http://%s:%d/", suite.GetNuclioExternalIP(), nodePort),
+		nil)
+	suite.Require().NoError(err)
+	if username != "" {
+		request.SetBasicAuth(username, password)
+	}
+
+	response, err := (&http.Client{Timeout: 10 * time.Second}).Do(request)
+	if err != nil {
+		suite.Logger.WarnWith("Failed to invoke function node port",
+			"nodePort", nodePort,
+			"err", err.Error())
+		return 0
+	}
+	defer response.Body.Close() // nolint: errcheck
+
+	return response.StatusCode
+}
+
+func (suite *DeployFunctionTestSuite) getContainer(containers []v1.Container, containerName string) *v1.Container {
+	for _, container := range containers {
+		if container.Name == containerName {
+			return &container
+		}
+	}
+	return nil
+}
+
+// buildAndPushAuthProxySidecarImage builds and pushes the auth-proxy sidecar image via the same
+// platform.BuildAndPushContainerImage primitive processor images are built with (see buildTestFunction),
+func (suite *DeployFunctionTestSuite) buildAndPushAuthProxySidecarImage() string {
+	err := suite.Platform.InitializeContainerBuilder()
+	suite.Require().NoError(err)
+
+	taggedImageName := fmt.Sprintf("auth-proxy:%s-%s",
+		common.GetEnvOrDefaultString("NUCLIO_LABEL", "latest"),
+		version.Get().Arch)
+
+	err = suite.Platform.BuildAndPushContainerImage(suite.Ctx,
+		&containerimagebuilderpusher.BuildOptions{
+			ContextDir: suite.GetNuclioSourceDir(),
+			Image:      taggedImageName,
+			DockerfileInfo: &runtime.ProcessorDockerfileInfo{
+				DockerfilePath: "cmd/authproxy/Dockerfile",
+			},
+			RegistryURL: suite.RegistryURL,
+			BuildArgs: map[string]string{
+				"ALPINE_IMAGE": common.GetEnvOrDefaultString("NUCLIO_DOCKER_ALPINE_IMAGE",
+					"gcr.io/iguazio/alpine:3.23"),
+				"NUCLIO_DOCKER_REPO": fmt.Sprintf("%s/%s",
+					common.GetEnvOrDefaultString("REPO", "quay.io"),
+					common.GetEnvOrDefaultString("REPO_NAME", "nuclio")),
+				"NUCLIO_DOCKER_IMAGE_TAG": fmt.Sprintf("%s-%s",
+					common.GetEnvOrDefaultString("NUCLIO_LABEL", "latest"),
+					version.Get().Arch),
+			},
+		})
+	suite.Require().NoError(err)
+
+	return fmt.Sprintf("%s/%s", suite.RegistryURL, taggedImageName)
+}
+
 type DeleteFunctionTestSuite struct {
 	kubesuite.KubeTestSuite
 }
@@ -1936,7 +2180,7 @@ func (suite *DeleteFunctionTestSuite) TestDeleteFunctionWhichHasApiGateway() {
 		apiGatewayName := "func-apigw"
 		createAPIGatewayOptions := suite.CompileCreateAPIGatewayOptions(apiGatewayName, functionName)
 		err := suite.DeployAPIGateway(createAPIGatewayOptions, func(ingress *networkingv1.Ingress) {
-			suite.Assert().Contains(ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Name, functionName)
+			suite.Assert().Contains(ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name, functionName)
 
 			// try to delete the function while it uses this api gateway without DeleteApiGateways flag
 			err := suite.Platform.DeleteFunction(suite.Ctx, &platform.DeleteFunctionOptions{


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

Extends the auth-proxy sidecar to front **every** port a function publishes, not just the main HTTP port.

Until now the sidecar owned port 8080 and forwarded to the processor on the pod-local loopback (6080), but a function's user-defined sidecar ports were still published by the Service straight to the sidecar containers. An in-cluster caller reaching one of those ports bypassed authentication entirely. This PR makes a single auth-proxy process serve one listener per published port — the function's own, plus one per user sidecar port — each forwarding to its own pod-local upstream.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

- `pkg/auth/authproxy/route.go` (new) — `Route` (listen port + upstream URL), shared by both ends of the wire: the controller renders it into the sidecar's `--routes` argument.
- `cmd/authproxy/main.go`, `app/config.go` — replaced `--listen-port` / `--upstream-url` with a single `--routes` flag.
- `cmd/authproxy/app/authproxy.go`, `server.go` — `newServers` builds one `http.Server` per route; `startServers` runs them under an `errgroup` and is all-or-nothing: a listener that fails to bind closes the others and returns the error, so a Service port is never left without a proxy behind it
- `pkg/platform/kube/functionres/lazy.go` — `authProxySidecarPortMapping` assigns each user sidecar port a proxy listen port from a reserved band (a sidecar keeps binding its own port, so the proxy cannot reuse it).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

Manual: verified on a dev environment that existing function-level authentication still works.

Unit tests:
- `cmd/authproxy/app/config_test.go` — route validation across both modes: single and multi-port `reverseProxy`, `authOnly` with a port only, no routes, out-of-range and well-known ports, duplicate listen port, missing upstream, and `authOnly` given an upstream or several routes
- `pkg/platform/kube/functionres/lazy_test.go` — listen-port assignment, the generated `--routes` argument and container ports, Service `targetPort` repointing with auth on and off, and failure when a sidecar port cannot be fronted
- `pkg/platform/kube/platform_test.go` — reserved-band and port-name-collision validation, both with function-level auth on and off

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-879
- Design docs links:
- External links: https://github.com/nuclio/nuclio/pull/4234#discussion_r3676865191

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

The auth-proxy's flags changed, but they are not a user-facing surface: the sidecar's args are generated by the controller in this same repo and both are released together, so nothing downstream needs updating.

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
- **Listen ports are assigned in spec order**, so reordering sidecars in the function spec reshuffles the mapping and rolls the deployment. Reordering already rolls it (container order changes), so this only affects which proxy port fronts which sidecar port.
- **The band holds 119 ports (6081–6199)**, so exhausting it takes 120+ sidecar ports on a single function. That case fails the reconcile with an error in the controller log rather than a 400 at deploy time; there is deliberately no API-level cap for a limit this far out of reach.
