### PR TITLE
[Security] Bump msgpack (PyPI) to 1.2.1 (CVE-2026-57585)

### DIFF
--- a/pkg/processor/runtime/python/py/requirements/common.txt
+++ b/pkg/processor/runtime/python/py/requirements/common.txt
@@ -1,4 +1,4 @@
 mock==2.0.0
 nuclio-sdk==0.6.3
 pip==26.1
-msgpack==1.1.0
+msgpack==1.2.1


### PR DESCRIPTION
### 📝 Description
Bumps the PyPI `msgpack` pin from `1.1.0` to `1.2.1` in the Python runtime requirements, fixing CVE-2026-57585 in the wheels baked into the `handler-builder-python-onbuild` image.

---

### 🛠️ Changes Made
- `pkg/processor/runtime/python/py/requirements/common.txt` — bump `msgpack` to `1.2.1`

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Installed `msgpack==1.2.1` in a clean venv and smoke-tested the exact `Unpacker(raw=..., max_buffer_size=...)` call pattern used by `pkg/processor/runtime/python/py/wrapper_common.py` — behavior unchanged
- Confirmed no other requirements file pins a different `msgpack` version

---

### 🔗 References
- Ticket link: [NUC-897](https://ecliptos.atlassian.net/browse/NUC-897)
- Design docs links:
- External links: CVE-2026-57585

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
None.