### PR TITLE
[Java] Do not use gradle daemon on onbuild

### DIFF
--- a/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
@@ -76,4 +76,4 @@ RUN cp nuclio-sdk-java-1.1.0.jar /home/gradle/src/wrapper/nuclio-sdk-java-1.1.0.
 
 # Download dependencies
 RUN cd /home/gradle/src/wrapper \
-    && gradle --build-cache compileJava
+    && gradle --no-daemon --build-cache compileJava

--- a/pkg/processor/build/runtime/java/docker/onbuild/build-user-handler.sh
+++ b/pkg/processor/build/runtime/java/docker/onbuild/build-user-handler.sh
@@ -23,8 +23,8 @@ num_jars=$(ls -1 /home/gradle/src/userHandler/src/main/java/*.jar 2>/dev/null | 
 
 # if there are zero jars, assume source and build
 if [ $num_jars = "0" ]; then
-    gradle tasks
-    gradle userHandler
+    gradle --no-daemon tasks
+    gradle --no-daemon userHandler
 
 # if there is 1 jar, use it as the user handler. Move it to the place it would've been built
 elif [ $num_jars = "1" ]; then

--- a/pkg/processor/build/runtime/java/docker/onbuild/build-wrapped-handler.sh
+++ b/pkg/processor/build/runtime/java/docker/onbuild/build-wrapped-handler.sh
@@ -16,8 +16,8 @@
 
 set -e
 
-# by default, pass no flags to gradle
-GRADLE_FLAGS=""
+# pass --no-daemon to gradle
+GRADLE_FLAGS="--no-daemon"
 
 # if specified to build offline, set the offline flag
 if [ "${NUCLIO_BUILD_OFFLINE}" = "true" ]; then


### PR DESCRIPTION
### 📝 Description
Fix Java function builds silently producing a broken processor image when built with the Buildah container-builder backend.

The `handler-builder-java-onbuild` image's build scripts let Gradle run with its background Daemon enabled; under Buildah's `chroot` isolation (which reuses the host PID namespace across `RUN` instructions), that daemon outlives the `RUN` step that started it and keep serving later steps from a stale filesystem view.

The wrapper jar (`nuclio-java-wrapper.jar`) then silently fails to get written, and the build only fails much later, at an unrelated `COPY --from` step in the next stage, with a confusing "no such file or directory" error.

---

### 🛠️ Changes Made
- Added `--no-daemon` to the two `gradle` invocations in `build-user-handler.sh` and to `build-wrapped-handler.sh`'s `GRADLE_FLAGS`
- Added `--no-daemon` to the onbuild image's own build-time `gradle --build-cache compileJava` call in the onbuild `Dockerfile`, so no daemon registry state gets baked into the published image either
- No changes to `pkg/containerimagebuilderpusher` or any dashboard/controller code — the fix lives entirely in the Java onbuild image's own build scripts

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Reproduced end-to-end on a live cluster: Java function deploys failed consistently under the Buildah backend, succeeded every time under Kaniko and under plain `docker build`, isolating the bug to Buildah's execution model rather than Gradle/Shadow-plugin configuration
- After applying `--no-daemon` and rebuilding/republishing the onbuild image, redeployed the same Java function against the live cluster's Buildah backend — build completed and pushed successfully

---

### 🔗 References
- Ticket link: 
- Design docs links:
- External links:
  - https://docs.gradle.org/current/userguide/docker.html - official Gradle guidance: "In short-lived containers that execute a single build, the daemon provides no benefit and adds startup overhead," disable it via `--no-daemon`
  - https://blog.gradle.org/gradle-on-ephemeral-ci-1 - official Gradle blog on ephemeral/container builds: `--no-daemon` "runs a single-use daemon that exits afterward rather than leaving a process behind"

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
This is the recommended way to run Gradle in this context: each Java function build is a one-shot, throwaway build stage that never gets reused for a second build, so a persistent daemon buys nothing here even ignoring the correctness issue - this is precisely the scenario Gradle's own docs call out as the case for disabling it.