### PR TITLE
[Security] Validate git clone inputs to prevent log injection

### DIFF
--- a/pkg/common/git/git.go
+++ b/pkg/common/git/git.go
@@ -71,11 +71,8 @@ func (agc *AbstractClient) Clone(outputDir, repositoryURL string, attributes *At
 	}
 
 	// reject malicious/malformed input before it can reach a log line or the git client
-	if err := validateRepositoryURL(repositoryURL); err != nil {
+	if err := validateRepositoryURL(repositoryURL, referenceName); err != nil {
 		return errors.Wrap(err, "Failed to validate git clone inputs")
-	}
-	if containsControlCharacters(referenceName) {
-		return errors.New("Invalid git reference: contains control characters")
 	}
 
 	// resolve git credentials when given
@@ -267,10 +264,14 @@ func isAzureDevopsRepositoryURL(repositoryURL string) bool {
 
 // validateRepositoryURL rejects malformed URLs and, as a side effect of net/url's own
 // validation, raw control characters (CR/LF, ANSI escapes, etc.) that would otherwise let this
-// value forge additional log lines when logged.
-func validateRepositoryURL(repositoryURL string) error {
+// value forge additional log lines when logged. It also rejects control characters in the
+// resolved git reference, which isn't a URL and so isn't covered by url.Parse.
+func validateRepositoryURL(repositoryURL string, referenceName string) error {
 	if _, err := url.Parse(repositoryURL); err != nil {
 		return errors.Wrap(err, "Invalid repository URL")
+	}
+	if containsControlCharacters(referenceName) {
+		return errors.New("Invalid git reference: contains control characters")
 	}
 	return nil
 }

--- a/pkg/common/git/git.go
+++ b/pkg/common/git/git.go
@@ -268,7 +268,7 @@ func isAzureDevopsRepositoryURL(repositoryURL string) bool {
 // resolved git reference, which isn't a URL and so isn't covered by url.Parse.
 func validateRepositoryURL(repositoryURL string, referenceName string) error {
 	if _, err := url.Parse(repositoryURL); err != nil {
-		return errors.Wrap(err, "Invalid repository URL")
+		return errors.New("Invalid repository URL")
 	}
 	if containsControlCharacters(referenceName) {
 		return errors.New("Invalid git reference: contains control characters")

--- a/pkg/common/git/git.go
+++ b/pkg/common/git/git.go
@@ -18,7 +18,9 @@ package git
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
+	"unicode"
 
 	"github.com/nuclio/nuclio/pkg/cmdrunner"
 	"github.com/nuclio/nuclio/pkg/common"
@@ -66,6 +68,14 @@ func (agc *AbstractClient) Clone(outputDir, repositoryURL string, attributes *At
 	referenceName, err = ResolveReference(repositoryURL, attributes)
 	if err != nil {
 		return errors.Wrap(err, "Failed to resolve git reference")
+	}
+
+	// reject malicious/malformed input before it can reach a log line or the git client
+	if err := validateRepositoryURL(repositoryURL); err != nil {
+		return errors.Wrap(err, "Failed to validate git clone inputs")
+	}
+	if containsControlCharacters(referenceName) {
+		return errors.New("Invalid git reference: contains control characters")
 	}
 
 	// resolve git credentials when given
@@ -253,4 +263,22 @@ func ResolveReference(repositoryURL string, attributes *Attributes) (string, err
 
 func isAzureDevopsRepositoryURL(repositoryURL string) bool {
 	return strings.Contains(repositoryURL, "dev.azure.com")
+}
+
+// validateRepositoryURL rejects malformed URLs and, as a side effect of net/url's own
+// validation, raw control characters (CR/LF, ANSI escapes, etc.) that would otherwise let this
+// value forge additional log lines when logged.
+func validateRepositoryURL(repositoryURL string) error {
+	if _, err := url.Parse(repositoryURL); err != nil {
+		return errors.Wrap(err, "Invalid repository URL")
+	}
+	return nil
+}
+
+// containsControlCharacters reports whether s contains raw control characters (e.g. CR/LF or
+// ANSI escape codes) that could be used to forge log lines when s is later logged. Reference
+// names aren't URLs, so they're checked directly rather than via url.Parse, which would also
+// reject legal-but-URL-unfriendly ref names (e.g. ones containing a bare '%').
+func containsControlCharacters(s string) bool {
+	return strings.ContainsFunc(s, unicode.IsControl)
 }

--- a/pkg/common/git/git_test.go
+++ b/pkg/common/git/git_test.go
@@ -71,36 +71,28 @@ func (suite *CloneValidationTestSuite) TestValidateRepositoryURLRejectsMalicious
 	}
 }
 
-// TestContainsControlCharactersAcceptsLegitimateReferenceNames guards against a future
-// tightening of containsControlCharacters breaking any branch/tag/reference shape this repo
-// already supports (see builder_test.go's TestResolveFunctionPathGitCodeEntry).
-func (suite *CloneValidationTestSuite) TestContainsControlCharactersAcceptsLegitimateReferenceNames() {
+// TestContainsControlCharacters guards against a future tightening of containsControlCharacters
+// breaking any branch/tag/reference shape this repo already supports (see builder_test.go's
+// TestResolveFunctionPathGitCodeEntry), while confirming it still rejects control characters.
+func (suite *CloneValidationTestSuite) TestContainsControlCharacters() {
 	for _, testCase := range []struct {
 		name          string
 		referenceName string
+		expected      bool
 	}{
+		// happy flows
 		{name: "Branch", referenceName: "refs/heads/go-func"},
 		{name: "BranchWithSlash", referenceName: "refs/heads/feature/foo"},
 		{name: "Tag", referenceName: "refs/tags/0.0.1"},
 		{name: "FullReference", referenceName: "refs/heads/go-func"},
 		{name: "PercentSignNotPercentEncoded", referenceName: "refs/heads/release%2024"},
-	} {
-		suite.Run(testCase.name, func() {
-			suite.Require().False(containsControlCharacters(testCase.referenceName))
-		})
-	}
-}
 
-func (suite *CloneValidationTestSuite) TestContainsControlCharactersRejectsMaliciousInput() {
-	for _, testCase := range []struct {
-		name          string
-		referenceName string
-	}{
-		{name: "NewlineInjection", referenceName: "refs/heads/main\n2024 ERROR fake"},
-		{name: "ANSIEscapeInjection", referenceName: "refs/heads/main\x1b[31mFAKE\x1b[0m"},
+		// malicious inputs
+		{name: "NewlineInjection", referenceName: "refs/heads/main\n2024 ERROR fake", expected: true},
+		{name: "ANSIEscapeInjection", referenceName: "refs/heads/main\x1b[31mFAKE\x1b[0m", expected: true},
 	} {
 		suite.Run(testCase.name, func() {
-			suite.Require().True(containsControlCharacters(testCase.referenceName))
+			suite.Equal(testCase.expected, containsControlCharacters(testCase.referenceName))
 		})
 	}
 }

--- a/pkg/common/git/git_test.go
+++ b/pkg/common/git/git_test.go
@@ -49,7 +49,7 @@ func (suite *CloneValidationTestSuite) TestValidateRepositoryURLAcceptsLegitimat
 		{name: "PlainHTTP", repositoryURL: "http://github.com/my-org/my-repo"},
 	} {
 		suite.Run(testCase.name, func() {
-			suite.Require().NoError(validateRepositoryURL(testCase.repositoryURL))
+			suite.Require().NoError(validateRepositoryURL(testCase.repositoryURL, "refs/heads/main"))
 		})
 	}
 }
@@ -58,13 +58,15 @@ func (suite *CloneValidationTestSuite) TestValidateRepositoryURLRejectsMalicious
 	for _, testCase := range []struct {
 		name          string
 		repositoryURL string
+		referenceName string
 	}{
-		{name: "CRLFInjection", repositoryURL: "https://github.com/org/repo.git\r\n[FAKE] admin login"},
-		{name: "ANSIEscapeInjection", repositoryURL: "https://github.com/org/repo.git\x1b[31mFAKE\x1b[0m"},
-		{name: "MalformedPercentEncoding", repositoryURL: "https://github.com/org/repo.git%zz"},
+		{name: "CRLFInjection", repositoryURL: "https://github.com/org/repo.git\r\n[FAKE] admin login", referenceName: "refs/heads/main"},
+		{name: "ANSIEscapeInjection", repositoryURL: "https://github.com/org/repo.git\x1b[31mFAKE\x1b[0m", referenceName: "refs/heads/main"},
+		{name: "MalformedPercentEncoding", repositoryURL: "https://github.com/org/repo.git%zz", referenceName: "refs/heads/main"},
+		{name: "MaliciousReferenceName", repositoryURL: "https://github.com/org/repo.git", referenceName: "refs/heads/main\n2024 ERROR fake"},
 	} {
 		suite.Run(testCase.name, func() {
-			suite.Require().Error(validateRepositoryURL(testCase.repositoryURL))
+			suite.Require().Error(validateRepositoryURL(testCase.repositoryURL, testCase.referenceName))
 		})
 	}
 }
@@ -103,14 +105,8 @@ func (suite *CloneValidationTestSuite) TestContainsControlCharactersRejectsMalic
 	}
 }
 
-// TestCloneLogsLegitimateInputAndRejectsMaliciousInput proves the "Cloning" log statement can no
-// longer be forged, while confirming every legitimate branch/tag/reference shape this repo
-// supports still reaches that log line unmodified. Uses a real nucliozap logger writing into a
-// buffer. Legitimate cases target a closed local port (127.0.0.1:1, which refuses instantly)
-// instead of a real git host: Clone must pass validation and log first - git.PlainClone only
-// dials out afterward - so the resulting connection-refused error is expected and irrelevant to
-// what's under test here. This keeps the test hermetic (no real network dependency) while still
-// exercising the exact same code path a real clone would take.
+// TestCloneLogsLegitimateInputAndRejectsMaliciousInput proves malicious input is rejected before
+// the "Cloning" log line, while every legitimate case still reaches that log line unmodified.
 func (suite *CloneValidationTestSuite) TestCloneLogsLegitimateInputAndRejectsMaliciousInput() {
 	const unreachableRepositoryURL = "https://127.0.0.1:1/test-org/test-repo.git"
 
@@ -137,7 +133,7 @@ func (suite *CloneValidationTestSuite) TestCloneLogsLegitimateInputAndRejectsMal
 			name:            "MaliciousReferenceName",
 			repositoryURL:   "https://github.com/org/repo.git",
 			attributes:      &Attributes{Branch: "main\n2024 ERROR fake"},
-			wantErrContains: "contains control characters",
+			wantErrContains: "Failed to validate git clone inputs",
 			wantLogAbsent:   []string{"ERROR fake"},
 		},
 		{

--- a/pkg/common/git/git_test.go
+++ b/pkg/common/git/git_test.go
@@ -1,0 +1,199 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package git
+
+import (
+	"bytes"
+	"testing"
+
+	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+)
+
+type CloneValidationTestSuite struct {
+	suite.Suite
+}
+
+// TestValidateRepositoryURLAcceptsLegitimateURLs guards against a future tightening of
+// validateRepositoryURL breaking any git provider/URL shape this repo already supports.
+func (suite *CloneValidationTestSuite) TestValidateRepositoryURLAcceptsLegitimateURLs() {
+	for _, testCase := range []struct {
+		name          string
+		repositoryURL string
+	}{
+		{name: "GitHubHTTPSWithGitSuffix", repositoryURL: "https://github.com/user92/test-nuclio-cet.git"},
+		{name: "BitBucketHTTPSWithGitSuffix", repositoryURL: "https://bitbucket.org/user/test-nuclio-cet.git"},
+		{name: "BitBucketHTTPSWithoutGitSuffix", repositoryURL: "https://bitbucket.org/my-user/my-repo"},
+		{name: "AzureDevOpsHTTPS", repositoryURL: "https://dev.azure.com/user920089/test-nuclio-cet/_git/test-nuclio-cet"},
+		{
+			name:          "AzureDevOpsHTTPSWithEmbeddedUserinfo",
+			repositoryURL: "https://user920089@dev.azure.com/user920089/test-nuclio-cet/_git/test-nuclio-cet",
+		},
+		{name: "SelfHostedGitServerHTTPS", repositoryURL: "https://git.example.com/my-user/my-repo"},
+		{name: "PlainHTTP", repositoryURL: "http://github.com/my-org/my-repo"},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Require().NoError(validateRepositoryURL(testCase.repositoryURL))
+		})
+	}
+}
+
+func (suite *CloneValidationTestSuite) TestValidateRepositoryURLRejectsMaliciousInput() {
+	for _, testCase := range []struct {
+		name          string
+		repositoryURL string
+	}{
+		{name: "CRLFInjection", repositoryURL: "https://github.com/org/repo.git\r\n[FAKE] admin login"},
+		{name: "ANSIEscapeInjection", repositoryURL: "https://github.com/org/repo.git\x1b[31mFAKE\x1b[0m"},
+		{name: "MalformedPercentEncoding", repositoryURL: "https://github.com/org/repo.git%zz"},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Require().Error(validateRepositoryURL(testCase.repositoryURL))
+		})
+	}
+}
+
+// TestContainsControlCharactersAcceptsLegitimateReferenceNames guards against a future
+// tightening of containsControlCharacters breaking any branch/tag/reference shape this repo
+// already supports (see builder_test.go's TestResolveFunctionPathGitCodeEntry).
+func (suite *CloneValidationTestSuite) TestContainsControlCharactersAcceptsLegitimateReferenceNames() {
+	for _, testCase := range []struct {
+		name          string
+		referenceName string
+	}{
+		{name: "Branch", referenceName: "refs/heads/go-func"},
+		{name: "BranchWithSlash", referenceName: "refs/heads/feature/foo"},
+		{name: "Tag", referenceName: "refs/tags/0.0.1"},
+		{name: "FullReference", referenceName: "refs/heads/go-func"},
+		{name: "PercentSignNotPercentEncoded", referenceName: "refs/heads/release%2024"},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Require().False(containsControlCharacters(testCase.referenceName))
+		})
+	}
+}
+
+func (suite *CloneValidationTestSuite) TestContainsControlCharactersRejectsMaliciousInput() {
+	for _, testCase := range []struct {
+		name          string
+		referenceName string
+	}{
+		{name: "NewlineInjection", referenceName: "refs/heads/main\n2024 ERROR fake"},
+		{name: "ANSIEscapeInjection", referenceName: "refs/heads/main\x1b[31mFAKE\x1b[0m"},
+	} {
+		suite.Run(testCase.name, func() {
+			suite.Require().True(containsControlCharacters(testCase.referenceName))
+		})
+	}
+}
+
+// TestCloneLogsLegitimateInputAndRejectsMaliciousInput proves the "Cloning" log statement can no
+// longer be forged, while confirming every legitimate branch/tag/reference shape this repo
+// supports still reaches that log line unmodified. Uses a real nucliozap logger writing into a
+// buffer. Legitimate cases target a closed local port (127.0.0.1:1, which refuses instantly)
+// instead of a real git host: Clone must pass validation and log first - git.PlainClone only
+// dials out afterward - so the resulting connection-refused error is expected and irrelevant to
+// what's under test here. This keeps the test hermetic (no real network dependency) while still
+// exercising the exact same code path a real clone would take.
+func (suite *CloneValidationTestSuite) TestCloneLogsLegitimateInputAndRejectsMaliciousInput() {
+	const unreachableRepositoryURL = "https://127.0.0.1:1/test-org/test-repo.git"
+
+	// every legitimate case must not be blocked by our own validation, whatever happens
+	// afterward when git.PlainClone dials the (deliberately unreachable) host
+	validationErrors := []string{"Failed to validate git clone inputs", "contains control characters"}
+
+	for _, testCase := range []struct {
+		name            string
+		repositoryURL   string
+		attributes      *Attributes
+		wantErrContains string // set only for cases validation must reject
+		wantLogContains []string
+		wantLogAbsent   []string // injected payloads that must never reach the log
+	}{
+		{
+			name:            "MaliciousRepositoryURL",
+			repositoryURL:   "https://github.com/org/repo.git\r\n[FAKE] admin login",
+			attributes:      &Attributes{Branch: "main"},
+			wantErrContains: "Failed to validate git clone inputs",
+			wantLogAbsent:   []string{"[FAKE]"},
+		},
+		{
+			name:            "MaliciousReferenceName",
+			repositoryURL:   "https://github.com/org/repo.git",
+			attributes:      &Attributes{Branch: "main\n2024 ERROR fake"},
+			wantErrContains: "contains control characters",
+			wantLogAbsent:   []string{"ERROR fake"},
+		},
+		{
+			name:            "LegitimateRepositoryURL",
+			repositoryURL:   unreachableRepositoryURL,
+			attributes:      &Attributes{Branch: "main"},
+			wantLogContains: []string{unreachableRepositoryURL, "refs/heads/main"},
+		},
+		{
+			name:            "LegitimateBranchReferenceName",
+			repositoryURL:   unreachableRepositoryURL,
+			attributes:      &Attributes{Branch: "go-func"},
+			wantLogContains: []string{"refs/heads/go-func"},
+		},
+		{
+			name:            "LegitimateTagReferenceName",
+			repositoryURL:   unreachableRepositoryURL,
+			attributes:      &Attributes{Tag: "0.0.1"},
+			wantLogContains: []string{"refs/tags/0.0.1"},
+		},
+		{
+			name:            "LegitimateFullReferenceName",
+			repositoryURL:   unreachableRepositoryURL,
+			attributes:      &Attributes{Reference: "refs/heads/go-func"},
+			wantLogContains: []string{"refs/heads/go-func"},
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			var logBuf bytes.Buffer
+			captureLogger, err := nucliozap.NewNuclioZap("test", "json", nil, &logBuf, &logBuf, nucliozap.DebugLevel)
+			suite.Require().NoError(err)
+
+			abstractClient := &AbstractClient{logger: captureLogger}
+
+			err = abstractClient.Clone(suite.T().TempDir(), testCase.repositoryURL, testCase.attributes)
+			suite.Require().Error(err) // malicious: rejected by validation; legitimate: connection refused after logging
+
+			if testCase.wantErrContains != "" {
+				suite.Contains(err.Error(), testCase.wantErrContains)
+			} else {
+				for _, validationErr := range validationErrors {
+					suite.NotContains(err.Error(), validationErr)
+				}
+			}
+
+			logLine := logBuf.String()
+			for _, substr := range testCase.wantLogContains {
+				suite.Contains(logLine, substr)
+			}
+			for _, substr := range testCase.wantLogAbsent {
+				suite.NotContains(logLine, substr)
+			}
+		})
+	}
+}
+
+func TestCloneValidationTestSuite(t *testing.T) {
+	suite.Run(t, new(CloneValidationTestSuite))
+}

--- a/pkg/common/git/git_test.go
+++ b/pkg/common/git/git_test.go
@@ -97,37 +97,36 @@ func (suite *CloneValidationTestSuite) TestContainsControlCharacters() {
 	}
 }
 
-// TestCloneLogsLegitimateInputAndRejectsMaliciousInput proves malicious input is rejected before
-// the "Cloning" log line, while every legitimate case still reaches that log line unmodified.
+// TestCloneLogsLegitimateInputAndRejectsMaliciousInput proves malicious input is rejected by
+// validateRepositoryURL before Clone ever calls the logger, while every legitimate case still
+// reaches the "Cloning" log line unmodified. Legitimate cases target 127.0.0.1:1 (nothing listens
+// there) so Clone still errors afterward on the refused connection - that failure is expected and
+// irrelevant here; what matters is that it happens only after validation passed and logging ran.
 func (suite *CloneValidationTestSuite) TestCloneLogsLegitimateInputAndRejectsMaliciousInput() {
 	const unreachableRepositoryURL = "https://127.0.0.1:1/test-org/test-repo.git"
-
-	// every legitimate case must not be blocked by our own validation, whatever happens
-	// afterward when git.PlainClone dials the (deliberately unreachable) host
-	validationErrors := []string{"Failed to validate git clone inputs", "contains control characters"}
 
 	for _, testCase := range []struct {
 		name            string
 		repositoryURL   string
 		attributes      *Attributes
-		wantErrContains string // set only for cases validation must reject
+		malicious       bool
 		wantLogContains []string
-		wantLogAbsent   []string // injected payloads that must never reach the log
 	}{
+		// malicious inputs: rejected before anything is logged
 		{
-			name:            "MaliciousRepositoryURL",
-			repositoryURL:   "https://github.com/org/repo.git\r\n[FAKE] admin login",
-			attributes:      &Attributes{Branch: "main"},
-			wantErrContains: "Failed to validate git clone inputs",
-			wantLogAbsent:   []string{"[FAKE]"},
+			name:          "MaliciousRepositoryURL",
+			repositoryURL: "https://github.com/org/repo.git\r\n[FAKE] admin login",
+			attributes:    &Attributes{Branch: "main"},
+			malicious:     true,
 		},
 		{
-			name:            "MaliciousReferenceName",
-			repositoryURL:   "https://github.com/org/repo.git",
-			attributes:      &Attributes{Branch: "main\n2024 ERROR fake"},
-			wantErrContains: "Failed to validate git clone inputs",
-			wantLogAbsent:   []string{"ERROR fake"},
+			name:          "MaliciousReferenceName",
+			repositoryURL: "https://github.com/org/repo.git",
+			attributes:    &Attributes{Branch: "main\n2024 ERROR fake"},
+			malicious:     true,
 		},
+
+		// happy flows: pass validation and reach the "Cloning" log line unmodified
 		{
 			name:            "LegitimateRepositoryURL",
 			repositoryURL:   unreachableRepositoryURL,
@@ -161,22 +160,17 @@ func (suite *CloneValidationTestSuite) TestCloneLogsLegitimateInputAndRejectsMal
 			abstractClient := &AbstractClient{logger: captureLogger}
 
 			err = abstractClient.Clone(suite.T().TempDir(), testCase.repositoryURL, testCase.attributes)
-			suite.Require().Error(err) // malicious: rejected by validation; legitimate: connection refused after logging
+			suite.Require().Error(err)
 
-			if testCase.wantErrContains != "" {
-				suite.Contains(err.Error(), testCase.wantErrContains)
-			} else {
-				for _, validationErr := range validationErrors {
-					suite.NotContains(err.Error(), validationErr)
-				}
+			if testCase.malicious {
+				suite.Contains(err.Error(), "Failed to validate git clone inputs")
+				suite.Empty(logBuf.String(), "malicious input must be rejected before anything is logged")
+				return
 			}
 
 			logLine := logBuf.String()
 			for _, substr := range testCase.wantLogContains {
 				suite.Contains(logLine, substr)
-			}
-			for _, substr := range testCase.wantLogAbsent {
-				suite.NotContains(logLine, substr)
 			}
 		})
 	}


### PR DESCRIPTION
### 📝 Description
Closes CodeQL alert [#842](https://github.com/nuclio/nuclio/security/code-scanning/842) (`go/log-injection`, CWE-117) on `pkg/common/git/git.go`. `AbstractClient.clone()` logged the repository URL and resolved git reference name before using them, so a malicious repo URL or branch/tag name could inject CR/LF or ANSI escape sequences to forge log lines.

---

### 🛠️ Changes Made
- Added `validateRepositoryURL` (rejects malformed URLs, which as a side effect also rejects raw control characters) and `containsControlCharacters` (rejects control characters in the resolved git reference) in `pkg/common/git/git.go`.
- `Clone()` now runs both checks right after resolving the git reference and before anything is logged or passed to the git client.
- Added `pkg/common/git/git_test.go`: unit tests for both validators plus an end-to-end test proving malicious input is rejected before logging while every legitimate URL/branch/tag/reference shape still reaches the log line unchanged.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- `go test -tags=test_unit -race -run TestCloneValidationTestSuite ./pkg/common/git/...` — passes
- `make lint` — 0 issues

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links: https://github.com/nuclio/nuclio/security/code-scanning/842

---

### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
