### PR TITLE
[Controller] Disable API GW auth if FF is on

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -195,7 +195,7 @@ func createController(kubeconfigPath string,
 	}
 
 	// create api gateway provisioner
-	apigatewayresClient, err := apigatewayres.NewLazyClient(rootLogger, kubeClientSet, nuclioClientSet, ingressManager)
+	apigatewayresClient, err := apigatewayres.NewLazyClient(rootLogger, kubeClientSet, nuclioClientSet, ingressManager, platformConfiguration)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create api gateway provisioner")
 	}

--- a/pkg/platform/kube/apigatewayres/lazy.go
+++ b/pkg/platform/kube/apigatewayres/lazy.go
@@ -299,6 +299,10 @@ func (lc *lazyClient) configureIngressAuthentication(apiGateway nuclioio.NuclioA
 	if lc.platformConfiguration.IsFunctionAuthenticationEnabled() {
 		// when function-level authentication is enabled, the API Gateway no longer holds auth;
 		// render the ingress without any auth annotations regardless of what the CRD carries
+		if apiGateway.Spec.AuthenticationMode != "" && apiGateway.Spec.AuthenticationMode != auth.AuthenticationModeNone {
+			lc.logger.WarnWith("Function-level authentication is enabled, ignoring API Gateway authentication settings",
+				"api gateway name", apiGateway.Name, "ignored api gateway authentication mode", apiGateway.Spec.AuthenticationMode)
+		}
 		spec.AuthenticationMode = auth.AuthenticationModeNone
 		return nil
 	}

--- a/pkg/platform/kube/apigatewayres/lazy.go
+++ b/pkg/platform/kube/apigatewayres/lazy.go
@@ -32,6 +32,7 @@ import (
 	kubeclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
 	nuclioio_client "github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio/clientset/versioned"
 	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -43,24 +44,27 @@ import (
 //
 
 type lazyClient struct {
-	logger          logger.Logger
-	kubeClientSet   kubeclient.Client
-	nuclioClientSet nuclioio_client.Interface
-	ingressManager  *ingress.Manager
-	scrubber        *platform.APIGatewayScrubber
+	logger                logger.Logger
+	kubeClientSet         kubeclient.Client
+	nuclioClientSet       nuclioio_client.Interface
+	ingressManager        *ingress.Manager
+	scrubber              *platform.APIGatewayScrubber
+	platformConfiguration *platformconfig.Config
 }
 
 func NewLazyClient(loggerInstance logger.Logger,
 	kubeClientSet kubeclient.Client,
 	nuclioClientSet nuclioio_client.Interface,
-	ingressManager *ingress.Manager) (Client, error) {
+	ingressManager *ingress.Manager,
+	platformConfiguration *platformconfig.Config) (Client, error) {
 
 	newClient := lazyClient{
-		logger:          loggerInstance.GetChild("apigatewayres"),
-		kubeClientSet:   kubeClientSet,
-		nuclioClientSet: nuclioClientSet,
-		ingressManager:  ingressManager,
-		scrubber:        platform.NewAPIGatewayScrubber(loggerInstance, platform.GetAPIGatewaySensitiveField(), kubeClientSet),
+		logger:                loggerInstance.GetChild("apigatewayres"),
+		kubeClientSet:         kubeClientSet,
+		nuclioClientSet:       nuclioClientSet,
+		ingressManager:        ingressManager,
+		scrubber:              platform.NewAPIGatewayScrubber(loggerInstance, platform.GetAPIGatewaySensitiveField(), kubeClientSet),
+		platformConfiguration: platformConfiguration,
 	}
 
 	return &newClient, nil
@@ -239,34 +243,8 @@ func (lc *lazyClient) generateNginxIngress(ctx context.Context,
 		Labels:         upstream.ExtraLabels,
 	}
 
-	switch apiGateway.Spec.AuthenticationMode {
-	case auth.AuthenticationModeNone:
-		commonIngressSpec.AuthenticationMode = auth.AuthenticationModeNone
-	case auth.AuthenticationModeBasicAuth:
-		if apiGateway.Spec.Authentication == nil || apiGateway.Spec.Authentication.BasicAuth == nil {
-			return nil, errors.New("Basic auth specified but missing basic auth spec")
-		}
-		commonIngressSpec.AuthenticationMode = auth.AuthenticationModeBasicAuth
-		commonIngressSpec.Authentication = &ingress.Authentication{
-			BasicAuth: &ingress.BasicAuth{
-				Name:     kube.BasicAuthNameFromAPIGatewayName(apiGateway.Name),
-				Username: apiGateway.Spec.Authentication.BasicAuth.Username,
-				Password: apiGateway.Spec.Authentication.BasicAuth.Password,
-			},
-		}
-	case auth.AuthenticationModeOauth2:
-		commonIngressSpec.AuthenticationMode = auth.AuthenticationModeOauth2
-		if apiGateway.Spec.Authentication != nil && apiGateway.Spec.Authentication.DexAuth != nil {
-			commonIngressSpec.Authentication = &ingress.Authentication{
-				DexAuth: apiGateway.Spec.Authentication.DexAuth,
-			}
-		}
-	case auth.AuthenticationModeAccessKey:
-		commonIngressSpec.AuthenticationMode = auth.AuthenticationModeAccessKey
-	case auth.AuthenticationModeIguazio:
-		commonIngressSpec.AuthenticationMode = auth.AuthenticationModeIguazio
-	default:
-		return nil, errors.New("Unsupported ApiGateway authentication mode provided")
+	if err := lc.configureIngressAuthentication(apiGateway, &commonIngressSpec); err != nil {
+		return nil, errors.Wrap(err, "Failed to configure ingress authentication")
 	}
 
 	// if percentage is given, it is the canary deployment
@@ -315,6 +293,46 @@ func (lc *lazyClient) getServiceNameAndPort(upstream *platform.APIGatewayUpstrea
 	default:
 		return "", 0, errors.Errorf("Unsupported API gateway upstream kind: %s", upstream.Kind)
 	}
+}
+
+func (lc *lazyClient) configureIngressAuthentication(apiGateway nuclioio.NuclioAPIGateway, spec *ingress.Spec) error {
+	if lc.platformConfiguration.IsFunctionAuthenticationEnabled() {
+		// when function-level authentication is enabled, the API Gateway no longer holds auth;
+		// render the ingress without any auth annotations regardless of what the CRD carries
+		spec.AuthenticationMode = auth.AuthenticationModeNone
+		return nil
+	}
+
+	switch apiGateway.Spec.AuthenticationMode {
+	case auth.AuthenticationModeNone:
+		spec.AuthenticationMode = auth.AuthenticationModeNone
+	case auth.AuthenticationModeBasicAuth:
+		if apiGateway.Spec.Authentication == nil || apiGateway.Spec.Authentication.BasicAuth == nil {
+			return errors.New("Basic auth specified but missing basic auth spec")
+		}
+		spec.AuthenticationMode = auth.AuthenticationModeBasicAuth
+		spec.Authentication = &ingress.Authentication{
+			BasicAuth: &ingress.BasicAuth{
+				Name:     kube.BasicAuthNameFromAPIGatewayName(apiGateway.Name),
+				Username: apiGateway.Spec.Authentication.BasicAuth.Username,
+				Password: apiGateway.Spec.Authentication.BasicAuth.Password,
+			},
+		}
+	case auth.AuthenticationModeOauth2:
+		spec.AuthenticationMode = auth.AuthenticationModeOauth2
+		if apiGateway.Spec.Authentication != nil && apiGateway.Spec.Authentication.DexAuth != nil {
+			spec.Authentication = &ingress.Authentication{
+				DexAuth: apiGateway.Spec.Authentication.DexAuth,
+			}
+		}
+	case auth.AuthenticationModeAccessKey:
+		spec.AuthenticationMode = auth.AuthenticationModeAccessKey
+	case auth.AuthenticationModeIguazio:
+		spec.AuthenticationMode = auth.AuthenticationModeIguazio
+	default:
+		return errors.New("Unsupported ApiGateway authentication mode provided")
+	}
+	return nil
 }
 
 func (lc *lazyClient) resolveCommonAnnotations(canaryDeployment bool, upstreamPercentage int) map[string]string {

--- a/pkg/platform/kube/apigatewayres/lazy_test.go
+++ b/pkg/platform/kube/apigatewayres/lazy_test.go
@@ -65,8 +65,56 @@ func (suite *lazyTestSuite) SetupTest() {
 	suite.client, err = NewLazyClient(suite.logger,
 		kube.NewClientWithRetryFromClient(kubeClientset),
 		fake.NewSimpleClientset(),
-		suite.ingressManager)
+		suite.ingressManager,
+		platformConfig)
 	suite.Require().NoError(err)
+}
+
+func (suite *lazyTestSuite) TestConfigureIngressAuthenticationFunctionAuthEnabled() {
+	for _, testCase := range []struct {
+		name                   string
+		functionAuthEnabled    bool
+		authMode               auth.AuthenticationMode
+		expectedMode           auth.AuthenticationMode
+		expectedAuthentication *ingress.Authentication
+	}{
+		{
+			name:                   "Flag on: any auth mode is overridden to none",
+			functionAuthEnabled:    true,
+			authMode:               auth.AuthenticationModeIguazio,
+			expectedMode:           auth.AuthenticationModeNone,
+			expectedAuthentication: nil,
+		},
+		{
+			name:                   "Flag off: auth mode is preserved as-is (regression)",
+			functionAuthEnabled:    false,
+			authMode:               auth.AuthenticationModeAccessKey,
+			expectedMode:           auth.AuthenticationModeAccessKey,
+			expectedAuthentication: nil,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			lc := &lazyClient{
+				platformConfiguration: &platformconfig.Config{
+					Authentication: &platformconfig.Authentication{
+						FunctionAuthenticationEnabled: testCase.functionAuthEnabled,
+					},
+				},
+			}
+
+			agw := nuclioio.NuclioAPIGateway{
+				Spec: platform.APIGatewaySpec{
+					AuthenticationMode: testCase.authMode,
+					Authentication:     &platform.APIGatewayAuthenticationSpec{},
+				},
+			}
+
+			spec := ingress.Spec{}
+			suite.Require().NoError(lc.configureIngressAuthentication(agw, &spec))
+			suite.Require().Equal(testCase.expectedMode, spec.AuthenticationMode)
+			suite.Require().Equal(testCase.expectedAuthentication, spec.Authentication)
+		})
+	}
 }
 
 func (suite *lazyTestSuite) TestEnsurePrimaryIngressHasFunctionLabels() {

--- a/pkg/platform/kube/apigatewayres/lazy_test.go
+++ b/pkg/platform/kube/apigatewayres/lazy_test.go
@@ -100,6 +100,7 @@ func (suite *lazyTestSuite) TestConfigureIngressAuthenticationFunctionAuthEnable
 						FunctionAuthenticationEnabled: testCase.functionAuthEnabled,
 					},
 				},
+				logger: suite.logger,
 			}
 
 			agw := nuclioio.NuclioAPIGateway{

--- a/pkg/platform/kube/test/suite/suite.go
+++ b/pkg/platform/kube/test/suite/suite.go
@@ -685,7 +685,8 @@ func (suite *KubeTestSuite) createController() *controller.Controller {
 	apigatewayresClient, err := apigatewayres.NewLazyClient(suite.Logger,
 		kubeclient.NewClientWithRetryFromClient(suite.KubeClientSet),
 		suite.FunctionClientSet,
-		ingressManager)
+		ingressManager,
+		suite.PlatformConfiguration)
 	suite.Require().NoError(err)
 
 	controllerInstance, err := controller.NewController(suite.Logger,


### PR DESCRIPTION
### 📝 Description
This PR ensures that when the `function-level authentication` feature flag is enabled, the ingress auth annotation is set to 'none' regardless of what the API Gateway CRD specifies.

---

### 🛠️ Changes Made
- Added `platformConfiguration` parameter to `NewLazyClient` to access feature flag settings
- Extracted authentication configuration logic into a new `configureIngressAuthentication` method that checks the feature flag
- When function-level auth is enabled, auth mode defaults to 'none' regardless of CRD spec
- Updated controller and test suite initialization to pass platform configuration to the lazy client

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Added unit test `TestConfigureIngressAuthenticationFunctionAuthEnabled` with table-driven test cases:
  - Flag enabled: verifies any auth mode is overridden to 'none'
  - Flag disabled: verifies auth mode is preserved (regression test)
- Existing tests updated to pass platform configuration parameter

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-835
- Design docs links: 
- External links: 

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
Feature flag controlled - backward compatible. When flag is disabled, behavior is unchanged (auth handled at API Gateway level). When enabled, auth is delegated to function level.