### PR TITLE
[CI] Use archived Debian 11 in java runtime

### DIFF
--- a/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
@@ -16,14 +16,15 @@ ARG NUCLIO_DOCKER_IMAGE_TAG
 ARG NUCLIO_DOCKER_JAVA_OPENJDK
 ARG NUCLIO_DOCKER_REPO=quay.io/nuclio
 
-# Debian 11 "bullseye" reached LTS end-of-life on 2026-08-31 and was pulled from
-# deb.debian.org; pin apt to the last snapshot.debian.org snapshot taken before EOL.
-ARG DEBIAN_SNAPSHOT=20260831T204404Z
-ARG DEBIAN_SECURITY_SNAPSHOT=20260831T211327Z
 # Supplies processor
 FROM ${NUCLIO_DOCKER_REPO}/processor:${NUCLIO_DOCKER_IMAGE_TAG} as processor
 
 FROM ${NUCLIO_DOCKER_JAVA_OPENJDK} as user-handler-builder
+
+# Debian 11 "bullseye" reached LTS end-of-life on 2026-08-31 and was pulled from
+# deb.debian.org; pin apt to the last snapshot.debian.org snapshot taken before EOL.
+ARG DEBIAN_SNAPSHOT=20260831T204404Z
+ARG DEBIAN_SECURITY_SNAPSHOT=20260831T211327Z
 
 ENV GRADLEVERSION=8.14.5
 

--- a/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
+++ b/pkg/processor/build/runtime/java/docker/onbuild/Dockerfile
@@ -16,12 +16,19 @@ ARG NUCLIO_DOCKER_IMAGE_TAG
 ARG NUCLIO_DOCKER_JAVA_OPENJDK
 ARG NUCLIO_DOCKER_REPO=quay.io/nuclio
 
+# Debian 11 "bullseye" reached LTS end-of-life on 2026-08-31 and was pulled from
+# deb.debian.org; pin apt to the last snapshot.debian.org snapshot taken before EOL.
+ARG DEBIAN_SNAPSHOT=20260831T204404Z
+ARG DEBIAN_SECURITY_SNAPSHOT=20260831T211327Z
 # Supplies processor
 FROM ${NUCLIO_DOCKER_REPO}/processor:${NUCLIO_DOCKER_IMAGE_TAG} as processor
 
 FROM ${NUCLIO_DOCKER_JAVA_OPENJDK} as user-handler-builder
 
 ENV GRADLEVERSION=8.14.5
+
+RUN echo "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT} bullseye main" > /etc/apt/sources.list \
+    && echo "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/${DEBIAN_SECURITY_SNAPSHOT} bullseye-security main" >> /etc/apt/sources.list
 
 RUN apt-get update -qqy \
     && apt-get -s dist-upgrade | \


### PR DESCRIPTION
### 📝 Description
Debian 11 "bullseye" reached LTS end-of-life on 2026-08-31. `deb.debian.org`/`security.debian.org` no longer reliably serve `bullseye`/`bullseye-security` packages — some package fetches now 404, and `archive.debian.org` (the official replacement) hasn't ingested `bullseye-security` yet either. This breaks the `handler-builder-java-onbuild` image's `apt-get update && apt-get dist-upgrade` step in every nuclio CI job that builds it.

---

### 🛠️ Changes Made
- Pin `pkg/processor/build/runtime/java/docker/onbuild/Dockerfile`'s apt sources to a fixed `snapshot.debian.org` snapshot taken just before the EOL cutover (bullseye main + bullseye-security), instead of the live `deb.debian.org` mirror.
- Add `[check-valid-until=no]` since snapshot Release files carry an already-past `Valid-Until`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Built the `user-handler-builder` stage locally end-to-end (`docker build --target user-handler-builder ...`) against the real base image and a real `quay.io/nuclio/processor` tag. `apt-get install` succeeded, including `openssl`/`e2fsprogs` — the exact packages that 404'd in CI — and the Gradle `compileJava` step reported `BUILD SUCCESSFUL`.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:
  - Failing CI run: https://github.com/nuclio/nuclio/actions/runs/34016610336/job/101630286576
  - Debian 11 EOL announcement: https://www.debian.org/News/2026/20260831

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Pinned to a specific snapshot rather than `archive.debian.org` because, as of this writing, `archive.debian.org` has ingested `bullseye` main but not yet `bullseye-security` (404). Revisit once Debian finishes archiving `bullseye-security`.
