### PR TITLE
[Git] Support mutual TLS client certificates for the git code-entry type

### DIFF
--- a/docs/reference/function-configuration/code-entry-types.md
+++ b/docs/reference/function-configuration/code-entry-types.md
@@ -159,6 +159,11 @@ Set the [`spec.build.codeEntryType`](function-configuration-reference.md) functi
       - `workDir` (dashboard: **Work directory**) (Optional) &mdash; the relative path to the function-code directory within the configured repository.
       The default work directory is the root directory of the git repository (`"/"`).
 
+      // mutual-TLS, for a Git server that requires a client certificate
+      - `clientCert` (Optional) &mdash; a PEM-encoded client certificate to present to the Git server.
+      - `clientKey` (Optional) &mdash; the PEM-encoded private key matching `clientCert`.
+      - `caBundle` (Optional) &mdash; a PEM-encoded CA bundle used, together with the system cert pool, to verify the Git server's certificate. Only needed when the server's certificate isn't already trusted by the system pool (for example, a self-signed or internal CA).
+
 #### Examples of git code entry type
 
 Using Branch:
@@ -206,6 +211,32 @@ spec:
     codeEntryAttributes:
       workDir: "/go-function"
       reference: "refs/heads/go-func"
+```
+
+Using a client certificate (mutual TLS):
+```yaml
+spec:
+  description: my Go function
+  handler: main:Handler
+  runtime: golang
+  build:
+    codeEntryType: "git"
+    path: "https://git.example.com/<my-user>/<my-repo>"
+    codeEntryAttributes:
+      branch: "main"
+      clientCert: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+      clientKey: |
+        -----BEGIN PRIVATE KEY-----
+        ...
+        -----END PRIVATE KEY-----
+      # Only needed if the server's certificate isn't already trusted by the system cert pool
+      caBundle: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
 ```
 
 ### GitHub code-entry type

--- a/docs/reference/function-configuration/code-entry-types.md
+++ b/docs/reference/function-configuration/code-entry-types.md
@@ -159,7 +159,7 @@ Set the [`spec.build.codeEntryType`](function-configuration-reference.md) functi
       - `workDir` (dashboard: **Work directory**) (Optional) &mdash; the relative path to the function-code directory within the configured repository.
       The default work directory is the root directory of the git repository (`"/"`).
 
-      // mutual-TLS, for a Git server that requires a client certificate
+      **Mutual TLS (client certificates):**
       - `clientCert` (Optional) &mdash; a PEM-encoded client certificate to present to the Git server.
       - `clientKey` (Optional) &mdash; the PEM-encoded private key matching `clientCert`.
       - `caBundle` (Optional) &mdash; a PEM-encoded CA bundle used, together with the system cert pool, to verify the Git server's certificate. Only needed when the server's certificate isn't already trusted by the system pool (for example, a self-signed or internal CA).

--- a/pkg/common/git/git.go
+++ b/pkg/common/git/git.go
@@ -77,31 +77,49 @@ func (agc *AbstractClient) Clone(outputDir, repositoryURL string, attributes *At
 		return agc.cloneFromAzureDevops(outputDir, repositoryURL, referenceName, gitAuth, agc.cmdRunner)
 	}
 
-	return agc.clone(outputDir, repositoryURL, referenceName, gitAuth)
+	return agc.clone(outputDir, repositoryURL, referenceName, gitAuth, attributes)
 }
 
 func (agc *AbstractClient) clone(outputDir string,
 	repositoryURL string,
 	referenceName string,
-	gitAuth transport.AuthMethod) error {
+	gitAuth transport.AuthMethod,
+	attributes *Attributes) error {
 
 	agc.logger.DebugWith("Cloning",
 		"outputDir", outputDir,
 		"referenceName", referenceName,
 		"repositoryURL", repositoryURL)
 
-	if _, err := git.PlainClone(outputDir, false, &git.CloneOptions{
-		URL:           repositoryURL,
-		ReferenceName: plumbing.ReferenceName(referenceName),
-		Depth:         1,
-		Auth:          gitAuth,
-	}); err != nil {
+	if _, err := git.PlainClone(outputDir, false, buildCloneOptions(repositoryURL, referenceName, gitAuth, attributes)); err != nil {
 		return errors.Wrap(err, "Failed to clone git repository")
 	}
 
 	agc.logCurrentCommitSHA(outputDir, repositoryURL, referenceName)
 
 	return nil
+}
+
+// buildCloneOptions is split out from clone() so the mapping from Attributes onto
+// git.CloneOptions -- in particular the mutual-TLS fields -- can be unit-tested without
+// actually cloning a repository.
+func buildCloneOptions(repositoryURL string,
+	referenceName string,
+	gitAuth transport.AuthMethod,
+	attributes *Attributes) *git.CloneOptions {
+
+	return &git.CloneOptions{
+		URL:           repositoryURL,
+		ReferenceName: plumbing.ReferenceName(referenceName),
+		Depth:         1,
+		Auth:          gitAuth,
+
+		// mutual TLS: a client cert/key to present to the server, and/or an additional CA
+		// bundle to verify the server's certificate against (together with the system pool).
+		ClientCert: []byte(attributes.ClientCert),
+		ClientKey:  []byte(attributes.ClientKey),
+		CABundle:   []byte(attributes.CABundle),
+	}
 }
 
 func (agc *AbstractClient) cloneFromAzureDevops(outputDir string,

--- a/pkg/common/git/git.go
+++ b/pkg/common/git/git.go
@@ -91,7 +91,7 @@ func (agc *AbstractClient) clone(outputDir string,
 		"referenceName", referenceName,
 		"repositoryURL", repositoryURL)
 
-	if _, err := git.PlainClone(outputDir, false, buildCloneOptions(repositoryURL, referenceName, gitAuth, attributes)); err != nil {
+	if _, err := git.PlainClone(outputDir, false, agc.buildCloneOptions(repositoryURL, referenceName, gitAuth, attributes)); err != nil {
 		return errors.Wrap(err, "Failed to clone git repository")
 	}
 
@@ -103,7 +103,7 @@ func (agc *AbstractClient) clone(outputDir string,
 // buildCloneOptions is split out from clone() so the mapping from Attributes onto
 // git.CloneOptions -- in particular the mutual-TLS fields -- can be unit-tested without
 // actually cloning a repository.
-func buildCloneOptions(repositoryURL string,
+func (agc *AbstractClient) buildCloneOptions(repositoryURL string,
 	referenceName string,
 	gitAuth transport.AuthMethod,
 	attributes *Attributes) *git.CloneOptions {

--- a/pkg/common/git/types.go
+++ b/pkg/common/git/types.go
@@ -22,4 +22,11 @@ type Attributes struct {
 	Reference string `json:"reference,omitempty"`
 	Username  string `json:"username,omitempty"`
 	Password  string `json:"password,omitempty"`
+
+	// ClientCert and ClientKey are a PEM-encoded certificate/key pair presented for mutual TLS
+	// authentication to the git server. CABundle is an additional PEM-encoded CA bundle used
+	// (together with the system cert pool) to verify the server's certificate.
+	ClientCert string `json:"clientCert,omitempty"`
+	ClientKey  string `json:"clientKey,omitempty"`
+	CABundle   string `json:"caBundle,omitempty"`
 }

--- a/pkg/common/git/types_test.go
+++ b/pkg/common/git/types_test.go
@@ -80,7 +80,7 @@ func (suite *AttributesTestSuite) TestBuildCloneOptionsSetsMTLSFields() {
 		CABundle:   "ca-pem",
 	}
 
-	options := buildCloneOptions("https://example.com/repo.git", "refs/heads/main", nil, attributes)
+	options := (&AbstractClient{}).buildCloneOptions("https://example.com/repo.git", "refs/heads/main", nil, attributes)
 
 	suite.Require().Equal("https://example.com/repo.git", options.URL)
 	suite.Require().Equal([]byte("cert-pem"), options.ClientCert)
@@ -89,7 +89,7 @@ func (suite *AttributesTestSuite) TestBuildCloneOptionsSetsMTLSFields() {
 }
 
 func (suite *AttributesTestSuite) TestBuildCloneOptionsLeavesMTLSFieldsEmptyWhenUnset() {
-	options := buildCloneOptions("https://example.com/repo.git", "refs/heads/main", nil, &Attributes{})
+	options := (&AbstractClient{}).buildCloneOptions("https://example.com/repo.git", "refs/heads/main", nil, &Attributes{})
 
 	suite.Require().Empty(options.ClientCert)
 	suite.Require().Empty(options.ClientKey)

--- a/pkg/common/git/types_test.go
+++ b/pkg/common/git/types_test.go
@@ -1,0 +1,101 @@
+//go:build test_unit
+
+/*
+Copyright 2023 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package git
+
+import (
+	"testing"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/suite"
+)
+
+type AttributesTestSuite struct {
+	suite.Suite
+}
+
+// TestDecodeCodeEntryAttributesWithMTLSFields mirrors how builder.go's parseGitAttributes
+// decodes spec.build.codeEntryAttributes (a map[string]interface{} straight out of the
+// function config) into an Attributes struct, to guard the json tags that mapstructure's
+// default case-insensitive field matching relies on.
+func (suite *AttributesTestSuite) TestDecodeCodeEntryAttributesWithMTLSFields() {
+	codeEntryAttributes := map[string]interface{}{
+		"branch":     "main",
+		"username":   "myuser",
+		"password":   "mypassword",
+		"clientCert": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+		"clientKey":  "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----",
+		"caBundle":   "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+	}
+
+	var attributes Attributes
+	err := mapstructure.Decode(codeEntryAttributes, &attributes)
+	suite.Require().NoError(err)
+
+	suite.Require().Equal("main", attributes.Branch)
+	suite.Require().Equal("myuser", attributes.Username)
+	suite.Require().Equal("mypassword", attributes.Password)
+	suite.Require().Equal("-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----", attributes.ClientCert)
+	suite.Require().Equal("-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----", attributes.ClientKey)
+	suite.Require().Equal("-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----", attributes.CABundle)
+}
+
+func (suite *AttributesTestSuite) TestDecodeCodeEntryAttributesWithoutMTLSFieldsLeavesThemEmpty() {
+	codeEntryAttributes := map[string]interface{}{
+		"branch": "main",
+	}
+
+	var attributes Attributes
+	err := mapstructure.Decode(codeEntryAttributes, &attributes)
+	suite.Require().NoError(err)
+
+	suite.Require().Empty(attributes.ClientCert)
+	suite.Require().Empty(attributes.ClientKey)
+	suite.Require().Empty(attributes.CABundle)
+}
+
+// TestBuildCloneOptionsSetsMTLSFields guards against a future refactor of buildCloneOptions
+// (e.g. reordering fields, or swapping ClientCert/ClientKey) silently breaking mutual TLS --
+// git.PlainClone itself isn't mockable, so this is the only seam that can catch that class of
+// regression without a real git server.
+func (suite *AttributesTestSuite) TestBuildCloneOptionsSetsMTLSFields() {
+	attributes := &Attributes{
+		ClientCert: "cert-pem",
+		ClientKey:  "key-pem",
+		CABundle:   "ca-pem",
+	}
+
+	options := buildCloneOptions("https://example.com/repo.git", "refs/heads/main", nil, attributes)
+
+	suite.Require().Equal("https://example.com/repo.git", options.URL)
+	suite.Require().Equal([]byte("cert-pem"), options.ClientCert)
+	suite.Require().Equal([]byte("key-pem"), options.ClientKey)
+	suite.Require().Equal([]byte("ca-pem"), options.CABundle)
+}
+
+func (suite *AttributesTestSuite) TestBuildCloneOptionsLeavesMTLSFieldsEmptyWhenUnset() {
+	options := buildCloneOptions("https://example.com/repo.git", "refs/heads/main", nil, &Attributes{})
+
+	suite.Require().Empty(options.ClientCert)
+	suite.Require().Empty(options.ClientKey)
+	suite.Require().Empty(options.CABundle)
+}
+
+func TestAttributesTestSuite(t *testing.T) {
+	suite.Run(t, new(AttributesTestSuite))
+}

--- a/pkg/common/git/types_test.go
+++ b/pkg/common/git/types_test.go
@@ -1,7 +1,7 @@
 //go:build test_unit
 
 /*
-Copyright 2023 The Nuclio Authors.
+Copyright 2026 The Nuclio Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/common/git/types_test.go
+++ b/pkg/common/git/types_test.go
@@ -31,8 +31,8 @@ type AttributesTestSuite struct {
 
 // TestDecodeCodeEntryAttributesWithMTLSFields mirrors how builder.go's parseGitAttributes
 // decodes spec.build.codeEntryAttributes (a map[string]interface{} straight out of the
-// function config) into an Attributes struct, to guard the json tags that mapstructure's
-// default case-insensitive field matching relies on.
+// function config) into an Attributes struct, to ensure the expected keys (clientCert,
+// clientKey, caBundle) decode correctly with mapstructure's default matching.
 func (suite *AttributesTestSuite) TestDecodeCodeEntryAttributesWithMTLSFields() {
 	codeEntryAttributes := map[string]interface{}{
 		"branch":     "main",

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -452,6 +452,7 @@ func (sfc *SensitiveFieldsConfig) GetDefaultSensitiveFields() []string {
 
 		// build
 		"^/spec/build/codeentryattributes/password$",
+		"^/spec/build/codeentryattributes/clientkey$",
 		"^/spec/build/codeentryattributes/s3secretaccesskey$",
 		"^/spec/build/codeentryattributes/s3sessiontoken$",
 		"^/spec/build/codeentryattributes/headers/authorization$",

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1759,7 +1759,16 @@ func (b *Builder) cloneFunctionFromGit(outputDir, repositoryURL string) error {
 		return errors.Wrap(err, "Failed to parse git attributes")
 	}
 
-	b.logger.DebugWith("Parsed git attributes", "gitAttributes", gitAttributes)
+	// avoid logging the full struct: Password and ClientKey carry secret/private-key material
+	b.logger.DebugWith("Parsed git attributes",
+		"branch", gitAttributes.Branch,
+		"tag", gitAttributes.Tag,
+		"reference", gitAttributes.Reference,
+		"hasUsername", gitAttributes.Username != "",
+		"hasPassword", gitAttributes.Password != "",
+		"hasClientCert", gitAttributes.ClientCert != "",
+		"hasClientKey", gitAttributes.ClientKey != "",
+		"hasCABundle", gitAttributes.CABundle != "")
 
 	return b.gitClient.Clone(outputDir, repositoryURL, gitAttributes)
 }


### PR DESCRIPTION
### 📝 Description

Fixes #4250.

Some Git servers require clients to present an X.509 certificate during the TLS handshake — a common setup for self-hosted Git (Gitea/GitLab/Gogs) behind a reverse proxy, e.g. nginx with `ssl_verify_client on` or ingress-nginx with `auth-tls-verify-client: "on"`. `codeEntryType: git` offers only `username`/`password`, so a clone from such a repository is rejected during the handshake itself, before application-level credentials are ever evaluated:

```
Failed to clone git repository
    /nuclio/pkg/common/git/git.go:106
Failed to download function from git
    /nuclio/pkg/processor/build/builder.go:1693
```

The same applies to a Git server whose certificate is signed by an internal or self-signed CA that isn't in the system trust store — there was no way to supply an additional CA bundle for the clone (the server-verification half of #3555).

The underlying library already supports both. `pkg/common/git/git.go` clones via go-git's `git.PlainClone`, and `git.CloneOptions` has had `ClientCert`, `ClientKey` and `CABundle` for a long time — go-git builds a dedicated `http.Transport` per clone from them (`plumbing/transport/http/common.go`, `transportWithClientCert` / `transportWithCABundle`). Nuclio's own `Attributes` struct simply never exposed them, and `clone()` never passed them through.

---

### 🛠️ Changes Made

- `pkg/common/git/types.go`: three new optional `Attributes` fields — `clientCert`, `clientKey` (PEM client certificate/key presented for mutual TLS) and `caBundle` (an additional PEM CA bundle used together with the system cert pool to verify the server). They decode from `spec.build.codeEntryAttributes` through the existing `mapstructure` path in `builder.go`'s `parseGitAttributes`, so no plumbing beyond the struct is needed.
- `pkg/common/git/git.go`: pass the three fields into `git.PlainClone`. The `git.CloneOptions` construction is split out into a small `buildCloneOptions` helper — `git.PlainClone` isn't mockable, so this is the only seam at which the mapping can be unit-tested, and a swapped `ClientCert`/`ClientKey` would otherwise compile fine and fail only against a live mTLS server.
- `pkg/platformconfig/types.go`: add `^/spec/build/codeentryattributes/clientkey$` to `GetDefaultSensitiveFields()`, alongside the existing `password` entry, since it carries private key material. `clientCert` and `caBundle` are public and are left unmasked.
- `docs/reference/function-configuration/code-entry-types.md`: document the three attributes and add a mutual-TLS example.

`InsecureSkipTLS`, also available on `CloneOptions`, is deliberately **not** exposed here: the intent is to make it possible to specify certificates properly, not to add a verification bypass. Happy to look at it separately if maintainers want it.

---

### ✅ Checklist
- [X] I updated the documentation (if applicable)
- [X] I have tested the changes in this PR

---

### 🧪 Testing

**Unit** (`make test-unit`) — new `pkg/common/git/types_test.go`:
- decoding a `codeEntryAttributes` map through the same `mapstructure.Decode` call `parseGitAttributes` uses, asserting the three fields land on `Attributes` (and a companion case asserting they stay empty when absent);
- `buildCloneOptions` mapping `Attributes` onto `git.CloneOptions`, asserting `ClientCert`/`ClientKey`/`CABundle` are set from the right sources, plus a case asserting they stay empty when unset.

Full suite passes (1638 tests, 5 pre-existing skips); `make lint` reports no issues in the changed packages.

**Manual, end-to-end** — against a self-hosted Gitea behind ingress-nginx with `auth-tls-verify-client: "on"` and cert-manager-issued server/client certificates, on a kind cluster:

- Function with `codeEntryType: git` pointing at the Gitea repo through the mTLS-enforcing ingress, with `clientCert`/`clientKey`/`caBundle` set → clone, build and deploy succeed; invoking returns the expected response.
- Same function with `clientCert` blanked → the clone fails with `status code: 400`, which is exactly what the ingress returns for any TLS connection presenting no client certificate. Confirms the fields genuinely reach the handshake rather than being silently ignored.

**Regression check that the ordinary, non-mTLS path is unaffected** — a function deployed from the public `https://github.com/nuclio/nuclio` over HTTPS with no credentials and none of the new fields set:

```yaml
build:
  codeEntryType: git
  path: https://github.com/nuclio/nuclio
  codeEntryAttributes:
    branch: development
    workDir: hack/examples/python/helloworld
```

Clone, build and deploy succeed and the function returns `Hello, from nuclio :]`; `spec.description` is picked up from that directory's own `function.yaml`, so the `workDir` config merge is exercised too. Mechanically, unset fields are passed as zero-length slices and go-git's `configureTransport` only touches `TLSClientConfig` when `len(...) > 0`, so the transport is built exactly as before.

---

### 🔗 References
- Ticket link: #4250
- Related: #3555 (same area, but about server-certificate trust rather than client certificates)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [X] No

Purely additive optional attributes. With none of them set the `CloneOptions` are equivalent to the previous ones, and behavior is unchanged.

---

### 🔍️ Additional Notes

The mutual-TLS attributes apply to the standard go-git clone path. The Azure DevOps branch (`cloneFromAzureDevops`) shells out to the `git` binary as a workaround for go-git/go-git#64 and takes its own route; wiring client certificates through it would mean materialising the PEM values to temp files for `http.sslCert`/`http.sslKey`, which felt out of scope here. Happy to add it if it's wanted.
