### PR TITLE
[Go] Bump go version to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nuclio/nuclio
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cloud.google.com/go/pubsub/v2 v2.6.0

--- a/test/_functions/golang/with-modules/go.mod
+++ b/test/_functions/golang/with-modules/go.mod
@@ -1,6 +1,6 @@
 module my-awesome-test-function
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aidarkhanov/nanoid v1.0.8


### PR DESCRIPTION
## Summary
- Bump the Go toolchain directive from 1.26.5 to 1.26.6 in `go.mod` and the test fixture module `test/_functions/golang/with-modules/go.mod`.

## Test plan
- [x] `go build ./...` succeeds with Go 1.26.6