### PR TITLE
[Kafka] Fix redundant drain calls leading to scaling issues

### DIFF
--- a/pkg/processor/trigger/kafka/kafka_test.go
+++ b/pkg/processor/trigger/kafka/kafka_test.go
@@ -607,8 +607,9 @@ func (suite *TestSuite) TestDrainOnRebalanceTimeoutDoesNotPanic() {
 			WorkerAllocator: &eventprocessor.ZeroAllocator{},
 			Statistics:      &trigger.Statistics{},
 		},
-		configuration: &Configuration{},
-		ctx:           context.Background(),
+		configuration:      &Configuration{},
+		ctx:                context.Background(),
+		rebalanceDrainOnce: &sync.Once{},
 	}
 	k.configuration.maxWaitHandlerDuringRebalance = 30 * time.Millisecond
 

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -66,6 +66,16 @@ type kafka struct {
 	// timeout path only flags intent. Cleanup runs once per session and performs the actual
 	// recovery, restarting any worker that did not acknowledge draining.
 	restartWorkersOnCleanup atomic.Bool
+
+	// Drain() drains every worker regardless of partition, so P concurrent ConsumeClaim
+	// goroutines per rebalance should trigger it once, not P times. rebalanceDrainOnce is reset
+	// fresh each session (in Setup); its result is cached in rebalanceDrainResult for the
+	// other callers that block on Do.
+	rebalanceDrainOnce   *sync.Once
+	rebalanceDrainResult struct {
+		drained map[string]struct{}
+		err     error
+	}
 }
 
 func newTrigger(parentLogger logger.Logger,
@@ -194,6 +204,9 @@ func (k *kafka) GetConfig() map[string]interface{} {
 
 func (k *kafka) Setup(session sarama.ConsumerGroupSession) error {
 	var err error
+
+	// fresh Once per session for the deduplicated Drain() call
+	k.rebalanceDrainOnce = &sync.Once{}
 
 	k.Logger.InfoWith("Starting consumer session",
 		"claims", session.Claims(),
@@ -431,7 +444,15 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 			// dedupes acknowledgements by worker ID. Drain returns as soon as every worker has
 			// acknowledged over the control socket (or the context times out) rather than blocking
 			// for a fixed timeout.
-			if _, err := k.Drain(drainingContext); err != nil {
+			//
+			// Only the first of the P concurrent claim goroutines actually calls Drain; the
+			// rest block on Do and reuse its result.
+			k.rebalanceDrainOnce.Do(func() {
+				drained, err := k.Drain(drainingContext)
+				k.rebalanceDrainResult.drained = drained
+				k.rebalanceDrainResult.err = err
+			})
+			if err := k.rebalanceDrainResult.err; err != nil {
 				k.Logger.DebugWith("Failed to drain workers",
 					"err", err.Error(),
 					"partition", claim.Partition())

--- a/pkg/processor/trigger/kafka/trigger.go
+++ b/pkg/processor/trigger/kafka/trigger.go
@@ -69,13 +69,10 @@ type kafka struct {
 
 	// Drain() drains every worker regardless of partition, so P concurrent ConsumeClaim
 	// goroutines per rebalance should trigger it once, not P times. rebalanceDrainOnce is reset
-	// fresh each session (in Setup); its result is cached in rebalanceDrainResult for the
-	// other callers that block on Do.
-	rebalanceDrainOnce   *sync.Once
-	rebalanceDrainResult struct {
-		drained map[string]struct{}
-		err     error
-	}
+	// fresh each session (in Setup); rebalanceDrainErr is cached for the other callers that
+	// block on Do.
+	rebalanceDrainOnce *sync.Once
+	rebalanceDrainErr  error
 }
 
 func newTrigger(parentLogger logger.Logger,
@@ -205,8 +202,9 @@ func (k *kafka) GetConfig() map[string]interface{} {
 func (k *kafka) Setup(session sarama.ConsumerGroupSession) error {
 	var err error
 
-	// fresh Once per session for the deduplicated Drain() call
+	// fresh Once and error per session for the deduplicated rebalance Drain() call
 	k.rebalanceDrainOnce = &sync.Once{}
+	k.rebalanceDrainErr = nil
 
 	k.Logger.InfoWith("Starting consumer session",
 		"claims", session.Claims(),
@@ -448,13 +446,11 @@ func (k *kafka) drainOnRebalance(session sarama.ConsumerGroupSession,
 			// Only the first of the P concurrent claim goroutines actually calls Drain; the
 			// rest block on Do and reuse its result.
 			k.rebalanceDrainOnce.Do(func() {
-				drained, err := k.Drain(drainingContext)
-				k.rebalanceDrainResult.drained = drained
-				k.rebalanceDrainResult.err = err
+				_, k.rebalanceDrainErr = k.Drain(drainingContext)
 			})
-			if err := k.rebalanceDrainResult.err; err != nil {
+			if k.rebalanceDrainErr != nil {
 				k.Logger.DebugWith("Failed to drain workers",
-					"err", err.Error(),
+					"err", k.rebalanceDrainErr.Error(),
 					"partition", claim.Partition())
 			}
 			wg.Done()

--- a/pkg/processor/trigger/trigger.go
+++ b/pkg/processor/trigger/trigger.go
@@ -367,8 +367,16 @@ func (at *AbstractTrigger) SubscribeToControlMessageKind(kind controlcommunicati
 		"kind", kind,
 		"numWorkers", len(workers))
 
+	// Workers share one broker, dedupe by identity instead of subscribing per worker.
+	seenBrokers := make(map[controlcommunication.ControlMessageBroker]bool, len(workers))
 	subs := make([]controlcommunication.Subscription, 0, len(workers))
 	for _, workerInstance := range workers {
+		broker := workerInstance.GetRuntime().GetControlMessageBroker()
+		if seenBrokers[broker] {
+			continue
+		}
+		seenBrokers[broker] = true
+
 		sub, err := workerInstance.Subscribe(kind)
 		if err != nil {
 			// release any subscriptions we already created so we don't leak

--- a/pkg/processor/trigger/trigger_test.go
+++ b/pkg/processor/trigger/trigger_test.go
@@ -26,12 +26,24 @@ import (
 
 	"github.com/nuclio/nuclio/pkg/processor/controlcommunication"
 	"github.com/nuclio/nuclio/pkg/processor/eventprocessor"
+	"github.com/nuclio/nuclio/pkg/processor/runtime"
 	"github.com/nuclio/nuclio/pkg/processor/statistics"
 
 	"github.com/nuclio/logger"
 	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
 )
+
+// brokerOnlyRuntime satisfies runtime.Runtime by embedding the interface (nil, so any other
+// method panics rather than silently no-op'ing) and implementing only GetControlMessageBroker.
+type brokerOnlyRuntime struct {
+	runtime.Runtime
+	broker *controlcommunication.ControlMessageBrokerBase
+}
+
+func (r *brokerOnlyRuntime) GetControlMessageBroker() controlcommunication.ControlMessageBroker {
+	return r.broker
+}
 
 // drainTestWorker is a minimal EventProcessor whose Subscribe is backed by a real control-message
 // broker, so the test delivers drain acknowledgements exactly as the RPC reader would in
@@ -54,6 +66,12 @@ func (w *drainTestWorker) GetIndex() int {
 
 func (w *drainTestWorker) Subscribe(kind controlcommunication.ControlMessageKind) (controlcommunication.Subscription, error) {
 	return w.broker.Subscribe(kind)
+}
+
+// GetRuntime exposes this worker's broker for SubscribeToControlMessageKind's dedup - the
+// embedded mock's GetRuntime is unstubbed and would panic.
+func (w *drainTestWorker) GetRuntime() runtime.Runtime {
+	return &brokerOnlyRuntime{broker: w.broker}
 }
 
 // acknowledgeDrain simulates the Python wrapper sending its drain-complete control message.


### PR DESCRIPTION
### 📝 Description

A Kafka-triggered function with many workers never stabilizes under HPA: every rebalance (scale up or down) makes the processor re-subscribe and re-signal drain acks far more times than necessary, spiking CPU enough to trigger the *next* scale event, forever. This PR fixes the two redundancy bugs causing that storm.

---

### 🛠️ Changes Made

- **`pkg/processor/trigger/trigger.go`**: `SubscribeToControlMessageKind` subscribed once per worker even though all workers share one control-message broker, creating W identical subscriptions to the same broker. Now dedupes by broker identity, so it subscribes once per distinct broker (in practice, once).
- **`pkg/processor/trigger/kafka/trigger.go`**: `drainOnRebalance` fires once per partition-claim goroutine (P per rebalance), and each one independently called `Drain()`, even though one `Drain()` call already drains every worker. Now uses a per-session `sync.Once` so only the first of the P concurrent calls actually drains; the rest reuse its result.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Unit tests (`go test -race`) across the touched packages
- Manual on-prem repro: built + deployed the fix, triggered live scale-down/scale-up rebalances, confirmed via log instrumentation that `duplicateMessages` is 0 and `liveDrainCalls` peaks at 1 on every rebalance (previously up to ~56,000 duplicates and liveDrainCalls > 1)
- Confirmed via `pprof`/`go tool trace` captures that the redundant CPU cost (goroutine spawn, ack decoding) disappeared after the fix
- Watched HPA across multiple scale cycles post-fix: no more oscillation, converges to `minReplicas` when idle

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes

