### PR TITLE
[CI] Exclude bootstrap from dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,14 @@ updates:
     commit-message:
       prefix: "[Dependabot] "
     open-pull-requests-limit: 6
+
+  - package-ecosystem: "npm"
+    directory: "/pkg/dashboard/ui"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[Dependabot] "
+    open-pull-requests-limit: 6
+    ignore:
+      # bootstrap 5.x is a breaking major bump that broke the UI (see PR #4306, #4321, #4322)
+      - dependency-name: "bootstrap"


### PR DESCRIPTION
### 📝 Description
Dependabot keeps opening PRs that bump `bootstrap` from 3.4.1 to 5.0.0 in `/pkg/dashboard/ui`. This is a major breaking version jump that has broken the dashboard UI every time it landed as described [here](https://github.com/nuclio/nuclio/pull/4306#issuecomment-5490534921). The repo's `dependabot.yml` had no `npm` ecosystem entry at all, so there was nowhere to attach an `ignore` rule — dependabot's own bot comment on these PRs pointed at this exact gap.

---

### 🛠️ Changes Made
- Added an `npm` `package-ecosystem` entry for `/pkg/dashboard/ui` to `.github/dependabot.yml`.
- Added an `ignore` rule for `bootstrap` under that entry, so it is excluded from both version updates and security updates.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
- Behavior (no further bootstrap PRs) can only be confirmed by Dependabot's next scheduled run after merge.

---

### 🔗 References
- Ticket link:
- Design docs links: 
- External links:
  - https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#ignore
  - https://github.com/nuclio/nuclio/pull/4306
  - https://github.com/nuclio/nuclio/pull/4322

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
This only stops `bootstrap` updates. `js-yaml` (also flagged in #4306) was already resolved via a manual targeted bump (#4308) and doesn't need an ignore rule.