### PR TITLE
[Project] implement 2pc project CUD

### DIFF
--- a/pkg/platform/abstract/project/external/leader/common.go
+++ b/pkg/platform/abstract/project/external/leader/common.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leader
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/nuclio/nuclio-sdk-go"
+)
+
+// RequireCASMatch enforces the compare-and-swap invariant shared by every CAS-style leader
+// mutation: the caller's prevOpID must match the op_id currently stored on the CRD. An empty
+// storedOpID means no CAS key has been written yet — the one-shot migration path for CRDs
+// that pre-date 2PC, where nothing has stamped an op_id, so there is nothing to CAS against;
+// the request is accepted unconditionally and the current write is what stamps it. After that
+// first write, normal CAS enforcement resumes for every subsequent operation.
+func RequireCASMatch(storedOpID, prevOpID string) error {
+	if storedOpID == "" || storedOpID == prevOpID {
+		return nil
+	}
+	return nuclio.GetByStatusCode(http.StatusConflict)(
+		fmt.Sprintf("op_id mismatch; requested:(%q), stored:(%q)", prevOpID, storedOpID))
+}
+
+// IsOpIDOrdered returns true when newOpID is strictly newer than storedOpID. UUIDv7 encodes a
+// millisecond-precision timestamp in the most-significant bits, so lexicographic string
+// comparison is equivalent to chronological ordering.
+func IsOpIDOrdered(newOpID, storedOpID string) bool {
+	return newOpID > storedOpID
+}

--- a/pkg/platform/abstract/project/external/leader/common.go
+++ b/pkg/platform/abstract/project/external/leader/common.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/nuclio/errors"
 	"github.com/nuclio/nuclio-sdk-go"
 )
 
@@ -29,7 +30,7 @@ import (
 // that pre-date 2PC, where nothing has stamped an op_id, so there is nothing to CAS against;
 // the request is accepted unconditionally and the current write is what stamps it. After that
 // first write, normal CAS enforcement resumes for every subsequent operation.
-func RequireCASMatch(storedOpID, prevOpID string) error {
+func RequireCASMatch(prevOpID, storedOpID string) error {
 	if storedOpID == "" || storedOpID == prevOpID {
 		return nil
 	}
@@ -42,4 +43,25 @@ func RequireCASMatch(storedOpID, prevOpID string) error {
 // comparison is equivalent to chronological ordering.
 func IsOpIDOrdered(newOpID, storedOpID string) bool {
 	return newOpID > storedOpID
+}
+
+// RequireOpIDMatch returns a simple error when requestedOpID does not equal storedOpID, the
+// phase-binding check shared by callers where the request must match the op_id already
+// written on the CRD by a preceding phase. The caller wraps the result with its own status
+// code and operation-specific message.
+func RequireOpIDMatch(requestedOpID, storedOpID string) error {
+	if requestedOpID == storedOpID {
+		return nil
+	}
+	return errors.Errorf("op_id mismatch (requested %q, stored %q)", requestedOpID, storedOpID)
+}
+
+// RequireOpIDOrdered returns a simple error when newOpID is not strictly newer than storedOpID,
+// the replay-protection guard shared by every phase that advances the stored op_id. The caller
+// wraps the result with its own status code and operation-specific message.
+func RequireOpIDOrdered(newOpID, storedOpID string) error {
+	if IsOpIDOrdered(newOpID, storedOpID) {
+		return nil
+	}
+	return errors.Errorf("op_id is not newer than stored op_id (requested %q, stored %q)", newOpID, storedOpID)
 }

--- a/pkg/platform/abstract/project/external/leader/common.go
+++ b/pkg/platform/abstract/project/external/leader/common.go
@@ -31,7 +31,7 @@ import (
 // the request is accepted unconditionally and the current write is what stamps it. After that
 // first write, normal CAS enforcement resumes for every subsequent operation.
 func RequireCASMatch(prevOpID, storedOpID string) error {
-	if storedOpID == "" || storedOpID == prevOpID {
+	if storedOpID == "" || IsOpIDEqual(storedOpID, prevOpID) {
 		return nil
 	}
 	return nuclio.GetByStatusCode(http.StatusConflict)(
@@ -43,6 +43,11 @@ func RequireCASMatch(prevOpID, storedOpID string) error {
 // comparison is equivalent to chronological ordering.
 func IsOpIDOrdered(newOpID, storedOpID string) bool {
 	return newOpID > storedOpID
+}
+
+// IsOpIDEqual returns true when newOpID is equal to storedOpID.
+func IsOpIDEqual(newOpID, storedOpID string) bool {
+	return newOpID == storedOpID
 }
 
 // RequireOpIDMatch returns a simple error when requestedOpID does not equal storedOpID, the

--- a/pkg/platform/abstract/project/external/leader/mlrun/leader.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/leader.go
@@ -239,7 +239,7 @@ func (l *LeaderOps) validateProvision(labels map[string]string, existing platfor
 
 	// Replay protection: the incoming op_id is older than what is already stored.
 	// This means an out-of-order or stale request arrived. Reject it.
-	if !l.isOpIDOrdered(requestedOpID, storedOpID) {
+	if !leaderCommon.IsOpIDOrdered(requestedOpID, storedOpID) {
 		return false, nuclio.GetByStatusCode(http.StatusConflict)(
 			fmt.Sprintf("Provision rejected: op_id %q is older than stored op_id %q (replay protection)",
 				requestedOpID, storedOpID))
@@ -357,9 +357,9 @@ func (l *LeaderOps) validateMarkDelete(labels map[string]string, existing platfo
 	// CAS check: the current-op-id in the request must equal the op_id stored on the CRD.
 	// This ensures the caller is operating on the exact version it last read, preventing
 	// a concurrent update from being silently overwritten. The CAS is skipped on legacy
-	// CRDs that have no stored op_id yet — see requireCASOpIDMatch for the rationale.
-	if err := l.requireCASOpIDMatch(labels[leaderCommon.MLRunLabelKeyCurrentOpID], storedOpID, "Mark-delete"); err != nil {
-		return false, err
+	// CRDs that have no stored op_id yet — see leaderCommon.RequireCASMatch for the rationale.
+	if err := leaderCommon.RequireCASMatch(storedOpID, labels[leaderCommon.MLRunLabelKeyCurrentOpID]); err != nil {
+		return false, errors.Wrap(err, "Mark-delete CAS check failed")
 	}
 
 	// The new op_id must be strictly newer than the stored one, preventing replayed or
@@ -418,9 +418,9 @@ func (l *LeaderOps) validateSpecUpdate(labels map[string]string, existing platfo
 	// CAS check: the current-op-id in the request must equal the op_id stored on the CRD.
 	// This ensures the caller is operating on the exact version it last read, preventing
 	// a concurrent update from being silently overwritten. The CAS is skipped on legacy
-	// CRDs that have no stored op_id yet — see requireCASOpIDMatch for the rationale.
-	if err := l.requireCASOpIDMatch(labels[leaderCommon.MLRunLabelKeyCurrentOpID], storedOpID, "Update"); err != nil {
-		return false, err
+	// CRDs that have no stored op_id yet — see leaderCommon.RequireCASMatch for the rationale.
+	if err := leaderCommon.RequireCASMatch(storedOpID, labels[leaderCommon.MLRunLabelKeyCurrentOpID]); err != nil {
+		return false, errors.Wrap(err, "Update CAS check failed")
 	}
 
 	// The new op_id must be strictly newer than the stored one, preventing replayed or
@@ -520,7 +520,7 @@ func (l *LeaderOps) requireSyncStatus(effectiveStatus, expectedStatus, operation
 // equal the one already written on the CRD — by the matching Provision or Mark-delete.
 // For these callers an empty storedOpID is unreachable in practice (the preceding
 // requireSyncStatus check already excludes legacy / pre-2PC CRDs), so this helper does
-// not accommodate that case; use requireCASOpIDMatch for CAS-style mutations instead.
+// not accommodate that case; use leaderCommon.RequireCASMatch for CAS-style mutations instead.
 func (l *LeaderOps) requireOpIDMatch(requestedOpID, storedOpID, operation string) error {
 	if storedOpID != requestedOpID {
 		return nuclio.GetByStatusCode(http.StatusConflict)(
@@ -530,28 +530,12 @@ func (l *LeaderOps) requireOpIDMatch(requestedOpID, storedOpID, operation string
 	return nil
 }
 
-// requireCASOpIDMatch is a Compare-And-Swap variant of requireOpIDMatch for the CAS-style
-// mutation phases (Mark-delete, Spec-update). It treats an empty storedOpID as
-// "no CAS key has been written yet" and accepts the request unconditionally, which is the
-// one-shot migration path for legacy CRDs that pre-date 2PC: their op_id label is unset
-// because nothing has stamped it. The current write is what stamps it, so there is nothing
-// to CAS against and any non-empty current-op-id the leader sent is necessarily based on a
-// stale read — rejecting it would permanently block the CRD from ever being mutated again.
-// After the first leader-driven write the op_id is on the CRD and normal CAS enforcement
-// resumes for every subsequent operation.
-func (l *LeaderOps) requireCASOpIDMatch(requestedOpID, storedOpID, operation string) error {
-	if storedOpID == "" {
-		return nil
-	}
-	return l.requireOpIDMatch(requestedOpID, storedOpID, operation)
-}
-
 // requireNewerOpID returns a 409 Conflict when the incoming op_id is not strictly newer
 // than the one already stored on the CRD. This is the replay-protection guard: because
 // UUIDv7 embeds a millisecond timestamp in its most-significant bits, a lexicographically
 // smaller value means the request is older and must be rejected to prevent stale writes.
 func (l *LeaderOps) requireNewerOpID(newOpID, storedOpID, operation string) error {
-	if newOpID != "" && !l.isOpIDOrdered(newOpID, storedOpID) {
+	if newOpID != "" && !leaderCommon.IsOpIDOrdered(newOpID, storedOpID) {
 		return nuclio.GetByStatusCode(http.StatusConflict)(
 			fmt.Sprintf("new op_id %q is not newer than stored op_id %q, replay protection [%s]",
 				newOpID, storedOpID, operation))
@@ -567,11 +551,4 @@ func (l *LeaderOps) resolveSyncStatus(labels map[string]string) string {
 		return status
 	}
 	return leaderCommon.MLRunSyncStatusOnline
-}
-
-// isOpIDOrdered returns true when newOpID is strictly newer than storedOpID.
-// UUIDv7 encodes a millisecond-precision timestamp in the most-significant bits,
-// making lexicographic string comparison equivalent to chronological ordering.
-func (l *LeaderOps) isOpIDOrdered(newOpID, storedOpID string) bool {
-	return newOpID > storedOpID
 }

--- a/pkg/platform/abstract/project/external/leader/mlrun/leader.go
+++ b/pkg/platform/abstract/project/external/leader/mlrun/leader.go
@@ -358,7 +358,7 @@ func (l *LeaderOps) validateMarkDelete(labels map[string]string, existing platfo
 	// This ensures the caller is operating on the exact version it last read, preventing
 	// a concurrent update from being silently overwritten. The CAS is skipped on legacy
 	// CRDs that have no stored op_id yet — see leaderCommon.RequireCASMatch for the rationale.
-	if err := leaderCommon.RequireCASMatch(storedOpID, labels[leaderCommon.MLRunLabelKeyCurrentOpID]); err != nil {
+	if err := leaderCommon.RequireCASMatch(labels[leaderCommon.MLRunLabelKeyCurrentOpID], storedOpID); err != nil {
 		return false, errors.Wrap(err, "Mark-delete CAS check failed")
 	}
 
@@ -419,7 +419,7 @@ func (l *LeaderOps) validateSpecUpdate(labels map[string]string, existing platfo
 	// This ensures the caller is operating on the exact version it last read, preventing
 	// a concurrent update from being silently overwritten. The CAS is skipped on legacy
 	// CRDs that have no stored op_id yet — see leaderCommon.RequireCASMatch for the rationale.
-	if err := leaderCommon.RequireCASMatch(storedOpID, labels[leaderCommon.MLRunLabelKeyCurrentOpID]); err != nil {
+	if err := leaderCommon.RequireCASMatch(labels[leaderCommon.MLRunLabelKeyCurrentOpID], storedOpID); err != nil {
 		return false, errors.Wrap(err, "Update CAS check failed")
 	}
 

--- a/pkg/platform/abstract/project/external/leader/oris/leader.go
+++ b/pkg/platform/abstract/project/external/leader/oris/leader.go
@@ -56,7 +56,7 @@ func (l *LeaderOps) GenerateProjectRequestBody(projectConfig *platform.ProjectCo
 	return json.Marshal(project)
 }
 
-func (l *LeaderOps) GenerateProjectDeletionRequestBody(projectName string) ([]byte, error) {
+func (l *LeaderOps) GenerateProjectDeletionRequestBody(_ string) ([]byte, error) {
 	return []byte{}, nil
 }
 
@@ -132,6 +132,15 @@ func (l *LeaderOps) GetExpectedStatusCode(operation leaderCommon.ProjectOperatio
 	}
 }
 
+// GetDeleteStrategyHeaderName overrides the abstract default ("", meaning no header): an
+// empty header name reaching Client.Delete's requestHeaders map becomes a header with an
+// empty key, which Go's http.Client rejects outright before ever sending the request. Oris's
+// legacy delete endpoint has no deletion-strategy concept and never reads this header, so the
+// name only needs to be valid, not meaningful to the leader.
+func (l *LeaderOps) GetDeleteStrategyHeaderName() string {
+	return "x-oris-deletion-strategy"
+}
+
 func (l *LeaderOps) GenerateUpdateProjectRequestURL(apiAddress, projectName string) string {
 	return l.ProjectRequestURL(apiAddress, leaderCommon.APIVersionV1, projectName)
 }
@@ -146,4 +155,25 @@ func (l *LeaderOps) GenerateGetUpdatedAfterRequestURL(apiAddress string) string 
 
 func (l *LeaderOps) GenerateDeleteProjectRequestURL(apiAddress, projectName string) string {
 	return l.ProjectRequestURL(apiAddress, leaderCommon.APIVersionV1, projectName)
+}
+
+// ErrLegacySurfaceForbidden is returned by EvaluateLeaderRequest for every leader-origin call
+// on the legacy label-inferred surface. Exported as a sentinel (rather than constructed fresh
+// per call) so callers, including tests, can identify it with errors.Is instead of inspecting
+// the status code or message.
+var ErrLegacySurfaceForbidden = nuclio.GetByStatusCode(http.StatusForbidden)(
+	"leader writes must use /api/v1/follower/projects/*")
+
+// EvaluateLeaderRequest rejects every leader-origin call on this legacy surface: with Oris as
+// leader, project writes from the leader belong exclusively on the dedicated
+// /api/v1/follower/projects/* surface, never on the label-inferred api/projects path.
+func (l *LeaderOps) EvaluateLeaderRequest(_ context.Context, _ map[string]string, _ platform.Project) (bool, error) {
+	return false, ErrLegacySurfaceForbidden
+}
+
+// ProjectSync2PCEnabled returns true so the caller always runs EvaluateLeaderRequest above
+// instead of short-circuiting past it — unlike MLRun, Oris has no legacy pass-through mode to
+// preserve on this surface.
+func (l *LeaderOps) ProjectSync2PCEnabled() bool {
+	return true
 }

--- a/pkg/platform/abstract/project/external/leader/oris/leader.go
+++ b/pkg/platform/abstract/project/external/leader/oris/leader.go
@@ -31,6 +31,13 @@ import (
 	"github.com/nuclio/nuclio-sdk-go"
 )
 
+// ErrLegacySurfaceForbidden is returned by EvaluateLeaderRequest for every leader-origin call
+// on the legacy label-inferred surface. Exported as a sentinel (rather than constructed fresh
+// per call) so callers, including tests, can identify it with errors.Is instead of inspecting
+// the status code or message.
+var ErrLegacySurfaceForbidden = nuclio.GetByStatusCode(http.StatusForbidden)(
+	"leader writes must use /api/v1/follower/projects/*")
+
 // LeaderOps implements leader.LeaderOps for the Oris projects leader.
 type LeaderOps struct {
 	*leaderabstract.LeaderOps
@@ -156,13 +163,6 @@ func (l *LeaderOps) GenerateGetUpdatedAfterRequestURL(apiAddress string) string 
 func (l *LeaderOps) GenerateDeleteProjectRequestURL(apiAddress, projectName string) string {
 	return l.ProjectRequestURL(apiAddress, leaderCommon.APIVersionV1, projectName)
 }
-
-// ErrLegacySurfaceForbidden is returned by EvaluateLeaderRequest for every leader-origin call
-// on the legacy label-inferred surface. Exported as a sentinel (rather than constructed fresh
-// per call) so callers, including tests, can identify it with errors.Is instead of inspecting
-// the status code or message.
-var ErrLegacySurfaceForbidden = nuclio.GetByStatusCode(http.StatusForbidden)(
-	"leader writes must use /api/v1/follower/projects/*")
 
 // EvaluateLeaderRequest rejects every leader-origin call on this legacy surface: with Oris as
 // leader, project writes from the leader belong exclusively on the dedicated

--- a/pkg/platform/abstract/project/external/leader/oris/leader_test.go
+++ b/pkg/platform/abstract/project/external/leader/oris/leader_test.go
@@ -21,6 +21,7 @@ package oris
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"net/http"
 	"testing"
 
@@ -262,13 +263,13 @@ func (suite *LeaderTestSuite) TestGetExpectedStatusCode() {
 }
 
 func (suite *LeaderTestSuite) TestProjectSync2PCEnabled() {
-	suite.Require().False(suite.leaderOps.ProjectSync2PCEnabled())
+	suite.Require().True(suite.leaderOps.ProjectSync2PCEnabled())
 }
 
-func (suite *LeaderTestSuite) TestEvaluateLeaderRequestPassesThrough() {
+func (suite *LeaderTestSuite) TestEvaluateLeaderRequestRejectsLegacySurface() {
 	shouldApply, err := suite.leaderOps.EvaluateLeaderRequest(context.TODO(), map[string]string{}, nil)
-	suite.Require().NoError(err)
-	suite.Require().True(shouldApply)
+	suite.Require().False(shouldApply)
+	suite.Require().True(stderrors.Is(err, ErrLegacySurfaceForbidden))
 }
 
 func (suite *LeaderTestSuite) TestIsJobCompleted() {

--- a/pkg/platform/abstract/project/external/leader/types.go
+++ b/pkg/platform/abstract/project/external/leader/types.go
@@ -201,6 +201,23 @@ const (
 	MLRunSyncStatusDeleting = "deleting"
 )
 
+// 2PC sync label keys written on NuclioProject CRDs by internalc/kube.Client's follower
+// operations (the dedicated /api/v1/follower/projects/* surface).
+const (
+	OrisLabelKeySyncStatus = "oris/sync-status"
+	OrisLabelKeyOpID       = "oris/op-id"
+)
+
+// OrisSyncStatus is the 2PC phase stamped on a NuclioProject CRD's labels by internalc/kube.Client's
+// follower operations.
+type OrisSyncStatus string
+
+const (
+	OrisSyncStatusCreating OrisSyncStatus = "creating"
+	OrisSyncStatusOnline   OrisSyncStatus = "online"
+	OrisSyncStatusDeleting OrisSyncStatus = "deleting"
+)
+
 func ParseTimeFromTimestamp(timestamp string) time.Time {
 	t, _ := time.Parse(ProjectTimeLayout, timestamp)
 	return t

--- a/pkg/platform/abstract/project/internalc/kube/kube.go
+++ b/pkg/platform/abstract/project/internalc/kube/kube.go
@@ -19,10 +19,13 @@ package kube
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"sort"
 	"time"
 
 	"github.com/nuclio/nuclio/pkg/platform"
 	"github.com/nuclio/nuclio/pkg/platform/abstract/project"
+	leaderCommon "github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader"
 	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
 	nuclioclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio"
 
@@ -177,45 +180,341 @@ func (c *Client) Delete(ctx context.Context, deleteProjectOptions *platform.Dele
 // Follower operations: the dedicated /api/follower/projects/* surface is only ever
 // reachable when Oris is the configured leader. This is the only client that implements
 // these for real -- external.Client and the local platform's client are permanently
-// unsupported. The CAS validation against the existing CRD state (comparing stored vs.
-// incoming OpID/SyncStatus, enforcing phase ordering) is this client's own private concern;
-// not yet implemented (NUC-988), along with the CRD mutation itself.
+// unsupported.
 
-// PrepareCreate is not yet implemented: provisions a new project CRD (2PC step 1).
-func (c *Client) PrepareCreate(context.Context,
-	*platform.PrepareCreateProjectOptions) (*platform.Project2PCState, error) {
-	return nil, platform.ErrUnsupportedMethod
+// PrepareCreate provisions a new project CRD (2PC step 1).
+func (c *Client) PrepareCreate(ctx context.Context,
+	options *platform.PrepareCreateProjectOptions) (*platform.Project2PCState, error) {
+	name := options.ProjectConfig.Meta.Name
+	namespace := options.ProjectConfig.Meta.Namespace
+	c.Logger.DebugWithCtx(ctx, "PrepareCreate received", "name", name, "new opID", options.OpID)
+
+	existProject, err := c.getProject(ctx, name, namespace)
+	if err != nil {
+		c.Logger.DebugWithCtx(ctx, "PrepareCreate failed to fetch project", "name", name, "new opID", options.OpID, "err", err.Error())
+		return nil, errors.Wrap(err, "Failed to prepare create")
+	}
+
+	// no CRD exists yet — this is the first time we see this existProject.
+	if existProject == nil {
+		c.Logger.DebugWithCtx(ctx, "PrepareCreate writing new project", "name", name, "new opID", options.OpID)
+		if err := c.writeFollowerProject(ctx, false, options.ProjectConfig, options.OpID, leaderCommon.OrisSyncStatusCreating); err != nil {
+			c.Logger.WarnWithCtx(ctx, "PrepareCreate failed to write project", "name", name, "new opID", options.OpID, "err", err.Error())
+			return nil, errors.Wrap(err, "Failed to prepare create")
+		}
+		c.Logger.DebugWithCtx(ctx, "PrepareCreate completed successfully", "name", name, "new opID", options.OpID)
+		return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusCreating)}, nil
+	}
+
+	currentOpID, currentStatus := c.extractProjectLabels(existProject)
+	c.Logger.DebugWithCtx(ctx, "PrepareCreate read current state", "name", name, "new opID", options.OpID,
+		"current opID", currentOpID, "currentStatus", currentStatus)
+
+	// The CRD is already in the correct state — skip the write and return the existing state.
+	if currentOpID == options.OpID {
+		c.Logger.DebugWithCtx(ctx, "PrepareCreate completed successfully", "name", name, "new opID", options.OpID)
+		return &platform.Project2PCState{Name: name, OpID: currentOpID, SyncStatus: string(currentStatus)}, nil
+	}
+
+	if !leaderCommon.IsOpIDOrdered(options.OpID, currentOpID) {
+		c.Logger.DebugWithCtx(ctx, "PrepareCreate rejected: op_id older than stored", "name", name, "new opID", options.OpID, "current opID", currentOpID)
+		return nil, nuclio.GetByStatusCode(http.StatusConflict)(
+			fmt.Sprintf("Provision rejected: op_id is older than stored op_id (requested %q, stored %q)", options.OpID, currentOpID))
+	}
+
+	// The incoming op_id is newer. If the CRD is still "creating" this is a recovery scenario:
+	// the leader abandoned the previous provision and is starting fresh with a new op_id.
+	// Allow the overwrite so the existProject is not stuck.
+	if currentStatus == leaderCommon.OrisSyncStatusCreating {
+		c.Logger.DebugWithCtx(ctx, "PrepareCreate overwriting abandoned provision", "name", name, "new opID", options.OpID, "current opID", currentOpID)
+		if err := c.writeFollowerProject(ctx, true, options.ProjectConfig, options.OpID, leaderCommon.OrisSyncStatusCreating); err != nil {
+			c.Logger.WarnWithCtx(ctx, "PrepareCreate failed to write project", "name", name, "new opID", options.OpID, "err", err.Error())
+			return nil, errors.Wrap(err, "Failed to prepare create")
+		}
+		c.Logger.DebugWithCtx(ctx, "PrepareCreate completed successfully", "name", name, "new opID", options.OpID)
+		return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusCreating)}, nil
+	}
+
+	// The op_id is newer, but the project isn't in "creating" state — it's already
+	// provisioned (online or deleting) and cannot be re-provisioned.
+	c.Logger.DebugWithCtx(ctx, "PrepareCreate rejected: already provisioned", "name", name, "new opID", options.OpID, "currentStatus", currentStatus)
+	return nil, nuclio.GetByStatusCode(http.StatusConflict)(
+		fmt.Sprintf("Provision rejected: project already provisioned and not in creating state (state %q)", currentStatus))
 }
 
-// CommitCreate is not yet implemented: activates a provisioned project (2PC step 2).
-func (c *Client) CommitCreate(context.Context,
-	*platform.CommitCreateProjectOptions) (*platform.Project2PCState, error) {
-	return nil, platform.ErrUnsupportedMethod
+// CommitCreate activates a provisioned project (2PC step 2): flips its sync-status from creating to online.
+func (c *Client) CommitCreate(ctx context.Context,
+	options *platform.CommitCreateProjectOptions) (*platform.Project2PCState, error) {
+	name := options.Meta.Name
+	c.Logger.DebugWithCtx(ctx, "CommitCreate received", "name", name, "new opID", options.OpID)
+
+	existing, err := c.getProject(ctx, name, options.Meta.Namespace)
+	if err != nil {
+		c.Logger.DebugWithCtx(ctx, "CommitCreate failed to fetch project", "name", name, "new opID", options.OpID, "err", err.Error())
+		return nil, errors.Wrap(err, "Failed to commit create")
+	}
+	if existing == nil {
+		c.Logger.DebugWithCtx(ctx, "CommitCreate rejected: no CRD", "name", name, "new opID", options.OpID)
+		return nil, nuclio.GetByStatusCode(http.StatusPreconditionFailed)(
+			fmt.Sprintf("Commit rejected: project has no CRD, provision must run first (project %q)", name))
+	}
+
+	currentOpID, currentStatus := c.extractProjectLabels(existing)
+	c.Logger.DebugWithCtx(ctx, "CommitCreate read current state", "name", name, "new opID", options.OpID,
+		"current opID", currentOpID, "currentStatus", currentStatus)
+	if currentOpID != options.OpID {
+		c.Logger.DebugWithCtx(ctx, "CommitCreate rejected: op_id mismatch", "name", name, "new opID", options.OpID, "current opID", currentOpID)
+		return nil, nuclio.GetByStatusCode(http.StatusConflict)(
+			fmt.Sprintf("Commit rejected: op_id mismatch (requested %q, stored %q)", options.OpID, currentOpID))
+	}
+
+	switch currentStatus {
+	case leaderCommon.OrisSyncStatusOnline:
+		// Idempotency: already online with this op_id — the commit was already applied.
+		c.Logger.DebugWithCtx(ctx, "CommitCreate idempotent: already applied", "name", name, "new opID", options.OpID, "current opID", currentOpID)
+		return &platform.Project2PCState{Name: name, OpID: currentOpID, SyncStatus: string(currentStatus)}, nil
+	case leaderCommon.OrisSyncStatusCreating:
+		// Expected state — fall through and complete the commit.
+		c.Logger.DebugWithCtx(ctx, "CommitCreate: project status is creating", "name", name, "new opID", options.OpID)
+	default:
+		c.Logger.DebugWithCtx(ctx, "CommitCreate rejected: unexpected state", "name", name, "new opID", options.OpID, "currentStatus", currentStatus)
+		return nil, nuclio.GetByStatusCode(http.StatusPreconditionFailed)(
+			fmt.Sprintf("Commit rejected: project is in unexpected state (project %q, state %q, expected %q)",
+				name, currentStatus, leaderCommon.OrisSyncStatusCreating))
+	}
+
+	c.Logger.DebugWithCtx(ctx, "CommitCreate writing project online", "name", name, "new opID", options.OpID)
+	if err := c.updateFollowerProjectLabels(ctx, existing, options.OpID, leaderCommon.OrisSyncStatusOnline); err != nil {
+		c.Logger.WarnWithCtx(ctx, "CommitCreate failed to write project", "name", name, "new opID", options.OpID, "err", err.Error())
+		return nil, errors.Wrap(err, "Failed to commit create")
+	}
+	c.Logger.DebugWithCtx(ctx, "CommitCreate completed successfully", "name", name, "new opID", options.OpID)
+	return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusOnline)}, nil
 }
 
-// CommitUpdate is not yet implemented: applies a common-set update to an online project.
-func (c *Client) CommitUpdate(context.Context,
-	*platform.CommitUpdateProjectOptions) (*platform.Project2PCState, error) {
-	return nil, platform.ErrUnsupportedMethod
+// CommitUpdate applies a common-set update to an online project: CAS against PrevOpID,
+// require the new OpID to be strictly newer, then advance the CRD's spec/labels.
+func (c *Client) CommitUpdate(ctx context.Context,
+	options *platform.CommitUpdateProjectOptions) (*platform.Project2PCState, error) {
+	name := options.ProjectConfig.Meta.Name
+	c.Logger.DebugWithCtx(ctx, "CommitUpdate received", "name", name, "new opID", options.OpID, "new opID", options.PrevOpID)
+
+	existing, err := c.getProject(ctx, name, options.ProjectConfig.Meta.Namespace)
+	if err != nil {
+		c.Logger.DebugWithCtx(ctx, "CommitUpdate failed to fetch project", "name", name, "new opID", options.OpID, "err", err.Error())
+		return nil, errors.Wrap(err, "Failed to commit update")
+	}
+	if existing == nil {
+		c.Logger.DebugWithCtx(ctx, "CommitUpdate rejected: project not found", "name", name, "new opID", options.OpID)
+		return nil, nuclio.NewErrNotFound(fmt.Sprintf("Update rejected: project not found (project %q)", name))
+	}
+
+	currentOpID, currentStatus := c.extractProjectLabels(existing)
+	c.Logger.DebugWithCtx(ctx, "CommitUpdate read current state", "name", name, "new opID", options.OpID,
+		"current opID", currentOpID, "currentStatus", currentStatus)
+
+	// "must be online" precondition by design
+	if currentStatus != leaderCommon.OrisSyncStatusOnline {
+		c.Logger.DebugWithCtx(ctx, "CommitUpdate rejected: unexpected state", "name", name, "new opID", options.OpID, "currentStatus", currentStatus)
+		return nil, nuclio.GetByStatusCode(http.StatusPreconditionFailed)(
+			fmt.Sprintf("Update rejected: project is in unexpected state (project %q, state %q, expected %q)",
+				name, currentStatus, leaderCommon.OrisSyncStatusOnline))
+	}
+
+	// Idempotency: already applied — must be checked before CAS, since after a successful
+	// update the stored op_id has advanced past the request's PrevOpID.
+	if currentOpID == options.OpID {
+		c.Logger.DebugWithCtx(ctx, "CommitUpdate idempotent: already applied", "name", name,
+			"new opID", options.OpID, "current opID", currentOpID)
+		return &platform.Project2PCState{Name: name, OpID: currentOpID, SyncStatus: string(currentStatus)}, nil
+	}
+
+	if err := leaderCommon.RequireCASMatch(currentOpID, options.PrevOpID); err != nil {
+		c.Logger.DebugWithCtx(ctx, "CommitUpdate CAS check failed", "name", name, "new opID", options.OpID,
+			"new opID", options.PrevOpID, "current opID", currentOpID, "err", err.Error())
+		return nil, errors.Wrap(err, "Update CAS check failed")
+	}
+	if !leaderCommon.IsOpIDOrdered(options.OpID, currentOpID) {
+		c.Logger.DebugWithCtx(ctx, "CommitUpdate rejected: op_id not newer than stored", "name", name, "new opID", options.OpID, "current opID", currentOpID)
+		return nil, nuclio.GetByStatusCode(http.StatusConflict)(
+			fmt.Sprintf("Update rejected: op_id is not newer than stored op_id (requested %q, stored %q)", options.OpID, currentOpID))
+	}
+
+	c.Logger.DebugWithCtx(ctx, "CommitUpdate writing project", "name", name, "new opID", options.OpID)
+	if err := c.writeFollowerProject(ctx, true, options.ProjectConfig, options.OpID, leaderCommon.OrisSyncStatusOnline); err != nil {
+		c.Logger.WarnWithCtx(ctx, "CommitUpdate failed to write project", "name", name, "new opID", options.OpID, "err", err.Error())
+		return nil, errors.Wrap(err, "Failed to commit update")
+	}
+	c.Logger.DebugWithCtx(ctx, "CommitUpdate completed successfully", "name", name, "new opID", options.OpID)
+	return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusOnline)}, nil
 }
 
-// PrepareDelete is not yet implemented: marks a project deleting (2PC delete step 1).
-func (c *Client) PrepareDelete(context.Context,
-	*platform.PrepareDeleteProjectOptions) (*platform.Project2PCState, error) {
-	return nil, platform.ErrUnsupportedMethod
+// PrepareDelete marks a project deleting (2PC delete step 1).
+func (c *Client) PrepareDelete(ctx context.Context,
+	options *platform.PrepareDeleteProjectOptions) (*platform.Project2PCState, error) {
+	name := options.Meta.Name
+	c.Logger.DebugWithCtx(ctx, "PrepareDelete received", "name", name, "new opID", options.OpID, "new opID", options.PrevOpID)
+
+	existing, err := c.getProject(ctx, name, options.Meta.Namespace)
+	if err != nil {
+		c.Logger.DebugWithCtx(ctx, "PrepareDelete failed to fetch project", "name", name, "new opID", options.OpID, "err", err.Error())
+		return nil, errors.Wrap(err, "Failed to prepare delete")
+	}
+
+	// Idempotency: the CRD does not exist - no need to mark it deleting, the commit will be a no-op.
+	if existing == nil {
+		c.Logger.DebugWithCtx(ctx, "PrepareDelete completed successfully", "name", name, "new opID", options.OpID)
+		return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusDeleting)}, nil
+	}
+
+	currentOpID, currentStatus := c.extractProjectLabels(existing)
+	c.Logger.DebugWithCtx(ctx, "PrepareDelete read current state", "name", name,
+		"new opID", options.OpID, "current opID", currentOpID, "currentStatus", currentStatus)
+
+	// Idempotency: this exact mark-delete already applied. Only a prior, successful call to
+	// this function could have stamped this op_id, so the status is guaranteed to be deleting.
+	if currentOpID == options.OpID {
+		c.Logger.DebugWithCtx(ctx, "PrepareDelete idempotent: already applied", "name", name, "new opID", options.OpID, "current opID", currentOpID)
+		return &platform.Project2PCState{Name: name, OpID: currentOpID, SyncStatus: string(currentStatus)}, nil
+	}
+
+	switch currentStatus {
+	case leaderCommon.OrisSyncStatusDeleting:
+		// Conflict: already deleting under a different op_id — a different delete is in
+		// progress, must not be silently overwritten (mlrun's validateMarkDelete rejects the
+		// same way, rather than treating any in-progress delete as idempotent).
+		c.Logger.DebugWithCtx(ctx, "PrepareDelete rejected: different delete in progress", "name", name, "current opID", currentOpID, "new opID", options.OpID)
+		return nil, nuclio.GetByStatusCode(http.StatusConflict)(
+			fmt.Sprintf("Mark-delete rejected: different delete already in progress (requested %q, stored %q)",
+				options.OpID, currentOpID))
+	case leaderCommon.OrisSyncStatusOnline:
+		// Expected state — fall through and continue below.
+		c.Logger.DebugWithCtx(ctx, "PrepareDelete: project status is online", "name", name, "new opID", options.OpID)
+	default:
+		c.Logger.DebugWithCtx(ctx, "PrepareDelete rejected: unexpected state", "name", name, "new opID", options.OpID, "currentStatus", currentStatus)
+		return nil, nuclio.GetByStatusCode(http.StatusPreconditionFailed)(
+			fmt.Sprintf("Mark-delete rejected: project is in unexpected state (project %q, state %q, expected %q)",
+				name, currentStatus, leaderCommon.OrisSyncStatusOnline))
+	}
+
+	if err := leaderCommon.RequireCASMatch(currentOpID, options.PrevOpID); err != nil {
+		c.Logger.DebugWithCtx(ctx, "PrepareDelete CAS check failed", "name", name,
+			"current opID", currentOpID, "new OpID", options.PrevOpID, "err", err.Error())
+		return nil, errors.Wrap(err, "Mark-delete CAS check failed")
+	}
+	if !leaderCommon.IsOpIDOrdered(options.OpID, currentOpID) {
+		c.Logger.DebugWithCtx(ctx, "PrepareDelete rejected: op_id not newer than stored", "name", name, "new opID", options.OpID, "current opID", currentOpID)
+		return nil, nuclio.GetByStatusCode(http.StatusConflict)(
+			fmt.Sprintf("Mark-delete rejected: op_id is not newer than stored op_id (requested %q, stored %q)", options.OpID, currentOpID))
+	}
+
+	c.Logger.DebugWithCtx(ctx, "PrepareDelete writing project deleting", "name", name, "new opID", options.OpID)
+	if err := c.updateFollowerProjectLabels(ctx, existing, options.OpID, leaderCommon.OrisSyncStatusDeleting); err != nil {
+		c.Logger.WarnWithCtx(ctx, "PrepareDelete failed to write project", "name", name, "new opID", options.OpID, "err", err.Error())
+		return nil, errors.Wrap(err, "Failed to prepare delete")
+	}
+	c.Logger.DebugWithCtx(ctx, "PrepareDelete completed successfully", "name", name, "new opID", options.OpID)
+	return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusDeleting)}, nil
 }
 
-// CommitDelete is not yet implemented: purges the project CRD (2PC delete step 2).
-func (c *Client) CommitDelete(context.Context,
-	*platform.CommitDeleteProjectOptions) (*platform.Project2PCState, error) {
-	return nil, platform.ErrUnsupportedMethod
+// CommitDelete purges the project CRD (2PC delete step 2).
+func (c *Client) CommitDelete(ctx context.Context,
+	options *platform.CommitDeleteProjectOptions) (*platform.Project2PCState, error) {
+	name := options.Meta.Name
+	c.Logger.DebugWithCtx(ctx, "CommitDelete received", "name", name, "new opID", options.OpID)
+
+	existing, err := c.getProject(ctx, name, options.Meta.Namespace)
+	if err != nil {
+		c.Logger.DebugWithCtx(ctx, "CommitDelete failed to fetch project", "name", name, "new opID", options.OpID, "err", err.Error())
+		return nil, errors.Wrap(err, "Failed to commit delete")
+	}
+
+	// Idempotency: already gone, a previous call already deleted it.
+	if existing == nil {
+		c.Logger.DebugWithCtx(ctx, "CommitDelete idempotent: already deleted", "name", name, "new opID", options.OpID)
+		return &platform.Project2PCState{Name: name, OpID: options.OpID}, nil
+	}
+
+	currentOpID, currentStatus := c.extractProjectLabels(existing)
+	c.Logger.DebugWithCtx(ctx, "CommitDelete read current state", "name", name, "new opID", options.OpID,
+		"current opID", currentOpID, "currentStatus", currentStatus)
+
+	if currentStatus != leaderCommon.OrisSyncStatusDeleting {
+		c.Logger.DebugWithCtx(ctx, "CommitDelete rejected: unexpected state", "name", name, "new opID", options.OpID, "currentStatus", currentStatus)
+		return nil, nuclio.GetByStatusCode(http.StatusConflict)(
+			fmt.Sprintf("Final-delete rejected: project is in unexpected state (project %q, state %q, expected %q)",
+				name, currentStatus, leaderCommon.OrisSyncStatusDeleting))
+	}
+	if currentOpID != options.OpID {
+		c.Logger.DebugWithCtx(ctx, "CommitDelete rejected: op_id mismatch", "name", name, "new opID", options.OpID, "current opID", currentOpID)
+		return nil, nuclio.GetByStatusCode(http.StatusConflict)(
+			fmt.Sprintf("Final-delete rejected: op_id mismatch (requested %q, stored %q)", options.OpID, currentOpID))
+	}
+
+	c.Logger.DebugWithCtx(ctx, "CommitDelete deleting project CRD", "name", name, "new opID", options.OpID)
+	if err := c.Delete(ctx, &platform.DeleteProjectOptions{Meta: options.Meta}); err != nil {
+		c.Logger.WarnWithCtx(ctx, "CommitDelete failed to delete project CRD", "name", name, "new opID", options.OpID, "err", err.Error())
+		return nil, errors.Wrap(err, "Failed to delete project CRD")
+	}
+
+	c.Logger.DebugWithCtx(ctx, "CommitDelete completed successfully", "name", name, "new opID", options.OpID)
+	return &platform.Project2PCState{Name: name, OpID: options.OpID}, nil
 }
 
-// List is not yet implemented: lists this follower's project states for the leader's
-// reconciliation sweep.
-func (c *Client) List(context.Context,
-	*platform.ListProjectStatesOptions) (*platform.Project2PCStatesPage, error) {
-	return nil, platform.ErrUnsupportedMethod
+// List lists this follower's project states for the leader's reconciliation sweep.
+func (c *Client) List(ctx context.Context,
+	options *platform.ListProjectStatesOptions) (*platform.Project2PCStatesPage, error) {
+	c.Logger.DebugWithCtx(ctx, "List received", "namespace", options.Namespace, "cursor", options.Cursor, "limit", options.Limit)
+
+	projects, err := c.Get(ctx, &platform.GetProjectsOptions{Meta: platform.ProjectMeta{Namespace: options.Namespace}})
+	if err != nil {
+		c.Logger.DebugWithCtx(ctx, "List failed to fetch projects", "namespace", options.Namespace, "err", err.Error())
+		return nil, errors.Wrap(err, "Failed to list projects")
+	}
+
+	states := make([]*platform.Project2PCState, 0, len(projects))
+	for _, proj := range projects {
+		config := proj.GetConfig()
+		// Skip projects that haven't changed since the cutoff — nothing for the leader to reconcile.
+		if options.UpdatedAfter != nil && config.Status.UpdatedAt != nil &&
+			!config.Status.UpdatedAt.After(*options.UpdatedAfter) {
+			continue
+		}
+		currentOpID, currentStatus := c.extractProjectLabels(proj)
+		states = append(states, &platform.Project2PCState{
+			Name:       config.Meta.Name,
+			OpID:       currentOpID,
+			SyncStatus: string(currentStatus),
+		})
+	}
+
+	// Get returns projects in whatever order the k8s client/cache happens to produce, which is
+	// not stable across calls. The keyset pagination below requires a deterministic order to
+	// page through every project exactly once, so impose one here by Name.
+	sort.Slice(states, func(i, j int) bool { return states[i].Name < states[j].Name })
+
+	// Cursor is the Name of the last project returned in the previous page. The leader's
+	// reconciliation sweep pages through a follower's entire project set by repeatedly calling
+	// List and feeding the previous response's NextCursor back in as Cursor, so it never has to
+	// hold the whole set in memory at once (see orca's HTTPFollowerClient.ListStates).
+	if options.Cursor != "" {
+		remaining := states[:0]
+		for _, state := range states {
+			if state.Name > options.Cursor {
+				remaining = append(remaining, state)
+			}
+		}
+		states = remaining
+	}
+
+	var nextCursor string
+	if options.Limit > 0 && len(states) > options.Limit {
+		states = states[:options.Limit]
+		nextCursor = states[len(states)-1].Name
+	}
+
+	c.Logger.DebugWithCtx(ctx, "List returning page", "namespace", options.Namespace, "count", len(states), "nextCursor", nextCursor)
+	return &platform.Project2PCStatesPage{States: states, NextCursor: nextCursor}, nil
 }
 
 func (c *Client) platformProjectToProject(platformProject *platform.ProjectConfig, project *nuclioio.NuclioProject) {
@@ -240,4 +539,73 @@ func (c *Client) nuclioProjectToPlatformProject(nuclioProject *nuclioio.NuclioPr
 			Spec:   nuclioProject.Spec,
 			Status: nuclioProject.Status,
 		})
+}
+
+// getProject get the project by name and namespace.
+func (c *Client) getProject(ctx context.Context, name, namespace string) (platform.Project, error) {
+	projects, err := c.Get(ctx, &platform.GetProjectsOptions{Meta: platform.ProjectMeta{Name: name, Namespace: namespace}})
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to fetch existing project")
+	}
+	if len(projects) == 0 {
+		return nil, nil
+	}
+	return projects[0], nil
+}
+
+// extractProjectLabels reads the op_id and oris/sync-status labels off an existing CRD.
+func (c *Client) extractProjectLabels(existing platform.Project) (currentOpID string, syncStatus leaderCommon.OrisSyncStatus) {
+	labels := existing.GetConfig().Meta.Labels
+	currentOpID = labels[leaderCommon.OrisLabelKeyOpID]
+	if status, exists := labels[leaderCommon.OrisLabelKeySyncStatus]; exists {
+		return currentOpID, leaderCommon.OrisSyncStatus(status)
+	}
+	// absent sync-status label means the CRD pre-dates this follower surface — treated as
+	// "online", the same convention MLRun's evaluator uses for its own legacy labels.
+	return currentOpID, leaderCommon.OrisSyncStatusOnline
+}
+
+// writeFollowerProject creates or updates the project CRD, stamped with the given op_id/sync-status labels.
+func (c *Client) writeFollowerProject(ctx context.Context, isUpdate bool,
+	projectConfig platform.ProjectConfig, opID string, syncStatus leaderCommon.OrisSyncStatus) error {
+	projectConfig.Meta.Labels = c.stampFollowerLabels(projectConfig.Meta.Labels, opID, syncStatus)
+
+	if isUpdate {
+		_, err := c.Update(ctx, &platform.UpdateProjectOptions{ProjectConfig: projectConfig})
+		return errors.Wrap(err, "Failed to update project CRD")
+	}
+
+	// Update always stamps UpdatedAt itself; Create doesn't, so stamp it here too, keeping
+	// List's UpdatedAfter reconciliation sweep accurate from the very first write.
+	now := time.Now()
+	projectConfig.Status.UpdatedAt = &now
+	_, err := c.Create(ctx, &platform.CreateProjectOptions{ProjectConfig: &projectConfig})
+	return errors.Wrap(err, "Failed to create project CRD")
+}
+
+// updateFollowerProjectLabels re-writes an existing project's full config with only its op_id/
+// sync-status labels advanced, leaving Spec and every other label/annotation untouched.
+func (c *Client) updateFollowerProjectLabels(ctx context.Context, existing platform.Project,
+	opID string, syncStatus leaderCommon.OrisSyncStatus) error {
+	// existing is never nil here: every caller already handles the not-found/idempotent case
+	// before reaching this point, so GetConfig() is always safe to dereference.
+	projectConfig := *existing.GetConfig()
+	projectConfig.Meta.Labels = c.stampFollowerLabels(projectConfig.Meta.Labels, opID, syncStatus)
+
+	// Update replaces Spec/Labels/Annotations/Status wholesale rather than merging, so this must start
+	// from the existing CRD's full ProjectConfig, not a labels-only partial one.
+	_, err := c.Update(ctx, &platform.UpdateProjectOptions{ProjectConfig: projectConfig})
+	return errors.Wrap(err, "Failed to update project CRD")
+}
+
+// stampFollowerLabels returns a copy of labels with the oris/* 2PC labels set to opID/
+// syncStatus, without mutating the caller's map.
+func (c *Client) stampFollowerLabels(labels map[string]string, opID string, syncStatus leaderCommon.OrisSyncStatus) map[string]string {
+	stamped := make(map[string]string, len(labels)+2)
+	for key, value := range labels {
+		stamped[key] = value
+	}
+	stamped[leaderCommon.OrisLabelKeyOpID] = opID
+	stamped[leaderCommon.OrisLabelKeySyncStatus] = string(syncStatus)
+	return stamped
 }

--- a/pkg/platform/abstract/project/internalc/kube/kube.go
+++ b/pkg/platform/abstract/project/internalc/kube/kube.go
@@ -187,105 +187,86 @@ func (c *Client) PrepareCreate(ctx context.Context,
 	options *platform.PrepareCreateProjectOptions) (*platform.Project2PCState, error) {
 	name := options.ProjectConfig.Meta.Name
 	namespace := options.ProjectConfig.Meta.Namespace
-	c.Logger.DebugWithCtx(ctx, "PrepareCreate received", "name", name, "new opID", options.OpID)
-
-	existProject, err := c.getProject(ctx, name, namespace)
+	existingProject, err := c.getProject(ctx, name, namespace)
 	if err != nil {
-		c.Logger.DebugWithCtx(ctx, "PrepareCreate failed to fetch project", "name", name, "new opID", options.OpID, "err", err.Error())
 		return nil, errors.Wrap(err, "Failed to prepare create")
 	}
 
-	// no CRD exists yet — this is the first time we see this existProject.
-	if existProject == nil {
-		c.Logger.DebugWithCtx(ctx, "PrepareCreate writing new project", "name", name, "new opID", options.OpID)
+	if existingProject == nil {
 		if err := c.writeFollowerProject(ctx, false, options.ProjectConfig, options.OpID, leaderCommon.OrisSyncStatusCreating); err != nil {
-			c.Logger.WarnWithCtx(ctx, "PrepareCreate failed to write project", "name", name, "new opID", options.OpID, "err", err.Error())
 			return nil, errors.Wrap(err, "Failed to prepare create")
 		}
-		c.Logger.DebugWithCtx(ctx, "PrepareCreate completed successfully", "name", name, "new opID", options.OpID)
+		c.Logger.DebugWithCtx(ctx, "completed successfully", "name", name, "opID", options.OpID)
 		return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusCreating)}, nil
 	}
 
-	currentOpID, currentStatus := c.extractProjectLabels(existProject)
-	c.Logger.DebugWithCtx(ctx, "PrepareCreate read current state", "name", name, "new opID", options.OpID,
-		"current opID", currentOpID, "currentStatus", currentStatus)
+	currentOpID, currentStatus := c.extractProjectLabels(existingProject)
 
-	// The CRD is already in the correct state — skip the write and return the existing state.
+	// Idempotency: the project already exists with this opID
 	if leaderCommon.IsOpIDEqual(currentOpID, options.OpID) {
-		c.Logger.DebugWithCtx(ctx, "PrepareCreate completed successfully", "name", name, "new opID", options.OpID)
+		c.Logger.DebugWithCtx(ctx, "opID already applied, considered as completed successfully", "name", name, "opID", options.OpID)
 		return &platform.Project2PCState{Name: name, OpID: currentOpID, SyncStatus: string(currentStatus)}, nil
 	}
 
 	if err := leaderCommon.RequireOpIDOrdered(options.OpID, currentOpID); err != nil {
-		c.Logger.DebugWithCtx(ctx, "PrepareCreate rejected: op_id older than stored", "name", name, "new opID", options.OpID, "current opID", currentOpID)
 		return nil, nuclio.GetByStatusCode(http.StatusConflict)(
-			fmt.Sprintf("Provision rejected: %s", err.Error()))
+			fmt.Sprintf("opID ordering check failed for project %q: %s", name, err.Error()))
 	}
 
-	// The incoming op_id is newer. If the CRD is still "creating" this is a recovery scenario:
-	// the leader abandoned the previous provision and is starting fresh with a new op_id.
-	// Allow the overwrite so the existProject is not stuck.
+	// The incoming opID is newer. If the project is still "creating" this is a recovery scenario:
+	// the leader abandoned the previous provision and is starting fresh with a new opID.
+	// Allow the overwrite so the existingProject is not stuck.
 	if currentStatus == leaderCommon.OrisSyncStatusCreating {
-		c.Logger.DebugWithCtx(ctx, "PrepareCreate overwriting abandoned provision", "name", name, "new opID", options.OpID, "current opID", currentOpID)
+		c.Logger.DebugWithCtx(ctx, "overwriting abandoned provision", "name", name, "opID", options.OpID, "currentOpID", currentOpID)
 		if err := c.writeFollowerProject(ctx, true, options.ProjectConfig, options.OpID, leaderCommon.OrisSyncStatusCreating); err != nil {
-			c.Logger.WarnWithCtx(ctx, "PrepareCreate failed to write project", "name", name, "new opID", options.OpID, "err", err.Error())
 			return nil, errors.Wrap(err, "Failed to prepare create")
 		}
-		c.Logger.DebugWithCtx(ctx, "PrepareCreate completed successfully", "name", name, "new opID", options.OpID)
+		c.Logger.DebugWithCtx(ctx, "completed successfully", "name", name, "opID", options.OpID)
 		return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusCreating)}, nil
 	}
 
-	// The op_id is newer, but the project isn't in "creating" state — it's already
+	// The opID is newer, but the project isn't in "creating" state — it's already
 	// provisioned (online or deleting) and cannot be re-provisioned.
-	c.Logger.DebugWithCtx(ctx, "PrepareCreate rejected: already provisioned", "name", name, "new opID", options.OpID, "currentStatus", currentStatus)
 	return nil, nuclio.GetByStatusCode(http.StatusConflict)(
-		fmt.Sprintf("Provision rejected: project already provisioned and not in creating state (state %q)", currentStatus))
+		fmt.Sprintf("opID is newer than stored opID, but project is not in creating state (opID %q, storedOpID %q, status %q)",
+			options.OpID, currentOpID, currentStatus))
 }
 
 // CommitCreate activates a provisioned project (2PC step 2): flips its sync-status from creating to online.
 func (c *Client) CommitCreate(ctx context.Context,
 	options *platform.CommitCreateProjectOptions) (*platform.Project2PCState, error) {
 	name := options.Meta.Name
-	c.Logger.DebugWithCtx(ctx, "CommitCreate received", "name", name, "new opID", options.OpID)
-
-	existing, err := c.getProject(ctx, name, options.Meta.Namespace)
+	existingProject, err := c.getProject(ctx, name, options.Meta.Namespace)
 	if err != nil {
-		c.Logger.DebugWithCtx(ctx, "CommitCreate failed to fetch project", "name", name, "new opID", options.OpID, "err", err.Error())
 		return nil, errors.Wrap(err, "Failed to commit create")
 	}
-	if existing == nil {
-		c.Logger.DebugWithCtx(ctx, "CommitCreate rejected: no CRD", "name", name, "new opID", options.OpID)
+	if existingProject == nil {
 		return nil, nuclio.GetByStatusCode(http.StatusPreconditionFailed)(
-			fmt.Sprintf("Commit rejected: project has no CRD, provision must run first (project %q)", name))
+			fmt.Sprintf("project does not exist, prepare create must run first (project %q)", name))
 	}
 
-	currentOpID, currentStatus := c.extractProjectLabels(existing)
-	c.Logger.DebugWithCtx(ctx, "CommitCreate read current state", "name", name, "new opID", options.OpID,
-		"current opID", currentOpID, "currentStatus", currentStatus)
+	currentOpID, currentStatus := c.extractProjectLabels(existingProject)
 	if err := leaderCommon.RequireOpIDMatch(options.OpID, currentOpID); err != nil {
-		c.Logger.DebugWithCtx(ctx, "CommitCreate rejected: op_id mismatch", "name", name, "new opID", options.OpID, "current opID", currentOpID)
-		return nil, nuclio.GetByStatusCode(http.StatusConflict)(fmt.Sprintf("Commit rejected: %s", err.Error()))
+		return nil, nuclio.GetByStatusCode(http.StatusConflict)(err.Error())
 	}
 
 	switch currentStatus {
 	case leaderCommon.OrisSyncStatusOnline:
-		// Idempotency: already online with this op_id — the commit was already applied.
-		c.Logger.DebugWithCtx(ctx, "CommitCreate idempotent: already applied", "name", name, "new opID", options.OpID, "current opID", currentOpID)
+		// Idempotency: already online with this opID — the commit was already applied.
+		c.Logger.DebugWithCtx(ctx, "project status is already online, considered as completed successfully",
+			"name", name, "opID", options.OpID, "current opID", currentOpID)
 		return &platform.Project2PCState{Name: name, OpID: currentOpID, SyncStatus: string(currentStatus)}, nil
 	case leaderCommon.OrisSyncStatusCreating:
 		// Expected state — fall through and complete the commit.
-		c.Logger.DebugWithCtx(ctx, "CommitCreate: project status is creating", "name", name, "new opID", options.OpID)
+		c.Logger.DebugWithCtx(ctx, "project status is creating, committing to online", "name", name, "opID", options.OpID)
 	default:
-		c.Logger.DebugWithCtx(ctx, "CommitCreate rejected: unexpected state", "name", name, "new opID", options.OpID, "currentStatus", currentStatus)
 		return nil, unexpectedStateError(http.StatusPreconditionFailed, name, currentStatus, leaderCommon.OrisSyncStatusCreating)
 	}
 
-	c.Logger.DebugWithCtx(ctx, "CommitCreate writing project online", "name", name, "new opID", options.OpID)
-	if err := c.updateFollowerProjectLabels(ctx, existing, options.OpID, leaderCommon.OrisSyncStatusOnline); err != nil {
-		c.Logger.WarnWithCtx(ctx, "CommitCreate failed to write project", "name", name, "new opID", options.OpID, "err", err.Error())
+	if err := c.updateFollowerProjectLabels(ctx, existingProject, options.OpID, leaderCommon.OrisSyncStatusOnline); err != nil {
 		return nil, errors.Wrap(err, "Failed to commit create")
 	}
-	c.Logger.DebugWithCtx(ctx, "CommitCreate completed successfully", "name", name, "new opID", options.OpID)
+	c.Logger.DebugWithCtx(ctx, "completed successfully", "name", name, "opID", options.OpID)
 	return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusOnline)}, nil
 }
 
@@ -294,52 +275,40 @@ func (c *Client) CommitCreate(ctx context.Context,
 func (c *Client) CommitUpdate(ctx context.Context,
 	options *platform.CommitUpdateProjectOptions) (*platform.Project2PCState, error) {
 	name := options.ProjectConfig.Meta.Name
-	c.Logger.DebugWithCtx(ctx, "CommitUpdate received", "name", name, "new opID", options.OpID, "prev opID", options.PrevOpID)
-
-	existing, err := c.getProject(ctx, name, options.ProjectConfig.Meta.Namespace)
+	existingProject, err := c.getProject(ctx, name, options.ProjectConfig.Meta.Namespace)
 	if err != nil {
-		c.Logger.DebugWithCtx(ctx, "CommitUpdate failed to fetch project", "name", name, "new opID", options.OpID, "err", err.Error())
 		return nil, errors.Wrap(err, "Failed to commit update")
 	}
-	if existing == nil {
-		c.Logger.DebugWithCtx(ctx, "CommitUpdate rejected: project not found", "name", name, "new opID", options.OpID)
+	if existingProject == nil {
 		return nil, nuclio.NewErrNotFound(fmt.Sprintf("Update rejected: project not found (project %q)", name))
 	}
 
-	currentOpID, currentStatus := c.extractProjectLabels(existing)
-	c.Logger.DebugWithCtx(ctx, "CommitUpdate read current state", "name", name, "new opID", options.OpID,
-		"current opID", currentOpID, "currentStatus", currentStatus)
+	currentOpID, currentStatus := c.extractProjectLabels(existingProject)
 
 	// "must be online" precondition by design
 	if currentStatus != leaderCommon.OrisSyncStatusOnline {
-		c.Logger.DebugWithCtx(ctx, "CommitUpdate rejected: unexpected state", "name", name, "new opID", options.OpID, "currentStatus", currentStatus)
 		return nil, unexpectedStateError(http.StatusPreconditionFailed, name, currentStatus, leaderCommon.OrisSyncStatusOnline)
 	}
 
 	// Idempotency: already applied — must be checked before CAS, since after a successful
-	// update the stored op_id has advanced past the request's PrevOpID.
+	// update the stored opID has advanced past the request's PrevOpID.
 	if leaderCommon.IsOpIDEqual(currentOpID, options.OpID) {
-		c.Logger.DebugWithCtx(ctx, "CommitUpdate idempotent: already applied", "name", name,
-			"new opID", options.OpID, "current opID", currentOpID)
+		c.Logger.DebugWithCtx(ctx, "opID already applied, considered as completed successfully",
+			"name", name, "opID", options.OpID, "current opID", currentOpID)
 		return &platform.Project2PCState{Name: name, OpID: currentOpID, SyncStatus: string(currentStatus)}, nil
 	}
 
 	if err := leaderCommon.RequireCASMatch(options.PrevOpID, currentOpID); err != nil {
-		c.Logger.DebugWithCtx(ctx, "CommitUpdate CAS check failed", "name", name, "new opID", options.OpID,
-			"prev opID", options.PrevOpID, "current opID", currentOpID, "err", err.Error())
 		return nil, errors.Wrap(err, "Update CAS check failed")
 	}
 	if err := leaderCommon.RequireOpIDOrdered(options.OpID, currentOpID); err != nil {
-		c.Logger.DebugWithCtx(ctx, "CommitUpdate rejected: op_id not newer than stored", "name", name, "new opID", options.OpID, "current opID", currentOpID)
-		return nil, nuclio.GetByStatusCode(http.StatusConflict)(fmt.Sprintf("Update rejected: %s", err.Error()))
+		return nil, nuclio.GetByStatusCode(http.StatusConflict)(fmt.Sprintf("opID ordering check failed for project %q: %s", name, err.Error()))
 	}
 
-	c.Logger.DebugWithCtx(ctx, "CommitUpdate writing project", "name", name, "new opID", options.OpID)
 	if err := c.writeFollowerProject(ctx, true, options.ProjectConfig, options.OpID, leaderCommon.OrisSyncStatusOnline); err != nil {
-		c.Logger.WarnWithCtx(ctx, "CommitUpdate failed to write project", "name", name, "new opID", options.OpID, "err", err.Error())
 		return nil, errors.Wrap(err, "Failed to commit update")
 	}
-	c.Logger.DebugWithCtx(ctx, "CommitUpdate completed successfully", "name", name, "new opID", options.OpID)
+	c.Logger.DebugWithCtx(ctx, "completed successfully", "name", name, "opID", options.OpID)
 	return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusOnline)}, nil
 }
 
@@ -347,64 +316,52 @@ func (c *Client) CommitUpdate(ctx context.Context,
 func (c *Client) PrepareDelete(ctx context.Context,
 	options *platform.PrepareDeleteProjectOptions) (*platform.Project2PCState, error) {
 	name := options.Meta.Name
-	c.Logger.DebugWithCtx(ctx, "PrepareDelete received", "name", name, "new opID", options.OpID, "prev opID", options.PrevOpID)
-
-	existing, err := c.getProject(ctx, name, options.Meta.Namespace)
+	existingProject, err := c.getProject(ctx, name, options.Meta.Namespace)
 	if err != nil {
-		c.Logger.DebugWithCtx(ctx, "PrepareDelete failed to fetch project", "name", name, "new opID", options.OpID, "err", err.Error())
 		return nil, errors.Wrap(err, "Failed to prepare delete")
 	}
 
-	// Idempotency: the CRD does not exist - no need to mark it deleting, the commit will be a no-op.
-	if existing == nil {
-		c.Logger.DebugWithCtx(ctx, "PrepareDelete completed successfully", "name", name, "new opID", options.OpID)
+	// Idempotency: the CRD does not exist - no need to mark it deleting, the commit delete will be a no-op.
+	if existingProject == nil {
+		c.Logger.DebugWithCtx(ctx, "project does not exist, considered as completed successfully", "name", name, "opID", options.OpID)
 		return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusDeleting)}, nil
 	}
 
-	currentOpID, currentStatus := c.extractProjectLabels(existing)
-	c.Logger.DebugWithCtx(ctx, "PrepareDelete read current state", "name", name,
-		"new opID", options.OpID, "current opID", currentOpID, "currentStatus", currentStatus)
+	currentOpID, currentStatus := c.extractProjectLabels(existingProject)
 
 	// Idempotency: this exact mark-delete already applied. Only a prior, successful call to
-	// this function could have stamped this op_id, so the status is guaranteed to be deleting.
+	// this function could have stamped this opID, so the status is guaranteed to be deleting.
 	if leaderCommon.IsOpIDEqual(currentOpID, options.OpID) {
-		c.Logger.DebugWithCtx(ctx, "PrepareDelete idempotent: already applied", "name", name, "new opID", options.OpID, "current opID", currentOpID)
+		c.Logger.DebugWithCtx(ctx, "opID with deleting status already applied, considered as completed successfully",
+			"name", name, "opID", options.OpID, "current opID", currentOpID)
 		return &platform.Project2PCState{Name: name, OpID: currentOpID, SyncStatus: string(currentStatus)}, nil
 	}
 
 	switch currentStatus {
 	case leaderCommon.OrisSyncStatusDeleting:
-		// Conflict: already deleting under a different op_id — a different delete is in
+		// Conflict: already deleting under a different opID — a different delete is in
 		// progress, must not be silently overwritten (mlrun's validateMarkDelete rejects the
 		// same way, rather than treating any in-progress delete as idempotent).
-		c.Logger.DebugWithCtx(ctx, "PrepareDelete rejected: different delete in progress", "name", name, "current opID", currentOpID, "new opID", options.OpID)
 		return nil, nuclio.GetByStatusCode(http.StatusConflict)(
-			fmt.Sprintf("Mark-delete rejected: different delete already in progress (requested %q, stored %q)",
-				options.OpID, currentOpID))
+			fmt.Sprintf("project status is already deleting under a different opID (current opID %q, opID %q)", currentOpID, options.OpID))
 	case leaderCommon.OrisSyncStatusOnline:
 		// Expected state — fall through and continue below.
-		c.Logger.DebugWithCtx(ctx, "PrepareDelete: project status is online", "name", name, "new opID", options.OpID)
+		c.Logger.DebugWithCtx(ctx, "project status is online, marking deleting", "name", name, "opID", options.OpID)
 	default:
-		c.Logger.DebugWithCtx(ctx, "PrepareDelete rejected: unexpected state", "name", name, "new opID", options.OpID, "currentStatus", currentStatus)
 		return nil, unexpectedStateError(http.StatusPreconditionFailed, name, currentStatus, leaderCommon.OrisSyncStatusOnline)
 	}
 
 	if err := leaderCommon.RequireCASMatch(options.PrevOpID, currentOpID); err != nil {
-		c.Logger.DebugWithCtx(ctx, "PrepareDelete CAS check failed", "name", name,
-			"current opID", currentOpID, "prev opID", options.PrevOpID, "err", err.Error())
-		return nil, errors.Wrap(err, "Mark-delete CAS check failed")
+		return nil, errors.Wrap(err, "CAS check failed")
 	}
 	if err := leaderCommon.RequireOpIDOrdered(options.OpID, currentOpID); err != nil {
-		c.Logger.DebugWithCtx(ctx, "PrepareDelete rejected: op_id not newer than stored", "name", name, "new opID", options.OpID, "current opID", currentOpID)
-		return nil, nuclio.GetByStatusCode(http.StatusConflict)(fmt.Sprintf("Mark-delete rejected: %s", err.Error()))
+		return nil, nuclio.GetByStatusCode(http.StatusConflict)(fmt.Sprintf("opID ordering check failed for project %q: %s", name, err.Error()))
 	}
 
-	c.Logger.DebugWithCtx(ctx, "PrepareDelete writing project deleting", "name", name, "new opID", options.OpID)
-	if err := c.updateFollowerProjectLabels(ctx, existing, options.OpID, leaderCommon.OrisSyncStatusDeleting); err != nil {
-		c.Logger.WarnWithCtx(ctx, "PrepareDelete failed to write project", "name", name, "new opID", options.OpID, "err", err.Error())
+	if err := c.updateFollowerProjectLabels(ctx, existingProject, options.OpID, leaderCommon.OrisSyncStatusDeleting); err != nil {
 		return nil, errors.Wrap(err, "Failed to prepare delete")
 	}
-	c.Logger.DebugWithCtx(ctx, "PrepareDelete completed successfully", "name", name, "new opID", options.OpID)
+	c.Logger.DebugWithCtx(ctx, "completed successfully", "name", name, "opID", options.OpID)
 	return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusDeleting)}, nil
 }
 
@@ -412,51 +369,38 @@ func (c *Client) PrepareDelete(ctx context.Context,
 func (c *Client) CommitDelete(ctx context.Context,
 	options *platform.CommitDeleteProjectOptions) (*platform.Project2PCState, error) {
 	name := options.Meta.Name
-	c.Logger.DebugWithCtx(ctx, "CommitDelete received", "name", name, "new opID", options.OpID)
-
-	existing, err := c.getProject(ctx, name, options.Meta.Namespace)
+	existingProject, err := c.getProject(ctx, name, options.Meta.Namespace)
 	if err != nil {
-		c.Logger.DebugWithCtx(ctx, "CommitDelete failed to fetch project", "name", name, "new opID", options.OpID, "err", err.Error())
 		return nil, errors.Wrap(err, "Failed to commit delete")
 	}
 
 	// Idempotency: already gone, a previous call already deleted it.
-	if existing == nil {
-		c.Logger.DebugWithCtx(ctx, "CommitDelete idempotent: already deleted", "name", name, "new opID", options.OpID)
+	if existingProject == nil {
+		c.Logger.DebugWithCtx(ctx, "project does not exist, considered as completed successfully", "name", name, "opID", options.OpID)
 		return &platform.Project2PCState{Name: name, OpID: options.OpID}, nil
 	}
 
-	currentOpID, currentStatus := c.extractProjectLabels(existing)
-	c.Logger.DebugWithCtx(ctx, "CommitDelete read current state", "name", name, "new opID", options.OpID,
-		"current opID", currentOpID, "currentStatus", currentStatus)
-
+	currentOpID, currentStatus := c.extractProjectLabels(existingProject)
 	if currentStatus != leaderCommon.OrisSyncStatusDeleting {
-		c.Logger.DebugWithCtx(ctx, "CommitDelete rejected: unexpected state", "name", name, "new opID", options.OpID, "currentStatus", currentStatus)
 		return nil, unexpectedStateError(http.StatusConflict, name, currentStatus, leaderCommon.OrisSyncStatusDeleting)
 	}
 	if err := leaderCommon.RequireOpIDMatch(options.OpID, currentOpID); err != nil {
-		c.Logger.DebugWithCtx(ctx, "CommitDelete rejected: op_id mismatch", "name", name, "new opID", options.OpID, "current opID", currentOpID)
-		return nil, nuclio.GetByStatusCode(http.StatusConflict)(fmt.Sprintf("Final-delete rejected: %s", err.Error()))
+		return nil, nuclio.GetByStatusCode(http.StatusConflict)(err.Error())
 	}
 
-	c.Logger.DebugWithCtx(ctx, "CommitDelete deleting project CRD", "name", name, "new opID", options.OpID)
 	if err := c.Delete(ctx, &platform.DeleteProjectOptions{Meta: options.Meta}); err != nil {
-		c.Logger.WarnWithCtx(ctx, "CommitDelete failed to delete project CRD", "name", name, "new opID", options.OpID, "err", err.Error())
-		return nil, errors.Wrap(err, "Failed to delete project CRD")
+		return nil, errors.Wrap(err, "Failed to delete project")
 	}
 
-	c.Logger.DebugWithCtx(ctx, "CommitDelete completed successfully", "name", name, "new opID", options.OpID)
+	c.Logger.DebugWithCtx(ctx, "completed successfully", "name", name, "opID", options.OpID)
 	return &platform.Project2PCState{Name: name, OpID: options.OpID}, nil
 }
 
 // List lists this follower's project states for the leader's reconciliation sweep.
 func (c *Client) List(ctx context.Context,
 	options *platform.ListProjectStatesOptions) (*platform.Project2PCStatesPage, error) {
-	c.Logger.DebugWithCtx(ctx, "List received", "namespace", options.Namespace, "cursor", options.Cursor, "limit", options.Limit)
-
 	projects, err := c.Get(ctx, &platform.GetProjectsOptions{Meta: platform.ProjectMeta{Namespace: options.Namespace}})
 	if err != nil {
-		c.Logger.DebugWithCtx(ctx, "List failed to fetch projects", "namespace", options.Namespace, "err", err.Error())
 		return nil, errors.Wrap(err, "Failed to list projects")
 	}
 
@@ -501,7 +445,6 @@ func (c *Client) List(ctx context.Context,
 		nextCursor = states[len(states)-1].Name
 	}
 
-	c.Logger.DebugWithCtx(ctx, "List returning page", "namespace", options.Namespace, "count", len(states), "nextCursor", nextCursor)
 	return &platform.Project2PCStatesPage{States: states, NextCursor: nextCursor}, nil
 }
 
@@ -541,7 +484,7 @@ func (c *Client) getProject(ctx context.Context, name, namespace string) (platfo
 	return projects[0], nil
 }
 
-// extractProjectLabels reads the op_id and oris/sync-status labels off an existing CRD.
+// extractProjectLabels reads the opID and oris/sync-status labels off an existing CRD.
 func (c *Client) extractProjectLabels(existing platform.Project) (currentOpID string, syncStatus leaderCommon.OrisSyncStatus) {
 	labels := existing.GetConfig().Meta.Labels
 	currentOpID = labels[leaderCommon.OrisLabelKeyOpID]
@@ -553,22 +496,14 @@ func (c *Client) extractProjectLabels(existing platform.Project) (currentOpID st
 	return currentOpID, leaderCommon.OrisSyncStatusOnline
 }
 
-// unexpectedStateError builds the error returned when a project's currentStatus is not the
-// expectedStatus for the operation being attempted.
-func unexpectedStateError(statusCode int, name string, currentStatus, expectedStatus leaderCommon.OrisSyncStatus) error {
-	return nuclio.GetByStatusCode(statusCode)(
-		fmt.Sprintf("project is in unexpected state (project %q, state %q, expected %q)",
-			name, currentStatus, expectedStatus))
-}
-
-// writeFollowerProject creates or updates the project CRD, stamped with the given op_id/sync-status labels.
+// writeFollowerProject creates or updates the project CRD, stamped with the given opID/sync-status labels.
 func (c *Client) writeFollowerProject(ctx context.Context, isUpdate bool,
 	projectConfig platform.ProjectConfig, opID string, syncStatus leaderCommon.OrisSyncStatus) error {
 	projectConfig.Meta.Labels = c.stampFollowerLabels(projectConfig.Meta.Labels, opID, syncStatus)
 
 	if isUpdate {
 		_, err := c.Update(ctx, &platform.UpdateProjectOptions{ProjectConfig: projectConfig})
-		return errors.Wrap(err, "Failed to update project CRD")
+		return errors.Wrap(err, "Failed to update project")
 	}
 
 	// Update always stamps UpdatedAt itself; Create doesn't, so stamp it here too, keeping
@@ -576,10 +511,10 @@ func (c *Client) writeFollowerProject(ctx context.Context, isUpdate bool,
 	now := time.Now()
 	projectConfig.Status.UpdatedAt = &now
 	_, err := c.Create(ctx, &platform.CreateProjectOptions{ProjectConfig: &projectConfig})
-	return errors.Wrap(err, "Failed to create project CRD")
+	return errors.Wrap(err, "Failed to create project")
 }
 
-// updateFollowerProjectLabels re-writes an existing project's full config with only its op_id/
+// updateFollowerProjectLabels re-writes an existing project's full config with only its opID/
 // sync-status labels advanced, leaving Spec and every other label/annotation untouched.
 func (c *Client) updateFollowerProjectLabels(ctx context.Context, existing platform.Project,
 	opID string, syncStatus leaderCommon.OrisSyncStatus) error {
@@ -591,7 +526,7 @@ func (c *Client) updateFollowerProjectLabels(ctx context.Context, existing platf
 	// Update replaces Spec/Labels/Annotations/Status wholesale rather than merging, so this must start
 	// from the existing CRD's full ProjectConfig, not a labels-only partial one.
 	_, err := c.Update(ctx, &platform.UpdateProjectOptions{ProjectConfig: projectConfig})
-	return errors.Wrap(err, "Failed to update project CRD")
+	return errors.Wrap(err, "Failed to update project")
 }
 
 // stampFollowerLabels returns a copy of labels with the oris/* 2PC labels set to opID/
@@ -604,4 +539,12 @@ func (c *Client) stampFollowerLabels(labels map[string]string, opID string, sync
 	stamped[leaderCommon.OrisLabelKeyOpID] = opID
 	stamped[leaderCommon.OrisLabelKeySyncStatus] = string(syncStatus)
 	return stamped
+}
+
+// unexpectedStateError builds the error returned when a project's currentStatus is not the
+// expectedStatus for the operation being attempted.
+func unexpectedStateError(statusCode int, name string, currentStatus, expectedStatus leaderCommon.OrisSyncStatus) error {
+	return nuclio.GetByStatusCode(statusCode)(
+		fmt.Sprintf("project is in unexpected state (project %q, state %q, expected %q)",
+			name, currentStatus, expectedStatus))
 }

--- a/pkg/platform/abstract/project/internalc/kube/kube.go
+++ b/pkg/platform/abstract/project/internalc/kube/kube.go
@@ -211,7 +211,7 @@ func (c *Client) PrepareCreate(ctx context.Context,
 		"current opID", currentOpID, "currentStatus", currentStatus)
 
 	// The CRD is already in the correct state — skip the write and return the existing state.
-	if currentOpID == options.OpID {
+	if leaderCommon.IsOpIDEqual(currentOpID, options.OpID) {
 		c.Logger.DebugWithCtx(ctx, "PrepareCreate completed successfully", "name", name, "new opID", options.OpID)
 		return &platform.Project2PCState{Name: name, OpID: currentOpID, SyncStatus: string(currentStatus)}, nil
 	}
@@ -318,7 +318,7 @@ func (c *Client) CommitUpdate(ctx context.Context,
 
 	// Idempotency: already applied — must be checked before CAS, since after a successful
 	// update the stored op_id has advanced past the request's PrevOpID.
-	if currentOpID == options.OpID {
+	if leaderCommon.IsOpIDEqual(currentOpID, options.OpID) {
 		c.Logger.DebugWithCtx(ctx, "CommitUpdate idempotent: already applied", "name", name,
 			"new opID", options.OpID, "current opID", currentOpID)
 		return &platform.Project2PCState{Name: name, OpID: currentOpID, SyncStatus: string(currentStatus)}, nil
@@ -367,7 +367,7 @@ func (c *Client) PrepareDelete(ctx context.Context,
 
 	// Idempotency: this exact mark-delete already applied. Only a prior, successful call to
 	// this function could have stamped this op_id, so the status is guaranteed to be deleting.
-	if currentOpID == options.OpID {
+	if leaderCommon.IsOpIDEqual(currentOpID, options.OpID) {
 		c.Logger.DebugWithCtx(ctx, "PrepareDelete idempotent: already applied", "name", name, "new opID", options.OpID, "current opID", currentOpID)
 		return &platform.Project2PCState{Name: name, OpID: currentOpID, SyncStatus: string(currentStatus)}, nil
 	}

--- a/pkg/platform/abstract/project/internalc/kube/kube.go
+++ b/pkg/platform/abstract/project/internalc/kube/kube.go
@@ -297,7 +297,7 @@ func (c *Client) CommitCreate(ctx context.Context,
 func (c *Client) CommitUpdate(ctx context.Context,
 	options *platform.CommitUpdateProjectOptions) (*platform.Project2PCState, error) {
 	name := options.ProjectConfig.Meta.Name
-	c.Logger.DebugWithCtx(ctx, "CommitUpdate received", "name", name, "new opID", options.OpID, "new opID", options.PrevOpID)
+	c.Logger.DebugWithCtx(ctx, "CommitUpdate received", "name", name, "new opID", options.OpID, "prev opID", options.PrevOpID)
 
 	existing, err := c.getProject(ctx, name, options.ProjectConfig.Meta.Namespace)
 	if err != nil {
@@ -331,7 +331,7 @@ func (c *Client) CommitUpdate(ctx context.Context,
 
 	if err := leaderCommon.RequireCASMatch(currentOpID, options.PrevOpID); err != nil {
 		c.Logger.DebugWithCtx(ctx, "CommitUpdate CAS check failed", "name", name, "new opID", options.OpID,
-			"new opID", options.PrevOpID, "current opID", currentOpID, "err", err.Error())
+			"prev opID", options.PrevOpID, "current opID", currentOpID, "err", err.Error())
 		return nil, errors.Wrap(err, "Update CAS check failed")
 	}
 	if !leaderCommon.IsOpIDOrdered(options.OpID, currentOpID) {
@@ -353,7 +353,7 @@ func (c *Client) CommitUpdate(ctx context.Context,
 func (c *Client) PrepareDelete(ctx context.Context,
 	options *platform.PrepareDeleteProjectOptions) (*platform.Project2PCState, error) {
 	name := options.Meta.Name
-	c.Logger.DebugWithCtx(ctx, "PrepareDelete received", "name", name, "new opID", options.OpID, "new opID", options.PrevOpID)
+	c.Logger.DebugWithCtx(ctx, "PrepareDelete received", "name", name, "new opID", options.OpID, "prev opID", options.PrevOpID)
 
 	existing, err := c.getProject(ctx, name, options.Meta.Namespace)
 	if err != nil {
@@ -399,7 +399,7 @@ func (c *Client) PrepareDelete(ctx context.Context,
 
 	if err := leaderCommon.RequireCASMatch(currentOpID, options.PrevOpID); err != nil {
 		c.Logger.DebugWithCtx(ctx, "PrepareDelete CAS check failed", "name", name,
-			"current opID", currentOpID, "new OpID", options.PrevOpID, "err", err.Error())
+			"current opID", currentOpID, "prev opID", options.PrevOpID, "err", err.Error())
 		return nil, errors.Wrap(err, "Mark-delete CAS check failed")
 	}
 	if !leaderCommon.IsOpIDOrdered(options.OpID, currentOpID) {

--- a/pkg/platform/abstract/project/internalc/kube/kube.go
+++ b/pkg/platform/abstract/project/internalc/kube/kube.go
@@ -196,7 +196,7 @@ func (c *Client) PrepareCreate(ctx context.Context,
 		if err := c.writeFollowerProject(ctx, false, options.ProjectConfig, options.OpID, leaderCommon.OrisSyncStatusCreating); err != nil {
 			return nil, errors.Wrap(err, "Failed to prepare create")
 		}
-		c.Logger.DebugWithCtx(ctx, "completed successfully", "name", name, "opID", options.OpID)
+		c.Logger.DebugWithCtx(ctx, "Successfully prepared project for creation", "name", name, "opID", options.OpID)
 		return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusCreating)}, nil
 	}
 
@@ -204,7 +204,7 @@ func (c *Client) PrepareCreate(ctx context.Context,
 
 	// Idempotency: the project already exists with this opID
 	if leaderCommon.IsOpIDEqual(currentOpID, options.OpID) {
-		c.Logger.DebugWithCtx(ctx, "opID already applied, considered as completed successfully", "name", name, "opID", options.OpID)
+		c.Logger.DebugWithCtx(ctx, "OpID already applied, considered as completed successfully", "name", name, "opID", options.OpID)
 		return &platform.Project2PCState{Name: name, OpID: currentOpID, SyncStatus: string(currentStatus)}, nil
 	}
 
@@ -217,11 +217,11 @@ func (c *Client) PrepareCreate(ctx context.Context,
 	// the leader abandoned the previous provision and is starting fresh with a new opID.
 	// Allow the overwrite so the existingProject is not stuck.
 	if currentStatus == leaderCommon.OrisSyncStatusCreating {
-		c.Logger.DebugWithCtx(ctx, "overwriting abandoned provision", "name", name, "opID", options.OpID, "currentOpID", currentOpID)
+		c.Logger.DebugWithCtx(ctx, "Overwriting abandoned provision", "name", name, "opID", options.OpID, "currentOpID", currentOpID)
 		if err := c.writeFollowerProject(ctx, true, options.ProjectConfig, options.OpID, leaderCommon.OrisSyncStatusCreating); err != nil {
 			return nil, errors.Wrap(err, "Failed to prepare create")
 		}
-		c.Logger.DebugWithCtx(ctx, "completed successfully", "name", name, "opID", options.OpID)
+		c.Logger.DebugWithCtx(ctx, "Successfully prepared project for creation", "name", name, "opID", options.OpID)
 		return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusCreating)}, nil
 	}
 
@@ -253,12 +253,12 @@ func (c *Client) CommitCreate(ctx context.Context,
 	switch currentStatus {
 	case leaderCommon.OrisSyncStatusOnline:
 		// Idempotency: already online with this opID — the commit was already applied.
-		c.Logger.DebugWithCtx(ctx, "project status is already online, considered as completed successfully",
-			"name", name, "opID", options.OpID, "current opID", currentOpID)
+		c.Logger.DebugWithCtx(ctx, "Project status is already online, considered as completed successfully",
+			"name", name, "opID", options.OpID, "currentOpID", currentOpID)
 		return &platform.Project2PCState{Name: name, OpID: currentOpID, SyncStatus: string(currentStatus)}, nil
 	case leaderCommon.OrisSyncStatusCreating:
 		// Expected state — fall through and complete the commit.
-		c.Logger.DebugWithCtx(ctx, "project status is creating, committing to online", "name", name, "opID", options.OpID)
+		c.Logger.DebugWithCtx(ctx, "Project status is creating, committing to online", "name", name, "opID", options.OpID)
 	default:
 		return nil, unexpectedStateError(http.StatusPreconditionFailed, name, currentStatus, leaderCommon.OrisSyncStatusCreating)
 	}
@@ -266,7 +266,7 @@ func (c *Client) CommitCreate(ctx context.Context,
 	if err := c.updateFollowerProjectLabels(ctx, existingProject, options.OpID, leaderCommon.OrisSyncStatusOnline); err != nil {
 		return nil, errors.Wrap(err, "Failed to commit create")
 	}
-	c.Logger.DebugWithCtx(ctx, "completed successfully", "name", name, "opID", options.OpID)
+	c.Logger.DebugWithCtx(ctx, "Successfully committed project creation", "name", name, "opID", options.OpID)
 	return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusOnline)}, nil
 }
 
@@ -293,8 +293,8 @@ func (c *Client) CommitUpdate(ctx context.Context,
 	// Idempotency: already applied — must be checked before CAS, since after a successful
 	// update the stored opID has advanced past the request's PrevOpID.
 	if leaderCommon.IsOpIDEqual(currentOpID, options.OpID) {
-		c.Logger.DebugWithCtx(ctx, "opID already applied, considered as completed successfully",
-			"name", name, "opID", options.OpID, "current opID", currentOpID)
+		c.Logger.DebugWithCtx(ctx, "OpID already applied, considered as completed successfully",
+			"name", name, "opID", options.OpID, "currentOpID", currentOpID)
 		return &platform.Project2PCState{Name: name, OpID: currentOpID, SyncStatus: string(currentStatus)}, nil
 	}
 
@@ -308,7 +308,7 @@ func (c *Client) CommitUpdate(ctx context.Context,
 	if err := c.writeFollowerProject(ctx, true, options.ProjectConfig, options.OpID, leaderCommon.OrisSyncStatusOnline); err != nil {
 		return nil, errors.Wrap(err, "Failed to commit update")
 	}
-	c.Logger.DebugWithCtx(ctx, "completed successfully", "name", name, "opID", options.OpID)
+	c.Logger.DebugWithCtx(ctx, "Successfully committed project update", "name", name, "opID", options.OpID)
 	return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusOnline)}, nil
 }
 
@@ -323,7 +323,7 @@ func (c *Client) PrepareDelete(ctx context.Context,
 
 	// Idempotency: the CRD does not exist - no need to mark it deleting, the commit delete will be a no-op.
 	if existingProject == nil {
-		c.Logger.DebugWithCtx(ctx, "project does not exist, considered as completed successfully", "name", name, "opID", options.OpID)
+		c.Logger.DebugWithCtx(ctx, "Project does not exist, considered as completed successfully", "name", name, "opID", options.OpID)
 		return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusDeleting)}, nil
 	}
 
@@ -332,8 +332,8 @@ func (c *Client) PrepareDelete(ctx context.Context,
 	// Idempotency: this exact mark-delete already applied. Only a prior, successful call to
 	// this function could have stamped this opID, so the status is guaranteed to be deleting.
 	if leaderCommon.IsOpIDEqual(currentOpID, options.OpID) {
-		c.Logger.DebugWithCtx(ctx, "opID with deleting status already applied, considered as completed successfully",
-			"name", name, "opID", options.OpID, "current opID", currentOpID)
+		c.Logger.DebugWithCtx(ctx, "OpID with deleting status already applied, considered as completed successfully",
+			"name", name, "opID", options.OpID, "currentOpID", currentOpID)
 		return &platform.Project2PCState{Name: name, OpID: currentOpID, SyncStatus: string(currentStatus)}, nil
 	}
 
@@ -346,7 +346,7 @@ func (c *Client) PrepareDelete(ctx context.Context,
 			fmt.Sprintf("project status is already deleting under a different opID (current opID %q, opID %q)", currentOpID, options.OpID))
 	case leaderCommon.OrisSyncStatusOnline:
 		// Expected state — fall through and continue below.
-		c.Logger.DebugWithCtx(ctx, "project status is online, marking deleting", "name", name, "opID", options.OpID)
+		c.Logger.DebugWithCtx(ctx, "Project status is online, marking deleting", "name", name, "opID", options.OpID)
 	default:
 		return nil, unexpectedStateError(http.StatusPreconditionFailed, name, currentStatus, leaderCommon.OrisSyncStatusOnline)
 	}
@@ -361,7 +361,7 @@ func (c *Client) PrepareDelete(ctx context.Context,
 	if err := c.updateFollowerProjectLabels(ctx, existingProject, options.OpID, leaderCommon.OrisSyncStatusDeleting); err != nil {
 		return nil, errors.Wrap(err, "Failed to prepare delete")
 	}
-	c.Logger.DebugWithCtx(ctx, "completed successfully", "name", name, "opID", options.OpID)
+	c.Logger.DebugWithCtx(ctx, "Successfully prepared project for deletion", "name", name, "opID", options.OpID)
 	return &platform.Project2PCState{Name: name, OpID: options.OpID, SyncStatus: string(leaderCommon.OrisSyncStatusDeleting)}, nil
 }
 
@@ -376,7 +376,7 @@ func (c *Client) CommitDelete(ctx context.Context,
 
 	// Idempotency: already gone, a previous call already deleted it.
 	if existingProject == nil {
-		c.Logger.DebugWithCtx(ctx, "project does not exist, considered as completed successfully", "name", name, "opID", options.OpID)
+		c.Logger.DebugWithCtx(ctx, "Project does not exist, considered as completed successfully", "name", name, "opID", options.OpID)
 		return &platform.Project2PCState{Name: name, OpID: options.OpID}, nil
 	}
 
@@ -392,7 +392,7 @@ func (c *Client) CommitDelete(ctx context.Context,
 		return nil, errors.Wrap(err, "Failed to delete project")
 	}
 
-	c.Logger.DebugWithCtx(ctx, "completed successfully", "name", name, "opID", options.OpID)
+	c.Logger.DebugWithCtx(ctx, "Successfully committed project deletion", "name", name, "opID", options.OpID)
 	return &platform.Project2PCState{Name: name, OpID: options.OpID}, nil
 }
 

--- a/pkg/platform/abstract/project/internalc/kube/kube.go
+++ b/pkg/platform/abstract/project/internalc/kube/kube.go
@@ -216,10 +216,10 @@ func (c *Client) PrepareCreate(ctx context.Context,
 		return &platform.Project2PCState{Name: name, OpID: currentOpID, SyncStatus: string(currentStatus)}, nil
 	}
 
-	if !leaderCommon.IsOpIDOrdered(options.OpID, currentOpID) {
+	if err := leaderCommon.RequireOpIDOrdered(options.OpID, currentOpID); err != nil {
 		c.Logger.DebugWithCtx(ctx, "PrepareCreate rejected: op_id older than stored", "name", name, "new opID", options.OpID, "current opID", currentOpID)
 		return nil, nuclio.GetByStatusCode(http.StatusConflict)(
-			fmt.Sprintf("Provision rejected: op_id is older than stored op_id (requested %q, stored %q)", options.OpID, currentOpID))
+			fmt.Sprintf("Provision rejected: %s", err.Error()))
 	}
 
 	// The incoming op_id is newer. If the CRD is still "creating" this is a recovery scenario:
@@ -262,10 +262,9 @@ func (c *Client) CommitCreate(ctx context.Context,
 	currentOpID, currentStatus := c.extractProjectLabels(existing)
 	c.Logger.DebugWithCtx(ctx, "CommitCreate read current state", "name", name, "new opID", options.OpID,
 		"current opID", currentOpID, "currentStatus", currentStatus)
-	if currentOpID != options.OpID {
+	if err := leaderCommon.RequireOpIDMatch(options.OpID, currentOpID); err != nil {
 		c.Logger.DebugWithCtx(ctx, "CommitCreate rejected: op_id mismatch", "name", name, "new opID", options.OpID, "current opID", currentOpID)
-		return nil, nuclio.GetByStatusCode(http.StatusConflict)(
-			fmt.Sprintf("Commit rejected: op_id mismatch (requested %q, stored %q)", options.OpID, currentOpID))
+		return nil, nuclio.GetByStatusCode(http.StatusConflict)(fmt.Sprintf("Commit rejected: %s", err.Error()))
 	}
 
 	switch currentStatus {
@@ -278,9 +277,7 @@ func (c *Client) CommitCreate(ctx context.Context,
 		c.Logger.DebugWithCtx(ctx, "CommitCreate: project status is creating", "name", name, "new opID", options.OpID)
 	default:
 		c.Logger.DebugWithCtx(ctx, "CommitCreate rejected: unexpected state", "name", name, "new opID", options.OpID, "currentStatus", currentStatus)
-		return nil, nuclio.GetByStatusCode(http.StatusPreconditionFailed)(
-			fmt.Sprintf("Commit rejected: project is in unexpected state (project %q, state %q, expected %q)",
-				name, currentStatus, leaderCommon.OrisSyncStatusCreating))
+		return nil, unexpectedStateError(http.StatusPreconditionFailed, name, currentStatus, leaderCommon.OrisSyncStatusCreating)
 	}
 
 	c.Logger.DebugWithCtx(ctx, "CommitCreate writing project online", "name", name, "new opID", options.OpID)
@@ -316,9 +313,7 @@ func (c *Client) CommitUpdate(ctx context.Context,
 	// "must be online" precondition by design
 	if currentStatus != leaderCommon.OrisSyncStatusOnline {
 		c.Logger.DebugWithCtx(ctx, "CommitUpdate rejected: unexpected state", "name", name, "new opID", options.OpID, "currentStatus", currentStatus)
-		return nil, nuclio.GetByStatusCode(http.StatusPreconditionFailed)(
-			fmt.Sprintf("Update rejected: project is in unexpected state (project %q, state %q, expected %q)",
-				name, currentStatus, leaderCommon.OrisSyncStatusOnline))
+		return nil, unexpectedStateError(http.StatusPreconditionFailed, name, currentStatus, leaderCommon.OrisSyncStatusOnline)
 	}
 
 	// Idempotency: already applied — must be checked before CAS, since after a successful
@@ -329,15 +324,14 @@ func (c *Client) CommitUpdate(ctx context.Context,
 		return &platform.Project2PCState{Name: name, OpID: currentOpID, SyncStatus: string(currentStatus)}, nil
 	}
 
-	if err := leaderCommon.RequireCASMatch(currentOpID, options.PrevOpID); err != nil {
+	if err := leaderCommon.RequireCASMatch(options.PrevOpID, currentOpID); err != nil {
 		c.Logger.DebugWithCtx(ctx, "CommitUpdate CAS check failed", "name", name, "new opID", options.OpID,
 			"prev opID", options.PrevOpID, "current opID", currentOpID, "err", err.Error())
 		return nil, errors.Wrap(err, "Update CAS check failed")
 	}
-	if !leaderCommon.IsOpIDOrdered(options.OpID, currentOpID) {
+	if err := leaderCommon.RequireOpIDOrdered(options.OpID, currentOpID); err != nil {
 		c.Logger.DebugWithCtx(ctx, "CommitUpdate rejected: op_id not newer than stored", "name", name, "new opID", options.OpID, "current opID", currentOpID)
-		return nil, nuclio.GetByStatusCode(http.StatusConflict)(
-			fmt.Sprintf("Update rejected: op_id is not newer than stored op_id (requested %q, stored %q)", options.OpID, currentOpID))
+		return nil, nuclio.GetByStatusCode(http.StatusConflict)(fmt.Sprintf("Update rejected: %s", err.Error()))
 	}
 
 	c.Logger.DebugWithCtx(ctx, "CommitUpdate writing project", "name", name, "new opID", options.OpID)
@@ -392,20 +386,17 @@ func (c *Client) PrepareDelete(ctx context.Context,
 		c.Logger.DebugWithCtx(ctx, "PrepareDelete: project status is online", "name", name, "new opID", options.OpID)
 	default:
 		c.Logger.DebugWithCtx(ctx, "PrepareDelete rejected: unexpected state", "name", name, "new opID", options.OpID, "currentStatus", currentStatus)
-		return nil, nuclio.GetByStatusCode(http.StatusPreconditionFailed)(
-			fmt.Sprintf("Mark-delete rejected: project is in unexpected state (project %q, state %q, expected %q)",
-				name, currentStatus, leaderCommon.OrisSyncStatusOnline))
+		return nil, unexpectedStateError(http.StatusPreconditionFailed, name, currentStatus, leaderCommon.OrisSyncStatusOnline)
 	}
 
-	if err := leaderCommon.RequireCASMatch(currentOpID, options.PrevOpID); err != nil {
+	if err := leaderCommon.RequireCASMatch(options.PrevOpID, currentOpID); err != nil {
 		c.Logger.DebugWithCtx(ctx, "PrepareDelete CAS check failed", "name", name,
 			"current opID", currentOpID, "prev opID", options.PrevOpID, "err", err.Error())
 		return nil, errors.Wrap(err, "Mark-delete CAS check failed")
 	}
-	if !leaderCommon.IsOpIDOrdered(options.OpID, currentOpID) {
+	if err := leaderCommon.RequireOpIDOrdered(options.OpID, currentOpID); err != nil {
 		c.Logger.DebugWithCtx(ctx, "PrepareDelete rejected: op_id not newer than stored", "name", name, "new opID", options.OpID, "current opID", currentOpID)
-		return nil, nuclio.GetByStatusCode(http.StatusConflict)(
-			fmt.Sprintf("Mark-delete rejected: op_id is not newer than stored op_id (requested %q, stored %q)", options.OpID, currentOpID))
+		return nil, nuclio.GetByStatusCode(http.StatusConflict)(fmt.Sprintf("Mark-delete rejected: %s", err.Error()))
 	}
 
 	c.Logger.DebugWithCtx(ctx, "PrepareDelete writing project deleting", "name", name, "new opID", options.OpID)
@@ -441,14 +432,11 @@ func (c *Client) CommitDelete(ctx context.Context,
 
 	if currentStatus != leaderCommon.OrisSyncStatusDeleting {
 		c.Logger.DebugWithCtx(ctx, "CommitDelete rejected: unexpected state", "name", name, "new opID", options.OpID, "currentStatus", currentStatus)
-		return nil, nuclio.GetByStatusCode(http.StatusConflict)(
-			fmt.Sprintf("Final-delete rejected: project is in unexpected state (project %q, state %q, expected %q)",
-				name, currentStatus, leaderCommon.OrisSyncStatusDeleting))
+		return nil, unexpectedStateError(http.StatusConflict, name, currentStatus, leaderCommon.OrisSyncStatusDeleting)
 	}
-	if currentOpID != options.OpID {
+	if err := leaderCommon.RequireOpIDMatch(options.OpID, currentOpID); err != nil {
 		c.Logger.DebugWithCtx(ctx, "CommitDelete rejected: op_id mismatch", "name", name, "new opID", options.OpID, "current opID", currentOpID)
-		return nil, nuclio.GetByStatusCode(http.StatusConflict)(
-			fmt.Sprintf("Final-delete rejected: op_id mismatch (requested %q, stored %q)", options.OpID, currentOpID))
+		return nil, nuclio.GetByStatusCode(http.StatusConflict)(fmt.Sprintf("Final-delete rejected: %s", err.Error()))
 	}
 
 	c.Logger.DebugWithCtx(ctx, "CommitDelete deleting project CRD", "name", name, "new opID", options.OpID)
@@ -563,6 +551,14 @@ func (c *Client) extractProjectLabels(existing platform.Project) (currentOpID st
 	// absent sync-status label means the CRD pre-dates this follower surface — treated as
 	// "online", the same convention MLRun's evaluator uses for its own legacy labels.
 	return currentOpID, leaderCommon.OrisSyncStatusOnline
+}
+
+// unexpectedStateError builds the error returned when a project's currentStatus is not the
+// expectedStatus for the operation being attempted.
+func unexpectedStateError(statusCode int, name string, currentStatus, expectedStatus leaderCommon.OrisSyncStatus) error {
+	return nuclio.GetByStatusCode(statusCode)(
+		fmt.Sprintf("project is in unexpected state (project %q, state %q, expected %q)",
+			name, currentStatus, expectedStatus))
 }
 
 // writeFollowerProject creates or updates the project CRD, stamped with the given op_id/sync-status labels.

--- a/pkg/platform/abstract/project/internalc/kube/kube_test.go
+++ b/pkg/platform/abstract/project/internalc/kube/kube_test.go
@@ -118,35 +118,16 @@ func (suite *FollowerTestSuite) TestPrepareCreate() {
 		},
 	} {
 		suite.Run(testCase.name, func() {
-			mockClient := &nuclioclientmock.Client{}
-			var getErr error
-			if testCase.existing == nil {
-				getErr = apierrors.NewNotFound(schema.GroupResource{}, testProject)
-			}
-			mockClient.On("GetNuclioProject", mock.Anything, testNamespace, testProject).Return(testCase.existing, getErr)
-			if testCase.mockWrites != nil {
-				testCase.mockWrites(mockClient)
-			}
-
-			client := suite.newClient(mockClient)
-			state, err := client.PrepareCreate(context.TODO(), &platform.PrepareCreateProjectOptions{
-				ProjectConfig: platform.ProjectConfig{
-					Meta: platform.ProjectMeta{Name: testProject, Namespace: testNamespace},
-					Spec: platform.ProjectSpec{Owner: testCase.owner},
-				},
-				OpID: testCase.opID,
-			})
-
-			if testCase.expectedError {
-				suite.Require().Error(err)
-				var statusErr nuclio.WithStatusCode
-				suite.Require().True(errors.As(err, &statusErr))
-				suite.Require().Equal(testCase.expectedCode, statusErr.StatusCode())
-			} else {
-				suite.Require().NoError(err)
-				suite.Require().Equal(testCase.expectedState, state)
-			}
-			mockClient.AssertExpectations(suite.T())
+			suite.runFollowerTestCase(testCase.existing, testCase.mockWrites, testCase.expectedError, testCase.expectedCode, testCase.expectedState,
+				func(client project.Client) (*platform.Project2PCState, error) {
+					return client.PrepareCreate(context.TODO(), &platform.PrepareCreateProjectOptions{
+						ProjectConfig: platform.ProjectConfig{
+							Meta: platform.ProjectMeta{Name: testProject, Namespace: testNamespace},
+							Spec: platform.ProjectSpec{Owner: testCase.owner},
+						},
+						OpID: testCase.opID,
+					})
+				})
 		})
 	}
 }
@@ -194,32 +175,13 @@ func (suite *FollowerTestSuite) TestCommitCreate() {
 		},
 	} {
 		suite.Run(testCase.name, func() {
-			mockClient := &nuclioclientmock.Client{}
-			var getErr error
-			if testCase.existing == nil {
-				getErr = apierrors.NewNotFound(schema.GroupResource{}, testProject)
-			}
-			mockClient.On("GetNuclioProject", mock.Anything, testNamespace, testProject).Return(testCase.existing, getErr)
-			if testCase.mockWrites != nil {
-				testCase.mockWrites(mockClient)
-			}
-
-			client := suite.newClient(mockClient)
-			state, err := client.CommitCreate(context.TODO(), &platform.CommitCreateProjectOptions{
-				Meta: platform.ProjectMeta{Name: testProject, Namespace: testNamespace},
-				OpID: testCase.opID,
-			})
-
-			if testCase.expectedError {
-				suite.Require().Error(err)
-				var statusErr nuclio.WithStatusCode
-				suite.Require().True(errors.As(err, &statusErr))
-				suite.Require().Equal(testCase.expectedCode, statusErr.StatusCode())
-			} else {
-				suite.Require().NoError(err)
-				suite.Require().Equal(testCase.expectedState, state)
-			}
-			mockClient.AssertExpectations(suite.T())
+			suite.runFollowerTestCase(testCase.existing, testCase.mockWrites, testCase.expectedError, testCase.expectedCode, testCase.expectedState,
+				func(client project.Client) (*platform.Project2PCState, error) {
+					return client.CommitCreate(context.TODO(), &platform.CommitCreateProjectOptions{
+						Meta: platform.ProjectMeta{Name: testProject, Namespace: testNamespace},
+						OpID: testCase.opID,
+					})
+				})
 		})
 	}
 }
@@ -263,6 +225,7 @@ func (suite *FollowerTestSuite) TestCommitUpdate() {
 			opID:          "op-1",
 			prevOpID:      "",
 			expectedError: true,
+			expectedCode:  404,
 		},
 		{
 			name:          "RejectedOnCASMismatch",
@@ -282,38 +245,17 @@ func (suite *FollowerTestSuite) TestCommitUpdate() {
 		},
 	} {
 		suite.Run(testCase.name, func() {
-			mockClient := &nuclioclientmock.Client{}
-			var getErr error
-			if testCase.existing == nil {
-				getErr = apierrors.NewNotFound(schema.GroupResource{}, testProject)
-			}
-			mockClient.On("GetNuclioProject", mock.Anything, testNamespace, testProject).Return(testCase.existing, getErr)
-			if testCase.mockWrites != nil {
-				testCase.mockWrites(mockClient)
-			}
-
-			client := suite.newClient(mockClient)
-			state, err := client.CommitUpdate(context.TODO(), &platform.CommitUpdateProjectOptions{
-				ProjectConfig: platform.ProjectConfig{
-					Meta: platform.ProjectMeta{Name: testProject, Namespace: testNamespace},
-					Spec: platform.ProjectSpec{Owner: testCase.owner},
-				},
-				OpID:     testCase.opID,
-				PrevOpID: testCase.prevOpID,
-			})
-
-			if testCase.expectedError {
-				suite.Require().Error(err)
-				if testCase.expectedCode != 0 {
-					var statusErr nuclio.WithStatusCode
-					suite.Require().True(errors.As(err, &statusErr))
-					suite.Require().Equal(testCase.expectedCode, statusErr.StatusCode())
-				}
-			} else {
-				suite.Require().NoError(err)
-				suite.Require().Equal(testCase.expectedState, state)
-			}
-			mockClient.AssertExpectations(suite.T())
+			suite.runFollowerTestCase(testCase.existing, testCase.mockWrites, testCase.expectedError, testCase.expectedCode, testCase.expectedState,
+				func(client project.Client) (*platform.Project2PCState, error) {
+					return client.CommitUpdate(context.TODO(), &platform.CommitUpdateProjectOptions{
+						ProjectConfig: platform.ProjectConfig{
+							Meta: platform.ProjectMeta{Name: testProject, Namespace: testNamespace},
+							Spec: platform.ProjectSpec{Owner: testCase.owner},
+						},
+						OpID:     testCase.opID,
+						PrevOpID: testCase.prevOpID,
+					})
+				})
 		})
 	}
 }
@@ -372,33 +314,14 @@ func (suite *FollowerTestSuite) TestPrepareDelete() {
 		},
 	} {
 		suite.Run(testCase.name, func() {
-			mockClient := &nuclioclientmock.Client{}
-			var getErr error
-			if testCase.existing == nil {
-				getErr = apierrors.NewNotFound(schema.GroupResource{}, testProject)
-			}
-			mockClient.On("GetNuclioProject", mock.Anything, testNamespace, testProject).Return(testCase.existing, getErr)
-			if testCase.mockWrites != nil {
-				testCase.mockWrites(mockClient)
-			}
-
-			client := suite.newClient(mockClient)
-			state, err := client.PrepareDelete(context.TODO(), &platform.PrepareDeleteProjectOptions{
-				Meta:     platform.ProjectMeta{Name: testProject, Namespace: testNamespace},
-				OpID:     testCase.opID,
-				PrevOpID: testCase.prevOpID,
-			})
-
-			if testCase.expectedError {
-				suite.Require().Error(err)
-				var statusErr nuclio.WithStatusCode
-				suite.Require().True(errors.As(err, &statusErr))
-				suite.Require().Equal(testCase.expectedCode, statusErr.StatusCode())
-			} else {
-				suite.Require().NoError(err)
-				suite.Require().Equal(testCase.expectedState, state)
-			}
-			mockClient.AssertExpectations(suite.T())
+			suite.runFollowerTestCase(testCase.existing, testCase.mockWrites, testCase.expectedError, testCase.expectedCode, testCase.expectedState,
+				func(client project.Client) (*platform.Project2PCState, error) {
+					return client.PrepareDelete(context.TODO(), &platform.PrepareDeleteProjectOptions{
+						Meta:     platform.ProjectMeta{Name: testProject, Namespace: testNamespace},
+						OpID:     testCase.opID,
+						PrevOpID: testCase.prevOpID,
+					})
+				})
 		})
 	}
 }
@@ -443,32 +366,13 @@ func (suite *FollowerTestSuite) TestCommitDelete() {
 		},
 	} {
 		suite.Run(testCase.name, func() {
-			mockClient := &nuclioclientmock.Client{}
-			var getErr error
-			if testCase.existing == nil {
-				getErr = apierrors.NewNotFound(schema.GroupResource{}, testProject)
-			}
-			mockClient.On("GetNuclioProject", mock.Anything, testNamespace, testProject).Return(testCase.existing, getErr)
-			if testCase.mockWrites != nil {
-				testCase.mockWrites(mockClient)
-			}
-
-			client := suite.newClient(mockClient)
-			state, err := client.CommitDelete(context.TODO(), &platform.CommitDeleteProjectOptions{
-				Meta: platform.ProjectMeta{Name: testProject, Namespace: testNamespace},
-				OpID: testCase.opID,
-			})
-
-			if testCase.expectedError {
-				suite.Require().Error(err)
-				var statusErr nuclio.WithStatusCode
-				suite.Require().True(errors.As(err, &statusErr))
-				suite.Require().Equal(testCase.expectedCode, statusErr.StatusCode())
-			} else {
-				suite.Require().NoError(err)
-				suite.Require().Equal(testCase.expectedState, state)
-			}
-			mockClient.AssertExpectations(suite.T())
+			suite.runFollowerTestCase(testCase.existing, testCase.mockWrites, testCase.expectedError, testCase.expectedCode, testCase.expectedState,
+				func(client project.Client) (*platform.Project2PCState, error) {
+					return client.CommitDelete(context.TODO(), &platform.CommitDeleteProjectOptions{
+						Meta: platform.ProjectMeta{Name: testProject, Namespace: testNamespace},
+						OpID: testCase.opID,
+					})
+				})
 		})
 	}
 }
@@ -536,6 +440,41 @@ func (suite *FollowerTestSuite) TestList() {
 }
 
 // --- test helpers (private, below public functions) ---
+
+// runFollowerTestCase runs the mock setup, method invocation, and assertions shared by every
+// follower 2PC test (TestPrepareCreate/TestCommitCreate/TestCommitUpdate/TestPrepareDelete/
+// TestCommitDelete): it wires GetNuclioProject and mockWrites into a fresh mock client, invokes
+// call with the resulting client, and asserts the expected error/state. Only the client call
+// under test varies between those five.
+func (suite *FollowerTestSuite) runFollowerTestCase(existingProject *nuclioio.NuclioProject,
+	mockWrites func(*nuclioclientmock.Client), expectedError bool, expectedCode int,
+	expectedState *platform.Project2PCState, call func(project.Client) (*platform.Project2PCState, error)) {
+
+	mockClient := &nuclioclientmock.Client{}
+	var getErr error
+	if existingProject == nil {
+		getErr = apierrors.NewNotFound(schema.GroupResource{}, testProject)
+	}
+	mockClient.On("GetNuclioProject", mock.Anything, testNamespace, testProject).Return(existingProject, getErr)
+	if mockWrites != nil {
+		mockWrites(mockClient)
+	}
+
+	state, err := call(suite.newClient(mockClient))
+
+	if expectedError {
+		suite.Require().Error(err)
+		if expectedCode != 0 {
+			var statusErr nuclio.WithStatusCode
+			suite.Require().True(errors.As(err, &statusErr))
+			suite.Require().Equal(expectedCode, statusErr.StatusCode())
+		}
+	} else {
+		suite.Require().NoError(err)
+		suite.Require().Equal(expectedState, state)
+	}
+	mockClient.AssertExpectations(suite.T())
+}
 
 // newClient builds a follower Client backed by the given mock.
 func (suite *FollowerTestSuite) newClient(nuclioClientSet nuclioclient.Client) project.Client {

--- a/pkg/platform/abstract/project/internalc/kube/kube_test.go
+++ b/pkg/platform/abstract/project/internalc/kube/kube_test.go
@@ -1,0 +1,571 @@
+//go:build test_unit
+
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nuclio/nuclio/pkg/platform"
+	"github.com/nuclio/nuclio/pkg/platform/abstract/project"
+	leaderCommon "github.com/nuclio/nuclio/pkg/platform/abstract/project/external/leader"
+	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+	nuclioclient "github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio"
+	nuclioclientmock "github.com/nuclio/nuclio/pkg/platform/kube/clients/nuclio/mock"
+
+	"github.com/nuclio/logger"
+	nuclio "github.com/nuclio/nuclio-sdk-go"
+	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	testNamespace = "test-namespace"
+	testProject   = "test-project"
+)
+
+var testUpdatedAt = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+type FollowerTestSuite struct {
+	suite.Suite
+	logger logger.Logger
+}
+
+func (suite *FollowerTestSuite) SetupSuite() {
+	var err error
+	suite.logger, err = nucliozap.NewNuclioZapTest("test-internalc-kube")
+	suite.Require().NoError(err)
+}
+
+func (suite *FollowerTestSuite) TestPrepareCreate() {
+	for _, testCase := range []struct {
+		name          string
+		existing      *nuclioio.NuclioProject
+		mockWrites    func(*nuclioclientmock.Client)
+		opID          string
+		owner         string
+		expectedState *platform.Project2PCState
+		expectedError bool
+		expectedCode  int
+	}{
+		{
+			name: "HappyPathCreatesCRD",
+			mockWrites: func(m *nuclioclientmock.Client) {
+				m.On("CreateNuclioProject", mock.Anything, testNamespace, mock.MatchedBy(func(p *nuclioio.NuclioProject) bool {
+					return p.Labels[leaderCommon.OrisLabelKeyOpID] == "op-1" &&
+						p.Labels[leaderCommon.OrisLabelKeySyncStatus] == string(leaderCommon.OrisSyncStatusCreating) &&
+						p.Status.UpdatedAt != nil
+				})).Return(&nuclioio.NuclioProject{}, nil).Once()
+			},
+			opID:          "op-1",
+			expectedState: &platform.Project2PCState{Name: testProject, OpID: "op-1", SyncStatus: "creating"},
+		},
+		{
+			name:          "IdempotentReplaySameOpID",
+			existing:      newProjectFixture("op-1", leaderCommon.OrisSyncStatusCreating),
+			opID:          "op-1",
+			expectedState: &platform.Project2PCState{Name: testProject, OpID: "op-1", SyncStatus: "creating"},
+		},
+		{
+			name:          "OlderOpIDRejected",
+			existing:      newProjectFixture("op-2", leaderCommon.OrisSyncStatusCreating),
+			opID:          "op-1",
+			expectedError: true,
+			expectedCode:  409,
+		},
+		{
+			name:     "RecoversAbandonedProvisionWithNewerOpID",
+			existing: newProjectFixture("op-1", leaderCommon.OrisSyncStatusCreating),
+			mockWrites: func(m *nuclioclientmock.Client) {
+				m.On("UpdateNuclioProject", mock.Anything, testNamespace, mock.MatchedBy(func(p *nuclioio.NuclioProject) bool {
+					return p.Labels[leaderCommon.OrisLabelKeyOpID] == "op-2" &&
+						p.Labels[leaderCommon.OrisLabelKeySyncStatus] == string(leaderCommon.OrisSyncStatusCreating) &&
+						p.Spec.Owner == "second-attempt"
+				})).Return(&nuclioio.NuclioProject{}, nil).Once()
+			},
+			opID:          "op-2",
+			owner:         "second-attempt",
+			expectedState: &platform.Project2PCState{Name: testProject, OpID: "op-2", SyncStatus: "creating"},
+		},
+		{
+			name:          "RejectedWhenAlreadyOnline",
+			existing:      newProjectFixture("op-1", leaderCommon.OrisSyncStatusOnline),
+			opID:          "op-2",
+			expectedError: true,
+			expectedCode:  409,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			mockClient := &nuclioclientmock.Client{}
+			var getErr error
+			if testCase.existing == nil {
+				getErr = apierrors.NewNotFound(schema.GroupResource{}, testProject)
+			}
+			mockClient.On("GetNuclioProject", mock.Anything, testNamespace, testProject).Return(testCase.existing, getErr)
+			if testCase.mockWrites != nil {
+				testCase.mockWrites(mockClient)
+			}
+
+			client := suite.newClient(mockClient)
+			state, err := client.PrepareCreate(context.TODO(), &platform.PrepareCreateProjectOptions{
+				ProjectConfig: platform.ProjectConfig{
+					Meta: platform.ProjectMeta{Name: testProject, Namespace: testNamespace},
+					Spec: platform.ProjectSpec{Owner: testCase.owner},
+				},
+				OpID: testCase.opID,
+			})
+
+			if testCase.expectedError {
+				suite.Require().Error(err)
+				var statusErr nuclio.WithStatusCode
+				suite.Require().True(errors.As(err, &statusErr))
+				suite.Require().Equal(testCase.expectedCode, statusErr.StatusCode())
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(testCase.expectedState, state)
+			}
+			mockClient.AssertExpectations(suite.T())
+		})
+	}
+}
+
+func (suite *FollowerTestSuite) TestCommitCreate() {
+	for _, testCase := range []struct {
+		name          string
+		existing      *nuclioio.NuclioProject
+		mockWrites    func(*nuclioclientmock.Client)
+		opID          string
+		expectedState *platform.Project2PCState
+		expectedError bool
+		expectedCode  int
+	}{
+		{
+			name:     "HappyPathFlipsToOnline",
+			existing: newProjectFixture("op-1", leaderCommon.OrisSyncStatusCreating),
+			mockWrites: func(m *nuclioclientmock.Client) {
+				m.On("UpdateNuclioProject", mock.Anything, testNamespace, mock.MatchedBy(func(p *nuclioio.NuclioProject) bool {
+					return p.Labels[leaderCommon.OrisLabelKeyOpID] == "op-1" &&
+						p.Labels[leaderCommon.OrisLabelKeySyncStatus] == string(leaderCommon.OrisSyncStatusOnline)
+				})).Return(&nuclioio.NuclioProject{}, nil).Once()
+			},
+			opID:          "op-1",
+			expectedState: &platform.Project2PCState{Name: testProject, OpID: "op-1", SyncStatus: "online"},
+		},
+		{
+			name:          "IdempotentReplay",
+			existing:      newProjectFixture("op-1", leaderCommon.OrisSyncStatusOnline),
+			opID:          "op-1",
+			expectedState: &platform.Project2PCState{Name: testProject, OpID: "op-1", SyncStatus: "online"},
+		},
+		{
+			name:          "RejectedWhenNoCRD",
+			opID:          "op-1",
+			expectedError: true,
+			expectedCode:  412,
+		},
+		{
+			name:          "RejectedOnOpIDMismatch",
+			existing:      newProjectFixture("op-1", leaderCommon.OrisSyncStatusCreating),
+			opID:          "op-2",
+			expectedError: true,
+			expectedCode:  409,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			mockClient := &nuclioclientmock.Client{}
+			var getErr error
+			if testCase.existing == nil {
+				getErr = apierrors.NewNotFound(schema.GroupResource{}, testProject)
+			}
+			mockClient.On("GetNuclioProject", mock.Anything, testNamespace, testProject).Return(testCase.existing, getErr)
+			if testCase.mockWrites != nil {
+				testCase.mockWrites(mockClient)
+			}
+
+			client := suite.newClient(mockClient)
+			state, err := client.CommitCreate(context.TODO(), &platform.CommitCreateProjectOptions{
+				Meta: platform.ProjectMeta{Name: testProject, Namespace: testNamespace},
+				OpID: testCase.opID,
+			})
+
+			if testCase.expectedError {
+				suite.Require().Error(err)
+				var statusErr nuclio.WithStatusCode
+				suite.Require().True(errors.As(err, &statusErr))
+				suite.Require().Equal(testCase.expectedCode, statusErr.StatusCode())
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(testCase.expectedState, state)
+			}
+			mockClient.AssertExpectations(suite.T())
+		})
+	}
+}
+
+func (suite *FollowerTestSuite) TestCommitUpdate() {
+	for _, testCase := range []struct {
+		name          string
+		existing      *nuclioio.NuclioProject
+		mockWrites    func(*nuclioclientmock.Client)
+		owner         string
+		opID          string
+		prevOpID      string
+		expectedState *platform.Project2PCState
+		expectedError bool
+		expectedCode  int
+	}{
+		{
+			name:     "HappyPathAdvancesSpecAndOpID",
+			existing: newProjectFixture("op-1", leaderCommon.OrisSyncStatusOnline),
+			mockWrites: func(m *nuclioclientmock.Client) {
+				m.On("UpdateNuclioProject", mock.Anything, testNamespace, mock.MatchedBy(func(p *nuclioio.NuclioProject) bool {
+					return p.Labels[leaderCommon.OrisLabelKeyOpID] == "op-2" &&
+						p.Labels[leaderCommon.OrisLabelKeySyncStatus] == string(leaderCommon.OrisSyncStatusOnline) &&
+						p.Spec.Owner == "new-owner"
+				})).Return(&nuclioio.NuclioProject{}, nil).Once()
+			},
+			owner:         "new-owner",
+			opID:          "op-2",
+			prevOpID:      "op-1",
+			expectedState: &platform.Project2PCState{Name: testProject, OpID: "op-2", SyncStatus: "online"},
+		},
+		{
+			name:          "IdempotentReplay",
+			existing:      newProjectFixture("op-2", leaderCommon.OrisSyncStatusOnline),
+			opID:          "op-2",
+			prevOpID:      "op-1",
+			expectedState: &platform.Project2PCState{Name: testProject, OpID: "op-2", SyncStatus: "online"},
+		},
+		{
+			name:          "RejectedWhenNotFound",
+			opID:          "op-1",
+			prevOpID:      "",
+			expectedError: true,
+		},
+		{
+			name:          "RejectedOnCASMismatch",
+			existing:      newProjectFixture("op-1", leaderCommon.OrisSyncStatusOnline),
+			opID:          "op-2",
+			prevOpID:      "wrong-prev-op",
+			expectedError: true,
+			expectedCode:  409,
+		},
+		{
+			name:          "RejectedOnStaleOpIDOrdering",
+			existing:      newProjectFixture("op-2", leaderCommon.OrisSyncStatusOnline),
+			opID:          "op-1",
+			prevOpID:      "op-2",
+			expectedError: true,
+			expectedCode:  409,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			mockClient := &nuclioclientmock.Client{}
+			var getErr error
+			if testCase.existing == nil {
+				getErr = apierrors.NewNotFound(schema.GroupResource{}, testProject)
+			}
+			mockClient.On("GetNuclioProject", mock.Anything, testNamespace, testProject).Return(testCase.existing, getErr)
+			if testCase.mockWrites != nil {
+				testCase.mockWrites(mockClient)
+			}
+
+			client := suite.newClient(mockClient)
+			state, err := client.CommitUpdate(context.TODO(), &platform.CommitUpdateProjectOptions{
+				ProjectConfig: platform.ProjectConfig{
+					Meta: platform.ProjectMeta{Name: testProject, Namespace: testNamespace},
+					Spec: platform.ProjectSpec{Owner: testCase.owner},
+				},
+				OpID:     testCase.opID,
+				PrevOpID: testCase.prevOpID,
+			})
+
+			if testCase.expectedError {
+				suite.Require().Error(err)
+				if testCase.expectedCode != 0 {
+					var statusErr nuclio.WithStatusCode
+					suite.Require().True(errors.As(err, &statusErr))
+					suite.Require().Equal(testCase.expectedCode, statusErr.StatusCode())
+				}
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(testCase.expectedState, state)
+			}
+			mockClient.AssertExpectations(suite.T())
+		})
+	}
+}
+
+func (suite *FollowerTestSuite) TestPrepareDelete() {
+	for _, testCase := range []struct {
+		name          string
+		existing      *nuclioio.NuclioProject
+		mockWrites    func(*nuclioclientmock.Client)
+		opID          string
+		prevOpID      string
+		expectedState *platform.Project2PCState
+		expectedError bool
+		expectedCode  int
+	}{
+		{
+			name:          "IdempotentWhenAlreadyGone",
+			opID:          "op-1",
+			expectedState: &platform.Project2PCState{Name: testProject, OpID: "op-1", SyncStatus: "deleting"},
+		},
+		{
+			name:     "HappyPathFlipsToDeleting",
+			existing: newProjectFixture("op-1", leaderCommon.OrisSyncStatusOnline),
+			mockWrites: func(m *nuclioclientmock.Client) {
+				m.On("UpdateNuclioProject", mock.Anything, testNamespace, mock.MatchedBy(func(p *nuclioio.NuclioProject) bool {
+					return p.Labels[leaderCommon.OrisLabelKeyOpID] == "op-2" &&
+						p.Labels[leaderCommon.OrisLabelKeySyncStatus] == string(leaderCommon.OrisSyncStatusDeleting)
+				})).Return(&nuclioio.NuclioProject{}, nil).Once()
+			},
+			opID:          "op-2",
+			prevOpID:      "op-1",
+			expectedState: &platform.Project2PCState{Name: testProject, OpID: "op-2", SyncStatus: "deleting"},
+		},
+		{
+			name:          "IdempotentReplaySameOpID",
+			existing:      newProjectFixture("op-2", leaderCommon.OrisSyncStatusDeleting),
+			opID:          "op-2",
+			prevOpID:      "op-1",
+			expectedState: &platform.Project2PCState{Name: testProject, OpID: "op-2", SyncStatus: "deleting"},
+		},
+		{
+			name:          "ConflictOnDifferentConcurrentDelete",
+			existing:      newProjectFixture("op-2", leaderCommon.OrisSyncStatusDeleting),
+			opID:          "op-3",
+			prevOpID:      "op-1",
+			expectedError: true,
+			expectedCode:  409,
+		},
+		{
+			name:          "RejectedOnCASMismatch",
+			existing:      newProjectFixture("op-1", leaderCommon.OrisSyncStatusOnline),
+			opID:          "op-2",
+			prevOpID:      "wrong-prev-op",
+			expectedError: true,
+			expectedCode:  409,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			mockClient := &nuclioclientmock.Client{}
+			var getErr error
+			if testCase.existing == nil {
+				getErr = apierrors.NewNotFound(schema.GroupResource{}, testProject)
+			}
+			mockClient.On("GetNuclioProject", mock.Anything, testNamespace, testProject).Return(testCase.existing, getErr)
+			if testCase.mockWrites != nil {
+				testCase.mockWrites(mockClient)
+			}
+
+			client := suite.newClient(mockClient)
+			state, err := client.PrepareDelete(context.TODO(), &platform.PrepareDeleteProjectOptions{
+				Meta:     platform.ProjectMeta{Name: testProject, Namespace: testNamespace},
+				OpID:     testCase.opID,
+				PrevOpID: testCase.prevOpID,
+			})
+
+			if testCase.expectedError {
+				suite.Require().Error(err)
+				var statusErr nuclio.WithStatusCode
+				suite.Require().True(errors.As(err, &statusErr))
+				suite.Require().Equal(testCase.expectedCode, statusErr.StatusCode())
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(testCase.expectedState, state)
+			}
+			mockClient.AssertExpectations(suite.T())
+		})
+	}
+}
+
+func (suite *FollowerTestSuite) TestCommitDelete() {
+	for _, testCase := range []struct {
+		name          string
+		existing      *nuclioio.NuclioProject
+		mockWrites    func(*nuclioclientmock.Client)
+		opID          string
+		expectedState *platform.Project2PCState
+		expectedError bool
+		expectedCode  int
+	}{
+		{
+			name:          "IdempotentWhenAlreadyGone",
+			opID:          "op-1",
+			expectedState: &platform.Project2PCState{Name: testProject, OpID: "op-1"},
+		},
+		{
+			name:     "HappyPathRemovesCRD",
+			existing: newProjectFixture("op-2", leaderCommon.OrisSyncStatusDeleting),
+			mockWrites: func(m *nuclioclientmock.Client) {
+				m.On("DeleteNuclioProject", mock.Anything, testNamespace, testProject, metav1.DeleteOptions{}).Return(nil).Once()
+			},
+			opID:          "op-2",
+			expectedState: &platform.Project2PCState{Name: testProject, OpID: "op-2"},
+		},
+		{
+			name:          "RejectedWhenNotInDeletingState",
+			existing:      newProjectFixture("op-1", leaderCommon.OrisSyncStatusOnline),
+			opID:          "op-1",
+			expectedError: true,
+			expectedCode:  409,
+		},
+		{
+			name:          "RejectedOnOpIDMismatch",
+			existing:      newProjectFixture("op-2", leaderCommon.OrisSyncStatusDeleting),
+			opID:          "op-3",
+			expectedError: true,
+			expectedCode:  409,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			mockClient := &nuclioclientmock.Client{}
+			var getErr error
+			if testCase.existing == nil {
+				getErr = apierrors.NewNotFound(schema.GroupResource{}, testProject)
+			}
+			mockClient.On("GetNuclioProject", mock.Anything, testNamespace, testProject).Return(testCase.existing, getErr)
+			if testCase.mockWrites != nil {
+				testCase.mockWrites(mockClient)
+			}
+
+			client := suite.newClient(mockClient)
+			state, err := client.CommitDelete(context.TODO(), &platform.CommitDeleteProjectOptions{
+				Meta: platform.ProjectMeta{Name: testProject, Namespace: testNamespace},
+				OpID: testCase.opID,
+			})
+
+			if testCase.expectedError {
+				suite.Require().Error(err)
+				var statusErr nuclio.WithStatusCode
+				suite.Require().True(errors.As(err, &statusErr))
+				suite.Require().Equal(testCase.expectedCode, statusErr.StatusCode())
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(testCase.expectedState, state)
+			}
+			mockClient.AssertExpectations(suite.T())
+		})
+	}
+}
+
+func (suite *FollowerTestSuite) TestList() {
+	for _, testCase := range []struct {
+		name      string
+		listItems []nuclioio.NuclioProject
+		run       func(client project.Client)
+	}{
+		{
+			name: "FiltersSortsAndPages",
+			listItems: []nuclioio.NuclioProject{
+				*namedProjectFixture("proj-a", "op-1", leaderCommon.OrisSyncStatusCreating),
+				*namedProjectFixture("proj-b", "op-1", leaderCommon.OrisSyncStatusCreating),
+				*namedProjectFixture("proj-c", "op-1", leaderCommon.OrisSyncStatusCreating),
+			},
+			run: func(client project.Client) {
+				firstPage, err := client.List(context.TODO(), &platform.ListProjectStatesOptions{
+					Namespace: testNamespace,
+					Limit:     2,
+				})
+				suite.Require().NoError(err)
+				suite.Require().Len(firstPage.States, 2)
+				suite.Require().Equal("proj-a", firstPage.States[0].Name)
+				suite.Require().Equal("proj-b", firstPage.States[1].Name)
+				suite.Require().Equal("proj-b", firstPage.NextCursor)
+
+				secondPage, err := client.List(context.TODO(), &platform.ListProjectStatesOptions{
+					Namespace: testNamespace,
+					Cursor:    firstPage.NextCursor,
+					Limit:     2,
+				})
+				suite.Require().NoError(err)
+				suite.Require().Len(secondPage.States, 1)
+				suite.Require().Equal("proj-c", secondPage.States[0].Name)
+				suite.Require().Empty(secondPage.NextCursor)
+			},
+		},
+		{
+			name:      "FiltersByUpdatedAfter",
+			listItems: []nuclioio.NuclioProject{*newProjectFixture("op-1", leaderCommon.OrisSyncStatusCreating)},
+			run: func(client project.Client) {
+				cutoff := testUpdatedAt.Add(time.Hour)
+				page, err := client.List(context.TODO(), &platform.ListProjectStatesOptions{
+					Namespace:    testNamespace,
+					UpdatedAfter: &cutoff,
+				})
+				suite.Require().NoError(err)
+				suite.Require().Empty(page.States)
+			},
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			mockClient := &nuclioclientmock.Client{}
+			mockClient.On("ListNuclioProjects", mock.Anything, testNamespace, metav1.ListOptions{}).
+				Return(&nuclioio.NuclioProjectList{Items: testCase.listItems}, nil)
+
+			client := suite.newClient(mockClient)
+			testCase.run(client)
+
+			mockClient.AssertExpectations(suite.T())
+		})
+	}
+}
+
+// --- test helpers (private, below public functions) ---
+
+// newClient builds a follower Client backed by the given mock.
+func (suite *FollowerTestSuite) newClient(nuclioClientSet nuclioclient.Client) project.Client {
+	client, err := NewClient(suite.logger, nil, &nuclioclient.Consumer{NuclioClientSet: nuclioClientSet})
+	suite.Require().NoError(err)
+	return client
+}
+
+// namedProjectFixture builds an in-memory NuclioProject stamped with the given op_id/sync-status
+// labels, used only as mock return data - it is never persisted anywhere.
+func namedProjectFixture(name, opID string, syncStatus leaderCommon.OrisSyncStatus) *nuclioio.NuclioProject {
+	return &nuclioio.NuclioProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				leaderCommon.OrisLabelKeyOpID:       opID,
+				leaderCommon.OrisLabelKeySyncStatus: string(syncStatus),
+			},
+		},
+		Status: platform.ProjectStatus{UpdatedAt: &testUpdatedAt},
+	}
+}
+
+// newProjectFixture is namedProjectFixture for testProject, the name every test case but
+// TestList's FiltersSortsAndPages uses.
+func newProjectFixture(opID string, syncStatus leaderCommon.OrisSyncStatus) *nuclioio.NuclioProject {
+	return namedProjectFixture(testProject, opID, syncStatus)
+}
+
+func TestFollowerTestSuite(t *testing.T) {
+	suite.Run(t, new(FollowerTestSuite))
+}

--- a/pkg/platform/kube/clients/nuclio/mock/client.go
+++ b/pkg/platform/kube/clients/nuclio/mock/client.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mock
+
+import (
+	"context"
+
+	nuclioio "github.com/nuclio/nuclio/pkg/platform/kube/apis/nuclio.io/v1beta1"
+
+	"github.com/stretchr/testify/mock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Client mocks nuclioclient.Client.
+type Client struct {
+	mock.Mock
+}
+
+func (c *Client) GetNuclioFunction(ctx context.Context, namespace, name string) (*nuclioio.NuclioFunction, error) {
+	args := c.Called(ctx, namespace, name)
+	function, _ := args.Get(0).(*nuclioio.NuclioFunction)
+	return function, args.Error(1)
+}
+
+func (c *Client) ListNuclioFunctions(ctx context.Context, namespace string, opts metav1.ListOptions) (*nuclioio.NuclioFunctionList, error) {
+	args := c.Called(ctx, namespace, opts)
+	list, _ := args.Get(0).(*nuclioio.NuclioFunctionList)
+	return list, args.Error(1)
+}
+
+func (c *Client) CreateNuclioFunction(ctx context.Context, namespace string, function *nuclioio.NuclioFunction) (*nuclioio.NuclioFunction, error) {
+	args := c.Called(ctx, namespace, function)
+	created, _ := args.Get(0).(*nuclioio.NuclioFunction)
+	return created, args.Error(1)
+}
+
+func (c *Client) UpdateNuclioFunction(ctx context.Context, namespace string, function *nuclioio.NuclioFunction) (*nuclioio.NuclioFunction, error) {
+	args := c.Called(ctx, namespace, function)
+	updated, _ := args.Get(0).(*nuclioio.NuclioFunction)
+	return updated, args.Error(1)
+}
+
+func (c *Client) DeleteNuclioFunction(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
+	args := c.Called(ctx, namespace, name, opts)
+	return args.Error(0)
+}
+
+func (c *Client) GetNuclioProject(ctx context.Context, namespace, name string) (*nuclioio.NuclioProject, error) {
+	args := c.Called(ctx, namespace, name)
+	project, _ := args.Get(0).(*nuclioio.NuclioProject)
+	return project, args.Error(1)
+}
+
+func (c *Client) ListNuclioProjects(ctx context.Context, namespace string, opts metav1.ListOptions) (*nuclioio.NuclioProjectList, error) {
+	args := c.Called(ctx, namespace, opts)
+	list, _ := args.Get(0).(*nuclioio.NuclioProjectList)
+	return list, args.Error(1)
+}
+
+func (c *Client) CreateNuclioProject(ctx context.Context, namespace string, project *nuclioio.NuclioProject) (*nuclioio.NuclioProject, error) {
+	args := c.Called(ctx, namespace, project)
+	created, _ := args.Get(0).(*nuclioio.NuclioProject)
+	return created, args.Error(1)
+}
+
+func (c *Client) UpdateNuclioProject(ctx context.Context, namespace string, project *nuclioio.NuclioProject) (*nuclioio.NuclioProject, error) {
+	args := c.Called(ctx, namespace, project)
+	updated, _ := args.Get(0).(*nuclioio.NuclioProject)
+	return updated, args.Error(1)
+}
+
+func (c *Client) DeleteNuclioProject(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
+	args := c.Called(ctx, namespace, name, opts)
+	return args.Error(0)
+}
+
+func (c *Client) GetNuclioAPIGateway(ctx context.Context, namespace, name string) (*nuclioio.NuclioAPIGateway, error) {
+	args := c.Called(ctx, namespace, name)
+	apiGateway, _ := args.Get(0).(*nuclioio.NuclioAPIGateway)
+	return apiGateway, args.Error(1)
+}
+
+func (c *Client) ListNuclioAPIGateways(ctx context.Context, namespace string, opts metav1.ListOptions) (*nuclioio.NuclioAPIGatewayList, error) {
+	args := c.Called(ctx, namespace, opts)
+	list, _ := args.Get(0).(*nuclioio.NuclioAPIGatewayList)
+	return list, args.Error(1)
+}
+
+func (c *Client) CreateNuclioAPIGateway(ctx context.Context, namespace string, apiGateway *nuclioio.NuclioAPIGateway) (*nuclioio.NuclioAPIGateway, error) {
+	args := c.Called(ctx, namespace, apiGateway)
+	created, _ := args.Get(0).(*nuclioio.NuclioAPIGateway)
+	return created, args.Error(1)
+}
+
+func (c *Client) UpdateNuclioAPIGateway(ctx context.Context, namespace string, apiGateway *nuclioio.NuclioAPIGateway) (*nuclioio.NuclioAPIGateway, error) {
+	args := c.Called(ctx, namespace, apiGateway)
+	updated, _ := args.Get(0).(*nuclioio.NuclioAPIGateway)
+	return updated, args.Error(1)
+}
+
+func (c *Client) DeleteNuclioAPIGateway(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
+	args := c.Called(ctx, namespace, name, opts)
+	return args.Error(0)
+}
+
+func (c *Client) GetNuclioFunctionEvent(ctx context.Context, namespace, name string) (*nuclioio.NuclioFunctionEvent, error) {
+	args := c.Called(ctx, namespace, name)
+	functionEvent, _ := args.Get(0).(*nuclioio.NuclioFunctionEvent)
+	return functionEvent, args.Error(1)
+}
+
+func (c *Client) ListNuclioFunctionEvents(ctx context.Context, namespace string, opts metav1.ListOptions) (*nuclioio.NuclioFunctionEventList, error) {
+	args := c.Called(ctx, namespace, opts)
+	list, _ := args.Get(0).(*nuclioio.NuclioFunctionEventList)
+	return list, args.Error(1)
+}
+
+func (c *Client) CreateNuclioFunctionEvent(ctx context.Context, namespace string, functionEvent *nuclioio.NuclioFunctionEvent) (*nuclioio.NuclioFunctionEvent, error) {
+	args := c.Called(ctx, namespace, functionEvent)
+	created, _ := args.Get(0).(*nuclioio.NuclioFunctionEvent)
+	return created, args.Error(1)
+}
+
+func (c *Client) UpdateNuclioFunctionEvent(ctx context.Context, namespace string, functionEvent *nuclioio.NuclioFunctionEvent) (*nuclioio.NuclioFunctionEvent, error) {
+	args := c.Called(ctx, namespace, functionEvent)
+	updated, _ := args.Get(0).(*nuclioio.NuclioFunctionEvent)
+	return updated, args.Error(1)
+}
+
+func (c *Client) DeleteNuclioFunctionEvent(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
+	args := c.Called(ctx, namespace, name, opts)
+	return args.Error(0)
+}


### PR DESCRIPTION
### 📝 Description
Extracts the shared 2PC CAS and replay-protection logic into a common leader package, so Oris's leader and follower-side project CUD operations reuse the same implementation. Also implements the missing 2PC functionality required for project synchronization with Oris as the leader.

---

### 🛠️ Changes Made
- Added `pkg/platform/abstract/project/external/leader/common.go` with `RequireCASMatch` and `IsOpIDOrdered` — the CAS/replay-protection logic previously private to mlrun's `LeaderOps`.
- Refactored `mlrun/leader.go` to call the new common functions instead of its own `requireCASOpIDMatch`/`isOpIDOrdered` methods (removed as dead code).
- Added Oris 2PC label/status constants (`OrisLabelKeySyncStatus`, `OrisLabelKeyOpID`, `OrisSyncStatus`) to `leader/types.go`.
- Implemented `oris/leader.go`'s previously-missing methods on top of the same common logic: `GetDeleteStrategyHeaderName`, `EvaluateLeaderRequest` (now rejects all leader-origin writes on the legacy label-inferred surface via a new `ErrLegacySurfaceForbidden` sentinel), and `ProjectSync2PCEnabled` (now returns `true`).
- Implemented `internalc/kube.Client`'s follower-side project CUD (`PrepareCreate`, `CommitCreate`, `CommitUpdate`, `PrepareDelete`, `CommitDelete`, `List`) on the `/api/v1/follower/projects/*` surface, using `RequireCASMatch`/`IsOpIDOrdered` for CAS and replay protection, and stamping `oris/op-id` + `oris/sync-status` labels on the CRD.
- Added a hand-written `nuclioclient.Client` mock and unit tests (`kube_test.go`) covering the new follower CUD methods.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Unit tests added in `kube_test.go` covering `PrepareCreate`, `CommitCreate`, `CommitUpdate`, `PrepareDelete`, `CommitDelete`, `List` — happy path, idempotent replay, CAS mismatch, stale op_id ordering, and unexpected-state rejection.
- Dev test on the lab setup:
```
# create project curl - oris
curl -X POST '<ORIS_ENDPOINT>/api/v1/projects/projects' \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer '"${TOKEN}" \
  -d '{
    "name": "test-10",
    "description": "NUC-856 2PC follower test"
  }'


# Get project
curl -X GET '<ORIS_ENDPOINT>/api/v1/projects/projects/test-10' \
  -H 'Authorization: Bearer '"${TOKEN}" | jq .

# Update project (PUT — full replace, prevOpId from the last GET's status.opId)
curl -X PUT '<ORIS_ENDPOINT>/api/v1/projects/projects/test-10' \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer '"${TOKEN}" \
  -d '{
    "owner": "test-owner",
    "prevOpId": "<PREV_OP_ID>",
    "description": "NUC-856 2PC follower test - updated"
  }' | jq .

# Delete project
curl -X DELETE '<ORIS_ENDPOINT>/api/v1/projects/projects/test-10' \
  -H 'Authorization: Bearer '"${TOKEN}"
```

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-988
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

