### PR TITLE
[Scripts] Use kubeconfig for patch-remote

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,9 @@ linkcheck_ignore = [
     # httpie.org blocks automated link checking
     r"https://httpie\.org.*",
 
+    # Slack links are not accessible via GH Actions, since they tightened bot detection
+    "https://nuclio-io.slack.com/",
+
 ]
 linkcheck_anchors = True
 linkcheck_timeout = 60

--- a/hack/scripts/patch-remote/README.md
+++ b/hack/scripts/patch-remote/README.md
@@ -13,11 +13,12 @@ pip install -r hack/scripts/patch-remote/requirements.txt
 * Create a `patch_env.yml` based on `patch_env_template.yml`, and fill in the required and optional fields
 * Have a docker registry you can push to (e.g. docker.io via account on docker.com)
 * Make sure you are logged in into your registry (docker login --username user --password user_password), or optionally add username/password to config
+* The script can reach the remote system in two ways: over SSH, or directly via `kubectl` using a local kubeconfig - a more convenient and secure alternative, since it avoids ssh key/password management entirely. To use it, set `KUBECONFIG` in `patch_env.yml` to a local kubeconfig file pointed at the remote cluster; in that case `HOST_IP`/`SSH_USER` and the private key file are not required. If `KUBECONFIG` is not set (or the path doesn't exist), the script falls back to SSH.
 * From nuclio root dir run:
 ~~~bash
 make patch-remote-nuclio
 ~~~
-* On first run, you will need to manually input the remote system's password. This will create a new ssh key that will be used for future connections, so you will not need to input the password again.
+* On first run (SSH mode only), you will need to manually input the remote system's password. This will create a new ssh key that will be used for future connections, so you will not need to input the password again.
 * The script will automatically patch the remote system with your current code changes
 
 For ease of use, you can add the specific make commands to patch only the dashboard or the controller:

--- a/hack/scripts/patch-remote/patch_env_template.yml
+++ b/hack/scripts/patch-remote/patch_env_template.yml
@@ -15,10 +15,10 @@
 # The patch script expects the yaml file to be in the same directory
 # this is a template file for the patch env file
 
-# REQUIRED: Remote host IPs/hostnames (e.g. 1.1.1.3)
+# REQUIRED unless KUBECONFIG below is set: Remote host IPs/hostnames (e.g. 1.1.1.3)
 HOST_IP:
 
-# REQUIRED: Username for ssh
+# REQUIRED unless KUBECONFIG below is set: Username for ssh
 SSH_USER:
 
 # REQUIRED: Docker registry you can push images to.
@@ -58,6 +58,10 @@ REGISTRY_USERNAME:
 
 # Optional: will attempt docker login if defined
 REGISTRY_PASSWORD:
+
+# Optional: path to a kubeconfig file. When it exists, kubectl runs against the remote cluster directly.
+# If it is not set, or the path does not exist, the script falls back to SSH.
+KUBECONFIG:
 
 # Optional: set to true to enable verbose logging
 VERBOSE:

--- a/hack/scripts/patch-remote/patch_remote.py
+++ b/hack/scripts/patch-remote/patch_remote.py
@@ -48,7 +48,9 @@ class NuclioPatcher:
     class Consts:
         log_level = logging.INFO
         fmt = "%(asctime)s %(levelname)s %(message)s"
-        mandatory_fields = {"HOST_IP", "SSH_USER", "DOCKER_REGISTRY"}
+        mandatory_fields = {"DOCKER_REGISTRY"}
+        # only required when KUBECONFIG is not set/resolved, since ssh is then unused
+        ssh_mandatory_fields = {"HOST_IP", "SSH_USER"}
         nuclio_version_annotation = "nuclio.io/version"
         deployment_policy_patch_dict = {
             "spec": {
@@ -84,6 +86,18 @@ class NuclioPatcher:
         self._private_key = private_key
         self._os = self._get_config_value_or_default("NUCLIO_OS", "linux")
 
+        kubeconfig_path = self._get_config_value_or_default("KUBECONFIG", "")
+        self._kubeconfig = self._resolve_kubeconfig(kubeconfig_path)
+        if not kubeconfig_path:
+            self._logger.warning("KUBECONFIG is not set, falling back to SSH")
+        elif not self._kubeconfig:
+            self._logger.warning(
+                "KUBECONFIG path '%s' does not exist, falling back to SSH", kubeconfig_path
+            )
+
+        if not self._kubeconfig and not self._private_key:
+            raise RuntimeError("--private-key-file is required when KUBECONFIG is not set")
+
     def patch_nuclio(self):
         self._logger.info(
             f"Patching Nuclio targets to remote system: {', '.join(self._targets)}"
@@ -110,7 +124,10 @@ class NuclioPatcher:
         )
 
     def _validate_config(self):
-        missing_fields = self.Consts.mandatory_fields - set(self._config.keys())
+        mandatory_fields = set(self.Consts.mandatory_fields)
+        if not self._resolve_kubeconfig(self._config.get("KUBECONFIG", "")):
+            mandatory_fields |= self.Consts.ssh_mandatory_fields
+        missing_fields = mandatory_fields - set(self._config.keys())
         if len(missing_fields) > 0:
             raise RuntimeError(f"Mandatory options not defined: {missing_fields}")
 
@@ -179,6 +196,12 @@ class NuclioPatcher:
             ],
         )
         self._tag = version.strip()
+
+    @staticmethod
+    def _resolve_kubeconfig(path: str) -> typing.Optional[str]:
+        if not path or not os.path.exists(path):
+            return None
+        return path
 
     def _get_config_value_or_default(self, key: str, default):
         value = self._config.get(key, default)
@@ -389,33 +412,52 @@ class NuclioPatcher:
         output = buf.getvalue()
         return output
 
-    def _exec_remote(self, cmd: list[str], live=False) -> str:
-        # run the command on the remote machine using ssh in a subprocess
-        cmd_str = " ".join(cmd)
-        self._logger.debug("Executing remote command: %s", cmd_str)
-        ssh_cmd = [
-            "/usr/bin/ssh",
-            "-i",
-            self._private_key,
-            f"{self._user}@{self._node}",
-        ]
-        ssh_cmd.extend(cmd)
-        proc = subprocess.Popen(
-            ssh_cmd,
+    def _popen_kubectl(self, cmd_str: str) -> subprocess.Popen:
+        self._logger.debug("Executing kubectl command (via kubeconfig): %s", cmd_str)
+        env = os.environ | {"KUBECONFIG": self._kubeconfig}
+        return subprocess.Popen(
+            cmd_str,
+            shell=True,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            env=env,
         )
+
+    def _exec_remote(self, cmd: list[str], live=False) -> str:
+        cmd_str = " ".join(cmd)
+        if self._kubeconfig:
+            proc = self._popen_kubectl(cmd_str)
+        else:
+            # run the command on the remote machine using ssh in a subprocess
+            self._logger.debug("Executing remote command: %s", cmd_str)
+            ssh_cmd = [
+                "/usr/bin/ssh",
+                "-i",
+                self._private_key,
+                f"{self._user}@{self._node}",
+            ]
+            ssh_cmd.extend(cmd)
+            proc = subprocess.Popen(
+                ssh_cmd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        return self._wait_for_proc_output(proc, cmd_str, live)
+
+    @staticmethod
+    def _wait_for_proc_output(proc, cmd_str, live) -> str:
         stdout = ""
         if live:
             for line in proc.stdout:
                 stdout += line
                 print(line, end="")
+            _, stderr = proc.communicate()
         else:
-            stdout = proc.stdout.read()
-        stderr = proc.stderr.read()
-        proc.wait()
+            stdout, stderr = proc.communicate()
         if proc.returncode:
             raise RuntimeError(
                 f"Command '{cmd_str}' finished with failure ({proc.returncode})\n{stderr}"
@@ -435,9 +477,10 @@ class NuclioPatcher:
 @click.option(
     "-p",
     "--private-key-file",
-    help="Private ssh key file",
+    help="Private ssh key file (required unless KUBECONFIG is set)",
     type=str,
-    required=True,
+    required=False,
+    default=None,
 )
 @click.option(
     "-t",

--- a/hack/scripts/patch-remote/patch_remote.py
+++ b/hack/scripts/patch-remote/patch_remote.py
@@ -88,12 +88,9 @@ class NuclioPatcher:
 
         kubeconfig_path = self._get_config_value_or_default("KUBECONFIG", "")
         self._kubeconfig = self._resolve_kubeconfig(kubeconfig_path)
-        if not kubeconfig_path:
-            self._logger.warning("KUBECONFIG is not set, falling back to SSH")
-        elif not self._kubeconfig:
-            self._logger.warning(
-                "KUBECONFIG path '%s' does not exist, falling back to SSH", kubeconfig_path
-            )
+        if not self._kubeconfig:
+            reason = f"KUBECONFIG path '{kubeconfig_path}' does not exist" if kubeconfig_path else "KUBECONFIG is not set"
+            self._logger.warning("%s, falling back to SSH", reason)
 
         if not self._kubeconfig and not self._private_key:
             raise RuntimeError("--private-key-file is required when KUBECONFIG is not set")


### PR DESCRIPTION
### 📝 Description
Adds an optional `KUBECONFIG` setting to `patch-remote` so it can execute commands on the remote cluster directly via `kubectl`, instead of always going over SSH. Fully backward compatible: if `KUBECONFIG` is not set in `patch_env.yml` (or the path doesn't exist), the script falls back to the existing SSH-based flow.

---

### 🛠️ Changes Made
- `patch_env_template.yml`: added an optional `KUBECONFIG` field, and marked `HOST_IP`/`SSH_USER` as required only when it isn't set.
- `patch_remote.py`:
  - Resolve `KUBECONFIG` on startup; when it points to an existing file, execute remote `kubectl` commands locally against that kubeconfig (`_popen_kubectl`) instead of over SSH.
  - `HOST_IP`/`SSH_USER` are now only mandatory when `KUBECONFIG` isn't set/resolved, and `--private-key-file` is optional in that case too.
  - Unified the SSH and kubectl execution paths into a shared `_wait_for_proc_output` helper, so live output streaming works the same way for both, and replaced sequential `stdout`/`stderr` reads with `proc.communicate()` to avoid a pipe deadlock.
- `README.md`: documented the kubeconfig option as an alternative to SSH.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
Regular SSH output:
```
2026-09-02 10:31:47 DEBUG Resolving current version from remote system
2026-09-02 10:31:47 DEBUG Executing remote command: kubectl --namespace oris get deployment nuclio-dlx -o yaml | grep nuclio.io/version | awk '{print $2}' | awk -F '-' '{print $1}'
iguazio@app1.vmdev132ig4.lab.iguaz.io's password: 
```
With kubeconfig:
```
2026-09-02 10:30:55 DEBUG Resolving current version from remote system
2026-09-02 10:30:55 DEBUG Executing kubectl command (via kubeconfig): kubectl --namespace oris get deployment nuclio-dlx -o yaml | grep nuclio.io/version | awk '{print $2}' | awk -F '-' '{print $1}'                                                                                                                                                                                  
2026-09-02 10:30:55 INFO Building nuclio docker images for targets: ['dlx'], tag: 1.17.3
```


---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
SSH remains the default when `KUBECONFIG` is unset - no config changes required for existing users.
<!-- ### 📸 Screenshots / Logs -->
