### PR TITLE
[Security] Mask secrets in platform config logs

### DIFF
--- a/pkg/opa/types.go
+++ b/pkg/opa/types.go
@@ -55,6 +55,16 @@ func (c Config) MarshalJSON() ([]byte, error) {
 	return json.Marshal(configAlias(c))
 }
 
+// String redacts the same way as MarshalJSON, so fmt's %v/%+v/%s - which format via
+// reflection and don't call json.Marshaler - can't be used to bypass the redaction.
+func (c Config) String() string {
+	encoded, err := c.MarshalJSON()
+	if err != nil {
+		return redactedSecretValue
+	}
+	return string(encoded)
+}
+
 type AuthorizationNamespace struct {
 	Resources  string `json:"resources,omitempty"`
 	Management string `json:"management,omitempty"`

--- a/pkg/opa/types.go
+++ b/pkg/opa/types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package opa
 
 import (
+	"encoding/json"
+
 	"github.com/nuclio/nuclio/pkg/auth"
 
 	"github.com/nuclio/opa-client"
@@ -26,12 +28,31 @@ const (
 	DefaultRequestTimeout       = 10
 	DefaultPermissionQueryPath  = "/v1/data/iguazio/authz/allow"
 	DefaultPermissionFilterPath = "/v1/data/iguazio/authz/filter_allowed"
+
+	// redactedSecretValue mirrors the "[redacted]" convention already used in
+	// pkg/restful/middleware/middleware.go and pkg/cmdrunner/shellrunner.go.
+	redactedSecretValue = "[redacted]"
 )
 
 type Config struct {
 	*opaclient.Config
 	AuthKind                auth.Kind              `json:"authKind,omitempty"`
 	AuthorizationNamespaces AuthorizationNamespace `json:"authorizationNamespaces"`
+}
+
+// configAlias has Config's exact fields/tags but none of its methods, so marshaling it
+// from within MarshalJSON below can't recurse.
+type configAlias Config
+
+// MarshalJSON redacts OverrideHeaderValue, the OPA-bypass shared secret, so it never
+// reaches a log sink or other JSON output.
+func (c Config) MarshalJSON() ([]byte, error) {
+	if c.Config != nil && c.OverrideHeaderValue != "" {
+		clonedClientConfig := *c.Config
+		clonedClientConfig.OverrideHeaderValue = redactedSecretValue
+		c.Config = &clonedClientConfig
+	}
+	return json.Marshal(configAlias(c))
 }
 
 type AuthorizationNamespace struct {

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -18,6 +18,7 @@ package platformconfig
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"strings"
 	"time"
@@ -79,6 +80,19 @@ type Config struct {
 
 	// stores the encoded ScaleToZero.ReadinessPollInterval as time.Duration
 	scaleToZeroReadinessPollInterval *time.Duration
+}
+
+// configAlias has Config's exact fields/tags but none of its methods, so marshaling it
+// from within MarshalJSON below can't recurse.
+type configAlias Config
+
+// MarshalJSON redacts IguazioSessionCookie, a live, replayable session token, so it
+// never reaches a log sink or other JSON output.
+func (c Config) MarshalJSON() ([]byte, error) {
+	if c.IguazioSessionCookie != "" {
+		c.IguazioSessionCookie = redactedSecretValue
+	}
+	return json.Marshal(configAlias(c))
 }
 
 func NewPlatformConfig(configurationPath string) (*Config, error) {

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -95,6 +95,16 @@ func (c Config) MarshalJSON() ([]byte, error) {
 	return json.Marshal(configAlias(c))
 }
 
+// String redacts the same way as MarshalJSON, so fmt's %v/%+v/%s - which format via
+// reflection and don't call json.Marshaler - can't be used to bypass the redaction.
+func (c Config) String() string {
+	encoded, err := c.MarshalJSON()
+	if err != nil {
+		return redactedSecretValue
+	}
+	return string(encoded)
+}
+
 func NewPlatformConfig(configurationPath string) (*Config, error) {
 
 	// read or get default platform config

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -1218,7 +1218,40 @@ func (suite *PlatformConfigTestSuite) TestConfigMarshalJSONThroughLoggerRedactsS
 
 	logLine := buf.String()
 	suite.NotContains(logLine, "super-secret-es-password")
-	suite.Contains(logLine, `"password":"[redacted]"`)
+	suite.Contains(logLine, `password\":\"[redacted]`)
+}
+
+func (suite *PlatformConfigTestSuite) TestElasticSearchConfigStringRedactsSecrets() {
+	config := ElasticSearchConfig{Username: "elastic", Password: "super-secret-es-password", APIKey: "super-secret-es-key"}
+
+	// %+v is the exact verb a nuclio-zap logger sink configured with a flattened
+	// VarGroupMode uses to render arguments, bypassing MarshalJSON entirely - the
+	// Stringer implementation must catch what MarshalJSON alone would miss.
+	rendered := fmt.Sprintf("%+v", config)
+	suite.NotContains(rendered, "super-secret-es-password")
+	suite.NotContains(rendered, "super-secret-es-key")
+	suite.Contains(rendered, `"password":"[redacted]"`)
+	suite.Contains(rendered, `"apiKey":"[redacted]"`)
+}
+
+func (suite *PlatformConfigTestSuite) TestConfigStringRedactsSecretsUnderPlusV() {
+	config := Config{
+		IguazioSessionCookie: "super-secret-session-token",
+		Kube: PlatformKubeConfig{
+			ElasticSearchConfig: &ElasticSearchConfig{
+				Password: "super-secret-es-password",
+			},
+		},
+		Opa: &opa.Config{
+			Config: &opaclient.Config{OverrideHeaderValue: "super-secret-opa-header"},
+		},
+	}
+
+	rendered := fmt.Sprintf("%+v", config)
+	suite.NotContains(rendered, "super-secret-session-token")
+	suite.NotContains(rendered, "super-secret-es-password")
+	suite.NotContains(rendered, "super-secret-opa-header")
+	suite.Contains(rendered, redactedSecretValue)
 }
 
 func (suite *PlatformConfigTestSuite) TestTrustsLeaderOrigin() {

--- a/pkg/platformconfig/platformconfig_test.go
+++ b/pkg/platformconfig/platformconfig_test.go
@@ -21,6 +21,7 @@ package platformconfig
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
@@ -30,11 +31,13 @@ import (
 	"github.com/nuclio/nuclio/pkg/auth/iguazio"
 	"github.com/nuclio/nuclio/pkg/common"
 	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/opa"
 	"github.com/nuclio/nuclio/pkg/processor/build/runtimeconfig"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/nuclio/logger"
+	opaclient "github.com/nuclio/opa-client"
 	nucliozap "github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1087,6 +1090,135 @@ func (suite *PlatformConfigTestSuite) TestValidatePlatformConfigElasticSearchMut
 	err := config.ValidatePlatformConfig()
 	suite.Require().Error(err)
 	suite.Contains(err.Error(), "Elasticsearch config")
+}
+
+func (suite *PlatformConfigTestSuite) TestElasticSearchConfigMarshalJSONRedactsSecrets() {
+	testCases := []struct {
+		name   string
+		config ElasticSearchConfig
+	}{
+		{
+			name:   "passwordOnly",
+			config: ElasticSearchConfig{URL: "https://es:9200", Username: "elastic", Password: "super-secret"},
+		},
+		{
+			name:   "apiKeyOnly",
+			config: ElasticSearchConfig{URL: "https://es:9200", Username: "elastic", APIKey: "super-secret-key"},
+		},
+		{
+			name:   "bothSet",
+			config: ElasticSearchConfig{Password: "super-secret", APIKey: "super-secret-key"},
+		},
+		{
+			name:   "neitherSet",
+			config: ElasticSearchConfig{URL: "https://es:9200", Username: "elastic"},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			originalPassword := tc.config.Password
+			originalAPIKey := tc.config.APIKey
+
+			encoded, err := json.Marshal(tc.config)
+			suite.Require().NoError(err)
+			encodedStr := string(encoded)
+
+			if originalPassword != "" {
+				suite.Contains(encodedStr, `"password":"[redacted]"`)
+				suite.NotContains(encodedStr, originalPassword)
+			} else {
+				suite.NotContains(encodedStr, `"password"`)
+			}
+
+			if originalAPIKey != "" {
+				suite.Contains(encodedStr, `"apiKey":"[redacted]"`)
+				suite.NotContains(encodedStr, originalAPIKey)
+			} else {
+				suite.NotContains(encodedStr, `"apiKey"`)
+			}
+
+			// non-secret fields must pass through untouched
+			if tc.config.URL != "" {
+				suite.Contains(encodedStr, `"url":"`+tc.config.URL+`"`)
+			}
+			if tc.config.Username != "" {
+				suite.Contains(encodedStr, `"username":"`+tc.config.Username+`"`)
+			}
+
+			// marshaling must never mutate the live credentials
+			suite.Equal(originalPassword, tc.config.Password)
+			suite.Equal(originalAPIKey, tc.config.APIKey)
+		})
+	}
+}
+
+func (suite *PlatformConfigTestSuite) TestElasticSearchConfigMarshalJSONNilPointer() {
+	var nilConfig *ElasticSearchConfig
+	encoded, err := json.Marshal(nilConfig)
+	suite.Require().NoError(err)
+	suite.Equal("null", string(encoded))
+
+	kubeConfig := PlatformKubeConfig{}
+	encoded, err = json.Marshal(kubeConfig)
+	suite.Require().NoError(err)
+	suite.NotContains(string(encoded), "elasticSearchConfig")
+}
+
+func (suite *PlatformConfigTestSuite) TestConfigMarshalJSONRedactsSecretsThroughNesting() {
+	config := &Config{
+		IguazioSessionCookie: "super-secret-session-token",
+		Kube: PlatformKubeConfig{
+			ElasticSearchConfig: &ElasticSearchConfig{
+				Password: "super-secret-es-password",
+				APIKey:   "super-secret-es-key",
+			},
+		},
+		Opa: &opa.Config{
+			Config: &opaclient.Config{
+				OverrideHeaderValue: "super-secret-opa-header",
+			},
+		},
+	}
+
+	encoded, err := json.Marshal(config)
+	suite.Require().NoError(err)
+	encodedStr := string(encoded)
+
+	suite.NotContains(encodedStr, "super-secret-session-token")
+	suite.NotContains(encodedStr, "super-secret-es-password")
+	suite.NotContains(encodedStr, "super-secret-es-key")
+	suite.NotContains(encodedStr, "super-secret-opa-header")
+	suite.Contains(encodedStr, `"iguazioSessionCookie":"[redacted]"`)
+	suite.Contains(encodedStr, `"password":"[redacted]"`)
+	suite.Contains(encodedStr, `"apiKey":"[redacted]"`)
+	suite.Contains(encodedStr, `"overrideHeaderValue":"[redacted]"`)
+
+	// marshaling must never mutate the live config
+	suite.Equal("super-secret-session-token", config.IguazioSessionCookie)
+	suite.Equal("super-secret-es-password", config.Kube.ElasticSearchConfig.Password)
+	suite.Equal("super-secret-opa-header", config.Opa.OverrideHeaderValue)
+}
+
+func (suite *PlatformConfigTestSuite) TestConfigMarshalJSONThroughLoggerRedactsSecrets() {
+	var buf bytes.Buffer
+	testLogger, err := nucliozap.NewNuclioZap("test", "json", nil, &buf, &buf, nucliozap.InfoLevel)
+	suite.Require().NoError(err)
+
+	config := &Config{
+		Kube: PlatformKubeConfig{
+			ElasticSearchConfig: &ElasticSearchConfig{
+				Username: "elastic",
+				Password: "super-secret-es-password",
+			},
+		},
+	}
+
+	testLogger.InfoWith("Starting dashboard", "platformConfiguration", config)
+
+	logLine := buf.String()
+	suite.NotContains(logLine, "super-secret-es-password")
+	suite.Contains(logLine, `"password":"[redacted]"`)
 }
 
 func (suite *PlatformConfigTestSuite) TestTrustsLeaderOrigin() {

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package platformconfig
 
 import (
+	"encoding/json"
 	"regexp"
 	"sort"
 	"time"
@@ -31,6 +32,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	machinarymetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// redactedSecretValue mirrors the "[redacted]" convention already used in
+// pkg/restful/middleware/middleware.go and pkg/cmdrunner/shellrunner.go.
+const redactedSecretValue = "[redacted]"
 
 const (
 	DefaultFunctionReadinessTimeoutSeconds  = 120
@@ -405,6 +410,23 @@ type ElasticSearchConfig struct {
 	// If not set, the backend type is auto-detected by querying the search engine.
 	// Valid values: "elasticsearch", "opensearch"
 	Kind LogProxyKind `json:"kind,omitempty"`
+}
+
+// elasticSearchConfigAlias has ElasticSearchConfig's exact fields/tags but none of its
+// methods, so marshaling it from within MarshalJSON below can't recurse.
+type elasticSearchConfigAlias ElasticSearchConfig
+
+// MarshalJSON redacts Password and APIKey so neither ever reaches a log sink or other
+// JSON output. Value receiver: mutating a copy must never touch the live credentials
+// backing the real ElasticSearch/OpenSearch client.
+func (c ElasticSearchConfig) MarshalJSON() ([]byte, error) {
+	if c.Password != "" {
+		c.Password = redactedSecretValue
+	}
+	if c.APIKey != "" {
+		c.APIKey = redactedSecretValue
+	}
+	return json.Marshal(elasticSearchConfigAlias(c))
 }
 
 type CronTriggerCreationMode string

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -429,6 +429,16 @@ func (c ElasticSearchConfig) MarshalJSON() ([]byte, error) {
 	return json.Marshal(elasticSearchConfigAlias(c))
 }
 
+// String redacts the same way as MarshalJSON, so fmt's %v/%+v/%s - which format via
+// reflection and don't call json.Marshaler - can't be used to bypass the redaction.
+func (c ElasticSearchConfig) String() string {
+	encoded, err := c.MarshalJSON()
+	if err != nil {
+		return redactedSecretValue
+	}
+	return string(encoded)
+}
+
 type CronTriggerCreationMode string
 
 const (


### PR DESCRIPTION
### 📝 Description
The dashboard logs the platform configuration wholesale at startup (INFO). The controller and resource scaler log the same struct at DEBUG level. Because the log sink JSON-encodes structured fields, this wrote the ElasticSearch password (and the adjacent API key field on the same struct), the Iguazio session cookie, and the OPA override-header secret in plaintext.

---

### 🛠️ Changes Made
- Added `ElasticSearchConfig.MarshalJSON` (`pkg/platformconfig/types.go`) to redact `Password`/`APIKey`.
- Added `platformconfig.Config.MarshalJSON` (`pkg/platformconfig/platformconfig.go`) to redact `IguazioSessionCookie`.
- Added `opa.Config.MarshalJSON` (`pkg/opa/types.go`) to redact the embedded `OverrideHeaderValue`.
- Each method redacts a copy via a value receiver + type alias (to avoid recursing back into itself), so only JSON serialization changes — config loading and the real ElasticSearch/OPA clients read these fields directly and are unaffected. No log call sites needed editing; every current and future log site inherits the fix.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Added unit tests in `pkg/platformconfig/platformconfig_test.go` covering per-field redaction (password/API key/both/neither, including that non-secret fields still pass through), a no-mutation guarantee on the live credentials, nil-pointer safety, redaction nested through `Config` (session cookie + ES + OPA header together), and an end-to-end assertion through a real `nucliozap` JSON-encoding logger.
- `go build`, and `go test -tags=test_unit -race -short ./pkg/platformconfig/... ./pkg/opa/...`, pass; `golangci-lint run` on the touched packages reports 0 issues.
- Independently reviewed by a code-review pass; no blocking issues found.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-907
- Design docs links: n/a
- External links: n/a

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
None.