### PR TITLE
[Dashboard] Disable API GW auth when function auth flag is on

### DIFF
--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -2649,6 +2649,17 @@ func (p *Platform) validateProbeSpec(probe *v1.Probe) error {
 }
 
 func (p *Platform) validateAPIGatewayAuthentication(apiGatewayConfig *platform.APIGatewayConfig) error {
+	if p.IsFunctionAuthenticationEnabled() {
+		spec := apiGatewayConfig.Spec
+		if spec.AuthenticationMode != "" || spec.Authentication != nil {
+			return nuclio.NewErrBadRequest(
+				"API Gateway authentication is no longer supported; " +
+					"configure authentication on the function HTTP trigger " +
+					"(spec.triggers.<http>.attributes.authenticationMode) instead")
+		}
+		return nil
+	}
+
 	switch apiGatewayConfig.Spec.AuthenticationMode {
 	case auth.AuthenticationModeIguazio:
 		// In iguazio authentication mode, overriding the authentication's annotations is restricted by design

--- a/pkg/platform/kube/platform_test.go
+++ b/pkg/platform/kube/platform_test.go
@@ -2564,19 +2564,22 @@ func (suite *FunctionKubePlatformTestSuite) TestUsernameLabelsEnrichment() {
 
 func (suite *FunctionKubePlatformTestSuite) TestValidateAPIGatewayAuthentication() {
 	for _, testCase := range []struct {
-		name               string
-		authenticationMode auth.AuthenticationMode
-		annotations        map[string]string
-		expectError        bool
+		name                string
+		authenticationMode  auth.AuthenticationMode
+		annotations         map[string]string
+		expectError         bool
+		authentication      *platform.APIGatewayAuthenticationSpec
+		functionAuthEnabled bool
 	}{
+		// flag off — legacy behavior
 		{
-			name:               "Valid iguazio authentication with empty annotations",
+			name:               "Flag off: valid iguazio authentication with empty annotations",
 			authenticationMode: auth.AuthenticationModeIguazio,
 			annotations:        map[string]string{},
 			expectError:        false,
 		},
 		{
-			name:               "Valid not iguazio authentication mode with overrides",
+			name:               "Flag off: valid non-iguazio authentication mode with overrides",
 			authenticationMode: auth.AuthenticationModeNone,
 			annotations: map[string]string{
 				annotations.NginxProxyBodySize: "100",
@@ -2584,7 +2587,7 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateAPIGatewayAuthentication
 			expectError: false,
 		},
 		{
-			name:               "Iguazio authentication with overrides",
+			name:               "Flag off: iguazio authentication with restricted annotation overrides",
 			authenticationMode: auth.AuthenticationModeIguazio,
 			annotations: map[string]string{
 				annotations.NginxAuthResponseHeaders: "test-header",
@@ -2598,21 +2601,76 @@ func (suite *FunctionKubePlatformTestSuite) TestValidateAPIGatewayAuthentication
 			expectError: true,
 		},
 		{
-			name:               "Iguazio authentication with a different annotation",
+			name:               "Flag off: iguazio authentication with a non-restricted annotation",
 			authenticationMode: auth.AuthenticationModeIguazio,
 			annotations: map[string]string{
 				"test-annotation": "test-value",
 			},
 			expectError: false,
 		},
+
+		// flag on — any auth is rejected
+
+		{
+			name:                "Flag on: AuthenticationMode set to none is rejected",
+			authenticationMode:  auth.AuthenticationModeNone,
+			functionAuthEnabled: true,
+			expectError:         true,
+		},
+		{
+			name:                "Flag on: AuthenticationMode set to basicAuth is rejected",
+			authenticationMode:  auth.AuthenticationModeBasicAuth,
+			functionAuthEnabled: true,
+			expectError:         true,
+		},
+		{
+			name:                "Flag on: AuthenticationMode set to iguazio is rejected",
+			authenticationMode:  auth.AuthenticationModeIguazio,
+			functionAuthEnabled: true,
+			expectError:         true,
+		},
+		{
+			name:                "Flag on: AuthenticationMode set to accessKey is rejected",
+			authenticationMode:  auth.AuthenticationModeAccessKey,
+			functionAuthEnabled: true,
+			expectError:         true,
+		},
+		{
+			name:                "Flag on: AuthenticationMode set to oauth2 is rejected",
+			authenticationMode:  auth.AuthenticationModeOauth2,
+			functionAuthEnabled: true,
+			expectError:         true,
+		},
+		{
+			name:                "Flag on: empty AuthenticationMode with non-nil Authentication is rejected",
+			authentication:      &platform.APIGatewayAuthenticationSpec{BasicAuth: &platform.BasicAuth{Username: "user", Password: "pass"}},
+			functionAuthEnabled: true,
+			expectError:         true,
+		},
+		{
+			name:                "Flag on: empty AuthenticationMode and nil Authentication is accepted",
+			functionAuthEnabled: true,
+			expectError:         false,
+		},
 	} {
 		suite.Run(testCase.name, func() {
+			previousAuthentication := suite.platform.Config.Authentication
+			defer func() {
+				suite.platform.Config.Authentication = previousAuthentication
+			}()
+			if testCase.functionAuthEnabled {
+				suite.platform.Config.Authentication = &platformconfig.Authentication{
+					FunctionAuthenticationEnabled: true,
+				}
+			}
+
 			testApiGatewayConfig := &platform.APIGatewayConfig{
 				Meta: platform.APIGatewayMeta{
 					Annotations: testCase.annotations,
 				},
 				Spec: platform.APIGatewaySpec{
 					AuthenticationMode: testCase.authenticationMode,
+					Authentication:     testCase.authentication,
 				},
 			}
 

--- a/pkg/platform/kube/test/function/function_test.go
+++ b/pkg/platform/kube/test/function/function_test.go
@@ -1876,7 +1876,6 @@ func (suite *DeployFunctionTestSuite) TestDeployFromGitPythonRuntime() {
 	})
 }
 
-
 // TestDeployFunctionWithSidecarBasicAuth is TestDeployFunctionWithSidecarMultiplePorts with function-level
 // basic-auth turned on: the auth-proxy is injected and fronts every port the Service publishes - the
 // function's own and both of the sidecar's - so none of them can be reached without credentials.


### PR DESCRIPTION
### 📝 Description

This PR adds validation to reject API Gateway authentication configurations when the function authentication flag is enabled, guiding users to configure authentication on the function HTTP trigger instead.

---

### 🛠️ Changes Made

- Modified `validateAPIGatewayAuthentication()` to check if function authentication is enabled
- Updated test cases to cover both legacy behavior (flag off) and new behavior (flag on)

---

### ✅ Checklist
- [x] I have tested the changes in this PR

---

### 🧪 Testing

- Added 7 new test cases covering:
  - Rejection of all authentication modes when flag is on (none, basicAuth, iguazio, accessKey, oauth2)
  - Rejection of non-nil Authentication spec when flag is on
  - Acceptance of empty config when flag is on
  - Existing legacy tests for flag-off behavior remain unchanged
- Tests use table-driven approach with proper test isolation

---

### 🔗 References

Ticket link: https://ecliptos.atlassian.net/browse/NUC-834
Design docs links:
External links: 

---

### 🚨 Breaking Changes?

- [x] No

---

### 🔍️ Additional Notes
- Controller changes in a separated PR