### PR TITLE
[DLX] Add authenticator to DLX on startup

### DIFF
--- a/cmd/authproxy/app/server.go
+++ b/cmd/authproxy/app/server.go
@@ -129,14 +129,8 @@ func newReverseProxyHandler(parentLogger logger.Logger,
 	}), nil
 }
 
-// newAuthOnlyHandler serves the DLX's decision endpoint: 200 when authorized, and on reject whatever
-// the authenticator already wrote (401/302/403).
-//
-// Every path is answered rather than just a fixed /auth, because the DLX asks about a request by
-// replaying the caller's own request line to this listener. That is what lets browser-mode redirects
-// point back at the URL the caller actually requested, with no out-of-band header carrying it. Serving
-// any path is safe here: the listener is bound to pod loopback and forwards nothing - it only ever
-// returns a verdict.
+// newAuthOnlyHandler serves the DLX decision endpoint, returning the authenticator's response on reject
+// and 200 on success. It handles any path because the DLX replays the original request to preserve its URL for browser redirects.
 func newAuthOnlyHandler(authenticator authproxy.Authenticator) http.Handler {
 	return http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
 		if authenticator.Authenticate(responseWriter, request) {

--- a/cmd/authproxy/app/server.go
+++ b/cmd/authproxy/app/server.go
@@ -129,16 +129,20 @@ func newReverseProxyHandler(parentLogger logger.Logger,
 	}), nil
 }
 
-// newAuthOnlyHandler serves the DLX /auth decision endpoint. Only /auth is routed; any other path 404s.
-// It returns 200 when authorized; on reject the authenticator already wrote the 401/302/403 response.
+// newAuthOnlyHandler serves the DLX's decision endpoint: 200 when authorized, and on reject whatever
+// the authenticator already wrote (401/302/403).
+//
+// Every path is answered rather than just a fixed /auth, because the DLX asks about a request by
+// replaying the caller's own request line to this listener. That is what lets browser-mode redirects
+// point back at the URL the caller actually requested, with no out-of-band header carrying it. Serving
+// any path is safe here: the listener is bound to pod loopback and forwards nothing - it only ever
+// returns a verdict.
 func newAuthOnlyHandler(authenticator authproxy.Authenticator) http.Handler {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/auth", func(responseWriter http.ResponseWriter, request *http.Request) {
+	return http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
 		if authenticator.Authenticate(responseWriter, request) {
 			responseWriter.WriteHeader(http.StatusOK)
 		}
 	})
-	return mux
 }
 
 // startServers starts every server concurrently, so a single auth-proxy process fronts all of a function's ports.

--- a/cmd/authproxy/app/server_test.go
+++ b/cmd/authproxy/app/server_test.go
@@ -224,7 +224,8 @@ func (suite *ServerTestSuite) TestReverseProxyReadinessAllowlisted() {
 	suite.Require().Equal(0, authenticator.calls)
 }
 
-// TestAuthOnlyHandler verifies /auth returns 200 when authorized, the reject code otherwise, and 404 elsewhere.
+// TestAuthOnlyHandler verifies the decision endpoint returns 200 when authorized and the reject code
+// otherwise, on whatever path the request arrives - the DLX replays the caller's own request line.
 func (suite *ServerTestSuite) TestAuthOnlyHandler() {
 	suite.Run("authorized returns 200", func() {
 		handler := newAuthOnlyHandler(&fakeAuthenticator{authorized: true})
@@ -238,10 +239,17 @@ func (suite *ServerTestSuite) TestAuthOnlyHandler() {
 		suite.Require().Equal(http.StatusUnauthorized, statusCode)
 	})
 
-	suite.Run("other paths are not routed", func() {
+	// a scaled-to-zero function is invoked on its own path, and that path is what reaches this listener
+	suite.Run("a caller path is authorized like any other", func() {
 		handler := newAuthOnlyHandler(&fakeAuthenticator{authorized: true})
-		statusCode, _ := suite.doRequest(handler, "/invoke")
-		suite.Require().Equal(http.StatusNotFound, statusCode)
+		statusCode, _ := suite.doRequest(handler, "/some/function/path?q=1")
+		suite.Require().Equal(http.StatusOK, statusCode)
+	})
+
+	suite.Run("a caller path is rejected like any other", func() {
+		handler := newAuthOnlyHandler(&fakeAuthenticator{authorized: false, rejectCode: http.StatusUnauthorized})
+		statusCode, _ := suite.doRequest(handler, "/some/function/path?q=1")
+		suite.Require().Equal(http.StatusUnauthorized, statusCode)
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -229,3 +229,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	zombiezen.com/go/capnproto2 v2.18.2+incompatible // indirect
 )
+
+// TODO - remove this once we have a new scaler release
+replace github.com/v3io/scaler => github.com/weilerN/scaler v0.9.1-0.20260805103127-a8b11f5eb89c

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/tsenart/vegeta/v12 v12.13.0
-	github.com/v3io/scaler v0.10.7
+	github.com/v3io/scaler v0.10.8
 	github.com/v3io/v3io-go v0.3.14
 	github.com/v3io/v3io-go-http v0.0.1
 	github.com/v3io/version-go v0.0.2
@@ -229,6 +229,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	zombiezen.com/go/capnproto2 v2.18.2+incompatible // indirect
 )
-
-// TODO - remove this once we have a new scaler release
-replace github.com/v3io/scaler => github.com/weilerN/scaler v0.9.1-0.20260805103127-a8b11f5eb89c

--- a/go.sum
+++ b/go.sum
@@ -463,6 +463,8 @@ github.com/tsenart/vegeta/v12 v12.13.0/go.mod h1:gpdfR++WHV9/RZh4oux0f6lNPhsOH8p
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/v3io/scaler v0.10.8 h1:WtHSAqlnnSYSE09ZO2mIHYr/vKNzW6A0m3H6gpWghxQ=
+github.com/v3io/scaler v0.10.8/go.mod h1:BneVZDn3qYQJcv3eta9226wsFVTQ+xgnXC2Yuca9gzU=
 github.com/v3io/v3io-go v0.3.14 h1:uKljOj7Th47Ux4TeU0BMGiMrxUFj4caccuZ6JQ2mG5E=
 github.com/v3io/v3io-go v0.3.14/go.mod h1:2yxhXiw3dI+tufu5Kk09TS82q/jyJKASEFqfmi5dQHU=
 github.com/v3io/v3io-go-http v0.0.1 h1:uE+PmPkVfGi6vIMpoFgrSot4yIow5Id48Gj9ZPt02pU=
@@ -480,8 +482,6 @@ github.com/vmihailenco/tagparser v0.1.2 h1:gnjoVuB/kljJ5wICEEOpx98oXMWPLj22G67Vb
 github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/wI2L/jsondiff v0.7.0 h1:1lH1G37GhBPqCfp/lrs91rf/2j3DktX6qYAKZkLuCQQ=
 github.com/wI2L/jsondiff v0.7.0/go.mod h1:KAEIojdQq66oJiHhDyQez2x+sRit0vIzC9KeK0yizxM=
-github.com/weilerN/scaler v0.9.1-0.20260805103127-a8b11f5eb89c h1:Xco4+uR+tnnBvF+HZXCEuuA073YhANo5+fXdNtU5mQU=
-github.com/weilerN/scaler v0.9.1-0.20260805103127-a8b11f5eb89c/go.mod h1:BneVZDn3qYQJcv3eta9226wsFVTQ+xgnXC2Yuca9gzU=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/go.sum
+++ b/go.sum
@@ -463,8 +463,6 @@ github.com/tsenart/vegeta/v12 v12.13.0/go.mod h1:gpdfR++WHV9/RZh4oux0f6lNPhsOH8p
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/v3io/scaler v0.10.7 h1:sUut1wReJAF/SLm93hZjXaTwUi57XOb7MT6wnI2sw/Q=
-github.com/v3io/scaler v0.10.7/go.mod h1:BneVZDn3qYQJcv3eta9226wsFVTQ+xgnXC2Yuca9gzU=
 github.com/v3io/v3io-go v0.3.14 h1:uKljOj7Th47Ux4TeU0BMGiMrxUFj4caccuZ6JQ2mG5E=
 github.com/v3io/v3io-go v0.3.14/go.mod h1:2yxhXiw3dI+tufu5Kk09TS82q/jyJKASEFqfmi5dQHU=
 github.com/v3io/v3io-go-http v0.0.1 h1:uE+PmPkVfGi6vIMpoFgrSot4yIow5Id48Gj9ZPt02pU=
@@ -482,6 +480,8 @@ github.com/vmihailenco/tagparser v0.1.2 h1:gnjoVuB/kljJ5wICEEOpx98oXMWPLj22G67Vb
 github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/wI2L/jsondiff v0.7.0 h1:1lH1G37GhBPqCfp/lrs91rf/2j3DktX6qYAKZkLuCQQ=
 github.com/wI2L/jsondiff v0.7.0/go.mod h1:KAEIojdQq66oJiHhDyQez2x+sRit0vIzC9KeK0yizxM=
+github.com/weilerN/scaler v0.9.1-0.20260805103127-a8b11f5eb89c h1:Xco4+uR+tnnBvF+HZXCEuuA073YhANo5+fXdNtU5mQU=
+github.com/weilerN/scaler v0.9.1-0.20260805103127-a8b11f5eb89c/go.mod h1:BneVZDn3qYQJcv3eta9226wsFVTQ+xgnXC2Yuca9gzU=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/hack/k8s/helm/nuclio/templates/deployment/dlx.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dlx.yaml
@@ -64,6 +64,43 @@ spec:
         - name: platform-config
           mountPath: /etc/nuclio/config/platform
         {{- end }}
+      {{- $authentication := dig "authentication" dict (.Values.platform | default dict) }}
+      {{- if $authentication.functionAuthenticationEnabled }}
+      # A function scaled to zero has no pod, so its own auth-proxy does not exist: the Service routes
+      # the request to the DLX instead. This sidecar is the DLX's stand-in for it - the DLX asks it about
+      # every request before scaling anything up, and leaves the function at zero unless it allows.
+      #
+      # Gated on the same value that renders functionAuthenticationEnabled into platform.yaml, which is
+      # what the DLX reads to decide whether to check at all: one value, applied in one install, so the
+      # container and the flag that makes it get called always arrive together.
+      - name: auth-proxy
+        # the args replace the image's CMD wholesale, so the binary name has to lead
+        args:
+        - auth-proxy
+        - --mode=authOnly
+        # a bare port, with no "=upstream": authOnly answers rather than forwards, and is bound to
+        # loopback rather than published. The port is the one the auth-proxy always listens on.
+        - --routes=6080
+        - --auth-url={{ $authentication.authURL }}
+        - --signin-url={{ $authentication.signInURL }}
+        - --namespace={{ .Values.dlx.namespace | default .Release.Namespace }}
+        {{- if $authentication.authKind }}
+        - --auth-kind={{ $authentication.authKind }}
+        {{- end }}
+        image: {{ $authentication.authSidecarImage }}
+        {{- with (include "nuclio.containerSecurityContext.dlx" .) }}
+        # without this the sidecar would be the one container in the pod missing the hardening the
+        # operator asked for, which is enough for restricted Pod Security admission to reject the pod
+        securityContext:
+          {{- . | nindent 10 }}
+        {{- end }}
+        # the sidecar reads platform config for one thing: its logger. Absent, it does not fail - it falls
+        # back to stdout at debug, which on a per-request component is louder than anyone asked for and
+        # sends nothing to a configured sink. Function pods mount it for the same reason.
+        volumeMounts:
+        - name: platform-config
+          mountPath: /etc/nuclio/config/platform
+      {{- end }}
         {{- if .Values.platform }}
       volumes:
       - name: platform-config

--- a/pkg/auth/authproxy/authonly.go
+++ b/pkg/auth/authproxy/authonly.go
@@ -34,8 +34,7 @@ import (
 
 // authOnlyAuthenticator serves the DLX (authOnly) topology: a single sidecar guards every scaled-to-zero
 // function, so it resolves each request's auth config from the target function's CRD (fresh, no cache).
-// Bind it to a specific request via bindRequest to get a TargetAuthenticator the DLX can call by
-// function name alone.
+// The target is named on the request, so a caller holding only a name sets that header itself.
 type authOnlyAuthenticator struct {
 	*abstractAuthenticator
 	nuclioClientSet nuclioioclient.Interface
@@ -43,24 +42,8 @@ type authOnlyAuthenticator struct {
 	namespace       string
 }
 
-// boundAuthenticator pairs an authOnlyAuthenticator with a specific request/response so that
-// AuthenticateTarget can be called with only a function name.
-type boundAuthenticator struct {
-	*authOnlyAuthenticator
-	responseWriter http.ResponseWriter
-	request        *http.Request
-}
-
-// AuthenticateTarget sets the target-function header and delegates to Authenticate, so the DLX needs
-// only the function name — the same code path as an inbound HTTP request to the /auth endpoint.
-func (b *boundAuthenticator) AuthenticateTarget(functionName string) bool {
-	b.request.Header.Set(headers.TargetFunctionName, functionName)
-	return b.Authenticate(b.responseWriter, b.request)
-}
-
 // NewAuthOnlyAuthenticator creates an authenticator that resolves auth config per request from the function
-// CRD. It is used both by the sidecar /auth endpoint (via Authenticate) and, bound to a request, by the
-// in-process DLX (via AuthenticateTarget). The kube client is used to restore scrubbed credentials
+// CRD, serving the sidecar's /auth endpoint. The kube client is used to restore scrubbed credentials
 // (e.g. the basicAuth password, stored as a $ref: to the function's dedicated Secret).
 func NewAuthOnlyAuthenticator(parentLogger logger.Logger,
 	authURL string,
@@ -96,16 +79,6 @@ func (a *authOnlyAuthenticator) Authenticate(responseWriter http.ResponseWriter,
 		return false
 	}
 	return a.authenticateTarget(responseWriter, request, functionName)
-}
-
-// bindRequest returns a TargetAuthenticator bound to the given request/response, so AuthenticateTarget
-// can be called with only a function name.
-func (a *authOnlyAuthenticator) bindRequest(responseWriter http.ResponseWriter, request *http.Request) TargetAuthenticator {
-	return &boundAuthenticator{
-		authOnlyAuthenticator: a,
-		responseWriter:        responseWriter,
-		request:               request,
-	}
 }
 
 // authenticateTarget authenticates the request against the named target function, resolving its

--- a/pkg/auth/authproxy/authproxy_test.go
+++ b/pkg/auth/authproxy/authproxy_test.go
@@ -21,6 +21,7 @@ package authproxy
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/auth"
@@ -121,6 +122,22 @@ func (suite *AuthProxyTestSuite) TestModeBrowser() {
 	suite.Run("valid is admitted", func() {
 		recorder := httptest.NewRecorder()
 		suite.Require().True(authenticator.Authenticate(recorder, suite.authenticatedRequest(validToken)))
+	})
+
+	// the DLX preserves the caller's request line when it asks about a scaled-to-zero function, so the
+	// rd= target is built from the request as received - no out-of-band URI plumbing
+	suite.Run("rd is built from the request line and forwarded host", func() {
+		request := suite.authenticatedRequest("bad-token")
+		request.Header.Set(headers.ForwardHost, "func.example.com")
+
+		recorder := httptest.NewRecorder()
+		suite.Require().False(authenticator.Authenticate(recorder, request))
+		suite.Require().Equal(http.StatusFound, recorder.Code)
+
+		redirectTarget, err := url.Parse(recorder.Header().Get("Location"))
+		suite.Require().NoError(err)
+		suite.Require().Equal("https://func.example.com/some/path?q=1",
+			redirectTarget.Query().Get("rd"))
 	})
 }
 
@@ -283,22 +300,6 @@ func (suite *AuthProxyTestSuite) TestCRDAuthenticatorResolvesFunctionAuthConfig(
 	suite.Run("unknown function fails closed", func() {
 		recorder := httptest.NewRecorder()
 		suite.Require().False(authenticator.Authenticate(recorder, suite.authenticatedRequestFor(validToken, "does-not-exist")))
-		suite.Require().Equal(http.StatusForbidden, recorder.Code)
-	})
-
-	// bindRequest yields the DLX-facing TargetAuthenticator: the function name is passed explicitly
-	// rather than resolved from the request header, and the caller stays HTTP-agnostic.
-	concreteAuth := authenticator.(*authOnlyAuthenticator)
-	suite.Run("AuthenticateTarget resolves by explicit function name", func() {
-		request := suite.authenticatedRequest(validToken)
-		recorder := httptest.NewRecorder()
-		suite.Require().True(concreteAuth.bindRequest(recorder, request).AuthenticateTarget("api-func"))
-	})
-
-	suite.Run("AuthenticateTarget fails closed for unknown function", func() {
-		request := suite.authenticatedRequest(validToken)
-		recorder := httptest.NewRecorder()
-		suite.Require().False(concreteAuth.bindRequest(recorder, request).AuthenticateTarget("does-not-exist"))
 		suite.Require().Equal(http.StatusForbidden, recorder.Code)
 	})
 }

--- a/pkg/auth/authproxy/types.go
+++ b/pkg/auth/authproxy/types.go
@@ -31,11 +31,3 @@ type Authenticator interface {
 	// mode-appropriate rejection (401, or a 302 to the sign-in URL) to responseWriter.
 	Authenticate(responseWriter http.ResponseWriter, request *http.Request) bool
 }
-
-// TargetAuthenticator extends Authenticator for callers that operate in authOnly mode and know the target
-// function by name rather than by inspecting the request. AuthenticateTarget sets the target header and
-// delegates to Authenticate, keeping the caller HTTP-agnostic.
-type TargetAuthenticator interface {
-	Authenticator
-	AuthenticateTarget(functionName string) bool
-}

--- a/pkg/platform/kube/resourcescaler/resourcescaler.go
+++ b/pkg/platform/kube/resourcescaler/resourcescaler.go
@@ -215,12 +215,12 @@ func (n *NuclioResourceScaler) newAuthOnlyAuthenticator() scalertypes.TargetAuth
 
 	authProxy := fmt.Sprintf("http://127.0.0.1:%d", abstract.AuthProxyProcessorListenPort)
 	n.logger.InfoWith("Function authentication is enabled, DLX will authenticate before scaling from zero",
-		"authProxy", authProxy)
+		"authProxyURL", authProxy)
 
 	return &AuthOnlyAuthenticator{
-		logger:     n.logger.GetChild("auth-only-authenticator"),
-		authProxy:  authProxy,
-		httpClient: newAuthProxyHTTPClient(),
+		logger:       n.logger.GetChild("auth-only-authenticator"),
+		authProxyURL: authProxy,
+		httpClient:   newAuthProxyHTTPClient(),
 	}
 }
 

--- a/pkg/platform/kube/resourcescaler/resourcescaler.go
+++ b/pkg/platform/kube/resourcescaler/resourcescaler.go
@@ -196,6 +196,7 @@ func (n *NuclioResourceScaler) GetConfig() (*scalertypes.ResourceScalerConfig, e
 			ResyncInterval:                    scalertypes.Duration{Duration: resyncInterval},
 			LabelSelector:                     common.NuclioLabelKeyClass,
 			ResolveTargetsFromIngressCallback: ResolveTargetsFromIngressCallback,
+			TargetAuthenticator:               n.newAuthOnlyAuthenticator(),
 		},
 	}, nil
 }

--- a/pkg/platform/kube/resourcescaler/resourcescaler.go
+++ b/pkg/platform/kube/resourcescaler/resourcescaler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/common/headers"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platform/abstract"
 	"github.com/nuclio/nuclio/pkg/platform/kube"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	nuclioioclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio/clientset/versioned"
@@ -203,6 +204,24 @@ func (n *NuclioResourceScaler) GetConfig() (*scalertypes.ResourceScalerConfig, e
 
 func (n *NuclioResourceScaler) ResolveServiceName(resource scalertypes.Resource) (string, error) {
 	return kube.ServiceNameFromFunctionName(resource.Name), nil
+}
+
+// newAuthOnlyAuthenticator returns the DLX's authentication hook, or nil when function-level
+// authentication is disabled platform-wide.
+func (n *NuclioResourceScaler) newAuthOnlyAuthenticator() scalertypes.TargetAuthenticator {
+	if !n.platformConfiguration.IsFunctionAuthenticationEnabled() {
+		return nil
+	}
+
+	authProxy := fmt.Sprintf("http://127.0.0.1:%d", abstract.AuthProxyProcessorListenPort)
+	n.logger.InfoWith("Function authentication is enabled, DLX will authenticate before scaling from zero",
+		"authProxy", authProxy)
+
+	return &AuthOnlyAuthenticator{
+		logger:     n.logger.GetChild("auth-only-authenticator"),
+		authProxy:  authProxy,
+		httpClient: newAuthProxyHTTPClient(),
+	}
 }
 
 func (n *NuclioResourceScaler) parseScaleResources(function nuclioio.NuclioFunction) ([]scalertypes.ScaleResource, error) {

--- a/pkg/platform/kube/resourcescaler/resourcescaler_test.go
+++ b/pkg/platform/kube/resourcescaler/resourcescaler_test.go
@@ -26,7 +26,10 @@ import (
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
 
+	"github.com/nuclio/logger"
+	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +37,13 @@ import (
 
 type ResourceScalerTestSuite struct {
 	suite.Suite
+	logger logger.Logger
+}
+
+func (suite *ResourceScalerTestSuite) SetupTest() {
+	var err error
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
 }
 
 func (suite *ResourceScalerTestSuite) TestGetResolveTargetsFromIngressCallback() {
@@ -90,6 +100,40 @@ func (suite *ResourceScalerTestSuite) TestGetResolveTargetsFromIngressCallback()
 			} else {
 				suite.Require().NoError(err)
 				suite.Require().Equal(testCase.expectedResult, res)
+			}
+		})
+	}
+}
+
+// TestDisabledFeatureFlagYieldsNoAuthenticator verifies the DLX skips the check entirely when the
+// platform-wide flag is off, which is what keeps the pre-feature behavior intact.
+func (suite *ResourceScalerTestSuite) TestDisabledFeatureFlagYieldsNoAuthenticator() {
+	for _, testCase := range []struct {
+		name                  string
+		authenticationConfig  *platformconfig.Authentication
+		expectedAuthenticator bool
+	}{
+		{name: "authentication config absent", authenticationConfig: nil},
+		{
+			name:                 "flag explicitly off",
+			authenticationConfig: &platformconfig.Authentication{FunctionAuthenticationEnabled: false},
+		},
+		{
+			name:                  "flag on",
+			authenticationConfig:  &platformconfig.Authentication{FunctionAuthenticationEnabled: true},
+			expectedAuthenticator: true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			resourceScaler := &NuclioResourceScaler{
+				logger:                suite.logger,
+				platformConfiguration: &platformconfig.Config{Authentication: testCase.authenticationConfig},
+			}
+
+			if testCase.expectedAuthenticator {
+				suite.Require().NotNil(resourceScaler.newAuthOnlyAuthenticator())
+			} else {
+				suite.Require().Nil(resourceScaler.newAuthOnlyAuthenticator())
 			}
 		})
 	}

--- a/pkg/platform/kube/resourcescaler/targetauthenticator.go
+++ b/pkg/platform/kube/resourcescaler/targetauthenticator.go
@@ -19,6 +19,7 @@ package resourcescaler
 import (
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/nuclio/nuclio/pkg/auth/authproxy"
 	"github.com/nuclio/nuclio/pkg/common/headers"
@@ -96,15 +97,23 @@ func newAuthProxyHTTPClient() *http.Client {
 	}
 }
 
-// requestVerdict asks the auth-proxy about req. The caller's method and request line are replayed at
-// the auth-proxy's loopback address so it sees the URL the caller actually asked for, which is what a
-// browser-mode redirect has to point back at. No body is sent: the decision rests on the headers alone,
+// requestVerdict asks the auth-proxy about req. The request line is replayed at the auth-proxy's
+// loopback address so it sees the URL the caller actually asked for, which is what a browser-mode
+// redirect has to point back at. No body is sent: the decision rests on the headers alone,
 // and the caller's body still has to reach the function once it is running.
 func (t *AuthOnlyAuthenticator) requestVerdict(req *http.Request,
 	functionName string) (*http.Response, error) {
+	authProxyURL, err := url.Parse(t.authProxy)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to parse auth-proxy URL: %s", t.authProxy)
+	}
+
+	targetURL := authProxyURL.JoinPath(req.URL.EscapedPath())
+	targetURL.RawQuery = req.URL.RawQuery
+
 	authRequest, err := http.NewRequestWithContext(req.Context(),
-		req.Method,
-		t.authProxy+req.URL.RequestURI(),
+		http.MethodGet,
+		targetURL.String(),
 		nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create auth request")

--- a/pkg/platform/kube/resourcescaler/targetauthenticator.go
+++ b/pkg/platform/kube/resourcescaler/targetauthenticator.go
@@ -17,17 +17,14 @@ limitations under the License.
 package resourcescaler
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 
 	"github.com/nuclio/nuclio/pkg/auth/authproxy"
 	"github.com/nuclio/nuclio/pkg/common/headers"
-	"github.com/nuclio/nuclio/pkg/platform/abstract"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
-	"github.com/v3io/scaler/pkg/scalertypes"
 )
 
 // forwardedHeaders are the headers the auth-proxy decides on, copied verbatim from the caller's
@@ -83,24 +80,6 @@ func (t *AuthOnlyAuthenticator) AuthenticateTarget(res http.ResponseWriter,
 		"statusCode", authResponse.StatusCode)
 	t.relayRejection(res, authResponse)
 	return false
-}
-
-// newAuthOnlyAuthenticator returns the DLX's authentication hook, or nil when function-level
-// authentication is disabled platform-wide.
-func (n *NuclioResourceScaler) newAuthOnlyAuthenticator() scalertypes.TargetAuthenticator {
-	if !n.platformConfiguration.IsFunctionAuthenticationEnabled() {
-		return nil
-	}
-
-	authProxy := fmt.Sprintf("http://127.0.0.1:%d", abstract.AuthProxyProcessorListenPort)
-	n.logger.InfoWith("Function authentication is enabled, DLX will authenticate before scaling from zero",
-		"authProxy", authProxy)
-
-	return &AuthOnlyAuthenticator{
-		logger:     n.logger.GetChild("auth-only-authenticator"),
-		authProxy:  authProxy,
-		httpClient: newAuthProxyHTTPClient(),
-	}
 }
 
 // newAuthProxyHTTPClient builds the client used to query the auth-proxy.

--- a/pkg/platform/kube/resourcescaler/targetauthenticator.go
+++ b/pkg/platform/kube/resourcescaler/targetauthenticator.go
@@ -42,9 +42,9 @@ var forwardedHeaders = []string{
 // deliberate: the DLX knows the request and which function it resolved to, the auth-proxy owns the
 // authentication logic.
 type AuthOnlyAuthenticator struct {
-	logger     logger.Logger
-	authProxy  string
-	httpClient *http.Client
+	logger       logger.Logger
+	authProxyURL string
+	httpClient   *http.Client
 }
 
 // AuthenticateTarget implements scalertypes.TargetAuthenticator by delegating to the co-located
@@ -54,7 +54,6 @@ func (t *AuthOnlyAuthenticator) AuthenticateTarget(res http.ResponseWriter,
 	functionName string) bool {
 	authResponse, err := t.requestVerdict(req, functionName)
 	if err != nil {
-
 		// no verdict at all, so there is nothing to honor - fail closed
 		t.logger.WarnWithCtx(req.Context(),
 			"Failed to reach the auth-proxy, failing closed",
@@ -103,9 +102,9 @@ func newAuthProxyHTTPClient() *http.Client {
 // and the caller's body still has to reach the function once it is running.
 func (t *AuthOnlyAuthenticator) requestVerdict(req *http.Request,
 	functionName string) (*http.Response, error) {
-	authProxyURL, err := url.Parse(t.authProxy)
+	authProxyURL, err := url.Parse(t.authProxyURL)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to parse auth-proxy URL: %s", t.authProxy)
+		return nil, errors.Wrapf(err, "Failed to parse auth-proxy URL: %s", t.authProxyURL)
 	}
 
 	targetURL := authProxyURL.JoinPath(req.URL.EscapedPath())

--- a/pkg/platform/kube/resourcescaler/targetauthenticator.go
+++ b/pkg/platform/kube/resourcescaler/targetauthenticator.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcescaler
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/nuclio/nuclio/pkg/auth/authproxy"
+	"github.com/nuclio/nuclio/pkg/common/headers"
+	"github.com/nuclio/nuclio/pkg/platform/abstract"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+	"github.com/v3io/scaler/pkg/scalertypes"
+)
+
+// forwardedHeaders are the headers the auth-proxy decides on, copied verbatim from the caller's
+// request. The credential itself is what the auth-url validates; the authenticator kind only selects a
+// validator, so a caller-supplied kind cannot bypass the check.
+//
+// A slice, not a set: these are iterated to pull each one out of the caller's request, so the cost is
+// one map lookup per name. Testing set membership while walking the caller's headers instead would cost
+// a lookup per header the caller happened to send, which is the larger number.
+var forwardedHeaders = []string{
+	headers.AuthorizationHeader,
+	headers.CookieHeader,
+	headers.IguazioAuthenticatorKind,
+}
+
+// AuthOnlyAuthenticator asks the auth-proxy co-located in the DLX pod whether a request may start a
+// scaled-to-zero function. The split is deliberate: the DLX knows the request and which function it
+// resolved to, the auth-proxy owns every bit of authentication logic. This type holds none - it
+// forwards the request, names the target, and relays whatever verdict comes back.
+//
+// It implements scalertypes.TargetAuthenticator, which is what the DLX calls: the target arrives as a
+// resolved name rather than as something already on the request.
+type AuthOnlyAuthenticator struct {
+	logger     logger.Logger
+	authProxy  string
+	httpClient *http.Client
+}
+
+// newAuthOnlyAuthenticator returns the DLX's authentication hook, or nil when function-level
+// authentication is disabled platform-wide. A nil hook is how the DLX skips the check entirely, which
+// is what keeps the feature-flag-off path byte-identical to the behavior before this feature.
+func (n *NuclioResourceScaler) newAuthOnlyAuthenticator() scalertypes.TargetAuthenticator {
+	if !n.platformConfiguration.IsFunctionAuthenticationEnabled() {
+		return nil
+	}
+
+	// the auth-proxy listens on the port it always listens on. The const is named for its function-pod
+	// role of fronting the processor, which is not the job here - in the DLX pod authOnly forwards
+	// nothing and only answers - but sharing it keeps this in step with the --routes the chart passes.
+	authProxy := fmt.Sprintf("http://127.0.0.1:%d", abstract.AuthProxyProcessorListenPort)
+
+	n.logger.InfoWith("Function authentication is enabled, DLX will authenticate before scaling from zero",
+		"authProxy", authProxy)
+
+	return &AuthOnlyAuthenticator{
+		logger:     n.logger.GetChild("auth-only-authenticator"),
+		authProxy:  authProxy,
+		httpClient: newAuthProxyHTTPClient(),
+	}
+}
+
+// newAuthProxyHTTPClient builds the client used to query the auth-proxy.
+func newAuthProxyHTTPClient() *http.Client {
+	return &http.Client{
+
+		// the same budget the auth-proxy gives its own auth-url call. Sharing it means a verdict that
+		// lands in the last few milliseconds of the window may be missed and treated as a rejection;
+		// an auth-url that slow is already failing the caller's request, so one timeout is enough
+		Timeout: authproxy.AuthTimeout,
+
+		// a browser-mode rejection is a 302 to the sign-in page: a verdict to hand back so the caller's
+		// browser can follow it, not a hop for the DLX to take. This sentinel is not a failure - it tells
+		// Do to return the 302 as the response. Left at the default, Do would instead try to fetch the
+		// sign-in URL from inside the DLX pod, fail to reach it, and surface a redirect as a dead proxy.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// AuthenticateTarget implements scalertypes.TargetAuthenticator by delegating to the co-located
+// auth-proxy. On false the rejection has already been written to res, so the caller must return
+// without touching it.
+func (t *AuthOnlyAuthenticator) AuthenticateTarget(res http.ResponseWriter,
+	req *http.Request,
+	functionName string) bool {
+	authResponse, err := t.requestVerdict(req, functionName)
+	if err != nil {
+
+		// no verdict at all, so there is nothing to honor - fail closed
+		t.logger.WarnWithCtx(req.Context(),
+			"Failed to reach the auth-proxy, failing closed",
+			"err", err.Error())
+		http.Error(res, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
+		return false
+	}
+	// defer closing the body so that the connection can be reused.
+	defer func(Body io.ReadCloser) {
+		if err := Body.Close(); err != nil {
+			t.logger.DebugWith("Failed to close the auth-proxy response body", "err", err.Error())
+		}
+	}(authResponse.Body) // nolint: errcheck
+
+	// the auth-proxy answers an allow with exactly 200 and nothing else, so anything unexpected is
+	// treated as a rejection rather than guessed at
+	if authResponse.StatusCode == http.StatusOK {
+		t.logger.DebugWithCtx(req.Context(), "Request authenticated")
+		return true
+	}
+
+	t.logger.DebugWithCtx(req.Context(),
+		"Request rejected by the auth-proxy",
+		"statusCode", authResponse.StatusCode)
+	t.relayRejection(res, authResponse)
+	return false
+}
+
+// requestVerdict asks the auth-proxy about req. The caller's method and request line are replayed at
+// the auth-proxy's loopback address so it sees the URL the caller actually asked for, which is what a
+// browser-mode redirect has to point back at. No body is sent: the decision rests on the headers alone,
+// and the caller's body still has to reach the function once it is running.
+func (t *AuthOnlyAuthenticator) requestVerdict(req *http.Request,
+	functionName string) (*http.Response, error) {
+	authRequest, err := http.NewRequestWithContext(req.Context(),
+		req.Method,
+		t.authProxy+req.URL.RequestURI(),
+		nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create auth request")
+	}
+
+	for _, headerName := range forwardedHeaders {
+		for _, headerValue := range req.Header.Values(headerName) {
+			authRequest.Header.Add(headerName, headerValue)
+		}
+	}
+
+	// the request line carries the path, but its host is now the loopback proxy, so the caller's host
+	// travels separately - the two together are what the redirect target is built from
+	authRequest.Header.Set(headers.ForwardHost, originalHost(req))
+
+	// the DLX resolved this name from the ingress, so it is what decides - set, not forwarded, so a
+	// caller cannot name a function other than the one about to be scaled
+	authRequest.Header.Set(headers.TargetFunctionName, functionName)
+
+	authResponse, err := t.httpClient.Do(authRequest)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to call the auth-proxy")
+	}
+	return authResponse, nil
+}
+
+// relayRejection copies the auth-proxy's rejection to the caller. Location and WWW-Authenticate carry
+// the browser redirect target and the basic-auth challenge, so a rejection stripped of them would
+// reach the caller as an unactionable error.
+func (t *AuthOnlyAuthenticator) relayRejection(res http.ResponseWriter, authResponse *http.Response) {
+	for _, headerName := range []string{"Location", "WWW-Authenticate"} {
+		for _, headerValue := range authResponse.Header.Values(headerName) {
+			res.Header().Add(headerName, headerValue)
+		}
+	}
+
+	res.WriteHeader(authResponse.StatusCode)
+	if _, err := io.Copy(res, authResponse.Body); err != nil {
+		t.logger.WarnWith("Failed to relay the rejection body", "err", err.Error())
+	}
+}
+
+// originalHost returns the host the caller addressed, which is what a browser-mode redirect must point
+// back at - the DLX is behind the function's Service, so its own host is not where the caller was going.
+func originalHost(req *http.Request) string {
+	if forwardedHost := req.Header.Get(headers.ForwardHost); forwardedHost != "" {
+		return forwardedHost
+	}
+	return req.Host
+}

--- a/pkg/platform/kube/resourcescaler/targetauthenticator.go
+++ b/pkg/platform/kube/resourcescaler/targetauthenticator.go
@@ -33,74 +33,24 @@ import (
 // forwardedHeaders are the headers the auth-proxy decides on, copied verbatim from the caller's
 // request. The credential itself is what the auth-url validates; the authenticator kind only selects a
 // validator, so a caller-supplied kind cannot bypass the check.
-//
-// A slice, not a set: these are iterated to pull each one out of the caller's request, so the cost is
-// one map lookup per name. Testing set membership while walking the caller's headers instead would cost
-// a lookup per header the caller happened to send, which is the larger number.
 var forwardedHeaders = []string{
 	headers.AuthorizationHeader,
 	headers.CookieHeader,
 	headers.IguazioAuthenticatorKind,
 }
 
-// AuthOnlyAuthenticator asks the auth-proxy co-located in the DLX pod whether a request may start a
-// scaled-to-zero function. The split is deliberate: the DLX knows the request and which function it
-// resolved to, the auth-proxy owns every bit of authentication logic. This type holds none - it
-// forwards the request, names the target, and relays whatever verdict comes back.
-//
-// It implements scalertypes.TargetAuthenticator, which is what the DLX calls: the target arrives as a
-// resolved name rather than as something already on the request.
+// AuthOnlyAuthenticator implements scalertypes.TargetAuthenticator, which is what the DLX calls with a
+// resolved function name to ask whether a request may start a scaled-to-zero function. The split is
+// deliberate: the DLX knows the request and which function it resolved to, the auth-proxy owns the
+// authentication logic.
 type AuthOnlyAuthenticator struct {
 	logger     logger.Logger
 	authProxy  string
 	httpClient *http.Client
 }
 
-// newAuthOnlyAuthenticator returns the DLX's authentication hook, or nil when function-level
-// authentication is disabled platform-wide. A nil hook is how the DLX skips the check entirely, which
-// is what keeps the feature-flag-off path byte-identical to the behavior before this feature.
-func (n *NuclioResourceScaler) newAuthOnlyAuthenticator() scalertypes.TargetAuthenticator {
-	if !n.platformConfiguration.IsFunctionAuthenticationEnabled() {
-		return nil
-	}
-
-	// the auth-proxy listens on the port it always listens on. The const is named for its function-pod
-	// role of fronting the processor, which is not the job here - in the DLX pod authOnly forwards
-	// nothing and only answers - but sharing it keeps this in step with the --routes the chart passes.
-	authProxy := fmt.Sprintf("http://127.0.0.1:%d", abstract.AuthProxyProcessorListenPort)
-
-	n.logger.InfoWith("Function authentication is enabled, DLX will authenticate before scaling from zero",
-		"authProxy", authProxy)
-
-	return &AuthOnlyAuthenticator{
-		logger:     n.logger.GetChild("auth-only-authenticator"),
-		authProxy:  authProxy,
-		httpClient: newAuthProxyHTTPClient(),
-	}
-}
-
-// newAuthProxyHTTPClient builds the client used to query the auth-proxy.
-func newAuthProxyHTTPClient() *http.Client {
-	return &http.Client{
-
-		// the same budget the auth-proxy gives its own auth-url call. Sharing it means a verdict that
-		// lands in the last few milliseconds of the window may be missed and treated as a rejection;
-		// an auth-url that slow is already failing the caller's request, so one timeout is enough
-		Timeout: authproxy.AuthTimeout,
-
-		// a browser-mode rejection is a 302 to the sign-in page: a verdict to hand back so the caller's
-		// browser can follow it, not a hop for the DLX to take. This sentinel is not a failure - it tells
-		// Do to return the 302 as the response. Left at the default, Do would instead try to fetch the
-		// sign-in URL from inside the DLX pod, fail to reach it, and surface a redirect as a dead proxy.
-		CheckRedirect: func(*http.Request, []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-}
-
 // AuthenticateTarget implements scalertypes.TargetAuthenticator by delegating to the co-located
-// auth-proxy. On false the rejection has already been written to res, so the caller must return
-// without touching it.
+// auth-proxy sidecar.
 func (t *AuthOnlyAuthenticator) AuthenticateTarget(res http.ResponseWriter,
 	req *http.Request,
 	functionName string) bool {
@@ -135,6 +85,38 @@ func (t *AuthOnlyAuthenticator) AuthenticateTarget(res http.ResponseWriter,
 	return false
 }
 
+// newAuthOnlyAuthenticator returns the DLX's authentication hook, or nil when function-level
+// authentication is disabled platform-wide.
+func (n *NuclioResourceScaler) newAuthOnlyAuthenticator() scalertypes.TargetAuthenticator {
+	if !n.platformConfiguration.IsFunctionAuthenticationEnabled() {
+		return nil
+	}
+
+	authProxy := fmt.Sprintf("http://127.0.0.1:%d", abstract.AuthProxyProcessorListenPort)
+	n.logger.InfoWith("Function authentication is enabled, DLX will authenticate before scaling from zero",
+		"authProxy", authProxy)
+
+	return &AuthOnlyAuthenticator{
+		logger:     n.logger.GetChild("auth-only-authenticator"),
+		authProxy:  authProxy,
+		httpClient: newAuthProxyHTTPClient(),
+	}
+}
+
+// newAuthProxyHTTPClient builds the client used to query the auth-proxy.
+func newAuthProxyHTTPClient() *http.Client {
+	return &http.Client{
+		// sharing the same timeout for the auth-proxy auth-url call
+		Timeout: authproxy.AuthTimeout,
+
+		// A 302 from browser-mode authentication is returned to the caller so the browser can follow the sign-in redirect.
+		// It must not be treated as a failure or followed by the DLX, which cannot access the sign-in URL from inside the pod.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
 // requestVerdict asks the auth-proxy about req. The caller's method and request line are replayed at
 // the auth-proxy's loopback address so it sees the URL the caller actually asked for, which is what a
 // browser-mode redirect has to point back at. No body is sent: the decision rests on the headers alone,
@@ -158,9 +140,6 @@ func (t *AuthOnlyAuthenticator) requestVerdict(req *http.Request,
 	// the request line carries the path, but its host is now the loopback proxy, so the caller's host
 	// travels separately - the two together are what the redirect target is built from
 	authRequest.Header.Set(headers.ForwardHost, originalHost(req))
-
-	// the DLX resolved this name from the ingress, so it is what decides - set, not forwarded, so a
-	// caller cannot name a function other than the one about to be scaled
 	authRequest.Header.Set(headers.TargetFunctionName, functionName)
 
 	authResponse, err := t.httpClient.Do(authRequest)

--- a/pkg/platform/kube/resourcescaler/targetauthenticator_test.go
+++ b/pkg/platform/kube/resourcescaler/targetauthenticator_test.go
@@ -274,8 +274,8 @@ func (suite *TargetAuthenticatorTestSuite) TestUnreachableAuthProxyFailsClosed()
 		logger: suite.logger,
 
 		// nothing is listening here
-		authProxy:  "http://127.0.0.1:1",
-		httpClient: newAuthProxyHTTPClient(),
+		authProxyURL: "http://127.0.0.1:1",
+		httpClient:   newAuthProxyHTTPClient(),
 	}
 
 	recorder := httptest.NewRecorder()
@@ -330,9 +330,9 @@ func (suite *TargetAuthenticatorTestSuite) newAuthOnlyAuthenticator(authURLCallC
 		}))
 
 	return &AuthOnlyAuthenticator{
-			logger:     suite.logger,
-			authProxy:  authProxyServer.URL,
-			httpClient: newAuthProxyHTTPClient(),
+			logger:       suite.logger,
+			authProxyURL: authProxyServer.URL,
+			httpClient:   newAuthProxyHTTPClient(),
 		}, func() {
 			authProxyServer.Close()
 			authURLServer.Close()

--- a/pkg/platform/kube/resourcescaler/targetauthenticator_test.go
+++ b/pkg/platform/kube/resourcescaler/targetauthenticator_test.go
@@ -31,7 +31,6 @@ import (
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	kubeclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
 	nuclioiofake "github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio/clientset/versioned/fake"
-	"github.com/nuclio/nuclio/pkg/platformconfig"
 
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
@@ -233,40 +232,6 @@ func (suite *TargetAuthenticatorTestSuite) TestUnreachableAuthProxyFailsClosed()
 	recorder := httptest.NewRecorder()
 	suite.Require().False(authenticator.AuthenticateTarget(recorder, suite.callerRequest(validToken), "api-func"))
 	suite.Require().Equal(http.StatusBadGateway, recorder.Code)
-}
-
-// TestDisabledFeatureFlagYieldsNoAuthenticator verifies the DLX skips the check entirely when the
-// platform-wide flag is off, which is what keeps the pre-feature behavior intact.
-func (suite *TargetAuthenticatorTestSuite) TestDisabledFeatureFlagYieldsNoAuthenticator() {
-	for _, testCase := range []struct {
-		name                  string
-		authenticationConfig  *platformconfig.Authentication
-		expectedAuthenticator bool
-	}{
-		{name: "authentication config absent", authenticationConfig: nil},
-		{
-			name:                 "flag explicitly off",
-			authenticationConfig: &platformconfig.Authentication{FunctionAuthenticationEnabled: false},
-		},
-		{
-			name:                  "flag on",
-			authenticationConfig:  &platformconfig.Authentication{FunctionAuthenticationEnabled: true},
-			expectedAuthenticator: true,
-		},
-	} {
-		suite.Run(testCase.name, func() {
-			resourceScaler := &NuclioResourceScaler{
-				logger:                suite.logger,
-				platformConfiguration: &platformconfig.Config{Authentication: testCase.authenticationConfig},
-			}
-
-			if testCase.expectedAuthenticator {
-				suite.Require().NotNil(resourceScaler.newAuthOnlyAuthenticator())
-			} else {
-				suite.Require().Nil(resourceScaler.newAuthOnlyAuthenticator())
-			}
-		})
-	}
 }
 
 // --- test helpers ---

--- a/pkg/platform/kube/resourcescaler/targetauthenticator_test.go
+++ b/pkg/platform/kube/resourcescaler/targetauthenticator_test.go
@@ -1,0 +1,343 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcescaler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/auth/authproxy"
+	"github.com/nuclio/nuclio/pkg/common/headers"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+	kubeclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
+	nuclioiofake "github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio/clientset/versioned/fake"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+
+	"github.com/nuclio/logger"
+	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	testNamespace = "nuclio-test"
+	testSigninURL = "https://signin.example.com/oauth2/start"
+	validToken    = "valid-token"
+)
+
+// TargetAuthenticatorTestSuite exercises the DLX-side client against a real authOnly auth-proxy, so
+// the whole hop is covered: client -> HTTP -> authOnly authenticator -> CRD lookup -> auth-url.
+type TargetAuthenticatorTestSuite struct {
+	suite.Suite
+	logger logger.Logger
+
+	// the request line the auth-proxy actually saw, to prove the caller's own is what reaches it
+	authProxyRequestURI string
+}
+
+func (suite *TargetAuthenticatorTestSuite) SetupTest() {
+	var err error
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+}
+
+// TestNoneModeAllowsWithoutCallingAuthURL verifies a function that opts out is admitted, and that the
+// admission costs no auth-url round trip.
+func (suite *TargetAuthenticatorTestSuite) TestNoneModeAllowsWithoutCallingAuthURL() {
+	authURLCallCount := 0
+	authenticator, closeServers := suite.newAuthOnlyAuthenticator(&authURLCallCount,
+		suite.newFunction("none-func", map[string]interface{}{
+			"authenticationMode": auth.AuthenticationModeNone,
+		}))
+	defer closeServers()
+
+	recorder := httptest.NewRecorder()
+	suite.Require().True(authenticator.AuthenticateTarget(recorder, suite.callerRequest(validToken), "none-func"))
+	suite.Require().Zero(authURLCallCount)
+}
+
+// TestAPIModeValidCredentialAllows verifies the happy path: the DLX forwards the credential, the proxy
+// validates it against the auth-url, and the function may be scaled.
+func (suite *TargetAuthenticatorTestSuite) TestAPIModeValidCredentialAllows() {
+	authURLCallCount := 0
+	authenticator, closeServers := suite.newAuthOnlyAuthenticator(&authURLCallCount,
+		suite.newFunction("api-func", map[string]interface{}{
+			"authenticationMode": auth.AuthenticationModeAPI,
+		}))
+	defer closeServers()
+
+	recorder := httptest.NewRecorder()
+	suite.Require().True(authenticator.AuthenticateTarget(recorder, suite.callerRequest(validToken), "api-func"))
+	suite.Require().Equal(1, authURLCallCount)
+}
+
+// TestAPIModeInvalidCredentialRelays401 is the core acceptance criterion: an invalid credential must
+// reach the caller as a 401, not as a silent success.
+func (suite *TargetAuthenticatorTestSuite) TestAPIModeInvalidCredentialRelays401() {
+	authURLCallCount := 0
+	authenticator, closeServers := suite.newAuthOnlyAuthenticator(&authURLCallCount,
+		suite.newFunction("api-func", map[string]interface{}{
+			"authenticationMode": auth.AuthenticationModeAPI,
+		}))
+	defer closeServers()
+
+	recorder := httptest.NewRecorder()
+	suite.Require().False(authenticator.AuthenticateTarget(recorder, suite.callerRequest("bad-token"), "api-func"))
+	suite.Require().Equal(http.StatusUnauthorized, recorder.Code)
+}
+
+// TestBrowserModeRelays302ToTheOriginalURL verifies the redirect points back at what the caller asked
+// for, reconstructed from the replayed request line plus the forwarded host - no header carries it.
+func (suite *TargetAuthenticatorTestSuite) TestBrowserModeRelays302ToTheOriginalURL() {
+	authURLCallCount := 0
+	authenticator, closeServers := suite.newAuthOnlyAuthenticator(&authURLCallCount,
+		suite.newFunction("browser-func", map[string]interface{}{
+			"authenticationMode": auth.AuthenticationModeBrowser,
+		}))
+	defer closeServers()
+
+	recorder := httptest.NewRecorder()
+	suite.Require().False(authenticator.AuthenticateTarget(recorder, suite.callerRequest("bad-token"), "browser-func"))
+	suite.Require().Equal(http.StatusFound, recorder.Code)
+
+	redirectTarget, err := url.Parse(recorder.Header().Get("Location"))
+	suite.Require().NoError(err)
+	suite.Require().Contains(redirectTarget.String(), "signin.example.com/oauth2/start")
+	suite.Require().Equal("https://func.example.com/some/path?q=1", redirectTarget.Query().Get("rd"))
+}
+
+// TestCallerRequestLineReachesTheAuthProxy verifies the DLX replays the caller's own request line
+// rather than a fixed decision path, which is what lets the proxy build a redirect back to it.
+func (suite *TargetAuthenticatorTestSuite) TestCallerRequestLineReachesTheAuthProxy() {
+	authURLCallCount := 0
+	authenticator, closeServers := suite.newAuthOnlyAuthenticator(&authURLCallCount,
+		suite.newFunction("api-func", map[string]interface{}{
+			"authenticationMode": auth.AuthenticationModeAPI,
+		}))
+	defer closeServers()
+
+	recorder := httptest.NewRecorder()
+	suite.Require().True(authenticator.AuthenticateTarget(recorder, suite.callerRequest(validToken), "api-func"))
+	suite.Require().Equal("/some/path?q=1", suite.authProxyRequestURI)
+}
+
+// TestDLXResolvedTargetOverridesTheCallerHeader verifies the name the DLX resolved is the one the
+// proxy decides on. A caller naming a permissive function must not get a stricter one scaled on that
+// verdict, so the target header is set from the argument rather than forwarded.
+func (suite *TargetAuthenticatorTestSuite) TestDLXResolvedTargetOverridesTheCallerHeader() {
+	authURLCallCount := 0
+	authenticator, closeServers := suite.newAuthOnlyAuthenticator(&authURLCallCount,
+		suite.newFunction("none-func", map[string]interface{}{
+			"authenticationMode": auth.AuthenticationModeNone,
+		}),
+		suite.newFunction("api-func", map[string]interface{}{
+			"authenticationMode": auth.AuthenticationModeAPI,
+		}))
+	defer closeServers()
+
+	// the caller claims the function that admits everyone, but api-func is what is about to be scaled
+	request := suite.callerRequest("bad-token")
+	request.Header.Set(headers.TargetFunctionName, "none-func")
+
+	recorder := httptest.NewRecorder()
+	suite.Require().False(authenticator.AuthenticateTarget(recorder, request, "api-func"))
+	suite.Require().Equal(http.StatusUnauthorized, recorder.Code)
+}
+
+// TestBasicAuthRelaysChallenge verifies the WWW-Authenticate challenge survives the relay - without it
+// the caller gets a 401 it cannot act on.
+func (suite *TargetAuthenticatorTestSuite) TestBasicAuthRelaysChallenge() {
+	authURLCallCount := 0
+	authenticator, closeServers := suite.newAuthOnlyAuthenticator(&authURLCallCount,
+		suite.newFunction("basic-func", map[string]interface{}{
+			"authenticationMode": auth.AuthenticationModeBasicAuth,
+			"authentication": map[string]interface{}{
+				"basicAuth": map[string]interface{}{"username": "user", "password": "pass"},
+			},
+		}))
+	defer closeServers()
+
+	suite.Run("valid credential allows", func() {
+		request := suite.callerRequest("")
+		request.SetBasicAuth("user", "pass")
+		recorder := httptest.NewRecorder()
+		suite.Require().True(authenticator.AuthenticateTarget(recorder, request, "basic-func"))
+	})
+
+	suite.Run("wrong password is rejected with a challenge", func() {
+		request := suite.callerRequest("")
+		request.SetBasicAuth("user", "wrong")
+		recorder := httptest.NewRecorder()
+		suite.Require().False(authenticator.AuthenticateTarget(recorder, request, "basic-func"))
+		suite.Require().Equal(http.StatusUnauthorized, recorder.Code)
+		suite.Require().Contains(recorder.Header().Get("WWW-Authenticate"), "Basic realm")
+	})
+}
+
+// TestUnknownFunctionFailsClosed verifies a target whose CRD cannot be read is never scaled.
+func (suite *TargetAuthenticatorTestSuite) TestUnknownFunctionFailsClosed() {
+	authURLCallCount := 0
+	authenticator, closeServers := suite.newAuthOnlyAuthenticator(&authURLCallCount,
+		suite.newFunction("api-func", map[string]interface{}{
+			"authenticationMode": auth.AuthenticationModeAPI,
+		}))
+	defer closeServers()
+
+	recorder := httptest.NewRecorder()
+	suite.Require().False(authenticator.AuthenticateTarget(recorder, suite.callerRequest(validToken), "does-not-exist"))
+	suite.Require().Equal(http.StatusForbidden, recorder.Code)
+}
+
+// TestUnreachableAuthProxyFailsClosed verifies the DLX rejects rather than scales when it cannot get a
+// verdict at all - the sidecar being down must not become an open door.
+func (suite *TargetAuthenticatorTestSuite) TestUnreachableAuthProxyFailsClosed() {
+	authenticator := &AuthOnlyAuthenticator{
+		logger: suite.logger,
+
+		// nothing is listening here
+		authProxy:  "http://127.0.0.1:1",
+		httpClient: newAuthProxyHTTPClient(),
+	}
+
+	recorder := httptest.NewRecorder()
+	suite.Require().False(authenticator.AuthenticateTarget(recorder, suite.callerRequest(validToken), "api-func"))
+	suite.Require().Equal(http.StatusBadGateway, recorder.Code)
+}
+
+// TestDisabledFeatureFlagYieldsNoAuthenticator verifies the DLX skips the check entirely when the
+// platform-wide flag is off, which is what keeps the pre-feature behavior intact.
+func (suite *TargetAuthenticatorTestSuite) TestDisabledFeatureFlagYieldsNoAuthenticator() {
+	for _, testCase := range []struct {
+		name                  string
+		authenticationConfig  *platformconfig.Authentication
+		expectedAuthenticator bool
+	}{
+		{name: "authentication config absent", authenticationConfig: nil},
+		{
+			name:                 "flag explicitly off",
+			authenticationConfig: &platformconfig.Authentication{FunctionAuthenticationEnabled: false},
+		},
+		{
+			name:                  "flag on",
+			authenticationConfig:  &platformconfig.Authentication{FunctionAuthenticationEnabled: true},
+			expectedAuthenticator: true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			resourceScaler := &NuclioResourceScaler{
+				logger:                suite.logger,
+				platformConfiguration: &platformconfig.Config{Authentication: testCase.authenticationConfig},
+			}
+
+			if testCase.expectedAuthenticator {
+				suite.Require().NotNil(resourceScaler.newAuthOnlyAuthenticator())
+			} else {
+				suite.Require().Nil(resourceScaler.newAuthOnlyAuthenticator())
+			}
+		})
+	}
+}
+
+// --- test helpers ---
+
+// newAuthOnlyAuthenticator stands up an auth-url stub plus a real authOnly auth-proxy over HTTP, and
+// returns a client pointed at it. The authenticator, its decision logic, and the handler shape are the
+// production ones, so the whole hop is under test.
+func (suite *TargetAuthenticatorTestSuite) newAuthOnlyAuthenticator(authURLCallCount *int,
+	functions ...*nuclioio.NuclioFunction) (*AuthOnlyAuthenticator, func()) {
+
+	authURLServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		*authURLCallCount++
+
+		// admit only the actual credential, never the caller-declared authenticator kind
+		if request.Header.Get(headers.AuthorizationHeader) != "Bearer "+validToken {
+			responseWriter.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		responseWriter.WriteHeader(http.StatusOK)
+		_, err := responseWriter.Write([]byte(`{"metadata":{"username":"alice","id":"user-1"}}`))
+		suite.Require().NoError(err)
+	}))
+
+	objects := make([]runtime.Object, 0, len(functions))
+	for _, function := range functions {
+		objects = append(objects, function)
+	}
+
+	authenticator, err := authproxy.NewAuthOnlyAuthenticator(suite.logger,
+		authURLServer.URL,
+		testSigninURL,
+		auth.KindIguazioV4,
+		nuclioiofake.NewSimpleClientset(objects...),
+		kubeclient.NewClientWithRetryFromClient(k8sfake.NewClientset()),
+		testNamespace)
+	suite.Require().NoError(err)
+
+	// the same catch-all shape as the production newAuthOnlyHandler: the DLX replays the caller's
+	// request line, so the path is whatever the caller asked for
+	authProxyServer := httptest.NewServer(http.HandlerFunc(
+		func(responseWriter http.ResponseWriter, request *http.Request) {
+			suite.authProxyRequestURI = request.URL.RequestURI()
+			if authenticator.Authenticate(responseWriter, request) {
+				responseWriter.WriteHeader(http.StatusOK)
+			}
+		}))
+
+	return &AuthOnlyAuthenticator{
+			logger:     suite.logger,
+			authProxy:  authProxyServer.URL,
+			httpClient: newAuthProxyHTTPClient(),
+		}, func() {
+			authProxyServer.Close()
+			authURLServer.Close()
+		}
+}
+
+// callerRequest builds the request as it reaches the DLX from the ingress: the caller's host and path
+// arrive on X-Forwarded-Host, which is what a browser-mode redirect must be built from.
+func (suite *TargetAuthenticatorTestSuite) callerRequest(token string) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, "http://dlx.nuclio/some/path?q=1", nil)
+	request.Header.Set(headers.ForwardHost, "func.example.com")
+	if token != "" {
+		request.Header.Set(headers.AuthorizationHeader, "Bearer "+token)
+	}
+	return request
+}
+
+func (suite *TargetAuthenticatorTestSuite) newFunction(name string,
+	attributes map[string]interface{}) *nuclioio.NuclioFunction {
+	return &nuclioio.NuclioFunction{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+		Spec: functionconfig.Spec{
+			Triggers: map[string]functionconfig.Trigger{
+				"http": {Kind: "http", Attributes: attributes},
+			},
+		},
+	}
+}
+
+func TestTargetAuthenticatorTestSuite(t *testing.T) {
+	suite.Run(t, new(TargetAuthenticatorTestSuite))
+}

--- a/pkg/platform/kube/resourcescaler/targetauthenticator_test.go
+++ b/pkg/platform/kube/resourcescaler/targetauthenticator_test.go
@@ -106,6 +106,7 @@ func (suite *TargetAuthenticatorTestSuite) TestAPIModeInvalidCredentialRelays401
 	recorder := httptest.NewRecorder()
 	suite.Require().False(authenticator.AuthenticateTarget(recorder, suite.callerRequest("bad-token"), "api-func"))
 	suite.Require().Equal(http.StatusUnauthorized, recorder.Code)
+	suite.Require().Equal(1, authURLCallCount)
 }
 
 // TestBrowserModeRelays302ToTheOriginalURL verifies the redirect points back at what the caller asked
@@ -126,6 +127,7 @@ func (suite *TargetAuthenticatorTestSuite) TestBrowserModeRelays302ToTheOriginal
 	suite.Require().NoError(err)
 	suite.Require().Contains(redirectTarget.String(), "signin.example.com/oauth2/start")
 	suite.Require().Equal("https://func.example.com/some/path?q=1", redirectTarget.Query().Get("rd"))
+	suite.Require().Equal(1, authURLCallCount)
 }
 
 // TestCallerRequestLineReachesTheAuthProxy verifies the DLX replays the caller's own request line
@@ -141,6 +143,7 @@ func (suite *TargetAuthenticatorTestSuite) TestCallerRequestLineReachesTheAuthPr
 	recorder := httptest.NewRecorder()
 	suite.Require().True(authenticator.AuthenticateTarget(recorder, suite.callerRequest(validToken), "api-func"))
 	suite.Require().Equal("/some/path?q=1", suite.authProxyRequestURI)
+	suite.Require().Equal(1, authURLCallCount)
 }
 
 // TestDLXResolvedTargetOverridesTheCallerHeader verifies the name the DLX resolved is the one the
@@ -164,6 +167,7 @@ func (suite *TargetAuthenticatorTestSuite) TestDLXResolvedTargetOverridesTheCall
 	recorder := httptest.NewRecorder()
 	suite.Require().False(authenticator.AuthenticateTarget(recorder, request, "api-func"))
 	suite.Require().Equal(http.StatusUnauthorized, recorder.Code)
+	suite.Require().Equal(1, authURLCallCount)
 }
 
 // TestBasicAuthRelaysChallenge verifies the WWW-Authenticate challenge survives the relay - without it
@@ -184,6 +188,9 @@ func (suite *TargetAuthenticatorTestSuite) TestBasicAuthRelaysChallenge() {
 		request.SetBasicAuth("user", "pass")
 		recorder := httptest.NewRecorder()
 		suite.Require().True(authenticator.AuthenticateTarget(recorder, request, "basic-func"))
+
+		// basicAuth is verified locally, never via the auth-url
+		suite.Require().Zero(authURLCallCount)
 	})
 
 	suite.Run("wrong password is rejected with a challenge", func() {
@@ -193,6 +200,7 @@ func (suite *TargetAuthenticatorTestSuite) TestBasicAuthRelaysChallenge() {
 		suite.Require().False(authenticator.AuthenticateTarget(recorder, request, "basic-func"))
 		suite.Require().Equal(http.StatusUnauthorized, recorder.Code)
 		suite.Require().Contains(recorder.Header().Get("WWW-Authenticate"), "Basic realm")
+		suite.Require().Zero(authURLCallCount)
 	})
 }
 
@@ -208,6 +216,7 @@ func (suite *TargetAuthenticatorTestSuite) TestUnknownFunctionFailsClosed() {
 	recorder := httptest.NewRecorder()
 	suite.Require().False(authenticator.AuthenticateTarget(recorder, suite.callerRequest(validToken), "does-not-exist"))
 	suite.Require().Equal(http.StatusForbidden, recorder.Code)
+	suite.Require().Zero(authURLCallCount)
 }
 
 // TestUnreachableAuthProxyFailsClosed verifies the DLX rejects rather than scales when it cannot get a

--- a/pkg/platform/kube/resourcescaler/targetauthenticator_test.go
+++ b/pkg/platform/kube/resourcescaler/targetauthenticator_test.go
@@ -52,8 +52,9 @@ type TargetAuthenticatorTestSuite struct {
 	suite.Suite
 	logger logger.Logger
 
-	// the request line the auth-proxy actually saw, to prove the caller's own is what reaches it
-	authProxyRequestURI string
+	// the request line and method the auth-proxy actually saw, to prove what reaches it
+	authProxyRequestURI    string
+	authProxyRequestMethod string
 }
 
 func (suite *TargetAuthenticatorTestSuite) SetupTest() {
@@ -143,6 +144,54 @@ func (suite *TargetAuthenticatorTestSuite) TestCallerRequestLineReachesTheAuthPr
 	suite.Require().True(authenticator.AuthenticateTarget(recorder, suite.callerRequest(validToken), "api-func"))
 	suite.Require().Equal("/some/path?q=1", suite.authProxyRequestURI)
 	suite.Require().Equal(1, authURLCallCount)
+}
+
+// TestCallerMethodNeverReachesTheAuthProxy verifies the auth-proxy always sees GET regardless of the
+// caller's own method. The caller's method is attacker-controlled; replaying it would let a reverse
+// proxy fronting the auth-proxy special-case OPTIONS/HEAD/TRACE into an unintended allow.
+func (suite *TargetAuthenticatorTestSuite) TestCallerMethodNeverReachesTheAuthProxy() {
+	for _, callerMethod := range []string{http.MethodPost, http.MethodOptions, http.MethodHead, http.MethodTrace} {
+		suite.Run(callerMethod, func() {
+			authURLCallCount := 0
+			authenticator, closeServers := suite.newAuthOnlyAuthenticator(&authURLCallCount,
+				suite.newFunction("api-func", map[string]interface{}{
+					"authenticationMode": auth.AuthenticationModeAPI,
+				}))
+			defer closeServers()
+
+			request := suite.callerRequest(validToken)
+			request.Method = callerMethod
+
+			recorder := httptest.NewRecorder()
+			suite.Require().True(authenticator.AuthenticateTarget(recorder, request, "api-func"))
+			suite.Require().Equal(http.MethodGet, suite.authProxyRequestMethod)
+		})
+	}
+}
+
+// TestMaliciousPathCannotHijackTheAuthProxyHost verifies a caller path shaped like userinfo (containing
+// "@") lands on the auth-proxy's path rather than being reparsed into a different host. The caller's
+// path is attacker-controlled; string-concatenating it into the auth-proxy URL would let a path such as
+// "@evil.example.com/steal" silently redirect the verdict request off the loopback auth-proxy.
+func (suite *TargetAuthenticatorTestSuite) TestMaliciousPathCannotHijackTheAuthProxyHost() {
+	authURLCallCount := 0
+	authenticator, closeServers := suite.newAuthOnlyAuthenticator(&authURLCallCount,
+		suite.newFunction("api-func", map[string]interface{}{
+			"authenticationMode": auth.AuthenticationModeAPI,
+		}))
+	defer closeServers()
+
+	request := suite.callerRequest(validToken)
+	request.URL.Path = "@evil.example.com/steal"
+	request.URL.RawPath = ""
+
+	recorder := httptest.NewRecorder()
+
+	// if the malicious path were reparsed into a host, the request would never reach the real
+	// auth-proxy stub, and this would fail closed with a 502 instead of authenticating
+	suite.Require().True(authenticator.AuthenticateTarget(recorder, request, "api-func"))
+	suite.Require().Equal(1, authURLCallCount)
+	suite.Require().Equal("/@evil.example.com/steal?q=1", suite.authProxyRequestURI)
 }
 
 // TestDLXResolvedTargetOverridesTheCallerHeader verifies the name the DLX resolved is the one the
@@ -274,6 +323,7 @@ func (suite *TargetAuthenticatorTestSuite) newAuthOnlyAuthenticator(authURLCallC
 	authProxyServer := httptest.NewServer(http.HandlerFunc(
 		func(responseWriter http.ResponseWriter, request *http.Request) {
 			suite.authProxyRequestURI = request.URL.RequestURI()
+			suite.authProxyRequestMethod = request.Method
 			if authenticator.Authenticate(responseWriter, request) {
 				responseWriter.WriteHeader(http.StatusOK)
 			}

--- a/pkg/platform/kube/test/function/function_test.go
+++ b/pkg/platform/kube/test/function/function_test.go
@@ -2018,13 +2018,19 @@ func (suite *DeployFunctionTestSuite) TestDeployFunctionWithSidecarBasicAuth() {
 			suite.Require().NoError(err, "Port did not answer the authorized status code; portName: %s",
 				testCase.portName)
 
-			// with no credentials, and with the wrong ones, the proxy rejects before the upstream is reached
-			suite.Require().Equal(http.StatusUnauthorized,
-				suite.invokeFunctionNodePort(servicePort.NodePort, "", ""),
-				"portName: %s", testCase.portName)
-			suite.Require().Equal(http.StatusUnauthorized,
-				suite.invokeFunctionNodePort(servicePort.NodePort, username, "wrong-password"),
-				"portName: %s", testCase.portName)
+			// with no credentials or invalid credentials, the proxy rejects the request before reaching the upstream.
+			// Retry because a freshly (re)created NodePort may temporarily reset connections while it settles.
+			err = common.RetryUntilSuccessful(90*time.Second, 2*time.Second, func() bool {
+				return suite.invokeFunctionNodePort(servicePort.NodePort, "", "") == http.StatusUnauthorized
+			})
+			suite.Require().NoError(err, "Port did not answer unauthorized with no credentials; portName: %s",
+				testCase.portName)
+			err = common.RetryUntilSuccessful(90*time.Second, 2*time.Second, func() bool {
+				return suite.invokeFunctionNodePort(servicePort.NodePort, username, "wrong-password") ==
+					http.StatusUnauthorized
+			})
+			suite.Require().NoError(err, "Port did not answer unauthorized with wrong password; portName: %s",
+				testCase.portName)
 		}
 
 		return true


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
The DLX (scale-to-zero proxy) currently scales a function back up before any authentication check, so a request that would normally be rejected by the function's own auth-proxy still triggers a cold start. This PR adds an authentication step to the DLX itself: before scaling a function from zero, the DLX asks a co-located `auth-proxy` sidecar (running in `authOnly` mode) whether the request is allowed, using the same auth config the function's own auth-proxy would use. If rejected, the DLX relays the auth-proxy's verdict (401/302/403) to the caller and never scales the function up.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
- Added `pkg/platform/kube/resourcescaler/targetauthenticator.go`: `AuthOnlyAuthenticator`, wired into `NuclioResourceScaler.GetConfig()` as the new `scalertypes.TargetAuthenticator` (from v3io/scaler#92), gated by `platform.authentication.functionAuthenticationEnabled`. It forwards the caller's request (relevant headers + request line) to the DLX-local `auth-proxy` sidecar over loopback and relays the verdict.
- `cmd/authproxy/app/server.go`: the `authOnly` handler now answers on any path instead of only `/auth`, since the DLX replays the caller's own request line so browser-mode redirects point back at the URL the caller actually requested.
- `pkg/auth/authproxy/authonly.go` / `types.go`: removed the now-unused in-process `bindRequest`/`boundAuthenticator` path and the `TargetAuthenticator` interface it implemented, superseded by the HTTP round-trip to the sidecar.
- `hack/k8s/helm/nuclio/templates/deployment/dlx.yaml`: adds the `auth-proxy` sidecar container to the DLX pod (in `authOnly` mode) when `functionAuthenticationEnabled` is set.
- Added/updated unit tests: `server_test.go`, `authproxy_test.go`, `targetauthenticator_test.go`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- UTs
- Dev test - deployed functions with all 3 possible scale to zero modes (`none`, `api`, `browser`) with minimun 0 replicas, was able to scale from zero after successful authentication 

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-837
- Design docs links:
- External links: https://github.com/v3io/scaler/pull/92

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
- This PR is blocked by https://github.com/v3io/scaler/pull/92, need a new DLX tag before merging this code changes
