### PR TITLE
[Kaniko] Fix ECR detection for path-suffixed registry URLs

### DIFF
--- a/pkg/common/helper_test.go
+++ b/pkg/common/helper_test.go
@@ -913,6 +913,11 @@ func (suite *NormalizeHostsTestSuite) TestNormalizeHostsStripsRepoPathAndDedupes
 			expected: []string{"us-central1-docker.pkg.dev"},
 		},
 		{
+			name:     "StripsECRTenantPath",
+			urls:     []string{"934638699319.dkr.ecr.us-east-2.amazonaws.com/iguazio-cloud/qa/vmdev214.lab.iguazeng.com"},
+			expected: []string{"934638699319.dkr.ecr.us-east-2.amazonaws.com"},
+		},
+		{
 			name:     "DropsEmptyAndDuplicates",
 			urls:     []string{"myregistry.azurecr.io", "", "myregistry.azurecr.io"},
 			expected: []string{"myregistry.azurecr.io"},

--- a/pkg/containerimagebuilderpusher/kaniko.go
+++ b/pkg/containerimagebuilderpusher/kaniko.go
@@ -154,7 +154,7 @@ func (k *Kaniko) compileKanikoContainer(buildOptions *BuildOptions) v1.Container
 // configureRegistryAuthentication wires the registry authfile into the kaniko container. Kaniko has
 // its own bundled cloud credential helpers, hence the nil cloudHosts - no login containers needed.
 func (k *Kaniko) configureRegistryAuthentication(ctx context.Context, namespace string, buildOptions *BuildOptions, kanikoJobSpec *batchv1.Job) error {
-	if k.awsHelper.Matches(buildOptions.RegistryURL) {
+	if k.awsHelper.Matches(common.GetHostname(buildOptions.RegistryURL)) {
 		k.configureECRInitContainerAndMount(buildOptions, kanikoJobSpec)
 		return nil
 	}

--- a/pkg/containerimagebuilderpusher/kaniko_test.go
+++ b/pkg/containerimagebuilderpusher/kaniko_test.go
@@ -19,13 +19,135 @@ limitations under the License.
 package containerimagebuilderpusher
 
 import (
+	"context"
 	"testing"
 
+	"github.com/nuclio/nuclio/pkg/containerimagebuilderpusher/registryhelpers"
+	"github.com/nuclio/nuclio/pkg/platform/kube/clients/kube"
+	"github.com/nuclio/nuclio/pkg/processor/build/runtime"
+
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
 	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
 type KanikoTestSuite struct {
 	suite.Suite
+	logger logger.Logger
+	kaniko *Kaniko
+}
+
+func (suite *KanikoTestSuite) SetupTest() {
+	var err error
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+
+	suite.T().Setenv("NUCLIO_DASHBOARD_DEPLOYMENT_NAME", "nuclio-dashboard")
+	dashboardDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "nuclio-dashboard", Namespace: "default", UID: "dashboard-uid"},
+	}
+
+	suite.kaniko = &Kaniko{
+		jobRunner: &jobRunner{
+			builderName:   KanikoKind,
+			logger:        suite.logger,
+			kubeClientSet: kube.NewClientWithRetryFromClient(k8sfake.NewClientset(dashboardDeployment)),
+			builderConfiguration: &ContainerBuilderConfiguration{
+				BusyBoxImage: "busybox:stable",
+				AuthConfig: registryhelpers.AuthConfig{
+					AWSCLIImage: "amazon/aws-cli:2.17.16",
+				},
+				Kaniko: KanikoConfig{
+					Image:           "gcr.io/kaniko-project/executor:latest",
+					ImagePullPolicy: "IfNotPresent",
+				},
+			},
+		},
+		awsHelper: &registryhelpers.AWSHelper{},
+	}
+}
+
+func (suite *KanikoTestSuite) newBuildOptions() *BuildOptions {
+	return &BuildOptions{
+		Image:       "my-func:latest",
+		ContextDir:  "/some/context",
+		RegistryURL: "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+		RepoName:    "my-func",
+		DockerfileInfo: &runtime.ProcessorDockerfileInfo{
+			DockerfilePath: "/some/context/Dockerfile",
+		},
+	}
+}
+
+func createReposContainer(initContainers []v1.Container) *v1.Container {
+	for i := range initContainers {
+		if initContainers[i].Name == "create-repos" {
+			return &initContainers[i]
+		}
+	}
+	return nil
+}
+
+func (suite *KanikoTestSuite) TestConfigureRegistryAuthenticationECRPathSuffixedRegistryURL() {
+	buildOptions := suite.newBuildOptions()
+	buildOptions.RegistryURL = "934638699319.dkr.ecr.us-east-2.amazonaws.com/iguazio-cloud/qa/vmdev214.lab.iguazeng.com"
+	buildOptions.RepoName = "iguazio-cloud/qa/vmdev214.lab.iguazeng.com/evfnivykxu-yxizqvjg-processor"
+
+	jobSpec, err := suite.kaniko.compileJobSpec(context.Background(), "default", buildOptions, "bundle.tar")
+	suite.Require().NoError(err)
+
+	podSpec := jobSpec.Spec.Template.Spec
+	createRepos := createReposContainer(podSpec.InitContainers)
+	suite.Require().NotNil(createRepos, "expected an ECR create-repos init container for a path-suffixed ECR registry URL")
+
+	command := createRepos.Args[1]
+	suite.Contains(command, "aws ecr create-repository --repository-name iguazio-cloud/qa/vmdev214.lab.iguazeng.com/evfnivykxu-yxizqvjg-processor --region us-east-2 --registry-id 934638699319")
+	suite.Contains(command, "aws ecr create-repository --repository-name iguazio-cloud/qa/vmdev214.lab.iguazeng.com/evfnivykxu-yxizqvjg-processor/cache --region us-east-2 --registry-id 934638699319")
+}
+
+func (suite *KanikoTestSuite) TestConfigureRegistryAuthenticationECRBareHostname() {
+	buildOptions := suite.newBuildOptions()
+
+	jobSpec, err := suite.kaniko.compileJobSpec(context.Background(), "default", buildOptions, "bundle.tar")
+	suite.Require().NoError(err)
+
+	podSpec := jobSpec.Spec.Template.Spec
+	createRepos := createReposContainer(podSpec.InitContainers)
+	suite.Require().NotNil(createRepos, "expected an ECR create-repos init container for a bare ECR hostname")
+	suite.Contains(createRepos.Args[1], "--region us-east-1 --registry-id 123456789012")
+}
+
+func (suite *KanikoTestSuite) TestConfigureRegistryAuthenticationNonECRHostWithSecret() {
+	buildOptions := suite.newBuildOptions()
+	buildOptions.RegistryURL = "myregistry.example.com"
+	buildOptions.SecretName = "my-registry-secret"
+
+	jobSpec, err := suite.kaniko.compileJobSpec(context.Background(), "default", buildOptions, "bundle.tar")
+	suite.Require().NoError(err)
+
+	podSpec := jobSpec.Spec.Template.Spec
+	suite.Nil(createReposContainer(podSpec.InitContainers), "non-ECR host must not get an ECR create-repos init container")
+
+	suite.Require().Len(podSpec.Containers[0].VolumeMounts, 2)
+	authMount := podSpec.Containers[0].VolumeMounts[1]
+	suite.Equal(registryhelpers.AuthVolumeName, authMount.Name)
+}
+
+func (suite *KanikoTestSuite) TestConfigureRegistryAuthenticationNonECRHostWithPathSuffix() {
+	buildOptions := suite.newBuildOptions()
+	buildOptions.RegistryURL = "registry.example.com/team/project"
+	buildOptions.SecretName = "my-registry-secret"
+
+	jobSpec, err := suite.kaniko.compileJobSpec(context.Background(), "default", buildOptions, "bundle.tar")
+	suite.Require().NoError(err)
+
+	podSpec := jobSpec.Spec.Template.Spec
+	suite.Nil(createReposContainer(podSpec.InitContainers),
+		"a non-AWS host with a path suffix must not be misdetected as ECR")
 }
 
 func (suite *KanikoTestSuite) TestNewContainerBuilderConfigurationParsesKanikoPodLabels() {

--- a/pkg/containerimagebuilderpusher/registryhelpers/aws_test.go
+++ b/pkg/containerimagebuilderpusher/registryhelpers/aws_test.go
@@ -54,6 +54,11 @@ func (suite *AWSTestSuite) TestECRRegistryID() {
 			registryURL: "111222333444.dkr.ecr.ap-southeast-1.amazonaws.com",
 			expected:    "111222333444",
 		},
+		{
+			name:        "PathSuffixedURL",
+			registryURL: "934638699319.dkr.ecr.us-east-2.amazonaws.com/iguazio-cloud/qa/vmdev214.lab.iguazeng.com",
+			expected:    "934638699319",
+		},
 	} {
 		suite.Run(testCase.name, func() {
 			suite.Require().Equal(testCase.expected, suite.helper.ECRRegistryID(testCase.registryURL))
@@ -82,6 +87,11 @@ func (suite *AWSTestSuite) TestECRRegion() {
 			registryURL: "111222333444.dkr.ecr.ap-southeast-1.amazonaws.com",
 			expected:    "ap-southeast-1",
 		},
+		{
+			name:        "PathSuffixedURL",
+			registryURL: "934638699319.dkr.ecr.us-east-2.amazonaws.com/iguazio-cloud/qa/vmdev214.lab.iguazeng.com",
+			expected:    "us-east-2",
+		},
 	} {
 		suite.Run(testCase.name, func() {
 			suite.Require().Equal(testCase.expected, suite.helper.ECRRegion(testCase.registryURL))
@@ -98,6 +108,16 @@ func (suite *AWSTestSuite) TestMatches() {
 		{name: "ECRHost", url: "123456789012.dkr.ecr.us-east-1.amazonaws.com", expected: true},
 		{name: "ArtifactoryHost", url: "system-registry.artifactory.example.com", expected: false},
 		{name: "AzureHost", url: "myregistry.azurecr.io", expected: false},
+		{
+			name:     "ECRHostWithPath",
+			url:      "123456789012.dkr.ecr.us-east-1.amazonaws.com/some/repo/path",
+			expected: false,
+		},
+		{
+			name:     "AWSLookalikeAccountWithPath",
+			url:      "12345.dkr.ecr.us-east-1.amazonaws.com/some/path",
+			expected: false,
+		},
 	} {
 		suite.Run(testCase.name, func() {
 			suite.Require().Equal(testCase.expected, suite.helper.Matches(testCase.url))


### PR DESCRIPTION
### 📝 Description
Nuclio functions deployed with an AWS ECR registry fail with `NAME_UNKNOWN` because Kaniko's ECR auto-detection never recognized registries whose configured URL carries a path suffix (e.g. a multi-tenant iguazio ECR setup: `<account>.dkr.ecr.<region>.amazonaws.com/<tenant>/<cluster>`). `AWSHelper.Matches` uses a fully-anchored regex that only matches a bare ECR hostname, so when Kaniko passed it the full `RegistryURL` (with path), the match failed, the `aws ecr create-repository` init container was skipped, and Kaniko's later push failed against a repository that was never created. This is a regression from the Buildah cloud-registry-auth migration (#4238 / NUC-688), which replaced Kaniko's old tolerant `strings.Contains(registryURL, ".ecr.")` check with the new strict, anchored `Matches`, without normalizing the host first — unlike Buildah's own registry-auth path, which already does.

---

### 🛠️ Changes Made
- Normalize `buildOptions.RegistryURL` to its bare host (`common.GetHostname`) before the `AWSHelper.Matches` ECR check in `Kaniko.configureRegistryAuthentication`, mirroring the pattern Buildah's registry-auth path already uses.
- Extend `kaniko_test.go` with a `SetupTest`/`newBuildOptions` harness and 4 new tests covering: the reported path-suffixed ECR URL, a bare ECR hostname (no regression), a non-ECR host with a secret, and a non-ECR host with an unrelated path suffix (guards against over-matching).
- Extend `registryhelpers/aws_test.go`'s `TestMatches`/`TestECRRegion`/`TestECRRegistryID` with path-suffixed cases.
- Extend `pkg/common/helper_test.go`'s `NormalizeHosts` coverage with the ECR-shaped path.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- `go test -tags=test_unit -race -short ./pkg/containerimagebuilderpusher/... ./pkg/common/...` — all green.
- Verified the new regression test fails without the fix (temporarily reverted the one-line change, confirmed the failure, restored it).
- `golangci-lint run` (pinned v2.12.1) on both touched packages — 0 issues.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/NUC-992
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- No documentation changes were needed — the existing docs already describe the intended (now-restored) behavior correctly.