### PR TITLE
[Helm] Make ServiceAccount token automount configurable on control-plane pods

### DIFF
--- a/hack/k8s/helm/nuclio/templates/deployment/autoscaler.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/autoscaler.yaml
@@ -37,6 +37,7 @@ spec:
         checksum/configmap-platform: {{ include (print $.Template.BasePath "/configmap/platform.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "nuclio.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.autoscaler.automountServiceAccountToken }}
       {{- include "nuclio.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- toYaml .Values.autoscaler.securityContext | nindent 8 }}

--- a/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/controller.yaml
@@ -37,6 +37,7 @@ spec:
         checksum/configmap-platform: {{ include (print $.Template.BasePath "/configmap/platform.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "nuclio.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.controller.automountServiceAccountToken }}
       {{- include "nuclio.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- toYaml .Values.controller.securityContext | nindent 8 }}

--- a/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dashboard.yaml
@@ -39,6 +39,7 @@ spec:
         checksum/configmap-platform: {{ include (print $.Template.BasePath "/configmap/platform.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "nuclio.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.dashboard.automountServiceAccountToken }}
       {{- include "nuclio.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- toYaml .Values.dashboard.securityContext | nindent 8 }}

--- a/hack/k8s/helm/nuclio/templates/deployment/dlx.yaml
+++ b/hack/k8s/helm/nuclio/templates/deployment/dlx.yaml
@@ -37,6 +37,7 @@ spec:
         checksum/configmap-platform: {{ include (print $.Template.BasePath "/configmap/platform.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "nuclio.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.dlx.automountServiceAccountToken }}
       {{- include "nuclio.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- toYaml .Values.dlx.securityContext | nindent 8 }}

--- a/hack/k8s/helm/nuclio/values.yaml
+++ b/hack/k8s/helm/nuclio/values.yaml
@@ -53,6 +53,12 @@ controller:
   ##
   nodeSelector: {}
 
+  ## Whether the controller pod mounts its ServiceAccount token. The controller talks to
+  ## the Kubernetes API, so this overrides any ServiceAccount-level or cluster-wide policy
+  ## that disables automount by default. Disable only if this component is not expected
+  ## to reach the Kubernetes API.
+  automountServiceAccountToken: true
+
   ## Pod-level security context
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
@@ -133,6 +139,12 @@ dashboard:
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
+
+  ## Whether the dashboard pod mounts its ServiceAccount token. The dashboard talks to
+  ## the Kubernetes API, so this overrides any ServiceAccount-level or cluster-wide policy
+  ## that disables automount by default. Disable only if this component is not expected
+  ## to reach the Kubernetes API.
+  automountServiceAccountToken: true
 
   ## Pod-level security context
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -424,6 +436,12 @@ autoscaler:
   ##
   nodeSelector: {}
 
+  ## Whether the autoscaler pod mounts its ServiceAccount token. The autoscaler talks to
+  ## the Kubernetes API, so this overrides any ServiceAccount-level or cluster-wide policy
+  ## that disables automount by default. Disable only if this component is not expected
+  ## to reach the Kubernetes API.
+  automountServiceAccountToken: true
+
   ## Pod-level security context
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
@@ -469,6 +487,12 @@ dlx:
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
+
+  ## Whether the dlx pod mounts its ServiceAccount token. The dlx talks to
+  ## the Kubernetes API, so this overrides any ServiceAccount-level or cluster-wide policy
+  ## that disables automount by default. Disable only if this component is not expected
+  ## to reach the Kubernetes API.
+  automountServiceAccountToken: true
 
   ## Pod-level security context
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/


### PR DESCRIPTION
### 📝 Description
During an app install with the org-wide `sa_token_automount` flag disabling ServiceAccount token automount by default, `nuclio-controller`, `nuclio-dashboard`, `nuclio-dlx`, and `nuclio-scaler` (autoscaler) crash-loop with `open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory`. These four workloads call `rest.InClusterConfig()` to talk to the Kubernetes API, which reads the token from that hardcoded path; when automount is disabled, the file doesn't exist. This PR adds a per-component `values.yaml` toggle that forces automount back on for these four pods, defaulting to `true` so the fix applies out-of-the-box.

---

### 🛠️ Changes Made
- Add an `automountServiceAccountToken` key (default `true`) to `values.yaml` for each of `controller`, `dashboard`, `dlx`, and `autoscaler`.
- Wire that value into the pod spec of the corresponding Deployment template (`hack/k8s/helm/nuclio/templates/deployment/{controller,dashboard,dlx,autoscaler}.yaml`), overriding any ServiceAccount-level or cluster-policy-level default that disables automount. Defaulting to `true` keeps the fix active out-of-the-box; the toggle lets operators override it per component if needed.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable) — N/A, no doc page describes automount behavior for these pods; the new key is self-documented in `values.yaml`
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- `helm lint hack/k8s/helm/nuclio` — 0 charts failed.
- `helm template` with default values confirmed `automountServiceAccountToken: true` renders in all four Deployments.
- `helm template` with an explicit `--set <component>.automountServiceAccountToken=false` override for all four components confirmed it renders `false`, proving the toggle works both ways.
- No Go code changed; this repo has no Helm chart-testing harness in CI, so no automated test was added.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ORIS-4076
- Design docs links: N/A — bugfix
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- This surfaced now because a devops-iac change (fixing a separate ticket, ORIS-4060) made an existing `sa_token_automount` flag start actually taking effect for the first time; before that it was a no-op. No change to devops-iac is included in or required by this PR.