### PR TITLE
[Dependencies] Bump java gradle

### DIFF
--- a/docs/reference/runtimes/java/java-reference.md
+++ b/docs/reference/runtimes/java/java-reference.md
@@ -34,7 +34,7 @@ The `handler` field must simply contain the class name. In the example above, th
 When instructed to build the user's handler (to create a user handler JAR), the Java runtime will generate a Gradle build script from the following template:
 ```
 plugins {
-  id 'com.github.johnrengelman.shadow' version '5.2.0'
+  id 'com.github.johnrengelman.shadow' version '8.1.1'
   id 'java'
 }
 
@@ -46,15 +46,15 @@ repositories {
 
 dependencies {
     {{ range .Dependencies }}
-    compile group: '{{.Group}}', name: '{{.Name}}', version: '{{.Version}}'
+    implementation group: '{{.Group}}', name: '{{.Name}}', version: '{{.Version}}'
     {{ end }}
 
-    compile files('./nuclio-sdk-java-1.1.0.jar')
+    implementation files('./nuclio-sdk-java-1.1.0.jar')
 }
 
 shadowJar {
-   baseName = 'user-handler'
-   classifier = null  // Don't append "all" to jar name
+   archiveBaseName = 'user-handler'
+   archiveClassifier = ''
 }
 
 task userHandler(dependsOn: shadowJar)
@@ -76,9 +76,9 @@ spec:
 will populate the Gradle build script as follows:
 ```
 dependencies {
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.0'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.0'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.0'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.0'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.0'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.0'
 }
 ```
 

--- a/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
@@ -21,7 +21,7 @@ FROM ${NUCLIO_DOCKER_REPO}/processor:${NUCLIO_DOCKER_IMAGE_TAG} as processor
 
 FROM ${NUCLIO_DOCKER_JAVA_OPENJDK} as user-handler-builder
 
-ENV GRADLEVERSION=5.6.4
+ENV GRADLEVERSION=8.14.5
 
 RUN apt-get update -qqy \
     && apt-get -s dist-upgrade | \

--- a/pkg/processor/build/runtime/java/runtime.go
+++ b/pkg/processor/build/runtime/java/runtime.go
@@ -148,7 +148,7 @@ func (j *java) createGradleBuildScript(stagingBuildDir string) error {
 
 func (j *java) getGradleBuildScriptTemplateContents() string {
 	return `plugins {
-  id 'com.github.johnrengelman.shadow' version '5.2.0'
+  id 'com.github.johnrengelman.shadow' version '8.1.1'
   id 'java'
 }
 
@@ -160,15 +160,15 @@ repositories {
 
 dependencies {
 	{{ range .Dependencies }}
-	compile group: '{{.Group}}', name: '{{.Name}}', version: '{{.Version}}'
+	implementation group: '{{.Group}}', name: '{{.Name}}', version: '{{.Version}}'
 	{{ end }}
 
-    compile files('./nuclio-sdk-java-1.1.0.jar')
+    implementation files('./nuclio-sdk-java-1.1.0.jar')
 }
 
 shadowJar {
-   baseName = 'user-handler'
-   classifier = null  // Don't append "all" to jar name
+   archiveBaseName = 'user-handler'
+   archiveClassifier = ''
 }
 
 task userHandler(dependsOn: shadowJar)

--- a/pkg/processor/build/runtime/java/types_test.go
+++ b/pkg/processor/build/runtime/java/types_test.go
@@ -230,7 +230,7 @@ func (suite *testSuite) TestGradleBuildScriptDependencyInjection() {
 		{
 			name:           "legitimate dependency renders through the template",
 			rawDependency:  "group: com.google.code.gson, name: gson, version: 2.8.9",
-			expectedRender: "compile group: 'com.google.code.gson', name: 'gson', version: '2.8.9'",
+			expectedRender: "implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'",
 		},
 	} {
 		suite.Run(testCase.name, func() {

--- a/pkg/processor/runtime/java/build.gradle
+++ b/pkg/processor/runtime/java/build.gradle
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '5.2.0'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'java'
 }
 
@@ -24,11 +24,11 @@ repositories {
 }
 
 dependencies {
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
-    compile group: 'commons-cli', name: 'commons-cli', version: '1.5.0'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
+    implementation group: 'commons-cli', name: 'commons-cli', version: '1.5.0'
 
-    compile files('./nuclio-sdk-java-1.1.0.jar')
-    compile files('./user-handler.jar')
+    implementation files('./nuclio-sdk-java-1.1.0.jar')
+    implementation files('./user-handler.jar')
 }
 
 jar {
@@ -40,8 +40,8 @@ jar {
 }
 
 shadowJar {
-    baseName = 'nuclio-java-wrapper'
-    classifier = null  // Don't append "all" to jar name
+    archiveBaseName = 'nuclio-java-wrapper'
+    archiveClassifier = ''
 }
 
 // This is the task build-handler.sh is running

--- a/test/_functions/java/custom-gradle-script/build.gradle
+++ b/test/_functions/java/custom-gradle-script/build.gradle
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 plugins {
-  id 'com.github.johnrengelman.shadow' version '5.2.0'
+  id 'com.github.johnrengelman.shadow' version '8.1.1'
   id 'java'
 }
 
@@ -25,16 +25,16 @@ repositories {
 
 dependencies {
 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.0'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.0'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.0'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.0'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.0'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.0'
 
-    compile files('./nuclio-sdk-java-1.1.0.jar')
+    implementation files('./nuclio-sdk-java-1.1.0.jar')
 }
 
 shadowJar {
-   baseName = 'user-handler'
-   classifier = null  // Don't append "all" to jar name
+   archiveBaseName = 'user-handler'
+   archiveClassifier = ''
 }
 
 task userHandler(dependsOn: shadowJar)


### PR DESCRIPTION
### 📝 Description
Bumps the pinned Gradle distribution and Shadow Gradle plugin used to build `handler-builder-java-onbuild`, without changing the base JDK (stays on JDK 11).

---

### 🛠️ Changes Made
- Bump `GRADLEVERSION` `5.6.4` → `8.14.5` in `pkg/processor/build/runtime/java/docker/onbuild/Dockerfile` (latest Gradle 8.x release; Gradle 9.0+ requires JVM 17+, which is out of scope here since the base image stays on JDK 11).
- Bump the Shadow plugin `com.github.johnrengelman.shadow` `5.2.0` → `8.1.1` 
- Migrated the Gradle DSL these files use, since both `compile` and `baseName`/`classifier` were removed in the Gradle/Shadow versions above:
  - `compile` → `implementation`
  - `baseName` / `classifier = null` → `archiveBaseName` / `archiveClassifier = ''`

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
This was validated by reproduction, not by version-number inspection alone:

1. **Confirmed the CVEs are actually fixed at these versions**, by downloading the real artifacts and inspecting their contents:
   - Downloaded `gradle-8.14.5-bin.zip` directly from `services.gradle.org` and listed its bundled `lib/`/`lib/plugins/` jars: `jackson-databind-2.18.6.jar`, `snakeyaml-2.0.jar`, `google-oauth-client-1.34.1.jar` — all past the CVE thresholds in NUC-894 — and confirmed `maven-core`/`maven-compat` are no longer bundled at all (removed upstream, closing CVE-2021-26291).
   - Pulled the Shadow plugin `8.1.1` POM from Maven Central and confirmed its `log4j-core` dependency is `2.20.0`, past the Log4Shell thresholds (CVE-2021-44228 / CVE-2021-45046).

2. **Reproduced the exact build environment in Docker**, using the same base image the Makefile pins (`gcr.io/iguazio/openjdk:11-jdk-slim-bullseye`) and the real downloaded Gradle 8.14.5 binary, then ran the same command the onbuild `Dockerfile` runs (`gradle --build-cache compileJava`) plus the wrapper's `wrapperJar` task against the actual (edited) `pkg/processor/runtime/java/build.gradle` from this branch — got `BUILD SUCCESSFUL`, and inspected the produced jar to confirm it's named `nuclio-java-wrapper.jar` with no `-all` suffix and contains the shaded `gson`/`commons-cli` classes as expected.
   - This same repro is what originally caught that the old `baseName`/`classifier`/`compile` syntax breaks under the new Gradle/Shadow versions (`Could not set unknown property 'baseName'` / `Could not find method compile()`), which is why the DSL migration above is included in this PR rather than just the version bumps.
   - Also used this to rule out Gradle 9.x (would have required a JDK 17 bump, out of scope) and `com.gradleup.shadow` (a different plugin/org from the currently used `com.github.johnrengelman.shadow`) — confirmed the JDK-11-compatible combination is `Gradle 8.14.5` + `com.github.johnrengelman.shadow:8.1.1`.

3. **Unit tests**: `go test -tags=test_unit -race ./pkg/processor/build/runtime/java/...` passes, including `types_test.go`'s template-render assertion (updated to expect `implementation` instead of `compile`).

4. **Swept the repo** for any other leftover references to the old plugin id/version or `compile`/`baseName`/`classifier` syntax (`grep` across `*.gradle`, `*.go`, `*.md`) — none remain outside the files changed here.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-894
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
The JDK bump to 17+ (which would allow moving further to Gradle 9.x / Shadow's `com.gradleup.shadow`) was explicitly kept out of scope for this PR — `NUCLIO_DOCKER_JAVA_OPENJDK` stays on `openjdk:11-jdk-slim-bullseye`. All version choices above were picked to be the newest release that still runs on JDK 11.
