### PR TITLE
[Security] Bump go-git/v5 to v5.19.2 (XRAY-1039308)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-chi/cors v1.2.2
-	github.com/go-git/go-git/v5 v5.19.1
+	github.com/go-git/go-git/v5 v5.19.2
 	github.com/gobuffalo/flect v1.0.3
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmm
 github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
-github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.2 h1:wkfn7vOlUBu8ivAWKBWisTiwJK4jYHzTF8Ndv1LyGqY=
+github.com/go-git/go-git/v5 v5.19.2/go.mod h1:QqCBE1EFN5ddFmrliLQ3/ntRCUjZU3EJuwuB/jWEHjk=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
### 📝 Description
Bumps `github.com/go-git/go-git/v5` from `5.19.1` to `5.19.2`. This dependency is compiled into every Nuclio Go binary (processor/controller/dlx/autoscaler), so the same finding was flagged by Xray on every image that embeds one of those binaries.

---

### 🛠️ Changes Made
- `go.mod` / `go.sum` — bump `github.com/go-git/go-git/v5` to `v5.19.2`

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- `go build` succeeds for `pkg/common/git`, `pkg/dashboard/functiontemplates`, and all `cmd/*` binaries
- `go test -tags=test_unit -race -short ./pkg/common/git/... ./pkg/dashboard/functiontemplates/...` passes
- `go vet` clean on the affected packages

---

### 🔗 References
- Ticket link: [NUC-885](https://ecliptos.atlassian.net/browse/NUC-885), [NUC-887](https://ecliptos.atlassian.net/browse/NUC-887), [NUC-890](https://ecliptos.atlassian.net/browse/NUC-890), [NUC-893](https://ecliptos.atlassian.net/browse/NUC-893), [NUC-897](https://ecliptos.atlassian.net/browse/NUC-897), [NUC-899](https://ecliptos.atlassian.net/browse/NUC-899)
- Design docs links:
- External links: XRAY-1039308

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
This single dependency bump resolves the identical Xray finding reported separately across 6 Jira tickets, since they all trace back to the same vendored `go-git` version.