### PR TITLE
[Project] Generalize leader expected status code per operation

### DIFF
--- a/pkg/platform/abstract/project/external/leader/abstract/leader.go
+++ b/pkg/platform/abstract/project/external/leader/abstract/leader.go
@@ -73,6 +73,22 @@ func (l *LeaderOps) GetDeleteStrategyHeaderName() string {
 	return ""
 }
 
+// GetExpectedStatusCode returns the expected HTTP status code from the leader's response
+// for the given project write operation. This default mirrors Iguazio's contract; leaders
+// whose codes differ per operation (e.g. MLRun's delete, Oris's async-always-202) override it.
+func (l *LeaderOps) GetExpectedStatusCode(operation leaderCommon.ProjectOperation) int {
+	switch operation {
+	case leaderCommon.ProjectOperationCreate:
+		return http.StatusCreated
+	case leaderCommon.ProjectOperationUpdate:
+		return http.StatusOK
+	case leaderCommon.ProjectOperationDelete:
+		return http.StatusAccepted
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
 // ParseJobStatusResponse defaults to "no job, not terminated": leaders without an
 // async job system never have a job to poll.
 func (l *LeaderOps) ParseJobStatusResponse(_ context.Context, _ []byte) (leaderCommon.JobResponse, bool) {

--- a/pkg/platform/abstract/project/external/leader/abstract/leader_test.go
+++ b/pkg/platform/abstract/project/external/leader/abstract/leader_test.go
@@ -20,9 +20,11 @@ package abstract
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/auth"
+	leaderCommon "github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -61,6 +63,24 @@ func (suite *LeaderOpsTestSuite) TestGetJobStatusRequestCookies() {
 
 func (suite *LeaderOpsTestSuite) TestGetJobRequestFilter() {
 	suite.Require().Equal("", suite.leaderOps.GetJobRequestFilter(nil))
+}
+
+func (suite *LeaderOpsTestSuite) TestGetExpectedStatusCode() {
+	for _, testCase := range []struct {
+		name      string
+		operation leaderCommon.ProjectOperation
+		expected  int
+	}{
+		{name: "Create", operation: leaderCommon.ProjectOperationCreate, expected: http.StatusCreated},
+		{name: "Update", operation: leaderCommon.ProjectOperationUpdate, expected: http.StatusOK},
+		{name: "Delete", operation: leaderCommon.ProjectOperationDelete, expected: http.StatusAccepted},
+		{name: "Unknown", operation: leaderCommon.ProjectOperation("unknown"), expected: http.StatusInternalServerError},
+	} {
+		suite.Run(testCase.name, func() {
+			code := suite.leaderOps.GetExpectedStatusCode(testCase.operation)
+			suite.Require().Equal(testCase.expected, code)
+		})
+	}
 }
 
 func (suite *LeaderOpsTestSuite) TestGetAuthSessionCookie() {

--- a/pkg/platform/abstract/project/external/leader/client/client.go
+++ b/pkg/platform/abstract/project/external/leader/client/client.go
@@ -139,7 +139,7 @@ func (c *Client) Create(ctx context.Context, createProjectOptions *platform.Crea
 		requestBody,
 		requestHeaders,
 		cookies,
-		http.StatusCreated)
+		c.leaderOps.GetExpectedStatusCode(leader.ProjectOperationCreate))
 	if err != nil {
 		c.logLeaderResponseError(ctx, response, "Failed to create project on leader")
 		return c.leaderOps.HandleCreateResponseErr(ctx, responseBody, response, err)
@@ -192,7 +192,7 @@ func (c *Client) Update(ctx context.Context, updateProjectOptions *platform.Upda
 		requestBody,
 		requestHeaders,
 		cookies,
-		http.StatusOK)
+		c.leaderOps.GetExpectedStatusCode(leader.ProjectOperationUpdate))
 	if err != nil {
 		c.logLeaderResponseError(ctx, response, "Failed to update project on leader")
 		return errors.Wrap(err, "Failed to send update project request to leader")
@@ -237,7 +237,7 @@ func (c *Client) Delete(ctx context.Context, deleteProjectOptions *platform.Dele
 		requestBody,
 		requestHeaders,
 		cookies,
-		c.leaderOps.GetDeleteExpectedStatusCode()); err != nil {
+		c.leaderOps.GetExpectedStatusCode(leader.ProjectOperationDelete)); err != nil {
 		c.logLeaderResponseError(ctx, response, "Failed to delete project on leader")
 		return errors.Wrap(err, "Failed to send delete project request to leader")
 	}

--- a/pkg/platform/abstract/project/external/leader/client/client_test.go
+++ b/pkg/platform/abstract/project/external/leader/client/client_test.go
@@ -711,6 +711,7 @@ func (suite *ClientTestSuite) generateMocksForClient(testSuiteType string, failu
 		newClient.On("GenerateCreateProjectRequestURL", mock.Anything).Return("test-url" + projectSuffix)
 		newClient.On("ResolveCreateProjectResponse", mock.Anything, mock.Anything).Return(mockClient.CreateProjectResponseMock{}, nil)
 		newClient.On("ShouldWaitForCreateCompletion").Return(true)
+		newClient.On("GetExpectedStatusCode", leader.ProjectOperationCreate).Return(http.StatusCreated)
 		newClient.On("GetJobIdUrl", mock.Anything, mock.Anything).Return("test-url" + getCreateProjectSuffix)
 		newClient.On("IsJobCompleted", mock.Anything, mock.Anything, mock.Anything).
 			Return(func(_ context.Context, jobResponse leader.JobResponse, _ string) error {
@@ -735,6 +736,7 @@ func (suite *ClientTestSuite) generateMocksForClient(testSuiteType string, failu
 	case updateTestSuite:
 		newClient.On("GenerateProjectRequestBody", mock.Anything).Return([]byte(`{"some":"data"}`), nil)
 		newClient.On("GenerateUpdateProjectRequestURL", mock.Anything, mock.Anything).Return("test-url" + projectSuffix)
+		newClient.On("GetExpectedStatusCode", leader.ProjectOperationUpdate).Return(http.StatusOK)
 		newClient.On("HandleCreateResponseErr", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 			func(_ context.Context, _ []byte, resp *http.Response, _ error) error {
 				if resp.StatusCode != http.StatusOK {
@@ -747,7 +749,7 @@ func (suite *ClientTestSuite) generateMocksForClient(testSuiteType string, failu
 		newClient.On("GenerateDeleteProjectRequestURL", mock.Anything, mock.Anything).Return("test-url" + projectSuffix)
 		newClient.On("GenerateProjectDeletionRequestBody", mock.Anything).Return([]byte(`{"some":"data"}`), nil)
 		newClient.On("GetDeleteStrategyHeaderName", mock.Anything, mock.Anything).Return("test-header")
-		newClient.On("GetDeleteExpectedStatusCode").Return(statusCode)
+		newClient.On("GetExpectedStatusCode", leader.ProjectOperationDelete).Return(statusCode)
 	}
 
 	return newClient

--- a/pkg/platform/abstract/project/external/leader/iguazio/leader.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/leader.go
@@ -186,8 +186,19 @@ func (l *LeaderOps) GenerateUpdateProjectRequestURL(apiAddress, projectName stri
 	return fmt.Sprintf("%s/%s/%s", apiAddress, "projects/__name__", projectName)
 }
 
-func (l *LeaderOps) GetDeleteExpectedStatusCode() int {
-	return http.StatusAccepted
+// GetExpectedStatusCode returns the expected HTTP status code from Iguazio's response for
+// the given project write operation.
+func (l *LeaderOps) GetExpectedStatusCode(operation leadercommon.ProjectOperation) int {
+	switch operation {
+	case leadercommon.ProjectOperationCreate:
+		return http.StatusCreated
+	case leadercommon.ProjectOperationUpdate:
+		return http.StatusOK
+	case leadercommon.ProjectOperationDelete:
+		return http.StatusAccepted
+	default:
+		return http.StatusInternalServerError
+	}
 }
 
 func (l *LeaderOps) GetDeleteStrategyHeaderName() string {

--- a/pkg/platform/abstract/project/external/leader/iguazio/leader.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/leader.go
@@ -186,21 +186,6 @@ func (l *LeaderOps) GenerateUpdateProjectRequestURL(apiAddress, projectName stri
 	return fmt.Sprintf("%s/%s/%s", apiAddress, "projects/__name__", projectName)
 }
 
-// GetExpectedStatusCode returns the expected HTTP status code from Iguazio's response for
-// the given project write operation.
-func (l *LeaderOps) GetExpectedStatusCode(operation leadercommon.ProjectOperation) int {
-	switch operation {
-	case leadercommon.ProjectOperationCreate:
-		return http.StatusCreated
-	case leadercommon.ProjectOperationUpdate:
-		return http.StatusOK
-	case leadercommon.ProjectOperationDelete:
-		return http.StatusAccepted
-	default:
-		return http.StatusInternalServerError
-	}
-}
-
 func (l *LeaderOps) GetDeleteStrategyHeaderName() string {
 	return "igz-project-deletion-strategy"
 }

--- a/pkg/platform/abstract/project/external/leader/iguazio/leader_test.go
+++ b/pkg/platform/abstract/project/external/leader/iguazio/leader_test.go
@@ -371,11 +371,21 @@ func (suite *LeaderTestSuite) TestGenerateUpdateProjectRequestURL() {
 	}
 }
 
-func (suite *LeaderTestSuite) TestGetDeleteExpectedStatusCode() {
-	suite.Run("AlwaysAccepted", func() {
-		code := suite.leaderOps.GetDeleteExpectedStatusCode()
-		suite.Require().Equal(http.StatusAccepted, code)
-	})
+func (suite *LeaderTestSuite) TestGetExpectedStatusCode() {
+	for _, testCase := range []struct {
+		name      string
+		operation leaderCommon.ProjectOperation
+		expected  int
+	}{
+		{name: "Create", operation: leaderCommon.ProjectOperationCreate, expected: http.StatusCreated},
+		{name: "Update", operation: leaderCommon.ProjectOperationUpdate, expected: http.StatusOK},
+		{name: "Delete", operation: leaderCommon.ProjectOperationDelete, expected: http.StatusAccepted},
+	} {
+		suite.Run(testCase.name, func() {
+			code := suite.leaderOps.GetExpectedStatusCode(testCase.operation)
+			suite.Require().Equal(testCase.expected, code)
+		})
+	}
 }
 
 func (suite *LeaderTestSuite) TestGetDeleteStrategyHeaderName() {

--- a/pkg/platform/abstract/project/external/leader/mlrun/leader.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/leader.go
@@ -111,8 +111,19 @@ func (l *LeaderOps) GenerateUpdateProjectRequestURL(apiAddress, projectName stri
 	return l.ProjectRequestURL(apiAddress, leaderCommon.APIVersionV1, projectName)
 }
 
-func (l *LeaderOps) GetDeleteExpectedStatusCode() int {
-	return http.StatusNoContent
+// GetExpectedStatusCode returns the expected HTTP status code from MLRun's response for
+// the given project write operation.
+func (l *LeaderOps) GetExpectedStatusCode(operation leaderCommon.ProjectOperation) int {
+	switch operation {
+	case leaderCommon.ProjectOperationCreate:
+		return http.StatusCreated
+	case leaderCommon.ProjectOperationUpdate:
+		return http.StatusOK
+	case leaderCommon.ProjectOperationDelete:
+		return http.StatusNoContent
+	default:
+		return http.StatusInternalServerError
+	}
 }
 
 func (l *LeaderOps) GetDeleteStrategyHeaderName() string {

--- a/pkg/platform/abstract/project/external/leader/mlrun/leader_test.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/leader_test.go
@@ -277,11 +277,21 @@ func (suite *LeaderTestSuite) TestGenerateUpdateProjectRequestURL() {
 	}
 }
 
-func (suite *LeaderTestSuite) TestGetDeleteExpectedStatusCode() {
-	suite.Run("AlwaysNoContent", func() {
-		code := suite.leaderOps.GetDeleteExpectedStatusCode()
-		suite.Require().Equal(http.StatusNoContent, code)
-	})
+func (suite *LeaderTestSuite) TestGetExpectedStatusCode() {
+	for _, testCase := range []struct {
+		name      string
+		operation leaderCommon.ProjectOperation
+		expected  int
+	}{
+		{name: "Create", operation: leaderCommon.ProjectOperationCreate, expected: http.StatusCreated},
+		{name: "Update", operation: leaderCommon.ProjectOperationUpdate, expected: http.StatusOK},
+		{name: "Delete", operation: leaderCommon.ProjectOperationDelete, expected: http.StatusNoContent},
+	} {
+		suite.Run(testCase.name, func() {
+			code := suite.leaderOps.GetExpectedStatusCode(testCase.operation)
+			suite.Require().Equal(testCase.expected, code)
+		})
+	}
 }
 
 func (suite *LeaderTestSuite) TestGetDeleteStrategyHeaderName() {

--- a/pkg/platform/abstract/project/external/leader/mock/leader.go
+++ b/pkg/platform/abstract/project/external/leader/mock/leader.go
@@ -112,8 +112,8 @@ func (l *LeaderOps) GenerateProjectDeletionRequestBody(projectID string) ([]byte
 	return args.Get(0).([]byte), args.Error(1)
 }
 
-func (l *LeaderOps) GetDeleteExpectedStatusCode() int {
-	args := l.Called()
+func (l *LeaderOps) GetExpectedStatusCode(operation leaderCommon.ProjectOperation) int {
+	args := l.Called(operation)
 	return args.Int(0)
 }
 

--- a/pkg/platform/abstract/project/external/leader/oris/leader.go
+++ b/pkg/platform/abstract/project/external/leader/oris/leader.go
@@ -120,8 +120,20 @@ func (l *LeaderOps) HandleCreateResponseErr(ctx context.Context, responseBody []
 	return errors.Wrap(err, "Failed to send request to leader")
 }
 
-func (l *LeaderOps) GetDeleteExpectedStatusCode() int {
-	return http.StatusNoContent
+// GetExpectedStatusCode returns the expected HTTP status code from Oris's response for
+// the given project write operation. Oris accepts every write asynchronously, so all
+// known operations expect the same 202.
+func (l *LeaderOps) GetExpectedStatusCode(operation leaderCommon.ProjectOperation) int {
+	switch operation {
+	case leaderCommon.ProjectOperationCreate:
+		return http.StatusAccepted
+	case leaderCommon.ProjectOperationUpdate:
+		return http.StatusAccepted
+	case leaderCommon.ProjectOperationDelete:
+		return http.StatusAccepted
+	default:
+		return http.StatusInternalServerError
+	}
 }
 
 func (l *LeaderOps) GenerateUpdateProjectRequestURL(apiAddress, projectName string) string {

--- a/pkg/platform/abstract/project/external/leader/oris/leader_test.go
+++ b/pkg/platform/abstract/project/external/leader/oris/leader_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/nuclio/nuclio/pkg/platform"
+	leaderCommon "github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -243,8 +244,21 @@ func (suite *LeaderTestSuite) TestShouldWaitForCreateCompletion() {
 	suite.Require().False(suite.leaderOps.ShouldWaitForCreateCompletion())
 }
 
-func (suite *LeaderTestSuite) TestGetDeleteExpectedStatusCode() {
-	suite.Require().Equal(204, suite.leaderOps.GetDeleteExpectedStatusCode())
+func (suite *LeaderTestSuite) TestGetExpectedStatusCode() {
+	for _, testCase := range []struct {
+		name      string
+		operation leaderCommon.ProjectOperation
+		expected  int
+	}{
+		{name: "Create", operation: leaderCommon.ProjectOperationCreate, expected: http.StatusAccepted},
+		{name: "Update", operation: leaderCommon.ProjectOperationUpdate, expected: http.StatusAccepted},
+		{name: "Delete", operation: leaderCommon.ProjectOperationDelete, expected: http.StatusAccepted},
+	} {
+		suite.Run(testCase.name, func() {
+			code := suite.leaderOps.GetExpectedStatusCode(testCase.operation)
+			suite.Require().Equal(testCase.expected, code)
+		})
+	}
 }
 
 func (suite *LeaderTestSuite) TestProjectSync2PCEnabled() {

--- a/pkg/platform/abstract/project/external/leader/types.go
+++ b/pkg/platform/abstract/project/external/leader/types.go
@@ -126,8 +126,9 @@ type LeaderOps interface {
 	// GenerateProjectDeletionRequestBody generates the request body for project deletion
 	GenerateProjectDeletionRequestBody(string) ([]byte, error)
 
-	// GetDeleteExpectedStatusCode returns the expected status code from the http response
-	GetDeleteExpectedStatusCode() int
+	// GetExpectedStatusCode returns the expected status code from the http response for
+	// the given project write operation
+	GetExpectedStatusCode(ProjectOperation) int
 
 	// GetDeleteStrategyHeaderName gets the delete strategy header to the request
 	GetDeleteStrategyHeaderName() string
@@ -169,6 +170,16 @@ type APIVersion string
 const (
 	APIVersionV1 APIVersion = "v1"
 	APIVersionV2 APIVersion = "v2"
+)
+
+// ProjectOperation identifies a project write operation, so a leader can report the
+// HTTP status code it expects to see for that specific operation.
+type ProjectOperation string
+
+const (
+	ProjectOperationCreate ProjectOperation = "create"
+	ProjectOperationUpdate ProjectOperation = "update"
+	ProjectOperationDelete ProjectOperation = "delete"
 )
 
 const (


### PR DESCRIPTION
### 📝 Description
Generalizes the per-leader "expected HTTP status code" check from delete-only to all three project write operations (Create/Update/Delete), so `client.go` no longer hardcodes `http.StatusCreated`/`http.StatusOK` for Create/Update. Stacked on #4301 (NUC-987).

---

### 🛠️ Changes Made
- Added `leader.ProjectOperation` (Create/Update/Delete) and replaced `LeaderOps.GetDeleteExpectedStatusCode() int` with `GetExpectedStatusCode(ProjectOperation) int` in the interface.
- `client.go`'s Create/Update/Delete now call `leaderOps.GetExpectedStatusCode(...)` instead of hardcoded status literals.
- Iguazio/MLRun/Oris each implement `GetExpectedStatusCode` with an explicit `case` per operation; `default` returns `http.StatusInternalServerError` instead of silently falling back to Create's code.
- Oris always expects `202 Accepted` for every operation (writes are accepted asynchronously).
- Updated `mock.LeaderOps` and existing unit tests to the new signature.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- `go test -tags=test_unit -race -short ./pkg/platform/abstract/project/external/leader/...` — all packages pass.
- `golangci-lint` clean on the changed packages.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-987
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Stacked on #4301 — base branch is `feature/NUC-987-add_2pc_endpoints`, not `development`.