### PR TITLE
[Security] Validate java dependency build options input

### DIFF
--- a/pkg/processor/build/runtime/java/types.go
+++ b/pkg/processor/build/runtime/java/types.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/nuclio/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/yaml"
 )
 
@@ -50,6 +51,22 @@ func newDependency(raw string) (*dependency, error) {
 
 	if err := yaml.Unmarshal([]byte(raw), &newDependency); err != nil {
 		return nil, errors.Wrapf(err, "Failed to parse dependency: %s", raw)
+	}
+
+	// validate every field before it is rendered into build.gradle, to prevent build time code injections
+	for _, component := range []struct {
+		field string
+		value string
+	}{
+		{"group", newDependency.Group},
+		{"name", newDependency.Name},
+		{"version", newDependency.Version},
+	} {
+		if errs := validation.IsValidLabelValue(component.value); len(errs) > 0 {
+			return nil, errors.Errorf(
+				"Invalid dependency component, must be a valid label value: field=%s value=%q errors=%s",
+				component.field, component.value, strings.Join(errs, "; "))
+		}
 	}
 
 	return &newDependency, nil

--- a/pkg/processor/build/runtime/java/types_test.go
+++ b/pkg/processor/build/runtime/java/types_test.go
@@ -19,7 +19,9 @@ limitations under the License.
 package java
 
 import (
+	"bytes"
 	"testing"
+	"text/template"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -152,6 +154,107 @@ func (suite *testSuite) TestNewBuildAttributesRepositoryValidation() {
 
 			suite.Require().NoError(err)
 			suite.Require().Equal(testCase.expected, buildAttributes.Repositories)
+		})
+	}
+}
+
+// TestNewDependencyRejectsGroovyInjection verifies newDependency rejects Group/Name/Version
+// values that would break out of the single-quoted Groovy literal they're rendered into.
+func (suite *testSuite) TestNewDependencyRejectsGroovyInjection() {
+	// closes the group string literal, runs a command, then reopens a literal so the
+	// generated line still parses as valid Groovy
+	injectionPayload := `x'; new ProcessBuilder(['sh','-c','id']).start(); y='`
+
+	for _, testCase := range []struct {
+		name           string
+		raw            string
+		expectError    bool
+		expectedResult *dependency
+	}{
+		{
+			name: "well-formed coordinate accepted",
+			raw:  `group: com.example, name: my-lib, version: 1.2.3`,
+			expectedResult: &dependency{
+				Group:   "com.example",
+				Name:    "my-lib",
+				Version: "1.2.3",
+			},
+		},
+		{
+			name:        "single quote breakout in group rejected",
+			raw:         `group: "` + injectionPayload + `", name: n, version: v`,
+			expectError: true,
+		},
+		{
+			name:        "single quote breakout in name rejected",
+			raw:         `group: g, name: "` + injectionPayload + `", version: v`,
+			expectError: true,
+		},
+		{
+			name:        "single quote breakout in version rejected",
+			raw:         `group: g, name: n, version: "` + injectionPayload + `"`,
+			expectError: true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			dep, err := newDependency(testCase.raw)
+
+			if testCase.expectError {
+				suite.Require().Error(err, "expected the malicious dependency %q to be rejected", testCase.raw)
+				return
+			}
+
+			suite.Require().NoError(err)
+			suite.Require().NotNil(dep)
+			suite.Require().Equal(testCase.expectedResult.Group, dep.Group)
+			suite.Require().Equal(testCase.expectedResult.Name, dep.Name)
+			suite.Require().Equal(testCase.expectedResult.Version, dep.Version)
+		})
+	}
+}
+
+// TestGradleBuildScriptDependencyInjection verifies a malicious dependency is rejected before
+// it reaches the build.gradle template, while a legitimate dependency still renders normally.
+func (suite *testSuite) TestGradleBuildScriptDependencyInjection() {
+	for _, testCase := range []struct {
+		name           string
+		rawDependency  string
+		expectError    bool
+		expectedRender string
+	}{
+		{
+			name:          "malicious dependency rejected before reaching the template",
+			rawDependency: `group: "x'; new ProcessBuilder(['sh','-c','id']).start(); y='", name: n, version: v`,
+			expectError:   true,
+		},
+		{
+			name:           "legitimate dependency renders through the template",
+			rawDependency:  "group: com.google.code.gson, name: gson, version: 2.8.9",
+			expectedRender: "compile group: 'com.google.code.gson', name: 'gson', version: '2.8.9'",
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			dependencies, err := (&java{}).parseDependencies([]string{testCase.rawDependency})
+
+			if testCase.expectError {
+				suite.Require().Error(err)
+				return
+			}
+			suite.Require().NoError(err)
+
+			buildAttributes, err := newBuildAttributes(nil)
+			suite.Require().NoError(err)
+
+			tmpl, err := template.New("gradleBuildScript").Parse((&java{}).getGradleBuildScriptTemplateContents())
+			suite.Require().NoError(err)
+
+			var rendered bytes.Buffer
+			err = tmpl.Execute(&rendered, map[string]interface{}{
+				"Dependencies": dependencies,
+				"Repositories": buildAttributes.Repositories,
+			})
+			suite.Require().NoError(err)
+			suite.Require().Contains(rendered.String(), testCase.expectedRender)
 		})
 	}
 }


### PR DESCRIPTION
### 📝 Description
Java function builds accept `spec.build.dependencies` entries (group/name/version) that are rendered, unescaped, into single-quoted Groovy literals in the generated `build.gradle`. A single quote in any field closes the literal and lets arbitrary Groovy run as root during Gradle's configuration phase, with no authentication required by default. This PR validates dependency fields before they reach the template so such values are rejected outright.

---

### 🛠️ Changes Made
- `pkg/processor/build/runtime/java/types.go`: `newDependency` now validates `Group`/`Name`/`Version` (after YAML parsing) against `k8s.io/apimachinery/pkg/util/validation.IsValidLabelValue`, rejecting any value that could break out of the Groovy string literal it's rendered into.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- TDD: Added assertions to verify that newDependency rejects single-quote breakout payloads in each field while continuing to accept well-formed Maven coordinates. This ensures malicious dependencies are rejected before reaching the `build.gradle` template, while legitimate dependencies are rendered correctly.
- Regression: Verified that the fix does not affect legitimate dependencies; for example, `com.google.code.gson:gson:2.8.9` is still rendered through the template unchanged.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-928
- Design docs links:
- External links: https://github.com/nuclio/nuclio/security/advisories/GHSA-c688-9r75-78fv

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Dependency fields must now conform to the Kubernetes label-value charset (alphanumeric, `-`, `_`, `.`; must start/end alphanumeric). This could reject unusual-but-legitimate Maven coordinates outside that charset — none observed in this codebase's existing usages/fixtures, flagging for reviewer awareness.
