### PR TITLE
[CI] Bump Traefik to v3.7.12

### DIFF
--- a/test/k8s/ci_assets/install_traefik.sh
+++ b/test/k8s/ci_assets/install_traefik.sh
@@ -32,7 +32,7 @@ helm install traefik traefik/traefik \
   --set providers.kubernetesGateway.enabled=true \
   --set gateway.enabled=false \
   --set gatewayClass.enabled=true \
-  --version 40.2.0
+  --version 41.4.0
 
 # create nginx IngressClass standalone resource mapping to Traefik
 kubectl apply -f - <<EOF


### PR DESCRIPTION
### 📝 Description
Bump the Traefik Helm chart used in our Kubernetes CI (`test/k8s/ci_assets/install_traefik.sh`) from `40.2.0` to the latest available release, `41.4.0`. The chart's pinned Traefik `appVersion` moves from `v3.7.1` to `v3.7.12`, picking up several patch releases' worth of fixes to the `kubernetesIngressNGINX` provider (Traefik's NGINX-Ingress-annotation compatibility mode), including four security advisories that are unpatched at `v3.7.1`.

---

### 🛠️ Changes Made
- `test/k8s/ci_assets/install_traefik.sh`: `--version 40.2.0` → `--version 41.4.0`

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
- Github CI

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:
  - https://github.com/traefik/traefik-helm-chart/releases — chart release notes
  - https://github.com/traefik/traefik/releases — Traefik proxy release notes (v3.7.x)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes