### PR TITLE
[Buildah] Remove function SecurityContext from Builder pod

### DIFF
--- a/pkg/containerimagebuilderpusher/jobrunner.go
+++ b/pkg/containerimagebuilderpusher/jobrunner.go
@@ -287,7 +287,6 @@ func (r *jobRunner) compileBaseJobSpec(ctx context.Context,
 		PriorityClassName:  buildOptions.PriorityClassName,
 		Tolerations:        buildOptions.Tolerations,
 		ServiceAccountName: serviceAccount,
-		SecurityContext:    buildOptions.SecurityContext,
 	}
 
 	return &batchv1.Job{

--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -56,7 +56,6 @@ type BuildOptions struct {
 	ReadinessTimeoutSeconds                  int
 	FunctionServiceAccount                   string
 	BuilderServiceAccount                    string
-	SecurityContext                          *v1.PodSecurityContext
 	Resources                                v1.ResourceRequirements
 	ProjectName                              string
 	ProjectSecretTemplate                    string

--- a/pkg/processor/build/builder.go
+++ b/pkg/processor/build/builder.go
@@ -1170,7 +1170,6 @@ func (b *Builder) buildProcessorImage(ctx context.Context) (string, error) {
 			BuilderServiceAccount:  b.options.FunctionConfig.Spec.Build.BuilderServiceAccount,
 			ReadinessTimeoutSeconds: b.platform.GetConfig().GetFunctionReadinessTimeoutOrDefault(
 				b.options.FunctionConfig.Spec.ReadinessTimeoutSeconds),
-			SecurityContext:                          b.options.FunctionConfig.Spec.SecurityContext,
 			BuildLogger:                              b.logger,
 			Resources:                                b.resolveResources(),
 			ProjectName:                              projectName,


### PR DESCRIPTION
### 📝 Description
The recent Buildah implementation changed the legacy behaviour by wrongly applying the function spec's SecurityContext to the builder pod.

This introduced a regression because the SecurityContext intended for function deployment generally has lower privileges than those required to build container images.

This PR removes that association, restoring the prior Kaniko behaviour: 
https://github.com/nuclio/nuclio/blob/a0f66aa7b881e33f5cbbb949f5087edebfb7941e/pkg/containerimagebuilderpusher/kaniko.go#L370-L376

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
- Removed FunctionSpec.SecurityContext from Builder pod (& BuildOptions as it's not used)

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->