### PR TITLE
[Dashboard] Migrate authentication to function level

### DIFF
--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -38,6 +38,11 @@ const (
 
 	// AttributeAuthenticationMode is the key for the authentication mode in HTTP trigger attributes.
 	AttributeAuthenticationMode = "authenticationMode"
+
+	// AttributeAuthentication and AttributeBasicAuth are the keys of the mode-specific authentication
+	// config nested inside the HTTP trigger attributes.
+	AttributeAuthentication = "authentication"
+	AttributeBasicAuth      = "basicAuth"
 )
 
 type Kind string

--- a/pkg/common/consts.go
+++ b/pkg/common/consts.go
@@ -47,6 +47,14 @@ const NuclioLabelKeyComponent = "nuclio.io/component"
 const NuclioLabelKeyFunctionCronTriggerName = "nuclio.io/function-cron-trigger-name"
 const NuclioLabelKeyFunctionCronJobPod = "nuclio.io/function-cron-job-pod"
 
+// NuclioLabelKeyMigrationPrefix prefixes the labels recording which one-time CRD migrations already ran on
+// a resource. Labels and not annotations, so a migration can list only the resources it has not marked yet.
+const NuclioLabelKeyMigrationPrefix = "nuclio.io/migration-"
+
+// NuclioLabelKeyMigrationFunctionAuth marks a CRD as already migrated to function-level authentication.
+const NuclioLabelKeyMigrationFunctionAuth = NuclioLabelKeyMigrationPrefix + "function-auth"
+const NuclioLabelValueMigrationApplied = "true"
+
 // Nuclio Annotations
 
 const NuclioAnnotationKeyVersion = "nuclio.io/version"

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -198,8 +198,13 @@ func (s *Server) Start() error {
 		return errors.Wrap(err, "Failed to start server")
 	}
 
-	go s.markStaleFunctionsAsError(context.Background())
-	go s.Platform.MigrateFunctionAuthentication(context.Background())
+	// one goroutine, in this order: both jobs write the same functions, so running them concurrently would
+	// make one of the two updates fail on a resource-version conflict. Running the sweep first also means
+	// the migration sees those functions in error state, and can give them a mode instead of only a label
+	go func() {
+		s.markStaleFunctionsAsError(context.Background())
+		s.Platform.MigrateFunctionAuthentication(context.Background())
+	}()
 
 	return nil
 }

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -191,13 +191,15 @@ func NewServer(parentLogger logger.Logger,
 	return newServer, nil
 }
 
-// Start Starts the server and launches background job to mark stale functions as errored
+// Start Starts the server and launches the background jobs: marking stale functions as errored, and
+// migrating existing functions and api gateways to function-level authentication
 func (s *Server) Start() error {
 	if err := s.AbstractServer.Start(); err != nil {
 		return errors.Wrap(err, "Failed to start server")
 	}
 
 	go s.markStaleFunctionsAsError(context.Background())
+	go s.Platform.MigrateFunctionAuthentication(context.Background())
 
 	return nil
 }
@@ -316,19 +318,13 @@ func (s *Server) markStaleFunctionsAsError(ctx context.Context) {
 		return
 	}
 
-	// states from which no process can advance the function after a dashboard restart
-	staleStates := map[functionconfig.FunctionState]struct{}{
-		functionconfig.FunctionStateWaitingForBuild: {},
-		functionconfig.FunctionStateBuilding:        {},
-	}
-
 	// update stale functions concurrently, bounded by a semaphore
 	var wg sync.WaitGroup
 	sem := semaphore.NewWeighted(staleFunctionUpdateConcurrency)
 
 	for _, function := range functions {
 		functionStatus := function.GetStatus()
-		if _, isStale := staleStates[functionStatus.State]; !isStale {
+		if !functionconfig.FunctionStateStale(functionStatus.State) {
 			continue
 		}
 
@@ -345,8 +341,11 @@ func (s *Server) markStaleFunctionsAsError(ctx context.Context) {
 			functionStatus.Message = "Function deployment was interrupted and could not be completed. Please redeploy the function."
 
 			if err := s.Platform.UpdateFunction(ctx, &platform.UpdateFunctionOptions{
-				FunctionMeta:   &functionConfig.Meta,
-				FunctionSpec:   &functionConfig.Spec,
+				FunctionMeta: &functionConfig.Meta,
+
+				// status only, no spec: the spec was read before this sweep started, so sending it back would
+				// revert any spec change made in between - a redeploy, a controller write, or the startup
+				// authentication migration
 				FunctionStatus: functionStatus,
 
 				// the sweep runs at startup with no user session; mark it as a system call so it

--- a/pkg/dashboard/server_test.go
+++ b/pkg/dashboard/server_test.go
@@ -123,6 +123,11 @@ func (suite *DashboardServerTestSuite) TestMarkStaleFunctionsAsError() {
 		suite.Require().True(expected, "unexpected function flipped to error: %s", name)
 		suite.Require().Equal(functionconfig.FunctionStateError, updateFunctionOptions.FunctionStatus.State)
 		suite.Require().NotEmpty(updateFunctionOptions.FunctionStatus.Message)
+
+		// status only: the spec was read before the sweep started, so sending it back would revert any spec
+		// change made in between
+		suite.Require().Nil(updateFunctionOptions.FunctionSpec)
+
 		expectedFlipped[name] = true
 		return true
 	}

--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -1123,6 +1123,15 @@ func FunctionStateProvisioning(functionState FunctionState) bool {
 	return !FunctionStateProvisioned(functionState)
 }
 
+// FunctionStateStale reports whether the function is in stale state
+func FunctionStateStale(functionState FunctionState) bool {
+	return FunctionStateInSlice(functionState,
+		[]FunctionState{
+			FunctionStateWaitingForBuild,
+			FunctionStateBuilding,
+		})
+}
+
 func IsPreviousFunctionStateAllowedToBeSet(prevState FunctionState) bool {
 	allowedPreviousStates := []FunctionState{
 		FunctionStateScaledToZero,

--- a/pkg/platform/abstract/platform.go
+++ b/pkg/platform/abstract/platform.go
@@ -1098,6 +1098,9 @@ func (ap *Platform) GetAllowedAuthenticationModes() []string {
 	return nil
 }
 
+// MigrateFunctionAuthentication is a no-op, since it is relevant only for the kube platform.
+func (ap *Platform) MigrateFunctionAuthentication(_ context.Context) {}
+
 // BuildAndPushContainerImage builds container image and pushes it into docker registry
 func (ap *Platform) BuildAndPushContainerImage(ctx context.Context, buildOptions *containerimagebuilderpusher.BuildOptions) error {
 	return ap.ContainerBuilder.BuildAndPushContainerImage(ctx,

--- a/pkg/platform/kube/authmigration.go
+++ b/pkg/platform/kube/authmigration.go
@@ -46,6 +46,7 @@ type functionAuthMigration struct {
 	// set only for basicAuth: the credentials live in that gateway's own secret and must be re-scrubbed
 	// into the function's secret, because a $ref resolves only against the secret of its owner
 	basicAuthAPIGateway *nuclioio.NuclioAPIGateway
+	migrated            bool
 }
 
 // MigrateFunctionAuthentication moves authentication off the api gateways and onto each function's HTTP
@@ -57,7 +58,7 @@ type functionAuthMigration struct {
 // The migration has three steps:
 //  1. list the unmigrated resources and decide which authentication mode each function should get
 //  2. write that mode onto the functions
-//  3. drain the authentication off the api gateways
+//  3. drain the authentication off the api gateways whose functions all migrated
 func (p *Platform) MigrateFunctionAuthentication(ctx context.Context) {
 	if !p.IsFunctionAuthenticationEnabled() {
 		p.Logger.InfoWithCtx(ctx, "Function authentication migration skipped: feature flag is off")
@@ -85,7 +86,7 @@ func (p *Platform) MigrateFunctionAuthentication(ctx context.Context) {
 	p.migrateFunctions(ctx, namespace, functionMigrations)
 
 	p.Logger.InfoWithCtx(ctx, "Migrating api gateways (step 3/3)")
-	p.migrateAPIGateways(ctx, namespace, apiGateways)
+	p.migrateAPIGateways(ctx, namespace, apiGateways, functionMigrations)
 
 	p.Logger.InfoWithCtx(ctx, "Finished function authentication migration")
 }
@@ -118,16 +119,16 @@ func (p *Platform) listUnmigratedResources(ctx context.Context,
 // translated from the api gateways in front of it.
 func (p *Platform) resolveFunctionAuthMigrations(ctx context.Context,
 	functions []nuclioio.NuclioFunction,
-	apiGateways []nuclioio.NuclioAPIGateway) []*functionAuthMigration {
+	apiGateways []nuclioio.NuclioAPIGateway) map[string]*functionAuthMigration {
 
-	migrations := make([]*functionAuthMigration, 0, len(functions))
+	migrations := make(map[string]*functionAuthMigration, len(functions))
 
-	// the functions still waiting for a mode, indexed by name for the api gateway pass below
-	migrationsByFunctionName := make(map[string]*functionAuthMigration, len(functions))
+	// the subset of the above still waiting for a mode, for the api gateway pass below
+	migrationsWaitingForMode := make(map[string]*functionAuthMigration, len(functions))
 
 	for _, function := range functions {
 		migration := &functionAuthMigration{function: &function}
-		migrations = append(migrations, migration)
+		migrations[function.Name] = migration
 
 		// a stale function is mid-deploy, so its spec is not ours to write - mark it and leave the spec
 		// alone. It cannot come up unauthenticated: the stale-function sweep fails it, and the redeploy the
@@ -156,7 +157,7 @@ func (p *Platform) resolveFunctionAuthMigrations(ctx context.Context,
 			continue
 		}
 
-		migrationsByFunctionName[function.Name] = migration
+		migrationsWaitingForMode[function.Name] = migration
 	}
 
 	// a gateway's mode is offered to every function behind it, so a canary gateway covers both of its
@@ -177,7 +178,7 @@ func (p *Platform) resolveFunctionAuthMigrations(ctx context.Context,
 				continue
 			}
 
-			migration, waitingForMode := migrationsByFunctionName[upstream.NuclioFunction.Name]
+			migration, waitingForMode := migrationsWaitingForMode[upstream.NuclioFunction.Name]
 			if !waitingForMode {
 				continue
 			}
@@ -202,7 +203,7 @@ func (p *Platform) resolveFunctionAuthMigrations(ctx context.Context,
 		}
 	}
 
-	for _, migration := range migrationsByFunctionName {
+	for _, migration := range migrationsWaitingForMode {
 		// no gateway carried authentication, so fall back to the platform default - the same thing the
 		// deploy-time enrichment does
 		if migration.mode == "" {
@@ -251,14 +252,15 @@ func (p *Platform) chooseAuthByPriority(modeA, modeB auth.AuthenticationMode) au
 }
 
 // migrateFunctions is step 2: it writes the resolved mode onto each function. A failure is not fatal - the
-// function stays unlabeled and is retried on the next dashboard restart.
+// function stays unlabeled and is retried on the next dashboard restart, and step 3 leaves the authentication
+// on the api gateways in front of it.
 func (p *Platform) migrateFunctions(ctx context.Context,
 	namespace string,
-	migrations []*functionAuthMigration) {
+	functionsToMigrate map[string]*functionAuthMigration) {
 	var wg sync.WaitGroup
 	sem := semaphore.NewWeighted(authMigrationConcurrency)
 
-	for _, migration := range migrations {
+	for _, function := range functionsToMigrate {
 		if err := sem.Acquire(ctx, 1); err != nil {
 			p.Logger.WarnWithCtx(ctx, "Failed to acquire a migration slot, stopping function migration",
 				"err", err.Error())
@@ -267,11 +269,14 @@ func (p *Platform) migrateFunctions(ctx context.Context,
 
 		wg.Go(func() {
 			defer sem.Release(1)
-			if err := p.migrateFunction(ctx, namespace, migration); err != nil {
+			if err := p.migrateFunction(ctx, namespace, function); err != nil {
 				p.Logger.WarnWithCtx(ctx, "Failed to migrate function authentication",
-					"functionName", migration.function.Name,
+					"functionName", function.function.Name,
 					"err", err.Error())
+				return
 			}
+			p.Logger.DebugWithCtx(ctx, "Successfully migrated function", "functionName", function.function.Name)
+			function.migrated = true
 		})
 	}
 	wg.Wait()
@@ -394,15 +399,39 @@ func (p *Platform) restoreAPIGatewayBasicAuth(ctx context.Context,
 	return restoredAPIGatewayConfig.Spec.Authentication.BasicAuth, nil
 }
 
-// migrateAPIGateways is step 3: it drains the authentication configuration off the api gateway CRDs.
-// Nothing changes in enforcement - with the feature flag on the ingress is already rendered without auth
-// annotations - this only drops dead config that the dashboard would reject on the user's next update.
+// migrateAPIGateways is step 3: it drains the authentication configuration off the api gateway CRDs and
+// re-provisions them, so the controller re-renders their ingresses without the nginx auth annotations. A
+// gateway whose functions did not all migrate is skipped: draining it would leave those functions
+// unauthenticated, and the next run could no longer derive their mode from it.
 func (p *Platform) migrateAPIGateways(ctx context.Context,
 	namespace string,
-	apiGateways []nuclioio.NuclioAPIGateway) {
+	apiGateways []nuclioio.NuclioAPIGateway,
+	functionMigrations map[string]*functionAuthMigration) {
+
 	var wg sync.WaitGroup
 	sem := semaphore.NewWeighted(authMigrationConcurrency)
 	for _, apiGateway := range apiGateways {
+		unmigratedFunctionName := ""
+		for _, upstream := range apiGateway.Spec.Upstreams {
+			if upstream.NuclioFunction == nil {
+				continue
+			}
+			if migration, found := functionMigrations[upstream.NuclioFunction.Name]; found &&
+				!migration.migrated {
+				// the function behind this gateway did not migrate, so skip the gateway and leave its authentication
+				unmigratedFunctionName = upstream.NuclioFunction.Name
+				break
+			}
+		}
+		if unmigratedFunctionName != "" {
+			// left unlabeled, so the next restart lists it again and re-migrates it.
+			p.Logger.WarnWithCtx(ctx,
+				"Api gateway fronts a function that did not migrate, skipping the gateway migration",
+				"apiGatewayName", apiGateway.Name,
+				"functionName", unmigratedFunctionName)
+			continue
+		}
+
 		if err := sem.Acquire(ctx, 1); err != nil {
 			p.Logger.WarnWithCtx(ctx, "Failed to acquire a migration slot, stopping api gateway migration",
 				"err", err.Error())

--- a/pkg/platform/kube/authmigration.go
+++ b/pkg/platform/kube/authmigration.go
@@ -1,0 +1,598 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platform"
+	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/nuclio-sdk-go"
+	"golang.org/x/sync/semaphore"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const authMigrationConcurrency = 5
+
+// functionAuthMigration is what step 1 decided for a single function.
+type functionAuthMigration struct {
+	function *nuclioio.NuclioFunction
+
+	// empty when there is nothing to write and the function only needs the migration label - it already
+	// declares a mode, it has no HTTP trigger to hold one, or it is mid-deploy
+	mode auth.AuthenticationMode
+
+	// set only for basicAuth: the credentials live in that gateway's own secret and must be re-scrubbed
+	// into the function's secret, because a $ref resolves only against the secret of its owner
+	basicAuthAPIGateway *nuclioio.NuclioAPIGateway
+}
+
+// MigrateFunctionAuthentication moves authentication off the api gateways and onto each function's HTTP
+// trigger. Without it, a function deployed before the feature flag was turned on carries no authentication
+// mode and gets no auth-proxy sidecar, while its api gateway ingress is already rendered without auth
+// annotations - leaving the function open. Runs in the background on dashboard startup, and is idempotent
+// because every migrated CRD is labeled and never listed again.
+//
+// The migration has three steps:
+//  1. list the unmigrated resources and decide which authentication mode each function should get
+//  2. write that mode onto the functions
+//  3. drain the authentication off the api gateways
+func (p *Platform) MigrateFunctionAuthentication(ctx context.Context) {
+	if !p.IsFunctionAuthenticationEnabled() {
+		p.Logger.InfoWithCtx(ctx, "Function authentication migration skipped: feature flag is off")
+		return
+	}
+
+	namespace := common.ResolveDefaultNamespace(p.DefaultNamespace)
+	p.Logger.InfoWithCtx(ctx, "Starting function authentication migration", "namespace", namespace)
+
+	p.Logger.InfoWithCtx(ctx, "Resolving the authentication mode of each function (step 1/3)")
+	functions, apiGateways, err := p.listUnmigratedResources(ctx, namespace)
+	if err != nil {
+		// a failed list should not block the dashboard from starting, and the whole migration is
+		// retried on the next restart
+		p.Logger.WarnWithCtx(ctx, "Failed to list resources pending authentication migration; skipping",
+			"err", err.Error())
+		return
+	}
+
+	functionMigrations := p.resolveFunctionAuthMigrations(ctx, functions, apiGateways)
+
+	// functions first: a gateway keeps its authentication until every function behind it carries the mode
+	// translated from it
+	p.Logger.InfoWithCtx(ctx, "Migrating functions (step 2/3)")
+	p.migrateFunctions(ctx, namespace, functionMigrations)
+
+	p.Logger.InfoWithCtx(ctx, "Migrating api gateways (step 3/3)")
+	p.migrateAPIGateways(ctx, namespace, apiGateways)
+
+	p.Logger.InfoWithCtx(ctx, "Finished function authentication migration")
+}
+
+// listUnmigratedResources lists only the CRDs that carry no migration label yet, so once the migration has
+// run, every later restart lists nothing.
+func (p *Platform) listUnmigratedResources(ctx context.Context,
+	namespace string) ([]nuclioio.NuclioFunction, []nuclioio.NuclioAPIGateway, error) {
+
+	unmigratedSelector := fmt.Sprintf("!%s", common.NuclioLabelKeyMigrationFunctionAuth)
+
+	functionList, err := p.consumer.NuclioClientSet.ListNuclioFunctions(ctx,
+		namespace,
+		metav1.ListOptions{LabelSelector: unmigratedSelector})
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "Failed to list unmigrated functions")
+	}
+
+	apiGatewayList, err := p.consumer.NuclioClientSet.ListNuclioAPIGateways(ctx,
+		namespace,
+		metav1.ListOptions{LabelSelector: unmigratedSelector})
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "Failed to list unmigrated api gateways")
+	}
+
+	return functionList.Items, apiGatewayList.Items, nil
+}
+
+// resolveFunctionAuthMigrations is step 1: it decides which authentication mode each function should get,
+// translated from the api gateways in front of it.
+func (p *Platform) resolveFunctionAuthMigrations(ctx context.Context,
+	functions []nuclioio.NuclioFunction,
+	apiGateways []nuclioio.NuclioAPIGateway) []*functionAuthMigration {
+
+	migrations := make([]*functionAuthMigration, 0, len(functions))
+
+	// the functions still waiting for a mode, indexed by name for the api gateway pass below
+	migrationsByFunctionName := make(map[string]*functionAuthMigration, len(functions))
+
+	for _, function := range functions {
+		migration := &functionAuthMigration{function: &function}
+		migrations = append(migrations, migration)
+
+		// a stale function is mid-deploy, so its spec is not ours to write - mark it and leave the spec
+		// alone. It cannot come up unauthenticated: the stale-function sweep fails it, and the redeploy the
+		// user then has to run enriches the authentication mode on its own
+		if functionconfig.FunctionStateStale(function.Status.State) {
+			p.Logger.DebugWithCtx(ctx, "Function is stale, marking as migrated without setting a mode",
+				"functionName", function.Name,
+				"functionState", function.Status.State)
+			continue
+		}
+
+		currentMode, err := functionconfig.GetHTTPTriggerMode(function.Spec.Triggers)
+		if err != nil {
+			// no single HTTP trigger means there is nowhere to put a mode, so the function is migrated by
+			// labeling it alone
+			p.Logger.DebugWithCtx(ctx, "Function has no single HTTP trigger, marking as migrated",
+				"functionName", function.Name,
+				"err", err.Error())
+			continue
+		}
+		if currentMode != "" {
+			// already on the new model, whether the user set it or the deploy-time enrichment did
+			p.Logger.DebugWithCtx(ctx, "Function already declares an authentication mode, marking as migrated",
+				"functionName", function.Name,
+				"authenticationMode", currentMode)
+			continue
+		}
+
+		migrationsByFunctionName[function.Name] = migration
+	}
+
+	// a gateway's mode is offered to every function behind it, so a canary gateway covers both of its
+	// targets, and a function behind gateways that disagree keeps the highest ranked mode
+	for _, apiGateway := range apiGateways {
+		candidateMode, err := translateAPIGatewayAuthenticationMode(&apiGateway)
+		if err != nil {
+			// an unmappable mode must never leave a function unauthenticated
+			p.Logger.ErrorWithCtx(ctx,
+				"Failed to translate api gateway authentication mode, falling back to the platform default",
+				"apiGatewayName", apiGateway.Name,
+				"err", err.Error())
+			candidateMode = p.Config.Authentication.DefaultMode
+		}
+
+		for _, upstream := range apiGateway.Spec.Upstreams {
+			if upstream.NuclioFunction == nil {
+				continue
+			}
+
+			migration, waitingForMode := migrationsByFunctionName[upstream.NuclioFunction.Name]
+			if !waitingForMode {
+				continue
+			}
+
+			chosenMode := p.chooseAuthByPriority(migration.mode, candidateMode)
+			if migration.mode != "" && migration.mode != candidateMode {
+				p.Logger.WarnWithCtx(ctx,
+					"Function is fronted by api gateways with divergent authentication, taking the higher priority",
+					"functionName", migration.function.Name,
+					"apiGatewayName", apiGateway.Name,
+					"previousMode", migration.mode,
+					"candidateMode", candidateMode,
+					"chosenMode", chosenMode)
+			}
+			migration.mode = chosenMode
+
+			// the first basicAuth gateway keeps the claim, and it is never cleared when a later gateway
+			// outranks it, because this field is only read once the final mode is basicAuth
+			if chosenMode == auth.AuthenticationModeBasicAuth && migration.basicAuthAPIGateway == nil {
+				migration.basicAuthAPIGateway = &apiGateway
+			}
+		}
+	}
+
+	for _, migration := range migrationsByFunctionName {
+		// no gateway carried authentication, so fall back to the platform default - the same thing the
+		// deploy-time enrichment does
+		if migration.mode == "" {
+			migration.mode = p.Config.Authentication.DefaultMode
+			p.Logger.DebugWithCtx(ctx,
+				"No api gateway carries authentication for function, using the platform default",
+				"functionName", migration.function.Name)
+		}
+
+		p.Logger.InfoWithCtx(ctx, "Resolved function authentication mode",
+			"functionName", migration.function.Name,
+			"authenticationMode", migration.mode)
+	}
+
+	return migrations
+}
+
+// authenticationModeRank ranks the modes for the tie-break between gateways that disagree. Higher wins: the
+// platform default first, then the other credential-less mode, and basicAuth last because it is the only
+// mode carrying per-function credentials.
+func (p *Platform) authenticationModeRank(mode auth.AuthenticationMode) int {
+	switch mode {
+	// lowest, so that authentication on any one gateway beats none - even when none is the platform default
+	case "", auth.AuthenticationModeNone:
+		return 0
+	// highest, so that the platform default beats any other mode by design
+	case p.Config.Authentication.DefaultMode:
+		return 4
+	case auth.AuthenticationModeAPI:
+		return 3
+	case auth.AuthenticationModeBrowser:
+		return 2
+	case auth.AuthenticationModeBasicAuth:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// chooseAuthByPriority returns whichever of the two modes outranks the other, keeping the first on a tie.
+func (p *Platform) chooseAuthByPriority(modeA, modeB auth.AuthenticationMode) auth.AuthenticationMode {
+	if p.authenticationModeRank(modeB) > p.authenticationModeRank(modeA) {
+		return modeB
+	}
+	return modeA
+}
+
+// migrateFunctions is step 2: it writes the resolved mode onto each function. A failure is not fatal - the
+// function stays unlabeled and is retried on the next dashboard restart.
+func (p *Platform) migrateFunctions(ctx context.Context,
+	namespace string,
+	migrations []*functionAuthMigration) {
+	var wg sync.WaitGroup
+	sem := semaphore.NewWeighted(authMigrationConcurrency)
+
+	for _, migration := range migrations {
+		if err := sem.Acquire(ctx, 1); err != nil {
+			p.Logger.WarnWithCtx(ctx, "Failed to acquire a migration slot, stopping function migration",
+				"err", err.Error())
+			break
+		}
+
+		wg.Go(func() {
+			defer sem.Release(1)
+			if err := p.migrateFunction(ctx, namespace, migration); err != nil {
+				p.Logger.WarnWithCtx(ctx, "Failed to migrate function authentication",
+					"functionName", migration.function.Name,
+					"err", err.Error())
+			}
+		})
+	}
+	wg.Wait()
+}
+
+func (p *Platform) migrateFunction(ctx context.Context,
+	namespace string,
+	migration *functionAuthMigration) error {
+	function := migration.function
+	p.Logger.InfoWithCtx(ctx, "Migrating function authentication",
+		"functionName", function.Name,
+		"authentication mode", migration.mode)
+
+	if migration.mode != "" {
+		if err := p.setFunctionAuthentication(ctx, function, migration); err != nil {
+			return errors.Wrap(err, "Failed to set the function's authentication mode")
+		}
+	}
+
+	markMigratedToFunctionAuthentication(function)
+
+	if _, err := p.consumer.NuclioClientSet.UpdateNuclioFunction(ctx, namespace, function); err != nil {
+		return errors.Wrap(err, "Failed to update function")
+	}
+
+	p.Logger.InfoWithCtx(ctx, "Successfully migrated function authentication",
+		"functionName", function.Name, "authentication mode", migration.mode)
+	return nil
+}
+
+// setFunctionAuthentication writes the resolved mode onto the function's HTTP trigger.
+func (p *Platform) setFunctionAuthentication(ctx context.Context,
+	function *nuclioio.NuclioFunction,
+	migration *functionAuthMigration) error {
+	if migration.mode != auth.AuthenticationModeBasicAuth {
+		return setHTTPTriggerAuthentication(&function.Spec, migration.mode, nil)
+	}
+
+	basicAuth, err := p.restoreAPIGatewayBasicAuth(ctx, migration.basicAuthAPIGateway)
+	if err != nil {
+		return errors.Wrap(err, "Failed to restore api gateway basic-auth credentials")
+	}
+
+	scrubber := p.GetFunctionScrubber()
+	if !p.shouldScrubFunctionConfig(function, scrubber) {
+		return setHTTPTriggerAuthentication(&function.Spec, migration.mode, basicAuth)
+	}
+
+	return p.setScrubbedFunctionBasicAuth(ctx, function, scrubber, basicAuth)
+}
+
+// setScrubbedFunctionBasicAuth writes the credentials through the function scrubber, so the password lands
+// in the function's own secret and the spec holds only a reference to it - the same shape a normal deploy
+// produces, and the only one the auth-proxy sidecar can restore.
+func (p *Platform) setScrubbedFunctionBasicAuth(ctx context.Context,
+	function *nuclioio.NuclioFunction,
+	scrubber *functionconfig.Scrubber,
+	basicAuth *platform.BasicAuth) error {
+	functionConfig := &functionconfig.Config{
+		Meta: functionconfig.Meta{
+			Name:      function.Name,
+			Namespace: function.Namespace,
+			Labels:    function.Labels,
+		},
+		Spec: function.Spec,
+	}
+
+	// restore first: scrubbing rewrites the function secret with only what it scrubbed in this pass, so any
+	// other sensitive field left as a $ref would be lost
+	restoredFunctionConfig, err := scrubber.RestoreFunctionConfig(ctx, functionConfig, common.KubePlatformName)
+	if err != nil {
+		return errors.Wrap(err, "Failed to restore function config")
+	}
+
+	if err := setHTTPTriggerAuthentication(&restoredFunctionConfig.Spec,
+		auth.AuthenticationModeBasicAuth,
+		basicAuth); err != nil {
+		return err
+	}
+
+	scrubbedFunctionConfig, err := scrubber.ScrubFunctionConfig(ctx, restoredFunctionConfig)
+	if err != nil {
+		return errors.Wrap(err, "Failed to scrub function config")
+	}
+
+	if scrubbedFunctionConfig == nil {
+		return errors.New("Scrubber returned nil function config")
+	}
+
+	function.Spec = scrubbedFunctionConfig.Spec
+	return nil
+}
+
+// restoreAPIGatewayBasicAuth reads the gateway's basic-auth credentials in plaintext, since in the CRD the
+// password is only a $ref into the gateway's own secret.
+func (p *Platform) restoreAPIGatewayBasicAuth(ctx context.Context,
+	apiGateway *nuclioio.NuclioAPIGateway) (*platform.BasicAuth, error) {
+	if apiGateway == nil {
+		return nil, errors.New("No api gateway to read basic-auth credentials from")
+	}
+
+	apiGatewayConfig := &platform.APIGatewayConfig{
+		Meta: platform.APIGatewayMeta{
+			Name:      apiGateway.Name,
+			Namespace: apiGateway.Namespace,
+			Labels:    apiGateway.Labels,
+		},
+		Spec: apiGateway.Spec,
+	}
+	restoredAPIGatewayConfig, err := p.GetAPIGatewayScrubber().RestoreAPIGatewayConfig(ctx, apiGatewayConfig)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to restore api gateway config (name=%s)", apiGateway.Name)
+	}
+
+	if restoredAPIGatewayConfig.Spec.Authentication == nil ||
+		restoredAPIGatewayConfig.Spec.Authentication.BasicAuth == nil {
+		return nil, errors.Errorf("Api gateway has no basic-auth credentials (name=%s)", apiGateway.Name)
+	}
+
+	return restoredAPIGatewayConfig.Spec.Authentication.BasicAuth, nil
+}
+
+// migrateAPIGateways is step 3: it drains the authentication configuration off the api gateway CRDs.
+// Nothing changes in enforcement - with the feature flag on the ingress is already rendered without auth
+// annotations - this only drops dead config that the dashboard would reject on the user's next update.
+func (p *Platform) migrateAPIGateways(ctx context.Context,
+	namespace string,
+	apiGateways []nuclioio.NuclioAPIGateway) {
+	var wg sync.WaitGroup
+	sem := semaphore.NewWeighted(authMigrationConcurrency)
+	for _, apiGateway := range apiGateways {
+		if err := sem.Acquire(ctx, 1); err != nil {
+			p.Logger.WarnWithCtx(ctx, "Failed to acquire a migration slot, stopping api gateway migration",
+				"err", err.Error())
+			break
+		}
+
+		wg.Go(func() {
+			defer sem.Release(1)
+			if err := p.migrateAPIGateway(ctx, namespace, &apiGateway); err != nil {
+				p.Logger.WarnWithCtx(ctx, "Failed to migrate api gateway authentication",
+					"apiGatewayName", apiGateway.Name,
+					"err", err.Error())
+			}
+		})
+	}
+	wg.Wait()
+}
+
+func (p *Platform) migrateAPIGateway(ctx context.Context,
+	namespace string,
+	apiGateway *nuclioio.NuclioAPIGateway) error {
+	p.Logger.InfoWithCtx(ctx, "Migrating api gateway authentication",
+		"apiGatewayName", apiGateway.Name,
+		"authenticationMode", apiGateway.Spec.AuthenticationMode)
+	hadAuthentication := apiGateway.Spec.AuthenticationMode != "" || apiGateway.Spec.Authentication != nil
+
+	// only a basicAuth gateway ever put anything in its config secret, so only that one needs cleaning up
+	hadBasicAuth := apiGateway.Spec.Authentication != nil && apiGateway.Spec.Authentication.BasicAuth != nil
+
+	apiGateway.Spec.AuthenticationMode = ""
+	apiGateway.Spec.Authentication = nil
+	markMigratedToFunctionAuthentication(apiGateway)
+
+	// the api gateway operator only acts on a gateway in waitingForProvisioning, so a spec write alone would
+	// leave a ready gateway's ingress still carrying the nginx auth annotations this migration is draining.
+	// Ask for a re-provision the same way UpdateAPIGateway does, and only if there is something to re-render
+	if hadAuthentication {
+		apiGateway.Status.State = platform.APIGatewayStateWaitingForProvisioning
+	}
+
+	if _, err := p.consumer.NuclioClientSet.UpdateNuclioAPIGateway(ctx, namespace, apiGateway); err != nil {
+		return errors.Wrap(err, "Failed to update api gateway")
+	}
+
+	if hadBasicAuth {
+		// the password now lives on the function, so delete only after the spec write, when nothing points
+		// at the secret anymore. A failure here leaves an orphan secret, which goes away with the gateway
+		if err := p.deleteAPIGatewayConfigSecret(ctx, namespace, apiGateway.Name); err != nil {
+			return errors.Wrap(err, "Failed to delete api gateway config secret")
+		}
+	}
+
+	p.Logger.InfoWithCtx(ctx, "Migrated api gateway authentication", "apiGatewayName", apiGateway.Name)
+	return nil
+}
+
+func (p *Platform) deleteAPIGatewayConfigSecret(ctx context.Context, namespace, apiGatewayName string) error {
+	// a gateway can own two secrets under the same apigateway-name label - this config secret and the nginx
+	// basic-auth one the ingress renders - and only GetObjectSecret tells them apart by type
+	secret, err := p.GetAPIGatewayScrubber().GetObjectSecret(ctx, apiGatewayName, namespace)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to resolve the api gateway's config secret (name=%s)", apiGatewayName)
+	}
+	if secret == nil {
+		return nil
+	}
+
+	p.Logger.DebugWithCtx(ctx, "Deleting migrated api gateway config secret",
+		"apiGatewayName", apiGatewayName,
+		"secretName", secret.Name)
+	if err := p.consumer.KubeClientSet.DeleteSecret(ctx, namespace, secret.Name); err != nil {
+		return errors.Wrapf(err, "Failed to delete secret %s", secret.Name)
+	}
+	return nil
+}
+
+// checkNotMigratedToFunctionAuthentication rejects a user write on a resource the migration has not marked
+// yet, because the migration still owns it and one of the two writes would be silently lost.
+func (p *Platform) checkNotMigratedToFunctionAuthentication(kind, name string, labels map[string]string) error {
+	if !p.IsFunctionAuthenticationEnabled() ||
+		labels[common.NuclioLabelKeyMigrationFunctionAuth] == common.NuclioLabelValueMigrationApplied {
+		return nil
+	}
+	return nuclio.NewErrPreconditionFailed(fmt.Sprintf(
+		"cannot be modified until its authentication migration completes (resource=%s) (name=%s)", kind, name))
+}
+
+// stampMigratedToFunctionAuthentication marks a resource created while function-level authentication is
+// already on: it is created with the feature, so there is nothing to migrate on it.
+func (p *Platform) stampMigratedToFunctionAuthentication(labels map[string]string) map[string]string {
+	if !p.IsFunctionAuthenticationEnabled() {
+		return labels
+	}
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[common.NuclioLabelKeyMigrationFunctionAuth] = common.NuclioLabelValueMigrationApplied
+	return labels
+}
+
+// preserveMigrationLabel carries the migration label from the stored resource into an update request that
+// does not echo it back. Needed for api gateways only - the function update paths never replace the label
+// map.
+func preserveMigrationLabel(requested, stored map[string]string) map[string]string {
+	storedValue, found := stored[common.NuclioLabelKeyMigrationFunctionAuth]
+	if !found {
+		return requested
+	}
+	if requested == nil {
+		requested = map[string]string{}
+	}
+	requested[common.NuclioLabelKeyMigrationFunctionAuth] = storedValue
+	return requested
+}
+
+func markMigratedToFunctionAuthentication(resource metav1.Object) {
+	labels := resource.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[common.NuclioLabelKeyMigrationFunctionAuth] = common.NuclioLabelValueMigrationApplied
+	resource.SetLabels(labels)
+}
+
+// translateAPIGatewayAuthenticationMode maps an api gateway's ingress-level authentication mode onto the
+// matching function-level one. The split follows what the ingress does today: a mode that sets auth-signin
+// redirects the browser, one that only sets auth-url returns 401.
+func translateAPIGatewayAuthenticationMode(
+	apiGateway *nuclioio.NuclioAPIGateway) (auth.AuthenticationMode, error) {
+
+	switch apiGateway.Spec.AuthenticationMode {
+	case "", auth.AuthenticationModeNone:
+		return "", nil
+	case auth.AuthenticationModeIguazio:
+		return auth.AuthenticationModeBrowser, nil
+	case auth.AuthenticationModeAccessKey:
+		return auth.AuthenticationModeAPI, nil
+	case auth.AuthenticationModeOauth2:
+		if apiGateway.Spec.Authentication != nil &&
+			apiGateway.Spec.Authentication.DexAuth != nil &&
+			apiGateway.Spec.Authentication.DexAuth.RedirectUnauthorizedToSignIn {
+			return auth.AuthenticationModeBrowser, nil
+		}
+		return auth.AuthenticationModeAPI, nil
+	case auth.AuthenticationModeBasicAuth:
+		return auth.AuthenticationModeBasicAuth, nil
+	default:
+		return "", errors.Errorf("Unknown api gateway authentication mode: %s",
+			apiGateway.Spec.AuthenticationMode)
+	}
+}
+
+// setHTTPTriggerAuthentication writes the mode onto the function's single HTTP trigger.
+func setHTTPTriggerAuthentication(functionSpec *functionconfig.Spec,
+	mode auth.AuthenticationMode,
+	basicAuth *platform.BasicAuth) error {
+
+	httpTrigger, err := functionconfig.GetHTTPTrigger(functionSpec.Triggers)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get the function's HTTP trigger")
+	}
+
+	// the trigger map is keyed by the trigger's name, so an unnamed trigger would be written back under an
+	// empty key and orphan the real one
+	if httpTrigger.Name == "" {
+		return errors.New("The function's HTTP trigger has no name")
+	}
+
+	if httpTrigger.Attributes == nil {
+		httpTrigger.Attributes = map[string]interface{}{}
+	}
+	httpTrigger.Attributes[auth.AttributeAuthenticationMode] = string(mode)
+	if basicAuth != nil {
+		httpTrigger.Attributes[auth.AttributeAuthentication] = map[string]interface{}{
+			auth.AttributeBasicAuth: map[string]interface{}{
+				"username": basicAuth.Username,
+				"password": basicAuth.Password,
+			},
+		}
+	}
+
+	functionSpec.Triggers[httpTrigger.Name] = httpTrigger
+	return nil
+}
+
+// shouldScrubFunctionConfig mirrors the deploy path's masking decision, so the migration stores the
+// basic-auth password exactly the way a normal deploy would.
+func (p *Platform) shouldScrubFunctionConfig(function *nuclioio.NuclioFunction,
+	scrubber *functionconfig.Scrubber) bool {
+	return p.GetConfig().SensitiveFields.MaskSensitiveFields &&
+		!function.Spec.DisableSensitiveFieldsMasking &&
+		scrubber != nil
+}

--- a/pkg/platform/kube/authmigration.go
+++ b/pkg/platform/kube/authmigration.go
@@ -44,7 +44,8 @@ type functionAuthMigration struct {
 	mode auth.AuthenticationMode
 
 	// set only for basicAuth: the credentials live in that gateway's own secret and must be re-scrubbed
-	// into the function's secret, because a $ref resolves only against the secret of its owner
+	// into the function's secret, because a $ref resolves only against the secret of its owner. When
+	// several basicAuth gateways front the function, this holds the newest one
 	basicAuthAPIGateway *nuclioio.NuclioAPIGateway
 	migrated            bool
 }
@@ -163,14 +164,15 @@ func (p *Platform) resolveFunctionAuthMigrations(ctx context.Context,
 	// a gateway's mode is offered to every function behind it, so a canary gateway covers both of its
 	// targets, and a function behind gateways that disagree keeps the highest ranked mode
 	for _, apiGateway := range apiGateways {
-		candidateMode, err := translateAPIGatewayAuthenticationMode(&apiGateway)
+		gatewayAuthenticationMode, err := translateAPIGatewayAuthenticationMode(&apiGateway)
 		if err != nil {
 			// an unmappable mode must never leave a function unauthenticated
 			p.Logger.ErrorWithCtx(ctx,
-				"Failed to translate api gateway authentication mode, falling back to the platform default",
+				"Failed to translate api gateway authentication mode, skipping the gateway authentication resolving",
 				"apiGatewayName", apiGateway.Name,
+				"gatewayAuthenticationMode", apiGateway.Spec.AuthenticationMode,
 				"err", err.Error())
-			candidateMode = p.Config.Authentication.DefaultMode
+			continue
 		}
 
 		for _, upstream := range apiGateway.Spec.Upstreams {
@@ -183,33 +185,44 @@ func (p *Platform) resolveFunctionAuthMigrations(ctx context.Context,
 				continue
 			}
 
-			chosenMode := p.chooseAuthByPriority(migration.mode, candidateMode)
-			if migration.mode != "" && migration.mode != candidateMode {
-				p.Logger.WarnWithCtx(ctx,
+			chosenMode := p.chooseAuthByPriority(migration.mode, gatewayAuthenticationMode)
+			if migration.mode != "" && migration.mode != gatewayAuthenticationMode {
+				p.Logger.DebugWithCtx(ctx,
 					"Function is fronted by api gateways with divergent authentication, taking the higher priority",
 					"functionName", migration.function.Name,
 					"apiGatewayName", apiGateway.Name,
 					"previousMode", migration.mode,
-					"candidateMode", candidateMode,
+					"gatewayAuthenticationMode", gatewayAuthenticationMode,
 					"chosenMode", chosenMode)
 			}
 			migration.mode = chosenMode
 
-			// the first basicAuth gateway keeps the claim, and it is never cleared when a later gateway
-			// outranks it, because this field is only read once the final mode is basicAuth
-			if chosenMode == auth.AuthenticationModeBasicAuth && migration.basicAuthAPIGateway == nil {
-				migration.basicAuthAPIGateway = &apiGateway
+			if gatewayAuthenticationMode == auth.AuthenticationModeBasicAuth {
+				if migration.basicAuthAPIGateway == nil {
+					migration.basicAuthAPIGateway = &apiGateway
+				} else {
+					// the function's HTTP trigger holds a single username and password, so only one
+					// gateway's credentials can move onto it
+					chosen, dropped := migration.basicAuthAPIGateway, &apiGateway
+					if isPreferredBasicAuthAPIGateway(dropped, chosen) {
+						chosen, dropped = dropped, chosen
+					}
+					p.Logger.WarnWithCtx(ctx,
+						"Function is fronted by multiple basicAuth api gateways, keeping the newest one's credentials",
+						"functionName", migration.function.Name,
+						"chosenAPIGatewayName", chosen.Name,
+						"droppedAPIGatewayName", dropped.Name)
+					migration.basicAuthAPIGateway = chosen
+				}
 			}
 		}
 	}
 
 	for _, migration := range migrationsWaitingForMode {
-		// no gateway carried authentication, so fall back to the platform default - the same thing the
-		// deploy-time enrichment does
 		if migration.mode == "" {
-			migration.mode = p.Config.Authentication.DefaultMode
+			// no gateway carried authentication, so the function keeps no authentication
 			p.Logger.DebugWithCtx(ctx,
-				"No api gateway carries authentication for function, using the platform default",
+				"No api gateway with authentication fronted the function, leaving it unauthenticated",
 				"functionName", migration.function.Name)
 		}
 
@@ -249,6 +262,17 @@ func (p *Platform) chooseAuthByPriority(modeA, modeB auth.AuthenticationMode) au
 		return modeB
 	}
 	return modeA
+}
+
+// isPreferredBasicAuthAPIGateway reports whether candidate should replace chosen as the credential source of
+// a function fronted by several basicAuth gateways: the newest gateway wins, and because creationTimestamp
+// is only second-granular, the greater name breaks a tie. Both keys are immutable, so the answer is the same
+// on every run and never depends on the order the gateways were listed in.
+func isPreferredBasicAuthAPIGateway(candidate, chosen *nuclioio.NuclioAPIGateway) bool {
+	if candidate.CreationTimestamp.Equal(&chosen.CreationTimestamp) {
+		return candidate.Name > chosen.Name
+	}
+	return chosen.CreationTimestamp.Before(&candidate.CreationTimestamp)
 }
 
 // migrateFunctions is step 2: it writes the resolved mode onto each function. A failure is not fatal - the
@@ -564,7 +588,7 @@ func translateAPIGatewayAuthenticationMode(
 
 	switch apiGateway.Spec.AuthenticationMode {
 	case "", auth.AuthenticationModeNone:
-		return "", nil
+		return auth.AuthenticationModeNone, nil
 	case auth.AuthenticationModeIguazio:
 		return auth.AuthenticationModeBrowser, nil
 	case auth.AuthenticationModeAccessKey:

--- a/pkg/platform/kube/authmigration.go
+++ b/pkg/platform/kube/authmigration.go
@@ -150,12 +150,20 @@ func (p *Platform) resolveFunctionAuthMigrations(ctx context.Context,
 				"err", err.Error())
 			continue
 		}
-		if currentMode != "" {
+		if functionconfig.IsAuthenticationEnabled(currentMode) {
 			// already on the new model, whether the user set it or the deploy-time enrichment did
 			p.Logger.DebugWithCtx(ctx, "Function already declares an authentication mode, marking as migrated",
 				"functionName", function.Name,
 				"authenticationMode", currentMode)
 			continue
+		}
+		if currentMode != "" {
+			// the mode was never validated while the feature flag was off, so a mode no auth-proxy can
+			// enforce is not a declaration - drop it and let the api gateways below resolve the mode instead
+			p.Logger.WarnWithCtx(ctx,
+				"Function declares an unsupported authentication mode, resolving it from the api gateways",
+				"functionName", function.Name,
+				"authenticationMode", currentMode)
 		}
 
 		migrationsWaitingForMode[function.Name] = migration

--- a/pkg/platform/kube/authmigration_test.go
+++ b/pkg/platform/kube/authmigration_test.go
@@ -19,8 +19,10 @@ limitations under the License.
 package kube
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/auth"
@@ -135,7 +137,7 @@ func (suite *AuthMigrationKubePlatformTestSuite) TestResolveModeFromSingleAPIGat
 				[]v1beta1.NuclioAPIGateway{*testCase.apiGateway})
 
 			suite.Require().Len(migrations, 1)
-			suite.Require().Equal(testCase.expectedMode, migrations[0].mode)
+			suite.Require().Equal(testCase.expectedMode, migrations["func"].mode)
 		})
 	}
 }
@@ -202,12 +204,12 @@ func (suite *AuthMigrationKubePlatformTestSuite) TestResolveModeFromDivergentAPI
 				apiGateways)
 
 			suite.Require().Len(migrations, 1)
-			suite.Require().Equal(testCase.expectedMode, migrations[0].mode)
+			suite.Require().Equal(testCase.expectedMode, migrations["func"].mode)
 
 			// the credential source is only ever read once the winning mode is basicAuth, so it is
 			// deliberately left claimed by an outranked gateway rather than cleared
 			if testCase.expectedMode == auth.AuthenticationModeBasicAuth {
-				suite.Require().NotNil(migrations[0].basicAuthAPIGateway)
+				suite.Require().NotNil(migrations["func"].basicAuthAPIGateway)
 			}
 		})
 	}
@@ -232,7 +234,7 @@ func (suite *AuthMigrationKubePlatformTestSuite) TestResolveModeForCanaryAPIGate
 			[]v1beta1.NuclioAPIGateway{*canaryAPIGateway})
 
 		suite.Require().Len(migrations, 1)
-		suite.Require().Equal(auth.AuthenticationModeBrowser, migrations[0].mode, functionName)
+		suite.Require().Equal(auth.AuthenticationModeBrowser, migrations[functionName].mode, functionName)
 	}
 }
 
@@ -264,7 +266,7 @@ func (suite *AuthMigrationKubePlatformTestSuite) TestResolveModeSkipsAlreadyMigr
 				[]v1beta1.NuclioAPIGateway{apiGateway})
 
 			suite.Require().Len(migrations, 1)
-			suite.Require().Equal(auth.AuthenticationMode(""), migrations[0].mode)
+			suite.Require().Equal(auth.AuthenticationMode(""), migrations["func"].mode)
 		})
 	}
 }
@@ -505,6 +507,68 @@ func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateBasicAuthScrubsCrede
 
 	suite.Require().Equal("test-pass",
 		functionSecrets[0].StringData[functionScrubber.EncodeSecretKey(passwordReference)])
+}
+
+// TestMigrateKeepsAPIGatewayAuthenticationWhenItsFunctionFails asserts a failed function write holds back
+// only the gateways in front of that function - draining them would leave it unauthenticated, and the next
+// restart could no longer derive its mode from them - while gateways whose functions all migrated are drained.
+func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateKeepsAPIGatewayAuthenticationWhenItsFunctionFails() {
+	suite.withFunctionAuthentication(auth.AuthenticationModeAPI)
+
+	migratedFunction := suite.compileFunction("migrated-func", functionconfig.FunctionStateReady, "")
+	failedFunction := suite.compileFunction("failed-func", functionconfig.FunctionStateReady, "")
+
+	// the canary gateway fronts both functions, so the one that fails holds it back on its own
+	canaryAPIGateway := suite.compileAPIGateway("canary-gw", "migrated-func", auth.AuthenticationModeIguazio, nil)
+	canaryAPIGateway.Spec.Upstreams = append(canaryAPIGateway.Spec.Upstreams, platform.APIGatewayUpstreamSpec{
+		Kind:           platform.APIGatewayUpstreamKindNuclioFunction,
+		NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{Name: "failed-func"},
+	})
+	migratedAPIGateway := suite.compileAPIGateway("migrated-gw", "migrated-func", auth.AuthenticationModeIguazio, nil)
+
+	suite.expectListUnmigrated(
+		[]v1beta1.NuclioFunction{*migratedFunction, *failedFunction},
+		[]v1beta1.NuclioAPIGateway{*canaryAPIGateway, *migratedAPIGateway})
+
+	suite.nuclioFunctionInterfaceMock.
+		On("Update", suite.ctx, mock.MatchedBy(func(function *v1beta1.NuclioFunction) bool {
+			return function.Name == "migrated-func"
+		}), metav1.UpdateOptions{}).
+		Return(migratedFunction, nil).
+		Once()
+	suite.nuclioFunctionInterfaceMock.
+		On("Update", suite.ctx, mock.MatchedBy(func(function *v1beta1.NuclioFunction) bool {
+			return function.Name == "failed-func"
+		}), metav1.UpdateOptions{}).
+		Return(nil, apierrors.NewBadRequest("failed to write the function")).
+		Once()
+
+	// deliberately matches any gateway, so the assertions below can pin down exactly which ones were drained
+	var updatedAPIGateways []*v1beta1.NuclioAPIGateway
+	var updatedAPIGatewaysLock sync.Mutex
+	suite.nuclioAPIGatewayInterfaceMock.
+		On("Update", suite.ctx, mock.Anything, metav1.UpdateOptions{}).
+		Return(func(_ context.Context,
+			apiGateway *v1beta1.NuclioAPIGateway,
+			_ metav1.UpdateOptions) *v1beta1.NuclioAPIGateway {
+			updatedAPIGatewaysLock.Lock()
+			defer updatedAPIGatewaysLock.Unlock()
+			updatedAPIGateways = append(updatedAPIGateways, apiGateway)
+			return apiGateway
+		}, nil)
+
+	suite.platform.MigrateFunctionAuthentication(suite.ctx)
+
+	// the canary gateway is left untouched - authentication, label and state - so the next restart lists it
+	// again and re-derives the mode from it
+	suite.Require().Len(updatedAPIGateways, 1)
+	suite.Require().Equal("migrated-gw", updatedAPIGateways[0].Name)
+	suite.Require().Equal(auth.AuthenticationMode(""), updatedAPIGateways[0].Spec.AuthenticationMode)
+	suite.Require().Equal(common.NuclioLabelValueMigrationApplied,
+		updatedAPIGateways[0].Labels[common.NuclioLabelKeyMigrationFunctionAuth])
+
+	suite.nuclioFunctionInterfaceMock.AssertExpectations(suite.T())
+	suite.nuclioAPIGatewayInterfaceMock.AssertExpectations(suite.T())
 }
 
 // TestMigrateIsIdempotent asserts a second sweep writes nothing, because the label selector excludes

--- a/pkg/platform/kube/authmigration_test.go
+++ b/pkg/platform/kube/authmigration_test.go
@@ -375,7 +375,7 @@ func (suite *AuthMigrationKubePlatformTestSuite) TestResolveModeSkipsAlreadyMigr
 	}{
 		{
 			name:     "an explicit mode is not overwritten",
-			function: suite.compileFunction("func", functionconfig.FunctionStateReady, auth.AuthenticationModeNone),
+			function: suite.compileFunction("func", functionconfig.FunctionStateReady, auth.AuthenticationModeAPI),
 		},
 		{
 			name: "a function with no HTTP trigger has nowhere to put a mode",
@@ -393,6 +393,59 @@ func (suite *AuthMigrationKubePlatformTestSuite) TestResolveModeSkipsAlreadyMigr
 
 			suite.Require().Len(migrations, 1)
 			suite.Require().Equal(auth.AuthenticationMode(""), migrations["func"].mode)
+		})
+	}
+}
+
+// TestResolveModeIgnoresUnenforceableMode asserts a mode the auth-proxy cannot enforce is treated as no mode
+// at all. Nothing validated the attribute while the feature flag was off, so keeping it would label the
+// function as migrated and drain the api gateway in front of it, leaving it open.
+func (suite *AuthMigrationKubePlatformTestSuite) TestResolveModeIgnoresUnenforceableMode() {
+	for _, testCase := range []struct {
+		name         string
+		currentMode  auth.AuthenticationMode
+		gatewayMode  auth.AuthenticationMode
+		expectedMode auth.AuthenticationMode
+	}{
+		{
+			name:         "a mode that does not exist is resolved from the gateway",
+			currentMode:  "not-exist",
+			gatewayMode:  auth.AuthenticationModeIguazio,
+			expectedMode: auth.AuthenticationModeBrowser,
+		},
+		{
+			// an api gateway mode is not a function-level one, and is the likeliest value to be copied over
+			name:         "an api gateway mode is resolved from the gateway",
+			currentMode:  auth.AuthenticationModeAccessKey,
+			gatewayMode:  auth.AuthenticationModeAccessKey,
+			expectedMode: auth.AuthenticationModeAPI,
+		},
+		{
+			// none is a valid mode, but one written while the flag was off carries no intent: nothing read it,
+			// while the gateway in front of the function did authenticate
+			name:         "an explicit none is resolved from the gateway",
+			currentMode:  auth.AuthenticationModeNone,
+			gatewayMode:  auth.AuthenticationModeIguazio,
+			expectedMode: auth.AuthenticationModeBrowser,
+		},
+		{
+			name:         "with no gateway authentication the function is left unauthenticated",
+			currentMode:  "not-exist",
+			gatewayMode:  auth.AuthenticationModeNone,
+			expectedMode: "",
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.abstractPlatform.Config.Authentication.DefaultMode = auth.AuthenticationModeAPI
+
+			migrations := suite.platform.resolveFunctionAuthMigrations(suite.ctx,
+				[]v1beta1.NuclioFunction{
+					*suite.compileFunction("func", functionconfig.FunctionStateReady, testCase.currentMode),
+				},
+				[]v1beta1.NuclioAPIGateway{*suite.compileAPIGateway("gw", "func", testCase.gatewayMode, nil)})
+
+			suite.Require().Len(migrations, 1)
+			suite.Require().Equal(testCase.expectedMode, migrations["func"].mode)
 		})
 	}
 }
@@ -540,7 +593,7 @@ func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateFunctionWithNoAPIGat
 // marked without its spec being touched, so the sweep never overwrites an explicit choice.
 func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateFunctionAlreadyOnTheNewModelOnlyMarksIt() {
 	suite.withFunctionAuthentication(auth.AuthenticationModeAPI)
-	function := suite.compileFunction("func", functionconfig.FunctionStateReady, auth.AuthenticationModeNone)
+	function := suite.compileFunction("func", functionconfig.FunctionStateReady, auth.AuthenticationModeBrowser)
 	apiGateway := suite.compileAPIGateway("gw", "func", auth.AuthenticationModeIguazio, nil)
 	suite.expectListUnmigrated([]v1beta1.NuclioFunction{*function}, []v1beta1.NuclioAPIGateway{*apiGateway})
 
@@ -556,7 +609,7 @@ func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateFunctionAlreadyOnThe
 
 	suite.platform.MigrateFunctionAuthentication(suite.ctx)
 
-	suite.Require().Equal(string(auth.AuthenticationModeNone),
+	suite.Require().Equal(string(auth.AuthenticationModeBrowser),
 		updatedFunction.Spec.Triggers["http"].Attributes[auth.AttributeAuthenticationMode])
 	suite.Require().Equal(common.NuclioLabelValueMigrationApplied,
 		updatedFunction.Labels[common.NuclioLabelKeyMigrationFunctionAuth])

--- a/pkg/platform/kube/authmigration_test.go
+++ b/pkg/platform/kube/authmigration_test.go
@@ -1,0 +1,828 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/auth"
+	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+	"github.com/nuclio/nuclio/pkg/platform/kube/ingress"
+	"github.com/nuclio/nuclio/pkg/platformconfig"
+
+	"github.com/nuclio/opa-client"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type AuthMigrationKubePlatformTestSuite struct {
+	KubePlatformTestSuite
+
+	previousAuthenticationConfig *platformconfig.Authentication
+}
+
+func (suite *AuthMigrationKubePlatformTestSuite) SetupSuite() {
+	suite.KubePlatformTestSuite.SetupSuite()
+}
+
+func (suite *AuthMigrationKubePlatformTestSuite) SetupTest() {
+	suite.KubePlatformTestSuite.SetupTest()
+
+	// the sweep resolves the namespace itself, so it must match the one the CRD mocks are wired for
+	suite.abstractPlatform.DefaultNamespace = suite.Namespace
+
+	// every test declares the authentication configuration it needs, so start from an empty one - which also
+	// leaves the feature flag off by default
+	suite.previousAuthenticationConfig = suite.abstractPlatform.Config.Authentication
+	suite.abstractPlatform.Config.Authentication = &platformconfig.Authentication{}
+}
+
+func (suite *AuthMigrationKubePlatformTestSuite) TearDownTest() {
+	suite.abstractPlatform.Config.Authentication = suite.previousAuthenticationConfig
+}
+
+// TestResolveModeFromSingleAPIGateway covers the legacy-to-function-level mode translation.
+func (suite *AuthMigrationKubePlatformTestSuite) TestResolveModeFromSingleAPIGateway() {
+	for _, testCase := range []struct {
+		name         string
+		apiGateway   *v1beta1.NuclioAPIGateway
+		defaultMode  auth.AuthenticationMode
+		expectedMode auth.AuthenticationMode
+	}{
+		{
+			name:         "iguazio redirects, so browser",
+			apiGateway:   suite.compileAPIGateway("gw", "func", auth.AuthenticationModeIguazio, nil),
+			defaultMode:  auth.AuthenticationModeAPI,
+			expectedMode: auth.AuthenticationModeBrowser,
+		},
+		{
+			name:         "accessKey does not redirect, so api",
+			apiGateway:   suite.compileAPIGateway("gw", "func", auth.AuthenticationModeAccessKey, nil),
+			defaultMode:  auth.AuthenticationModeAPI,
+			expectedMode: auth.AuthenticationModeAPI,
+		},
+		{
+			name: "oauth2 with redirect is browser",
+			apiGateway: suite.compileAPIGateway("gw", "func", auth.AuthenticationModeOauth2,
+				suite.compileDexAuthentication(true)),
+			defaultMode:  auth.AuthenticationModeAPI,
+			expectedMode: auth.AuthenticationModeBrowser,
+		},
+		{
+			name: "oauth2 without redirect is api",
+			apiGateway: suite.compileAPIGateway("gw", "func", auth.AuthenticationModeOauth2,
+				suite.compileDexAuthentication(false)),
+			defaultMode:  auth.AuthenticationModeAPI,
+			expectedMode: auth.AuthenticationModeAPI,
+		},
+		{
+			name: "basicAuth stays basicAuth",
+			apiGateway: suite.compileAPIGateway("gw", "func", auth.AuthenticationModeBasicAuth,
+				suite.compileBasicAuthentication("user", "pass")),
+			defaultMode:  auth.AuthenticationModeAPI,
+			expectedMode: auth.AuthenticationModeBasicAuth,
+		},
+		{
+			name:         "a gateway with no authentication falls back to the platform default",
+			apiGateway:   suite.compileAPIGateway("gw", "func", auth.AuthenticationModeNone, nil),
+			defaultMode:  auth.AuthenticationModeAPI,
+			expectedMode: auth.AuthenticationModeAPI,
+		},
+		{
+			name:         "an unknown gateway mode fails secure to the platform default",
+			apiGateway:   suite.compileAPIGateway("gw", "func", auth.AuthenticationMode("bogus"), nil),
+			defaultMode:  auth.AuthenticationModeAPI,
+			expectedMode: auth.AuthenticationModeAPI,
+		},
+		{
+			name:         "a none default is written explicitly, never left empty",
+			apiGateway:   suite.compileAPIGateway("gw", "func", auth.AuthenticationModeNone, nil),
+			defaultMode:  auth.AuthenticationModeNone,
+			expectedMode: auth.AuthenticationModeNone,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.abstractPlatform.Config.Authentication.DefaultMode = testCase.defaultMode
+
+			migrations := suite.platform.resolveFunctionAuthMigrations(suite.ctx,
+				[]v1beta1.NuclioFunction{
+					*suite.compileFunction("func", functionconfig.FunctionStateReady, ""),
+				},
+				[]v1beta1.NuclioAPIGateway{*testCase.apiGateway})
+
+			suite.Require().Len(migrations, 1)
+			suite.Require().Equal(testCase.expectedMode, migrations[0].mode)
+		})
+	}
+}
+
+// TestResolveModeFromDivergentAPIGateways covers the priority rule: the platform default wins, then the
+// other credential-less mode, then basicAuth.
+func (suite *AuthMigrationKubePlatformTestSuite) TestResolveModeFromDivergentAPIGateways() {
+	for _, testCase := range []struct {
+		name         string
+		gatewayModes []auth.AuthenticationMode
+		defaultMode  auth.AuthenticationMode
+		expectedMode auth.AuthenticationMode
+	}{
+		{
+			name:         "api default beats browser",
+			gatewayModes: []auth.AuthenticationMode{auth.AuthenticationModeIguazio, auth.AuthenticationModeAccessKey},
+			defaultMode:  auth.AuthenticationModeAPI,
+			expectedMode: auth.AuthenticationModeAPI,
+		},
+		{
+			name:         "browser default beats api",
+			gatewayModes: []auth.AuthenticationMode{auth.AuthenticationModeAccessKey, auth.AuthenticationModeIguazio},
+			defaultMode:  auth.AuthenticationModeBrowser,
+			expectedMode: auth.AuthenticationModeBrowser,
+		},
+		{
+			name:         "basicAuth is always last",
+			gatewayModes: []auth.AuthenticationMode{auth.AuthenticationModeBasicAuth, auth.AuthenticationModeIguazio},
+			defaultMode:  auth.AuthenticationModeAPI,
+			expectedMode: auth.AuthenticationModeBrowser,
+		},
+		{
+			name:         "basicAuth wins when it is the only mode configured",
+			gatewayModes: []auth.AuthenticationMode{auth.AuthenticationModeNone, auth.AuthenticationModeBasicAuth},
+			defaultMode:  auth.AuthenticationModeAPI,
+			expectedMode: auth.AuthenticationModeBasicAuth,
+		},
+		{
+			name:         "authentication always beats none",
+			gatewayModes: []auth.AuthenticationMode{auth.AuthenticationModeNone, auth.AuthenticationModeIguazio},
+			defaultMode:  auth.AuthenticationModeNone,
+			expectedMode: auth.AuthenticationModeBrowser,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.abstractPlatform.Config.Authentication.DefaultMode = testCase.defaultMode
+
+			var apiGateways []v1beta1.NuclioAPIGateway
+			for gatewayIndex, gatewayMode := range testCase.gatewayModes {
+				var authentication *platform.APIGatewayAuthenticationSpec
+				if gatewayMode == auth.AuthenticationModeBasicAuth {
+					authentication = suite.compileBasicAuthentication("user", "pass")
+				}
+				apiGateways = append(apiGateways, *suite.compileAPIGateway(fmt.Sprintf("gw-%d", gatewayIndex),
+					"func",
+					gatewayMode,
+					authentication))
+			}
+
+			migrations := suite.platform.resolveFunctionAuthMigrations(suite.ctx,
+				[]v1beta1.NuclioFunction{
+					*suite.compileFunction("func", functionconfig.FunctionStateReady, ""),
+				},
+				apiGateways)
+
+			suite.Require().Len(migrations, 1)
+			suite.Require().Equal(testCase.expectedMode, migrations[0].mode)
+
+			// the credential source is only ever read once the winning mode is basicAuth, so it is
+			// deliberately left claimed by an outranked gateway rather than cleared
+			if testCase.expectedMode == auth.AuthenticationModeBasicAuth {
+				suite.Require().NotNil(migrations[0].basicAuthAPIGateway)
+			}
+		})
+	}
+}
+
+// TestResolveModeForCanaryAPIGateway asserts a canary gateway contributes its mode to both of its targets.
+func (suite *AuthMigrationKubePlatformTestSuite) TestResolveModeForCanaryAPIGateway() {
+	suite.abstractPlatform.Config.Authentication.DefaultMode = auth.AuthenticationModeAPI
+
+	canaryAPIGateway := suite.compileAPIGateway("gw", "primary-func", auth.AuthenticationModeIguazio, nil)
+	canaryAPIGateway.Spec.Upstreams = append(canaryAPIGateway.Spec.Upstreams, platform.APIGatewayUpstreamSpec{
+		Kind:           platform.APIGatewayUpstreamKindNuclioFunction,
+		NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{Name: "canary-func"},
+		Percentage:     20,
+	})
+
+	for _, functionName := range []string{"primary-func", "canary-func"} {
+		migrations := suite.platform.resolveFunctionAuthMigrations(suite.ctx,
+			[]v1beta1.NuclioFunction{
+				*suite.compileFunction(functionName, functionconfig.FunctionStateReady, ""),
+			},
+			[]v1beta1.NuclioAPIGateway{*canaryAPIGateway})
+
+		suite.Require().Len(migrations, 1)
+		suite.Require().Equal(auth.AuthenticationModeBrowser, migrations[0].mode, functionName)
+	}
+}
+
+// TestResolveModeSkipsAlreadyMigratedFunctions asserts a function that is already on the new model, or has
+// no HTTP trigger to carry a mode, is migrated by labeling it alone.
+func (suite *AuthMigrationKubePlatformTestSuite) TestResolveModeSkipsAlreadyMigratedFunctions() {
+	suite.abstractPlatform.Config.Authentication.DefaultMode = auth.AuthenticationModeAPI
+	apiGateway := *suite.compileAPIGateway("gw", "func", auth.AuthenticationModeIguazio, nil)
+	for _, testCase := range []struct {
+		name     string
+		function *v1beta1.NuclioFunction
+	}{
+		{
+			name:     "an explicit mode is not overwritten",
+			function: suite.compileFunction("func", functionconfig.FunctionStateReady, auth.AuthenticationModeNone),
+		},
+		{
+			name: "a function with no HTTP trigger has nowhere to put a mode",
+			function: func() *v1beta1.NuclioFunction {
+				function := suite.compileFunction("func", functionconfig.FunctionStateReady, "")
+				function.Spec.Triggers = map[string]functionconfig.Trigger{}
+				return function
+			}(),
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			migrations := suite.platform.resolveFunctionAuthMigrations(suite.ctx,
+				[]v1beta1.NuclioFunction{*testCase.function},
+				[]v1beta1.NuclioAPIGateway{apiGateway})
+
+			suite.Require().Len(migrations, 1)
+			suite.Require().Equal(auth.AuthenticationMode(""), migrations[0].mode)
+		})
+	}
+}
+
+// TestMigrateLabelsStaleFunctionsWithoutMode asserts a mid-deploy function is labeled but keeps its spec
+// untouched, so the redeploy the user has to run is not blocked by the migration gate and sets the mode
+// itself.
+func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateLabelsStaleFunctionsWithoutMode() {
+	suite.withFunctionAuthentication(auth.AuthenticationModeAPI)
+
+	for _, testCase := range []struct {
+		functionState functionconfig.FunctionState
+		expectModeSet bool
+	}{
+		{functionState: functionconfig.FunctionStateReady, expectModeSet: true},
+		{functionState: functionconfig.FunctionStateScaledToZero, expectModeSet: true},
+		{functionState: functionconfig.FunctionStateError, expectModeSet: true},
+		{functionState: functionconfig.FunctionStateImported, expectModeSet: true},
+		{functionState: functionconfig.FunctionStateUnhealthy, expectModeSet: true},
+		{functionState: functionconfig.FunctionStateWaitingForResourceConfiguration, expectModeSet: true},
+		{functionState: functionconfig.FunctionStateConfiguringResources, expectModeSet: true},
+		{functionState: functionconfig.FunctionStateWaitingForScaleResourcesToZero, expectModeSet: true},
+		// mid-deploy, so the mode is left to the redeploy that follows
+		{functionState: functionconfig.FunctionStateBuilding, expectModeSet: false},
+		{functionState: functionconfig.FunctionStateWaitingForBuild, expectModeSet: false},
+	} {
+		suite.Run(string(testCase.functionState), func() {
+			suite.ResetCRDMocks()
+			suite.abstractPlatform.DefaultNamespace = suite.Namespace
+
+			function := suite.compileFunction("func", testCase.functionState, "")
+			suite.expectListUnmigrated([]v1beta1.NuclioFunction{*function}, nil)
+
+			updatedFunction := &v1beta1.NuclioFunction{}
+			suite.nuclioFunctionInterfaceMock.
+				On("Update", suite.ctx, mock.MatchedBy(func(function *v1beta1.NuclioFunction) bool {
+					*updatedFunction = *function
+					return true
+				}), metav1.UpdateOptions{}).
+				Return(updatedFunction, nil).
+				Once()
+
+			suite.platform.MigrateFunctionAuthentication(suite.ctx)
+
+			if testCase.expectModeSet {
+				suite.Require().Equal(string(auth.AuthenticationModeAPI),
+					updatedFunction.Spec.Triggers["http"].Attributes[auth.AttributeAuthenticationMode])
+			} else {
+				suite.Require().Empty(
+					updatedFunction.Spec.Triggers["http"].Attributes[auth.AttributeAuthenticationMode])
+			}
+
+			// every function is labeled either way, so none of them stays behind the write gate
+			suite.Require().Equal(common.NuclioLabelValueMigrationApplied,
+				updatedFunction.Labels[common.NuclioLabelKeyMigrationFunctionAuth])
+			suite.nuclioFunctionInterfaceMock.AssertExpectations(suite.T())
+		})
+	}
+}
+
+// TestMigrateFunctionStampsModeAndLabel is the end-to-end happy path over the CRD client.
+func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateFunctionStampsModeAndLabel() {
+	suite.withFunctionAuthentication(auth.AuthenticationModeAPI)
+
+	function := suite.compileFunction("func", functionconfig.FunctionStateReady, "")
+	apiGateway := suite.compileAPIGateway("gw", "func", auth.AuthenticationModeIguazio, nil)
+	suite.expectListUnmigrated([]v1beta1.NuclioFunction{*function}, []v1beta1.NuclioAPIGateway{*apiGateway})
+
+	updatedFunction := &v1beta1.NuclioFunction{}
+	suite.nuclioFunctionInterfaceMock.
+		On("Update", suite.ctx, mock.MatchedBy(func(function *v1beta1.NuclioFunction) bool {
+			*updatedFunction = *function
+			return true
+		}), metav1.UpdateOptions{}).
+		Return(updatedFunction, nil).
+		Once()
+	updatedAPIGateway := suite.expectAPIGatewayUpdate()
+
+	suite.platform.MigrateFunctionAuthentication(suite.ctx)
+
+	suite.Require().Equal(string(auth.AuthenticationModeBrowser),
+		updatedFunction.Spec.Triggers["http"].Attributes[auth.AttributeAuthenticationMode])
+	suite.Require().Equal(common.NuclioLabelValueMigrationApplied,
+		updatedFunction.Labels[common.NuclioLabelKeyMigrationFunctionAuth])
+
+	// the gateway keeps its upstreams and loses only its authentication
+	suite.Require().Equal(auth.AuthenticationMode(""), updatedAPIGateway.Spec.AuthenticationMode)
+	suite.Require().Nil(updatedAPIGateway.Spec.Authentication)
+	suite.Require().Len(updatedAPIGateway.Spec.Upstreams, 1)
+
+	// and is re-provisioned, so the controller re-renders its ingress without the nginx auth annotations
+	suite.Require().Equal(platform.APIGatewayStateWaitingForProvisioning, updatedAPIGateway.Status.State)
+	suite.Require().Equal(common.NuclioLabelValueMigrationApplied,
+		updatedAPIGateway.Labels[common.NuclioLabelKeyMigrationFunctionAuth])
+
+	suite.nuclioFunctionInterfaceMock.AssertExpectations(suite.T())
+	suite.nuclioAPIGatewayInterfaceMock.AssertExpectations(suite.T())
+}
+
+// TestMigrateFunctionWithNoAPIGatewayUsesPlatformDefault asserts a function no gateway speaks for still
+// ends up with a mode - the platform-wide default - rather than being left with none.
+func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateFunctionWithNoAPIGatewayUsesPlatformDefault() {
+	for _, defaultMode := range []auth.AuthenticationMode{
+		auth.AuthenticationModeAPI,
+		auth.AuthenticationModeBrowser,
+		auth.AuthenticationModeNone,
+	} {
+		suite.Run(string(defaultMode), func() {
+			suite.ResetCRDMocks()
+			suite.abstractPlatform.DefaultNamespace = suite.Namespace
+			suite.withFunctionAuthentication(defaultMode)
+
+			function := suite.compileFunction("func", functionconfig.FunctionStateReady, "")
+			suite.expectListUnmigrated([]v1beta1.NuclioFunction{*function}, nil)
+
+			updatedFunction := &v1beta1.NuclioFunction{}
+			suite.nuclioFunctionInterfaceMock.
+				On("Update", suite.ctx, mock.MatchedBy(func(function *v1beta1.NuclioFunction) bool {
+					*updatedFunction = *function
+					return true
+				}), metav1.UpdateOptions{}).
+				Return(updatedFunction, nil).
+				Once()
+
+			suite.platform.MigrateFunctionAuthentication(suite.ctx)
+
+			suite.Require().Equal(string(defaultMode),
+				updatedFunction.Spec.Triggers["http"].Attributes[auth.AttributeAuthenticationMode])
+			suite.Require().Equal(common.NuclioLabelValueMigrationApplied,
+				updatedFunction.Labels[common.NuclioLabelKeyMigrationFunctionAuth])
+			suite.nuclioFunctionInterfaceMock.AssertExpectations(suite.T())
+		})
+	}
+}
+
+// TestMigrateFunctionAlreadyOnTheNewModelOnlyMarksIt asserts a function that already declares a mode is
+// marked without its spec being touched, so the sweep never overwrites an explicit choice.
+func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateFunctionAlreadyOnTheNewModelOnlyMarksIt() {
+	suite.withFunctionAuthentication(auth.AuthenticationModeAPI)
+	function := suite.compileFunction("func", functionconfig.FunctionStateReady, auth.AuthenticationModeNone)
+	apiGateway := suite.compileAPIGateway("gw", "func", auth.AuthenticationModeIguazio, nil)
+	suite.expectListUnmigrated([]v1beta1.NuclioFunction{*function}, []v1beta1.NuclioAPIGateway{*apiGateway})
+
+	updatedFunction := &v1beta1.NuclioFunction{}
+	suite.nuclioFunctionInterfaceMock.
+		On("Update", suite.ctx, mock.MatchedBy(func(function *v1beta1.NuclioFunction) bool {
+			*updatedFunction = *function
+			return true
+		}), metav1.UpdateOptions{}).
+		Return(updatedFunction, nil).
+		Once()
+	suite.expectAPIGatewayUpdate()
+
+	suite.platform.MigrateFunctionAuthentication(suite.ctx)
+
+	suite.Require().Equal(string(auth.AuthenticationModeNone),
+		updatedFunction.Spec.Triggers["http"].Attributes[auth.AttributeAuthenticationMode])
+	suite.Require().Equal(common.NuclioLabelValueMigrationApplied,
+		updatedFunction.Labels[common.NuclioLabelKeyMigrationFunctionAuth])
+	suite.nuclioFunctionInterfaceMock.AssertExpectations(suite.T())
+}
+
+// TestChooseAuthByPriority covers the rank-based tie-break directly.
+func (suite *AuthMigrationKubePlatformTestSuite) TestChooseAuthByPriority() {
+	for _, testCase := range []struct {
+		defaultMode  auth.AuthenticationMode
+		modeA        auth.AuthenticationMode
+		modeB        auth.AuthenticationMode
+		expectedMode auth.AuthenticationMode
+	}{
+		// the platform default outranks everything
+		{auth.AuthenticationModeAPI, auth.AuthenticationModeBrowser, auth.AuthenticationModeAPI, auth.AuthenticationModeAPI},
+		{auth.AuthenticationModeBrowser, auth.AuthenticationModeAPI, auth.AuthenticationModeBrowser, auth.AuthenticationModeBrowser},
+		// basicAuth is last, since it is the only mode carrying per-function credentials
+		{auth.AuthenticationModeAPI, auth.AuthenticationModeBasicAuth, auth.AuthenticationModeBrowser, auth.AuthenticationModeBrowser},
+		{auth.AuthenticationModeAPI, auth.AuthenticationModeBasicAuth, "", auth.AuthenticationModeBasicAuth},
+		// authentication always beats none
+		{auth.AuthenticationModeNone, auth.AuthenticationModeNone, auth.AuthenticationModeBasicAuth, auth.AuthenticationModeBasicAuth},
+		{auth.AuthenticationModeAPI, auth.AuthenticationModeAPI, auth.AuthenticationModeNone, auth.AuthenticationModeAPI},
+		// with a none default there is still a deterministic order
+		{auth.AuthenticationModeNone, auth.AuthenticationModeBrowser, auth.AuthenticationModeAPI, auth.AuthenticationModeAPI},
+	} {
+		suite.Run(fmt.Sprintf("default=%s/%s-vs-%s", testCase.defaultMode, testCase.modeA, testCase.modeB), func() {
+			suite.abstractPlatform.Config.Authentication.DefaultMode = testCase.defaultMode
+			suite.Require().Equal(testCase.expectedMode,
+				suite.platform.chooseAuthByPriority(testCase.modeA, testCase.modeB))
+		})
+	}
+}
+
+// TestMigrateBasicAuthScrubsCredentialsOntoTheFunction asserts the password is copied by value into the
+// function's own secret, since a $ref cannot be moved - it resolves only against the secret of its owner.
+func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateBasicAuthScrubsCredentialsOntoTheFunction() {
+	suite.withFunctionAuthentication(auth.AuthenticationModeAPI)
+	suite.abstractPlatform.Config.EnableSensitiveFieldMasking()
+	// the test is not about the masking itself, so turn it off after the test to avoid polluting other tests
+	suite.T().Cleanup(suite.abstractPlatform.Config.DisableSensitiveFieldMasking)
+
+	function := suite.compileFunction("func", functionconfig.FunctionStateReady, "")
+	apiGateway := suite.compileAPIGateway("gw", "func", auth.AuthenticationModeBasicAuth,
+		suite.compileBasicAuthentication("some-user", "test-pass"))
+	suite.expectListUnmigrated([]v1beta1.NuclioFunction{*function}, []v1beta1.NuclioAPIGateway{*apiGateway})
+
+	updatedFunction := &v1beta1.NuclioFunction{}
+	suite.nuclioFunctionInterfaceMock.
+		On("Update", suite.ctx, mock.MatchedBy(func(function *v1beta1.NuclioFunction) bool {
+			*updatedFunction = *function
+			return true
+		}), metav1.UpdateOptions{}).
+		Return(updatedFunction, nil).
+		Once()
+	suite.expectAPIGatewayUpdate()
+
+	suite.platform.MigrateFunctionAuthentication(suite.ctx)
+
+	suite.Require().Equal(string(auth.AuthenticationModeBasicAuth),
+		updatedFunction.Spec.Triggers["http"].Attributes[auth.AttributeAuthenticationMode])
+
+	basicAuthAttributes := updatedFunction.Spec.Triggers["http"].
+		Attributes[auth.AttributeAuthentication].(map[string]interface{})[auth.AttributeBasicAuth].(map[string]interface{})
+	suite.Require().Equal("some-user", basicAuthAttributes["username"])
+
+	// the password is stored as a reference into the function's own secret, never in plaintext on the CRD,
+	// and the reference is the function-side field path rather than the gateway's
+	passwordReference, ok := basicAuthAttributes["password"].(string)
+	suite.Require().True(ok)
+	suite.Require().Equal(
+		functionconfig.ReferencePrefix+"/spec/triggers/http/attributes/authentication/basicauth/password",
+		passwordReference)
+
+	// asserted on the created secret rather than through GetObjectSecretMap, because the fake clientset does
+	// not do the api server's StringData -> Data conversion
+	functionScrubber := suite.platform.GetFunctionScrubber()
+	functionSecrets, err := functionScrubber.GetObjectSecrets(suite.ctx, "func", suite.Namespace)
+	suite.Require().NoError(err)
+	suite.Require().Len(functionSecrets, 1)
+	suite.Require().Equal(v1.SecretType(functionconfig.SecretTypeFunctionConfig), functionSecrets[0].Type)
+
+	suite.Require().Equal("test-pass",
+		functionSecrets[0].StringData[functionScrubber.EncodeSecretKey(passwordReference)])
+}
+
+// TestMigrateIsIdempotent asserts a second sweep writes nothing, because the label selector excludes
+// everything the first sweep stamped.
+func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateIsIdempotent() {
+	suite.withFunctionAuthentication(auth.AuthenticationModeAPI)
+
+	// the api server filters on the selector, so a second sweep sees empty lists
+	suite.expectListUnmigrated(nil, nil)
+
+	suite.platform.MigrateFunctionAuthentication(suite.ctx)
+
+	suite.nuclioFunctionInterfaceMock.AssertNotCalled(suite.T(), "Update", mock.Anything, mock.Anything, mock.Anything)
+	suite.nuclioAPIGatewayInterfaceMock.AssertNotCalled(suite.T(), "Update", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestMigrateDisabledByFeatureFlag asserts the sweep is a provable no-op while the flag is off.
+func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateDisabledByFeatureFlag() {
+	suite.platform.MigrateFunctionAuthentication(suite.ctx)
+
+	suite.nuclioFunctionInterfaceMock.AssertNotCalled(suite.T(), "List", mock.Anything, mock.Anything)
+	suite.nuclioAPIGatewayInterfaceMock.AssertNotCalled(suite.T(), "List", mock.Anything, mock.Anything)
+}
+
+// TestCheckNotMigratedToFunctionAuthentication covers the write gate in isolation.
+func (suite *AuthMigrationKubePlatformTestSuite) TestCheckNotMigratedToFunctionAuthentication() {
+	for _, testCase := range []struct {
+		name               string
+		featureFlagEnabled bool
+		labels             map[string]string
+		expectedFailure    bool
+	}{
+		{
+			name:               "flag off, so nothing is gated",
+			featureFlagEnabled: false,
+			labels:             nil,
+		},
+		{
+			name:               "migrated resources are writable",
+			featureFlagEnabled: true,
+			labels: map[string]string{
+				common.NuclioLabelKeyMigrationFunctionAuth: common.NuclioLabelValueMigrationApplied,
+			},
+		},
+		{
+			name:               "unmigrated resources are rejected",
+			featureFlagEnabled: true,
+			labels:             map[string]string{},
+			expectedFailure:    true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.abstractPlatform.Config.Authentication.FunctionAuthenticationEnabled = testCase.featureFlagEnabled
+
+			err := suite.platform.checkNotMigratedToFunctionAuthentication("Function", "func", testCase.labels)
+			if !testCase.expectedFailure {
+				suite.Require().NoError(err)
+				return
+			}
+
+			suite.Require().Error(err)
+			suite.Require().Equal(http.StatusPreconditionFailed,
+				common.ResolveErrorStatusCodeOrDefault(err, http.StatusInternalServerError))
+		})
+	}
+}
+
+// TestUpdateAPIGatewayIsGatedWhileUnmigrated asserts an unmigrated gateway is rejected before anything is
+// written, so a user edit cannot race the migration sweep.
+func (suite *AuthMigrationKubePlatformTestSuite) TestUpdateAPIGatewayIsGatedWhileUnmigrated() {
+	suite.withFunctionAuthentication(auth.AuthenticationModeAPI)
+
+	apiGateway := suite.compileAPIGateway("gw", "func", auth.AuthenticationModeIguazio, nil)
+	suite.nuclioAPIGatewayInterfaceMock.
+		On("Get", suite.ctx, "gw", metav1.GetOptions{}).
+		Return(apiGateway, nil).
+		Once()
+
+	err := suite.platform.UpdateAPIGateway(suite.ctx, &platform.UpdateAPIGatewayOptions{
+		APIGatewayConfig: &platform.APIGatewayConfig{
+			Meta: platform.APIGatewayMeta{Name: "gw", Namespace: suite.Namespace},
+			Spec: apiGateway.Spec,
+		},
+	})
+
+	suite.Require().Error(err)
+	suite.Require().Equal(http.StatusPreconditionFailed,
+		common.ResolveErrorStatusCodeOrDefault(err, http.StatusInternalServerError))
+
+	// nothing beyond the initial Get is mocked, so reaching the OPA query or the write would have failed
+	suite.nuclioAPIGatewayInterfaceMock.AssertNotCalled(suite.T(), "Update",
+		mock.Anything, mock.Anything, mock.Anything)
+	suite.nuclioAPIGatewayInterfaceMock.AssertExpectations(suite.T())
+}
+
+// TestUpdateAPIGatewayKeepsMigrationLabel asserts an update whose request omits the migration label does
+// not erase it, since the update replaces the whole label map and the gate would then reject every later
+// edit of a migrated gateway.
+func (suite *AuthMigrationKubePlatformTestSuite) TestUpdateAPIGatewayKeepsMigrationLabel() {
+	suite.withFunctionAuthentication(auth.AuthenticationModeAPI)
+
+	storedAPIGateway := suite.compileAPIGateway("gw", "func", "", nil)
+	markMigratedToFunctionAuthentication(storedAPIGateway)
+	suite.nuclioAPIGatewayInterfaceMock.
+		On("Get", suite.ctx, "gw", metav1.GetOptions{}).
+		Return(storedAPIGateway, nil).
+		Once()
+
+	suite.mockedOpaClient.
+		On("QueryPermissions",
+			mock.AnythingOfType("string"),
+			opaclient.ActionUpdate,
+			mock.AnythingOfType("*opaclient.PermissionOptions")).
+		Return(true, nil).
+		Once()
+
+	// the upstream function does not exist, which the update tolerates
+	suite.nuclioFunctionInterfaceMock.
+		On("Get", suite.ctx, "func", metav1.GetOptions{}).
+		Return(nil, &apierrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}).
+		Once()
+
+	updatedAPIGateway := suite.expectAPIGatewayUpdate()
+
+	// as a real client sends it: user labels only, no internal migration label
+	err := suite.platform.UpdateAPIGateway(suite.ctx, &platform.UpdateAPIGatewayOptions{
+		APIGatewayConfig: &platform.APIGatewayConfig{
+			Meta: platform.APIGatewayMeta{
+				Name:      "gw",
+				Namespace: suite.Namespace,
+				Labels: map[string]string{
+					common.NuclioResourceLabelKeyProjectName: suite.projectName,
+				},
+			},
+			Spec: storedAPIGateway.Spec,
+		},
+	})
+	suite.Require().NoError(err)
+
+	suite.Require().Equal(common.NuclioLabelValueMigrationApplied,
+		updatedAPIGateway.Labels[common.NuclioLabelKeyMigrationFunctionAuth])
+	suite.nuclioAPIGatewayInterfaceMock.AssertExpectations(suite.T())
+}
+
+// TestCreateAPIGatewayStampsMigrationLabel asserts a gateway created while the feature is already on is
+// marked as migrated, so it is never gated by a sweep that has already finished.
+func (suite *AuthMigrationKubePlatformTestSuite) TestCreateAPIGatewayStampsMigrationLabel() {
+	suite.withFunctionAuthentication(auth.AuthenticationModeAPI)
+
+	suite.mockedOpaClient.
+		On("QueryPermissions",
+			mock.AnythingOfType("string"),
+			opaclient.ActionCreate,
+			mock.AnythingOfType("*opaclient.PermissionOptions")).
+		Return(true, nil).
+		Once()
+
+	// the upstream function does not exist, which the create tolerates
+	suite.nuclioFunctionInterfaceMock.
+		On("Get", suite.ctx, "func", metav1.GetOptions{}).
+		Return(nil, &apierrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}).
+		Once()
+
+	createdAPIGateway := &v1beta1.NuclioAPIGateway{}
+	suite.nuclioAPIGatewayInterfaceMock.
+		On("Create", suite.ctx, mock.MatchedBy(func(apiGateway *v1beta1.NuclioAPIGateway) bool {
+			*createdAPIGateway = *apiGateway
+			return true
+		}), metav1.CreateOptions{}).
+		Return(createdAPIGateway, nil).
+		Once()
+
+	apiGateway := suite.compileAPIGateway("gw", "func", "", nil)
+	err := suite.platform.CreateAPIGateway(suite.ctx, &platform.CreateAPIGatewayOptions{
+		APIGatewayConfig: &platform.APIGatewayConfig{
+			Meta: platform.APIGatewayMeta{
+				Name:      "gw",
+				Namespace: suite.Namespace,
+				Labels: map[string]string{
+					common.NuclioResourceLabelKeyProjectName: suite.projectName,
+				},
+			},
+			Spec: apiGateway.Spec,
+		},
+	})
+	suite.Require().NoError(err)
+
+	suite.Require().Equal(common.NuclioLabelValueMigrationApplied,
+		createdAPIGateway.Labels[common.NuclioLabelKeyMigrationFunctionAuth])
+	suite.nuclioAPIGatewayInterfaceMock.AssertExpectations(suite.T())
+}
+
+// TestPreserveMigrationLabel asserts the migration label survives an update request that does not carry it,
+// since it is internal bookkeeping and not part of the client-facing API.
+func (suite *AuthMigrationKubePlatformTestSuite) TestPreserveMigrationLabel() {
+	stored := map[string]string{
+		common.NuclioLabelKeyMigrationFunctionAuth: common.NuclioLabelValueMigrationApplied,
+		common.NuclioResourceLabelKeyProjectName:   suite.projectName,
+	}
+
+	preserved := preserveMigrationLabel(map[string]string{"user-label": "value"}, stored)
+	suite.Require().Equal(common.NuclioLabelValueMigrationApplied,
+		preserved[common.NuclioLabelKeyMigrationFunctionAuth])
+	suite.Require().Equal("value", preserved["user-label"])
+
+	// nothing stored, nothing invented
+	suite.Require().NotContains(preserveMigrationLabel(nil, map[string]string{}),
+		common.NuclioLabelKeyMigrationFunctionAuth)
+}
+
+//
+// test helpers
+//
+
+// withFunctionAuthentication turns the feature flag on, so the sweep is not a no-op. SetupTest starts every
+// test from an empty authentication configuration, and TearDownTest restores the suite-wide one.
+func (suite *AuthMigrationKubePlatformTestSuite) withFunctionAuthentication(defaultMode auth.AuthenticationMode) {
+	suite.abstractPlatform.Config.Authentication.FunctionAuthenticationEnabled = true
+	suite.abstractPlatform.Config.Authentication.DefaultMode = defaultMode
+}
+
+func (suite *AuthMigrationKubePlatformTestSuite) compileFunction(name string,
+	state functionconfig.FunctionState,
+	authenticationMode auth.AuthenticationMode) *v1beta1.NuclioFunction {
+
+	attributes := map[string]interface{}{}
+	if authenticationMode != "" {
+		attributes[auth.AttributeAuthenticationMode] = string(authenticationMode)
+	}
+
+	return &v1beta1.NuclioFunction{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: suite.Namespace,
+			Labels: map[string]string{
+				common.NuclioResourceLabelKeyProjectName: suite.projectName,
+			},
+		},
+		Spec: functionconfig.Spec{
+			Triggers: map[string]functionconfig.Trigger{
+				"http": {Kind: "http", Name: "http", Attributes: attributes},
+			},
+		},
+		Status: functionconfig.Status{State: state},
+	}
+}
+
+func (suite *AuthMigrationKubePlatformTestSuite) compileAPIGateway(name, functionName string,
+	authenticationMode auth.AuthenticationMode,
+	authentication *platform.APIGatewayAuthenticationSpec) *v1beta1.NuclioAPIGateway {
+
+	return &v1beta1.NuclioAPIGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: suite.Namespace,
+			Labels: map[string]string{
+				common.NuclioResourceLabelKeyProjectName: suite.projectName,
+			},
+		},
+		Spec: platform.APIGatewaySpec{
+			Name:               name,
+			Host:               name + "-host",
+			AuthenticationMode: authenticationMode,
+			Authentication:     authentication,
+			Upstreams: []platform.APIGatewayUpstreamSpec{
+				{
+					Kind:           platform.APIGatewayUpstreamKindNuclioFunction,
+					NuclioFunction: &platform.NuclioFunctionAPIGatewaySpec{Name: functionName},
+				},
+			},
+		},
+	}
+}
+
+func (suite *AuthMigrationKubePlatformTestSuite) compileBasicAuthentication(username,
+	password string) *platform.APIGatewayAuthenticationSpec {
+	return &platform.APIGatewayAuthenticationSpec{
+		BasicAuth: &platform.BasicAuth{Username: username, Password: password},
+	}
+}
+
+func (suite *AuthMigrationKubePlatformTestSuite) compileDexAuthentication(
+	redirect bool) *platform.APIGatewayAuthenticationSpec {
+	return &platform.APIGatewayAuthenticationSpec{
+		DexAuth: &ingress.DexAuth{RedirectUnauthorizedToSignIn: redirect},
+	}
+}
+
+// expectListUnmigrated mocks both of the sweep's list calls, asserting each one filters on the migration
+// label rather than listing everything.
+func (suite *AuthMigrationKubePlatformTestSuite) expectListUnmigrated(functions []v1beta1.NuclioFunction,
+	apiGateways []v1beta1.NuclioAPIGateway) {
+
+	unmigratedSelector := fmt.Sprintf("!%s", common.NuclioLabelKeyMigrationFunctionAuth)
+
+	suite.nuclioFunctionInterfaceMock.
+		On("List", suite.ctx, metav1.ListOptions{LabelSelector: unmigratedSelector}).
+		Return(&v1beta1.NuclioFunctionList{Items: functions}, nil).
+		Once()
+	suite.nuclioAPIGatewayInterfaceMock.
+		On("List", suite.ctx, metav1.ListOptions{LabelSelector: unmigratedSelector}).
+		Return(&v1beta1.NuclioAPIGatewayList{Items: apiGateways}, nil).
+		Once()
+}
+
+// expectAPIGatewayUpdate captures the api gateway the sweep writes, so the test can assert on it.
+func (suite *AuthMigrationKubePlatformTestSuite) expectAPIGatewayUpdate() *v1beta1.NuclioAPIGateway {
+	captured := &v1beta1.NuclioAPIGateway{}
+	suite.nuclioAPIGatewayInterfaceMock.
+		On("Update", suite.ctx, mock.MatchedBy(func(apiGateway *v1beta1.NuclioAPIGateway) bool {
+			*captured = *apiGateway
+			return true
+		}), metav1.UpdateOptions{}).
+		Return(captured, nil).
+		Once()
+	return captured
+}
+
+func TestAuthMigrationKubePlatformTestSuite(t *testing.T) {
+	suite.Run(t, new(AuthMigrationKubePlatformTestSuite))
+}

--- a/pkg/platform/kube/authmigration_test.go
+++ b/pkg/platform/kube/authmigration_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/nuclio/nuclio/pkg/auth"
 	"github.com/nuclio/nuclio/pkg/common"
@@ -109,22 +110,25 @@ func (suite *AuthMigrationKubePlatformTestSuite) TestResolveModeFromSingleAPIGat
 			expectedMode: auth.AuthenticationModeBasicAuth,
 		},
 		{
-			name:         "a gateway with no authentication falls back to the platform default",
+			// a function no gateway carries authentication for is left unauthenticated, not stamped with
+			// the platform default - it was open before the migration and stays open after it
+			name:         "a gateway with no authentication leaves the function unauthenticated",
 			apiGateway:   suite.compileAPIGateway("gw", "func", auth.AuthenticationModeNone, nil),
 			defaultMode:  auth.AuthenticationModeAPI,
-			expectedMode: auth.AuthenticationModeAPI,
+			expectedMode: "",
 		},
 		{
-			name:         "an unknown gateway mode fails secure to the platform default",
+			// and the platform default does not leak in through the gateway pass either
+			name:         "a non-none platform default is not used as a fallback",
+			apiGateway:   suite.compileAPIGateway("gw", "func", auth.AuthenticationModeNone, nil),
+			defaultMode:  auth.AuthenticationModeBrowser,
+			expectedMode: "",
+		},
+		{
+			name:         "an unknown gateway mode is skipped, contributing nothing",
 			apiGateway:   suite.compileAPIGateway("gw", "func", auth.AuthenticationMode("bogus"), nil),
 			defaultMode:  auth.AuthenticationModeAPI,
-			expectedMode: auth.AuthenticationModeAPI,
-		},
-		{
-			name:         "a none default is written explicitly, never left empty",
-			apiGateway:   suite.compileAPIGateway("gw", "func", auth.AuthenticationModeNone, nil),
-			defaultMode:  auth.AuthenticationModeNone,
-			expectedMode: auth.AuthenticationModeNone,
+			expectedMode: "",
 		},
 	} {
 		suite.Run(testCase.name, func() {
@@ -215,6 +219,128 @@ func (suite *AuthMigrationKubePlatformTestSuite) TestResolveModeFromDivergentAPI
 	}
 }
 
+// TestResolveBasicAuthFromMultipleAPIGateways asserts a function fronted by more than one basicAuth gateway
+// takes the newest gateway's credentials. The function's HTTP trigger holds a single username and password,
+// so exactly one gateway can win, and which one must not depend on the order they were listed in.
+func (suite *AuthMigrationKubePlatformTestSuite) TestResolveBasicAuthFromMultipleAPIGateways() {
+	type apiGatewayTestCase struct {
+		name string
+		mode auth.AuthenticationMode
+
+		// minutes after a fixed base, so the newest gateway is stated rather than implied by list order
+		createdAfterMinutes int
+	}
+
+	for _, testCase := range []struct {
+		name        string
+		apiGateways []apiGatewayTestCase
+
+		expectedMode auth.AuthenticationMode
+
+		// asserted only when it is set, since the credential source is read only once basicAuth is the mode
+		// that won
+		expectedBasicAuthAPIGatewayName string
+	}{
+		{
+			name: "a single basicAuth gateway resolves",
+			apiGateways: []apiGatewayTestCase{
+				{name: "only-gw", mode: auth.AuthenticationModeBasicAuth},
+			},
+			expectedMode:                    auth.AuthenticationModeBasicAuth,
+			expectedBasicAuthAPIGatewayName: "only-gw",
+		},
+		{
+			name: "the newest of two basicAuth gateways carries the credentials",
+			apiGateways: []apiGatewayTestCase{
+				{name: "older-gw", mode: auth.AuthenticationModeBasicAuth},
+				{name: "newer-gw", mode: auth.AuthenticationModeBasicAuth, createdAfterMinutes: 10},
+			},
+			expectedMode:                    auth.AuthenticationModeBasicAuth,
+			expectedBasicAuthAPIGatewayName: "newer-gw",
+		},
+		{
+			// same gateways, reversed, so the answer is proven to come from the timestamps
+			name: "regardless of the order the gateways are listed in",
+			apiGateways: []apiGatewayTestCase{
+				{name: "newer-gw", mode: auth.AuthenticationModeBasicAuth, createdAfterMinutes: 10},
+				{name: "older-gw", mode: auth.AuthenticationModeBasicAuth},
+			},
+			expectedMode:                    auth.AuthenticationModeBasicAuth,
+			expectedBasicAuthAPIGatewayName: "newer-gw",
+		},
+		{
+			// creationTimestamp is only second-granular, so gateways created together must still resolve
+			name: "the greater name breaks a tie between gateways created at the same time",
+			apiGateways: []apiGatewayTestCase{
+				{name: "gw-b", mode: auth.AuthenticationModeBasicAuth},
+				{name: "gw-a", mode: auth.AuthenticationModeBasicAuth},
+			},
+			expectedMode:                    auth.AuthenticationModeBasicAuth,
+			expectedBasicAuthAPIGatewayName: "gw-b",
+		},
+		{
+			// the newer gateway carries no credentials of its own, so it must not displace the claim
+			name: "a newer gateway with no authentication is not a basicAuth claim",
+			apiGateways: []apiGatewayTestCase{
+				{name: "basic-auth-gw", mode: auth.AuthenticationModeBasicAuth},
+				{name: "none-gw", mode: auth.AuthenticationModeNone, createdAfterMinutes: 10},
+			},
+			expectedMode:                    auth.AuthenticationModeBasicAuth,
+			expectedBasicAuthAPIGatewayName: "basic-auth-gw",
+		},
+		{
+			// basicAuth lost, so no credentials are ever read and the choice between them does not matter
+			name: "two basicAuth gateways outranked by another mode still resolve",
+			apiGateways: []apiGatewayTestCase{
+				{name: "first-basic-auth-gw", mode: auth.AuthenticationModeBasicAuth},
+				{name: "second-basic-auth-gw", mode: auth.AuthenticationModeBasicAuth, createdAfterMinutes: 10},
+				{name: "iguazio-gw", mode: auth.AuthenticationModeIguazio},
+			},
+			expectedMode: auth.AuthenticationModeBrowser,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.abstractPlatform.Config.Authentication.DefaultMode = auth.AuthenticationModeAPI
+
+			baseCreationTime := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+			var apiGateways []v1beta1.NuclioAPIGateway
+			for _, apiGatewayTestCase := range testCase.apiGateways {
+				var authentication *platform.APIGatewayAuthenticationSpec
+				if apiGatewayTestCase.mode == auth.AuthenticationModeBasicAuth {
+
+					// distinct credentials per gateway, so exactly one of them can be the winner
+					authentication = suite.compileBasicAuthentication(
+						fmt.Sprintf("%s-user", apiGatewayTestCase.name),
+						fmt.Sprintf("%s-pass", apiGatewayTestCase.name))
+				}
+				apiGateway := suite.compileAPIGateway(apiGatewayTestCase.name,
+					"func",
+					apiGatewayTestCase.mode,
+					authentication)
+				apiGateway.CreationTimestamp = metav1.NewTime(
+					baseCreationTime.Add(time.Duration(apiGatewayTestCase.createdAfterMinutes) * time.Minute))
+				apiGateways = append(apiGateways, *apiGateway)
+			}
+
+			migrations := suite.platform.resolveFunctionAuthMigrations(suite.ctx,
+				[]v1beta1.NuclioFunction{
+					*suite.compileFunction("func", functionconfig.FunctionStateReady, ""),
+				},
+				apiGateways)
+
+			suite.Require().Len(migrations, 1)
+			suite.Require().Equal(testCase.expectedMode, migrations["func"].mode)
+
+			if testCase.expectedBasicAuthAPIGatewayName != "" {
+				suite.Require().NotNil(migrations["func"].basicAuthAPIGateway)
+				suite.Require().Equal(testCase.expectedBasicAuthAPIGatewayName,
+					migrations["func"].basicAuthAPIGateway.Name)
+			}
+		})
+	}
+}
+
 // TestResolveModeForCanaryAPIGateway asserts a canary gateway contributes its mode to both of its targets.
 func (suite *AuthMigrationKubePlatformTestSuite) TestResolveModeForCanaryAPIGateway() {
 	suite.abstractPlatform.Config.Authentication.DefaultMode = auth.AuthenticationModeAPI
@@ -298,7 +424,12 @@ func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateLabelsStaleFunctions
 			suite.abstractPlatform.DefaultNamespace = suite.Namespace
 
 			function := suite.compileFunction("func", testCase.functionState, "")
-			suite.expectListUnmigrated([]v1beta1.NuclioFunction{*function}, nil)
+
+			// the gateway is what supplies the mode - nothing falls back to the platform default anymore,
+			// so without one every state would look the same and the assertion below would prove nothing
+			apiGateway := suite.compileAPIGateway("gw", "func", auth.AuthenticationModeIguazio, nil)
+			suite.expectListUnmigrated([]v1beta1.NuclioFunction{*function},
+				[]v1beta1.NuclioAPIGateway{*apiGateway})
 
 			updatedFunction := &v1beta1.NuclioFunction{}
 			suite.nuclioFunctionInterfaceMock.
@@ -308,11 +439,12 @@ func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateLabelsStaleFunctions
 				}), metav1.UpdateOptions{}).
 				Return(updatedFunction, nil).
 				Once()
+			suite.expectAPIGatewayUpdate()
 
 			suite.platform.MigrateFunctionAuthentication(suite.ctx)
 
 			if testCase.expectModeSet {
-				suite.Require().Equal(string(auth.AuthenticationModeAPI),
+				suite.Require().Equal(string(auth.AuthenticationModeBrowser),
 					updatedFunction.Spec.Triggers["http"].Attributes[auth.AttributeAuthenticationMode])
 			} else {
 				suite.Require().Empty(
@@ -366,9 +498,11 @@ func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateFunctionStampsModeAn
 	suite.nuclioAPIGatewayInterfaceMock.AssertExpectations(suite.T())
 }
 
-// TestMigrateFunctionWithNoAPIGatewayUsesPlatformDefault asserts a function no gateway speaks for still
-// ends up with a mode - the platform-wide default - rather than being left with none.
-func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateFunctionWithNoAPIGatewayUsesPlatformDefault() {
+// TestMigrateFunctionWithNoAPIGatewayIsLeftUnauthenticated asserts a function no gateway carries
+// authentication for is only labeled, never given a mode. It was reachable without credentials before the
+// migration and stays that way after it - an absent mode is the same as none - so the platform default is
+// deliberately not used as a fallback, whatever it is set to.
+func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateFunctionWithNoAPIGatewayIsLeftUnauthenticated() {
 	for _, defaultMode := range []auth.AuthenticationMode{
 		auth.AuthenticationModeAPI,
 		auth.AuthenticationModeBrowser,
@@ -393,8 +527,8 @@ func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateFunctionWithNoAPIGat
 
 			suite.platform.MigrateFunctionAuthentication(suite.ctx)
 
-			suite.Require().Equal(string(defaultMode),
-				updatedFunction.Spec.Triggers["http"].Attributes[auth.AttributeAuthenticationMode])
+			suite.Require().NotContains(updatedFunction.Spec.Triggers["http"].Attributes,
+				auth.AttributeAuthenticationMode)
 			suite.Require().Equal(common.NuclioLabelValueMigrationApplied,
 				updatedFunction.Labels[common.NuclioLabelKeyMigrationFunctionAuth])
 			suite.nuclioFunctionInterfaceMock.AssertExpectations(suite.T())
@@ -566,6 +700,135 @@ func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateKeepsAPIGatewayAuthe
 	suite.Require().Equal(auth.AuthenticationMode(""), updatedAPIGateways[0].Spec.AuthenticationMode)
 	suite.Require().Equal(common.NuclioLabelValueMigrationApplied,
 		updatedAPIGateways[0].Labels[common.NuclioLabelKeyMigrationFunctionAuth])
+
+	suite.nuclioFunctionInterfaceMock.AssertExpectations(suite.T())
+	suite.nuclioAPIGatewayInterfaceMock.AssertExpectations(suite.T())
+}
+
+// TestMigrateBasicAuthTakesTheNewestAPIGatewayCredentials asserts a function fronted by two basicAuth
+// gateways migrates with the newest gateway's credentials, and that both gateways are still drained - the
+// older gateway's credentials stop working, which is the cost of the function holding a single pair.
+func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateBasicAuthTakesTheNewestAPIGatewayCredentials() {
+	suite.withFunctionAuthentication(auth.AuthenticationModeAPI)
+
+	function := suite.compileFunction("func", functionconfig.FunctionStateReady, "")
+
+	olderAPIGateway := suite.compileAPIGateway("older-gw",
+		"func",
+		auth.AuthenticationModeBasicAuth,
+		suite.compileBasicAuthentication("older-user", "older-pass"))
+	olderAPIGateway.CreationTimestamp = metav1.NewTime(
+		time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC))
+
+	newerAPIGateway := suite.compileAPIGateway("newer-gw",
+		"func",
+		auth.AuthenticationModeBasicAuth,
+		suite.compileBasicAuthentication("newer-user", "newer-pass"))
+	newerAPIGateway.CreationTimestamp = metav1.NewTime(
+		time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC))
+
+	// listed oldest last, so the winner cannot come from list order
+	suite.expectListUnmigrated([]v1beta1.NuclioFunction{*function},
+		[]v1beta1.NuclioAPIGateway{*newerAPIGateway, *olderAPIGateway})
+
+	updatedFunction := &v1beta1.NuclioFunction{}
+	suite.nuclioFunctionInterfaceMock.
+		On("Update", suite.ctx, mock.MatchedBy(func(function *v1beta1.NuclioFunction) bool {
+			*updatedFunction = *function
+			return true
+		}), metav1.UpdateOptions{}).
+		Return(updatedFunction, nil).
+		Once()
+
+	// matches any gateway, so the assertion below can pin down exactly which ones were drained
+	var updatedAPIGatewayNames []string
+	var updatedAPIGatewayNamesLock sync.Mutex
+	suite.nuclioAPIGatewayInterfaceMock.
+		On("Update", suite.ctx, mock.Anything, metav1.UpdateOptions{}).
+		Return(func(_ context.Context,
+			apiGateway *v1beta1.NuclioAPIGateway,
+			_ metav1.UpdateOptions) *v1beta1.NuclioAPIGateway {
+			updatedAPIGatewayNamesLock.Lock()
+			defer updatedAPIGatewayNamesLock.Unlock()
+			updatedAPIGatewayNames = append(updatedAPIGatewayNames, apiGateway.Name)
+			return apiGateway
+		}, nil)
+
+	suite.platform.MigrateFunctionAuthentication(suite.ctx)
+
+	suite.Require().Equal(string(auth.AuthenticationModeBasicAuth),
+		updatedFunction.Spec.Triggers["http"].Attributes[auth.AttributeAuthenticationMode])
+
+	basicAuthAttributes := updatedFunction.Spec.Triggers["http"].
+		Attributes[auth.AttributeAuthentication].(map[string]interface{})[auth.AttributeBasicAuth].(map[string]interface{})
+	suite.Require().Equal("newer-user", basicAuthAttributes["username"])
+	suite.Require().Equal("newer-pass", basicAuthAttributes["password"])
+
+	// the function migrated, so nothing holds either gateway back - including the one whose credentials lost
+	suite.Require().ElementsMatch([]string{"newer-gw", "older-gw"}, updatedAPIGatewayNames)
+
+	suite.nuclioFunctionInterfaceMock.AssertExpectations(suite.T())
+	suite.nuclioAPIGatewayInterfaceMock.AssertExpectations(suite.T())
+}
+
+// TestMigrateFunctionOutranksMultipleBasicAuthAPIGateways asserts the choice between several basicAuth
+// gateways is never made when basicAuth is not the mode that wins: two basicAuth gateways alongside one that
+// maps to api leave the function on api, with neither set of credentials copied onto it.
+func (suite *AuthMigrationKubePlatformTestSuite) TestMigrateFunctionOutranksMultipleBasicAuthAPIGateways() {
+
+	// deliberately not api, so the winning mode is proven to come from the gateway ranking rather than from
+	// the platform default
+	suite.withFunctionAuthentication(auth.AuthenticationModeBrowser)
+
+	function := suite.compileFunction("func", functionconfig.FunctionStateReady, "")
+	suite.expectListUnmigrated([]v1beta1.NuclioFunction{*function},
+		[]v1beta1.NuclioAPIGateway{
+			*suite.compileAPIGateway("first-basic-auth-gw", "func", auth.AuthenticationModeBasicAuth,
+				suite.compileBasicAuthentication("first-user", "first-pass")),
+			*suite.compileAPIGateway("second-basic-auth-gw", "func", auth.AuthenticationModeBasicAuth,
+				suite.compileBasicAuthentication("second-user", "second-pass")),
+			*suite.compileAPIGateway("access-key-gw", "func", auth.AuthenticationModeAccessKey, nil),
+		})
+
+	updatedFunction := &v1beta1.NuclioFunction{}
+	suite.nuclioFunctionInterfaceMock.
+		On("Update", suite.ctx, mock.MatchedBy(func(function *v1beta1.NuclioFunction) bool {
+			*updatedFunction = *function
+			return true
+		}), metav1.UpdateOptions{}).
+		Return(updatedFunction, nil).
+		Once()
+
+	// matches any gateway, so the assertion below can pin down exactly which ones were drained
+	var updatedAPIGatewayNames []string
+	var updatedAPIGatewayNamesLock sync.Mutex
+	suite.nuclioAPIGatewayInterfaceMock.
+		On("Update", suite.ctx, mock.Anything, metav1.UpdateOptions{}).
+		Return(func(_ context.Context,
+			apiGateway *v1beta1.NuclioAPIGateway,
+			_ metav1.UpdateOptions) *v1beta1.NuclioAPIGateway {
+			updatedAPIGatewayNamesLock.Lock()
+			defer updatedAPIGatewayNamesLock.Unlock()
+			updatedAPIGatewayNames = append(updatedAPIGatewayNames, apiGateway.Name)
+			return apiGateway
+		}, nil)
+
+	suite.platform.MigrateFunctionAuthentication(suite.ctx)
+
+	// api outranks basicAuth, so neither gateway's credentials are ever read
+	suite.Require().Equal(string(auth.AuthenticationModeAPI),
+		updatedFunction.Spec.Triggers["http"].Attributes[auth.AttributeAuthenticationMode])
+	suite.Require().Equal(common.NuclioLabelValueMigrationApplied,
+		updatedFunction.Labels[common.NuclioLabelKeyMigrationFunctionAuth])
+
+	// and no credentials are carried over, since api needs none - the losing gateways' claims are dropped
+	// with them
+	suite.Require().NotContains(updatedFunction.Spec.Triggers["http"].Attributes,
+		auth.AttributeAuthentication)
+
+	// the function migrated, so nothing holds any of the three gateways back
+	suite.Require().ElementsMatch([]string{"first-basic-auth-gw", "second-basic-auth-gw", "access-key-gw"},
+		updatedAPIGatewayNames)
 
 	suite.nuclioFunctionInterfaceMock.AssertExpectations(suite.T())
 	suite.nuclioAPIGatewayInterfaceMock.AssertExpectations(suite.T())

--- a/pkg/platform/kube/clients/nuclio/deployer_test.go
+++ b/pkg/platform/kube/clients/nuclio/deployer_test.go
@@ -1,0 +1,94 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nuclio
+
+import (
+	"testing"
+
+	"github.com/nuclio/nuclio/pkg/common"
+	"github.com/nuclio/nuclio/pkg/functionconfig"
+	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type DeployerTestSuite struct {
+	suite.Suite
+	deployer *Deployer
+}
+
+func (suite *DeployerTestSuite) SetupSuite() {
+	suite.deployer = &Deployer{}
+}
+
+// TestPopulateFunctionKeepsStoredLabelsOnUpdate pins the behavior the migration label relies on: an update
+// keeps the stored labels, so internal bookkeeping is never erased by a client request. Annotations are
+// deliberately replaced.
+func (suite *DeployerTestSuite) TestPopulateFunctionKeepsStoredLabelsOnUpdate() {
+	for _, testCase := range []struct {
+		name            string
+		functionExisted bool
+		expectedLabels  map[string]string
+	}{
+		{
+			name:            "an update keeps the stored labels",
+			functionExisted: true,
+			expectedLabels: map[string]string{
+				common.NuclioLabelKeyMigrationFunctionAuth: common.NuclioLabelValueMigrationApplied,
+			},
+		},
+		{
+			name:            "a create takes the request's labels",
+			functionExisted: false,
+			expectedLabels:  map[string]string{"user-label": "value"},
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			functionInstance := &nuclioio.NuclioFunction{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						common.NuclioLabelKeyMigrationFunctionAuth: common.NuclioLabelValueMigrationApplied,
+					},
+				},
+			}
+
+			functionConfig := &functionconfig.Config{
+				Meta: functionconfig.Meta{
+					Name:      "func",
+					Namespace: "namespace",
+
+					// as a real client sends it: user labels only, no internal migration label
+					Labels: map[string]string{"user-label": "value"},
+				},
+			}
+
+			err := suite.deployer.populateFunction(functionConfig,
+				&functionconfig.Status{State: functionconfig.FunctionStateWaitingForResourceConfiguration},
+				functionInstance,
+				testCase.functionExisted)
+			suite.Require().NoError(err)
+			suite.Require().Equal(testCase.expectedLabels, functionInstance.Labels)
+		})
+	}
+}
+
+func TestDeployerTestSuite(t *testing.T) {
+	suite.Run(t, new(DeployerTestSuite))
+}

--- a/pkg/platform/kube/functionres/lazy.go
+++ b/pkg/platform/kube/functionres/lazy.go
@@ -2057,6 +2057,14 @@ func (lc *lazyClient) getFunctionLabels(function *nuclioio.NuclioFunction) label
 	result := labels.Set{}
 
 	for labelKey, labelValue := range function.Labels {
+
+		// migration labels are platform bookkeeping on the CRD. They must not reach the rendered resources:
+		// this label set becomes the Service's selector and, on create, the pod template's labels, but the
+		// update path rewrites the Service selector without rewriting the pod labels - so a label added to
+		// an existing function would leave the Service selecting no pods at all
+		if strings.HasPrefix(labelKey, common.NuclioLabelKeyMigrationPrefix) {
+			continue
+		}
 		result[labelKey] = labelValue
 	}
 

--- a/pkg/platform/kube/functionres/lazy_test.go
+++ b/pkg/platform/kube/functionres/lazy_test.go
@@ -643,6 +643,26 @@ func (suite *lazyTestSuite) TestFunctionAuthenticationEnabled() {
 	}
 }
 
+// TestGetFunctionLabelsStripsMigrationLabels pins that migration labels never reach the rendered resources.
+// They would end up in the service selector, which an update rewrites without touching the labels of the
+// running pods - leaving the service with no pods at all.
+func (suite *lazyTestSuite) TestGetFunctionLabelsStripsMigrationLabels() {
+	functionInstance := &nuclioio.NuclioFunction{}
+	functionInstance.Name = "func"
+	functionInstance.Labels = map[string]string{
+		common.NuclioResourceLabelKeyProjectName:                       "some-project",
+		common.NuclioLabelKeyMigrationFunctionAuth:                     common.NuclioLabelValueMigrationApplied,
+		common.NuclioLabelKeyMigrationPrefix + "some-future-migration": "true",
+	}
+
+	functionLabels := suite.client.getFunctionLabels(functionInstance)
+
+	suite.Require().Equal("some-project", functionLabels[common.NuclioResourceLabelKeyProjectName])
+	for labelKey := range functionLabels {
+		suite.Require().NotContains(labelKey, common.NuclioLabelKeyMigrationPrefix)
+	}
+}
+
 // TestInjectAuthProxySidecar verifies the auth-proxy sidecar is appended with the expected image/args/ports,
 // and that the config-restore env var is only set for basicAuth mode (api/browser have no credentials to
 // restore).

--- a/pkg/platform/kube/platform.go
+++ b/pkg/platform/kube/platform.go
@@ -244,6 +244,22 @@ func (p *Platform) CreateFunction(ctx context.Context, createFunctionOptions *pl
 		return nil, errors.Wrap(err, "Failed to validate a function configuration against an existing configuration")
 	}
 
+	// block the deploy while the function still waits for the authentication migration, or the two writes
+	// would race and one of them would be lost. Checked here, before the deploy starts, so a rejection
+	// never leaves the function in error state
+	if existingFunctionInstance != nil {
+		if err := p.checkNotMigratedToFunctionAuthentication("Function",
+			existingFunctionInstance.Name,
+			existingFunctionInstance.Labels); err != nil {
+			return nil, err
+		}
+	} else {
+
+		// created while function-level authentication is already on, so there is nothing to migrate on it
+		createFunctionOptions.FunctionConfig.Meta.Labels = p.stampMigratedToFunctionAuthentication(
+			createFunctionOptions.FunctionConfig.Meta.Labels)
+	}
+
 	// wrap logger
 	logStream, err := abstract.NewLogStream("deployer", nucliozap.InfoLevel, createFunctionOptions.Logger)
 	if err != nil {
@@ -952,6 +968,9 @@ func (p *Platform) CreateAPIGateway(ctx context.Context,
 
 	p.platformAPIGatewayToAPIGateway(createAPIGatewayOptions.APIGatewayConfig, newAPIGateway)
 
+	// created while function-level authentication is already on, so there is nothing to migrate on it
+	newAPIGateway.Labels = p.stampMigratedToFunctionAuthentication(newAPIGateway.Labels)
+
 	// set api gateway state to "waitingForProvisioning", so the controller will know to create/update this resource
 	newAPIGateway.Status.State = platform.APIGatewayStateWaitingForProvisioning
 
@@ -971,6 +990,12 @@ func (p *Platform) UpdateAPIGateway(ctx context.Context, updateAPIGatewayOptions
 		updateAPIGatewayOptions.APIGatewayConfig.Meta.Name)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get api gateway to update")
+	}
+
+	if err := p.checkNotMigratedToFunctionAuthentication("Api gateway",
+		apiGateway.Name,
+		apiGateway.Labels); err != nil {
+		return err
 	}
 
 	projectName := apiGateway.Labels[common.NuclioResourceLabelKeyProjectName]
@@ -1027,7 +1052,11 @@ func (p *Platform) UpdateAPIGateway(ctx context.Context, updateAPIGatewayOptions
 	}
 
 	apiGateway.Annotations = updateAPIGatewayOptions.APIGatewayConfig.Meta.Annotations
-	apiGateway.Labels = updateAPIGatewayOptions.APIGatewayConfig.Meta.Labels
+
+	// the request replaces the whole label map. Migration labels are internal bookkeeping, not part of the
+	// client-facing API, so they must be kept regardless of the labels the client sent
+	apiGateway.Labels = preserveMigrationLabel(updateAPIGatewayOptions.APIGatewayConfig.Meta.Labels,
+		apiGateway.Labels)
 	apiGateway.Spec = updateAPIGatewayOptions.APIGatewayConfig.Spec
 
 	// set api gateway state to "waitingForProvisioning", so the controller will know to create/update this resource

--- a/pkg/platform/mock/platform.go
+++ b/pkg/platform/mock/platform.go
@@ -332,6 +332,11 @@ func (mp *Platform) GetAllowedAuthenticationModes() []string {
 	return args.Get(0).([]string)
 }
 
+// MigrateFunctionAuthentication migrates the function authentication to the new platform authentication
+func (mp *Platform) MigrateFunctionAuthentication(ctx context.Context) {
+	mp.Called(ctx)
+}
+
 // GetHealthCheckMode returns the healthcheck mode the platform requires
 func (mp *Platform) GetHealthCheckMode() platform.HealthCheckMode {
 	args := mp.Called()

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -190,6 +190,10 @@ type Platform interface {
 	// GetAllowedAuthenticationModes returns allowed authentication modes
 	GetAllowedAuthenticationModes() []string
 
+	// MigrateFunctionAuthentication moves authentication from the api gateways onto the functions' HTTP
+	// triggers. Runs in the background on startup, idempotent.
+	MigrateFunctionAuthentication(ctx context.Context)
+
 	// GetNamespaces returns all the namespaces in the platform
 	GetNamespaces(context.Context) ([]string, error)
 


### PR DESCRIPTION
### 📝 Description
Function-level authentication moves authentication off the api gateway's ingress and onto the function's HTTP trigger. 
The migration runs in the background on dashboard startup, in three steps:
1. **Resolve** - list every function and api gateway that carries no migration label yet, and decide which authentication mode each function should get, translated from the api gateways in front of it and fallback to platform-config's default.
2. **Migrate the functions** - write that mode onto each function's HTTP trigger, so the controller injects the sidecar.
3. **Migrate the api gateways** - drain the authentication configuration off the gateway CRDs and re-provision them, so the controller re-renders the ingress without the nginx auth annotations.

---

### 🛠️ Changes Made
- **`pkg/platform/kube/authmigration.go` (new)** - `MigrateFunctionAuthentication`, the three steps above. Only CRDs carrying no migration label are listed (`!nuclio.io/migration-function-auth`), and step 3 clears both `spec.authenticationMode` and `spec.authentication`.
- **Mode translation** - `iguazio` → `browser`, `accessKey` → `api`, `oauth2` → `browser` when `redirectUnauthorizedToSignIn` is set (otherwise `api`), `basicAuth` → `basicAuth`, `none`/unset → platform default. The split follows what the ingress actually does today: a mode that sets `auth-signin` redirects the browser, one that only sets `auth-url` returns 401.
- **Divergent gateways** - a gateway's mode is offered to every function behind it (so a canary gateway covers both targets); a function fronted by gateways that disagree keeps the highest-ranked mode, with the platform default ranked first and `none` last.
- **basicAuth credentials** - re-scrubbed from the gateway's secret into the function's own secret (a `$ref` only resolves against the secret of its owner), and the gateway's now-unreferenced config secret is deleted after the spec write.
- **Idempotency / write-safety** - migrated CRDs are labeled and never listed again; resources created while the flag is already on are stamped at creation (`CreateFunction`, `CreateAPIGateway`); `UpdateAPIGateway` preserves the label even though the request replaces the whole label map; a user write to a resource the migration has not marked yet is rejected with `PreconditionFailed`, so the two writes can't race and lose one another.
- **`pkg/platform/kube/functionres/lazy.go`** - migration labels are stripped from the rendered function resources. They must not reach the Service selector: the update path rewrites the selector without rewriting the pod labels, which would leave the Service selecting no pods.
- **`pkg/dashboard/server.go`** - the stale-function sweep and the migration now run in one goroutine, sweep first: both write the same functions, and the ordering also lets the migration see stale functions already in error state. The sweep's update is now status-only - it read the spec before the sweep started, so sending it back would revert any spec change made in between (including this migration's).
- **Plumbing** - `MigrateFunctionAuthentication` on the `Platform` interface (no-op in `abstract`, mocked in `mock`), `functionconfig.FunctionStateStale` extracted from the sweep's inline state map, and the migration label consts in `pkg/common/consts.go`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- **Unit tests** - `pkg/platform/kube/authmigration_test.go` covers mode resolution from a single gateway, from divergent gateways, and for a canary gateway; already-migrated and already-`authenticationMode`-declaring functions; stale functions (labeled, spec untouched); the no-gateway platform-default fallback; the basicAuth path end to end (credentials land scrubbed in the function's secret); idempotency across two runs; the feature-flag-off no-op; the update gate and label preservation on api gateways.

- **Dev testing** - deployed functions on my setup while the feature flag was **off**: a plain function with an HTTP trigger, a function fronted by an api gateway with `iguazio` authentication, and a function fronted by an api gateway with `basicAuth`. changed the FF to true and restarted the nuclio-dashboard and controller. After the migration ran: every function that had an api gateway with authentication was migrated to the matching function-level mode (no regression in what it enforces), and the function with no api gateway authentication got the platform default (`api`).

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-836
- Design docs links:
  - [HLD §3.7 Migration of Existing Functions](https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/594641703/HLD+BE+Nuclio+Function-level+Authentication#3.7-Migration-of-Existing-Functions)
  - [Open questions](https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/627769364/Open+questions+Nuclio+Function-level+Authentication)
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->
Everything here is behind `authentication.functionAuthenticationEnabled`; with the flag off the migration is a no-op and no resource is labeled, gated, or rewritten.

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
- **Retry semantics** - a per-resource failure is logged and not fatal: the resource stays unlabeled and is retried on the next dashboard restart. Same for a failed list, which skips the whole migration.
- **One-way** - the gateway's authentication config is deleted (and for basicAuth so is its config secret), so turning the flag back off after a migration does not restore gateway-level authentication.
