### PR TITLE
[Projects] Support SA auth in getUpdatedAfter requests

### DIFF
--- a/pkg/platform/abstract/project/external/leader/client/client.go
+++ b/pkg/platform/abstract/project/external/leader/client/client.go
@@ -251,11 +251,11 @@ func (c *Client) Delete(ctx context.Context, deleteProjectOptions *platform.Dele
 
 // GetUpdatedAfter retrieves projects from the leader that were updated after the specified time.
 func (c *Client) GetUpdatedAfter(ctx context.Context, updatedAfterTime *time.Time) ([]platform.Project, error) {
-	// TODO: The authentication of this request is currently handled in the leaderOps implementation. Which depends on
-	//       the specific leader implementation. When working on IG4 Project Sync, a new leaderOps implementation should
-	//       be created that handles authentication for this request with the service account token client.
 	requestURL := c.leaderOps.GenerateGetUpdatedAfterRequestURL(c.apiAddress)
-	requestHeaders := c.generateCommonRequestHeaders(ctx)
+	requestHeaders, _, err := c.generateRequestHeadersAndCookies(ctx, nil, nil, true)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to generate request headers")
+	}
 	if updatedAfterTime != nil && updatedAfterTime.IsZero() {
 		updatedAfterTime = nil
 	}

--- a/pkg/platform/abstract/project/external/leader/client/client_test.go
+++ b/pkg/platform/abstract/project/external/leader/client/client_test.go
@@ -419,6 +419,26 @@ func (suite *ClientTestSuite) TestGetUpdatedAfter() {
 	}
 }
 
+func (suite *ClientTestSuite) TestGetUpdatedAfterEscalatesServiceAccountAuth() {
+	mockSAClient := &serviceaccounttoken.MockClient{}
+	mockSAClient.On("EscalateAuthHeaders", mock.Anything).Return(nil)
+	suite.client.serviceAccountTokenClient = mockSAClient
+
+	*suite.client.httpClient = *testutils.CreateDummyHTTPClient(func(r *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       suite.mockIgzAPIGetProject(false),
+		}
+	})
+	suite.client.leaderOps = suite.generateMocksForClient(getUpdatedAfter, true, 0)
+
+	now := time.Now()
+	_, err := suite.client.GetUpdatedAfter(context.TODO(), &now)
+	suite.Require().NoError(err)
+
+	mockSAClient.AssertCalled(suite.T(), "EscalateAuthHeaders", mock.Anything)
+}
+
 func (suite *ClientTestSuite) TestGet() {
 	for _, testCase := range []struct {
 		name   string


### PR DESCRIPTION
### 📝 Description
`Client.GetUpdatedAfter` — the method Nuclio's project-sync `Synchronizer` calls (on startup and on its periodic interval) to pull incremental project changes from the leader — built its request headers without going through service-account (SA) token escalation, unlike `Create`/`Update`/`Delete`, which all escalate via `serviceAccountTokenClient.EscalateAuthHeaders`. Once SA auth is enabled for leader/follower traffic (part of the ORIS-1305 rollout), the synchronizer's pull would start failing auth while Create/Update/Delete kept working — a silent asymmetry that would break incremental project sync.

---

### 🛠️ Changes Made
- `GetUpdatedAfter` now builds its headers via `generateRequestHeadersAndCookies(ctx, nil, nil, true)` — the same helper `Create`/`Update`/`Delete` use.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Added `TestGetUpdatedAfterEscalatesServiceAccountAuth`, which fails without the fix (asserts `EscalateAuthHeaders` is invoked) and passes with it — TDD red/green.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-781
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
